### PR TITLE
[Frontend] Cast C128, C64 to dtype=complex128 and dtype=complex64

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -43,6 +43,9 @@
   This fixes a large majority of leaks in many typical quantum functions.
   [#61](https://github.com/PennyLaneAI/catalyst/pull/61)
 
+* Fix returning complex scalars from the compiled function.
+  [#77](https://github.com/PennyLaneAI/catalyst/pull/77)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -31,7 +31,7 @@ from jax.interpreters.mlir import ir
 
 import pennylane as qml
 
-from mlir_quantum.runtime import get_ranked_memref_descriptor, ranked_memref_to_numpy
+from mlir_quantum.runtime import get_ranked_memref_descriptor, ranked_memref_to_numpy, to_numpy
 
 import catalyst.jax_tracer as tracer
 from catalyst import compiler
@@ -262,7 +262,7 @@ class CompiledFunction:
             a numpy array with the contents of the ranked memref descriptor
         """
         assert not hasattr(ranked_memref, "shape")
-        return np.array(ranked_memref.aligned.contents)
+        return to_numpy(np.array(ranked_memref.aligned.contents))
 
     @staticmethod
     def ranked_memref_to_numpy(memref_desc):

--- a/frontend/test/pytest/test_buffer_args.py
+++ b/frontend/test/pytest/test_buffer_args.py
@@ -79,12 +79,20 @@ class TestReturnValues:
         assert jnp.allclose(result1[0], result2[1]) and jnp.allclose(result1[1], result2[0])
 
     @pytest.mark.parametrize("dtype", [(jnp.complex128), (jnp.complex64)])
-    def test_complex(self, dtype):
+    def test_return_complex_scalar(self, dtype):
+        """Complex scalars (and float16)* take a different path when being returned from the
+        compiled function. See `ranked_memref_to_numpy` and `to_numpy` in
+        llvm-project/mlir/python/mlir/runtime/np_to_memref.py.
+
+        * float16 isn't handled by the compiler, so it is not used as a test.
+        """
+
         @qjit
-        def f():
+        # pylint: disable=missing-function-docstring
+        def return_scalar():
             return jnp.array(0, dtype=dtype)
 
-        assert jnp.allclose(f(), complex(0, 0))
+        assert jnp.allclose(return_scalar(), complex(0, 0))
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_buffer_args.py
+++ b/frontend/test/pytest/test_buffer_args.py
@@ -78,6 +78,14 @@ class TestReturnValues:
         result2 = order2(data_in)
         assert jnp.allclose(result1[0], result2[1]) and jnp.allclose(result1[1], result2[0])
 
+    @pytest.mark.parametrize("dtype", [(jnp.complex128), (jnp.complex64)])
+    def test_complex(self, dtype):
+        @qjit
+        def f():
+            return jnp.array(0, dtype=dtype)
+
+        assert jnp.allclose(f(), complex(0, 0))
+
 
 if __name__ == "__main__":
     pytest.main(["-x", __file__])


### PR DESCRIPTION
**Context:** MLIR's runtime for converting memrefs back to numpy arrays does not handle the case for arrays of rank 0. At the moment, we handle this as a special case in the frontend. However, the special case was buggy since the dtype for complex scalars in numpy is C128 and C64, which need to be changed with a view that sees complex128 and complex64 instead. This is also already implemented in MLIR's runtime, but it is not a feasible path for arrays of rank 0.

**Description of the Change:** In all cases of tensor of rank 0 values being returned, match the behaviour for tensors of rank non-zero.

**Related GitHub Issues:** Fixes #76 
