### PR TITLE
Add support for the variance of general observables

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -14,6 +14,9 @@
   chosen as available backend devices from the frontend.
   [#89](https://github.com/PennyLaneAI/catalyst/pull/89)
 
+* Add support for ``var`` of general observables
+  [#124](https://github.com/PennyLaneAI/catalyst/pull/124)
+
 <h3>Improvements</h3>
 
 * Improving error handling by throwing descriptive and unified expressions for runtime

--- a/doc/dev/quick_start.rst
+++ b/doc/dev/quick_start.rst
@@ -250,7 +250,7 @@ are supported in Catalyst, although not all features are supported for all measu
    * - :func:`qml.expval() <pennylane.expval>`
      - The expectation value of all observables is supported.
    * - :func:`qml.var() <pennylane.var>`
-     - The variance of Pauli observables only is supported.
+     - The variance of all observables is supported.
    * - :func:`qml.sample() <pennylane.sample>`
      - Samples in the computational basis only are supported.
    * - :func:`qml.counts() <pennylane.counts>`

--- a/frontend/test/lit/test_measurements.py
+++ b/frontend/test/lit/test_measurements.py
@@ -399,11 +399,8 @@ print(var1.mlir)
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=3))
 def var2(x: float, y: float):
-    # CHECK: [[q0:%.+]] = "quantum.custom"({{%.+}}, {{%.+}}) {gate_name = "RX"
     qml.RX(x, wires=0)
-    # CHECK: [[q1:%.+]] = "quantum.custom"({{%.+}}, {{%.+}}) {gate_name = "RY"
     qml.RY(y, wires=1)
-    # CHECK: [[q2:%.+]] = "quantum.custom"({{%.+}}, {{%.+}}) {gate_name = "RZ"
     qml.RZ(0.1, wires=2)
 
     B = np.array(
@@ -415,43 +412,12 @@ def var2(x: float, y: float):
         ]
     )
 
-    # CHECK: [[p0:%.+]] = "quantum.namedobs"([[q1]]) {type = 1 : i8}
-    # CHECK: [[h0:%.+]] = "quantum.hermitian"({{%.+}}, [[q0]], [[q2]]) : (tensor<4x4xcomplex<f64>>, !quantum.bit, !quantum.bit) -> !quantum.obs
-    # CHECK: [[obs:%.+]] = "quantum.tensor"([[p0]], [[h0]])
+    # CHECK: [[obs:%.+]] = "quantum.tensor"({{.+}}, {{.+}})
     # CHECK: "quantum.var"([[obs]]) {{.+}} -> f64
     return qml.var(qml.PauliX(1) @ qml.Hermitian(B, wires=[0, 2]))
 
 
 print(var2.mlir)
-
-
-# CHECK-LABEL: private @var3(
-@qjit(target="mlir")
-@qml.qnode(qml.device("lightning.qubit", wires=2))
-def var3(x: float):
-    # CHECK: [[q0:%.+]] = "quantum.custom"({{%.+}}, {{%.+}}) {gate_name = "RX"
-    qml.RX(x, wires=0)
-
-    coeff = np.array([0.8, 0.2])
-    obs_matrix = np.array(
-        [
-            [0.5, 1.0j, 0.0, -3j],
-            [-1.0j, -1.1, 0.0, -0.1],
-            [0.0, 0.0, -0.9, 12.0],
-            [3j, -0.1, 12.0, 0.0],
-        ]
-    )
-
-    # CHECK: [[h0:%.+]] = "quantum.hermitian"({{%.+}}, {{%.+}}, {{%.+}}) : (tensor<4x4xcomplex<f64>>, !quantum.bit, !quantum.bit) -> !quantum.obs
-    obs = qml.Hermitian(obs_matrix, wires=[0, 1])
-
-    # CHECK: [[n0:%.+]] = "quantum.namedobs"([[q0]]) {type = 1 : i8}
-    # CHECK: [[obs:%.+]] = "quantum.hamiltonian"({{%.+}}, [[h0]], [[n0]]) : (tensor<2xf64>, !quantum.obs, !quantum.obs) -> !quantum.obs
-    # CHECK: "quantum.var"([[obs]]) {{.+}} -> f64
-    return qml.var(qml.Hamiltonian(coeff, [obs, qml.PauliX(0)]))
-
-
-print(var3.mlir)
 
 
 # CHECK-LABEL: private @probs1(

