### PR TITLE
[Frontend] Support `else if` in `@cond`

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,6 +2,9 @@
 
 <h3>New features</h3>
 
+* Add support for `else if` chains for `@cond` conditionals
+  [#104](https://github.com/PennyLaneAI/catalyst/pull/104)
+
 <h3>Improvements</h3>
 
 * Improving error handling by throwing descriptive and unified expressions for runtime
@@ -28,6 +31,7 @@ This release contains contributions from (in alphabetical order):
 
 Ali Asadi,
 Erick Ochoa Lopez
+Mai Jacob Peng
 
 # Release 0.1.2
 

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1039,6 +1039,8 @@ def _qcond_lowering(
 
     # recursively lower if-else chains to nested IfOps
     def emit_branches(preds, branch_jaxprs, ip):
+        # ip is an MLIR InsertionPoint. This allows recursive calls to emit their Operations inside
+        # the 'else' blocks of preceding IfOps.
         with ip:
             pred_extracted = TensorExtractOp(ir.IntegerType.get_signless(1), preds[0], []).result
             if_op_scf = IfOp(pred_extracted, result_types, hasElse=True)

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1010,77 +1010,87 @@ def _state_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shape: tup
 #
 # qcond
 #
-def qcond(true_jaxpr, false_jaxpr, *header_and_branch_args_plus_consts):
+def qcond(branch_jaxprs, *header_and_branch_args_plus_consts):
     """Bind operands to operation."""
-    return qcond_p.bind(
-        *header_and_branch_args_plus_consts,
-        true_jaxpr=true_jaxpr,
-        false_jaxpr=false_jaxpr,
-    )
+    return qcond_p.bind(*header_and_branch_args_plus_consts, branch_jaxprs=branch_jaxprs)
 
 
 @qcond_p.def_abstract_eval
 # pylint: disable=unused-argument
-def _qcond_abstract_eval(*args, true_jaxpr, false_jaxpr, **kwargs):
-    return true_jaxpr.out_avals
+def _qcond_abstract_eval(*args, branch_jaxprs, **kwargs):
+    return branch_jaxprs[0].out_avals
 
 
 @qcond_p.def_impl
-def _qcond_def_impl(
-    ctx, pred, *branch_args_plus_consts, true_jaxpr, false_jaxpr
-):  # pragma: no cover
+def _qcond_def_impl(ctx, *preds_and_branch_args_plus_consts, branch_jaxprs):  # pragma: no cover
     raise NotImplementedError()
 
 
 def _qcond_lowering(
     jax_ctx: mlir.LoweringRuleContext,
-    pred: ir.Value,
-    *branch_args_plus_consts: tuple,
-    true_jaxpr: jax.core.ClosedJaxpr,
-    false_jaxpr: jax.core.ClosedJaxpr,
+    *preds_and_branch_args_plus_consts: tuple,
+    branch_jaxprs: list[jax.core.ClosedJaxpr],
 ):
     result_types = [mlir.aval_to_ir_types(a)[0] for a in jax_ctx.avals_out]
+    num_preds = len(branch_jaxprs) - 1
+    preds = preds_and_branch_args_plus_consts[:num_preds]
+    branch_args_plus_consts = preds_and_branch_args_plus_consts[num_preds:]
     flat_args_plus_consts = mlir.flatten_lowering_ir_args(branch_args_plus_consts)
 
-    pred_extracted = TensorExtractOp(ir.IntegerType.get_signless(1), pred, []).result
+    # recursively lower if-else chains to nested IfOps
+    def emit_branches(preds, branch_jaxprs, ip):
+        with ip:
+            pred_extracted = TensorExtractOp(ir.IntegerType.get_signless(1), preds[0], []).result
+            if_op_scf = IfOp(pred_extracted, result_types, hasElse=True)
+            true_jaxpr = branch_jaxprs[0]
+            if_block = if_op_scf.then_block
 
-    if_op_scf = IfOp(pred_extracted, result_types, hasElse=True)
+            # if block
+            name_stack = util.extend_name_stack(jax_ctx.module_context.name_stack, "if")
+            if_ctx = jax_ctx.module_context.replace(
+                name_stack=xla.extend_name_stack(name_stack, "if")
+            )
+            with ir.InsertionPoint(if_block):
+                # recursively generate the mlir for the if block
+                out = mlir.jaxpr_subcomp(
+                    if_ctx,
+                    true_jaxpr.jaxpr,
+                    mlir.TokenSet(),
+                    [mlir.ir_constants(c) for c in true_jaxpr.consts],
+                    *([a] for a in flat_args_plus_consts),  # fn expects [a1], [a2], [a3] format
+                    dim_var_values=jax_ctx.dim_var_values,
+                )
 
-    # if block
-    if_block = if_op_scf.then_block
-    name_stack = util.extend_name_stack(jax_ctx.module_context.name_stack, "if")
-    if_ctx = jax_ctx.module_context.replace(name_stack=xla.extend_name_stack(name_stack, "if"))
-    with ir.InsertionPoint(if_block):
-        # recursively generate the mlir for the if block
-        out = mlir.jaxpr_subcomp(
-            if_ctx,
-            true_jaxpr.jaxpr,
-            mlir.TokenSet(),
-            [mlir.ir_constants(c) for c in true_jaxpr.consts],
-            *([a] for a in flat_args_plus_consts),  # fn expects [a1], [a2], [a3] format
-            dim_var_values=jax_ctx.dim_var_values,
-        )
+                YieldOp([o[0] for o in out[0]])
 
-        YieldOp([o[0] for o in out[0]])
+            # else block
+            name_stack = util.extend_name_stack(jax_ctx.module_context.name_stack, "else")
+            else_ctx = jax_ctx.module_context.replace(
+                name_stack=xla.extend_name_stack(name_stack, "else")
+            )
+            else_block = if_op_scf.else_block
+            if len(preds) == 1:
+                # Base case: reached the otherwise block
+                otherwise_jaxpr = branch_jaxprs[-1]
+                with ir.InsertionPoint(else_block):
+                    out = mlir.jaxpr_subcomp(
+                        else_ctx,
+                        otherwise_jaxpr.jaxpr,
+                        mlir.TokenSet(),
+                        [mlir.ir_constants(c) for c in otherwise_jaxpr.consts],
+                        *([a] for a in flat_args_plus_consts),
+                        dim_var_values=jax_ctx.dim_var_values,
+                    )
 
-    # else block
-    else_block = if_op_scf.else_block
-    name_stack = util.extend_name_stack(jax_ctx.module_context.name_stack, "else")
-    else_ctx = jax_ctx.module_context.replace(name_stack=xla.extend_name_stack(name_stack, "else"))
-    with ir.InsertionPoint(else_block):
-        # recursively generate the mlir for the else block
-        out = mlir.jaxpr_subcomp(
-            else_ctx,
-            false_jaxpr.jaxpr,
-            mlir.TokenSet(),
-            [mlir.ir_constants(c) for c in false_jaxpr.consts],
-            *([a] for a in flat_args_plus_consts),  # fn expects [a1], [a2], [a3] format
-            dim_var_values=jax_ctx.dim_var_values,
-        )
+                    YieldOp([o[0] for o in out[0]])
+            else:
+                with ir.InsertionPoint(else_block) as else_ip:
+                    child_if_op = emit_branches(preds[1:], branch_jaxprs[1:], else_ip)
+                    YieldOp(child_if_op.results)
+            return if_op_scf
 
-        YieldOp([o[0] for o in out[0]])
-
-    return if_op_scf.results
+    head_if_op = emit_branches(preds, branch_jaxprs, jax_ctx.module_context.ip.current)
+    return head_if_op.results
 
 
 #

--- a/frontend/catalyst/jax_tape.py
+++ b/frontend/catalyst/jax_tape.py
@@ -102,7 +102,7 @@ class JaxTape:
                 if isinstance(op, qml.Hamiltonian):
                     return op.coeffs
                 if op.__class__.__name__ == "Cond":
-                    return op.pred, op.consts
+                    return op.preds, op.consts
                 if op.__class__.__name__ == "WhileLoop":
                     return op.cond_consts, op.body_consts, op.iter_args
                 if op.__class__.__name__ == "ForLoop":

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -260,12 +260,11 @@ def trace_quantum_tape(
                 wires, new_qubits, qubit_states, qreg
             )
         elif op.__class__.__name__ == "Cond":
-            predicate, consts = op_args
+            predicates, consts = op_args
             qreg = insert_to_qreg(qubit_states, qreg)
-            header_and_branch_args_plus_consts = [predicate] + consts + [qreg]
+            header_and_branch_args_plus_consts = predicates + consts + [qreg]
             outs = jprim.qcond(
-                op.true_jaxpr,
-                op.false_jaxpr,
+                op.branch_jaxprs,
                 *header_and_branch_args_plus_consts,
             )
             v, qreg = tree_unflatten(op.out_trees[0], outs)

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -451,7 +451,7 @@ def cond(pred):
     """A :func:`~.qjit` compatible decorator for if-else conditionals in PennyLane/Catalyst.
 
     This form of control flow is a functional version of the traditional if-else conditional. This
-    means that each execution path, a 'if' branch, any 'else if' branches, and a final 'otherwise'
+    means that each execution path, an 'if' branch, any 'else if' branches, and a final 'otherwise'
     branch, is provided as a separate function. All functions will be traced during compilation,
     but only one of them the will be executed at runtime, depending of the value of one or more
     Boolean predicates. The JAX equivalent is the ``jax.lax.cond`` function, but this version is

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -322,6 +322,17 @@ class CondCallable:
         self.otherwise_fn = lambda: None
 
     def else_if(self, pred):
+        """
+        Block of code to be run if this predicate evaluates to true, skipping all subsequent
+        conditional blocks.
+
+        Args:
+            pred (bool): The predicate that will determine if this branch is executed.
+
+        Returns:
+            A callable decorator that wraps this 'else if' branch of the conditional and returns self.
+        """
+
         def decorator(branch_fn):
             if branch_fn.__code__.co_argcount != 0:
                 raise TypeError(
@@ -440,28 +451,29 @@ def cond(pred):
     """A :func:`~.qjit` compatible decorator for if-else conditionals in PennyLane/Catalyst.
 
     This form of control flow is a functional version of the traditional if-else conditional. This
-    means that each execution path, a 'True' branch and a 'False' branch, is provided as a separate
-    function. Both functions will be traced during compilation, but only one of them the will be
-    executed at runtime, depending of the value of a Boolean predicate. The JAX equivalent is the
-    ``jax.lax.cond`` function, but this version is optimized to work with quantum programs in
-    PennyLane.
+    means that each execution path, a 'if' branch, any 'else if' branches, and a final 'otherwise'
+    branch, is provided as a separate function. All functions will be traced during compilation,
+    but only one of them the will be executed at runtime, depending of the value of one or more
+    Boolean predicates. The JAX equivalent is the ``jax.lax.cond`` function, but this version is
+    optimized to work with quantum programs in PennyLane. This version also supports an 'else if'
+    construct which the JAX version does not.
 
     Values produced inside the scope of a conditional can be returned to the outside context, but
     the return type signature of each branch must be identical. If no values are returned, the
-    'False' branch is optional. Refer to the example below to learn more about the syntax of this
-    decorator.
+    'otherwise' branch is optional. Refer to the example below to learn more about the syntax of
+    this decorator.
 
     This form of control flow can also be called from the Python interpreter without needing to use
     :func:`~.qjit`.
 
     Args:
-        pred (bool): the predicate with which to control the branch to execute
+        pred (bool): the first predicate with which to control the branch to execute
 
     Returns:
-        A callable decorator that wraps the 'True' branch of the conditional.
+        A callable decorator that wraps the first 'if' branch of the conditional.
 
     Raises:
-        AssertionError: True- or False-branch functions cannot have arguments.
+        AssertionError: Branch functions cannot have arguments.
 
     **Example**
 

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -330,7 +330,8 @@ class CondCallable:
             pred (bool): The predicate that will determine if this branch is executed.
 
         Returns:
-            A callable decorator that wraps this 'else if' branch of the conditional and returns self.
+            A callable decorator that wraps this 'else if' branch of the conditional and returns
+            self.
         """
 
         def decorator(branch_fn):

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -414,7 +414,7 @@ class CondCallable:
         args_avals = tuple(map(_abstractify, args))
 
         branch_jaxprs, consts, out_trees = _initial_style_jaxprs_with_common_consts(
-            tuple(self.branch_fns) + (self.otherwise_fn,), args_tree, args_avals, "cond"
+            (*self.branch_fns, self.otherwise_fn), args_tree, args_avals, "cond"
         )
 
         CondCallable._check_branches_return_types(branch_jaxprs)

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -24,12 +24,7 @@ class TestCondToJaxpr:
         expected = """{ lambda ; a:i64[]. let
     b:bool[] = eq a 5
     c:i64[] = qcond[
-      false_jaxpr={ lambda ; d_:i64[] e:i64[]. let
-          f:i64[] = integer_pow[y=3] e
-        in (f,) }
-      true_jaxpr={ lambda ; g:i64[] h_:i64[]. let
-          i:i64[] = integer_pow[y=2] g
-        in (i,) }
+      branch_jaxprs=[{ lambda ; a:i64[] b_:i64[]. let c:i64[] = integer_pow[y=2] a in (c,) }, { lambda ; a_:i64[] b:i64[]. let c:i64[] = integer_pow[y=3] b in (c,) }]
     ] b a a
   in (c,) }"""
 
@@ -72,6 +67,55 @@ class TestCond:
         assert circuit(5) == 25
         assert circuit(6) == 36
 
+    def test_cond_one_else_if(self):
+        @qjit()
+        @qml.qnode(qml.device("lightning.qubit", wires=1))
+        def circuit(x):
+            @cond(x > 2.7)
+            def multiply():
+                return x * 4
+
+            @multiply.else_if(x > 1.4)
+            def multiply():
+                return x * 2
+
+            @multiply.otherwise
+            def multiply():
+                return x
+
+            return multiply()
+
+        assert circuit(4) == 16
+        assert circuit(2) == 4
+        assert circuit(1) == 1
+
+    def test_cond_many_else_if(self):
+        @qjit()
+        @qml.qnode(qml.device("lightning.qubit", wires=1))
+        def circuit(x):
+            @cond(x > 4.8)
+            def multiply():
+                return x * 8
+
+            @multiply.else_if(x > 2.7)
+            def multiply():
+                return x * 4
+
+            @multiply.else_if(x > 1.4)
+            def multiply():
+                return x * 2
+
+            @multiply.otherwise
+            def multiply():
+                return x
+
+            return multiply()
+
+        assert circuit(5) == 40
+        assert circuit(3) == 12
+        assert circuit(2) == 4
+        assert circuit(-3) == -3
+
     def test_qubit_manipulation_cond(self):
         @qjit()
         @qml.qnode(qml.device("lightning.qubit", wires=1))
@@ -95,7 +139,26 @@ class TestCond:
 
             return cond_fn()
 
-        with pytest.raises(TypeError, match="Conditional branches require the same return type"):
+        with pytest.raises(
+            TypeError, match="Conditional branches all require the same return type"
+        ):
+            qjit(qml.qnode(qml.device("lightning.qubit", wires=1))(circuit))
+
+    def test_branch_multi_return_mismatch(self):
+        def circuit():
+            @cond(True)
+            def cond_fn():
+                return measure(wires=0)
+
+            @cond_fn.else_if(False)
+            def cond_fn():
+                return measure(wires=0)
+
+            return cond_fn()
+
+        with pytest.raises(
+            TypeError, match="Conditional branches all require the same return type"
+        ):
             qjit(qml.qnode(qml.device("lightning.qubit", wires=1))(circuit))
 
     def test_identical_branch_names(self):

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -94,7 +94,7 @@ class TestCond:
     def test_cond_many_else_if(self):
         """Test a cond with multiple else_if branches"""
 
-        @qjit()
+        @qjit
         @qml.qnode(qml.device("lightning.qubit", wires=1))
         def circuit(x):
             @cond(x > 4.8)
@@ -118,6 +118,34 @@ class TestCond:
         assert circuit(5) == 40
         assert circuit(3) == 12
         assert circuit(2) == 4
+        assert circuit(-3) == -3
+
+    def test_cond_else_if_classical(self):
+        """Test a cond with multiple else_if branches using the classical compilation path."""
+
+        @qjit
+        def circuit(x):
+            @cond(x > 4.8)
+            def cond_fn():
+                return x * 16
+
+            @cond_fn.else_if(x > 2.7)
+            def cond_elif():
+                return x * 8
+
+            @cond_fn.else_if(x > 1.4)
+            def cond_elif2():
+                return x * 4
+
+            @cond_fn.otherwise
+            def cond_else():
+                return x
+
+            return cond_fn()
+
+        assert circuit(5) == 80
+        assert circuit(3) == 24
+        assert circuit(2) == 8
         assert circuit(-3) == -3
 
     def test_qubit_manipulation_cond(self):

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -204,6 +204,25 @@ class TestCond:
         ):
             qjit(qml.qnode(qml.device("lightning.qubit", wires=1))(circuit))
 
+    def test_branch_with_arg(self):
+        """Test that an exception is raised when an 'else if' branch function contains an arg"""
+
+        def circuit(pred: bool):
+            @cond(pred)
+            def cond_fn():
+                qml.PauliX(0)
+
+            @cond_fn.else_if(pred)
+            def cond_elif(x):
+                qml.PauliX(x)
+
+            return measure(wires=0)
+
+        with pytest.raises(
+            TypeError, match="Conditional 'else if' function is not allowed to have any arguments"
+        ):
+            qjit(qml.qnode(qml.device("lightning.qubit", wires=1))(circuit))
+
     def test_identical_branch_names(self):
         @qjit
         @qml.qnode(qml.device("lightning.qubit", wires=1))

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -70,7 +70,7 @@ class TestCond:
     def test_cond_one_else_if(self):
         """Test a cond with one else_if branch"""
 
-        @qjit()
+        @qjit
         @qml.qnode(qml.device("lightning.qubit", wires=1))
         def circuit(x):
             @cond(x > 2.7)

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -68,48 +68,52 @@ class TestCond:
         assert circuit(6) == 36
 
     def test_cond_one_else_if(self):
+        """Test a cond with one else_if branch"""
+
         @qjit()
         @qml.qnode(qml.device("lightning.qubit", wires=1))
         def circuit(x):
             @cond(x > 2.7)
-            def multiply():
+            def cond_fn():
                 return x * 4
 
-            @multiply.else_if(x > 1.4)
-            def multiply():
+            @cond_fn.else_if(x > 1.4)
+            def cond_elif():
                 return x * 2
 
-            @multiply.otherwise
-            def multiply():
+            @cond_fn.otherwise
+            def cond_else():
                 return x
 
-            return multiply()
+            return cond_fn()
 
         assert circuit(4) == 16
         assert circuit(2) == 4
         assert circuit(1) == 1
 
     def test_cond_many_else_if(self):
+        """Test a cond with multiple else_if branches"""
+
         @qjit()
         @qml.qnode(qml.device("lightning.qubit", wires=1))
         def circuit(x):
             @cond(x > 4.8)
-            def multiply():
+            def cond_fn():
                 return x * 8
 
-            @multiply.else_if(x > 2.7)
-            def multiply():
+            @cond_fn.else_if(x > 2.7)
+            def cond_elif():
                 return x * 4
 
-            @multiply.else_if(x > 1.4)
-            def multiply():
+            @cond_fn.else_if(x > 1.4)
+            def cond_elif2():
                 return x * 2
 
-            @multiply.otherwise
-            def multiply():
+            @cond_fn.otherwise
+            def cond_else():
                 return x
 
-            return multiply()
+            return cond_fn()
 
         assert circuit(5) == 40
         assert circuit(3) == 12
@@ -132,6 +136,11 @@ class TestCond:
         assert circuit(6) == True
 
     def test_branch_return_mismatch(self):
+        """
+        Test that an exception is raised when the true branch returns a value without an else
+        branch
+        """
+
         def circuit():
             @cond(True)
             def cond_fn():
@@ -145,13 +154,19 @@ class TestCond:
             qjit(qml.qnode(qml.device("lightning.qubit", wires=1))(circuit))
 
     def test_branch_multi_return_mismatch(self):
+        """Test that an exception is raised when the return types of all branches do not match"""
+
         def circuit():
             @cond(True)
             def cond_fn():
                 return measure(wires=0)
 
             @cond_fn.else_if(False)
-            def cond_fn():
+            def cond_elif():
+                return 0
+
+            @cond_fn.otherwise
+            def cond_else():
                 return measure(wires=0)
 
             return cond_fn()


### PR DESCRIPTION
**Context:** Supporting multiple branches with an `else-if`-like construct requires nesting `@cond` decorators with the user, which hurts readability.

**Description of the Change:** Add an `else_if` function directly to the front end.

**Benefits:** It is more ergonomic and readable to express programs with the desired branching functionality.

**Possible Drawbacks:** If the text formats of the JAXPRs are important, the use of a list to store the `branch_jaxprs` appears to mess with the variable naming with the inner branch functions. See how the function parameters in [frontend/test/pytest/test_conditionals.py](https://github.com/PennyLaneAI/catalyst/compare/main...pengmai:catalyst:multi-branch-cond?expand=1#diff-e8244850c25e67f887baf50586519acbbe13ffdfa432097adb8ffe3efda5282d) name their parameters "a" and "b" instead of continuing to use subsequent letters from the outside scope.

It's also possible, given my relative inexperience with JAX, that the variable name here is due to some misconfiguration.

**Related GitHub Issues:** Closes #95 
