### PR TITLE
[Backend] Build the runtime against stdlib v0.1.0

### DIFF
--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -477,6 +477,7 @@ jobs:
             ./runtime/build/tests/runner_tests --reporter junit --out ./runtime/build/tests/results/tests_result.xml
 
       - name: Upload to Codecov
+        if: ${{ matrix.simulator == 'lightning' }}
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -389,28 +389,11 @@ jobs:
         MDD_BENCHMARK_PRECISION=1 \
         pytest demos/*.ipynb --nbmake -n auto
 
-    - name: Upload code coverage results
-      uses: actions/upload-artifact@v3
+    - name: Upload to Codecov
+      uses: codecov/codecov-action@v3
       with:
-        name: ubuntu-codecov-results-python
-        path: ./coverage-${{ github.job }}.xml
-
-  upload-to-codecov-linux-python:
-    name: Upload coverage data to codecov (Python)
-    needs: [frontend]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download coverage reports
-        uses: actions/download-artifact@v3
-        with:
-          name: ubuntu-codecov-results-python
-
-      - name: Upload to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   runtime-tests:
     name: Runtime Tests (Linux)
@@ -492,24 +475,6 @@ jobs:
         run: |
             mkdir -p ./runtime/build/tests/results
             ./runtime/build/tests/runner_tests --reporter junit --out ./runtime/build/tests/results/tests_result.xml
-
-      - name: Upload tests
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: runtime-linux-test-report
-          path: ./runtime/build/tests/results/tests_result.xml
-
-  upload-to-codecov-linux-cpp:
-    name: Upload coverage data to codecov (C++)
-    needs: [runtime-tests]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download coverage reports
-        uses: actions/download-artifact@v3
-        with:
-          name: ubuntu-codecov-results-cpp
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -437,11 +437,14 @@ jobs:
         run: |
           echo "LIGHTNING_GIT_TAG_VALUE=master" >> $GITHUB_ENV
 
-      - name: Download QIR-stdlib Artifact
-        uses: actions/download-artifact@v3
+      - name: Get Cached qir-stdlib Build
+        id: cache-qir-stdlib
+        uses: actions/cache@v3
         with:
-          name: qir-stdlib-build
           path: ./runtime/qir-stdlib-build
+          key: Linux-qir-stdlib-build
+          enableCrossOsArchive: True
+          fail-on-cache-miss: True
 
       - name: Build Runtime test suite for Lightning simulator
         if: ${{ matrix.simulator == 'lightning' }}

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -23,13 +23,22 @@ jobs:
       - name: Checkout Catalyst repo
         uses: actions/checkout@v3
 
+      - name: Cache qir-stdlib Build
+        id: cache-qir-stdlib
+        uses: actions/cache@v3
+        with:
+          path: ./runtime/qir-stdlib-build
+          key: ${{ runner.os }}-qir-stdlib-build
+
       - name: Install rustup with llvm-tools-preview
+        if: steps.cache-qir-stdlib.outputs.cache-hit != 'true'
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
           components: llvm-tools-preview
 
       - name: Install QIR-stdlib
+        if: steps.cache-qir-stdlib.outputs.cache-hit != 'true'
         run: |
             cd ./runtime/qir-stdlib
             cargo build --release --verbose
@@ -37,13 +46,6 @@ jobs:
             cp ./target/release/libqir_stdlib.a ../qir-stdlib-build/
             cp ./target/release/build/include/* ../qir-stdlib-build/include/
             cargo clean
-
-      - name: Upload QIR-stdlib Artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: qir-stdlib-build
-          path: ./runtime/qir-stdlib-build
-          retention-days: 1
 
   runtime:
     name: Catalyst-Runtime
@@ -67,11 +69,14 @@ jobs:
         run: |
           echo "LIGHTNING_GIT_TAG_VALUE=master" >> $GITHUB_ENV
 
-      - name: Download QIR-stdlib Artifact
-        uses: actions/download-artifact@v3
+      - name: Get Cached qir-stdlib Build
+        id: cache-qir-stdlib
+        uses: actions/cache@v3
         with:
-          name: qir-stdlib-build
           path: ./runtime/qir-stdlib-build
+          key: Linux-qir-stdlib-build
+          enableCrossOsArchive: True
+          fail-on-cache-miss: True
 
       - name: Build Catalyst-Runtime
         run: |
@@ -126,8 +131,7 @@ jobs:
         enableCrossOsArchive: True
 
     - name: Clone LLVM Submodule
-      if: |
-        steps.cache-llvm-source.outputs.cache-hit != 'true'
+      if: steps.cache-llvm-source.outputs.cache-hit != 'true'
       uses: actions/checkout@v3
       with:
         repository: llvm/llvm-project

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -75,7 +75,6 @@ jobs:
         with:
           path: ./runtime/qir-stdlib-build
           key: Linux-qir-stdlib-build
-          enableCrossOsArchive: True
           fail-on-cache-miss: True
 
       - name: Build Catalyst-Runtime
@@ -426,7 +425,6 @@ jobs:
         with:
           path: ./runtime/qir-stdlib-build
           key: Linux-qir-stdlib-build
-          enableCrossOsArchive: True
           fail-on-cache-miss: True
 
       - name: Build Runtime test suite for Lightning simulator

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -4,6 +4,9 @@
 
 <h3>Improvements</h3>
 
+* Build the runtime against qir-stdlib v0.1.0.
+  [#58](https://github.com/PennyLaneAI/catalyst/pull/58)
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>
@@ -16,6 +19,7 @@
 
 This release contains contributions from (in alphabetical order):
 
+Ali Asadi,
 Erick Ochoa Lopez.
 
 # Release 0.1.1

--- a/runtime/qir-stdlib/Cargo.toml
+++ b/runtime/qir-stdlib/Cargo.toml
@@ -5,8 +5,9 @@ authors = ["Microsoft"]
 edition = "2021"
 license = "MIT"
 
-[dependencies]
-qir-stdlib = { git = "https://github.com/qir-alliance/qir-runner/", rev = "f04c90b1908a1bed7b7b21db1c2e10d84504227c" }
+[dependencies.qir-stdlib]
+git = "https://github.com/qir-alliance/qir-runner.git"
+tag = "v0.1.0"
 
 [lib]
 crate-type = ["staticlib"]


### PR DESCRIPTION
Build the runtime against the latest version of [qir-runner](https://github.com/qir-alliance/qir-runner/releases/tag/v0.1.0).