### PR TITLE
Redefine `jaxed_qfunc` for JAX integration.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -75,7 +75,7 @@
   execute on Braket simulator and hardware devices, including remote
   cloud-based simulators such as SV1.
 
-  ``` python
+  ```python
   def circuit(x, y):
       qml.RX(y * x, wires=0)
       qml.RX(x * 2, wires=1)
@@ -364,9 +364,7 @@
 
 * Provide a new abstraction to the `QuantumDevice` interface in the runtime
   called `DataView`. C++ implementations of the interface can iterate
-
   through and directly store results into the `DataView` independant of the
-
   underlying memory layout. This can eliminate redundant buffer copies at the
   interface boundaries, which has been applied to existing devices. [#109](https://github.com/PennyLaneAI/catalyst/pull/109)
 
@@ -379,22 +377,19 @@
   [#121](https://github.com/PennyLaneAI/catalyst/pull/121)
 
 * Fix file renaming within pass pipelines.
-
   [#126](https://github.com/PennyLaneAI/catalyst/pull/126)
 
 * Fix the issue with the `do_queue` deprecation warnings in PennyLane.
-
   [#146](https://github.com/PennyLaneAI/catalyst/pull/146)
 
 * Fix the issue with gradients failing to work with hybrid functions that
-
   contain constant `jnp.array` objects. This will enable PennyLane operators
   that have data in the form of a `jnp.array`, such as a Hamiltonian, to be
   included in a qjit-compiled function. [#152](https://github.com/PennyLaneAI/catalyst/pull/152)
 
   An example of a newly supported workflow:
 
-  ``` python
+  ```python
   coeffs = jnp.array([0.1, 0.2])
   terms = [qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0)]
   H = qml.Hamiltonian(coeffs, terms)

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -7,6 +7,7 @@
   [#96](https://github.com/PennyLaneAI/catalyst/pull/96)
   [#123](https://github.com/PennyLaneAI/catalyst/pull/123)
   [#167](https://github.com/PennyLaneAI/catalyst/pull/167)
+  [#192](https://github.com/PennyLaneAI/catalyst/pull/192)
 
   For example, call a Catalyst qjit-compiled function from within a JAX jit-compiled
   function:
@@ -405,39 +406,6 @@
   params = jnp.array([0.3, 0.4])
   jax.grad(circuit)(params)
   ```
-
-* Allow JIT compiled functions to be recompiled when recompilation is triggered by JAX.
-  For example:
-
-  ```python
-  @qjit
-  @qml.qnode(dev)
-  def circuit(params, n):
-    
-    def ansatz(i, x):
-      qml.RX(x[i, 0], wires=0)
-      qml.RY(x[i, 1], wires=1)
-      qml.CNOT(wires=[0, 1])
-      return x
-
-    catalyst.for_loop(0, n, 1)(ansatz)(jnp.reshape(params, (-1, 2)))
-
-    return qml.expval(qml.PauliZ(1))
-  ```
-
-  ```pycon
-  >>> params = jnp.array([0.54, 0.3154, 0.654, 0.123])
-  >>> circuit(params, 2)
-  0.7612754362314241
-  >>> jax.grad(circuit, argnums=0)(params, 2)
-  [ 0.07954928 -0.32372842 -0.50406511  0.00828534]
-  >>> params = jnp.array([0.54, 0.3154, 0.654, 0.123, 0.1, 0.2])
-  >>> jax.grad(circuit, argnums=0)(params, 3)
-  [-0.42763436 -0.46892463  0.13741047 -0.54825337 -0.42408931 -0.07123154]
-  ```
-
-  In the case above, recompilation is needed when calling `jax.grad` for the second time.
-  [#192](https://github.com/PennyLaneAI/catalyst/pull/192)
 
 <h3>Contributors</h3>
 


### PR DESCRIPTION
**Context:** `jax.grad(circuit, params)` fails if `params` changes shape

**Description of the Change:** Trigger recompilation when parameters change shape. Also redefine `jaxed_qfunc` upon recompilation/

**Related GitHub Issues:** Fixes #149 

**Note**: Might be a good idea to compile always for JAX integration as opposed to keep it lazily. This way, we could keep the redefinition of the compiled function close the the redefinition of the `JAX_QJIT` object.
