### PR TITLE
[Frontend] Improvements to the `catalyst.grad` UI

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -49,6 +49,7 @@
 This release contains contributions from (in alphabetical order):
 
 Ali Asadi,
+David Ittah,
 Erick Ochoa Lopez,
 Sergei Mironov.
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -9,6 +9,10 @@
   value method using the native Kokkos kernel for the Lightning-Kokkos device.
   [#70](https://github.com/PennyLaneAI/catalyst/pull/70)
 
+* Allow `catalyst.grad` to be used on any traceable function (within a qjit context).
+  This means the operation is no longer resticted to acting on `qml.qnode`s only.
+  [#75](https://github.com/PennyLaneAI/catalyst/pull/75)
+
 <h3>Improvements</h3>
 
 * Build the runtime against qir-stdlib v0.1.0.

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -182,7 +182,7 @@ class Grad:
             qnode_jaxpr = jaxpr.eqns[0].params["call_jaxpr"]
             return_ops = []
             for res in qnode_jaxpr.outvars:
-                for eq in reversed(qnode_jaxpr.eqns):
+                for eq in reversed(qnode_jaxpr.eqns):  # pragma: no branch
                     if res in eq.outvars:
                         return_ops.append(eq.primitive)
                         break

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -215,8 +215,8 @@ def grad(f, *, method=None, h=None, argnum=None):
 
     .. warning::
 
-        Currently, higher-order differentiation is only supported by the
-        finite-difference method.
+        Currently, higher-order differentiation or differentiation of non-QNode functions
+        is only supported by the finite-difference method.
 
     .. note:
 

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -182,9 +182,9 @@ class Grad:
             qnode_jaxpr = jaxpr.eqns[0].params["call_jaxpr"]
             return_ops = []
             for res in qnode_jaxpr.outvars:
-                return_ops.append(
-                    next(eq.primitive for eq in reversed(qnode_jaxpr.eqns) if res in eq.outvars)
-                )
+                for eq in reversed(qnode_jaxpr.eqns):
+                    if res in eq.outvars:
+                        return_ops.append(eq.primitive)
 
             if self.method == "ps" and any(prim not in [expval_p, probs_p] for prim in return_ops):
                 raise TypeError(

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -147,7 +147,7 @@ class Grad:
         argnum (int): the argument indices which define over which arguments to differentiate
 
     Raises:
-        ValueError: Higher-order derivatives and derivatives of arbitrary functions can only be
+        ValueError: Higher-order derivatives and derivatives of non-QNode functions can only be
                     computed with the finite difference method.
     """
 
@@ -160,7 +160,7 @@ class Grad:
         if self.method != "fd" and not isinstance(self.fn, qml.QNode):
             raise ValueError(
                 "Only finite difference can compute higher order derivatives "
-                "or gradients of arbitrary functions."
+                "or gradients of non-QNode functions."
             )
 
     def __call__(self, *args, **kwargs):
@@ -185,6 +185,7 @@ class Grad:
                 for eq in reversed(qnode_jaxpr.eqns):
                     if res in eq.outvars:
                         return_ops.append(eq.primitive)
+                        break
 
             if self.method == "ps" and any(prim not in [expval_p, probs_p] for prim in return_ops):
                 raise TypeError(

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
-import pennylane as qml
-import numpy as np
-from jax import numpy as jnp
 import jax
+import numpy as np
+import pennylane as qml
+import pytest
+from jax import numpy as jnp
 
-from catalyst import qjit, grad, cond, for_loop, CompileError
+from catalyst import CompileError, cond, for_loop, grad, qjit
 
 
 def test_grad_outside_qjit():
@@ -28,6 +27,42 @@ def test_grad_outside_qjit():
 
     with pytest.raises(CompileError, match="can only be used from within @qjit"):
         grad(f)(1.0)
+
+
+def test_param_shift_on_non_expval():
+    """Check for an error message when parameter-shift is used on QNodes that return anything but
+    qml.expval or qml.probs.
+    """
+
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    def func(p):
+        x = qml.expval(qml.PauliZ(0))
+        y = p**2
+        return x, y
+
+    def workflow(p: float):
+        return grad(func, method="ps")(p)
+
+    with pytest.raises(TypeError, match="The parameter-shift method can only be used"):
+        qjit(workflow)
+
+
+def test_adjoint_on_non_expval():
+    """Check for an error message when parameter-shift is used on QNodes that return anything but
+    qml.expval or qml.probs.
+    """
+
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    def func(p):
+        x = qml.expval(qml.PauliZ(0))
+        y = p**2
+        return x, y
+
+    def workflow(p: float):
+        return grad(func, method="adj")(p)
+
+    with pytest.raises(TypeError, match="The adjoint method can only be used"):
+        qjit(workflow)
 
 
 @pytest.mark.parametrize("inp", [(1.0), (2.0), (3.0), (4.0)])
@@ -348,6 +383,22 @@ def test_ps_qft(inp):
         return h(x, y, z)
 
     assert np.allclose(compiled(inp, 2, 2), interpreted(inp, 2, 2))
+
+
+@pytest.mark.xfail(reason="https://github.com/PennyLaneAI/catalyst/issues/73")
+def test_ps_probs():
+    """Check that the parameter-shift method works for qml.probs."""
+
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    def func(p):
+        qml.RY(p, wires=0)
+        return qml.probs(wires=0)
+
+    @qjit
+    def workflow(p: float):
+        return grad(func, method="ps")(p)
+
+    assert np.allclose(workflow(0.5), [0.93879128, 0.06120872])
 
 
 @pytest.mark.parametrize("inp", [(1.0), (2.0), (3.0), (4.0)])

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -571,28 +571,17 @@ def test_assert_no_higher_order_without_ps(method):
             return i(x)
 
 
-def test_assert_no_non_func_gradients():
-    """Test input validation for gradients"""
-    with pytest.raises(TypeError, match="something other than a function"):
+def test_finite_diff_arbitrary_functions():
+    """Test gradients on non-qnode functions."""
 
-        @qjit()
-        def workflow():
-            def _f(x):
-                return x + x
+    @qjit
+    def workflow(x):
+        def _f(x):
+            return 2 * x
 
-            return grad(_f, method="fd")(1.0)
+        return grad(_f, method="fd")(x)
 
-
-def test_assert_no_non_single_expression_gradients():
-    """Test input validation for gradients"""
-    with pytest.raises(TypeError, match="can only be used on QNodes"):
-
-        @qjit()
-        def workflow():
-            def _f(x):
-                return x
-
-            return grad(_f, method="fd")(1.0)
+    assert workflow(0.0) == 2.0
 
 
 @pytest.mark.parametrize("inp", [(1.0), (2.0), (3.0), (4.0)])

--- a/frontend/test/pytest/test_tracing.py
+++ b/frontend/test/pytest/test_tracing.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import jax
+import numpy as np
+import pennylane as qml
 import pytest
 
-import pennylane as qml
-from catalyst import qjit, measure, cond, while_loop
-import numpy as np
+from catalyst import cond, measure, qjit, while_loop
 
 
 class TestTracing:
@@ -89,6 +90,16 @@ class TestTracing:
         n_iter, state = circuit()
         assert n_iter > 0
         assert np.allclose(np.abs(state), [1, 0])
+
+    def test_tracing_through_qjit(self):
+        """Check for useful error message when JAX is used to trace through a qjit function."""
+
+        @qjit
+        def func(x):
+            return x**2
+
+        with pytest.raises(ValueError, match="Cannot use JAX to trace through a qjit"):
+            jax.grad(func)(2.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This patch contains the following improvements:

- Raise an error when a user attempts to use `jax.jit`, `jax.grad` or other jax transforms on `qjit` functions.
  ```py
  "Cannot use JAX to trace through a qjit compiled function. If you attempted to use jax.jit or jax.grad, please use their equivalent from Catalyst."
  ```
- Raise an error when a user uses quantum diff methods incorrectly, that is on functions which are not QNodes and do not exclusively return `qml.expval` and `qml.probs`.
  ```py
  "The parameter-shift method can only be used for QNodes which return either qml.expval or qml.probs."
  "The adjoint method can only be used for QNodes which return qml.expval."
  ```
- Allow `catalyst.grad` to be used on any traceable function. Currently, there is an artificial restriction allowing it to be used on QNodes only, requiring unnecessarily decorating functions with `qml.qnode` even if they are purely classical. Only works with non-quantum diff methods (i.e. `fd`).