### PR TITLE
[Frontend] Verbose printing during the compilation

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -25,6 +25,9 @@
 * Perform function inlining to improve optimizations and memory management within the compiler.
   [#72](https://github.com/PennyLaneAI/catalyst/pull/72)
 
+* Add an option to print verbose messages explaining the compilation process
+  [#68](https://github.com/PennyLaneAI/catalyst/pull/68)
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>

--- a/frontend/catalyst/__init__.py
+++ b/frontend/catalyst/__init__.py
@@ -30,7 +30,11 @@ if not INSTALLED:
 
         sys.path.insert(0, default_bindings_path)
 
-from catalyst.compilation_pipelines import qjit, QJIT, CompileOptions  # pylint: disable=wrong-import-position
+from catalyst.compilation_pipelines import (
+    qjit,
+    QJIT,
+    CompileOptions,
+)  # pylint: disable=wrong-import-position
 from catalyst.pennylane_extensions import (  # pylint: disable=wrong-import-position
     for_loop,
     while_loop,

--- a/frontend/catalyst/__init__.py
+++ b/frontend/catalyst/__init__.py
@@ -30,7 +30,7 @@ if not INSTALLED:
 
         sys.path.insert(0, default_bindings_path)
 
-from catalyst.compilation_pipelines import qjit, QJIT  # pylint: disable=wrong-import-position
+from catalyst.compilation_pipelines import qjit, QJIT, CompileOptions  # pylint: disable=wrong-import-position
 from catalyst.pennylane_extensions import (  # pylint: disable=wrong-import-position
     for_loop,
     while_loop,
@@ -50,4 +50,5 @@ __all__ = (
     "measure",
     "grad",
     "CompileError",
+    "CompileOptions"
 )

--- a/frontend/catalyst/__init__.py
+++ b/frontend/catalyst/__init__.py
@@ -54,5 +54,5 @@ __all__ = (
     "measure",
     "grad",
     "CompileError",
-    "CompileOptions"
+    "CompileOptions",
 )

--- a/frontend/catalyst/__init__.py
+++ b/frontend/catalyst/__init__.py
@@ -30,11 +30,11 @@ if not INSTALLED:
 
         sys.path.insert(0, default_bindings_path)
 
-from catalyst.compilation_pipelines import (
+from catalyst.compilation_pipelines import (  # pylint: disable=wrong-import-position
     qjit,
     QJIT,
     CompileOptions,
-)  # pylint: disable=wrong-import-position
+)
 from catalyst.pennylane_extensions import (  # pylint: disable=wrong-import-position
     for_loop,
     while_loop,

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -602,7 +602,8 @@ class QJIT:
 def qjit(fn=None, *,
          target="binary",
          keep_intermediate=False,
-         compile_options:Optional[CompileOptions]=None):
+         verbosity=0,
+         logfile=None):
     """A just-in-time decorator for PennyLane and JAX programs using Catalyst.
 
     This decorator enables both just-in-time and ahead-of-time compilation,
@@ -621,6 +622,9 @@ def qjit(fn=None, *,
             compilation. If ``True``, intermediate representations are available via the
             :attr:`~.QJIT.mlir`, :attr:`~.QJIT.jaxpr`, and :attr:`~.QJIT.qir`, representing
             different stages in the optimization process.
+        verbosity (int): Verbosity level (0 - disabled, >0 - enabled)
+        logfile (Optional[TextIOWrapper]): File object to write verose messages to (default -
+            sys.stderr).
 
     Returns:
         QJIT object.
@@ -687,9 +691,9 @@ def qjit(fn=None, *,
     """
 
     if fn is not None:
-        return QJIT(fn, target, keep_intermediate, compile_options)
+        return QJIT(fn, target, keep_intermediate, CompileOptions(verbosity, logfile))
 
     def wrap_fn(fn):
-        return QJIT(fn, target, keep_intermediate, compile_options)
+        return QJIT(fn, target, keep_intermediate, CompileOptions(verbosity, logfile))
 
     return wrap_fn

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -598,7 +598,7 @@ class QJIT:
         return self.compiled_function(*args, **kwargs)
 
 
-def qjit(fn=None, *, target="binary", keep_intermediate=False, verbosity=0, logfile=None):
+def qjit(fn=None, *, target="binary", keep_intermediate=False, verbose=False, logfile=None):
     """A just-in-time decorator for PennyLane and JAX programs using Catalyst.
 
     This decorator enables both just-in-time and ahead-of-time compilation,
@@ -686,9 +686,9 @@ def qjit(fn=None, *, target="binary", keep_intermediate=False, verbosity=0, logf
     """
 
     if fn is not None:
-        return QJIT(fn, target, keep_intermediate, CompileOptions(verbosity, logfile))
+        return QJIT(fn, target, keep_intermediate, CompileOptions(verbose, logfile))
 
     def wrap_fn(fn):
-        return QJIT(fn, target, keep_intermediate, CompileOptions(verbosity, logfile))
+        return QJIT(fn, target, keep_intermediate, CompileOptions(verbose, logfile))
 
     return wrap_fn

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -599,11 +599,7 @@ class QJIT:
         return self.compiled_function(*args, **kwargs)
 
 
-def qjit(fn=None, *,
-         target="binary",
-         keep_intermediate=False,
-         verbosity=0,
-         logfile=None):
+def qjit(fn=None, *, target="binary", keep_intermediate=False, verbosity=0, logfile=None):
     """A just-in-time decorator for PennyLane and JAX programs using Catalyst.
 
     This decorator enables both just-in-time and ahead-of-time compilation,

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -24,7 +24,6 @@ import tempfile
 import typing
 import warnings
 import functools
-from typing import Optional
 
 import numpy as np
 import jax

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -24,6 +24,7 @@ import tempfile
 import typing
 import warnings
 import functools
+from typing import Optional
 
 import numpy as np
 import jax
@@ -35,6 +36,7 @@ from mlir_quantum.runtime import get_ranked_memref_descriptor, ranked_memref_to_
 
 import catalyst.jax_tracer as tracer
 from catalyst import compiler
+from catalyst.compiler import CompileOptions
 from catalyst.utils.gen_mlir import append_modules
 from catalyst.utils.patching import Patcher
 from catalyst.pennylane_extensions import QFunc
@@ -468,9 +470,10 @@ class QJIT:
             after the Python process ends. If ``False``, these representations
             will instead be stored in a temporary folder, which will be deleted
             as soon as the QJIT instance is deleted.
+        compile_options (Optional[CompileOptions]): Common compilation options
     """
 
-    def __init__(self, fn, target, keep_intermediate):
+    def __init__(self, fn, target, keep_intermediate, compile_options=None):
         self.qfunc = fn
         self.c_sig = None
         functools.update_wrapper(self, fn)
@@ -486,6 +489,7 @@ class QJIT:
             # pylint: disable=consider-using-with
             self.workspace = tempfile.TemporaryDirectory()
             self.workspace_name = self.workspace.name
+        self.compile_options = compile_options
         self.passes = {}
         self._jaxpr = None
         self._mlir = None
@@ -563,7 +567,7 @@ class QJIT:
         """Compile the current MLIR module."""
 
         shared_object, self._llvmir = compiler.compile(
-            self.mlir_module, self.workspace_name, self.passes
+            self.mlir_module, self.workspace_name, self.passes, self.compile_options
         )
 
         # The function name out of MLIR has quotes around it, which we need to remove.
@@ -595,7 +599,10 @@ class QJIT:
         return self.compiled_function(*args, **kwargs)
 
 
-def qjit(fn=None, *, target="binary", keep_intermediate=False):
+def qjit(fn=None, *,
+         target="binary",
+         keep_intermediate=False,
+         compile_options:Optional[CompileOptions]=None):
     """A just-in-time decorator for PennyLane and JAX programs using Catalyst.
 
     This decorator enables both just-in-time and ahead-of-time compilation,
@@ -680,9 +687,9 @@ def qjit(fn=None, *, target="binary", keep_intermediate=False):
     """
 
     if fn is not None:
-        return QJIT(fn, target, keep_intermediate)
+        return QJIT(fn, target, keep_intermediate, compile_options)
 
     def wrap_fn(fn):
-        return QJIT(fn, target, keep_intermediate)
+        return QJIT(fn, target, keep_intermediate, compile_options)
 
     return wrap_fn

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -316,13 +316,14 @@ def transform_quantum_ir(filename: str, compile_options: Optional[CompileOptions
     if filename[-5:] != ".mlir":
         raise ValueError(f"Input file ({filename}) for quantum transforms is not an MLIR file")
 
+    new_fname = filename.replace(".mlir", ".opt.mlir")
+
     command = [quantum_opt_tool]
     command += [filename]
     command += quantum_compilation_pass_pipeline
+    command += ["-o", new_fname]
 
-    new_fname = filename.replace(".mlir", ".opt.mlir")
-
-    run_writing_command(command, new_fname, compile_options)
+    run_writing_command(command, compile_options)
 
     return new_fname
 

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -31,7 +31,7 @@ package_root = os.path.dirname(__file__)
 
 @dataclass
 class CompileOptions:
-    """Common compile options"""
+    """Generic compilation options"""
 
     verbosity: int
     logfile: Optional[TextIOWrapper] = None  # stdout/stderr or a file
@@ -260,6 +260,7 @@ class CompilerDriver:
             outfile (str): output file
             Optional flags (List[str]): flags to be passed down to the compiler
             Optional fallback_compilers (List[str]): name of executables to be looked for in PATH
+            Optional compile_options (CompileOptions): generic compilation options.
         Raises:
             EnvironmentError: The exception is raised when no compiler succeeded.
         """
@@ -283,6 +284,7 @@ def lower_mhlo_to_linalg(filename: str, compile_options: Optional[CompileOptions
 
     Args:
         filename (str): the path to a file were the program is stored.
+        Optional compile_options (CompileOptions): generic compilation options.
     Returns:
         a path to the output file
     """
@@ -332,6 +334,7 @@ def bufferize_tensors(filename: str, compile_options: Optional[CompileOptions] =
 
     Args:
         filename (str): the path to a file were the program is stored.
+        Optional compile_options (CompileOptions): generic compilation options.
     Returns:
         a path to the output file
     """
@@ -355,6 +358,7 @@ def lower_all_to_llvm(filename: str, compile_options: Optional[CompileOptions] =
 
     Args:
         filename (str): the path to a file were the program is stored.
+        Optional compile_options (CompileOptions): generic compilation options.
     Returns:
         a path to the output file
     """
@@ -378,6 +382,7 @@ def convert_mlir_to_llvmir(filename: str, compile_options: Optional[CompileOptio
 
     Args:
         filename (str): the path to a file were the program is stored.
+        Optional compile_options (CompileOptions): generic compilation options.
     Returns:
         a path to the output file
     """
@@ -403,6 +408,7 @@ def compile_llvmir(filename: str, compile_options: Optional[CompileOptions] = No
 
     Args:
         filename (str): the path to a file were the program is stored.
+        Optional compile_options (CompileOptions): generic compilation options.
     Returns:
         a path to the output file
     """
@@ -426,6 +432,7 @@ def link_lightning_runtime(filename: str, compile_options: Optional[CompileOptio
 
     Args:
         filename (str): the path to a file were the object file is stored.
+        Optional compile_options (CompileOptions): generic compilation options.
     Returns:
         a path to the output file
     """
@@ -452,6 +459,7 @@ def compile(mlir_module, workspace, passes, compile_options: Optional[CompileOpt
         workspace (str): the absolute path to the MLIR module
         has_hlo (bool): ``True`` if the MLIR module contains HLO code. Defaults to ``False``
         passes (List[str]): the list of compilation passes
+        Optional compile_options (CompileOptions): generic compilation options.
 
     Returns:
         Shared object

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -15,7 +15,6 @@
 MLIR/LLVM representations.
 """
 
-import io
 import os
 import sys
 import shutil
@@ -24,7 +23,6 @@ import warnings
 from io import TextIOWrapper
 from typing import Optional, List
 from dataclasses import dataclass
-from functools import partial
 
 from catalyst._configuration import INSTALLED
 
@@ -39,6 +37,7 @@ class CompileOptions:
     logfile: Optional[TextIOWrapper] = None  # stdout/stderr or a file
 
     def get_logfile(self) -> TextIOWrapper:
+        """Get the effective file object, as configured"""
         return self.logfile if self.logfile else sys.stderr
 
 
@@ -48,6 +47,7 @@ default_compile_options: CompileOptions = CompileOptions(0, None)
 def run_writing_command(
     command: List[str], compile_options: Optional[CompileOptions] = None
 ) -> None:
+    """Run the command after optionally announcing this fact to the user"""
     compile_options: CompileOptions = (
         compile_options if compile_options else default_compile_options
     )

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -239,7 +239,7 @@ class CompilerDriver:
         try:
             command = [compiler] + flags + [infile, "-o", outfile]
             if compile_options.verbose:
-                print(f"[RUNNING] {' '.join(command)}", file=compile_options.logfile)
+                print(f"[RUNNING] {' '.join(command)}", file=compile_options.get_logfile())
             subprocess.run(command, check=True)
             return True
         except subprocess.CalledProcessError:

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -33,7 +33,7 @@ package_root = os.path.dirname(__file__)
 class CompileOptions:
     """Generic compilation options"""
 
-    verbosity: int
+    verbose: bool
     logfile: Optional[TextIOWrapper] = None  # stdout/stderr or a file
 
     def get_logfile(self) -> TextIOWrapper:
@@ -51,7 +51,7 @@ def run_writing_command(
     compile_options: CompileOptions = (
         compile_options if compile_options else default_compile_options
     )
-    if compile_options.verbosity > 0:
+    if compile_options.verbose:
         print(f"[RUNNING] {' '.join(command)}", file=compile_options.get_logfile())
     subprocess.run(command, check=True)
 
@@ -238,7 +238,7 @@ class CompilerDriver:
         compile_options = compile_options if compile_options else default_compile_options
         try:
             command = [compiler] + flags + [infile, "-o", outfile]
-            if compile_options.verbosity > 0:
+            if compile_options.verbose:
                 print(f"[RUNNING] {' '.join(command)}", file=compile_options.logfile)
             subprocess.run(command, check=True)
             return True

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -328,8 +328,6 @@ def transform_quantum_ir(filename: str, compile_options: Optional[CompileOptions
     return new_fname
 
 
-# def bufferize_tensors(filename):
-# =======
 def bufferize_tensors(filename: str, compile_options: Optional[CompileOptions] = None) -> str:
     """Translate MHLO to linalg dialect.
 

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -33,19 +33,24 @@ package_root = os.path.dirname(__file__)
 
 @dataclass
 class CompileOptions:
-    """ Common compile options """
+    """Common compile options"""
+
     verbosity: int
-    logfile: Optional[TextIOWrapper] = None # stdout/stderr or a file
+    logfile: Optional[TextIOWrapper] = None  # stdout/stderr or a file
 
     def get_logfile(self) -> TextIOWrapper:
         return self.logfile if self.logfile else sys.stderr
 
-default_compile_options:CompileOptions = CompileOptions(0, None)
+
+default_compile_options: CompileOptions = CompileOptions(0, None)
 
 
-def run_writing_command(command:List[str],
-                        compile_options:Optional[CompileOptions] = None) -> None:
-    compile_options: CompileOptions = compile_options if compile_options else default_compile_options
+def run_writing_command(
+    command: List[str], compile_options: Optional[CompileOptions] = None
+) -> None:
+    compile_options: CompileOptions = (
+        compile_options if compile_options else default_compile_options
+    )
     if compile_options.verbosity > 0:
         print(f"[RUNNING] {' '.join(command)}", file=compile_options.get_logfile())
     subprocess.run(command, check=True)
@@ -238,8 +243,10 @@ class CompilerDriver:
             subprocess.run(command, check=True)
             return True
         except subprocess.CalledProcessError:
-            msg = (f"Compiler {compiler} failed during execution of command {command}. "
-                  "Will attempt fallback on available compilers.")
+            msg = (
+                f"Compiler {compiler} failed during execution of command {command}. "
+                "Will attempt fallback on available compilers."
+            )
             warnings.warn(msg, UserWarning)
             return False
 
@@ -262,7 +269,9 @@ class CompilerDriver:
             fallback_compilers = CompilerDriver._default_fallback_compilers
         # pylint: disable=redefined-outer-name
         for compiler in CompilerDriver._available_compilers(fallback_compilers):
-            success = CompilerDriver._attempt_link(compiler, flags, infile, outfile, compile_options)
+            success = CompilerDriver._attempt_link(
+                compiler, flags, infile, outfile, compile_options
+            )
             if success:
                 return
         msg = f"Unable to link {infile}. All available compiler options exhausted. Please provide a compatible compiler via $CATALYST_CC."
@@ -341,7 +350,7 @@ def bufferize_tensors(filename: str, compile_options: Optional[CompileOptions] =
     return new_fname
 
 
-def lower_all_to_llvm(filename: str, compile_options:Optional[CompileOptions] = None) -> str:
+def lower_all_to_llvm(filename: str, compile_options: Optional[CompileOptions] = None) -> str:
     """Translate MLIR dialects to LLVM dialect.
 
     Args:
@@ -364,7 +373,7 @@ def lower_all_to_llvm(filename: str, compile_options:Optional[CompileOptions] = 
     return new_fname
 
 
-def convert_mlir_to_llvmir(filename: str, compile_options:Optional[CompileOptions] = None) -> str:
+def convert_mlir_to_llvmir(filename: str, compile_options: Optional[CompileOptions] = None) -> str:
     """Translate LLVM dialect to LLVM IR.
 
     Args:
@@ -389,7 +398,7 @@ def convert_mlir_to_llvmir(filename: str, compile_options:Optional[CompileOption
     return new_fname
 
 
-def compile_llvmir(filename: str, compile_options:Optional[CompileOptions] = None) -> str:
+def compile_llvmir(filename: str, compile_options: Optional[CompileOptions] = None) -> str:
     """Translate LLVM IR to an object file.
 
     Args:
@@ -412,7 +421,7 @@ def compile_llvmir(filename: str, compile_options:Optional[CompileOptions] = Non
     return new_fname
 
 
-def link_lightning_runtime(filename: str, compile_options:Optional[CompileOptions] = None) -> str:
+def link_lightning_runtime(filename: str, compile_options: Optional[CompileOptions] = None) -> str:
     """Link the object file as a shared object.
 
     Args:
@@ -430,7 +439,7 @@ def link_lightning_runtime(filename: str, compile_options:Optional[CompileOption
     return new_fname
 
 
-def compile(mlir_module, workspace, passes, compile_options:Optional[CompileOptions] = None):
+def compile(mlir_module, workspace, passes, compile_options: Optional[CompileOptions] = None):
     """Compile an MLIR module to a shared object.
 
     .. note::

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -93,6 +93,8 @@ class TestCompilerDriver:
 
     @pytest.mark.parametrize("verbose", [True, False])
     def test_verbose_compilation(self, verbose, capsys):
+        """Test verbose compilation mode"""
+
         @qjit(verbose=verbose)
         @qml.qnode(qml.device("lightning.qubit", wires=1))
         def workflow():

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -6,6 +6,8 @@ import warnings
 
 import pytest
 
+import pennylane as qml
+from catalyst import qjit
 from catalyst.compiler import (
     CompilerDriver,
     CompileOptions,
@@ -88,3 +90,15 @@ class TestCompilerDriver:
         """Test if the function detects wrong extensions"""
         with pytest.raises(ValueError, match="is not an object file"):
             link_lightning_runtime("file-name.noo")
+
+    @pytest.mark.parametrize("verbose", [True, False])
+    def test_verbose_compilation(self, verbose, capsys):
+        @qjit(verbose=verbose)
+        @qml.qnode(qml.device("lightning.qubit", wires=1))
+        def workflow():
+            qml.X(wires=1)
+            return qml.state()
+
+        workflow()
+        stderr = "\n".join(capsys.readouterr())
+        assert ("[RUNNING]" in stderr) if verbose else ("[RUNNING]" not in stderr)

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -45,7 +45,7 @@ class TestCompilerDriver:
         compiler = "cc"
         with pytest.warns(UserWarning, match="Compiler .* failed .*"):
             # pylint: disable=protected-access
-            CompilerDriver._attempt_link(compiler, [""], "in.o", "out.so")
+            CompilerDriver._attempt_link(compiler, [""], "in.o", "out.so", None)
 
     def test_link_fail_exception(self):
         """Test that an exception is raised when all compiler possibilities are exhausted."""

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -8,6 +8,7 @@ import pytest
 
 from catalyst.compiler import (
     CompilerDriver,
+    CompileOptions,
     bufferize_tensors,
     compile_llvmir,
     convert_mlir_to_llvmir,
@@ -40,12 +41,13 @@ class TestCompilerDriver:
             # pylint: disable=protected-access
             CompilerDriver._get_compiler_fallback_order([])
 
-    def test_compiler_failed_warning(self):
+    @pytest.mark.parametrize("verbose", [True, False])
+    def test_compiler_failed_warning(self, verbose):
         """Test that a warning is emitted when a compiler failed."""
         compiler = "cc"
         with pytest.warns(UserWarning, match="Compiler .* failed .*"):
             # pylint: disable=protected-access
-            CompilerDriver._attempt_link(compiler, [""], "in.o", "out.so", None)
+            CompilerDriver._attempt_link(compiler, [""], "in.o", "out.so", CompileOptions(verbose))
 
     def test_link_fail_exception(self):
         """Test that an exception is raised when all compiler possibilities are exhausted."""


### PR DESCRIPTION
In this PR we propose a verbose compilation process reporting. `qjit` function gets new parameters. Internally,  `CompileOption` is used to transfer the parameters to functions. Currently, the parameters allow users to set the verbosity level (0 - off; 1 - on;) and specify the file to print messages to (default - sys.stderr).

Usage example:

``` python
import sys
import pennylane as qml
import jax.numpy as jnp
from catalyst import qjit

@qjit(verbose=True, logfile=sys.stderr)
@qml.qnode(qml.device("lightning.qubit", wires=1))
def circuit():
    qml.PhaseShift(phi=0, wires=[0])
    return qml.state()

print(circuit())
```

``` result
[RUNNING] /workspace/modules/catalyst/frontend/catalyst/../../mlir/mlir-hlo/build/bin/mlir-hlo-opt --allow-unregistered-dialect /tmp/tmpdbk_f90m/circuit.mlir --canonicalize --chlo-legalize-to-hlo --mhlo-legalize-control-flow --hlo-legalize-to-linalg --mhlo-legalize-to-std --convert-to-signless --canonicalize > /tmp/tmpdbk_f90m/circuit.nohlo.mlir
[RUNNING] quantum-opt /tmp/tmpdbk_f90m/circuit.nohlo.mlir --lower-gradients --gradient-bufferize --scf-bufferize --convert-tensor-to-linalg --convert-elementwise-to-linalg --arith-bufferize --empty-tensor-to-alloc-tensor --bufferization-bufferize --tensor-bufferize --linalg-bufferize --tensor-bufferize --quantum-bufferize --func-bufferize --finalizing-bufferize --buffer-hoisting --buffer-loop-hoisting --promote-buffers-to-stack --buffer-deallocation --convert-bufferization-to-memref --canonicalize --cse > /tmp/tmpdbk_f90m/circuit.nohlo.buff.mlir
[RUNNING] quantum-opt /tmp/tmpdbk_f90m/circuit.nohlo.buff.mlir --convert-linalg-to-loops --convert-scf-to-cf --expand-strided-metadata --lower-affine --convert-complex-to-standard --convert-complex-to-llvm --convert-math-to-llvm --convert-math-to-libm --convert-arith-to-llvm --convert-memref-to-llvm --convert-index-to-llvm --convert-gradient-to-llvm --convert-quantum-to-llvm --canonicalize --reconcile-unrealized-casts > /tmp/tmpdbk_f90m/circuit.nohlo.llvm.mlir
[RUNNING] /workspace/modules/catalyst/frontend/catalyst/../../mlir/llvm-project/build/bin/mlir-translate /tmp/tmpdbk_f90m/circuit.nohlo.llvm.mlir --mlir-to-llvmir > /tmp/tmpdbk_f90m/circuit.nohlo.ll
[RUNNING] /workspace/modules/catalyst/frontend/catalyst/../../mlir/llvm-project/build/bin/llc --filetype=obj --relocation-model=pic /tmp/tmpdbk_f90m/circuit.nohlo.ll -o /tmp/tmpdbk_f90m/circuit.nohlo.o
[RUNNING] clang -shared -rdynamic -L/workspace/_build_llvm/lib -Wl,-no-as-needed -Wl,-rpath,/workspace/_build_llvm/lib -L/workspace/_build_runtime/lib/capi -L/workspace/_build_runtime/lib/backend -Wl,-rpath,/workspace/_build_runtime/lib/capi:/workspace/_build_runtime/lib/backend -L/workspace/_build_runtime/lib/capi -L/workspace/_build_runtime/lib/backend -Wl,-rpath,/workspace/_build_runtime/lib/capi:/workspace/_build_runtime/lib/backend -lrt_backend -lrt_capi -lpthread -lmlir_c_runner_utils /tmp/tmpdbk_f90m/circuit.nohlo.o -o /tmp/tmpdbk_f90m/circuit.nohlo.so
[1.+0.j 0.+0.j]
```

