### PR TITLE
[Runtime] Avoid extra buffer copies in QuantumDevice

### DIFF
--- a/runtime/examples/probs_qfunc.ll
+++ b/runtime/examples/probs_qfunc.ll
@@ -70,14 +70,14 @@ define i32 @main() {
   call void @__quantum__qis__RY(%Qubit* %4, double 0.7, i8 0)
 
   ; Allocate buffers
-  %buffer_allocated = call i8* @aligned_alloc(i64 8, i64 32)
+  %buffer_allocated = call i8* @aligned_alloc(i64 32, i64 32)
   %buffer_cast = bitcast i8* %buffer_allocated to double*
 
   ; Insert buffers into result structure
   %t0 = insertvalue %struct.MemRefT undef, double* %buffer_cast, 0
   %t1 = insertvalue %struct.MemRefT %t0, double* %buffer_cast, 1
   %t2 = insertvalue %struct.MemRefT %t1, i64 0, 2
-  %t3 = insertvalue %struct.MemRefT %t2, i64 2, 3, 0
+  %t3 = insertvalue %struct.MemRefT %t2, i64 4, 3, 0
   %memref = insertvalue %struct.MemRefT %t3, i64 1, 4, 0
   %memref_ptr = alloca %struct.MemRefT, i64 1, align 8
   store %struct.MemRefT %memref, %struct.MemRefT* %memref_ptr, align 8

--- a/runtime/examples/state_qfunc.ll
+++ b/runtime/examples/state_qfunc.ll
@@ -66,14 +66,14 @@ define i32 @main() {
   call void @__quantum__qis__RY(%Qubit* %4, double 0.7, i8 0)
 
   ; Allocate buffers
-  %5 = call i8* @aligned_alloc(i64 8, i64 64)
+  %5 = call i8* @aligned_alloc(i64 32, i64 64)
   %buffer_cast = bitcast i8* %5 to %struct.CplxT*
 
   ; Insert buffers into result structure
   %t0 = insertvalue %struct.MemRefT undef, %struct.CplxT* %buffer_cast, 0
   %t1 = insertvalue %struct.MemRefT %t0, %struct.CplxT* %buffer_cast, 1
   %t2 = insertvalue %struct.MemRefT %t1, i64 0, 2
-  %t3 = insertvalue %struct.MemRefT %t2, i64 2, 3, 0
+  %t3 = insertvalue %struct.MemRefT %t2, i64 4, 3, 0
   %memref = insertvalue %struct.MemRefT %t3, i64 1, 4, 0
   %6= alloca %struct.MemRefT, i64 1, align 8
   store %struct.MemRefT %memref, %struct.MemRefT* %6, align 8

--- a/runtime/include/QuantumDevice.hpp
+++ b/runtime/include/QuantumDevice.hpp
@@ -18,6 +18,8 @@
 #include <memory>
 #include <vector>
 
+#include <span> // --std=c++20
+
 #include "Types.h"
 
 namespace Catalyst::Runtime {
@@ -197,69 +199,76 @@ struct QuantumDevice {
     /**
      * @brief Compute the probabilities of each computational basis state.
      *
-     * @return `std::vector<double>`
+     * @param probs Pointer to the first element of a pre-allocated contiguous
+     * sequence of `double`s in the form of `std::span<double>` representing probs
      */
-    virtual auto Probs() -> std::vector<double> = 0;
+    virtual void Probs(std::span<double> probs) = 0;
 
     /**
      * @brief Compute the probabilities for a subset of the full system.
      *
+     * @param probs Pointer to the first element of a pre-allocated contiguous
+     * sequence of `double`s in the form of `std::span<double>` representing partial-probs
      * @param wires Wires will restrict probabilities to a subset of the full system
-     *
-     * @return `std::vector<double>`
      */
-    virtual auto PartialProbs(const std::vector<QubitIdType> &wires) -> std::vector<double> = 0;
+    virtual void PartialProbs(std::span<double> probs, const std::vector<QubitIdType> &wires) = 0;
 
     /**
      * @brief Get the state-vector of a device.
      *
-     * @return `std::vector<std::complex<double>>`
+     * @param state Pointer to the first element of a pre-allocated contiguous
+     * sequence of complex numbers in the form of `std::span<std::complex<double>>`
+     * representing the state vector
      */
-    virtual auto State() -> std::vector<std::complex<double>> = 0;
+    virtual void State(std::span<std::complex<double>> state) = 0;
 
     /**
      * @brief Compute samples with the number of shots on the entire wires,
      * returing raw samples.
      *
+     * @param samples Pointer to the first element of a pre-allocated contiguous
+     * sequence of `double`s in the form of `std::span<double>` representing samples
      * @param shots The number of shots
-     *
-     * @return `std::vector<double>`
      */
-    virtual auto Sample(size_t shots) -> std::vector<double> = 0;
+    virtual void Sample(std::span<double> samples, size_t shots) = 0;
 
     /**
      * @brief Compute partial samples with the number of shots on `wires`,
      * returing raw samples.
      *
+     * @param samples Pointer to the first element of a pre-allocated contiguous
+     * sequence of `double`s in the form of `std::span<double>` representing partial-samples
      * @param wires Wires to compute samples on
      * @param shots The number of shots
-     *
-     * @return `std::vector<double>`
      */
-    virtual auto PartialSample(const std::vector<QubitIdType> &wires, size_t shots)
-        -> std::vector<double> = 0;
+    virtual void PartialSample(std::span<double> samples, const std::vector<QubitIdType> &wires,
+                               size_t shots) = 0;
 
     /**
      * @brief Sample with the number of shots on the entire wires, returning the
      * number of counts for each sample.
      *
+     * @param eigvals Pointer to the first element of a pre-allocated contiguous
+     * sequence of `double`s in the form of `std::span<double>` representing eigvals
+     * @param counts Pointer to the first element of a pre-allocated contiguous
+     * sequence of `int64_t`s in the form of `std::span<int64_t>` representing counts
      * @param shots The number of shots
-     *
-     * @return `std::tuple<std::vector<double>, std::vector<int64_t>>` (eigvals, counts)
      */
-    virtual auto Counts(size_t shots) -> std::tuple<std::vector<double>, std::vector<int64_t>> = 0;
+    virtual void Counts(std::span<double> eigvals, std::span<int64_t> counts, size_t shots) = 0;
 
     /**
      * @brief Partial sample with the number of shots on `wires`, returning the
      * number of counts for each sample.
      *
+     * @param eigvals Pointer to the first element of a pre-allocated contiguous
+     * sequence of `double`s in the form of `std::span<double>` representing partial-eigvals
+     * @param counts Pointer to the first element of a pre-allocated contiguous
+     * sequence of `int64_t`s in the form of `std::span<int64_t>` representing partial-counts
      * @param wires Wires to compute samples on
      * @param shots The number of shots
-     *
-     * @return `std::tuple<std::vector<double>, std::vector<int64_t>>` (eigvals, counts)
      */
-    virtual auto PartialCounts(const std::vector<QubitIdType> &wires, size_t shots)
-        -> std::tuple<std::vector<double>, std::vector<int64_t>> = 0;
+    virtual void PartialCounts(std::span<double> eigvals, std::span<int64_t> counts,
+                               const std::vector<QubitIdType> &wires, size_t shots) = 0;
 
     /**
      * @brief A general measurement method that acts on a single wire.

--- a/runtime/lib/backend/LightningKokkosSimulator.hpp
+++ b/runtime/lib/backend/LightningKokkosSimulator.hpp
@@ -135,15 +135,15 @@ class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
         -> ObsIdType override;
     auto Expval(ObsIdType obsKey) -> double override;
     auto Var(ObsIdType obsKey) -> double override;
-    auto State() -> std::vector<std::complex<double>> override;
-    auto Probs() -> std::vector<double> override;
-    auto PartialProbs(const std::vector<QubitIdType> &wires) -> std::vector<double> override;
-    auto Sample(size_t shots) -> std::vector<double> override;
-    auto PartialSample(const std::vector<QubitIdType> &wires, size_t shots)
-        -> std::vector<double> override;
-    auto Counts(size_t shots) -> std::tuple<std::vector<double>, std::vector<int64_t>> override;
-    auto PartialCounts(const std::vector<QubitIdType> &wires, size_t shots)
-        -> std::tuple<std::vector<double>, std::vector<int64_t>> override;
+    void State(std::span<std::complex<double>> state) override;
+    void Probs(std::span<double> probs) override;
+    void PartialProbs(std::span<double> probs, const std::vector<QubitIdType> &wires) override;
+    void Sample(std::span<double> samples, size_t shots) override;
+    void PartialSample(std::span<double> samples, const std::vector<QubitIdType> &wires,
+                       size_t shots) override;
+    void Counts(std::span<double> eigvals, std::span<int64_t> counts, size_t shots) override;
+    void PartialCounts(std::span<double> eigvals, std::span<int64_t> counts,
+                       const std::vector<QubitIdType> &wires, size_t shots) override;
     auto Measure(QubitIdType wire) -> Result override;
     auto Gradient(const std::vector<size_t> &trainParams)
         -> std::vector<std::vector<double>> override;

--- a/runtime/lib/backend/LightningSimulator.cpp
+++ b/runtime/lib/backend/LightningSimulator.cpp
@@ -211,20 +211,26 @@ auto LightningSimulator::Var(ObsIdType obsKey) -> double
     return result;
 }
 
-auto LightningSimulator::State() -> std::vector<std::complex<double>>
+void LightningSimulator::State(std::span<std::complex<double>> state)
 {
-    auto &&state = this->device_sv->getDataVector();
-    return std::vector<std::complex<double>>(state.begin(), state.end());
+    RT_ASSERT(!state.empty());
+    auto &&dv_state = this->device_sv->getDataVector();
+    RT_FAIL_IF(state.size() != dv_state.size(), "Invalid size for the pre-allocated state vector");
+
+    std::move(dv_state.begin(), dv_state.end(), state.begin());
 }
 
-auto LightningSimulator::Probs() -> std::vector<double>
+void LightningSimulator::Probs(std::span<double> probs)
 {
     Pennylane::Simulators::Measures m{*(this->device_sv)};
+    auto &&dv_probs = m.probs();
+    RT_FAIL_IF(probs.size() != dv_probs.size(), "Invalid size for the pre-allocated probabilities");
 
-    return m.probs();
+    std::move(dv_probs.begin(), dv_probs.end(), probs.begin());
 }
 
-auto LightningSimulator::PartialProbs(const std::vector<QubitIdType> &wires) -> std::vector<double>
+void LightningSimulator::PartialProbs(std::span<double> probs,
+                                      const std::vector<QubitIdType> &wires)
 {
     const size_t numWires = wires.size();
     const size_t numQubits = this->GetNumQubits();
@@ -234,11 +240,15 @@ auto LightningSimulator::PartialProbs(const std::vector<QubitIdType> &wires) -> 
 
     auto dev_wires = getDeviceWires(wires);
     Pennylane::Simulators::Measures m{*(this->device_sv)};
+    auto &&dv_probs = m.probs(dev_wires);
 
-    return m.probs(dev_wires);
+    RT_FAIL_IF(probs.size() != dv_probs.size(),
+               "Invalid size for the pre-allocated partial-probabilities");
+
+    std::move(dv_probs.begin(), dv_probs.end(), probs.begin());
 }
 
-auto LightningSimulator::Sample(size_t shots) -> std::vector<double>
+void LightningSimulator::Sample(std::span<double> samples, size_t shots)
 {
     // generate_samples is a member function of the Measures class.
     Pennylane::Simulators::Measures m{*(this->device_sv)};
@@ -250,6 +260,8 @@ auto LightningSimulator::Sample(size_t shots) -> std::vector<double>
     // the number of qubits.
     auto &&li_samples = m.generate_samples(shots);
 
+    RT_FAIL_IF(samples.size() != li_samples.size(), "Invalid size for the pre-allocated samples");
+
     const size_t numQubits = this->GetNumQubits();
 
     // The lightning samples are layed out as a single vector of size
@@ -257,25 +269,24 @@ auto LightningSimulator::Sample(size_t shots) -> std::vector<double>
     // corresponding shape is (shots, qubits). Gather the desired bits
     // corresponding to the input wires into a bitstring.
     // TODO: matrix transpose
-    std::vector<double> samples(li_samples.size());
     for (size_t shot = 0; shot < shots; shot++) {
         for (size_t wire = 0; wire < numQubits; wire++) {
             samples[shot * numQubits + wire] =
                 static_cast<double>(li_samples[shot * numQubits + wire]);
         }
     }
-
-    return samples;
 }
 
-auto LightningSimulator::PartialSample(const std::vector<QubitIdType> &wires, size_t shots)
-    -> std::vector<double>
+void LightningSimulator::PartialSample(std::span<double> samples,
+                                       const std::vector<QubitIdType> &wires, size_t shots)
 {
     const size_t numWires = wires.size();
     const size_t numQubits = this->GetNumQubits();
 
     RT_FAIL_IF(numWires > numQubits, "Invalid number of wires");
     RT_FAIL_IF(!isValidQubits(wires), "Invalid given wires to measure");
+    RT_FAIL_IF(samples.size() != shots * numWires,
+               "Invalid size for the pre-allocated partial-samples");
 
     // get device wires
     auto &&dev_wires = getDeviceWires(wires);
@@ -295,7 +306,6 @@ auto LightningSimulator::PartialSample(const std::vector<QubitIdType> &wires, si
     // corresponding shape is (shots, qubits). Gather the desired bits
     // corresponding to the input wires into a bitstring.
     // TODO: matrix transpose
-    std::vector<double> samples(shots * numWires);
     for (size_t shot = 0; shot < shots; shot++) {
         size_t idx = 0;
         for (auto wire : dev_wires) {
@@ -303,13 +313,16 @@ auto LightningSimulator::PartialSample(const std::vector<QubitIdType> &wires, si
                 static_cast<double>(li_samples[shot * numQubits + wire]);
         }
     }
-
-    return samples;
 }
 
-auto LightningSimulator::Counts(size_t shots)
-    -> std::tuple<std::vector<double>, std::vector<int64_t>>
+void LightningSimulator::Counts(std::span<double> eigvals, std::span<int64_t> counts, size_t shots)
 {
+    const size_t numQubits = this->GetNumQubits();
+    const size_t numElements = 1U << numQubits;
+
+    RT_FAIL_IF(eigvals.size() != numElements, "Invalid size for the pre-allocated eigvals");
+    RT_FAIL_IF(counts.size() != numElements, "Invalid size for the pre-allocated counts");
+
     // generate_samples is a member function of the Measures class.
     Pennylane::Simulators::Measures m{*(this->device_sv)};
 
@@ -324,12 +337,8 @@ auto LightningSimulator::Counts(size_t shots)
     // computational basis bitstring. In the future, eigenvalues can also be
     // obtained from an observable, hence the bitstring integer is stored as a
     // double.
-    const size_t numQubits = this->GetNumQubits();
-    const size_t numElements = 1U << numQubits;
-    std::vector<double> eigvals(numElements);
     std::iota(eigvals.begin(), eigvals.end(), 0);
-    eigvals.reserve(numElements);
-    std::vector<int64_t> counts(numElements);
+    std::fill(counts.begin(), counts.end(), 0);
 
     // The lightning samples are layed out as a single vector of size
     // shots*qubits, where each element represents a single bit. The
@@ -343,18 +352,19 @@ auto LightningSimulator::Counts(size_t shots)
         }
         counts[basisState.to_ulong()] += 1;
     }
-
-    return {eigvals, counts};
 }
 
-auto LightningSimulator::PartialCounts(const std::vector<QubitIdType> &wires, size_t shots)
-    -> std::tuple<std::vector<double>, std::vector<int64_t>>
+void LightningSimulator::PartialCounts(std::span<double> eigvals, std::span<int64_t> counts,
+                                       const std::vector<QubitIdType> &wires, size_t shots)
 {
     const size_t numWires = wires.size();
     const size_t numQubits = this->GetNumQubits();
+    const size_t numElements = 1U << numWires;
 
     RT_FAIL_IF(numWires > numQubits, "Invalid number of wires");
     RT_FAIL_IF(!isValidQubits(wires), "Invalid given wires to measure");
+    RT_FAIL_IF(eigvals.size() != numElements, "Invalid size for the pre-allocated partial-eigvals");
+    RT_FAIL_IF(counts.size() != numElements, "Invalid size for the pre-allocated partial-counts");
 
     // get device wires
     auto &&dev_wires = getDeviceWires(wires);
@@ -373,11 +383,8 @@ auto LightningSimulator::PartialCounts(const std::vector<QubitIdType> &wires, si
     // computational basis bitstring. In the future, eigenvalues can also be
     // obtained from an observable, hence the bitstring integer is stored as a
     // double.
-    const size_t numElements = 1U << numWires;
-    std::vector<double> eigvals(numElements);
     std::iota(eigvals.begin(), eigvals.end(), 0);
-    eigvals.reserve(numElements);
-    std::vector<int64_t> counts(numElements);
+    std::fill(counts.begin(), counts.end(), 0);
 
     // The lightning samples are layed out as a single vector of size
     // shots*qubits, where each element represents a single bit. The
@@ -391,15 +398,14 @@ auto LightningSimulator::PartialCounts(const std::vector<QubitIdType> &wires, si
         }
         counts[basisState.to_ulong()] += 1;
     }
-
-    return {eigvals, counts};
 }
 
 auto LightningSimulator::Measure(QubitIdType wire) -> Result
 {
     // get a measurement
     std::vector<QubitIdType> wires = {reinterpret_cast<QubitIdType>(wire)};
-    auto &&probs = this->PartialProbs(wires);
+    std::vector<double> probs(1U << wires.size());
+    this->PartialProbs(probs, wires);
 
     std::random_device rd;
     std::mt19937 gen(rd());

--- a/runtime/lib/backend/LightningSimulator.hpp
+++ b/runtime/lib/backend/LightningSimulator.hpp
@@ -27,7 +27,6 @@ throw std::logic_error("StateVectorDynamicCPU.hpp: No such header file");
 #include <limits>
 #include <numeric>
 #include <random>
-#include <span>
 
 #include "AdjointDiff.hpp"
 #include "JacobianTape.hpp"
@@ -137,15 +136,15 @@ class LightningSimulator final : public Catalyst::Runtime::QuantumDevice {
         -> ObsIdType override;
     auto Expval(ObsIdType obsKey) -> double override;
     auto Var(ObsIdType obsKey) -> double override;
-    auto State() -> std::vector<std::complex<double>> override;
-    auto Probs() -> std::vector<double> override;
-    auto PartialProbs(const std::vector<QubitIdType> &wires) -> std::vector<double> override;
-    auto Sample(size_t shots) -> std::vector<double> override;
-    auto PartialSample(const std::vector<QubitIdType> &wires, size_t shots)
-        -> std::vector<double> override;
-    auto Counts(size_t shots) -> std::tuple<std::vector<double>, std::vector<int64_t>> override;
-    auto PartialCounts(const std::vector<QubitIdType> &wires, size_t shots)
-        -> std::tuple<std::vector<double>, std::vector<int64_t>> override;
+    void State(std::span<std::complex<double>> state) override;
+    void Probs(std::span<double> probs) override;
+    void PartialProbs(std::span<double> probs, const std::vector<QubitIdType> &wires) override;
+    void Sample(std::span<double> samples, size_t shots) override;
+    void PartialSample(std::span<double> samples, const std::vector<QubitIdType> &wires,
+                       size_t shots) override;
+    void Counts(std::span<double> eigvals, std::span<int64_t> counts, size_t shots) override;
+    void PartialCounts(std::span<double> eigvals, std::span<int64_t> counts,
+                       const std::vector<QubitIdType> &wires, size_t shots) override;
     auto Measure(QubitIdType wire) -> Result override;
     auto Gradient(const std::vector<size_t> &trainParams)
         -> std::vector<std::vector<double>> override;

--- a/runtime/lib/capi/Driver.hpp
+++ b/runtime/lib/capi/Driver.hpp
@@ -53,6 +53,7 @@ class MemoryManager final {
 class Driver final {
   private:
     using DeviceInitializer = std::function<std::unique_ptr<QuantumDevice>(bool, size_t)>;
+
     std::unordered_map<std::string_view, DeviceInitializer> _device_map{
 #ifdef __device_lightning
         {"lightning.qubit",

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -699,8 +699,6 @@ void __quantum__qis__Probs(MemRefT_double_1d *result, int64_t numQubits, ...)
         Catalyst::Runtime::CAPI::DRIVER->get_device()->PartialProbs(
             std::span{result_p->data_allocated, result_p->sizes[0]}, wires);
     }
-
-    result_p->data_aligned = result_p->data_allocated;
 }
 
 void __quantum__qis__State(MemRefT_CplxT_double_1d *result, int64_t numQubits, ...)
@@ -723,7 +721,6 @@ void __quantum__qis__State(MemRefT_CplxT_double_1d *result, int64_t numQubits, .
     if (wires.empty()) {
         Catalyst::Runtime::CAPI::DRIVER->get_device()->State(
             std::span{result_p->data_allocated, result_p->sizes[0]});
-        result_p->data_aligned = result_p->data_allocated;
     }
     else {
         RT_FAIL("Partial State-Vector not supported yet");
@@ -760,8 +757,6 @@ void __quantum__qis__Sample(MemRefT_double_2d *result, int64_t shots, int64_t nu
             std::span{result_p->data_allocated, result_p->sizes[0] * result_p->sizes[1]}, wires,
             shots);
     }
-
-    result_p->data_aligned = result_p->data_allocated;
 }
 
 void __quantum__qis__Counts(PairT_MemRefT_double_int64_1d *result, int64_t shots, int64_t numQubits,
@@ -796,8 +791,5 @@ void __quantum__qis__Counts(PairT_MemRefT_double_int64_1d *result, int64_t shots
             std::span{result_eigvals_p->data_allocated, result_eigvals_p->sizes[0]},
             std::span{result_counts_p->data_allocated, result_counts_p->sizes[0]}, wires, shots);
     }
-
-    result_eigvals_p->data_aligned = result_eigvals_p->data_allocated;
-    result_counts_p->data_aligned = result_counts_p->data_allocated;
 }
 }

--- a/runtime/tests/Test_LightningCoreQIS.cpp
+++ b/runtime/tests/Test_LightningCoreQIS.cpp
@@ -1123,8 +1123,8 @@ TEST_CASE("Test __quantum__qis__Counts with num_qubits=2 calling Hadamard, Contr
 
     PairT_MemRefT_double_int64_1d result = getCounts(4);
     __quantum__qis__Counts(&result, shots, 0);
-    int64_t *counts = result.second.data_allocated;
     double *eigvals = result.first.data_allocated;
+    int64_t *counts = result.second.data_allocated;
 
     for (int i = 0; i < 4; i++) {
         CHECK(eigvals[i] == (double)i);
@@ -1166,8 +1166,8 @@ TEST_CASE("Test __quantum__qis__Counts with num_qubits=2 PartialCounts calling H
 
     PairT_MemRefT_double_int64_1d result = getCounts(2);
     __quantum__qis__Counts(&result, shots, 1, ctrls[0]);
-    int64_t *counts = result.second.data_allocated;
     double *eigvals = result.first.data_allocated;
+    int64_t *counts = result.second.data_allocated;
 
     CHECK(counts[0] + counts[1] == shots);
     CHECK(eigvals[0] + 1 == eigvals[1]);

--- a/runtime/tests/Test_LightningDriver.cpp
+++ b/runtime/tests/Test_LightningDriver.cpp
@@ -48,7 +48,9 @@ TEST_CASE("lightning Basis vector", "[lightning]")
 
     sim->ReleaseQubit(q);
 
-    auto state = sim->State();
+    std::vector<std::complex<double>> state(1U << sim->GetNumQubits());
+    sim->State(std::span{state});
+
     CHECK(state[0].real() == Approx(1.0).epsilon(1e-5));
     CHECK(state[0].imag() == Approx(0.0).epsilon(1e-5));
     CHECK(state[1].real() == Approx(0.0).epsilon(1e-5));
@@ -73,7 +75,8 @@ TEST_CASE("Qubit allocatation and deallocation", "[lightning]")
 
     CHECK(n == static_cast<size_t>(q) + 1);
 
-    std::vector<std::complex<double>> state = sim->State();
+    std::vector<std::complex<double>> state(1U << sim->GetNumQubits());
+    sim->State(std::span{state});
 
     CHECK(state.size() == (1UL << n));
     CHECK(state[0].real() == Approx(1.0).epsilon(1e-5));
@@ -93,7 +96,8 @@ TEST_CASE("Qubit allocatation and deallocation", "[lightning]")
 
         sim->ReleaseQubit(i - 1);
         sim->AllocateQubit();
-        state = sim->State();
+        std::vector<std::complex<double>> state(1U << sim->GetNumQubits());
+        sim->State(std::span{state});
     }
 #else
     for (size_t i = n; i > 0; i--) {
@@ -112,7 +116,8 @@ TEST_CASE("test AllocateQubits", "[lightning]")
 
     sim->ReleaseQubit(q[0]);
 
-    auto state = sim->State();
+    std::vector<std::complex<double>> state(1U << sim->GetNumQubits());
+    sim->State(std::span{state});
     CHECK(state[0].real() == Approx(1.0).epsilon(1e-5));
 }
 
@@ -180,7 +185,8 @@ TEST_CASE("QuantumDevice object test", "[lightning]")
     sim->NamedOperation("Identity", {}, {Qs[6]}, false);
     sim->NamedOperation("Identity", {}, {Qs[8]}, false);
 
-    std::vector<std::complex<double>> out_state = sim->State();
+    std::vector<std::complex<double>> out_state(1U << sim->GetNumQubits());
+    sim->State(std::span{out_state});
 
     CHECK(out_state[0].real() == Approx(1.0).epsilon(1e-5));
     CHECK(out_state[0].imag() == Approx(0.0).epsilon(1e-5));

--- a/runtime/tests/Test_LightningGateSet.cpp
+++ b/runtime/tests/Test_LightningGateSet.cpp
@@ -49,7 +49,8 @@ TEST_CASE("Identity Gate tests", "[lightning]")
     sim->NamedOperation("Identity", {}, {Qs[6]}, false);
     sim->NamedOperation("Identity", {}, {Qs[8]}, false);
 
-    std::vector<std::complex<double>> out_state = sim->State();
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     CHECK(out_state.at(0) == std::complex<double>{1, 0});
 
@@ -76,7 +77,8 @@ TEST_CASE("PauliX Gate tests num_qubits=1", "[lightning]")
 
     sim->NamedOperation("PauliX", {}, {Qs[0]}, false);
 
-    std::vector<std::complex<double>> out_state = sim->State();
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     CHECK(out_state.at(0) == std::complex<double>{0, 0});
     CHECK(out_state.at(1) == std::complex<double>{1, 0});
@@ -104,7 +106,8 @@ TEST_CASE("PauliX Gate tests num_qubits=3", "[lightning]")
     sim->NamedOperation("PauliX", {}, {Qs[1]}, false);
     sim->NamedOperation("PauliX", {}, {Qs[0]}, false);
 
-    std::vector<std::complex<double>> out_state = sim->State();
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     CHECK(out_state.at(0) == std::complex<double>{1, 0});
 
@@ -131,7 +134,8 @@ TEST_CASE("PauliY Gate tests num_qubits=1", "[lightning]")
 
     sim->NamedOperation("PauliY", {}, {Qs[0]}, false);
 
-    std::vector<std::complex<double>> out_state = sim->State();
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     CHECK(out_state.at(0) == std::complex<double>{0, 0});
     CHECK(out_state.at(1) == std::complex<double>{0, 1});
@@ -153,7 +157,8 @@ TEST_CASE("PauliY Gate tests num_qubits=2", "[lightning]")
     sim->NamedOperation("PauliY", {}, {Qs[0]}, false);
     sim->NamedOperation("PauliY", {}, {Qs[1]}, false);
 
-    std::vector<std::complex<double>> out_state = sim->State();
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     CHECK(out_state.at(0) == std::complex<double>{0, 0});
     CHECK(out_state.at(1) == std::complex<double>{0, 0});
@@ -177,7 +182,8 @@ TEST_CASE("PauliZ Gate tests num_qubits=2", "[lightning]")
     sim->NamedOperation("PauliY", {}, {Qs[0]}, false);
     sim->NamedOperation("PauliZ", {}, {Qs[1]}, false);
 
-    std::vector<std::complex<double>> out_state = sim->State();
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     CHECK(out_state.at(0) == std::complex<double>{0, 0});
     CHECK(out_state.at(1) == std::complex<double>{0, 0});
@@ -201,7 +207,8 @@ TEST_CASE("Hadamard Gate tests num_qubits=2", "[lightning]")
     sim->NamedOperation("Hadamard", {}, {Qs[0]}, false);
     sim->NamedOperation("Hadamard", {}, {Qs[1]}, false);
 
-    std::vector<std::complex<double>> out_state = sim->State();
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     CHECK(out_state[0].real() == Approx(0.5).epsilon(1e-5));
     CHECK(out_state[0].imag() == Approx(0).epsilon(1e-5));
@@ -226,7 +233,8 @@ TEST_CASE("Hadamard Gate tests num_qubits=3", "[lightning]")
     sim->NamedOperation("Hadamard", {}, {Qs[0]}, false);
     sim->NamedOperation("Hadamard", {}, {Qs[1]}, false);
 
-    std::vector<std::complex<double>> out_state = sim->State();
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     CHECK(out_state[0].real() == Approx(0.5).epsilon(1e-5));
     CHECK(out_state[0].imag() == Approx(0).epsilon(1e-5));
@@ -249,7 +257,8 @@ TEST_CASE("MIX Gate test R(X,Y,Z) num_qubits=1,4", "[lightning]")
     sim->NamedOperation("RY", {0.456}, {Qs[2]}, false);
     sim->NamedOperation("RZ", {0.789}, {Qs[3]}, false);
 
-    const auto &&out_state = sim->State();
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     // calculated by pennylane,
     CHECK(out_state.at(0) == std::complex<double>{0, 0});
@@ -297,7 +306,8 @@ TEST_CASE("test PhaseShift num_qubits=2", "[lightning]")
     sim->NamedOperation("RX", {0.123}, {Qs[1]}, false);
     sim->NamedOperation("PhaseShift", {0.456}, {Qs[0]}, false);
 
-    std::vector<std::complex<double>> out_state = sim->State();
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     // calculated by pennylane,
     CHECK(out_state[0].real() == Approx(0.7057699753).epsilon(1e-5));
@@ -330,7 +340,8 @@ TEST_CASE("CNOT Gate tests num_qubits=2 [0,1]", "[lightning]")
     sim->NamedOperation("PauliX", {}, {Qs[0]}, false);
     sim->NamedOperation("CNOT", {}, {Qs[0], Qs[1]}, false);
 
-    std::vector<std::complex<double>> out_state = sim->State();
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     CHECK(out_state.at(0) == std::complex<double>{0, 0});
     CHECK(out_state.at(1) == std::complex<double>{0, 0});
@@ -354,7 +365,8 @@ TEST_CASE("CNOT Gate tests num_qubits=2 [1,0]", "[lightning]")
     sim->NamedOperation("PauliX", {}, {Qs[0]}, false);
     sim->NamedOperation("CNOT", {}, {Qs[1], Qs[0]}, false);
 
-    std::vector<std::complex<double>> out_state = sim->State();
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     CHECK(out_state.at(0) == std::complex<double>{0, 0});
     CHECK(out_state.at(1) == std::complex<double>{0, 0});
@@ -375,7 +387,8 @@ TEST_CASE("MIX Gate test CR(X, Y, Z) num_qubits=1,4", "[lightning]")
     sim->NamedOperation("CRY", {0.456}, {Qs[0], Qs[2]}, false);
     sim->NamedOperation("CRZ", {0.789}, {Qs[0], Qs[3]}, false);
 
-    const auto &&out_state = sim->State();
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     // calculated by pennylane,
     CHECK(out_state[0].real() == Approx(0.7071067811865475).epsilon(1e-5));
@@ -420,7 +433,9 @@ TEST_CASE("CRot", "[lightning]")
 
     sim->NamedOperation("Hadamard", {}, {Qs[0]}, false);
     sim->NamedOperation("CRot", {M_PI, M_PI_2, 0.5}, {Qs[0], Qs[1]}, false);
-    std::vector<std::complex<double>> out_state = sim->State();
+
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     CHECK(out_state[0].real() == Approx(0.7071067812).epsilon(1e-5));
     CHECK(out_state[0].imag() == Approx(0).epsilon(1e-5));
@@ -448,7 +463,9 @@ TEST_CASE("CSWAP test", "[lightning]")
     sim->NamedOperation("RX", {M_PI}, {Qs[0]}, false);
     sim->NamedOperation("RX", {M_PI}, {Qs[1]}, false);
     sim->NamedOperation("CSWAP", {}, {Qs[0], Qs[1], Qs[2]}, false);
-    std::vector<std::complex<double>> out_state = sim->State();
+
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     CHECK(out_state[5].real() == Approx(-1).epsilon(1e-5));
     CHECK(out_state[5].imag() == Approx(0).epsilon(1e-5));
@@ -472,7 +489,8 @@ TEST_CASE("IsingXY Gate tests num_qubits=2 [1,0]", "[lightning]")
     sim->NamedOperation("IsingXY", {0.2}, {Qs[1], Qs[0]}, false);
     sim->NamedOperation("SWAP", {}, {Qs[0], Qs[1]}, false);
 
-    std::vector<std::complex<double>> out_state = sim->State();
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     CHECK(out_state[0].real() == Approx(0.70710678).epsilon(1e-5));
     CHECK(out_state[0].imag() == Approx(0).epsilon(1e-5));
@@ -501,7 +519,8 @@ TEST_CASE("Toffoli test", "[lightning]")
     sim->NamedOperation("PauliX", {}, {Qs[1]}, false);
     sim->NamedOperation("Toffoli", {}, {Qs[0], Qs[1], Qs[2]}, false);
 
-    std::vector<std::complex<double>> out_state = sim->State();
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     CHECK(out_state.at(0) == std::complex<double>{0, 0});
     CHECK(out_state.at(1) == std::complex<double>{0, 0});
@@ -534,7 +553,9 @@ TEST_CASE("MultiRZ test", "[lightning]")
     sim->NamedOperation("MultiRZ", {M_PI}, {Qs[0], Qs[1]}, false);
     sim->NamedOperation("Hadamard", {}, {Qs[0]}, false);
     sim->NamedOperation("Hadamard", {}, {Qs[1]}, false);
-    std::vector<std::complex<double>> out_state = sim->State();
+
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     CHECK(out_state[2].real() == Approx(-1).epsilon(1e-5));
     CHECK(out_state[2].imag() == Approx(0).epsilon(1e-5));
@@ -565,7 +586,8 @@ TEST_CASE("MatrixOperation test with 2-qubit", "[lightning]")
     };
     sim->MatrixOperation(matrix, wires, false);
 
-    std::vector<std::complex<double>> out_state = sim->State();
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     CHECK(out_state[0].real() == Approx(-0.474432).epsilon(1e-5));
     CHECK(out_state[0].imag() == Approx(-0.44579).epsilon(1e-5));
@@ -609,7 +631,8 @@ TEST_CASE("MatrixOperation test with 3-qubit", "[lightning]")
     };
     sim->MatrixOperation(matrix, wires, false);
 
-    std::vector<std::complex<double>> out_state = sim->State();
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     CHECK(out_state[0].real() == Approx(0.349135).epsilon(1e-5));
     CHECK(out_state[0].imag() == Approx(0.180548).epsilon(1e-5));
@@ -709,7 +732,8 @@ TEST_CASE("MatrixOperation test with 4-qubit", "[lightning]")
     };
     sim->MatrixOperation(matrix, wires, false);
 
-    std::vector<std::complex<double>> out_state = sim->State();
+    std::vector<std::complex<double>> out_state(1U << n);
+    sim->State(std::span{out_state});
 
     CHECK(out_state[0].real() == Approx(-0.141499).epsilon(1e-5));
     CHECK(out_state[0].imag() == Approx(-0.230993).epsilon(1e-5));


### PR DESCRIPTION
**Context:**
This PR fixes the issue with unnecessary buffer copies between C and C++ APIs in the runtime using the C++20 `std::span` feature. This issue was investigated in PR #91 at first.

**Description of the Change:**
Fix the issue in the following methods,
- [X] `State`
- [X] `Probs`
- [X] `PartialProbs`
- [X] `Sample`
- [X] `PartialSample`
- [X] `Counts`
- [X] `PartialCounts`

**Benefits:**
By avoiding these extra buffer copies, we should be able to see some performance improvements and a better memory usage.

[sc-37584]