### PR TITLE
Fix Catalyst fetch depth for release tag checkout in CPL test matrix

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -26,6 +26,8 @@ jobs:
 
     - name: Checkout Catalyst repo
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - if: ${{ inputs.catalyst == 'stable' }}
       run: |
         git checkout $(git tag | sort -V | tail -1)


### PR DESCRIPTION
By default, the `checkout` action only clones with depth 1.

The fix now correctly fails a stable/latest/latest configuration: https://github.com/PennyLaneAI/catalyst/actions/runs/5245934702/jobs/9474076050