### PR TITLE
Fix type hints for python 3.8.

### DIFF
--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -84,7 +84,7 @@ class PassPipeline(abc.ABC):
     """Abstract PassPipeline class."""
 
     _executable: Optional[str] = None
-    _default_flags: Optional[list[str]] = None
+    _default_flags: Optional[List[str]] = None
 
     @staticmethod
     @abc.abstractmethod

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -15,7 +15,7 @@
 of quantum operations, measurements, and observables to JAXPR.
 """
 
-import typing
+from typing import List
 import numpy as np
 
 import jax
@@ -1030,7 +1030,7 @@ def _qcond_def_impl(ctx, *preds_and_branch_args_plus_consts, branch_jaxprs):  # 
 def _qcond_lowering(
     jax_ctx: mlir.LoweringRuleContext,
     *preds_and_branch_args_plus_consts: tuple,
-    branch_jaxprs: typing.List[jax.core.ClosedJaxpr],
+    branch_jaxprs: List[jax.core.ClosedJaxpr],
 ):
     result_types = [mlir.aval_to_ir_types(a)[0] for a in jax_ctx.avals_out]
     num_preds = len(branch_jaxprs) - 1

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -15,6 +15,7 @@
 of quantum operations, measurements, and observables to JAXPR.
 """
 
+import typing
 import numpy as np
 
 import jax
@@ -1029,7 +1030,7 @@ def _qcond_def_impl(ctx, *preds_and_branch_args_plus_consts, branch_jaxprs):  # 
 def _qcond_lowering(
     jax_ctx: mlir.LoweringRuleContext,
     *preds_and_branch_args_plus_consts: tuple,
-    branch_jaxprs: list[jax.core.ClosedJaxpr],
+    branch_jaxprs: typing.List[jax.core.ClosedJaxpr],
 ):
     result_types = [mlir.aval_to_ir_types(a)[0] for a in jax_ctx.avals_out]
     num_preds = len(branch_jaxprs) - 1


### PR DESCRIPTION
**Description of the Change:** Add type hints compatible with python 3.8.

**Benefits:** The wheel should be compatible with python 3.8.
