### PR TITLE
Change the ABI to make it statically known AOT.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -12,6 +12,9 @@
   These are called pipelines, as they contain multiple passes.
   [#38](https://github.com/PennyLaneAI/catalyst/pull/38)
 
+* Improve python compatibility by providing a stable signature for user generated functions.
+  [#106](https://github.com/PennyLaneAI/catalyst/pull/106)
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -205,7 +205,7 @@ class CompiledFunction:
         teardown.restypes = None
 
         # We are calling the c-interface
-        function = shared_object["_mlir_ciface_" + func_name]
+        function = shared_object["_catalyst_pyface_" + func_name]
         # Guaranteed from _mlir_ciface specification
         function.restypes = None
         # Not needed, computed from the arguments.
@@ -283,7 +283,7 @@ class CompiledFunction:
 
         Args:
             shared_object_file: path to the shared object file containing the JIT compiled function
-            func_name: name of the JIT compiled function
+            func_name: name of compiled function to be executed
             has_return: whether the function returns a value or not
             *args: arguments to the function
 
@@ -386,19 +386,38 @@ class CompiledFunction:
                 numpy arrays.
 
         """
-        c_abi_args = []
         numpy_arg_buffer = []
+        return_value_pointer = ctypes.POINTER(ctypes.c_int)()  # This is the null pointer
 
         if restype:
             return_value_pointer = CompiledFunction.restype_to_memref_descs(restype)
-            c_abi_args.append(return_value_pointer)
+
+        c_abi_args = []
 
         for arg in args:
             numpy_arg = np.asarray(arg)
             numpy_arg_buffer.append(numpy_arg)
-            c_abi_arg = get_ranked_memref_descriptor(numpy_arg)
-            c_abi_arg_ptr = ctypes.pointer(c_abi_arg)
-            c_abi_args.append(c_abi_arg_ptr)
+            c_abi_ptr = ctypes.pointer(get_ranked_memref_descriptor(numpy_arg))
+            c_abi_args.append(c_abi_ptr)
+
+        # pylint: disable=too-few-public-methods
+        class CompiledFunctionArgValue(ctypes.Structure):
+            """Programmatically create a structure which holds N tensors of possibly different T base types."""
+
+            _fields_ = [("f" + str(i), type(t)) for i, t in enumerate(c_abi_args)]
+
+            def __init__(self, c_abi_args):
+                for ft_tuple, c_abi_arg in zip(CompiledFunctionArgValue._fields_, c_abi_args):
+                    f = ft_tuple[0]
+                    setattr(self, f, c_abi_arg)
+
+        arg_value_pointer = ctypes.POINTER(ctypes.c_int)()
+
+        if len(args) > 0:
+            arg_value = CompiledFunctionArgValue(c_abi_args)
+            arg_value_pointer = ctypes.pointer(arg_value)
+
+        c_abi_args = [return_value_pointer] + [arg_value_pointer]
         return c_abi_args, numpy_arg_buffer
 
     def __call__(self, *args, **kwargs):

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -213,6 +213,7 @@ class MLIRToLLVMDialect(PassPipeline):
         "--convert-index-to-llvm",
         "--convert-gradient-to-llvm",
         "--convert-quantum-to-llvm",
+        "--wrapper-for-wrapper",
         # Remove any dead casts as the final pass expects to remove all existing casts,
         # but only those that form a loop back to the original type.
         "--canonicalize",

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -213,7 +213,7 @@ class MLIRToLLVMDialect(PassPipeline):
         "--convert-index-to-llvm",
         "--convert-gradient-to-llvm",
         "--convert-quantum-to-llvm",
-        "--wrapper-for-wrapper",
+        "--emit-catalyst-py-interface",
         # Remove any dead casts as the final pass expects to remove all existing casts,
         # but only those that form a loop back to the original type.
         "--canonicalize",

--- a/mlir/include/Quantum/Transforms/Passes.h
+++ b/mlir/include/Quantum/Transforms/Passes.h
@@ -22,6 +22,6 @@ namespace catalyst {
 
 std::unique_ptr<mlir::Pass> createQuantumBufferizationPass();
 std::unique_ptr<mlir::Pass> createQuantumConversionPass();
-std::unique_ptr<mlir::Pass> createWrapperForWrapperPass();
+std::unique_ptr<mlir::Pass> createEmitCatalystPyInterfacePass();
 
 } // namespace catalyst

--- a/mlir/include/Quantum/Transforms/Passes.h
+++ b/mlir/include/Quantum/Transforms/Passes.h
@@ -22,5 +22,6 @@ namespace catalyst {
 
 std::unique_ptr<mlir::Pass> createQuantumBufferizationPass();
 std::unique_ptr<mlir::Pass> createQuantumConversionPass();
+std::unique_ptr<mlir::Pass> createWrapperForWrapperPass();
 
 } // namespace catalyst

--- a/mlir/lib/Quantum/Transforms/CMakeLists.txt
+++ b/mlir/lib/Quantum/Transforms/CMakeLists.txt
@@ -5,7 +5,7 @@ file(GLOB SRC
     quantum_bufferize.cpp
     ConversionPatterns.cpp
     quantum_to_llvm.cpp
-    wrapper_for_wrapper.cpp
+    emit_catalyst_pyface.cpp
 )
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)

--- a/mlir/lib/Quantum/Transforms/CMakeLists.txt
+++ b/mlir/lib/Quantum/Transforms/CMakeLists.txt
@@ -5,6 +5,7 @@ file(GLOB SRC
     quantum_bufferize.cpp
     ConversionPatterns.cpp
     quantum_to_llvm.cpp
+    wrapper_for_wrapper.cpp
 )
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)

--- a/mlir/lib/Quantum/Transforms/emit_catalyst_pyface.cpp
+++ b/mlir/lib/Quantum/Transforms/emit_catalyst_pyface.cpp
@@ -25,7 +25,7 @@ using namespace catalyst::quantum;
 
 namespace {
 
-static Optional<LLVM::LLVMFuncOp> getCallee(LLVM::LLVMFuncOp op)
+Optional<LLVM::LLVMFuncOp> getCallee(LLVM::LLVMFuncOp op)
 {
     size_t counter = 0;
     Optional<LLVM::LLVMFuncOp> callee = std::nullopt;
@@ -41,12 +41,12 @@ static Optional<LLVM::LLVMFuncOp> getCallee(LLVM::LLVMFuncOp op)
     return counter == 1 ? callee : std::nullopt;
 }
 
-static bool hasCWrapperAttribute(LLVM::LLVMFuncOp op)
+bool hasCWrapperAttribute(LLVM::LLVMFuncOp op)
 {
     return (bool)(op->getAttrOfType<UnitAttr>(LLVM::LLVMDialect::getEmitCWrapperAttrName()));
 }
 
-static bool hasCalleeCWrapperAttribute(LLVM::LLVMFuncOp op)
+bool hasCalleeCWrapperAttribute(LLVM::LLVMFuncOp op)
 {
     Optional<LLVM::LLVMFuncOp> callee = getCallee(op);
     if (!callee)
@@ -54,7 +54,7 @@ static bool hasCalleeCWrapperAttribute(LLVM::LLVMFuncOp op)
     return hasCWrapperAttribute(callee.value());
 }
 
-static bool matchesNamingConvention(LLVM::LLVMFuncOp op)
+bool matchesNamingConvention(LLVM::LLVMFuncOp op)
 {
     std::string _mlir_ciface = "_mlir_ciface_";
     size_t _mlir_ciface_len = _mlir_ciface.length();
@@ -69,7 +69,7 @@ static bool matchesNamingConvention(LLVM::LLVMFuncOp op)
     return nameMatches;
 }
 
-static bool isFunctionMLIRCWrapper(LLVM::LLVMFuncOp op)
+bool isFunctionMLIRCWrapper(LLVM::LLVMFuncOp op)
 {
     if (!matchesNamingConvention(op))
         return false;
@@ -78,21 +78,21 @@ static bool isFunctionMLIRCWrapper(LLVM::LLVMFuncOp op)
     return true;
 }
 
-static bool functionHasReturns(LLVM::LLVMFuncOp op)
+bool functionHasReturns(LLVM::LLVMFuncOp op)
 {
     auto functionType = op.getFunctionType();
     return !functionType.getReturnType().isa<LLVM::LLVMVoidType>();
 }
 
-static bool functionHasInputs(LLVM::LLVMFuncOp op)
+bool functionHasInputs(LLVM::LLVMFuncOp op)
 {
     auto functionType = op.getFunctionType();
     return !(functionType.getParams().empty());
 }
 
-static LLVM::LLVMFunctionType
-convertFunctionTypeCatalystWrapper(PatternRewriter &rewriter, LLVM::LLVMFunctionType functionType,
-                                   bool hasReturns, bool hasInputs)
+LLVM::LLVMFunctionType convertFunctionTypeCatalystWrapper(PatternRewriter &rewriter,
+                                                          LLVM::LLVMFunctionType functionType,
+                                                          bool hasReturns, bool hasInputs)
 {
     SmallVector<Type, 2> transformedInputs;
 
@@ -122,8 +122,8 @@ convertFunctionTypeCatalystWrapper(PatternRewriter &rewriter, LLVM::LLVMFunction
     return LLVM::LLVMFunctionType::get(voidType, transformedInputs);
 }
 
-static void wrapResultsAndArgsInTwoStructs(LLVM::LLVMFuncOp op, PatternRewriter &rewriter,
-                                           std::string nameWithoutPrefix)
+void wrapResultsAndArgsInTwoStructs(LLVM::LLVMFuncOp op, PatternRewriter &rewriter,
+                                    std::string nameWithoutPrefix)
 {
     // Guaranteed by match
     LLVM::LLVMFuncOp callee = getCallee(op).value();

--- a/mlir/lib/Quantum/Transforms/emit_catalyst_pyface.cpp
+++ b/mlir/lib/Quantum/Transforms/emit_catalyst_pyface.cpp
@@ -167,10 +167,6 @@ static void wrapResultsAndArgsInTwoStructs(LLVM::LLVMFuncOp op, PatternRewriter 
     rewriter.create<LLVM::ReturnOp>(loc, call.getResults());
 }
 
-} // namespace
-
-namespace catalyst {
-
 struct EmitCatalystPyInterfaceTransform : public OpRewritePattern<LLVM::LLVMFuncOp> {
     using OpRewritePattern<LLVM::LLVMFuncOp>::OpRewritePattern;
 
@@ -196,6 +192,10 @@ void EmitCatalystPyInterfaceTransform::rewrite(LLVM::LLVMFuncOp op, PatternRewri
     rewriter.updateRootInPlace(op, [&] { op.setSymName(newName); });
     wrapResultsAndArgsInTwoStructs(op, rewriter, functionNameWithoutPrefix);
 }
+
+} // namespace
+
+namespace catalyst {
 
 struct EmitCatalystPyInterfacePass
     : public PassWrapper<EmitCatalystPyInterfacePass, OperationPass<ModuleOp>> {

--- a/mlir/lib/Quantum/Transforms/emit_catalyst_pyface.cpp
+++ b/mlir/lib/Quantum/Transforms/emit_catalyst_pyface.cpp
@@ -104,9 +104,9 @@ convertFunctionTypeCatalystWrapper(PatternRewriter &rewriter, LLVM::LLVMFunction
 {
     SmallVector<Type, 2> transformedInputs;
 
-    Type ptr = LLVM::LLVMPointerType::get(rewriter.getContext());
+    Type ptrType = LLVM::LLVMPointerType::get(rewriter.getContext());
     auto inputs = functionType.getParams();
-    Type resultType = hasReturns ? inputs.front() : ptr;
+    Type resultType = hasReturns ? inputs.front() : ptrType;
     transformedInputs.push_back(resultType);
 
     if (hasReturns) {
@@ -114,7 +114,7 @@ convertFunctionTypeCatalystWrapper(PatternRewriter &rewriter, LLVM::LLVMFunction
     }
 
     LLVMTypeConverter typeConverter(rewriter.getContext());
-    Type inputType = hasInputs ? typeConverter.packFunctionResults(inputs) : ptr;
+    Type inputType = hasInputs ? typeConverter.packFunctionResults(inputs) : ptrType;
     bool noChange = inputs.size() == 1;
     if (noChange) {
         // Still wrap the pointer into a struct

--- a/mlir/lib/Quantum/Transforms/emit_catalyst_pyface.cpp
+++ b/mlir/lib/Quantum/Transforms/emit_catalyst_pyface.cpp
@@ -51,14 +51,14 @@ static bool callsiteHasAttribute(LLVM::LLVMFuncOp op)
     return retval;
 }
 
-struct WrapperForWrapperTransform : public OpRewritePattern<LLVM::LLVMFuncOp> {
+struct EmitCatalystPyInterfaceTransform : public OpRewritePattern<LLVM::LLVMFuncOp> {
     using OpRewritePattern<LLVM::LLVMFuncOp>::OpRewritePattern;
 
     LogicalResult match(LLVM::LLVMFuncOp op) const override;
     void rewrite(LLVM::LLVMFuncOp op, PatternRewriter &rewriter) const override;
 };
 
-LogicalResult WrapperForWrapperTransform::match(LLVM::LLVMFuncOp op) const
+LogicalResult EmitCatalystPyInterfaceTransform::match(LLVM::LLVMFuncOp op) const
 {
     std::string _mlir_ciface = "_mlir_ciface_";
     size_t _mlir_ciface_len = _mlir_ciface.length();
@@ -172,7 +172,7 @@ static void wrapResultsAndArgsInTwoStructs(LLVM::LLVMFuncOp op, PatternRewriter 
     rewriter.create<LLVM::ReturnOp>(loc, call.getResults());
 }
 
-void WrapperForWrapperTransform::rewrite(LLVM::LLVMFuncOp op, PatternRewriter &rewriter) const
+void EmitCatalystPyInterfaceTransform::rewrite(LLVM::LLVMFuncOp op, PatternRewriter &rewriter) const
 {
     // Find substr after _mlir_ciface_
     std::string _mlir_ciface = "_mlir_ciface_";
@@ -186,12 +186,16 @@ void WrapperForWrapperTransform::rewrite(LLVM::LLVMFuncOp op, PatternRewriter &r
     wrapResultsAndArgsInTwoStructs(op, rewriter, functionNameWithoutPrefix);
 }
 
-struct WrapperForWrapperPass : public PassWrapper<WrapperForWrapperPass, OperationPass<ModuleOp>> {
-    WrapperForWrapperPass() {}
+struct EmitCatalystPyInterfacePass
+    : public PassWrapper<EmitCatalystPyInterfacePass, OperationPass<ModuleOp>> {
+    EmitCatalystPyInterfacePass() {}
 
-    StringRef getArgument() const override { return "wrapper-for-wrapper"; }
+    StringRef getArgument() const override { return "emit-catalyst-py-interface"; }
 
-    StringRef getDescription() const override { return "Wrapper around wrapper"; }
+    StringRef getDescription() const override
+    {
+        return "Emit catalyst python's default interface.";
+    }
 
     void getDependentDialects(DialectRegistry &registry) const override
     {
@@ -202,7 +206,7 @@ struct WrapperForWrapperPass : public PassWrapper<WrapperForWrapperPass, Operati
     {
         MLIRContext *context = &getContext();
         RewritePatternSet patterns(context);
-        patterns.add<WrapperForWrapperTransform>(context);
+        patterns.add<EmitCatalystPyInterfaceTransform>(context);
 
         if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
             signalPassFailure();
@@ -212,9 +216,9 @@ struct WrapperForWrapperPass : public PassWrapper<WrapperForWrapperPass, Operati
 
 } // namespace quantum
 
-std::unique_ptr<Pass> createWrapperForWrapperPass()
+std::unique_ptr<Pass> createEmitCatalystPyInterfacePass()
 {
-    return std::make_unique<quantum::WrapperForWrapperPass>();
+    return std::make_unique<quantum::EmitCatalystPyInterfacePass>();
 }
 
 } // namespace catalyst

--- a/mlir/lib/Quantum/Transforms/emit_catalyst_pyface.cpp
+++ b/mlir/lib/Quantum/Transforms/emit_catalyst_pyface.cpp
@@ -23,8 +23,7 @@
 using namespace mlir;
 using namespace catalyst::quantum;
 
-namespace catalyst {
-namespace quantum {
+namespace {
 
 static size_t countCallsites(LLVM::LLVMFuncOp op)
 {
@@ -138,6 +137,11 @@ static void wrapResultsAndArgsInTwoStructs(LLVM::LLVMFuncOp op, PatternRewriter 
 
     rewriter.create<LLVM::ReturnOp>(loc, call.getResults());
 }
+
+} // namespace
+
+namespace catalyst {
+namespace quantum {
 
 struct EmitCatalystPyInterfaceTransform : public OpRewritePattern<LLVM::LLVMFuncOp> {
     using OpRewritePattern<LLVM::LLVMFuncOp>::OpRewritePattern;

--- a/mlir/lib/Quantum/Transforms/emit_catalyst_pyface.cpp
+++ b/mlir/lib/Quantum/Transforms/emit_catalyst_pyface.cpp
@@ -179,7 +179,6 @@ static void wrapResultsAndArgsInTwoStructs(LLVM::LLVMFuncOp op, PatternRewriter 
 } // namespace
 
 namespace catalyst {
-namespace quantum {
 
 struct EmitCatalystPyInterfaceTransform : public OpRewritePattern<LLVM::LLVMFuncOp> {
     using OpRewritePattern<LLVM::LLVMFuncOp>::OpRewritePattern;
@@ -235,11 +234,10 @@ struct EmitCatalystPyInterfacePass
     }
 };
 
-} // namespace quantum
 
 std::unique_ptr<Pass> createEmitCatalystPyInterfacePass()
 {
-    return std::make_unique<quantum::EmitCatalystPyInterfacePass>();
+    return std::make_unique<EmitCatalystPyInterfacePass>();
 }
 
 } // namespace catalyst

--- a/mlir/lib/Quantum/Transforms/emit_catalyst_pyface.cpp
+++ b/mlir/lib/Quantum/Transforms/emit_catalyst_pyface.cpp
@@ -33,7 +33,7 @@ static size_t countCallsites(LLVM::LLVMFuncOp op)
     return count;
 }
 
-static bool callsiteHasAttribute(LLVM::LLVMFuncOp op)
+static bool callsiteHasCWrapperAttribute(LLVM::LLVMFuncOp op)
 {
     bool retval = false;
     ModuleOp moduleOp = cast<ModuleOp>(op->getParentOp());
@@ -79,7 +79,7 @@ LogicalResult EmitCatalystPyInterfaceTransform::match(LLVM::LLVMFuncOp op) const
         return failure();
 
     // The only call must contain the emitCWrapper attribute
-    bool hasAttribute = callsiteHasAttribute(op);
+    bool hasAttribute = callsiteHasCWrapperAttribute(op);
 
     return hasAttribute ? success() : failure();
 }

--- a/mlir/lib/Quantum/Transforms/emit_catalyst_pyface.cpp
+++ b/mlir/lib/Quantum/Transforms/emit_catalyst_pyface.cpp
@@ -122,8 +122,8 @@ convertFunctionTypeCatalystWrapper(PatternRewriter &rewriter, LLVM::LLVMFunction
         // for uniformity in Python and in the unwrapping.
         inputType = LLVM::LLVMStructType::getLiteral(rewriter.getContext(), inputType);
     }
-    if (auto structType = inputType.dyn_cast<LLVM::LLVMStructType>()) {
-        inputType = LLVM::LLVMPointerType::get(structType);
+    if (inputType.isa<LLVM::LLVMStructType>()) {
+        inputType = LLVM::LLVMPointerType::get(inputType);
     }
     transformedInputs.push_back(inputType);
 

--- a/mlir/lib/Quantum/Transforms/wrapper_for_wrapper.cpp
+++ b/mlir/lib/Quantum/Transforms/wrapper_for_wrapper.cpp
@@ -1,0 +1,220 @@
+// Copyright 2022-2023 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/Support/FormatVariadic.h"
+
+#include "Quantum/Transforms/Passes.h"
+#include "Quantum/Transforms/Patterns.h"
+
+using namespace mlir;
+using namespace catalyst::quantum;
+
+namespace catalyst {
+namespace quantum {
+
+static size_t countCallsites(LLVM::LLVMFuncOp op)
+{
+    size_t count = 0;
+    op.walk([&](LLVM::CallOp callOp) { count++; });
+    return count;
+}
+
+static bool callsiteHasAttribute(LLVM::LLVMFuncOp op)
+{
+    bool retval = false;
+    ModuleOp moduleOp = cast<ModuleOp>(op->getParentOp());
+    if (!moduleOp)
+        return retval;
+    op.walk([&](LLVM::CallOp callOp) {
+        auto callee = callOp.getCallee();
+        if (callee) {
+            auto stringRef = callee.value().data();
+            Operation *fnDecl = moduleOp.lookupSymbol<LLVM::LLVMFuncOp>(stringRef);
+            retval = (bool)(fnDecl->getAttrOfType<UnitAttr>(
+                LLVM::LLVMDialect::getEmitCWrapperAttrName()));
+        }
+    });
+    return retval;
+}
+
+struct WrapperForWrapperTransform : public OpRewritePattern<LLVM::LLVMFuncOp> {
+    using OpRewritePattern<LLVM::LLVMFuncOp>::OpRewritePattern;
+
+    LogicalResult match(LLVM::LLVMFuncOp op) const override;
+    void rewrite(LLVM::LLVMFuncOp op, PatternRewriter &rewriter) const override;
+};
+
+LogicalResult WrapperForWrapperTransform::match(LLVM::LLVMFuncOp op) const
+{
+    std::string _mlir_ciface = "_mlir_ciface_";
+    size_t _mlir_ciface_len = _mlir_ciface.length();
+    auto symName = op.getSymName();
+    const char *symNameStr = symName.data();
+    size_t symNameLength = strlen(symNameStr);
+    // Filter based on name.
+    if (symNameLength <= _mlir_ciface_len)
+        return failure();
+
+    bool nameMatches = 0 == strncmp(symNameStr, _mlir_ciface.c_str(), _mlir_ciface_len);
+    if (!nameMatches)
+        return failure();
+
+    // Function must only contain a single function call.
+    size_t callsites = countCallsites(op);
+    if (callsites != 1)
+        return failure();
+
+    // The only call must contain the emitCWrapper attribute
+    bool hasAttribute = callsiteHasAttribute(op);
+
+    return hasAttribute ? success() : failure();
+}
+
+static bool functionHasReturns(LLVM::LLVMFuncOp op)
+{
+    bool result = false;
+    op.walk([&](LLVM::CallOp callOp) { result = (bool)callOp.getResult(); });
+    return result;
+}
+
+static bool functionHasInputs(LLVM::LLVMFuncOp op)
+{
+    bool result = false;
+    op.walk([&](LLVM::CallOp callOp) { result = !callOp.getOperandTypes().empty(); });
+    return result;
+}
+
+static LLVM::LLVMFunctionType
+convertFunctionTypeCatalystWrapper(PatternRewriter &rewriter, LLVM::LLVMFunctionType functionType,
+                                   bool hasReturns, bool hasInputs)
+{
+    SmallVector<Type, 2> transformedInputs;
+
+    Type ptr = LLVM::LLVMPointerType::get(rewriter.getContext());
+    auto inputs = functionType.getParams();
+    Type resultType = hasReturns ? inputs.front() : ptr;
+    transformedInputs.push_back(resultType);
+
+    if (hasReturns) {
+        inputs = inputs.drop_front();
+    }
+
+    LLVMTypeConverter typeConverter(rewriter.getContext());
+    Type inputType = hasInputs ? typeConverter.packFunctionResults(inputs) : ptr;
+    bool noChange = inputs.size() == 1;
+    if (noChange) {
+        // Still wrap the pointer into a struct
+        // for uniformity in Python and in the unwrapping.
+        inputType = LLVM::LLVMStructType::getLiteral(rewriter.getContext(), inputType);
+    }
+    if (auto structType = inputType.dyn_cast<LLVM::LLVMStructType>()) {
+        inputType = LLVM::LLVMPointerType::get(structType);
+    }
+    transformedInputs.push_back(inputType);
+
+    Type voidType = LLVM::LLVMVoidType::get(rewriter.getContext());
+    return LLVM::LLVMFunctionType::get(voidType, transformedInputs);
+}
+
+static void wrapResultsAndArgsInTwoStructs(LLVM::LLVMFuncOp op, PatternRewriter &rewriter,
+                                           std::string nameWithoutPrefix)
+{
+    bool hasReturns = functionHasReturns(op);
+    bool hasInputs = functionHasInputs(op);
+    LLVM::LLVMFunctionType functionType = op.getFunctionType();
+    LLVM::LLVMFunctionType wrapperFuncType =
+        convertFunctionTypeCatalystWrapper(rewriter, functionType, hasReturns, hasInputs);
+
+    Location loc = op.getLoc();
+    auto wrapperFuncOp = rewriter.create<LLVM::LLVMFuncOp>(
+        loc, llvm::formatv("_catalyst_pyface_{0}", nameWithoutPrefix).str(), wrapperFuncType,
+        LLVM::Linkage::External, /*dsoLocal*/ false,
+        /*cconv*/ LLVM::CConv::C);
+
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPointToStart(wrapperFuncOp.addEntryBlock());
+
+    auto type = op.getFunctionType();
+    auto params = type.getParams();
+    SmallVector<Value, 8> args;
+
+    if (hasReturns) {
+        args.push_back(wrapperFuncOp.getArgument(0));
+        params = params.drop_front();
+    }
+
+    if (hasInputs) {
+        Value arg = wrapperFuncOp.getArgument(1);
+        Value structOfMemrefs = rewriter.create<LLVM::LoadOp>(loc, arg);
+
+        for (auto &en : llvm::enumerate(params)) {
+            Value pointer = rewriter.create<LLVM::ExtractValueOp>(loc, structOfMemrefs, en.index());
+            args.push_back(pointer);
+        }
+    }
+
+    auto call = rewriter.create<LLVM::CallOp>(loc, op, args);
+
+    rewriter.create<LLVM::ReturnOp>(loc, call.getResults());
+}
+
+void WrapperForWrapperTransform::rewrite(LLVM::LLVMFuncOp op, PatternRewriter &rewriter) const
+{
+    // Find substr after _mlir_ciface_
+    std::string _mlir_ciface = "_mlir_ciface_";
+    size_t _mlir_ciface_len = _mlir_ciface.length();
+    auto symName = op.getSymName();
+    const char *symNameStr = symName.data();
+    const char *functionNameWithoutPrefix = symNameStr + _mlir_ciface_len;
+    auto newName = llvm::formatv("_catalyst_ciface_{0}", functionNameWithoutPrefix).str();
+
+    rewriter.updateRootInPlace(op, [&] { op.setSymName(newName); });
+    wrapResultsAndArgsInTwoStructs(op, rewriter, functionNameWithoutPrefix);
+}
+
+struct WrapperForWrapperPass : public PassWrapper<WrapperForWrapperPass, OperationPass<ModuleOp>> {
+    WrapperForWrapperPass() {}
+
+    StringRef getArgument() const override { return "wrapper-for-wrapper"; }
+
+    StringRef getDescription() const override { return "Wrapper around wrapper"; }
+
+    void getDependentDialects(DialectRegistry &registry) const override
+    {
+        registry.insert<LLVM::LLVMDialect>();
+    }
+
+    void runOnOperation() final
+    {
+        MLIRContext *context = &getContext();
+        RewritePatternSet patterns(context);
+        patterns.add<WrapperForWrapperTransform>(context);
+
+        if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+            signalPassFailure();
+        }
+    }
+};
+
+} // namespace quantum
+
+std::unique_ptr<Pass> createWrapperForWrapperPass()
+{
+    return std::make_unique<quantum::WrapperForWrapperPass>();
+}
+
+} // namespace catalyst

--- a/mlir/lib/Quantum/Transforms/wrapper_for_wrapper.cpp
+++ b/mlir/lib/Quantum/Transforms/wrapper_for_wrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Xanadu Quantum Technologies Inc.
+// Copyright 2023 Xanadu Quantum Technologies Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mlir/test/Quantum/WrapperTest.mlir
+++ b/mlir/test/Quantum/WrapperTest.mlir
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Xanadu Quantum Technologies Inc.
+// Copyright 2023 Xanadu Quantum Technologies Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/mlir/test/Quantum/WrapperTest.mlir
+++ b/mlir/test/Quantum/WrapperTest.mlir
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// RUN: quantum-opt --wrapper-for-wrapper --split-input-file %s | FileCheck %s
+// RUN: quantum-opt --emit-catalyst-py-interface --split-input-file %s | FileCheck %s
 
 llvm.func @foo() -> () attributes {llvm.emit_c_interface} 
 

--- a/mlir/test/Quantum/WrapperTest.mlir
+++ b/mlir/test/Quantum/WrapperTest.mlir
@@ -1,0 +1,172 @@
+// Copyright 2022-2023 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RUN: quantum-opt --wrapper-for-wrapper --split-input-file %s | FileCheck %s
+
+llvm.func @foo() -> () attributes {llvm.emit_c_interface} 
+
+// Test name change
+// CHECK-LABEL: @_catalyst_ciface_foo
+llvm.func @_mlir_ciface_foo() {
+    llvm.call @foo() : () -> ()
+    llvm.return
+}
+
+// -----
+
+llvm.func @foo() -> () attributes {llvm.emit_c_interface} 
+
+// Test new function exists
+// CHECK-LABEL: @_catalyst_pyface_foo
+llvm.func @_mlir_ciface_foo() {
+    llvm.call @foo() : () -> ()
+    llvm.return
+}
+
+// -----
+
+llvm.func @foo() -> () attributes {llvm.emit_c_interface} 
+
+// Test opaque pointers when no input and no return
+// CHECK-LABEL: @_catalyst_pyface_foo(%arg0: !llvm.ptr, %arg1: !llvm.ptr)
+llvm.func @_mlir_ciface_foo() {
+    llvm.call @foo() : () -> ()
+    llvm.return
+}
+
+// -----
+
+llvm.func @foo(%arg0: !llvm.ptr<f64>, %arg1: !llvm.ptr<f64>, %arg2: i64, %arg3: !llvm.ptr<f64>, %arg4: !llvm.ptr<f64>, %arg5: i64) -> !llvm.struct<(ptr<struct<(f64, f64)>>, ptr<struct<(f64, f64)>>, i64, array<1 x i64>, array<1 x i64>)> attributes {llvm.emit_c_interface} 
+
+// Test that the return argument type remains unchanged in wrapper function
+// CHECK-LABEL: llvm.func @_catalyst_pyface_foo(%arg0: !llvm.ptr<struct<(ptr<struct<(f64, f64)>>, ptr<struct<(f64, f64)>>, i64, array<1 x i64>, array<1 x i64>)>>, %arg1: !llvm.ptr<struct<(ptr<struct<(ptr<f64>, ptr<f64>, i64)>>, ptr<struct<(ptr<f64>, ptr<f64>, i64)>>)>>)  
+
+llvm.func @_mlir_ciface_foo(%arg0: !llvm.ptr<struct<(ptr<struct<(f64, f64)>>, ptr<struct<(f64, f64)>>, i64, array<1 x i64>, array<1 x i64>)>>, %arg1: !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>, %arg2: !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>) {
+    %0 = llvm.load %arg1 : !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>
+    %1 = llvm.extractvalue %0[0] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %2 = llvm.extractvalue %0[1] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %3 = llvm.extractvalue %0[2] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %4 = llvm.load %arg2 : !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>
+    %5 = llvm.extractvalue %4[0] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %6 = llvm.extractvalue %4[1] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %7 = llvm.extractvalue %4[2] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %8 = llvm.call @foo(%1, %2, %3, %5, %6, %7) : (!llvm.ptr<f64>, !llvm.ptr<f64>, i64, !llvm.ptr<f64>, !llvm.ptr<f64>, i64) -> !llvm.struct<(ptr<struct<(f64, f64)>>, ptr<struct<(f64, f64)>>, i64, array<1 x i64>, array<1 x i64>)>
+    llvm.store %8, %arg0 : !llvm.ptr<struct<(ptr<struct<(f64, f64)>>, ptr<struct<(f64, f64)>>, i64, array<1 x i64>, array<1 x i64>)>>
+    llvm.return
+}
+
+// -----
+
+llvm.func @foo(%arg0: !llvm.ptr<f64>, %arg1: !llvm.ptr<f64>, %arg2: i64, %arg3: !llvm.ptr<f64>, %arg4: !llvm.ptr<f64>, %arg5: i64) -> !llvm.struct<(ptr<struct<(f64, f64)>>, ptr<struct<(f64, f64)>>, i64, array<1 x i64>, array<1 x i64>)> attributes {llvm.emit_c_interface} 
+
+// Test that the return argument is passed without modification to the wrapped function
+// CHECK-LABEL: llvm.call @_catalyst_ciface_foo(%arg0
+
+llvm.func @_mlir_ciface_foo(%arg0: !llvm.ptr<struct<(ptr<struct<(f64, f64)>>, ptr<struct<(f64, f64)>>, i64, array<1 x i64>, array<1 x i64>)>>, %arg1: !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>, %arg2: !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>) {
+    %0 = llvm.load %arg1 : !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>
+    %1 = llvm.extractvalue %0[0] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %2 = llvm.extractvalue %0[1] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %3 = llvm.extractvalue %0[2] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %4 = llvm.load %arg2 : !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>
+    %5 = llvm.extractvalue %4[0] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %6 = llvm.extractvalue %4[1] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %7 = llvm.extractvalue %4[2] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %8 = llvm.call @foo(%1, %2, %3, %5, %6, %7) : (!llvm.ptr<f64>, !llvm.ptr<f64>, i64, !llvm.ptr<f64>, !llvm.ptr<f64>, i64) -> !llvm.struct<(ptr<struct<(f64, f64)>>, ptr<struct<(f64, f64)>>, i64, array<1 x i64>, array<1 x i64>)>
+    llvm.store %8, %arg0 : !llvm.ptr<struct<(ptr<struct<(f64, f64)>>, ptr<struct<(f64, f64)>>, i64, array<1 x i64>, array<1 x i64>)>>
+    llvm.return
+}
+
+// -----
+
+llvm.func @foo(%arg0: !llvm.ptr<f64>, %arg1: !llvm.ptr<f64>, %arg2: i64, %arg3: !llvm.ptr<f64>, %arg4: !llvm.ptr<f64>, %arg5: i64) -> () attributes {llvm.emit_c_interface} 
+
+// Test that the input argument is wrapped around a structure and a pointer
+// CHECK-LABEL: llvm.func @_catalyst_pyface_foo(%arg0: !llvm.ptr, %arg1: !llvm.ptr<struct<(ptr<struct<(ptr<f64>, ptr<f64>, i64)>>, ptr<struct<(ptr<f64>, ptr<f64>, i64)>>)>>)
+
+llvm.func @_mlir_ciface_foo(%arg0: !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>, %arg1: !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>) {
+    %0 = llvm.load %arg0 : !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>
+    %1 = llvm.extractvalue %0[0] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %2 = llvm.extractvalue %0[1] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %3 = llvm.extractvalue %0[2] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %4 = llvm.load %arg1 : !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>
+    %5 = llvm.extractvalue %4[0] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %6 = llvm.extractvalue %4[1] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %7 = llvm.extractvalue %4[2] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    llvm.call @foo(%1, %2, %3, %5, %6, %7) : (!llvm.ptr<f64>, !llvm.ptr<f64>, i64, !llvm.ptr<f64>, !llvm.ptr<f64>, i64) -> ()
+    llvm.return
+}
+
+// -----
+
+llvm.func @foo(%arg0: !llvm.ptr<f64>, %arg1: !llvm.ptr<f64>, %arg2: i64, %arg3: !llvm.ptr<f64>, %arg4: !llvm.ptr<f64>, %arg5: i64) -> () attributes {llvm.emit_c_interface} 
+
+// Test that the input argument is correctly translated to the one needed by _mlir_ciface_foo
+
+// CHECK-LABEL: llvm.func @_catalyst_pyface_foo
+// CHECK:    [[var0:%.+]] = llvm.load %arg1
+// CHECK:    [[var1:%.+]] = llvm.extractvalue [[var0]][0]
+// CHECK:    [[var2:%.+]] = llvm.extractvalue [[var0]][1]
+// CHECK:    llvm.call @_catalyst_ciface_foo([[var1]], [[var2]])
+
+llvm.func @_mlir_ciface_foo(%arg0: !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>, %arg1: !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>) {
+    %0 = llvm.load %arg0 : !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>
+    %1 = llvm.extractvalue %0[0] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %2 = llvm.extractvalue %0[1] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %3 = llvm.extractvalue %0[2] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %4 = llvm.load %arg1 : !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>
+    %5 = llvm.extractvalue %4[0] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %6 = llvm.extractvalue %4[1] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %7 = llvm.extractvalue %4[2] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    llvm.call @foo(%1, %2, %3, %5, %6, %7) : (!llvm.ptr<f64>, !llvm.ptr<f64>, i64, !llvm.ptr<f64>, !llvm.ptr<f64>, i64) -> ()
+    llvm.return
+}
+
+// -----
+
+llvm.func @foo(%arg0: !llvm.ptr<f64>, %arg1: !llvm.ptr<f64>, %arg2: i64) -> () attributes {llvm.emit_c_interface} 
+
+// Test that the input argument is wrapped around a structure and a pointer for only one
+// CHECK-LABEL: llvm.func @_catalyst_pyface_foo(%arg0: !llvm.ptr, %arg1: !llvm.ptr<struct<(ptr<struct<(ptr<f64>, ptr<f64>, i64)>>)>>)
+
+llvm.func @_mlir_ciface_foo(%arg0: !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>) {
+    %0 = llvm.load %arg0 : !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>
+    %1 = llvm.extractvalue %0[0] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %2 = llvm.extractvalue %0[1] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %3 = llvm.extractvalue %0[2] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    llvm.call @foo(%1, %2, %3) : (!llvm.ptr<f64>, !llvm.ptr<f64>, i64) -> ()
+    llvm.return
+}
+
+// -----
+
+llvm.func @foo(%arg0: !llvm.ptr<f64>, %arg1: !llvm.ptr<f64>, %arg2: i64) -> () attributes {llvm.emit_c_interface} 
+
+// Test that the input argument is correctly translated to the one needed by _mlir_ciface_foo
+// For only one argument
+
+// CHECK-LABEL: llvm.func @_catalyst_pyface_foo
+// CHECK:    [[var0:%.+]] = llvm.load %arg1
+// CHECK:    [[var1:%.+]] = llvm.extractvalue [[var0]][0]
+// CHECK:    llvm.call @_catalyst_ciface_foo([[var1]])
+
+llvm.func @_mlir_ciface_foo(%arg0: !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>) {
+    %0 = llvm.load %arg0 : !llvm.ptr<struct<(ptr<f64>, ptr<f64>, i64)>>
+    %1 = llvm.extractvalue %0[0] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %2 = llvm.extractvalue %0[1] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    %3 = llvm.extractvalue %0[2] : !llvm.struct<(ptr<f64>, ptr<f64>, i64)> 
+    llvm.call @foo(%1, %2, %3) : (!llvm.ptr<f64>, !llvm.ptr<f64>, i64) -> ()
+    llvm.return
+}
+
+

--- a/mlir/tools/quantum-opt/quantum-opt.cpp
+++ b/mlir/tools/quantum-opt/quantum-opt.cpp
@@ -31,7 +31,7 @@ int main(int argc, char **argv)
     mlir::registerPass(catalyst::createGradientConversionPass);
     mlir::registerPass(catalyst::createQuantumBufferizationPass);
     mlir::registerPass(catalyst::createQuantumConversionPass);
-    mlir::registerPass(catalyst::createWrapperForWrapperPass);
+    mlir::registerPass(catalyst::createEmitCatalystPyInterfacePass);
 
     mlir::DialectRegistry registry;
     mlir::registerAllDialects(registry);

--- a/mlir/tools/quantum-opt/quantum-opt.cpp
+++ b/mlir/tools/quantum-opt/quantum-opt.cpp
@@ -31,6 +31,7 @@ int main(int argc, char **argv)
     mlir::registerPass(catalyst::createGradientConversionPass);
     mlir::registerPass(catalyst::createQuantumBufferizationPass);
     mlir::registerPass(catalyst::createQuantumConversionPass);
+    mlir::registerPass(catalyst::createWrapperForWrapperPass);
 
     mlir::DialectRegistry registry;
     mlir::registerAllDialects(registry);


### PR DESCRIPTION
When the arity of the function is not known statically, it is not possible to call a function from C/C++-like languages without using libffi. To avoid introducing a dependency on libffi, we fix the arity to be always two from within the compiler.

The first argument is a structure of memrefs which correspond to the possible return values.

The second argument is a structure of pointers to memrefs which correspond to the arguments to the functions.

To make this change we introduce the new flag `--wrapper-for-wrapper`. Please note that the original `_mlir_ciface_` wrapper still be available but with the name changed. This is because in some contexts like testing, it might be easier to use `_mlir_ciface_` wrapper instead of creating a brand new struct to hold this information.

**Benefits:** No need for libffi (see #99) , no need to JIT compile the wrapper (#97)

**Related GitHub Issues:**  #99
