### PR TITLE
[Frontend] Remove unnecessary memory allocation.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -25,6 +25,9 @@
 * Fix a bug in the way gradient result type is inferred.
   [#84](https://github.com/PennyLaneAI/catalyst/pull/84)
 
+* Fix a memory regression and reduce memory footprint by removing unnecessary temporary buffers.
+  [#100](https://github.com/PennyLaneAI/catalyst/pull/100)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -29,6 +29,9 @@ from mlir_quantum.runtime import (
     get_ranked_memref_descriptor,
     ranked_memref_to_numpy,
     to_numpy,
+    as_ctype,
+    make_nd_memref_descriptor,
+    make_zero_d_memref_descriptor,
 )
 
 from catalyst.utils.gen_mlir import inject_functions
@@ -334,8 +337,12 @@ class CompiledFunction:
         shape = ir.RankedTensorType(mlir_tensor_type).shape
         mlir_element_type = ir.RankedTensorType(mlir_tensor_type).element_type
         numpy_element_type = mlir_type_to_numpy_type(mlir_element_type)
-        array_numpy_type = np.empty(shape, dtype=numpy_element_type)
-        memref_descriptor = get_ranked_memref_descriptor(array_numpy_type)
+        ctp = as_ctype(numpy_element_type)
+        if shape:
+            memref_descriptor = make_nd_memref_descriptor(len(shape), ctp)()
+        else:
+            memref_descriptor = make_zero_d_memref_descriptor(ctp)()
+
         return memref_descriptor
 
     @staticmethod

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -209,7 +209,7 @@ class MLIRToLLVMDialect(PassPipeline):
         # Must be run after -convert-math-to-llvm as it marks math::powf illegal but doesn't convert it.
         "--convert-math-to-libm",
         "--convert-arith-to-llvm",
-        "--convert-memref-to-llvm",
+        "--convert-memref-to-llvm=use-generic-functions",
         "--convert-index-to-llvm",
         "--convert-gradient-to-llvm",
         "--convert-quantum-to-llvm",


### PR DESCRIPTION
**Context:** The frontend was allocating unnecessary memory for temporary numpy arrays that were never initialized but were used as inputs to another function. By having this unnecessary memory allocation it would increase unnecessarily the peak memory utilization by the amount returned by the generated function. When the function is returned, then this can add another 1x, which adds up with other copies.

EDIT: Also corrects regression introduced by #38 that removed the custom memory management function lowerings.

**Description of the Change:** Instead of allocating unnecessary memory for temporary numpy arrays, obtain the memref type descriptor without initializing them.

**Benefits:** Less memory usage.

Note, this is analogous to #91 but in the front-end and not in the runtime.

Profiled with scalene shows this issue. 
