### PR TITLE
Fix the SV1 supporting quantum circuits issue with braket-pl-plugin and boto3 v1.27

### DIFF
--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -507,7 +507,9 @@ jobs:
 
     - name: Install additional dependencies (OpenQasm device)
       run: |
-        pip install numpy amazon-braket-sdk amazon-braket-pennylane-plugin
+        # TODO: Use the latest version of boto3 after fixing the issue with
+        # "Device SV1 does not support quantum circuits" from braket-pl-plugin.
+        pip install numpy amazon-braket-sdk amazon-braket-pennylane-plugin "boto3==1.26"
         echo "AWS_DEFAULT_REGION=us-east-1" >> $GITHUB_ENV
 
     - name: Get Cached qir-stdlib Build


### PR DESCRIPTION
The OQ3/Braket GH action started failing due to some incompatibilities between amazon-braket-pennylane-plugin and the new release of boto3 (v1.27). This PR pins the version to v1.26 in the `check-catalyst.yaml` GH action to fix the issue temporarily in the repo until a proper fix will be available upstream. 