### PR TITLE
Temporary fix for memory issues.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -54,6 +54,9 @@
   as global buffers cannot be transferred to Python.
   [#112](https://github.com/PennyLaneAI/catalyst/pull/112)
 
+* Temporary fix of use-after-free and dependency of uninitialized memory.
+  [#121](https://github.com/PennyLaneAI/catalyst/pull/121)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -173,10 +173,10 @@ class BufferizationPass(PassPipeline):
         "--finalizing-bufferize",
         "--buffer-hoisting",
         "--buffer-loop-hoisting",
-        "--buffer-deallocation",
+        # "--buffer-deallocation",
         "--convert-bufferization-to-memref",
         "--canonicalize",
-        "--cse",
+        # "--cse",
         "--cp-global-memref",
     ]
 

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -171,7 +171,7 @@ class BufferizationPass(PassPipeline):
         "--quantum-bufferize",
         "--func-bufferize",
         "--finalizing-bufferize",
-        "--buffer-hoisting",
+        # "--buffer-hoisting",
         "--buffer-loop-hoisting",
         # "--buffer-deallocation",
         "--convert-bufferization-to-memref",


### PR DESCRIPTION
**Context:** There's a [bug](https://github.com/llvm/llvm-project/issues/62644) in upstream LLVM where `linalg.index` is marked as pure. This causes CSE to change the semantics of the program when loops are being iterated on leading to errors. There's also another issue with the bufferization pipeline and that is that buffer deallocation appears to not take into account aliasing. Deallocating an aliasing buffer leads to use after free errors.

**Description of the Change:** Temporarily disable CSE until issue is resolved upstream. Temporarily disable deallocation of buffers while a longer term solution is found.

**Benefits:** No use of uninitialized memory bugs. No use after free bugs.

**Possible Drawbacks:** Increased memory footprint during the execution of JIT compiled.

**Related GitHub Issues:** #83 
