### PR TITLE
[Frontend + Runtime] Track allocations

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -46,6 +46,11 @@
 * Fix returning complex scalars from the compiled function.
   [#77](https://github.com/PennyLaneAI/catalyst/pull/77)
 
+* Eliminate all memory leaks by tracking memory allocations at runtime. The memory allocations
+  which are still alive when the compiled function terminates, will be freed in the
+  finalization / teardown function.
+  [#78](https://github.com/PennyLaneAI/catalyst/pull/78)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -309,10 +309,6 @@ class CompiledFunction:
             shared_object_file, func_name
         )
 
-        numpy_managed_memory = set()
-        for arg in args[1:]:
-            numpy_managed_memory.add(arg.contents.allocated)
-
         params_to_setup = [b"jitted-function"]
         argc = len(params_to_setup)
         array_of_char_ptrs = (ctypes.c_char_p * len(params_to_setup))()

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -195,13 +195,7 @@ class CompiledFunction:
         # Not needed, computed from the arguments.
         # function.argyptes
 
-        # free, as defined in stdlib.h
-        # free is not defined in the shared object, however
-        # it is declared and we can use this declaration to
-        # get a handle to it.
-        free = shared_object.free
-
-        return shared_object, function, setup, teardown, free
+        return shared_object, function, setup, teardown
 
     @staticmethod
     def get_runtime_signature(*args):
@@ -311,7 +305,7 @@ class CompiledFunction:
         Returns:
             retval: the value computed by the function or None if the function has no return value
         """
-        shared_object, function, setup, teardown, free = CompiledFunction.load_symbols(
+        shared_object, function, setup, teardown = CompiledFunction.load_symbols(
             shared_object_file, func_name
         )
 

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -326,24 +326,12 @@ class CompiledFunction:
 
         setup(ctypes.c_int(argc), array_of_char_ptrs)
         function(*args)
-        teardown()
 
         result = args[0] if has_return else None
         retval = CompiledFunction.return_value_ptr_to_numpy(result) if result else None
 
-        if has_return:
-            raw_return = args[0].contents
-            for memref in raw_return:
-                is_constant = memref.allocated == 0xDEADBEEF
-                if is_constant:
-                    continue
-
-                if memref.allocated in numpy_managed_memory:
-                    continue
-
-                pointer_type = ctypes.POINTER(ctypes.c_int)
-                pointer_to_free = ctypes.cast(memref.allocated, pointer_type)
-                free(pointer_to_free)
+        # Teardown has to be made after the return valued has been copied.
+        teardown()
 
         # Unmap the shared library. This is necessary in case the function is re-compiled.
         # Without unmapping the shared library, there would be a conflict in the name of

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -143,7 +143,7 @@ llvm_lowering_pass_pipeline = [
     # Must be run after -convert-math-to-llvm as it marks math::powf illegal but doesn't convert it.
     "--convert-math-to-libm",
     "--convert-arith-to-llvm",
-    "--convert-memref-to-llvm",
+    "--convert-memref-to-llvm=use-generic-functions",
     "--convert-index-to-llvm",
     "--convert-gradient-to-llvm",
     "--convert-quantum-to-llvm",

--- a/runtime/lib/capi/MemRefUtils.hpp
+++ b/runtime/lib/capi/MemRefUtils.hpp
@@ -2,6 +2,12 @@
 #include <cassert>
 #include <cstring>
 
+extern "C" {
+void *_mlir_memref_to_llvm_alloc(size_t size);
+void *_mlir_memref_to_llvm_aligned_alloc(size_t alignment, size_t size);
+void _mlir_memref_to_llvm_free(void *ptr);
+}
+
 template <typename T, size_t R> struct MemRefT {
     T *data_allocated;
     T *data_aligned;

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -57,7 +57,7 @@ class MemoryManager {
     void erase(void *ptr);
 };
 
-MemoryManager::MemoryManager() { _impl.reserve(1028); }
+MemoryManager::MemoryManager() { _impl.reserve(1024); }
 
 MemoryManager::~MemoryManager()
 {

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -50,6 +50,15 @@ static auto get_device() -> std::unique_ptr<Catalyst::Runtime::QuantumDevice> &
 
 extern "C" {
 
+void *_mlir_memref_to_llvm_alloc(size_t size) { return malloc(size); }
+
+void *_mlir_memref_to_llvm_aligned_alloc(size_t alignment, size_t size)
+{
+    return aligned_alloc(alignment, size);
+}
+
+void _mlir_memref_to_llvm_free(void *ptr) { free(ptr); }
+
 void __quantum__rt__fail_cstr(const char *cstr) { throw std::runtime_error(cstr); }
 
 void __quantum__rt__initialize()

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -93,6 +93,9 @@ void __quantum__rt__initialize()
 void __quantum__rt__finalize()
 {
     Catalyst::Runtime::CAPI::GLOBAL_DEVICE_PTR.reset(nullptr);
+    for (auto allocation : *Catalyst::Runtime::CAPI::GLOBAL_ALLOCATIONS) {
+        free(allocation);
+    }
     Catalyst::Runtime::CAPI::GLOBAL_ALLOCATIONS.reset(nullptr);
     assert(Catalyst::Runtime::CAPI::get_device() == nullptr);
 }

--- a/runtime/tests/Test_LightningCoreQIS.cpp
+++ b/runtime/tests/Test_LightningCoreQIS.cpp
@@ -256,6 +256,34 @@ TEST_CASE("Test copy to strided array", "[qir_lightning_core]")
     delete[] buffer_strided;
 }
 
+TEST_CASE("Test memref alloc", "[qir_lightning_core]")
+{
+    __quantum__rt__initialize();
+    int *a = (int *)_mlir_memref_to_llvm_alloc(sizeof(int));
+    CHECK(a != NULL);
+    *a = 1;
+    __quantum__rt__finalize();
+}
+
+TEST_CASE("Test memref aligned alloc", "[qir_lightning_core]")
+{
+    __quantum__rt__initialize();
+    int *a = (int *)_mlir_memref_to_llvm_aligned_alloc(sizeof(int), sizeof(int));
+    CHECK(a != NULL);
+    *a = 1;
+    __quantum__rt__finalize();
+}
+
+TEST_CASE("Test memref free", "[qir_lightning_core]")
+{
+    __quantum__rt__initialize();
+    int *a = (int *)_mlir_memref_to_llvm_alloc(sizeof(int));
+    CHECK(a != NULL);
+    *a = 1;
+    _mlir_memref_to_llvm_free(a);
+    __quantum__rt__finalize();
+}
+
 TEST_CASE("Test __quantum__qis__Measure", "[qir_lightning_core]")
 {
     // initialize the simulator


### PR DESCRIPTION
**Context:** [Not all memory allocations can be deallocated using the `--buffer-deallocation` pass.](https://mlir.llvm.org/docs/Bufferization/#buffer-deallocation) Therefore, it is necessary to deallocate them via some other alternative. 

**Description of the Change:** One way to achieve this is to keep track of the calls to memory functions such as malloc and aligned_alloc in a set. When a call to free is made, remove this pointer from the set. At the end of the execution of the function, all remaining allocations in the set should be freed.

**Benefits:** No memory leaks as long as the generated function only calls the generic memory management functions. This is a soft guarantee provided by the memref dialect. It can be broken by other dialects if they choose some lowerings that call other memory management functions.

**Possible Drawbacks:** There is a performance penalty for every insertion and deletion of items in the set. Ideally, these memory allocations would not be needed to be tracked in the set and lack of memory leaks should be guaranteed statically. These wrappers could then still be used to collect statistics without the performance penalty by having some compilation flag like `-DPROFILE_MEM` and having some macro if statements.

Using the following program as a test:

```python
from catalyst import qjit, grad
import pennylane as qml
import jax

device = qml.device("lightning.qubit", wires=1)
@qml.qnode(device, wires=1)
def main(x):
    return 2 * x

@qjit(keep_intermediate=True, verbose=True)
def g(x: jax.core.ShapedArray([], float)):
    h = grad(main)
    return h(x)[0] + 2
```

Running it with inlining disabled, we get a memory leak running with sanitizers in a python-free environment. However after applying these set of patches, with inlining disabled, we get no memory leaks in a python-free environment.

I believe that better and easier testing will be possible once we have a C wrapper generator.

[sc-35382]
