### PR TITLE
Fix the issue with gradients failing to work with `jnp.array` as constants

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -81,7 +81,7 @@
 
   @qjit
   def workflow(params, tangent):
-      return jvp(f, [params], [tangent])
+    return jvp(f, [params], [tangent])
 
   workflow(jnp.zeros([4], dtype=float), jnp.ones([4], dtype=float))
   ```
@@ -140,6 +140,29 @@
 
 * Fixes the issue with the ``do_queue`` deprecation warnings in PennyLane.
   [#146](https://github.com/PennyLaneAI/catalyst/pull/146)
+
+* Fixes the issue with gradients failing to work with ``jnp.array`` as constants.
+  [#152](https://github.com/PennyLaneAI/catalyst/pull/152)
+  
+  An example of a newly supported workflow:
+  
+  ``` python
+  coeffs = jnp.array([0.1, 0.2])
+  terms = [qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0)]
+  H = qml.Hamiltonian(coeffs, terms)
+
+  @qjit
+  @qml.qnode(qml.device("lightning.qubit", wires=2))
+  def circuit(x):
+    qml.RX(x[0], wires=0)
+    qml.RY(x[1], wires=0)
+    qml.CNOT(wires=[0, 1])
+    return qml.expval(H)
+
+  params = jnp.array([0.3, 0.4])
+  jax.grad(circuit)(params)
+  ```
+
 
 <h3>Contributors</h3>
 

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -316,8 +316,9 @@ def _grad_lowering(ctx, *args, jaxpr, fn, grad_params):
     output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
     flat_output_types = util.flatten(output_types)
 
-    # ``ir.DenseElementsAttr.get()`` constructs a dense elements attribute from an array of element values.
-    # This doesn't support ``jaxlib.xla_extension.Array``, so we have to cast such constants to numpy array types.
+    # ``ir.DenseElementsAttr.get()`` constructs a dense elements attribute from an array of
+    # element values. This doesn't support ``jaxlib.xla_extension.Array``, so we have to cast
+    # such constants to numpy array types.
     constants = [
         ConstantOp(ir.DenseElementsAttr.get(np.asarray(const))).results for const in jaxpr.consts
     ]

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -706,14 +706,16 @@ def test_finite_diff_higher_order(inp, backend):
     assert np.allclose(compiled_grad2_default(inp), interpretted_grad2_default(inp), rtol=0.1)
 
 
+@pytest.mark.parametrize(
+    "h_coeffs", [[0.2, -0.53], np.array([0.2, -0.53]), jnp.array([0.2, -0.53])]
+)
 @pytest.mark.parametrize("inp", [([1.0, 2.0])])
-def test_jax_consts(inp, backend):
-    """Test jax consts."""
+def test_jax_consts(inp, h_coeffs, backend):
+    """Test jax constants."""
 
     def circuit(params):
         qml.CRX(params[0], wires=[0, 1])
         qml.CRX(params[0], wires=[0, 2])
-        h_coeffs = np.array([0.2, -0.53])
         h_obs = [qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.Hadamard(2)]
         return qml.expval(qml.Hamiltonian(h_coeffs, h_obs))
 

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -706,11 +706,12 @@ def test_finite_diff_higher_order(inp, backend):
     assert np.allclose(compiled_grad2_default(inp), interpretted_grad2_default(inp), rtol=0.1)
 
 
+@pytest.mark.parametrize("g_method", ["fd", "ps", "adj"])
 @pytest.mark.parametrize(
     "h_coeffs", [[0.2, -0.53], np.array([0.2, -0.53]), jnp.array([0.2, -0.53])]
 )
 @pytest.mark.parametrize("inp", [([1.0, 2.0])])
-def test_jax_consts(inp, h_coeffs, backend):
+def test_jax_consts(inp, h_coeffs, g_method, backend):
     """Test jax constants."""
 
     def circuit(params):
@@ -722,7 +723,7 @@ def test_jax_consts(inp, h_coeffs, backend):
     @qjit()
     def compile_grad(params):
         g = qml.qnode(qml.device(backend, wires=3))(circuit)
-        h = grad(g)
+        h = grad(g, method=g_method)
         return h(params)
 
     def interpret_grad(params):


### PR DESCRIPTION
This PR fixed the issue with Hamiltonians fail to work if the coefficients are not vanilla NumPy float arrays. It turned out this is not related to Hamiltonians and comes from the way that the gradient (as well as vjp and jvp) lowering (to MLIR) methods construct dense elements attributes from arrays (as constants) of hybrid circuits.

I'm proposing to cast from `jaxlib.xla_extension.Array` or other array types (e.g., set, list) constants to `np.array` data types in the gradient, vjp, and jvp lowering methods in `jax_primitives.py` as this is fully supported by ``ir.DenseElementsAttr.get()``.

Closes #151 