### PR TITLE
Update qir-stdlib to v0.3.0

### DIFF
--- a/runtime/qir-stdlib/Cargo.toml
+++ b/runtime/qir-stdlib/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "qir-stdlib"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["Microsoft"]
 edition = "2021"
 license = "MIT"
 
 [dependencies.qir-stdlib]
 git = "https://github.com/qir-alliance/qir-runner.git"
-tag = "v0.1.0"
+tag = "v0.3.0"
 
 [lib]
 crate-type = ["staticlib"]


### PR DESCRIPTION
Check and update the version of `qir-stdlib` to v0.3.0.