### PR TITLE
Fix broken test configuration after removing hard-coded bindings

### DIFF
--- a/.github/workflows/check-formatting.yaml
+++ b/.github/workflows/check-formatting.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   format-python:
-    name: Python Formatting
+    name: Python Formatting & Linting
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/check-jax-release.yaml
+++ b/.github/workflows/check-jax-release.yaml
@@ -83,9 +83,13 @@ jobs:
       run: |
         make runtime
 
-    - name: Run Frontend Test suite
+    - name: Run Frontend LIT suite
       run: |
-        make test-frontend
+        make lit
+
+    - name: Run Frontend PyTest suite
+      run: |
+        make pytest
 
     - name: Run Demos
       run: |

--- a/Makefile
+++ b/Makefile
@@ -47,18 +47,20 @@ dialects:
 runtime:
 	$(MAKE) -C runtime all
 
-.PHONY: test test-runtime test-dialects test-frontend test-demos
-test: test-runtime test-dialects test-frontend test-demos
+.PHONY: test test-runtime test-frontend lit pytest test-demos
+test: test-runtime test-frontend test-demos
 
 test-runtime:
 	$(MAKE) -C runtime test
 
-test-dialects:
-	$(MAKE) -C mlir test
+test-frontend: lit pytest
 
-test-frontend:
-	@echo "check the Catalyst lit and Python test suites"
+lit:
+	@echo "check the Catalyst lit test suite"
 	cmake --build $(DIALECTS_BUILD_DIR) --target check-frontend
+
+pytest:
+	@echo "check the Catalyst PyTest suite"
 	$(PYTHON) pytest frontend/test/pytest --tb=native -n auto
 
 test-demos:

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -181,5 +181,5 @@ To check Catalyst modules and the compiler test suites in Catalyst:
 
   make test
 
-You can also check each module test suite by using ``test-frontend``,
+You can also check each module test suite by using the ``test-frontend``,
 ``test-dialects``, and ``test-runtime`` Make targets.

--- a/frontend/catalyst/__init__.py
+++ b/frontend/catalyst/__init__.py
@@ -17,9 +17,6 @@ This package contains the Catalyst Python interface.
 
 
 from catalyst._version import __version__
-from catalyst.compiler import compile
-from catalyst.compilation_pipelines import qjit, QJIT
-from catalyst.pennylane_extensions import for_loop, while_loop, cond, measure, grad
 from catalyst._configuration import INSTALLED
 
 if not INSTALLED:
@@ -32,6 +29,15 @@ if not INSTALLED:
         import sys
 
         sys.path.insert(0, default_bindings_path)
+
+from catalyst.compilation_pipelines import qjit, QJIT  # pylint: disable=wrong-import-position
+from catalyst.pennylane_extensions import (  # pylint: disable=wrong-import-position
+    for_loop,
+    while_loop,
+    cond,
+    measure,
+    grad,
+)
 
 
 __all__ = (

--- a/mlir/test/frontend/CMakeLists.txt
+++ b/mlir/test/frontend/CMakeLists.txt
@@ -7,5 +7,4 @@ configure_lit_site_cfg(
 
 add_lit_testsuite(check-frontend "Run the frontend tests"
     .  # the frontend tests are located in the same directory as the config file
-    DEPENDS ${DIALECT_TESTS_DEPEND}
 )

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -13,7 +13,8 @@ BUILD_TYPE?=Release
 
 coverage: CODE_COVERAGE=ON
 coverage: BUILD_TYPE=Debug
-test: BUILD_TYPE=Debug
+test: CODE_COVERAGE=OFF
+test: BUILD_TYPE=Release
 
 .PHONY: help
 help:
@@ -99,12 +100,13 @@ endif
 .PHONY: check-tidy
 check-tidy: | qir
 	@echo "build Catalyst Runtime with RUNTIME_CLANG_TIDY=ON"
-	rm -rf 
+	rm -rf
 	cmake -G Ninja -B $(MK_DIR)/BuildTidy . \
+		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
 		-DCMAKE_C_COMPILER=$(C_COMPILER) \
 		-DCMAKE_CXX_COMPILER=$(CXX_COMPILER) \
 		-DQIR_STDLIB_LIB=$(QIR_STDLIB_DIR) \
 		-DQIR_STDLIB_INCLUDES=$(QIR_STDLIB_INCLUDES_DIR) \
-		-DRUNTIME_CLANG_TIDY=ON 
+		-DRUNTIME_CLANG_TIDY=ON
 
 	cmake --build $(MK_DIR)/BuildTidy --target rt_capi -j$(if $(nprocs:-=),$(nprocs),$$(nproc))


### PR DESCRIPTION
Currently, frontend lit tests cannot be run via the makefile as the patches introduced in #40 are automatically overwritten.