### PR TITLE
Switch to GA4

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -192,7 +192,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Catalyst"
-copyright = "2022, Xanadu Quantum Technologies"
+copyright = "2023, Xanadu Quantum Technologies"
 author = "Xanadu Inc."
 
 add_module_names = False
@@ -253,7 +253,7 @@ html_theme = "pennylane"
 html_theme_options = {
     "navbar_name": "Catalyst",
     "navbar_active_link": 3,
-    "google_analytics_tracking_id": "UA-130507810-1",
+    "google_analytics_tracking_id": "G-C480Z9JL0D",
     "extra_copyrights": [
         "TensorFlow, the TensorFlow logo, and any related marks are trademarks " "of Google Inc."
     ],


### PR DESCRIPTION
Google is deprecating Universal Analytics on July 1st. This PR replaces that tag with the newer GA4 tag. This change only impacts the docs and has no effect on the plugin code or any user-facing features.