### PR TITLE
[Runtime][WIP] Remove unnecessary copy

### DIFF
--- a/runtime/include/QuantumDevice.hpp
+++ b/runtime/include/QuantumDevice.hpp
@@ -215,7 +215,7 @@ struct QuantumDevice {
      *
      * @return `std::vector<std::complex<double>>`
      */
-    virtual auto State() -> std::vector<std::complex<double>> = 0;
+    virtual auto State() -> std::complex<double>* = 0;
 
     /**
      * @brief Compute samples with the number of shots on the entire wires,

--- a/runtime/lib/backend/LightningSimulator.cpp
+++ b/runtime/lib/backend/LightningSimulator.cpp
@@ -210,10 +210,10 @@ auto LightningSimulator::Var(ObsIdType obsKey) -> double
     return result;
 }
 
-auto LightningSimulator::State() -> std::vector<std::complex<double>>
+auto LightningSimulator::State() -> std::complex<double>*
 {
     auto &&state = this->device_sv->getDataVector();
-    return std::vector<std::complex<double>>(state.begin(), state.end());
+    return state.data();
 }
 
 auto LightningSimulator::Probs() -> std::vector<double>

--- a/runtime/lib/backend/LightningSimulator.hpp
+++ b/runtime/lib/backend/LightningSimulator.hpp
@@ -135,7 +135,7 @@ class LightningSimulator final : public Catalyst::Runtime::QuantumDevice {
         -> ObsIdType override;
     auto Expval(ObsIdType obsKey) -> double override;
     auto Var(ObsIdType obsKey) -> double override;
-    auto State() -> std::vector<std::complex<double>> override;
+    auto State() -> std::complex<double>* override;
     auto Probs() -> std::vector<double> override;
     auto PartialProbs(const std::vector<QubitIdType> &wires) -> std::vector<double> override;
     auto Sample(size_t shots) -> std::vector<double> override;

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -716,7 +716,7 @@ void __quantum__qis__State(MemRefT_CplxT_double_1d *result, int64_t numQubits, .
         numQubits = __quantum__rt__num_qubits();
     }
 
-    std::vector<std::complex<double>> sv_state;
+    std::complex<double>* sv_state = NULL;
 
     if (wires.empty()) {
         sv_state = Catalyst::Runtime::CAPI::get_device()->State();
@@ -727,13 +727,10 @@ void __quantum__qis__State(MemRefT_CplxT_double_1d *result, int64_t numQubits, .
         // numElements, wires);
     }
 
-    const size_t numElements = sv_state.size();
-    assert(numElements == (1U << numQubits));
-    std::complex<double> *buffer = sv_state.data();
-    size_t buffer_len = sv_state.size();
-    MemRefT<std::complex<double>, 1> src = {buffer, buffer, 0, {buffer_len}, {1}};
+    size_t buffer_len = 1U << numQubits;
+    MemRefT<std::complex<double>, 1> src = {sv_state, sv_state, 0, {buffer_len}, {1}};
     memref_copy<std::complex<double>, 1>(result_p, &src,
-                                         numElements * sizeof(std::complex<double>));
+                                         1U << numQubits * sizeof(std::complex<double>));
 }
 
 void __quantum__qis__Sample(MemRefT_double_2d *result, int64_t shots, int64_t numQubits, ...)


### PR DESCRIPTION
**Context:** The state was copied from a vector to another vector to a memref buffer. There was a redundant vector copy. For the following program:

```c
#include <stdio.h>
#include <stdlib.h>

struct MemRefDouble {
  double *allocated;
  double *aligned;
  int offset;
};

// complex<double> type
struct CplxT_double {
    double real;
    double imag;
};

typedef struct CplxT_double CplxT_double;

struct MemRefT_CplxT_double_1d {
    CplxT_double *data_allocated;
    CplxT_double *data_aligned;
    size_t offset;
    size_t sizes[1];
    size_t strides[1];
};

extern void __quantum__rt__finalize();
extern void __quantum__rt__initialize();

extern void* __quantum__rt__qubit_allocate_array(int);
extern void __quantum__qis__State(struct MemRefT_CplxT_double_1d *, int, ...);
extern void *_mlir_memref_to_llvm_alloc(size_t);

int
main(int argc, char** argv)
{
  double buffer[1] = {0.0};
  __quantum__rt__initialize();
  char* endptr = NULL;
  size_t num_qubits = strtol(argv[1], &endptr, 10);
  CplxT_double *buffer_result = (CplxT_double *) _mlir_memref_to_llvm_alloc(sizeof(struct CplxT_double) * 1U << num_qubits);
  struct MemRefT_CplxT_double_1d result;
  result.data_allocated = buffer_result;
  result.data_aligned = buffer_result;
  void* array = __quantum__rt__qubit_allocate_array(num_qubits);
  __quantum__qis__State(&result, 0);
  __quantum__rt__finalize();
}

```

running 

```
valgrind --tool=massif ./a.out 25
```

Shows a peak memory usage of 1.5 GB evenly distributed between three callsites

```
    GB
1.500^                                                                       #
     |                                                                       #
     |                                                                       #
     |                                                                       #
     |                                                                       #
     |                                                                       #
     |                                                                       #
     |                @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@#
     |                @                                                      #
     |                @                                                      #
     |                @                                                      #
     |                @                                                      #
     |                @                                                      #
     |                @                                                      #
     | @@@@@@@@@@@@@@@@                                                      #
     | @              @                                                      #
     | @              @                                                      #
     | @              @                                                      #
     | @              @                                                      #
     | @              @                                                      #
   0 +----------------------------------------------------------------------->Mi
     0                                                                   433.1

Number of snapshots: 75
 Detailed snapshots: [12, 14, 16, 24, 44, 45, 48, 50, 51, 53, 54, 55, 57, 58, 60, 62, 64, 68, 69, 70 (peak)]

```

```
--------------------------------------------------------------------------------
  n        time(i)         total(B)   useful-heap(B) extra-heap(B)    stacks(B)
--------------------------------------------------------------------------------
 70    454,061,636    1,610,785,072    1,610,763,090        21,982            0
100.00% (1,610,763,090B) (heap allocation functions) malloc/new/new[], --alloc-fns, etc.
->33.33% (536,870,912B) 0x48F1D66: Catalyst::Runtime::Simulator::LightningSimulator::State() (in /home/eo/Code/catalyst-latest/runtime/build/lib/backend/librt_backend.so)
| ->33.33% (536,870,912B) 0x4A4388F: __quantum__qis__State (in /home/eo/Code/catalyst-latest/runtime/build/lib/capi/librt_capi.so)
|   ->33.33% (536,870,912B) 0x1093B8: main (a.c:45)
|     
->33.33% (536,870,912B) 0x48F66B9: std::vector<std::complex<double>, Pennylane::Util::AlignedAllocator<std::complex<double> > >::vector(unsigned long, std::complex<double> const&, Pennylane::Util::AlignedAllocator<std::complex<double> > const&) (in /home/eo/Code/catalyst-latest/runtime/build/lib/backend/librt_backend.so)
| ->33.33% (536,870,912B) 0x48F6593: Pennylane::StateVectorDynamicCPU<double>::StateVectorDynamicCPU(unsigned long, Pennylane::Threading, Pennylane::CPUMemoryModel) (in /home/eo/Code/catalyst-latest/runtime/build/lib/backend/librt_backend.so)
|   ->33.33% (536,870,912B) 0x48F04BA: Catalyst::Runtime::Simulator::LightningSimulator::AllocateQubits(unsigned long) (in /home/eo/Code/catalyst-latest/runtime/build/lib/backend/librt_backend.so)
|   | ->33.33% (536,870,912B) 0x4A3EB65: __quantum__rt__qubit_allocate_array (in /home/eo/Code/catalyst-latest/runtime/build/lib/capi/librt_capi.so)
|   |   ->33.33% (536,870,912B) 0x1093A7: main (a.c:44)
|   |     
|   ->00.00% (0B) in 1+ places, all below ms_print's threshold (01.00%)
|   
->33.33% (536,870,912B) 0x4A3E5CD: _mlir_memref_to_llvm_alloc (in /home/eo/Code/catalyst-latest/runtime/build/lib/capi/librt_capi.so)
| ->33.33% (536,870,912B) 0x109388: main (a.c:40)
|   
->00.01% (150,354B) in 1+ places, all below ms_print's threshold (01.00%)

```

The first callsite is the temporary vector used to pass results from PL-lightning library to the C-API runtime. The second callsite to the aligned allocator in PL-lightning. The third one is the memory requested in the main function to hold the result values.


**Description of the Change:** This is just a WIP to find other possible redundant copies. The changes involve passing the data pointer directly to the memref for copying. After this change, the same program shows the following memory profile:

```
    GB
1.000^                            ########################################### 
     |                            #                                           
     |                            #                                           
     |                            #                                           
     |                            #                                           
     |                            #                                           
     |                            #                                           
     |                            #                                           
     |                            #                                           
     |                            #                                           
     |  @@@@@@@@@@@@@@@@@@@@@@@@@@#                                          :
     |  @                         #                                          :
     |  @                         #                                          :
     |  @                         #                                          :
     |  @                         #                                          :
     |  @                         #                                          :
     |  @                         #                                          :
     |  @                         #                                          :
     |  @                         #                                          :
     |  @                         #                                          :
   0 +----------------------------------------------------------------------->Mi
     0                                                                   241.1
```

```
100.00% (1,073,892,930B) (heap allocation functions) malloc/new/new[], --alloc-fns, etc.
->49.99% (536,870,944B) 0x48F6619: std::vector<std::complex<double>, Pennylane::Util::AlignedAllocator<std::complex<double> > >::vector(unsigned long, std::complex<double> const&, Pennylane::Util::AlignedAllocator<std::complex<double> > const&) (in /home/eo/Code/catalyst-latest/runtime/build/lib/backend/librt_backend.so)
| ->49.99% (536,870,944B) 0x48F64F3: Pennylane::StateVectorDynamicCPU<double>::StateVectorDynamicCPU(unsigned long, Pennylane::Threading, Pennylane::CPUMemoryModel) (in /home/eo/Code/catalyst-latest/runtime/build/lib/backend/librt_backend.so)
|   ->49.99% (536,870,912B) 0x48F04BA: Catalyst::Runtime::Simulator::LightningSimulator::AllocateQubits(unsigned long) (in /home/eo/Code/catalyst-latest/runtime/build/lib/backend/librt_backend.so)
|   | ->49.99% (536,870,912B) 0x4A3EB65: __quantum__rt__qubit_allocate_array (in /home/eo/Code/catalyst-latest/runtime/build/lib/capi/librt_capi.so)
|   |   ->49.99% (536,870,912B) 0x1093B0: main (a.c:44)
|   |     
|   ->00.00% (32B) in 1+ places, all below ms_print's threshold (01.00%)
|   
->49.99% (536,870,912B) 0x4A3E5CD: _mlir_memref_to_llvm_alloc (in /home/eo/Code/catalyst-latest/runtime/build/lib/capi/librt_capi.so)
| ->49.99% (536,870,912B) 0x109391: main (a.c:40)
|   
->00.01% (151,074B) in 1+ places, all below ms_print's threshold (01.00%)
```

**Benefits:** Less time spent copying data, less memory usage. 
