### PR TITLE
Remove the temporary solution for propagating runtime exceptions in the frontend

### DIFF
--- a/runtime/include/Exception.hpp
+++ b/runtime/include/Exception.hpp
@@ -81,10 +81,6 @@ class RuntimeException : public std::exception {
     sstream << "[" << file_name << "][Line:" << line << "][Function:" << function_name
             << "] Error in Catalyst Runtime: " << message;
 
-    // TODO: This should be removed after runtime error
-    // messages can propagate in the frontend.
-    std::cerr << sstream.str() << std::endl;
-
     throw RuntimeException(sstream.str());
 } // LCOV_EXCL_LINE
 


### PR DESCRIPTION
Removes printing to stderr from the runtime. This prevents messages like this:

```
[/home/runner/work/catalyst/catalyst/runtime/lib/capi/./RuntimeCAPI.cpp][Line:65][Function:__quantum__rt__fail_cstr] Error in Catalyst Runtime: Test!
```

to show up during runtime [tests](https://github.com/PennyLaneAI/catalyst/actions/runs/4915977471/jobs/8779161559) even if the runtime test succeed.