--- a/runtime/README.rst
+++ b/runtime/README.rst
@@ -69,7 +69,7 @@ The following table shows the available devices along with supported features:
      - All observables; Finite-shots not supported
      - All observables; Finite-shots not supported
    * - Variance
-     - Only for ``Identity``, ``PauliX``, ``PauliY``, ``PauliZ``, and ``Hadamard``; Finite-shots not supported
+     - All observables; Finite-shots not supported
      - All observables; Finite-shots not supported
    * - Probability
      - Only for the computational basis on the supplied qubits; Finite-shots not supported

--- a/runtime/lib/backend/LightningSimulator.cpp
+++ b/runtime/lib/backend/LightningSimulator.cpp
@@ -187,7 +187,6 @@ auto LightningSimulator::Var(ObsIdType obsKey) -> double
 {
     RT_FAIL_IF(!this->obs_manager.isValidObservables({obsKey}),
                "Invalid key for cached observables");
-
     auto &&obs = this->obs_manager.getObservable(obsKey);
 
     // update tape caching
@@ -195,19 +194,9 @@ auto LightningSimulator::Var(ObsIdType obsKey) -> double
         this->cache_manager.addObservable(obsKey, Lightning::Measurements::Var);
     }
 
-    auto obs_str = obs->getObsName();
-    size_t found = obs_str.find_first_of("[");
-    if (found != std::string::npos) {
-        obs_str = obs_str.substr(0, found);
-    }
-
-    auto obs_wires = obs->getWires();
-
     Pennylane::Simulators::Measures m{*(this->device_sv)};
 
-    const double result = m.var(obs_str, obs_wires);
-
-    return result;
+    return m.var(*obs);
 }
 
 void LightningSimulator::State(DataView<std::complex<double>, 1> &state)

--- a/runtime/tests/Test_LightningMeasures.cpp
+++ b/runtime/tests/Test_LightningMeasures.cpp
@@ -474,9 +474,7 @@ TEMPLATE_LIST_TEST_CASE("Var(NamedObs) test with numWires=4", "[Measures]", SimT
     CHECK(sim->Var(pz) == Approx(.0).margin(1e-5));
 }
 
