### PR TITLE
[CI/CD] Add llvm dependency to openqasm3 frontend tests.

### DIFF
--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -549,7 +549,7 @@ jobs:
 
   frontend-tests-openqasm-device:
     name: Frontend Tests (backend="openqasm3")
-    needs: [qir-stdlib, mhlo, quantum, enzyme]
+    needs: [qir-stdlib, mhlo, quantum, enzyme, llvm]
     runs-on: ubuntu-latest
 
     steps:
@@ -576,7 +576,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: llvm-build
-        key: ${{ runner.os }}-llvm-${{ steps.llvm-hash.outputs.llvm-hash }}-default-build
+        key: ${{ runner.os }}-llvm-${{ steps.llvm-hash.outputs.llvm-hash }}-default-build-opt
         fail-on-cache-miss: True
 
     - name: Get MHLO Version


### PR DESCRIPTION
**Context:** With the integration of Enzyme, OpenQASM 3 needs to use the correct LLVM cache to get access to `opt`.

**Description of the Change:** Add llvm as a dependency when running frontend tests for OpenQASM 3 support. Fix cache.
