### PR TITLE
Fix shallow submodule cloning in docs

### DIFF
--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -114,7 +114,7 @@ including all its submodules:
 
 .. code-block:: console
 
-  git clone --recurse-submodules -j8 https://github.com/PennyLaneAI/catalyst.git
+  git clone --recurse-submodules --shallow-submodules -j2 https://github.com/PennyLaneAI/catalyst.git
 
 For an existing copy of the repository without its submodules, they can also
 be fetched via:


### PR DESCRIPTION
For some reason it appears that git doesn't shallow clone our submodules by default, even though it is set in `.gitmodules`. This command ensures they are cloned without history, which is very important for the llvm repo since it is so large.