### PR TITLE
[Frontend] Bugfix for infering gradient's results signature

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -11,6 +11,9 @@
 * Fix a bug in the mapping from logical to concrete qubits for mid-circuit measurements.
   [#80](https://github.com/PennyLaneAI/catalyst/pull/80)
 
+* Fix a bug in the way gradient result type is inferred.
+  [#84](https://github.com/PennyLaneAI/catalyst/pull/84)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/frontend/catalyst/utils/calculate_grad_shape.py
+++ b/frontend/catalyst/utils/calculate_grad_shape.py
@@ -86,6 +86,9 @@ class Signature:
         """
         return isinstance(x, ShapedArray)
 
+    def __eq__(self, other):
+        return self.xs == other.xs and self.ys == other.ys
+
 
 def calculate_grad_shape(signature, indices):
     """calculate_grad_shape: Given a signature and a list of indices over which arguments

--- a/frontend/catalyst/utils/calculate_grad_shape.py
+++ b/frontend/catalyst/utils/calculate_grad_shape.py
@@ -111,7 +111,7 @@ def calculate_grad_shape(signature, indices):
                 diff_arg_shape.append(axis)
 
         for y in signature.get_results():
-            grad_res_shape = diff_arg_shape
+            grad_res_shape = diff_arg_shape.copy()
             if Signature.is_tensor(y):
                 for axis in y.shape:
                     grad_res_shape.append(axis)

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -20,6 +20,26 @@ from jax import numpy as jnp
 
 from catalyst import CompileError, cond, for_loop, grad, qjit
 
+import catalyst.utils.calculate_grad_shape as infer
+
+
+class TestGradShape:
+    """Unit tests for the calculate_grad_shape module."""
+
+    @pytest.mark.parametrize("sig", [infer.Signature([int], [int])])
+    def test_repr(self, sig):
+        """Sanity check to make sure that we have a human readable representation."""
+        assert str(sig) == "[<class 'int'>] -> [<class 'int'>]"
+
+    def test_deduction(self):
+        """Test case from https://github.com/PennyLaneAI/catalyst/issues/83"""
+        params = [jax.core.ShapedArray([], float)]
+        returns = [jax.core.ShapedArray([2], float), jax.core.ShapedArray([], float)]
+        in_signature = infer.Signature(params, returns)
+        observed_output = infer.calculate_grad_shape(in_signature, [0])
+        expected_output = infer.Signature(params, returns)
+        assert observed_output == expected_output
+
 
 def test_grad_outside_qjit():
     def f(x: float):


### PR DESCRIPTION
**Context:** Frontend's algorithm for inferring gradient's result types was incorrect. It differed from the middle-end's algorithm.

**Description of the Change:** Instead of obtaining a reference to a list and mutating the list, the list is copied over each iteration of a function's range. Frontend's algorithm now matches middle-end's.

**Related GitHub Issues:** Fixes: #83 

[sc-36481]