-// TODO: Fix the following tests after the next release of PennyLane-Lightning
-#ifdef __device_lightning_kokkos
-TEMPLATE_TEST_CASE("Var(HermitianObs) test with numWires=1", "[Measures]", LightningKokkosSimulator)
+TEMPLATE_LIST_TEST_CASE("Var(HermitianObs) test with numWires=1", "[Measures]", SimTypes)
 {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
@@ -501,7 +499,7 @@ TEMPLATE_TEST_CASE("Var(HermitianObs) test with numWires=1", "[Measures]", Light
     CHECK(sim->Var(h2) == Approx(1.0).margin(1e-5));
 }
 
-TEMPLATE_TEST_CASE("Var(TensorProd(NamedObs)) test", "[Measures]", LightningKokkosSimulator)
+TEMPLATE_LIST_TEST_CASE("Var(TensorProd(NamedObs)) test", "[Measures]", SimTypes)
 {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
@@ -530,7 +528,7 @@ TEMPLATE_TEST_CASE("Var(TensorProd(NamedObs)) test", "[Measures]", LightningKokk
     CHECK(sim->Var(tpz) == Approx(.0).margin(1e-5));
 }
 
-TEMPLATE_TEST_CASE("Var(TensorProd(NamedObs[])) test", "[Measures]", LightningKokkosSimulator)
+TEMPLATE_LIST_TEST_CASE("Var(TensorProd(NamedObs[])) test", "[Measures]", SimTypes)
 {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
@@ -557,7 +555,7 @@ TEMPLATE_TEST_CASE("Var(TensorProd(NamedObs[])) test", "[Measures]", LightningKo
     CHECK(sim->Var(tpxz) == Approx(0.0).margin(1e-5));
 }
 
-TEMPLATE_TEST_CASE("Var(TensorProd(HermitianObs)) test", "[Measures]", LightningKokkosSimulator)
+TEMPLATE_LIST_TEST_CASE("Var(TensorProd(HermitianObs)) test", "[Measures]", SimTypes)
 {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
@@ -584,7 +582,7 @@ TEMPLATE_TEST_CASE("Var(TensorProd(HermitianObs)) test", "[Measures]", Lightning
     CHECK(sim->Var(tph2) == Approx(1.0).margin(1e-5));
 }
 
-TEMPLATE_TEST_CASE("Var(TensorProd(HermitianObs[])) test", "[Measures]", LightningKokkosSimulator)
+TEMPLATE_LIST_TEST_CASE("Var(TensorProd(HermitianObs[])) test", "[Measures]", SimTypes)
 {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
@@ -609,7 +607,7 @@ TEMPLATE_TEST_CASE("Var(TensorProd(HermitianObs[])) test", "[Measures]", Lightni
     CHECK(sim->Var(tp) == Approx(2.0).margin(1e-5));
 }
 
-TEMPLATE_TEST_CASE("Var(TensorProd(Obs[])) test", "[Measures]", LightningKokkosSimulator)
+TEMPLATE_LIST_TEST_CASE("Var(TensorProd(Obs[])) test", "[Measures]", SimTypes)
 {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
@@ -637,7 +635,7 @@ TEMPLATE_TEST_CASE("Var(TensorProd(Obs[])) test", "[Measures]", LightningKokkosS
     CHECK(sim->Var(tp) == Approx(4.0).margin(1e-5));
 }
 
-TEMPLATE_TEST_CASE("Var(Hamiltonian(NamedObs[])) test", "[Measures]", LightningKokkosSimulator)
+TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian(NamedObs[])) test", "[Measures]", SimTypes)
 {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
@@ -662,7 +660,7 @@ TEMPLATE_TEST_CASE("Var(Hamiltonian(NamedObs[])) test", "[Measures]", LightningK
     CHECK(sim->Var(hxyz) == Approx(0.64).margin(1e-5));
 }
 
-TEMPLATE_TEST_CASE("Var(Hamiltonian(TensorObs[])) test", "[Measures]", LightningKokkosSimulator)
+TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian(TensorObs[])) test", "[Measures]", SimTypes)
 {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
@@ -689,7 +687,7 @@ TEMPLATE_TEST_CASE("Var(Hamiltonian(TensorObs[])) test", "[Measures]", Lightning
     CHECK(sim->Var(hxyz) == Approx(0.04).margin(1e-5));
 }
 
-TEMPLATE_TEST_CASE("Var(Hamiltonian(Hermitian[])) test", "[Measures]", LightningKokkosSimulator)
+TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian(Hermitian[])) test", "[Measures]", SimTypes)
 {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
@@ -716,8 +714,7 @@ TEMPLATE_TEST_CASE("Var(Hamiltonian(Hermitian[])) test", "[Measures]", Lightning
     CHECK(sim->Var(hxhz) == Approx(0.36).margin(1e-5));
 }
 
-TEMPLATE_TEST_CASE("Var(Hamiltonian({TensorProd, Hermitian}[])) test", "[Measures]",
-                   LightningKokkosSimulator)
+TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian({TensorProd, Hermitian}[])) test", "[Measures]", SimTypes)
 {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
@@ -744,7 +741,6 @@ TEMPLATE_TEST_CASE("Var(Hamiltonian({TensorProd, Hermitian}[])) test", "[Measure
 
     CHECK(sim->Var(hhtp) == Approx(1.0).margin(1e-5));
 }
-#endif
 
 TEMPLATE_LIST_TEST_CASE("State test with incorrect size", "[Measures]", SimTypes)
 {


### PR DESCRIPTION
**Context:**
Using the latest version of Lightning, we can calculate the variance of all supported observables including Hermitian, Hamiltonian, and tensor product of named observables. This PR adds this support to the entire stack.

**Benefits:**
Feature parity with `qml.var` in PennyLane

[sc-38512]
