### PR TITLE
Improve the build from source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ all: runtime mlir frontend
 .PHONY: frontend
 frontend:
 	@echo "install Catalyst Frontend"
-	$(PYTHON) pip install -e . --user --no-use-pep517
+	$(PYTHON) pip install -e . --no-use-pep517
 
 .PHONY: mlir llvm mhlo dialects runtime
 mlir:

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -103,7 +103,8 @@ Runtime
 """""""
 
 By default, the runtime is backed by `PennyLane-Lightning
-<https://github.com/PennyLaneAI/pennylane-lightning>`_ and leverages the `QIR
+<https://github.com/PennyLaneAI/pennylane-lightning>`_
+requiring the use of C++20 standard library headers, and leverages the `QIR
 standard library <https://github.com/qir-alliance/qir-runner>`_. Assuming
 ``libomp-dev`` and the ``llvm-tools-preview`` Rustup component are available,
 you can build ``qir-stdlib`` and the runtime from the top level directory:

--- a/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
@@ -556,7 +556,6 @@ template <typename T> struct StatsBasedPattern : public OpConversionPattern<T> {
     LogicalResult matchAndRewrite(T op, typename T::Adaptor adaptor,
                                   ConversionPatternRewriter &rewriter) const override
     {
-        Location loc = op.getLoc();
         MLIRContext *ctx = this->getContext();
         TypeConverter *conv = this->getTypeConverter();
 

--- a/runtime/README.rst
+++ b/runtime/README.rst
@@ -88,7 +88,7 @@ Requirements
 ============
 
 To build the runtime from source, it is required to have an up to date version of a C/C++ compiler such as gcc or clang
-and the static library of ``stdlib`` from `qir-runner <https://github.com/qir-alliance/qir-runner/tree/main/stdlib>`_.
+with support for the C++20 standard library and the static library of ``stdlib`` from `qir-runner <https://github.com/qir-alliance/qir-runner/tree/main/stdlib>`_.
 
 The runtime leverages the ``stdlib`` Rust package for the QIR standard runtime instructions. To build this package from source,
 the `Rust <https://www.rust-lang.org/tools/install>`_ toolchain installed via ``rustup`` is also required.


### PR DESCRIPTION
A few fixes that would improve the installation of Catalyst from source,
- Removing the `--user` option from `make frontend` that would fix the site-packages user visibility issue with installing `catalyst` in virtual environments.
- Updating the installation and runtime guidelines regarding the runtime dependency to the C++20 standard library. This isn't really a concern while using an up-to-date C/C++ compiler. However, if one tries building runtime with an old compiler (e.g `clang-10`), they this is the responsibility of the developer to install the proper C++20 stdl library.
- Fix dialects build warnings with unused variables.