### PR TITLE
lighting -> lightning in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MK_ABSPATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MK_DIR := $(dir $(MK_ABSPATH))
 DIALECTS_BUILD_DIR ?= $(MK_DIR)/mlir/build
 COVERAGE_REPORT ?= term-missing
-TEST_BACKEND ?= "lighting.qubit"
+TEST_BACKEND ?= "lightning.qubit"
 
 .PHONY: help
 help:


### PR DESCRIPTION
Fix the issue with `make test-frontend` by rectifying the name of the default backend device to `"lightning.qubit"` in the Makefile. 