### PR TITLE
[MLIR] Improve buffer deallocation by inlining functions

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -22,6 +22,9 @@
   [MLIR bufferization infrastructure](https://mlir.llvm.org/docs/Bufferization/).
   [#63](https://github.com/PennyLaneAI/catalyst/pull/63)
 
+* Perform function inlining to improve optimizations and memory management within the compiler.
+  [#72](https://github.com/PennyLaneAI/catalyst/pull/72)
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -66,6 +66,10 @@ mhlo_lowering_pass_pipeline = [
     "--canonicalize",
 ]
 
+quantum_compilation_pass_pipeline = [
+    "--lower-gradients",
+]
+
 bufferization_pass_pipeline = [
     "--lower-gradients",
     "--gradient-bufferize",
@@ -258,6 +262,30 @@ def lower_mhlo_to_linalg(filename):
     return new_fname
 
 
+def transform_quantum_ir(filename):
+    """Runs quantum optimizations and transformations, as well gradient transforms, on the hybrid
+    IR.
+
+    Args:
+        filename (str): the path to a file were the program is stored.
+    Returns:
+        a path to the output file
+    """
+    if filename[-5:] != ".mlir":
+        raise ValueError(f"Input file ({filename}) for quantum transforms is not an MLIR file")
+
+    command = [quantum_opt_tool]
+    command += [filename]
+    command += quantum_compilation_pass_pipeline
+
+    new_fname = filename.replace(".mlir", ".opt.mlir")
+
+    with open(new_fname, "w", encoding="utf-8") as file:
+        subprocess.run(command, stdout=file, check=True)
+
+    return new_fname
+
+
 def bufferize_tensors(filename):
     """Translate MHLO to linalg dialect.
 
@@ -395,11 +423,13 @@ def compile(mlir_module, workspace, passes):
     with open(filename, "w", encoding="utf-8") as f:
         mlir_module.operation.print(f, print_generic_op_form=False, assume_verified=True)
 
-    passes["mlir"] = filename
     mlir = filename
-    mlir = lower_mhlo_to_linalg(mlir)
-    passes["nohlo"] = mlir
-    buff = bufferize_tensors(mlir)
+    passes["mlir"] = filename
+    nohlo = lower_mhlo_to_linalg(mlir)
+    passes["nohlo"] = nohlo
+    optimized = transform_quantum_ir(nohlo)
+    passes["opt"] = optimized
+    buff = bufferize_tensors(optimized)
     passes["buff"] = buff
     llvm_dialect = lower_all_to_llvm(buff)
     passes["llvm"] = llvm_dialect

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -71,7 +71,7 @@ quantum_compilation_pass_pipeline = [
 ]
 
 bufferization_pass_pipeline = [
-    "--lower-gradients",
+    "--inline",
     "--gradient-bufferize",
     "--scf-bufferize",
     "--convert-tensor-to-linalg",  # tensor.pad

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -267,7 +267,7 @@ def transform_quantum_ir(filename):
     IR.
 
     Args:
-        filename (str): the path to a file were the program is stored.
+        filename (str): the path to a file where the program is stored.
     Returns:
         a path to the output file
     """
@@ -424,7 +424,7 @@ def compile(mlir_module, workspace, passes):
         mlir_module.operation.print(f, print_generic_op_form=False, assume_verified=True)
 
     mlir = filename
-    passes["mlir"] = filename
+    passes["mlir"] = mlir
     nohlo = lower_mhlo_to_linalg(mlir)
     passes["nohlo"] = nohlo
     optimized = transform_quantum_ir(nohlo)

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -3,16 +3,18 @@ Unit tests for CompilerDriver class
 """
 
 import warnings
+
 import pytest
 
 from catalyst.compiler import (
     CompilerDriver,
-    lower_mhlo_to_linalg,
     bufferize_tensors,
-    lower_all_to_llvm,
-    convert_mlir_to_llvmir,
     compile_llvmir,
+    convert_mlir_to_llvmir,
     link_lightning_runtime,
+    lower_all_to_llvm,
+    lower_mhlo_to_linalg,
+    transform_quantum_ir,
 )
 
 
@@ -55,7 +57,12 @@ class TestCompilerDriver:
         with pytest.raises(ValueError, match="is not an MLIR file"):
             lower_mhlo_to_linalg("file-name.nomlir")
 
-    def test_bufferize_tensors(self):
+    def test_quantum_compilation_input_validation(self):
+        """Test if the function detects wrong extensions"""
+        with pytest.raises(ValueError, match="is not an MLIR file"):
+            transform_quantum_ir("file-name.nomlir")
+
+    def test_bufferize_tensors_input_validation(self):
         """Test if the function detects wrong extensions"""
         with pytest.raises(ValueError, match="is not an MLIR file"):
             bufferize_tensors("file-name.nomlir")

--- a/frontend/test/pytest/test_tracing.py
+++ b/frontend/test/pytest/test_tracing.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import jax.numpy as jnp
+import numpy as np
+import pennylane as qml
 import pytest
 
-import pennylane as qml
-from catalyst import qjit, measure, cond, while_loop
-import numpy as np
+from catalyst import cond, measure, qjit, while_loop
 
 
 class TestTracing:
@@ -89,6 +90,21 @@ class TestTracing:
         n_iter, state = circuit()
         assert n_iter > 0
         assert np.allclose(np.abs(state), [1, 0])
+
+
+def test_complex_dialect():
+    """Test that we can use functions that turn into complex dialect operations in MLIR."""
+
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    def circuit():
+        return qml.state()
+
+    @qjit
+    def workflow():
+        x = circuit()[0]
+        return jnp.sum(x).real
+
+    assert workflow() == 1.0
 
 
 if __name__ == "__main__":

--- a/mlir/lib/Gradient/IR/GradientDialect.cpp
+++ b/mlir/lib/Gradient/IR/GradientDialect.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "mlir/Transforms/InliningUtils.h"
+
 #include "Gradient/IR/GradientDialect.h"
 #include "Gradient/IR/GradientOps.h"
 
@@ -19,6 +21,23 @@ using namespace mlir;
 using namespace catalyst::gradient;
 
 #include "Gradient/IR/GradientOpsDialect.cpp.inc"
+
+//===----------------------------------------------------------------------===//
+// Complex Dialect Interfaces
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct GradientInlinerInterface : public DialectInlinerInterface {
+    using DialectInlinerInterface::DialectInlinerInterface;
+
+    /// Operations in Gradient dialect are always legal to inline.
+    bool isLegalToInline(Operation *, Region *, bool,
+                         BlockAndValueMapping &valueMapping) const final
+    {
+        return true;
+    }
+};
+} // namespace
 
 //===----------------------------------------------------------------------===//
 // Gradient dialect.
@@ -30,4 +49,5 @@ void GradientDialect::initialize()
 #define GET_OP_LIST
 #include "Gradient/IR/GradientOps.cpp.inc"
         >();
+    addInterface<GradientInlinerInterface>();
 }

--- a/mlir/lib/Gradient/IR/GradientDialect.cpp
+++ b/mlir/lib/Gradient/IR/GradientDialect.cpp
@@ -23,7 +23,7 @@ using namespace catalyst::gradient;
 #include "Gradient/IR/GradientOpsDialect.cpp.inc"
 
 //===----------------------------------------------------------------------===//
-// Complex Dialect Interfaces
+// Gradient Dialect Interfaces
 //===----------------------------------------------------------------------===//
 
 namespace {

--- a/mlir/test/Gradient/InliningTest.mlir
+++ b/mlir/test/Gradient/InliningTest.mlir
@@ -1,0 +1,20 @@
+// RUN: quantum-opt %s -inline | FileCheck %s
+
+func.func private @fun(f64) -> f64
+
+// CHECK-LABEL: @target
+// CHECK-SAME: ([[arg0:%.*]]: f64)
+func.func @target(%x: f64) -> tensor<?xf64> {
+    // CHECK-NEXT: [[v0:%.*]] = arith.constant
+    // CHECK-NEXT: [[v1:%.*]] = gradient.adjoint @fun([[arg0]]) size([[v0]])
+    %0 = func.call @source(%x) : (f64) -> (tensor<?xf64>)
+    // CHECK-NEXT: return [[v1]]
+    return %0 : tensor<?xf64>
+}
+
+// CHECK-NOT: @source
+func.func private @source(%x: f64) -> tensor<?xf64> {
+    %s = arith.constant 1 : index
+    %0 = gradient.adjoint @fun(%x) size(%s) : (f64) -> tensor<?xf64>
+    return %0 : tensor<?xf64>
+}

--- a/mlir/tools/quantum-opt/quantum-opt.cpp
+++ b/mlir/tools/quantum-opt/quantum-opt.cpp
@@ -33,21 +33,9 @@ int main(int argc, char **argv)
     mlir::registerPass(catalyst::createQuantumConversionPass);
 
     mlir::DialectRegistry registry;
-    registry.insert<mlir::func::FuncDialect>();
-    registry.insert<mlir::arith::ArithDialect>();
-    registry.insert<mlir::scf::SCFDialect>();
-    registry.insert<mlir::LLVM::LLVMDialect>();
-    registry.insert<mlir::memref::MemRefDialect>();
-    registry.insert<mlir::tensor::TensorDialect>();
-    registry.insert<mlir::linalg::LinalgDialect>();
-    registry.insert<mlir::index::IndexDialect>();
-    registry.insert<mlir::bufferization::BufferizationDialect>();
+    mlir::registerAllDialects(registry);
     registry.insert<catalyst::quantum::QuantumDialect>();
     registry.insert<catalyst::gradient::GradientDialect>();
-    // Add the following to include *all* MLIR Core dialects, or selectively
-    // include what you need like above. You only need to register dialects that
-    // will be *parsed* by the tool, not the one generated
-    // registerAllDialects(registry);
 
     return mlir::asMainReturnCode(
         mlir::MlirOptMain(argc, argv, "Quantum optimizer driver\n", registry));


### PR DESCRIPTION
This change makes buffer-deallocation much more effective since the pass cannot deallocate buffers across function boundaries.
Inlining could also be used to make other passes more effective, such folding, cse, and other standard optimizations.

Currently, inlining gradient operations is supported, while inlining quantum functions is not (can easily be enabled by implementing the `DialectInlinerInterface`). I'm not yet sure about the pros/cons of doing so.

Fixes #64 