### PR TITLE
[MLIR] Introduce `OpInterface`s for better pass design

### DIFF
--- a/mlir/include/Quantum/IR/CMakeLists.txt
+++ b/mlir/include/Quantum/IR/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_mlir_dialect(QuantumOps quantum)
+add_mlir_interface(QuantumInterfaces)
 add_mlir_doc(QuantumDialect -gen-dialect-doc QuantumDialect Quantum/)
 add_mlir_doc(QuantumOps -gen-op-doc QuantumOps Quantum/)
+add_mlir_doc(QuantumInterfaces -gen-op-interface-docs QuantumInterfaces Quantum/)

--- a/mlir/include/Quantum/IR/QuantumInterfaces.h
+++ b/mlir/include/Quantum/IR/QuantumInterfaces.h
@@ -1,0 +1,23 @@
+// Copyright 2023 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "mlir/IR/OpDefinition.h"
+
+//===----------------------------------------------------------------------===//
+// Quantum interface declarations.
+//===----------------------------------------------------------------------===//
+
+#include "Quantum/IR/QuantumInterfaces.h.inc"

--- a/mlir/include/Quantum/IR/QuantumInterfaces.td
+++ b/mlir/include/Quantum/IR/QuantumInterfaces.td
@@ -1,0 +1,53 @@
+// Copyright 2023 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef QUANTUM_INTERFACES
+#define QUANTUM_INTERFACES
+
+include "mlir/IR/OpBase.td"
+
+def QuantumGate : OpInterface<"QuantumGate"> {
+    let description = [{
+        This interface provides a generic way to interact with instructions that are
+        considered quantum logic gates. These are characterized operating on at least
+        one qubit value, and returning the same amount of qubit values.
+    }];
+
+    let cppNamespace = "::catalyst::quantum";
+
+    let methods = [
+        InterfaceMethod<
+            "Return all operands which are considered input qubit values.",
+            "mlir::ValueRange", "getQubitOperands"
+        >,
+        InterfaceMethod<
+            "Return all results which are considered output qubit values.",
+            "mlir::ValueRange", "getQubitResults"
+        >,
+    ];
+
+    let verify = [{
+        auto gate = mlir::cast<ConcreteOp>($_op);
+
+        if (gate.getQubitOperands().size() < 1)
+            return $_op->emitOpError("must have at least 1 qubit");
+
+        if (gate.getQubitOperands().size() != gate.getQubitResults().size())
+            return $_op->emitOpError("number of qubits in input and output must be the same");
+
+        return mlir::success();
+    }];
+}
+
+#endif // QUANTUM_INTERFACES

--- a/mlir/include/Quantum/IR/QuantumInterfaces.td
+++ b/mlir/include/Quantum/IR/QuantumInterfaces.td
@@ -50,4 +50,28 @@ def QuantumGate : OpInterface<"QuantumGate"> {
     }];
 }
 
+// TODO: Make this interface inherit from QuantumGate (available since llvm/llvm-project@83a635c).
+def DifferentiableGate : OpInterface<"DifferentiableGate"> {
+    let description = [{
+        This interface provides a generic way to interact with differentiable
+        quantum instructions. These are quantum operations with differentiable
+        gate parameters.
+    }];
+
+    let cppNamespace = "::catalyst::quantum";
+
+    let methods = [
+        InterfaceMethod<
+            "Return all operands which are considered differentiable gate parameters.",
+            "mlir::ValueRange", "getDiffParams"
+        >,
+        InterfaceMethod<
+            "Return the starting index at which to find differentiable operands in the Operation*."
+            "Differentiable gate parameter operands do not need to be stored in a single ODS "
+            "argument or be located in a particular position, but are assumed to be contiguous.",
+            "size_t", "getDiffOperandIdx"
+        >,
+    ];
+}
+
 #endif // QUANTUM_INTERFACES

--- a/mlir/include/Quantum/IR/QuantumInterfaces.td
+++ b/mlir/include/Quantum/IR/QuantumInterfaces.td
@@ -74,4 +74,16 @@ def DifferentiableGate : OpInterface<"DifferentiableGate"> {
     ];
 }
 
+def MeasurementProcess : OpInterface<"MeasurementProcess"> {
+    let description = [{
+        This interface provides a generic way to interact with quantum measurement processes.
+        These are instructions that represent some information extraction procedure on the
+        underlying statevector. On simulators, they may be implemented by direct manipulation
+        of the statevector, but on hardware they typically turn into procedures over the quantum
+        program as a whole, usually requiring many executions of the same circuit.
+    }];
+
+    let cppNamespace = "::catalyst::quantum";
+}
+
 #endif // QUANTUM_INTERFACES

