### PR TITLE
Add changelog reminder action

### DIFF
--- a/.github/workflows/changelog_reminder.yaml
+++ b/.github/workflows/changelog_reminder.yaml
@@ -1,0 +1,24 @@
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+name: Changelog Reminder
+
+jobs:
+  remind:
+    name: Changelog Reminder
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Changelog Reminder
+      uses: peterjgrainger/action-changelog-reminder@v1.3.0
+      with:
+        changelog_regex: 'doc/changelog.md'
+        customPrMessage: |
+          Hello. You may have forgotten to update the changelog!
+          Please edit [`doc/changelog.md`](/PennyLaneAI/catalyst/blob/master/doc/changelog.md) on your branch with:
+          * A one-to-two sentence description of the change. You may include a small working example for new features.
+          * A link back to this PR.
+          * Your name (or GitHub username) in the contributors section.
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/changelog_reminder.yaml
+++ b/.github/workflows/changelog_reminder.yaml
@@ -1,6 +1,8 @@
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [ready_for_review, review_requested]
+  pull_request_review:
+    types: [submitted]
 
 name: Changelog Reminder
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,6 +1,16 @@
 # Release 0.2.0-dev
 
+<h3>New features</h3>
+
+<h3>Improvements</h3>
+
+<h3>Breaking changes</h3>
+
+<h3>Bug fixes</h3>
+
 <h3>Contributors</h3>
+
+This release contains contributions from (in alphabetical order):
 
 # Release 0.1.0
 


### PR DESCRIPTION
**Context:** Now that we are working on v0.2.0, having a changelog reminder will help us avoid additional work during the release, by ensuring all changes are documented in PRs :)

**Description of the Change:** Adds an action to remind us to edit the changelog if we haven't already.

**Benefits:** As above!

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a
