### PR TITLE
Fix the issue with the `do_queue` deprecation warnings in Catalyst

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -138,6 +138,9 @@
 * Fixes file renaming within pass pipelines.
   [#126](https://github.com/PennyLaneAI/catalyst/pull/126)
 
+* Fixes the issue with the ``do_queue`` deprecation warnings in PennyLane.
+  [#146](https://github.com/PennyLaneAI/catalyst/pull/146)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -120,31 +120,32 @@ def get_traceable_fn(qfunc, device):
         qreg = jprim.qalloc(num_wires)
 
         JaxTape.device = device
-        with JaxTape(do_queue=False) as tape:
-            with tape.quantum_tape:
-                out = qfunc(*args, **kwargs)
+        with qml.QueuingManager.stop_recording():
+            with JaxTape() as tape:
+                with tape.quantum_tape:
+                    out = qfunc(*args, **kwargs)
 
-            return_values = out if isinstance(out, (tuple, list)) else (out,)
-            meas_return_values = []
-            meas_ret_val_indices = []
-            non_meas_return_values = []
-            for i, ret_val in enumerate(return_values):
-                if isinstance(ret_val, MeasurementProcess):
-                    meas_return_values.append(ret_val)
-                    meas_ret_val_indices.append(i)
-                else:
-                    non_meas_return_values.append(ret_val)
+                return_values = out if isinstance(out, (tuple, list)) else (out,)
+                meas_return_values = []
+                meas_ret_val_indices = []
+                non_meas_return_values = []
+                for i, ret_val in enumerate(return_values):
+                    if isinstance(ret_val, MeasurementProcess):
+                        meas_return_values.append(ret_val)
+                        meas_ret_val_indices.append(i)
+                    else:
+                        non_meas_return_values.append(ret_val)
 
-            # pylint: disable=protected-access
-            tape.quantum_tape._measurements = meas_return_values
+                # pylint: disable=protected-access
+                tape.quantum_tape._measurements = meas_return_values
 
-            has_tracer_return_values = len(non_meas_return_values) > 0
-            if has_tracer_return_values:
-                tape.set_return_val(tuple(non_meas_return_values))
+                has_tracer_return_values = len(non_meas_return_values) > 0
+                if has_tracer_return_values:
+                    tape.set_return_val(tuple(non_meas_return_values))
 
-            new_quantum_tape = JaxTape.device.expand_fn(tape.quantum_tape)
-            tape.quantum_tape = new_quantum_tape
-            tape.quantum_tape.jax_tape = tape
+                new_quantum_tape = JaxTape.device.expand_fn(tape.quantum_tape)
+                tape.quantum_tape = new_quantum_tape
+                tape.quantum_tape.jax_tape = tape
 
         return_values, _, _ = trace_quantum_tape(
             tape, qreg, has_tracer_return_values, meas_ret_val_indices, num_wires, shots

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -537,13 +537,14 @@ class CondCallable:
     def _call_with_quantum_ctx(self, ctx):
         def new_branch_fn(branch_fn):
             def callback(qreg):
-                with JaxTape(do_queue=False) as tape:
-                    with tape.quantum_tape:
-                        out = branch_fn()
-                    tape.set_return_val(out)
-                    new_quantum_tape = JaxTape.device.expand_fn(tape.quantum_tape)
-                    tape.quantum_tape = new_quantum_tape
-                    tape.quantum_tape.jax_tape = tape
+                with qml.QueuingManager.stop_recording():
+                    with JaxTape() as tape:
+                        with tape.quantum_tape:
+                            out = branch_fn()
+                        tape.set_return_val(out)
+                        new_quantum_tape = JaxTape.device.expand_fn(tape.quantum_tape)
+                        tape.quantum_tape = new_quantum_tape
+                        tape.quantum_tape.jax_tape = tape
 
                 has_tracer_return_values = out is not None
                 return_values, qreg, qubit_states = trace_quantum_tape(
@@ -766,13 +767,14 @@ class WhileCallable:
         def new_body(*args_and_qreg):
             args, qreg = args_and_qreg[:-1], args_and_qreg[-1]
 
-            with JaxTape(do_queue=False) as tape:
-                with tape.quantum_tape:
-                    out = self.body_fn(*args)
-                tape.set_return_val(out)
-                new_quantum_tape = JaxTape.device.expand_fn(tape.quantum_tape)
-                tape.quantum_tape = new_quantum_tape
-                tape.quantum_tape.jax_tape = tape
+            with qml.QueuingManager.stop_recording():
+                with JaxTape() as tape:
+                    with tape.quantum_tape:
+                        out = self.body_fn(*args)
+                    tape.set_return_val(out)
+                    new_quantum_tape = JaxTape.device.expand_fn(tape.quantum_tape)
+                    tape.quantum_tape = new_quantum_tape
+                    tape.quantum_tape.jax_tape = tape
 
             has_tracer_return_values = True
             return_values, qreg, qubit_states = trace_quantum_tape(
@@ -955,13 +957,14 @@ class ForLoopCallable:
         def new_body(*args_and_qreg):
             args, qreg = args_and_qreg[:-1], args_and_qreg[-1]
 
-            with JaxTape(do_queue=False) as tape:
-                with tape.quantum_tape:
-                    out = self.body_fn(*args)
-                tape.set_return_val(out)
-                new_quantum_tape = JaxTape.device.expand_fn(tape.quantum_tape)
-                tape.quantum_tape = new_quantum_tape
-                tape.quantum_tape.jax_tape = tape
+            with qml.QueuingManager.stop_recording():
+                with JaxTape() as tape:
+                    with tape.quantum_tape:
+                        out = self.body_fn(*args)
+                    tape.set_return_val(out)
+                    new_quantum_tape = JaxTape.device.expand_fn(tape.quantum_tape)
+                    tape.quantum_tape = new_quantum_tape
+                    tape.quantum_tape.jax_tape = tape
 
             has_tracer_return_values = out is not None
             return_values, qreg, qubit_states = trace_quantum_tape(


### PR DESCRIPTION
Fix issue #145 targeting the latest version of PennyLane `v0.31.0-dev`.