--- a/mlir/include/Quantum/IR/QuantumOps.h
+++ b/mlir/include/Quantum/IR/QuantumOps.h
@@ -24,6 +24,8 @@
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
 
+#include "Quantum/IR/QuantumInterfaces.h"
+
 //===----------------------------------------------------------------------===//
 // Quantum trait declarations.
 //===----------------------------------------------------------------------===//

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -171,7 +171,7 @@ class Gate_Op<string mnemonic, list<Trait> traits = []> :
     let extraClassDeclaration = extraBaseClassDeclaration;
 }
 
-def CustomOp : Gate_Op<"custom", [NoMemoryEffect, AttrSizedOperandSegments]> {
+def CustomOp : Gate_Op<"custom", [NoMemoryEffect, AttrSizedOperandSegments, DifferentiableGate]> {
     let summary = "A generic quantum gate on n qubits with m floating point parameters.";
     let description = [{
     }];
@@ -189,9 +189,18 @@ def CustomOp : Gate_Op<"custom", [NoMemoryEffect, AttrSizedOperandSegments]> {
     let assemblyFormat = [{
         $gate_name `(` $params `)` $in_qubits attr-dict `:` type($out_qubits)
     }];
+
+    let extraClassDeclaration = extraBaseClassDeclaration # [{
+        mlir::ValueRange getDiffParams() {
+            return getParams();
+        }
+        size_t getDiffOperandIdx() {
+            return 0;
+        }
+    }];
 }
 
