### PR TITLE
[Makefile] Stop using lowercase build_dir vars; Add missing dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,8 @@ BLACKVERSIONMAJOR := $(shell black --version | head -n1 | awk '{ print $$2 }' | 
 BLACKVERSIONMINOR := $(shell black --version | head -n1 | awk '{ print $$2 }' | cut -d. -f2)
 MK_ABSPATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MK_DIR := $(dir $(MK_ABSPATH))
-DIALECTS_BUILD_DIR := $(if $(dialects_build_dir:-=),$(dialects_build_dir),$(MK_DIR)/mlir/build)
-RT_BUILD_DIR := $(if $(runtime_build_dir:-=),$(runtime_build_dir),$(MK_DIR)/runtime/build)
-LLVM_BUILD_DIR := $(if $(llvm_build_dir:-=),$(llvm_build_dir),$(MK_DIR)/llvm-project/build)
-MHLO_BUILD_DIR := $(if $(mhlo_build_dir:-=),$(mhlo_build_dir),$(MK_DIR)/mlir-hlo/build)
+DIALECTS_BUILD_DIR ?= $(MK_DIR)/mlir/build
 COVERAGE := --cov=catalyst --cov-report=term-missing --tb=native
-
-export DIALECTS_BUILD_DIR
-export RT_BUILD_DIR
-export LLVM_BUILD_DIR
-export MHLO_BUILD_DIR
 
 .PHONY: help
 help:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,14 @@ MK_ABSPATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MK_DIR := $(dir $(MK_ABSPATH))
 DIALECTS_BUILD_DIR := $(if $(dialects_build_dir:-=),$(dialects_build_dir),$(MK_DIR)/mlir/build)
 RT_BUILD_DIR := $(if $(runtime_build_dir:-=),$(runtime_build_dir),$(MK_DIR)/runtime/build)
+LLVM_BUILD_DIR := $(if $(llvm_build_dir:-=),$(llvm_build_dir),$(MK_DIR)/llvm-project/build)
+MHLO_BUILD_DIR := $(if $(mhlo_build_dir:-=),$(mhlo_build_dir),$(MK_DIR)/mlir-hlo/build)
 COVERAGE := --cov=catalyst --cov-report=term-missing --tb=native
+
+export DIALECTS_BUILD_DIR
+export RT_BUILD_DIR
+export LLVM_BUILD_DIR
+export MHLO_BUILD_DIR
 
 .PHONY: help
 help:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ numpy
 pybind11>=2.8.0
 PyYAML
 dataclasses
+jaxopt
 
 black[jupyter]
 clang-format==14.*


### PR DESCRIPTION
Just this:
* Top-level Makefile computed upper-case `_BUILD_DIR` vars from the lower-case ones, but it didn't propagate the result of computation to nested Makefiles. We remove the lowercase variables completely.
* `jaxopt` is now used in tests, so we should list it in the `requirements.txt`. 