### PR TITLE
Free malloc'ed memory that flows to python.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -8,9 +8,14 @@
 
 <h3>Bug fixes</h3>
 
+* Fix memory leaks that flow back into the Python environment.
+  [#54](https://github.com/PennyLaneAI/catalyst/pull/54)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
+
+Erick Ochoa Lopez.
 
 # Release 0.1.1
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -8,7 +8,8 @@
 
 <h3>Bug fixes</h3>
 
-* Fix memory leaks that flow back into the Python environment.
+* Fix memory leaks from data that flows back into the Python environment.
+
   [#54](https://github.com/PennyLaneAI/catalyst/pull/54)
 
 <h3>Contributors</h3>

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -9,8 +9,8 @@
 <h3>Bug fixes</h3>
 
 * Fix memory leaks from data that flows back into the Python environment.
-
   [#54](https://github.com/PennyLaneAI/catalyst/pull/54)
+
 
 <h3>Contributors</h3>
 

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -289,7 +289,7 @@ class CompiledFunction:
             memref_ptr = ctypes.pointer(memref)
             numpy_array = CompiledFunction.ranked_memref_to_numpy(memref_ptr)
             numpy_arrays.append(numpy_array)
-        return numpy_arrays[0] if len(numpy_arrays) == 1 else numpy_arrays
+        return numpy_arrays[0] if len(numpy_arrays) == 1 else tuple(numpy_arrays)
 
     @staticmethod
     def _exec(shared_object_file, func_name, has_return, *args):

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -193,6 +193,11 @@ class CompiledFunction:
         function.restypes = None
         # Not needed, computed from the arguments.
         # function.argyptes
+
+        # free, as defined in stdlib.h
+        # free is not defined in the shared object, however
+        # it is declared and we can use this declaration to
+        # get a handle to it.
         free = shared_object.free
 
         return shared_object, function, setup, teardown, free

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -284,12 +284,13 @@ class CompiledFunction:
             list or single numpy array
         """
         return_value = return_value_ptr.contents
-        numpy_arrays = []
+        jax_arrays = []
         for memref in return_value:
             memref_ptr = ctypes.pointer(memref)
             numpy_array = CompiledFunction.ranked_memref_to_numpy(memref_ptr)
-            numpy_arrays.append(numpy_array)
-        return numpy_arrays[0] if len(numpy_arrays) == 1 else tuple(numpy_arrays)
+            jax_array = jax.numpy.asarray(numpy_array)
+            jax_arrays.append(jax_array)
+        return jax_arrays[0] if len(jax_arrays) == 1 else tuple(jax_arrays)
 
     @staticmethod
     def _exec(shared_object_file, func_name, has_return, *args):

--- a/frontend/test/pytest/test_loops.py
+++ b/frontend/test/pytest/test_loops.py
@@ -304,7 +304,7 @@ class TestInterpretationControlFlow:
             return x_times_n
 
         mulc = qjit(muli)
-        assert mulc(1, 2) == muli(1, 2)
+        assert np.allclose(mulc(1, 2), muli(1, 2))
 
     # pylint: disable=missing-function-docstring
     def test_qnode_with_while_loop(self):


### PR DESCRIPTION
**Context:** Some of the memory allocations performed in the generated function and the runtime flow back to the python run time and must be freed.

**Description of the Change:** Free memory allocations that flow back to the python runtime which are:
* not constants
* not managed by numpy

**Benefits:** Less memory leaks.

[sc-34594]
