### PR TITLE
Commuting evolution is no longer expected to fail.

### DIFF
--- a/frontend/test/pytest/test_template.py
+++ b/frontend/test/pytest/test_template.py
@@ -423,7 +423,6 @@ def test_qft():
     assert np.allclose(interpreted_fn(params), jitted_fn(params))
 
 
-@pytest.mark.xfail
 def test_commuting_evolution():
     n_wires = 2
     device = qml.device("lightning.qubit", wires=n_wires)
@@ -574,7 +573,7 @@ def test_quantum_montecarlo():
     N = 2**n
     target_wires = range(m + 1)
     estimation_wires = range(m + 1, n + m + 1)
-    device = qml.device("lightning.qubit", wires=(n + m + 1))
+    device = qml.device("lightning.qubit", n + m + 1)
 
     def circuit():
         qml.templates.QuantumMonteCarlo(


### PR DESCRIPTION
**Context:** Test for commuting evolution was marked as failing due to a potentially upstream bug. Not a lot of investigation went into determine the exact reason beyond it being a concretization error. 

**Description of the Change:** Since the test no longer fails, the expectation to fail is removed.
