### PR TITLE
Change naming convention for entry function.

### DIFF
--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -68,7 +68,7 @@ def get_mlir(func, *args, **kwargs):
     axis_context = ReplicaAxisContext(xla.AxisEnv(nrep, (), ()))
     name_stack = util.new_name_stack(util.wrap_name("ok", "jit"))
     module, context = custom_lower_jaxpr_to_module(
-        func_name="jit." + func.__name__,
+        func_name="jit_" + func.__name__,
         module_name=func.__name__,
         jaxpr=jaxpr,
         effects=effects,
@@ -523,7 +523,7 @@ def custom_lower_jaxpr_to_module(
 
         for op in ctx.module.body.operations:
             func_name = str(op.name)
-            is_entry_point = func_name.startswith('"jit.')
+            is_entry_point = func_name.startswith('"jit_')
             if is_entry_point:
                 continue
             op.attributes["llvm.linkage"] = ir.Attribute.parse("#llvm.linkage<internal>")

--- a/frontend/test/lit/test_aot_compilation.py
+++ b/frontend/test/lit/test_aot_compilation.py
@@ -26,7 +26,7 @@ Currently unsupported:
 """
 
 
-# CHECK-LABEL: public @jit.function_complex
+# CHECK-LABEL: public @jit_function_complex
 # CHECK-SAME: tensor<complex<f64>>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -41,7 +41,7 @@ def function_complex(x: complex, y: complex):
 print(function_complex.mlir)
 
 
-# CHECK-LABEL: public @jit.function_jaxnumpy_csingle
+# CHECK-LABEL: public @jit_function_jaxnumpy_csingle
 # CHECK-SAME: tensor<complex<f32>>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -56,7 +56,7 @@ def function_jaxnumpy_csingle(x: jax.numpy.csingle, y: jax.numpy.csingle):
 print(function_jaxnumpy_csingle.mlir)
 
 
-# CHECK-LABEL: public @jit.function_jaxnumpy_cdouble
+# CHECK-LABEL: public @jit_function_jaxnumpy_cdouble
 # CHECK-SAME: tensor<complex<f64>>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -71,7 +71,7 @@ def function_jaxnumpy_cdouble(x: jax.numpy.cdouble, y: jax.numpy.cdouble):
 print(function_jaxnumpy_cdouble.mlir)
 
 
-# CHECK-LABEL: public @jit.function_jaxnumpy_complex_
+# CHECK-LABEL: public @jit_function_jaxnumpy_complex_
 # CHECK-SAME: tensor<complex<f64>>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -86,7 +86,7 @@ def function_jaxnumpy_complex_(x: jax.numpy.complex_, y: jax.numpy.complex_):
 print(function_jaxnumpy_complex_.mlir)
 
 
-# CHECK-LABEL: public @jit.function_jaxnumpy_complex64
+# CHECK-LABEL: public @jit_function_jaxnumpy_complex64
 # CHECK-SAME: tensor<complex<f32>>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -101,7 +101,7 @@ def function_jaxnumpy_complex64(x: jax.numpy.complex64, y: jax.numpy.complex64):
 print(function_jaxnumpy_complex64.mlir)
 
 
-# CHECK-LABEL: public @jit.function_jaxnumpy_complex128
+# CHECK-LABEL: public @jit_function_jaxnumpy_complex128
 # CHECK-SAME: tensor<complex<f64>>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -116,7 +116,7 @@ def function_jaxnumpy_complex128(x: jax.numpy.complex128, y: jax.numpy.complex12
 print(function_jaxnumpy_complex128.mlir)
 
 
-# CHECK-LABEL: public @jit.function_bool
+# CHECK-LABEL: public @jit_function_bool
 # CHECK-SAME: tensor<i1>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -129,7 +129,7 @@ def function_bool(x: bool, y: bool):
 print(function_bool.mlir)
 
 
-# CHECK-LABEL: public @jit.function_int
+# CHECK-LABEL: public @jit_function_int
 # CHECK-SAME: tensor<i64>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -142,7 +142,7 @@ def function_int(x: int, y: int):
 print(function_int.mlir)
 
 
-# CHECK-LABEL: public @jit.function_float
+# CHECK-LABEL: public @jit_function_float
 # CHECK-SAME: tensor<f64>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -155,7 +155,7 @@ def function_float(x: float, y: float):
 print(function_float.mlir)
 
 
-# CHECK-LABEL: public @jit.function_jaxnumpy_float64
+# CHECK-LABEL: public @jit_function_jaxnumpy_float64
 # CHECK-SAME: tensor<f64>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -168,7 +168,7 @@ def function_jaxnumpy_float64(x: jax.numpy.float64, y: jax.numpy.float64):
 print(function_jaxnumpy_float64.mlir)
 
 
-# CHECK-LABEL: public @jit.function_jaxnumpy_double
+# CHECK-LABEL: public @jit_function_jaxnumpy_double
 # CHECK-SAME: tensor<f64>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -181,7 +181,7 @@ def function_jaxnumpy_double(x: jax.numpy.double, y: jax.numpy.double):
 print(function_jaxnumpy_double.mlir)
 
 
-# CHECK-LABEL: public @jit.function_jaxnumpy_int_
+# CHECK-LABEL: public @jit_function_jaxnumpy_int_
 # CHECK-SAME: tensor<i64>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -194,7 +194,7 @@ def function_jaxnumpy_int_(x: jax.numpy.int_, y: jax.numpy.int_):
 print(function_jaxnumpy_int_.mlir)
 
 
-# CHECK-LABEL: public @jit.function_jaxnumpy_int64
+# CHECK-LABEL: public @jit_function_jaxnumpy_int64
 # CHECK-SAME: tensor<i64>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -207,7 +207,7 @@ def function_jaxnumpy_int64(x: jax.numpy.int64, y: jax.numpy.int64):
 print(function_jaxnumpy_int64.mlir)
 
 
-# CHECK-LABEL: public @jit.function_scalar_tensor_bool
+# CHECK-LABEL: public @jit_function_scalar_tensor_bool
 # CHECK-SAME: tensor<i1>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -220,7 +220,7 @@ def function_scalar_tensor_bool(x: ShapedArray([], bool), y: ShapedArray([], boo
 print(function_scalar_tensor_bool.mlir)
 
 
-# CHECK-LABEL: public @jit.function_scalar_tensor_int
+# CHECK-LABEL: public @jit_function_scalar_tensor_int
 # CHECK-SAME: tensor<i64>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -233,7 +233,7 @@ def function_scalar_tensor_int(x: ShapedArray([], int), y: ShapedArray([], int))
 print(function_scalar_tensor_int.mlir)
 
 
-# CHECK-LABEL: public @jit.function_scalar_tensor_float
+# CHECK-LABEL: public @jit_function_scalar_tensor_float
 # CHECK-SAME: tensor<f64>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -246,7 +246,7 @@ def function_scalar_tensor_float(x: ShapedArray([], float), y: ShapedArray([], f
 print(function_scalar_tensor_float.mlir)
 
 
-# CHECK-LABEL: public @jit.function_scalar_tensor_jaxnumpy_float64
+# CHECK-LABEL: public @jit_function_scalar_tensor_jaxnumpy_float64
 # CHECK-SAME: tensor<f64>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -261,7 +261,7 @@ def function_scalar_tensor_jaxnumpy_float64(
 print(function_scalar_tensor_jaxnumpy_float64.mlir)
 
 
-# CHECK-LABEL: public @jit.function_scalar_tensor_jaxnumpy_double
+# CHECK-LABEL: public @jit_function_scalar_tensor_jaxnumpy_double
 # CHECK-SAME: tensor<f64>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -276,7 +276,7 @@ def function_scalar_tensor_jaxnumpy_double(
 print(function_scalar_tensor_jaxnumpy_double.mlir)
 
 
-# CHECK-LABEL: public @jit.function_scalar_tensor_jaxnumpy_int_
+# CHECK-LABEL: public @jit_function_scalar_tensor_jaxnumpy_int_
 # CHECK-SAME: tensor<i64>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -291,7 +291,7 @@ def function_scalar_tensor_jaxnumpy_int_(
 print(function_scalar_tensor_jaxnumpy_int_.mlir)
 
 
-# CHECK-LABEL: public @jit.function_scalar_tensor_jaxnumpy_int64
+# CHECK-LABEL: public @jit_function_scalar_tensor_jaxnumpy_int64
 # CHECK-SAME: tensor<i64>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -306,7 +306,7 @@ def function_scalar_tensor_jaxnumpy_int64(
 print(function_scalar_tensor_jaxnumpy_int64.mlir)
 
 
-# CHECK-LABEL: public @jit.function_tensor_bool
+# CHECK-LABEL: public @jit_function_tensor_bool
 # CHECK-SAME: tensor<1xi1>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -319,7 +319,7 @@ def function_tensor_bool(x: ShapedArray([1], bool), y: ShapedArray([1], bool)):
 print(function_tensor_bool.mlir)
 
 
-# CHECK-LABEL: public @jit.function_tensor_int
+# CHECK-LABEL: public @jit_function_tensor_int
 # CHECK-SAME: tensor<1xi64>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -332,7 +332,7 @@ def function_tensor_int(x: ShapedArray([1], int), y: ShapedArray([1], int)):
 print(function_tensor_int.mlir)
 
 
-# CHECK-LABEL: public @jit.function_tensor_float
+# CHECK-LABEL: public @jit_function_tensor_float
 # CHECK-SAME: tensor<1xf64>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -345,7 +345,7 @@ def function_tensor_float(x: ShapedArray([1], float), y: ShapedArray([1], float)
 print(function_tensor_float.mlir)
 
 
-# CHECK-LABEL: public @jit.function_tensor_jaxnumpy_float64
+# CHECK-LABEL: public @jit_function_tensor_jaxnumpy_float64
 # CHECK-SAME: tensor<1xf64>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -360,7 +360,7 @@ def function_tensor_jaxnumpy_float64(
 print(function_tensor_jaxnumpy_float64.mlir)
 
 
-# CHECK-LABEL: public @jit.function_tensor_jaxnumpy_double
+# CHECK-LABEL: public @jit_function_tensor_jaxnumpy_double
 # CHECK-SAME: tensor<1xf64>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -375,7 +375,7 @@ def function_tensor_jaxnumpy_double(
 print(function_tensor_jaxnumpy_double.mlir)
 
 
-# CHECK-LABEL: public @jit.function_tensor_jaxnumpy_int_
+# CHECK-LABEL: public @jit_function_tensor_jaxnumpy_int_
 # CHECK-SAME: tensor<1xi64>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -390,7 +390,7 @@ def function_tensor_jaxnumpy_int_(
 print(function_tensor_jaxnumpy_int_.mlir)
 
 
-# CHECK-LABEL: public @jit.function_tensor_jaxnumpy_int64
+# CHECK-LABEL: public @jit_function_tensor_jaxnumpy_int64
 # CHECK-SAME: tensor<1xi64>
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))

--- a/frontend/test/lit/test_custom_ops.py
+++ b/frontend/test/lit/test_custom_ops.py
@@ -83,12 +83,12 @@ def compile_circuit_with_device(device):
     print(f.mlir)
 
 
-# CHECK-LABEL: public @jit.f
+# CHECK-LABEL: public @jit_f
 # CHECK-NOT: RXX
 # CHECK: multirz
 # CHECK-NOT: RXX
 compile_circuit_with_device(devMultiRZ)
-# CHECK-LABEL: public @jit.f
+# CHECK-LABEL: public @jit_f
 # CHECK-NOT: multirz
 # CHECK: RXX
 # CHECK-NOT: multirz

--- a/frontend/test/lit/test_decomposition.py
+++ b/frontend/test/lit/test_decomposition.py
@@ -52,7 +52,7 @@ def test_decompose_multicontrolledx():
 
     @qjit(target="mlir")
     @qfunc(5, device=dev)
-    # CHECK-LABEL: public @jit.decompose_multicontrolled_x1
+    # CHECK-LABEL: public @jit_decompose_multicontrolled_x1
     def decompose_multicontrolled_x1(theta: float):
         qml.RX(theta, wires=[0])
         # CHECK-NOT: name = "MultiControlledX"
@@ -78,7 +78,7 @@ def test_decompose_multicontrolledx_in_conditional():
 
     @qjit(target="mlir")
     @qfunc(5, device=dev)
-    # CHECK-LABEL: @jit.decompose_multicontrolled_x2
+    # CHECK-LABEL: @jit_decompose_multicontrolled_x2
     def decompose_multicontrolled_x2(theta: float, n: int):
         qml.RX(theta, wires=[0])
 
@@ -110,7 +110,7 @@ def test_decompose_multicontrolledx_in_while_loop():
 
     @qjit(target="mlir")
     @qfunc(5, device=dev)
-    # CHECK-LABEL: @jit.decompose_multicontrolled_x3
+    # CHECK-LABEL: @jit_decompose_multicontrolled_x3
     def decompose_multicontrolled_x3(theta: float, n: int):
         qml.RX(theta, wires=[0])
 
@@ -142,7 +142,7 @@ def test_decompose_multicontrolledx_in_for_loop():
 
     @qjit(target="mlir")
     @qfunc(5, device=dev)
-    # CHECK-LABEL: @jit.decompose_multicontrolled_x4
+    # CHECK-LABEL: @jit_decompose_multicontrolled_x4
     def decompose_multicontrolled_x4(theta: float, n: int):
         qml.RX(theta, wires=[0])
 
@@ -173,7 +173,7 @@ def test_decompose_rot():
 
     @qjit(target="mlir")
     @qfunc(1, device=dev)
-    # CHECK-LABEL: public @jit.decompose_rot
+    # CHECK-LABEL: public @jit_decompose_rot
     def decompose_rot(phi: float, theta: float, omega: float):
         # CHECK-NOT: name = "Rot"
         # CHECK: [[phi:%.+]] = tensor.extract %arg0[] : tensor<f64>
@@ -202,7 +202,7 @@ def test_decompose_s():
 
     @qjit(target="mlir")
     @qfunc(1, device=dev)
-    # CHECK-LABEL: public @jit.decompose_s
+    # CHECK-LABEL: public @jit_decompose_s
     def decompose_s():
         # CHECK-NOT: name="S"
         # CHECK: [[pi_div_2_t:%.+]] = mhlo.constant dense<1.57079{{.+}}> : tensor<f64>
@@ -225,7 +225,7 @@ def test_decompose_qubitunitary():
 
     @qjit(target="mlir")
     @qfunc(1, device=dev)
-    # CHECK-LABEL: public @jit.decompose_qubit_unitary
+    # CHECK-LABEL: public @jit_decompose_qubit_unitary
     def decompose_qubit_unitary(U: jax.core.ShapedArray([2, 2], float)):
         # CHECK-NOT: name = "QubitUnitary"
         # CHECK: name = "Rot"
@@ -244,7 +244,7 @@ def test_decompose_singleexcitationplus():
 
     @qjit(target="mlir")
     @qfunc(2, device=dev)
-    # CHECK-LABEL: public @jit.decompose_singleexcitationplus
+    # CHECK-LABEL: public @jit_decompose_singleexcitationplus
     def decompose_singleexcitationplus(theta: float):
         # CHECK-NOT: name = "SingleExcitationPlus"
         # CHECK: [[a_scalar_tensor_float_2:%.+]] = mhlo.constant dense<2.{{[0]+}}e+00>

--- a/frontend/test/lit/test_for_loop.py
+++ b/frontend/test/lit/test_for_loop.py
@@ -20,7 +20,7 @@ import pennylane as qml
 
 
 # CHECK-NOT: Verification failed
-# CHECK-LABEL: @jit.loop_circuit
+# CHECK-LABEL: @jit_loop_circuit
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=3))
 def loop_circuit(n: int, inc: float):

--- a/frontend/test/lit/test_function_attributes.py
+++ b/frontend/test/lit/test_function_attributes.py
@@ -28,7 +28,7 @@ def qnode(x):
 
 @qjit(target="mlir")
 # The entry point has no internal linkage.
-# CHECK-DAG: func.func public @jit.workload(%arg0: tensor<f64>) -> tensor<4xcomplex<f64>> attributes {llvm.emit_c_interface} {
+# CHECK-DAG: func.func public @jit_workload(%arg0: tensor<f64>) -> tensor<4xcomplex<f64>> attributes {llvm.emit_c_interface} {
 def workload(x: float):
     y = x * qml.numpy.pi
     return qnode(y)

--- a/frontend/test/lit/test_gradient.py
+++ b/frontend/test/lit/test_gradient.py
@@ -20,7 +20,7 @@ import jax
 import numpy as np
 
 
-# CHECK-LABEL: public @jit.grad_default
+# CHECK-LABEL: public @jit_grad_default
 @qjit(target="mlir")
 def grad_default(x: float):
     @qml.qnode(qml.device("lightning.qubit", wires=1))
@@ -36,7 +36,7 @@ def grad_default(x: float):
 print(grad_default.mlir)
 
 
-# CHECK-LABEL: public @jit.override_method
+# CHECK-LABEL: public @jit_override_method
 @qjit(target="mlir")
 def override_method(x: float):
     @qml.qnode(qml.device("lightning.qubit", wires=1))
@@ -52,7 +52,7 @@ def override_method(x: float):
 print(override_method.mlir)
 
 
-# CHECK-LABEL: public @jit.override_h
+# CHECK-LABEL: public @jit_override_h
 @qjit(target="mlir")
 def override_h(x: float):
     @qml.qnode(qml.device("lightning.qubit", wires=1))
@@ -68,7 +68,7 @@ def override_h(x: float):
 print(override_h.mlir)
 
 
-# CHECK-LABEL: public @jit.override_diff_arg
+# CHECK-LABEL: public @jit_override_diff_arg
 @qjit(target="mlir")
 def override_diff_arg(x: float):
     @qml.qnode(qml.device("lightning.qubit", wires=1))
@@ -84,7 +84,7 @@ def override_diff_arg(x: float):
 print(override_diff_arg.mlir)
 
 
-# CHECK-LABEL: public @jit.second_grad
+# CHECK-LABEL: public @jit_second_grad
 @qjit(target="mlir")
 def second_grad(x: float):
     @qml.qnode(qml.device("lightning.qubit", wires=1))
@@ -102,7 +102,7 @@ def second_grad(x: float):
 print(second_grad.mlir)
 
 
-# CHECK-LABEL: public @jit.grad_range_change
+# CHECK-LABEL: public @jit_grad_range_change
 @qjit(target="mlir")
 def grad_range_change():
     @qml.qnode(qml.device("lightning.qubit", wires=1))
@@ -119,7 +119,7 @@ def grad_range_change():
 print(grad_range_change.mlir)
 
 
-# CHECK-LABEL: public @jit.grad_hoist_constant(%arg0
+# CHECK-LABEL: public @jit_grad_hoist_constant(%arg0
 @qjit(target="mlir")
 def grad_hoist_constant(params: jax.core.ShapedArray([2], float)):
     @qml.qnode(qml.device("lightning.qubit", wires=3))

--- a/frontend/test/lit/test_if_else.py
+++ b/frontend/test/lit/test_if_else.py
@@ -19,7 +19,7 @@ import pennylane as qml
 
 
 # CHECK-NOT: Verification failed
-# CHECK-LABEL: public @jit.circuit
+# CHECK-LABEL: public @jit_circuit
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=1))
 def circuit(n: int):

--- a/frontend/test/lit/test_multi_qubit_gates.py
+++ b/frontend/test/lit/test_multi_qubit_gates.py
@@ -19,7 +19,7 @@ import pennylane as qml
 import numpy as np
 
 
-# CHECK-LABEL: public @jit.circuit
+# CHECK-LABEL: public @jit_circuit
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=5))
 def circuit(x: float):
@@ -37,7 +37,7 @@ def circuit(x: float):
 print(circuit.mlir)
 
 
-# CHECK-LABEL: public @jit.circuit
+# CHECK-LABEL: public @jit_circuit
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=3))
 def circuit():

--- a/frontend/test/lit/test_param_types.py
+++ b/frontend/test/lit/test_param_types.py
@@ -82,32 +82,32 @@ def test_tensor_accept(type):
 
 # The compiled quantum function should accept
 # * JAX tensors of type int8
-# CHECK-LABEL: jit.jax_untyped(%arg0: tensor<1xi8>)
-# CHECK-LABEL: jit.jax_typed(%arg0: tensor<1xi8>)
+# CHECK-LABEL: jit_jax_untyped(%arg0: tensor<1xi8>)
+# CHECK-LABEL: jit_jax_typed(%arg0: tensor<1xi8>)
 test_tensor_accept(jnp.int8)
 # * JAX tensors of type int16
-# CHECK-LABEL: jit.jax_untyped(%arg0: tensor<1xi16>)
-# CHECK-LABEL: jit.jax_typed(%arg0: tensor<1xi16>)
+# CHECK-LABEL: jit_jax_untyped(%arg0: tensor<1xi16>)
+# CHECK-LABEL: jit_jax_typed(%arg0: tensor<1xi16>)
 test_tensor_accept(jnp.int16)
 # * JAX tensors of type int32
-# CHECK-LABEL: jit.jax_untyped(%arg0: tensor<1xi32>)
-# CHECK-LABEL: jit.jax_typed(%arg0: tensor<1xi32>)
+# CHECK-LABEL: jit_jax_untyped(%arg0: tensor<1xi32>)
+# CHECK-LABEL: jit_jax_typed(%arg0: tensor<1xi32>)
 test_tensor_accept(jnp.int32)
 # * JAX tensors of type float32
-# CHECK-LABEL: jit.jax_untyped(%arg0: tensor<1xf32>)
-# CHECK-LABEL: jit.jax_typed(%arg0: tensor<1xf32>)
+# CHECK-LABEL: jit_jax_untyped(%arg0: tensor<1xf32>)
+# CHECK-LABEL: jit_jax_typed(%arg0: tensor<1xf32>)
 test_tensor_accept(jnp.float32)
 # * JAX tensors of type float64
-# CHECK-LABEL: jit.jax_untyped(%arg0: tensor<1xf64>)
-# CHECK-LABEL: jit.jax_typed(%arg0: tensor<1xf64>)
+# CHECK-LABEL: jit_jax_untyped(%arg0: tensor<1xf64>)
+# CHECK-LABEL: jit_jax_typed(%arg0: tensor<1xf64>)
 test_tensor_accept(jnp.float64)
 # * JAX tensors of type complex64
-# CHECK-LABEL: jit.jax_untyped(%arg0: tensor<1xcomplex<f32>>)
-# CHECK-LABEL: jit.jax_typed(%arg0: tensor<1xcomplex<f32>>)
+# CHECK-LABEL: jit_jax_untyped(%arg0: tensor<1xcomplex<f32>>)
+# CHECK-LABEL: jit_jax_typed(%arg0: tensor<1xcomplex<f32>>)
 test_tensor_accept(jnp.complex64)
 # * JAX tensors of type complex128
-# CHECK-LABEL: jit.jax_untyped(%arg0: tensor<1xcomplex<f64>>)
-# CHECK-LABEL: jit.jax_typed(%arg0: tensor<1xcomplex<f64>>)
+# CHECK-LABEL: jit_jax_untyped(%arg0: tensor<1xcomplex<f64>>)
+# CHECK-LABEL: jit_jax_typed(%arg0: tensor<1xcomplex<f64>>)
 test_tensor_accept(jnp.complex128)
 
 
@@ -160,18 +160,18 @@ def test_python_accept(type):
 
 # The compiled function should accept
 # * python booleans
-# CHECK-LABEL: jit.jax_untyped(%arg0: tensor<i1>)
-# CHECK-LABEL: jit.jax_typed(%arg0: tensor<i1>)
+# CHECK-LABEL: jit_jax_untyped(%arg0: tensor<i1>)
+# CHECK-LABEL: jit_jax_typed(%arg0: tensor<i1>)
 test_python_accept(bool)
 # * python integers
-# CHECK-LABEL: jit.jax_untyped(%arg0: tensor<i64>)
-# CHECK-LABEL: jit.jax_typed(%arg0: tensor<i64>)
+# CHECK-LABEL: jit_jax_untyped(%arg0: tensor<i64>)
+# CHECK-LABEL: jit_jax_typed(%arg0: tensor<i64>)
 test_python_accept(int)
 # * python floats
-# CHECK-LABEL: jit.jax_untyped(%arg0: tensor<f64>)
-# CHECK-LABEL: jit.jax_typed(%arg0: tensor<f64>)
+# CHECK-LABEL: jit_jax_untyped(%arg0: tensor<f64>)
+# CHECK-LABEL: jit_jax_typed(%arg0: tensor<f64>)
 test_python_accept(float)
 # * python complex
-# CHECK-LABEL: jit.jax_untyped(%arg0: tensor<complex<f64>>)
-# CHECK-LABEL: jit.jax_typed(%arg0: tensor<complex<f64>>)
+# CHECK-LABEL: jit_jax_untyped(%arg0: tensor<complex<f64>>)
+# CHECK-LABEL: jit_jax_typed(%arg0: tensor<complex<f64>>)
 test_python_accept(complex)

--- a/frontend/test/lit/test_while_loop.py
+++ b/frontend/test/lit/test_while_loop.py
@@ -19,7 +19,7 @@ import pennylane as qml
 
 
 # CHECK-NOT: Verification failed
-# CHECK-LABEL: @jit.circuit
+# CHECK-LABEL: @jit_circuit
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=1))
 def circuit(n: int):
@@ -47,7 +47,7 @@ print(circuit.mlir)
 
 
 # CHECK-NOT: Verification failed
-# CHECK-LABEL: func.func public @jit.circuit_outer_scope_reference
+# CHECK-LABEL: func.func public @jit_circuit_outer_scope_reference
 # CHECK-SAME: ([[c1:%[a-zA-Z0-9_]+]]
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=1))
@@ -78,7 +78,7 @@ print(circuit_outer_scope_reference.mlir)
 
 
 # CHECK-NOT: Verification failed
-# CHECK-LABEL: public @jit.circuit_multiple_args
+# CHECK-LABEL: public @jit_circuit_multiple_args
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=1))
 def circuit_multiple_args(n: int):


### PR DESCRIPTION
**Context:** There are a couple of PRs that depend on this, and while they are on review I would like to add this change to avoid having to rebase, re-implement.

**Description of the Change:** Change the naming convention for the entry function from `jit.` to `jit_`
