### PR TITLE
Avoid verification of JAX MLIR modules

### DIFF
--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -359,7 +359,9 @@ class QJIT:
         ):
             mlir_module, ctx, jaxpr = tracer.get_mlir(self.qfunc, *args_or_argtypes)
         self._jaxpr = jaxpr
-        self._mlir = str(mlir_module)
+        self._mlir = mlir_module.operation.get_asm(
+            binary=False, print_generic_op_form=False, assume_verified=True
+        )
 
         # Inject setup and finalize functions.
         append_modules(mlir_module, ctx)

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -246,7 +246,7 @@ def compile(mlir_module, workspace, passes):
     # need to create a temporary file with the string contents
     filename = workspace + f"/{module_name}.mlir"
     with open(filename, "w") as f:
-        f.write(str(mlir_module) + "\n")
+        mlir_module.operation.print(f, print_generic_op_form=False, assume_verified=True)
 
     passes["mlir"] = filename
     mlir = filename

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -406,5 +406,4 @@ def custom_lower_jaxpr_to_module(
                 continue
             op.attributes["llvm.linkage"] = ir.Attribute.parse("#llvm.linkage<internal>")
 
-    ctx.module.operation.verify()
     return ctx.module, ctx.context

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -23,8 +23,6 @@ import numpy as np
 import random
 import jax
 import warnings
-import contextlib
-import io
 
 from catalyst.compilation_pipelines import CompiledFunction
 
@@ -660,7 +658,6 @@ class TestDefaultAvailableIR:
         assert "__quantum__qis" in g.qir
 
 
-@pytest.mark.xfail
 class TestAvoidVerification:
     def test_no_verification(self, capfd):
         dev1 = qml.device("lightning.qubit", wires=1)


### PR DESCRIPTION
**Context:** JAX MLIR modules are verified whenever they are printed, converted to a string, or when the method `verify` is called. MLIR verification involves verifying that the constraints in the IR are met. MLIR modules also allow for unregistered dialects to be placed in the same module as registered dialects. This means that the verification sometimes has to verify unregistered dialects for which it doesn't know the constraints nor the semantics.

Due to this, it is possible that the verification prints warning messages. A concrete example is when an operation may be a symbol table. Since a symbol table may contain symbol definitions, all uses inside a symbol table should be resolved by the nearest symbol table. However, if the nearest symbol table may be an unknown operation, then the symbol cannot be resolved successfully.

The above case happens when symbols attributes are used inside the SCF::ForOp in the MLIR modules created by JAX contexts. SCF::ForOp may be a symbol table due to having only one region, and its dialect is unloaded in this context. Therefore, even though it isn't a symbol table, it is unknown if it is a symbol table and the verification will issue warnings.

**Description of the Change:** Avoid verification path. Instead of verifying the MLIR module in python, we avoid all paths that lead to verification.

**Benefits:** No more warnings.

**Possible Drawbacks:** No more warnings. This means that errors must be caught later since we cannot rely on verification to capture errors at the verification stage.
