### PR TITLE
[CI] Provide separate actions for main build and testing against PL dev

### DIFF
--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -371,16 +371,16 @@ jobs:
         pytest frontend/test/pytest -n auto $COVERAGE_FLAGS
         mv coverage.xml coverage-${{ github.job }}.xml
 
-    - name: Check Catalyst Demos
-      run: |
-        MDD_BENCHMARK_PRECISION=1 \
-        pytest demos --nbmake -n auto
-
     - name: Upload to Codecov
       uses: codecov/codecov-action@v3
       with:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
+
+    - name: Check Catalyst Demos
+      run: |
+        MDD_BENCHMARK_PRECISION=1 \
+        pytest demos --nbmake -n auto
 
   runtime-tests:
     name: Runtime Tests (Linux)
@@ -450,6 +450,13 @@ jobs:
           name: ubuntu-codecov-results-cpp
           path: ./coverage-${{ github.job }}.info
 
+      - name: Upload to Codecov
+        if: ${{ matrix.simulator == 'lightning' }}
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Build examples
         if: ${{ matrix.simulator == 'lightning' }}
         run: |
@@ -466,10 +473,3 @@ jobs:
         run: |
             mkdir -p ./runtime/build/tests/results
             ./runtime/build/tests/runner_tests --reporter junit --out ./runtime/build/tests/results/tests_result.xml
-
-      - name: Upload to Codecov
-        if: ${{ matrix.simulator == 'lightning' }}
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -65,9 +65,6 @@ jobs:
         run: |
           sudo apt-get -y -q install ninja-build make cmake clang libomp-dev
           echo "LIGHTNING_GIT_TAG_VALUE=latest_release" >> $GITHUB_ENV
-      - if: ${{ github.event_name == 'push' }}
-        run: |
-          echo "LIGHTNING_GIT_TAG_VALUE=master" >> $GITHUB_ENV
 
       - name: Get Cached qir-stdlib Build
         id: cache-qir-stdlib
@@ -318,16 +315,6 @@ jobs:
         python3 -m pip install jax==${{ steps.jax-version.outputs.v }} jaxlib==${{ steps.jax-version.outputs.v }}
         python3 -m pip install .
 
-    - name: Install PennyLane-master
-      if: ${{ github.event_name == 'push' }}
-      uses: actions/checkout@v3
-      with:
-        repository: PennyLaneAI/pennylane
-        path: pennylane
-    - if: ${{ github.event_name == 'push' }}
-      run: |
-        python3 -m pip install --upgrade ./pennylane
-
     - name: Get LLVM Version
       id: llvm-hash
       run: echo "llvm-hash=$(grep llvm .dep-versions | awk -F '=' '{ print $2 }')" >> $GITHUB_OUTPUT
@@ -418,10 +405,6 @@ jobs:
           sudo apt-get -y -q install cmake ninja-build libomp-dev lcov
           echo "LIGHTNING_TAG_VALUE=latest_release" >> $GITHUB_ENV
           # TODO: Update this to latest_release for the v0.30.0 release
-          echo "LIGHTNING_KOKKOS_TAG_VALUE=main" >> $GITHUB_ENV
-      - if: ${{ github.event_name == 'push' }}
-        run: |
-          echo "LIGHTNING_TAG_VALUE=master" >> $GITHUB_ENV
           echo "LIGHTNING_KOKKOS_TAG_VALUE=main" >> $GITHUB_ENV
 
       - name: Get Cached qir-stdlib Build

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -6,12 +6,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-env:
-  COVERAGE_FLAGS: "--cov=catalyst --cov-report=term-missing --cov-report=xml:./coverage.xml -p no:warnings --tb=native"
-
 jobs:
-  runtime-qir-stdlib:
-    name: Catalyst-Runtime (qir-stdlib)
+  qir-stdlib:
+    name: QIR-stdlib Build
     runs-on: ubuntu-latest
 
     steps:
@@ -27,7 +24,7 @@ jobs:
         id: cache-qir-stdlib
         uses: actions/cache@v3
         with:
-          path: ./runtime/qir-stdlib-build
+          path: qir-stdlib-build
           key: ${{ runner.os }}-qir-stdlib-build
 
       - name: Install rustup with llvm-tools-preview
@@ -40,16 +37,14 @@ jobs:
       - name: Install QIR-stdlib
         if: steps.cache-qir-stdlib.outputs.cache-hit != 'true'
         run: |
