### PR TITLE
[Frontend] Remove dangerous default.

### DIFF
--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -144,10 +144,12 @@ def trace_quantum_tape(
     tape,
     qreg,
     has_tracer_return_values,
-    meas_ret_val_indices=[],
+    meas_ret_val_indices=None,
     num_wires=None,
     shots=None,
 ):
+    if meas_ret_val_indices is None:
+        meas_ret_val_indices = []
     qubit_states = {}
     p = tape.get_parameter_evaluator()
     for op in tape.quantum_tape.operations:

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -240,8 +240,9 @@ class CondCallable:
                 tape.quantum_tape = new_quantum_tape
                 tape.quantum_tape.jax_tape = tape
 
+            has_tracer_return_values = out is not None
             return_values, qreg, qubit_states = trace_quantum_tape(
-                tape, qreg, has_tracer_return_values=out is not None
+                tape, qreg, has_tracer_return_values
             )
             qreg = insert_to_qreg(qubit_states, qreg)
 
@@ -256,8 +257,9 @@ class CondCallable:
                 tape.quantum_tape = new_quantum_tape
                 tape.quantum_tape.jax_tape = tape
 
+            has_tracer_return_values = out is not None
             return_values, qreg, qubit_states = trace_quantum_tape(
-                tape, qreg, has_tracer_return_values=out is not None
+                tape, qreg, has_tracer_return_values
             )
             qreg = insert_to_qreg(qubit_states, qreg)
 
@@ -428,8 +430,9 @@ class WhileCallable:
                 tape.quantum_tape = new_quantum_tape
                 tape.quantum_tape.jax_tape = tape
 
+            has_tracer_return_values = True
             return_values, qreg, qubit_states = trace_quantum_tape(
-                tape, qreg, has_tracer_return_values=True
+                tape, qreg, has_tracer_return_values
             )
             qreg = insert_to_qreg(qubit_states, qreg)
 
@@ -556,8 +559,9 @@ class ForLoopCallable:
                 tape.quantum_tape = new_quantum_tape
                 tape.quantum_tape.jax_tape = tape
 
+            has_tracer_return_values = out is not None
             return_values, qreg, qubit_states = trace_quantum_tape(
-                tape, qreg, has_tracer_return_values=out is not None
+                tape, qreg, has_tracer_return_values
             )
             qreg = insert_to_qreg(qubit_states, qreg)
 


### PR DESCRIPTION
**Context:** Mutable data structures as default arguments will persist across function calls.

**Description of the Change:** Do not make default arguments mutable data structures.

**Benefits:** Data does not persist across function calls.
