### PR TITLE
[Backend] C/C++ code separation in CAPIs and QuantumDevice

### DIFF
--- a/runtime/include/QuantumDevice.hpp
+++ b/runtime/include/QuantumDevice.hpp
@@ -74,7 +74,7 @@ struct QuantumDevice {
      *
      * @return `size_t`
      */
-    virtual auto GetNumQubits() -> size_t = 0;
+    virtual auto GetNumQubits() -> size_t const = 0;
 
     /**
      * @brief Set the number of device shots.
@@ -88,7 +88,7 @@ struct QuantumDevice {
      *
      * @return `size_t`
      */
-    virtual auto GetDeviceShots() -> size_t = 0;
+    virtual auto GetDeviceShots() -> size_t const = 0;
 
     /**
      * @brief Start recording a quantum tape if provided.
@@ -105,26 +105,19 @@ struct QuantumDevice {
      *
      * @return `Result`
      */
-    virtual auto Zero() -> Result = 0;
+    virtual auto Zero() -> Result const = 0;
 
     /**
      * @brief Result value for "One"  used in the measurement process.
      *
      * @return `Result`
      */
-    virtual auto One() -> Result = 0;
+    virtual auto One() -> Result const = 0;
 
     /**
      * @brief A helper method to print the state vector of a device.
      */
     virtual void PrintState() = 0;
-
-    /**
-     * @brief A helper method to dump the state vector of a device.
-     *
-     * @return `std::vector<std::complex<double>>`
-     */
-    virtual auto DumpState() -> std::vector<std::complex<double>> = 0;
 
     /**
      * @brief Apply a single gate to the state vector of a device with its name if this is
@@ -202,74 +195,69 @@ struct QuantumDevice {
     /**
      * @brief Compute the probabilities of each computational basis state.
      *
-     * @param probs The pointer to a pre-allocated C-style array to store results
-     * @param numAlloc The size of `probs`
+     * @return `std::vector<double>`
      */
-    virtual void Probs(double *probs, size_t numAlloc) = 0;
+    virtual auto Probs() -> std::vector<double> = 0;
 
     /**
      * @brief Compute the probabilities for a subset of the full system.
      *
-     * @param probs The pointer to a pre-allocated C-style array to store results
-     * @param numAlloc The size of `probs`
      * @param wires Wires will restrict probabilities to a subset of the full system
+     *
+     * @return `std::vector<double>`
      */
-    virtual void PartialProbs(double *probs, size_t numAlloc,
-                              const std::vector<QubitIdType> &wires) = 0;
+    virtual auto PartialProbs(const std::vector<QubitIdType> &wires) -> std::vector<double> = 0;
 
     /**
      * @brief Get the state-vector of a device.
      *
-     * @param stateVec The pointer to a pre-allocated C-style array to store results
-     * @param numAlloc The size of `stateVec`
+     * @return `std::vector<std::complex<double>>`
      */
-    virtual void State(CplxT_double *stateVec, size_t numAlloc) = 0;
+    virtual auto State() -> std::vector<std::complex<double>> = 0;
 
     /**
      * @brief Compute samples with the number of shots on the entire wires,
      * returing raw samples.
      *
-     * @param samples The pointer to a pre-allocated C-style array to store results
-     * @param numAlloc The size of `samples`
      * @param shots The number of shots
+     *
+     * @return `std::vector<double>`
      */
-    virtual void Sample(double *samples, size_t numAlloc, size_t shots) = 0;
+    virtual auto Sample(size_t shots) -> std::vector<double> = 0;
 
     /**
      * @brief Compute partial samples with the number of shots on `wires`,
      * returing raw samples.
      *
-     * @param samples The pointer to a pre-allocated C-style array to store results
-     * @param numAlloc The size of `samples`
      * @param wires Wires to compute samples on
      * @param shots The number of shots
+     *
+     * @return `std::vector<double>`
      */
-    virtual void PartialSample(double *samples, size_t numAlloc,
-                               const std::vector<QubitIdType> &wires, size_t shots) = 0;
+    virtual auto PartialSample(const std::vector<QubitIdType> &wires, size_t shots)
+        -> std::vector<double> = 0;
 
     /**
      * @brief Sample with the number of shots on the entire wires, returning the
      * number of counts for each sample.
      *
-     * @param eigvals The pointer to a pre-allocated C-style array to store eigvals
-     * @param counts The pointer to a pre-allocated C-style array to store results
-     * @param numAlloc The size of `counts` (or `eigvals`)
      * @param shots The number of shots
+     *
+     * @return `std::tuple<std::vector<double>, std::vector<int64_t>>` (eigvals, counts)
      */
-    virtual void Counts(double *eigvals, int64_t *counts, size_t numAlloc, size_t shots) = 0;
+    virtual auto Counts(size_t shots) -> std::tuple<std::vector<double>, std::vector<int64_t>> = 0;
 
     /**
      * @brief Partial sample with the number of shots on `wires`, returning the
      * number of counts for each sample.
      *
-     * @param eigvals The pointer to a pre-allocated C-style array to store eigvals
-     * @param counts The pointer to a pre-allocated C-style array to store results
-     * @param numAlloc The size of `counts` (or `eigvals`)
      * @param wires Wires to compute samples on
      * @param shots The number of shots
+     *
+     * @return `std::tuple<std::vector<double>, std::vector<int64_t>>` (eigvals, counts)
      */
-    virtual void PartialCounts(double *eigvals, int64_t *counts, size_t numAlloc,
-                               const std::vector<QubitIdType> &wires, size_t shots) = 0;
+    virtual auto PartialCounts(const std::vector<QubitIdType> &wires, size_t shots)
+        -> std::tuple<std::vector<double>, std::vector<int64_t>> = 0;
 
     /**
      * @brief A general measurement method that acts on a single wire.

--- a/runtime/lib/backend/LightningKokkosSimulator.hpp
+++ b/runtime/lib/backend/LightningKokkosSimulator.hpp
@@ -104,15 +104,14 @@ class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
     auto AllocateQubits(size_t num_qubits) -> std::vector<QubitIdType> override;
     void ReleaseQubit(QubitIdType q) override;
     void ReleaseAllQubits() override;
-    auto GetNumQubits() -> size_t override;
+    auto GetNumQubits() -> size_t const override;
     void StartTapeRecording() override;
     void StopTapeRecording() override;
     void SetDeviceShots(size_t shots) override;
-    auto GetDeviceShots() -> size_t override;
+    auto GetDeviceShots() -> size_t const override;
     void PrintState() override;
-    auto DumpState() -> VectorCplxT<double> override;
-    auto Zero() -> Result override;
-    auto One() -> Result override;
+    auto Zero() -> Result const override;
+    auto One() -> Result const override;
 
     auto CacheManagerInfo()
         -> std::tuple<size_t, size_t, size_t, std::vector<std::string>, std::vector<ObsIdType>>;
@@ -129,16 +128,15 @@ class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
         -> ObsIdType override;
     auto Expval(ObsIdType obsKey) -> double override;
     auto Var(ObsIdType obsKey) -> double override;
-    void State(CplxT_double *stateVec, size_t numAlloc) override;
-    void Probs(double *probs, size_t numAlloc) override;
-    void PartialProbs(double *probs, size_t numAlloc,
-                      const std::vector<QubitIdType> &wires) override;
-    void Sample(double *samples, size_t numAlloc, size_t shots) override;
-    void PartialSample(double *samples, size_t numAlloc, const std::vector<QubitIdType> &wires,
-                       size_t shots) override;
-    void Counts(double *eigvals, int64_t *counts, size_t numAlloc, size_t shots) override;
-    void PartialCounts(double *eigvals, int64_t *counts, size_t numAlloc,
-                       const std::vector<QubitIdType> &wires, size_t shots) override;
+    auto State() -> std::vector<std::complex<double>> override;
+    auto Probs() -> std::vector<double> override;
+    auto PartialProbs(const std::vector<QubitIdType> &wires) -> std::vector<double> override;
+    auto Sample(size_t shots) -> std::vector<double> override;
+    auto PartialSample(const std::vector<QubitIdType> &wires, size_t shots)
+        -> std::vector<double> override;
+    auto Counts(size_t shots) -> std::tuple<std::vector<double>, std::vector<int64_t>> override;
+    auto PartialCounts(const std::vector<QubitIdType> &wires, size_t shots)
+        -> std::tuple<std::vector<double>, std::vector<int64_t>> override;
     auto Measure(QubitIdType wire) -> Result override;
     auto Gradient(const std::vector<size_t> &trainParams)
         -> std::vector<std::vector<double>> override;

--- a/runtime/lib/backend/LightningSimulator.hpp
+++ b/runtime/lib/backend/LightningSimulator.hpp
@@ -24,6 +24,7 @@ throw std::logic_error("StateVectorDynamicCPU.hpp: No such header file");
 #include <cstdint>
 #include <iostream>
 #include <limits>
+#include <numeric>
 #include <random>
 #include <span>
 
@@ -106,15 +107,14 @@ class LightningSimulator final : public Catalyst::Runtime::QuantumDevice {
     auto AllocateQubits(size_t num_qubits) -> std::vector<QubitIdType> override;
     void ReleaseQubit(QubitIdType q) override;
     void ReleaseAllQubits() override;
-    auto GetNumQubits() -> size_t override;
+    auto GetNumQubits() -> size_t const override;
     void StartTapeRecording() override;
     void StopTapeRecording() override;
     void SetDeviceShots(size_t shots) override;
-    auto GetDeviceShots() -> size_t override;
+    auto GetDeviceShots() -> size_t const override;
     void PrintState() override;
-    auto DumpState() -> VectorCplxT<double> override;
-    auto Zero() -> Result override;
-    auto One() -> Result override;
+    auto Zero() -> Result const override;
+    auto One() -> Result const override;
 
     auto CacheManagerInfo()
         -> std::tuple<size_t, size_t, size_t, std::vector<std::string>, std::vector<ObsIdType>>;
@@ -131,16 +131,15 @@ class LightningSimulator final : public Catalyst::Runtime::QuantumDevice {
         -> ObsIdType override;
     auto Expval(ObsIdType obsKey) -> double override;
     auto Var(ObsIdType obsKey) -> double override;
-    void State(CplxT_double *stateVec, size_t numAlloc) override;
-    void Probs(double *probs, size_t numAlloc) override;
-    void PartialProbs(double *probs, size_t numAlloc,
-                      const std::vector<QubitIdType> &wires) override;
-    void Sample(double *samples, size_t numAlloc, size_t shots) override;
-    void PartialSample(double *samples, size_t numAlloc, const std::vector<QubitIdType> &wires,
-                       size_t shots) override;
-    void Counts(double *eigvals, int64_t *counts, size_t numAlloc, size_t shots) override;
-    void PartialCounts(double *eigvals, int64_t *counts, size_t numAlloc,
-                       const std::vector<QubitIdType> &wires, size_t shots) override;
+    auto State() -> std::vector<std::complex<double>> override;
+    auto Probs() -> std::vector<double> override;
+    auto PartialProbs(const std::vector<QubitIdType> &wires) -> std::vector<double> override;
+    auto Sample(size_t shots) -> std::vector<double> override;
+    auto PartialSample(const std::vector<QubitIdType> &wires, size_t shots)
+        -> std::vector<double> override;
+    auto Counts(size_t shots) -> std::tuple<std::vector<double>, std::vector<int64_t>> override;
+    auto PartialCounts(const std::vector<QubitIdType> &wires, size_t shots)
+        -> std::tuple<std::vector<double>, std::vector<int64_t>> override;
     auto Measure(QubitIdType wire) -> Result override;
     auto Gradient(const std::vector<size_t> &trainParams)
         -> std::vector<std::vector<double>> override;

--- a/runtime/tests/Test_LightningDriver.cpp
+++ b/runtime/tests/Test_LightningDriver.cpp
@@ -35,7 +35,7 @@ TEST_CASE("lightning Basis vector", "[lightning]")
 
     sim->ReleaseQubit(q);
 
-    auto state = sim->DumpState();
+    auto state = sim->State();
     REQUIRE(state[0].real() == Approx(1.0).epsilon(1e-5));
     REQUIRE(state[0].imag() == Approx(0.0).epsilon(1e-5));
     REQUIRE(state[1].real() == Approx(0.0).epsilon(1e-5));
@@ -60,7 +60,7 @@ TEST_CASE("Qubit allocatation and deallocation", "[lightning]")
 
     REQUIRE(n == static_cast<size_t>(q) + 1);
 
-    VectorCplxT<double> state = sim->DumpState();
+    VectorCplxT<double> state = sim->State();
 
     REQUIRE(state.size() == (1ul << n));
     REQUIRE(state[0].real() == Approx(1.0).epsilon(1e-5));
@@ -80,7 +80,7 @@ TEST_CASE("Qubit allocatation and deallocation", "[lightning]")
 
         sim->ReleaseQubit(i - 1);
         sim->AllocateQubit();
-        state = sim->DumpState();
+        state = sim->State();
     }
 #else
     for (size_t i = n; i > 0; i--) {
@@ -99,7 +99,7 @@ TEST_CASE("test AllocateQubits", "[lightning]")
 
     sim->ReleaseQubit(q[0]);
 
-    auto state = sim->DumpState();
+    auto state = sim->State();
     REQUIRE(state[0].real() == Approx(1.0).epsilon(1e-5));
 }
 
@@ -156,7 +156,7 @@ TEST_CASE("QuantumDevice object test", "[lightning]")
     sim->NamedOperation("Identity", {}, {Qs[6]}, false);
     sim->NamedOperation("Identity", {}, {Qs[8]}, false);
 
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state[0].real() == Approx(1.0).epsilon(1e-5));
     REQUIRE(out_state[0].imag() == Approx(0.0).epsilon(1e-5));

--- a/runtime/tests/Test_LightningGateSet.cpp
+++ b/runtime/tests/Test_LightningGateSet.cpp
@@ -49,7 +49,7 @@ TEST_CASE("Identity Gate tests", "[lightning]")
     sim->NamedOperation("Identity", {}, {Qs[6]}, false);
     sim->NamedOperation("Identity", {}, {Qs[8]}, false);
 
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state.at(0) == std::complex<double>{1, 0});
 
@@ -76,7 +76,7 @@ TEST_CASE("PauliX Gate tests num_qubits=1", "[lightning]")
 
     sim->NamedOperation("PauliX", {}, {Qs[0]}, false);
 
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state.at(0) == std::complex<double>{0, 0});
     REQUIRE(out_state.at(1) == std::complex<double>{1, 0});
@@ -104,7 +104,7 @@ TEST_CASE("PauliX Gate tests num_qubits=3", "[lightning]")
     sim->NamedOperation("PauliX", {}, {Qs[1]}, false);
     sim->NamedOperation("PauliX", {}, {Qs[0]}, false);
 
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state.at(0) == std::complex<double>{1, 0});
 
@@ -131,7 +131,7 @@ TEST_CASE("PauliY Gate tests num_qubits=1", "[lightning]")
 
     sim->NamedOperation("PauliY", {}, {Qs[0]}, false);
 
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state.at(0) == std::complex<double>{0, 0});
     REQUIRE(out_state.at(1) == std::complex<double>{0, 1});
@@ -153,7 +153,7 @@ TEST_CASE("PauliY Gate tests num_qubits=2", "[lightning]")
     sim->NamedOperation("PauliY", {}, {Qs[0]}, false);
     sim->NamedOperation("PauliY", {}, {Qs[1]}, false);
 
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state.at(0) == std::complex<double>{0, 0});
     REQUIRE(out_state.at(1) == std::complex<double>{0, 0});
@@ -177,7 +177,7 @@ TEST_CASE("PauliZ Gate tests num_qubits=2", "[lightning]")
     sim->NamedOperation("PauliY", {}, {Qs[0]}, false);
     sim->NamedOperation("PauliZ", {}, {Qs[1]}, false);
 
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state.at(0) == std::complex<double>{0, 0});
     REQUIRE(out_state.at(1) == std::complex<double>{0, 0});
@@ -201,7 +201,7 @@ TEST_CASE("Hadamard Gate tests num_qubits=2", "[lightning]")
     sim->NamedOperation("Hadamard", {}, {Qs[0]}, false);
     sim->NamedOperation("Hadamard", {}, {Qs[1]}, false);
 
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state[0].real() == Approx(0.5).epsilon(1e-5));
     REQUIRE(out_state[0].imag() == Approx(0).epsilon(1e-5));
@@ -226,7 +226,7 @@ TEST_CASE("Hadamard Gate tests num_qubits=3", "[lightning]")
     sim->NamedOperation("Hadamard", {}, {Qs[0]}, false);
     sim->NamedOperation("Hadamard", {}, {Qs[1]}, false);
 
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state[0].real() == Approx(0.5).epsilon(1e-5));
     REQUIRE(out_state[0].imag() == Approx(0).epsilon(1e-5));
@@ -247,7 +247,7 @@ TEST_CASE("MIX Gate test R(X,Y,Z) num_qubits=1,4", "[lightning]")
     Qs[0] = sim->AllocateQubit();
     sim->NamedOperation("PauliX", {}, {Qs[0]}, false);
 
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state.at(0) == std::complex<double>{0, 0});
     REQUIRE(out_state.at(1) == std::complex<double>{1, 0});
@@ -261,7 +261,7 @@ TEST_CASE("MIX Gate test R(X,Y,Z) num_qubits=1,4", "[lightning]")
     Qs[3] = sim->AllocateQubit();
     sim->NamedOperation("RZ", {0.789}, {Qs[3]}, false);
 
-    out_state = sim->DumpState();
+    out_state = sim->State();
 
     // calculated by pennylane,
 #if defined(_KOKKOS)
@@ -314,7 +314,7 @@ TEST_CASE("test PhaseShift num_qubits=2", "[lightning]")
     sim->NamedOperation("RX", {0.123}, {Qs[1]}, false);
     sim->NamedOperation("PhaseShift", {0.456}, {Qs[0]}, false);
 
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     // calculated by pennylane,
     REQUIRE(out_state[0].real() == Approx(0.7057699753).epsilon(1e-5));
@@ -347,7 +347,7 @@ TEST_CASE("CNOT Gate tests num_qubits=2 [0,1]", "[lightning]")
     sim->NamedOperation("PauliX", {}, {Qs[0]}, false);
     sim->NamedOperation("CNOT", {}, {Qs[0], Qs[1]}, false);
 
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state.at(0) == std::complex<double>{0, 0});
     REQUIRE(out_state.at(1) == std::complex<double>{0, 0});
@@ -371,7 +371,7 @@ TEST_CASE("CNOT Gate tests num_qubits=2 [1,0]", "[lightning]")
     sim->NamedOperation("PauliX", {}, {Qs[0]}, false);
     sim->NamedOperation("CNOT", {}, {Qs[1], Qs[0]}, false);
 
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state.at(0) == std::complex<double>{0, 0});
     REQUIRE(out_state.at(1) == std::complex<double>{0, 0});
@@ -391,7 +391,7 @@ TEST_CASE("MIX Gate test CR(X, Y, Z) num_qubits=1,4", "[lightning]")
     Qs[0] = sim->AllocateQubit();
     sim->NamedOperation("Hadamard", {}, {Qs[0]}, false);
 
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state[0].real() == Approx(0.7071067811865475).epsilon(1e-5));
     REQUIRE(out_state[0].imag() == Approx(0).epsilon(1e-5));
@@ -407,7 +407,7 @@ TEST_CASE("MIX Gate test CR(X, Y, Z) num_qubits=1,4", "[lightning]")
     Qs[3] = sim->AllocateQubit();
     sim->NamedOperation("CRZ", {0.789}, {Qs[0], Qs[3]}, false);
 
-    out_state = sim->DumpState();
+    out_state = sim->State();
 
     // calculated by pennylane,
 #if defined(_KOKKOS)
@@ -456,7 +456,7 @@ TEST_CASE("CRot", "[lightning]")
 
     sim->NamedOperation("Hadamard", {}, {Qs[0]}, false);
     sim->NamedOperation("CRot", {M_PI, M_PI_2, 0.5}, {Qs[0], Qs[1]}, false);
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state[0].real() == Approx(0.7071067812).epsilon(1e-5));
     REQUIRE(out_state[0].imag() == Approx(0).epsilon(1e-5));
@@ -484,7 +484,7 @@ TEST_CASE("CSWAP test", "[lightning]")
     sim->NamedOperation("RX", {M_PI}, {Qs[0]}, false);
     sim->NamedOperation("RX", {M_PI}, {Qs[1]}, false);
     sim->NamedOperation("CSWAP", {}, {Qs[0], Qs[1], Qs[2]}, false);
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state[5].real() == Approx(-1).epsilon(1e-5));
     REQUIRE(out_state[5].imag() == Approx(0).epsilon(1e-5));
@@ -508,7 +508,7 @@ TEST_CASE("IsingXY Gate tests num_qubits=2 [1,0]", "[lightning]")
     sim->NamedOperation("IsingXY", {0.2}, {Qs[1], Qs[0]}, false);
     sim->NamedOperation("SWAP", {}, {Qs[0], Qs[1]}, false);
 
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state[0].real() == Approx(0.70710678).epsilon(1e-5));
     REQUIRE(out_state[0].imag() == Approx(0).epsilon(1e-5));
@@ -537,7 +537,7 @@ TEST_CASE("Toffoli test", "[lightning]")
     sim->NamedOperation("PauliX", {}, {Qs[1]}, false);
     sim->NamedOperation("Toffoli", {}, {Qs[0], Qs[1], Qs[2]}, false);
 
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state.at(0) == std::complex<double>{0, 0});
     REQUIRE(out_state.at(1) == std::complex<double>{0, 0});
@@ -570,7 +570,7 @@ TEST_CASE("MultiRZ test", "[lightning]")
     sim->NamedOperation("MultiRZ", {M_PI}, {Qs[0], Qs[1]}, false);
     sim->NamedOperation("Hadamard", {}, {Qs[0]}, false);
     sim->NamedOperation("Hadamard", {}, {Qs[1]}, false);
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state[2].real() == Approx(-1).epsilon(1e-5));
     REQUIRE(out_state[2].imag() == Approx(0).epsilon(1e-5));
@@ -602,7 +602,7 @@ TEST_CASE("MatrixOperation test with 2-qubit", "[lightning]")
     };
     sim->MatrixOperation(matrix, wires, false);
 
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state[0].real() == Approx(-0.474432).epsilon(1e-5));
     REQUIRE(out_state[0].imag() == Approx(-0.44579).epsilon(1e-5));
@@ -646,7 +646,7 @@ TEST_CASE("MatrixOperation test with 3-qubit", "[lightning]")
     };
     sim->MatrixOperation(matrix, wires, false);
 
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state[0].real() == Approx(0.349135).epsilon(1e-5));
     REQUIRE(out_state[0].imag() == Approx(0.180548).epsilon(1e-5));
@@ -746,7 +746,7 @@ TEST_CASE("MatrixOperation test with 4-qubit", "[lightning]")
     };
     sim->MatrixOperation(matrix, wires, false);
 
-    VectorCplxT<double> out_state = sim->DumpState();
+    VectorCplxT<double> out_state = sim->State();
 
     REQUIRE(out_state[0].real() == Approx(-0.141499).epsilon(1e-5));
     REQUIRE(out_state[0].imag() == Approx(-0.230993).epsilon(1e-5));


### PR DESCRIPTION
**Context:**
This PR addresses the code style inconsistency issues in the implementation of CAPIs and interface of QIS instructions.

**Description of the Change:**
- [x] Move the entire C-style memory management to CAPIs.
- [x] Remove C-style arrays from the C++ interface and use std containers for return data types.
- [x] Remove `DumpState` as this is now redundant to the `State` measurement process. 
- [x] Clean-up tests 

**Benefits:**
A cleaner C/C++ code separation. The entire C-style memory allocations/deallocations is now limited to CAPIs which will be tackled using a safer (and modern) approach in future.

**Possible Drawbacks:**
n/a

**Related GitHub Issues:**
n/a