### PR TITLE
[Runtime] Fix concrete to logical qubit mapping.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -8,7 +8,7 @@
 
 <h3>Bug fixes</h3>
 
-* Fix error in logical to concrete qubit mapping during measurements.
+* Fix a bug in the mapping from logical to concrete qubits for mid-circuit measurements.
   [#80](https://github.com/PennyLaneAI/catalyst/pull/80)
 
 <h3>Contributors</h3>

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -8,9 +8,14 @@
 
 <h3>Bug fixes</h3>
 
+* Fix error in logical to concrete qubit mapping during measurements.
+  [#80](https://github.com/PennyLaneAI/catalyst/pull/80)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
+
+Erick Ochoa Lopez
 
 # Release 0.1.2
 

--- a/runtime/lib/backend/LightningKokkosSimulator.cpp
+++ b/runtime/lib/backend/LightningKokkosSimulator.cpp
@@ -438,7 +438,9 @@ auto LightningKokkosSimulator::Measure(QubitIdType wire) -> Result
 
     const size_t num_qubits = this->GetNumQubits();
 
-    const auto stride = pow(2, num_qubits - (1 + wire));
+    auto &&dev_wires = this->getDeviceWires(wires);
+    const auto stride = pow(2, num_qubits - (1 + dev_wires[0]));
+    assert(std::finite(stride));
     const auto vec_size = pow(2, num_qubits);
     const auto section_size = vec_size / stride;
     const auto half_section_size = section_size / 2;

--- a/runtime/lib/backend/LightningKokkosSimulator.cpp
+++ b/runtime/lib/backend/LightningKokkosSimulator.cpp
@@ -440,7 +440,6 @@ auto LightningKokkosSimulator::Measure(QubitIdType wire) -> Result
 
     auto &&dev_wires = this->getDeviceWires(wires);
     const auto stride = pow(2, num_qubits - (1 + dev_wires[0]));
-    assert(std::finite(stride));
     const auto vec_size = pow(2, num_qubits);
     const auto section_size = vec_size / stride;
     const auto half_section_size = section_size / 2;

--- a/runtime/lib/backend/LightningSimulator.cpp
+++ b/runtime/lib/backend/LightningSimulator.cpp
@@ -410,7 +410,8 @@ auto LightningSimulator::Measure(QubitIdType wire) -> Result
 
     auto &&state = this->device_sv->getDataVector();
 
-    const auto stride = pow(2, numQubits - (1 + wire));
+    auto &&dev_wires = getDeviceWires(wires);
+    const auto stride = pow(2, numQubits - (1 + dev_wires[0]));
     const auto vec_size = pow(2, numQubits);
     const auto section_size = vec_size / stride;
     const auto half_section_size = section_size / 2;

--- a/runtime/lib/backend/LightningSimulator.cpp
+++ b/runtime/lib/backend/LightningSimulator.cpp
@@ -410,8 +410,9 @@ auto LightningSimulator::Measure(QubitIdType wire) -> Result
 
     auto &&state = this->device_sv->getDataVector();
 
-    auto &&dev_wires = getDeviceWires(wires);
+    auto &&dev_wires = this->getDeviceWires(wires);
     const auto stride = pow(2, numQubits - (1 + dev_wires[0]));
+    assert(std::isfinite(stride));
     const auto vec_size = pow(2, numQubits);
     const auto section_size = vec_size / stride;
     const auto half_section_size = section_size / 2;

--- a/runtime/lib/backend/LightningSimulator.cpp
+++ b/runtime/lib/backend/LightningSimulator.cpp
@@ -412,7 +412,6 @@ auto LightningSimulator::Measure(QubitIdType wire) -> Result
 
     auto &&dev_wires = this->getDeviceWires(wires);
     const auto stride = pow(2, numQubits - (1 + dev_wires[0]));
-    assert(std::isfinite(stride));
     const auto vec_size = pow(2, numQubits);
     const auto section_size = vec_size / stride;
     const auto half_section_size = section_size / 2;

--- a/runtime/tests/Test_LightningMeasures.cpp
+++ b/runtime/tests/Test_LightningMeasures.cpp
@@ -91,6 +91,33 @@ TEST_CASE("Measurement collapse test with 2 wires", "[lightning]")
     // LCOV_EXCL_STOP
 }
 
+TEST_CASE("Measurement collapse concrete logical qubit difference", "[lightning]")
+{
+    std::unique_ptr<QuantumDevice> sim = CreateQuantumDevice();
+
+    constexpr size_t n = 1;
+    // The first time an array is allocated, logical and concrete qubits
+    // are the same.
+    std::vector<QubitIdType> Qs = sim->AllocateQubits(n);
+    sim->ReleaseAllQubits();
+
+    // Now in this the concrete qubits are shifted by n.
+    Qs = sim->AllocateQubits(n);
+
+    sim->NamedOperation("Hadamard", {}, {Qs[0]}, false);
+    sim->Measure(Qs[0]);
+    auto &&state = sim->State();
+
+    // LCOV_EXCL_START
+    bool is_zero = pow(std::abs(std::real(state[0])), 2) + pow(std::abs(std::imag(state[0])), 2) ==
+                   Approx(1.0).margin(1e-5);
+    bool is_one = pow(std::abs(std::real(state[1])), 2) + pow(std::abs(std::imag(state[1])), 2) ==
+                  Approx(1.0).margin(1e-5);
+    bool is_valid = is_zero ^ is_one;
+    CHECK(is_valid);
+    // LCOV_EXCL_STOP
+}
+
 TEST_CASE("Mid-circuit measurement naive test", "[lightning]")
 {
     std::unique_ptr<QuantumDevice> sim = CreateQuantumDevice();


### PR DESCRIPTION
**Context:** Concrete and logical qubit mapping was not being taken into account when projecting the state after measurements.

**Description of the Change:** Fix the mapping.

[sc-36430]
Fixes #82 