-            cd ./runtime/qir-stdlib
-            cargo build --release --verbose
-            mkdir -p ../qir-stdlib-build/include
-            cp ./target/release/libqir_stdlib.a ../qir-stdlib-build/
-            cp ./target/release/build/include/* ../qir-stdlib-build/include/
-            cargo clean
+            make qir
+            mkdir -p qir-stdlib-build/include
+            cp runtime/qir-stdlib/target/release/libqir_stdlib.a qir-stdlib-build/
+            cp runtime/qir-stdlib/target/release/build/include/* qir-stdlib-build/include/
 
   runtime:
-    name: Catalyst-Runtime
-    needs: [runtime-qir-stdlib]
+    name: Catalyst-Runtime Build
+    needs: [qir-stdlib]
     runs-on: ubuntu-latest
 
     steps:
@@ -70,18 +65,17 @@ jobs:
         id: cache-qir-stdlib
         uses: actions/cache@v3
         with:
-          path: ./runtime/qir-stdlib-build
+          path: qir-stdlib-build
           key: Linux-qir-stdlib-build
           fail-on-cache-miss: True
 
       - name: Build Catalyst-Runtime
         run: |
-          pushd runtime
-          RT_BUILD_DIR=../runtime-build \
           COMPILER_LAUNCHER="" \
+          RT_BUILD_DIR="$(pwd)/runtime-build" \
+          QIR_STDLIB_DIR="$(pwd)/qir-stdlib-build" \
           QIR_STDLIB_INCLUDES_DIR="$(pwd)/qir-stdlib-build/include" \
-          QIR_STDLIB_DIR="$(pwd)/qir-stdlib-build/" make runtime
-          popd
+          make runtime
 
       - name: Upload Catalyst-Runtime Artifact
         uses: actions/upload-artifact@v3
@@ -148,9 +142,8 @@ jobs:
       run: |
         # echo 'target_compile_options(mlir_c_runner_utils PRIVATE "-fno-sanitize=all")' \
         #       >> mlir/llvm-project/mlir/lib/ExecutionEngine/CMakeLists.txt
-        pushd mlir
-        LLVM_BUILD_DIR=../llvm-build make llvm
-        popd
+        LLVM_BUILD_DIR="$(pwd)/llvm-build" \
+        make llvm
 
   mhlo:
     name: MHLO Dialect Build
@@ -187,7 +180,7 @@ jobs:
       if: steps.cache-mhlo.outputs.cache-hit != 'true'
       uses: actions/cache@v3
       with:
-        path:  mlir/llvm-project
+        path: mlir/llvm-project
         key: Linux-llvm-${{ steps.llvm-hash.outputs.llvm-hash }}-default-source
         enableCrossOsArchive: True
         fail-on-cache-miss: True
@@ -197,7 +190,7 @@ jobs:
       if: steps.cache-mhlo.outputs.cache-hit != 'true'
       uses: actions/cache@v3
       with:
-        path:  llvm-build
+        path: llvm-build
         key: ${{ runner.os }}-llvm-${{ steps.llvm-hash.outputs.llvm-hash }}-default-build
         fail-on-cache-miss: True
 
@@ -219,9 +212,9 @@ jobs:
     - name: Build MHLO Dialect
       if: steps.cache-mhlo.outputs.cache-hit != 'true'
       run: |
-        pushd mlir
-        LLVM_BUILD_DIR="../llvm-build" MHLO_BUILD_DIR="../mhlo-build" make mhlo
-        popd
+        LLVM_BUILD_DIR="$(pwd)/llvm-build" \
+        MHLO_BUILD_DIR="$(pwd)/mhlo-build" \
+        make mhlo
 
   quantum:
     name: Quantum Dialects Build
@@ -275,10 +268,11 @@ jobs:
 
     - name: Build MLIR Dialects
       run: |
-        export CCACHE_DIR=$GITHUB_WORKSPACE/.ccache
-        pushd mlir
-        LLVM_BUILD_DIR="../llvm-build" MHLO_BUILD_DIR="../mhlo-build" DIALECTS_BUILD_DIR="../quantum-build" make dialects
-        popd
+        CCACHE_DIR="$(pwd)/.ccache" \
+        LLVM_BUILD_DIR="$(pwd)/llvm-build" \
+        MHLO_BUILD_DIR="$(pwd)/mhlo-build" \
+        DIALECTS_BUILD_DIR="$(pwd)/quantum-build" \
+        make dialects
 
     - name: Upload Quantum Build Artifact
       uses: actions/upload-artifact@v3
@@ -290,7 +284,7 @@ jobs:
           quantum-build/python_packages/*
         retention-days: 1
 
-  frontend:
+  frontend-tests:
     name: Frontend Tests
     needs: [runtime, mhlo, quantum]
     runs-on: ubuntu-latest
@@ -304,15 +298,10 @@ jobs:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v3
 
-    - name: Get JAX Version
-      id: jax-version
-      run: echo "v=$(grep jax .dep-versions | awk -F '=' '{ print $2 }')" >> $GITHUB_OUTPUT
-
     - name: Install Deps
       run: |
         sudo apt-get install -y python3 python3-pip libomp-dev
-        python3 -m pip install lit pytest pytest-xdist pytest-cov nbmake nbconvert ipykernel matplotlib jaxopt
-        python3 -m pip install jax==${{ steps.jax-version.outputs.v }} jaxlib==${{ steps.jax-version.outputs.v }}
+        python3 -m pip install -r requirements.txt
         python3 -m pip install .
 
     - name: Get LLVM Version
@@ -367,8 +356,9 @@ jobs:
 
     - name: Run Python Pytest Tests
       run: |
-        export ASAN_OPTIONS=detect_odr_violation=0
-        pytest frontend/test/pytest -n auto $COVERAGE_FLAGS
+        # export ASAN_OPTIONS=detect_odr_violation=0
+        COVERAGE_REPORT="xml:coverage.xml -p no:warnings" \
+        make coverage-frontend
         mv coverage.xml coverage-${{ github.job }}.xml
 
     - name: Upload to Codecov
@@ -384,7 +374,7 @@ jobs:
 
   runtime-tests:
     name: Runtime Tests (Linux)
-    needs: [runtime-qir-stdlib]
+    needs: [qir-stdlib]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -411,44 +401,33 @@ jobs:
         id: cache-qir-stdlib
         uses: actions/cache@v3
         with:
-          path: ./runtime/qir-stdlib-build
+          path: qir-stdlib-build
           key: Linux-qir-stdlib-build
           fail-on-cache-miss: True
 
       - name: Build Runtime test suite for Lightning simulator
         if: ${{ matrix.simulator == 'lightning' }}
         run: |
-            pushd runtime
             C_COMPILER=$(which gcc) \
             CXX_COMPILER=$(which g++) \
             COMPILER_LAUNCHER="" \
-            QIR_STDLIB_DIR="$(pwd)/qir-stdlib-build/" \
-            QIR_STDLIB_INCLUDES_DIR="$(pwd)/qir-stdlib-build/include/" \
+            QIR_STDLIB_DIR="$(pwd)/qir-stdlib-build" \
+            QIR_STDLIB_INCLUDES_DIR="$(pwd)/qir-stdlib-build/include" \
             LIGHTNING_GIT_TAG_VALUE=$LIGHTNING_TAG_VALUE \
-            make coverage
-            popd
+            make coverage-runtime
             mv runtime/build/coverage.info coverage-${{ github.job }}.info
 
       - name: Build Runtime test suite for Lightning-Kokkos simulator
         if: ${{ matrix.simulator == 'lightning-kokkos' }}
         run: |
-            pushd runtime
             C_COMPILER=$(which gcc) \
             CXX_COMPILER=$(which g++) \
             COMPILER_LAUNCHER="" \
-            QIR_STDLIB_DIR="$(pwd)/qir-stdlib-build/" \
-            QIR_STDLIB_INCLUDES_DIR="$(pwd)/qir-stdlib-build/include/" \
+            QIR_STDLIB_DIR="$(pwd)/qir-stdlib-build" \
+            QIR_STDLIB_INCLUDES_DIR="$(pwd)/qir-stdlib-build/include" \
             LIGHTNING_GIT_TAG_VALUE=$LIGHTNING_KOKKOS_TAG_VALUE \
             ENABLE_KOKKOS=ON \
-            make test
-            popd
-
-      - name: Upload code coverage results
-        if: ${{ matrix.simulator == 'lightning' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: ubuntu-codecov-results-cpp
-          path: ./coverage-${{ github.job }}.info
+            make test-runtime
 
       - name: Upload to Codecov
         if: ${{ matrix.simulator == 'lightning' }}
@@ -460,16 +439,9 @@ jobs:
       - name: Build examples
         if: ${{ matrix.simulator == 'lightning' }}
         run: |
-          pushd runtime
           C_COMPILER=$(which gcc) \
           CXX_COMPILER=$(which g++) \
           COMPILER_LAUNCHER="" \
-          QIR_STDLIB_DIR="$(pwd)/qir-stdlib-build/" \
-          QIR_STDLIB_INCLUDES_DIR="$(pwd)/qir-stdlib-build/include/" \
-          make examples
-          popd
-
-      - name: Create tests report
-        run: |
-            mkdir -p ./runtime/build/tests/results
-            ./runtime/build/tests/runner_tests --reporter junit --out ./runtime/build/tests/results/tests_result.xml
+          QIR_STDLIB_DIR="$(pwd)/qir-stdlib-build" \
+          QIR_STDLIB_INCLUDES_DIR="$(pwd)/qir-stdlib-build/include" \
+          make examples-runtime

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -110,14 +110,14 @@ jobs:
       id: cache-llvm-build
       uses: actions/cache@v3
       with:
-        path:  llvm-build
+        path: llvm-build
         key: ${{ runner.os }}-llvm-${{ steps.llvm-hash.outputs.llvm-hash }}-default-build
 
     - name: Cache LLVM Source
       id: cache-llvm-source
       uses: actions/cache@v3
       with:
-        path:  mlir/llvm-project
+        path: mlir/llvm-project
         key: Linux-llvm-${{ steps.llvm-hash.outputs.llvm-hash }}-default-source
         enableCrossOsArchive: True
 
@@ -167,7 +167,7 @@ jobs:
       id: cache-mhlo
       uses: actions/cache@v3
       with:
-        path:  mhlo-build
+        path: mhlo-build
         key: ${{ runner.os }}-mhlo-${{ steps.mhlo-hash.outputs.mhlo-hash }}-default-build
 
     - name: Get LLVM Version
@@ -195,7 +195,7 @@ jobs:
         fail-on-cache-miss: True
 
     - name: Clone MHLO Submodule
-      if:  |
+      if: |
         steps.cache-mhlo.outputs.cache-hit != 'true' &&
         steps.cache-mhlo-source.outputs.cache-hit != 'true'
       uses: actions/checkout@v3
@@ -312,7 +312,7 @@ jobs:
       id: cache-llvm-build
       uses: actions/cache@v3
       with:
-        path:  llvm-build
+        path: llvm-build
         key: ${{ runner.os }}-llvm-${{ steps.llvm-hash.outputs.llvm-hash }}-default-build
         fail-on-cache-miss: True
 
@@ -324,7 +324,7 @@ jobs:
       id: cache-mhlo
       uses: actions/cache@v3
       with:
-        path:  mhlo-build
+        path: mhlo-build
         key: ${{ runner.os }}-mhlo-${{ steps.mhlo-hash.outputs.mhlo-hash }}-default-build
         fail-on-cache-miss: True
 

--- a/.github/workflows/check-pl-matrix.yaml
+++ b/.github/workflows/check-pl-matrix.yaml
@@ -1,0 +1,136 @@
+name: Check PennyLane Compatibility
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  check-matrix:
+    name: Build Compatibility Matrix against PL/Lightning
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        catalyst: ['latest', 'release']
+        pennylane: ['latest', 'release']
+        lightning: ['latest', 'release']
+
+    steps:
+    - name: Cancel previous runs
+      uses: styfle/cancel-workflow-action@0.11.0
+      with:
+        access_token: ${{ github.token }}
+
+    - name: Checkout Catalyst repo
+      uses: actions/checkout@v3
+    - if: ${{ matrix.catalyst == 'release' }}
+      run: |
+        git checkout $(git tag | sort -V | tail -1)
+
+    - name: Get LLVM version
+      id: llvm-hash
+      run: echo "llvm-hash=$(grep llvm .dep-versions | awk -F '=' '{ print $2 }')" >> $GITHUB_OUTPUT
+
+    - name: Get MHLO version
+      id: mhlo-hash
+      run: echo "mhlo-hash=$(grep mhlo .dep-versions | awk -F '=' '{ print $2 }')" >> $GITHUB_OUTPUT
+
+    - name: Install deps
+      run: |
+        sudo apt-get install -y cmake ninja-build ccache clang lld libomp-dev
+        python3 -m pip install -r requirements.txt
+
+    - name: Get Catalyst Build Dependencies (latest)
+      uses: actions/cache@v3
+      with:
+        path: qir-stdlib-build
+        key: Linux-qir-stdlib-build
+        fail-on-cache-miss: True
+    - uses: actions/cache@v3
+      with:
+        path: mlir/llvm-project
+        key: Linux-llvm-${{ steps.llvm-hash.outputs.llvm-hash }}-default-source
+        enableCrossOsArchive: True
+        fail-on-cache-miss: True
+    - uses: actions/cache@v3
+      with:
+        path: llvm-build
+        key: ${{ runner.os }}-llvm-${{ steps.llvm-hash.outputs.llvm-hash }}-default-build
+        fail-on-cache-miss: True
+    - uses: actions/cache@v3
+      with:
+        path: mhlo-build
+        key: ${{ runner.os }}-mhlo-${{ steps.mhlo-hash.outputs.mhlo-hash }}-default-build
+        fail-on-cache-miss: True
+    - uses: actions/cache@v3
+      with:
+        path: .ccache
+        key: ${{ runner.os }}-ccache-${{ github.run_id }}
+        restore-keys: ${{ runner.os }}-ccache-
+
+
+    - name: Build Lightning Runtime (latest)
+      if: ${{ matrix.lightning == 'latest' }}
+      run: |
+        COMPILER_LAUNCHER="" \
+        RT_BUILD_DIR="$(pwd)/runtime-build" \
+        QIR_STDLIB_DIR="$(pwd)/qir-stdlib-build" \
+        QIR_STDLIB_INCLUDES_DIR="$(pwd)/qir-stdlib-build/include" \
+        LIGHTNING_GIT_TAG_VALUE=master \
+        make runtime
+
+    - name: Build Lightning Runtime (release)
+      if: ${{ matrix.lightning == 'release' }}
+      run: |
+        COMPILER_LAUNCHER="" \
+        RT_BUILD_DIR="$(pwd)/runtime-build" \
+        QIR_STDLIB_DIR="$(pwd)/qir-stdlib-build" \
+        QIR_STDLIB_INCLUDES_DIR="$(pwd)/qir-stdlib-build/include" \
+        LIGHTNING_GIT_TAG_VALUE=latest_release \
+        make runtime
+
+
+    - name: Install Catalyst
+      run: |
+        CCACHE_DIR="$(pwd)/.ccache" \
+        LLVM_BUILD_DIR="$(pwd)/llvm-build" \
+        MHLO_BUILD_DIR="$(pwd)/mhlo-build" \
+        DIALECTS_BUILD_DIR="$(pwd)/quantum-build" \
+        make dialects
+        pip install --upgrade .
+
+
+    - name: Install PennyLane (latest)
+      if: ${{ matrix.pennylane == 'latest' }}
+      uses: actions/checkout@v3
+      with:
+        repository: PennyLaneAI/pennylane
+        path: pennylane
+    - if: ${{ matrix.pennylane == 'latest' }}
+      run: |
+        pip install --upgrade ./pennylane
+
+    - name: Install PennyLane (release)
+      if: ${{ matrix.pennylane == 'release' }}
+      run: |
+        pip install --upgrade pennylane
+
+
+    - name: Add Frontend Dependencies to PATH
+      run: |
+        echo "$(pwd)/llvm-build/bin" >> $GITHUB_PATH
+        echo "$(pwd)/mhlo-build/bin" >> $GITHUB_PATH
+        echo "$(pwd)/quantum-build/bin" >> $GITHUB_PATH
+        echo "PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum" >> $GITHUB_ENV
+        echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
+        echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
+
+    - name: Run Frontend Tests
+      run: |
+        make pytest
+
+    - name: Run Demos
+      run: |
+        make test-demos

--- a/.github/workflows/check-pl-matrix.yaml
+++ b/.github/workflows/check-pl-matrix.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
-  pull_request:
 
 jobs:
   check-matrix:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ numpy
 pybind11>=2.8.0
 PyYAML
 dataclasses
+matplotlib
 jaxopt
 
 black[jupyter]
@@ -9,6 +10,7 @@ clang-format==14.*
 clang-tidy==14.*
 pylint
 
+lit
 pytest
 pytest-xdist
 pytest-cov


### PR DESCRIPTION
Besides some refactoring of the `check-catalyst` action, this PR adds a new action with simplified and modular build job that can selectively install release or dev versions of Catalyst, PennyLane, and Lightning. All 8 configurations are tested on the Catalyst frontend test suite and demos.

Latest run matches expected state, where PennyLane-latest fails one of our demos, and every other configuration passes:
https://github.com/PennyLaneAI/catalyst/actions/runs/4623596505

Some other minor changes include:
 - fixed top-level Makefile printing errors when black is not installed
 - upload coverage reports before running additional steps in the main action
 - move some additional tools to our `requirements.txt` that were explicitly installed in the main action 
 - add qir target to top-level makefile
 - remove obsolete steps in the main action

[sc-36482]