### PR TITLE
Add merge option to patch.

### DIFF
--- a/mlir/Makefile
+++ b/mlir/Makefile
@@ -49,7 +49,7 @@ llvm:
 .PHONY: mhlo
 mhlo:
 	# TODO: We can remove this patch whenever this ticket is solved https://github.com/tensorflow/mlir-hlo/issues/68
-	patch -d mlir-hlo/mhlo/analysis --follow-symlinks < patches/add-lmhlo-dependency.patch
+	patch -d mlir-hlo/mhlo/analysis --merge --follow-symlinks < patches/add-lmhlo-dependency.patch
 
 	@echo "build MLIR-HLO"
 	cmake -G Ninja -S mlir-hlo -B $(MHLO_BUILD_DIR) \


### PR DESCRIPTION
**Context:** When patching, if a patch has already been applied `patch` interactively requests some decisions from the user. 

**Description of the Change:** Use `--merge` flag which works similar to git merges where if a hunk has already been applied, it assumes success.

**Benefits:** Recompile mhlo without issues.