-def MultiRZOp : Gate_Op<"multirz", [NoMemoryEffect]> {
+def MultiRZOp : Gate_Op<"multirz", [NoMemoryEffect, DifferentiableGate]> {
     let summary = "Apply an arbitrary multi Z rotation";
     let description = [{
         The `quantum.multirz` operation applies an arbitrary multi Z rotation to the state-vector.
@@ -209,6 +218,15 @@ def MultiRZOp : Gate_Op<"multirz", [NoMemoryEffect]> {
 
     let assemblyFormat = [{
         `(` $theta `)` $in_qubits attr-dict `:` type($out_qubits)
+    }];
+
+    let extraClassDeclaration = extraBaseClassDeclaration # [{
+        mlir::ValueRange getDiffParams() {
+            return getODSOperands(0);
+        }
+        size_t getDiffOperandIdx() {
+            return 0;
+        }
     }];
 }
 

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -422,9 +422,10 @@ def HamiltonianOp : Observable_Op<"hamiltonian", [Pure]> {
 
 // -----
 
-class Measurement_Op<string mnemonic, list<Trait> traits = []> : Quantum_Op<mnemonic, traits>;
+class Measurement_Op<string mnemonic, list<Trait> traits = []> :
+        Quantum_Op<mnemonic, traits # [MeasurementProcess]>;
 
-def MeasureOp : Measurement_Op<"measure"> {
+def MeasureOp : Quantum_Op<"measure"> {
     let summary = "A single-qubit projective measurement in the computational basis.";
     let description = [{
     }];

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -20,6 +20,7 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Dialect/Bufferization/IR/AllocationOpInterface.td"
 
 include "Quantum/IR/QuantumDialect.td"
+include "Quantum/IR/QuantumInterfaces.td"
 
 //===----------------------------------------------------------------------===//
 // Quantum dialect traits.
@@ -154,16 +155,20 @@ def InsertOp : Memory_Op<"insert", [NoMemoryEffect]> {
 
 // -----
 
-class Gate_Op<string mnemonic, list<Trait> traits = []> : Quantum_Op<mnemonic, traits # [Unitary]> {
-    let hasVerifier = 1;
+class Gate_Op<string mnemonic, list<Trait> traits = []> :
+        Quantum_Op<mnemonic, traits # [QuantumGate, Unitary]> {
 
-    let extraClassDeclaration = [{
-        mlir::LogicalResult verifyQubitNumbers() {
-            if (this->getInQubits().size() != this->getOutQubits().size())
-                return emitOpError("number of qubits in input and output must be the same");
-            return mlir::success();
+    code extraBaseClassDeclaration = [{
+        mlir::ValueRange getQubitOperands() {
+            return getInQubits();
+        }
+
+        mlir::ValueRange getQubitResults() {
+            return getOutQubits();
         }
     }];
+
+    let extraClassDeclaration = extraBaseClassDeclaration;
 }
 
 def CustomOp : Gate_Op<"custom", [NoMemoryEffect, AttrSizedOperandSegments]> {
@@ -229,6 +234,8 @@ def QubitUnitaryOp : Gate_Op<"unitary", [NoMemoryEffect]> {
     let assemblyFormat = [{
         `(` $matrix `:` type($matrix) `)` $in_qubits attr-dict `:` type($out_qubits)
     }];
+
+    let hasVerifier = 1;
 }
 
 // -----

--- a/mlir/lib/Gradient/Transforms/GradMethods/ClassicalJacobian.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/ClassicalJacobian.cpp
@@ -23,6 +23,7 @@
 #include "mlir/Dialect/Index/IR/IndexOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 
+#include "Quantum/IR/QuantumInterfaces.h"
 #include "Quantum/IR/QuantumOps.h"
 #include "Quantum/Utils/RemoveQuantumMeasurements.h"
 
@@ -52,35 +53,37 @@ func::FuncOp genParamCountFunction(PatternRewriter &rewriter, Location loc, func
     func::FuncOp paramCountFn =
         SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(callee, rewriter.getStringAttr(fnName));
     if (!paramCountFn) {
-        PatternRewriter::InsertionGuard insertGuard(rewriter);
-
         // First copy the original function as is, then we can replace all quantum ops by counting
         // their gate parameters instead.
         rewriter.setInsertionPointAfter(callee);
         paramCountFn = rewriter.create<func::FuncOp>(loc, fnName, fnType, visibility);
         rewriter.cloneRegionBefore(callee.getBody(), paramCountFn.getBody(), paramCountFn.end());
 
+        PatternRewriter::InsertionGuard insertGuard(rewriter);
+        rewriter.setInsertionPointToStart(&paramCountFn.getBody().front());
+
         // Store the counter in memory since we don't want to deal with returning the SSA value
         // for updated parameter counts from arbitrary regions/ops.
-        rewriter.setInsertionPointToStart(&paramCountFn.getBody().front());
         MemRefType paramCountType = MemRefType::get({}, rewriter.getIndexType());
         Value paramCountBuffer = rewriter.create<memref::AllocaOp>(loc, paramCountType);
         Value cZero = rewriter.create<index::ConstantOp>(loc, 0);
         rewriter.create<memref::StoreOp>(loc, cZero, paramCountBuffer);
 
         // For each quantum gate add the number of parameters to the counter.
-        paramCountFn.walk([&](quantum::CustomOp gate) {
+        paramCountFn.walk([&](quantum::DifferentiableGate op) {
             PatternRewriter::InsertionGuard insertGuard(rewriter);
-            rewriter.setInsertionPoint(gate);
+            rewriter.setInsertionPoint(op);
 
-            if (!gate.getParams().empty()) {
+            ValueRange diffParams = op.getDiffParams();
+            if (!diffParams.empty()) {
                 Value currCount = rewriter.create<memref::LoadOp>(loc, paramCountBuffer);
-                Value numParams = rewriter.create<index::ConstantOp>(loc, gate.getParams().size());
+                Value numParams = rewriter.create<index::ConstantOp>(loc, diffParams.size());
                 Value newCount = rewriter.create<index::AddOp>(loc, currCount, numParams);
                 rewriter.create<memref::StoreOp>(loc, newCount, paramCountBuffer);
             }
 
-            rewriter.replaceOp(gate, gate.getInQubits());
+            auto gate = cast<quantum::QuantumGate>(op.getOperation());
+            rewriter.replaceOp(gate, gate.getQubitOperands());
         });
 
         // Replace any return statements from the original function with the parameter count.
@@ -121,8 +124,6 @@ func::FuncOp genArgMapFunction(PatternRewriter &rewriter, Location loc, func::Fu
     func::FuncOp argMapFn =
         SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(callee, rewriter.getStringAttr(fnName));
     if (!argMapFn) {
-        PatternRewriter::InsertionGuard insertGuard(rewriter);
-
         // First copy the original function as is, then we can replace all quantum ops by collecting
         // their gate parameters in a memory buffer instead. The size of this vector is passed as an
         // input to the new function.
@@ -130,8 +131,10 @@ func::FuncOp genArgMapFunction(PatternRewriter &rewriter, Location loc, func::Fu
         rewriter.cloneRegionBefore(callee.getBody(), argMapFn.getBody(), argMapFn.end());
         Value numParams = argMapFn.getBody().front().addArgument(rewriter.getIndexType(), loc);
 
-        // Allocate the memory for the gate parameters collected at runtime.
+        PatternRewriter::InsertionGuard insertGuard(rewriter);
         rewriter.setInsertionPointToStart(&argMapFn.getBody().front());
+
+        // Allocate the memory for the gate parameters collected at runtime.
         MemRefType paramsBufferType =
             MemRefType::get({ShapedType::kDynamic}, rewriter.getF64Type());
         Value paramsBuffer = rewriter.create<memref::AllocOp>(loc, paramsBufferType, numParams);
@@ -141,24 +144,26 @@ func::FuncOp genArgMapFunction(PatternRewriter &rewriter, Location loc, func::Fu
         rewriter.create<memref::StoreOp>(loc, cZero, paramsProcessed);
         Value cOne = rewriter.create<index::ConstantOp>(loc, 1);
 
-        // Erase redundant device specifications
+        // Erase redundant device specifications.
         argMapFn.walk([&](quantum::DeviceOp device) { rewriter.eraseOp(device); });
 
         // Insert gate parameters into the params buffer.
-        argMapFn.walk([&](quantum::CustomOp gate) {
+        argMapFn.walk([&](quantum::DifferentiableGate op) {
             PatternRewriter::InsertionGuard insertGuard(rewriter);
-            rewriter.setInsertionPoint(gate);
+            rewriter.setInsertionPoint(op);
 
-            if (!gate.getParams().empty()) {
+            ValueRange diffParams = op.getDiffParams();
+            if (!diffParams.empty()) {
                 Value paramIdx = rewriter.create<memref::LoadOp>(loc, paramsProcessed);
-                for (auto param : gate.getParams()) {
+                for (auto param : diffParams) {
                     rewriter.create<memref::StoreOp>(loc, param, paramsBuffer, paramIdx);
                     paramIdx = rewriter.create<index::AddOp>(loc, paramIdx, cOne);
                 }
                 rewriter.create<memref::StoreOp>(loc, paramIdx, paramsProcessed);
             }
 
-            rewriter.replaceOp(gate, gate.getInQubits());
+            auto gate = cast<quantum::QuantumGate>(op.getOperation());
+            rewriter.replaceOp(gate, gate.getQubitOperands());
         });
 
         // Replace any return statements from the original function with the params vector.

--- a/mlir/lib/Gradient/Transforms/GradMethods/PS_QuantumGradient.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/PS_QuantumGradient.cpp
@@ -288,10 +288,10 @@ func::FuncOp ParameterShiftLowering::genQGradFunction(PatternRewriter &rewriter,
         });
 
         // Post-order traversal is required when deleting nodes during traversal.
-        gradientFn.walk<WalkOrder::PostOrder>([&](quantum::CustomOp gate) {
+        gradientFn.walk<WalkOrder::PostOrder>([&](quantum::QuantumGate gate) {
             // We are undoing the def-use chains of this gate's return values
             // so that we can safely delete it (all quantum ops must be eliminated).
-            rewriter.replaceOp(gate, gate.getInQubits());
+            rewriter.replaceOp(gate, gate.getQubitOperands());
         });
 
         quantum::removeQuantumMeasurements(gradientFn);

--- a/mlir/lib/Gradient/Transforms/GradMethods/PS_QuantumGradient.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/PS_QuantumGradient.cpp
@@ -247,11 +247,11 @@ func::FuncOp ParameterShiftLowering::genQGradFunction(PatternRewriter &rewriter,
                 selectorsToStore.push_back({forOp, loopLevel});
                 loopLevel++;
             }
-            else if (auto gate = dyn_cast<quantum::CustomOp>(op)) {
+            else if (auto gate = dyn_cast<quantum::DifferentiableGate>(op)) {
                 PatternRewriter::InsertionGuard insertGuard(rewriter);
                 rewriter.setInsertionPoint(gate);
 
-                size_t numParams = gate.getParams().size();
+                size_t numParams = gate.getDiffParams().size();
                 if (numParams) {
                     updateSelectorVector(rewriter, loc, selectorsToStore, selectorBuffer);
 

--- a/mlir/lib/Gradient/Transforms/GradMethods/ParameterShift.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/ParameterShift.cpp
@@ -82,11 +82,11 @@ std::pair<int64_t, int64_t> ParameterShiftLowering::analyzeFunction(func::FuncOp
         if (isa<scf::ForOp>(op)) {
             loopLevel++;
         }
-        else if (auto gate = dyn_cast<quantum::CustomOp>(op)) {
-            if (gate.getParams().empty())
+        else if (auto gate = dyn_cast<quantum::DifferentiableGate>(op)) {
+            if (gate.getDiffParams().empty())
                 return;
 
-            numShifts += gate.getParams().size();
+            numShifts += gate.getDiffParams().size();
             maxLoopDepth = std::max(loopLevel, maxLoopDepth);
         }
         else if (isa<scf::YieldOp>(op) && isa<scf::ForOp>(op->getParentOp())) {

--- a/mlir/lib/Quantum/IR/CMakeLists.txt
+++ b/mlir/lib/Quantum/IR/CMakeLists.txt
@@ -1,10 +1,12 @@
 add_mlir_library(MLIRQuantum
     QuantumDialect.cpp
+    QuantumInterfaces.cpp
     QuantumOps.cpp
 
     ADDITIONAL_HEADER_DIRS
     ${PROJECT_SOURCE_DIR}/include/Quantum
 
     DEPENDS
+    MLIRQuantumInterfacesIncGen
     MLIRQuantumOpsIncGen
 )

--- a/mlir/lib/Quantum/IR/QuantumInterfaces.cpp
+++ b/mlir/lib/Quantum/IR/QuantumInterfaces.cpp
@@ -1,0 +1,24 @@
+// Copyright 2023 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Quantum/IR/QuantumInterfaces.h"
+
+using namespace mlir;
+using namespace catalyst::quantum;
+
+//===----------------------------------------------------------------------===//
+// Quantum interface definitions.
+//===----------------------------------------------------------------------===//
+
+#include "Quantum/IR/QuantumInterfaces.cpp.inc"

--- a/mlir/lib/Quantum/IR/QuantumOps.cpp
+++ b/mlir/lib/Quantum/IR/QuantumOps.cpp
@@ -114,29 +114,14 @@ static LogicalResult verifyTensorResult(Type ty, int64_t length0, int64_t length
 
 // ----- gates
 
-LogicalResult CustomOp::verify() { return verifyQubitNumbers(); }
-
-LogicalResult MultiRZOp::verify()
-{
-    if (getInQubits().size() < 1) {
-        return emitOpError("must have at least 1 qubit");
-    }
-
-    return verifyQubitNumbers();
-}
-
 LogicalResult QubitUnitaryOp::verify()
 {
-    if (getInQubits().size() < 1) {
-        return emitOpError("must have at least 1 qubit");
-    }
-
     size_t dim = std::pow(2, getInQubits().size());
     if (failed(verifyTensorResult(getMatrix().getType().cast<ShapedType>(), dim, dim))) {
         return emitOpError("The Unitary matrix must be of size 2^(num_qubits) * 2^(num_qubits)");
     }
 
-    return verifyQubitNumbers();
+    return success();
 }
 
 // ----- measurements

--- a/mlir/lib/Quantum/Utils/RemoveQuantumMeasurements.cpp
+++ b/mlir/lib/Quantum/Utils/RemoveQuantumMeasurements.cpp
@@ -14,6 +14,7 @@
 
 #include <deque>
 
+#include "Quantum/IR/QuantumInterfaces.h"
 #include "Quantum/IR/QuantumOps.h"
 #include "Quantum/Utils/RemoveQuantumMeasurements.h"
 
@@ -27,14 +28,7 @@ void removeQuantumMeasurements(func::FuncOp &function)
 
     // Delete measurement operations.
     std::deque<Operation *> opsToDelete;
-    function.walk<WalkOrder::PreOrder>([&](Operation *op) {
-        bool is_measurement = dyn_cast<SampleOp>(op) || dyn_cast<CountsOp>(op) ||
-                              dyn_cast<ExpvalOp>(op) || dyn_cast<VarianceOp>(op) ||
-                              dyn_cast<ProbsOp>(op) || dyn_cast<StateOp>(op);
-        if (!is_measurement)
-            return;
-        opsToDelete.push_back(op);
-    });
+    function.walk([&](MeasurementProcess op) { opsToDelete.push_back(op); });
 
     // Measurement operations are not allowed inside scf dialects.
     // This means that we can remove them.


### PR DESCRIPTION
Introduces three op interfaces:

- `QuantumGate`: generically interact with operations that act on qubits using value semantics
   - `getOperandQubits`
   - `getResultQubits`
- `DifferentiableGate`: generically interact with `QuantumGate`s who (may) also accept float parameters
  - `getDiffParams`: get a value range of this op's differentiable parameters
  - `getDiffOperandIdx`: get the op's operand index at which the differentiable parameters start
- `MeasurementProcess`: generically match against measurement processes like `sample`, `expval`, ...


Closes #51 
[sc-36475]
[sc-36474]
