### PR TITLE
Update the Braket/OQ3 support

### DIFF
--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -499,12 +499,6 @@ jobs:
         name: quantum-build
         path: quantum-build
 
-    - name: Install awscli (OpenQasm device)
-      id: install-aws-cli
-      uses: unfor19/install-aws-cli-action@v1
-      with:
-        version: 2
-
     - name: Install additional dependencies (OpenQasm device)
       run: |
         # TODO: Use the latest version of boto3 after fixing the issue with
@@ -541,11 +535,8 @@ jobs:
         chmod +x quantum-build/bin/quantum-opt  # artifact upload does not preserve permissions
 
     - name: Run Python Pytest Tests
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_BRAKET_DEVICE_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_BRAKET_DEVICE_ACCESS_KEY }}
       run: |
-        make pytest TEST_BRAKET=ON
+        make pytest TEST_BRAKET=LOCAL
 
   runtime-tests:
     name: Runtime Tests (Linux)
@@ -568,13 +559,6 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get -y -q install cmake ninja-build libomp-dev lcov
-
-      - name: Install awscli (OpenQasm device)
-        if: ${{ matrix.simulator == 'openqasm' }}
-        id: install-aws-cli
-        uses: unfor19/install-aws-cli-action@v1
-        with:
-          version: 2
 
       - name: Install additional dependencies (OpenQasm device)
         if: ${{ matrix.simulator == 'openqasm' }}
@@ -615,9 +599,6 @@ jobs:
 
       - name: Build Runtime test suite for OpenQasm device
         if: ${{ matrix.simulator == 'openqasm' }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_BRAKET_DEVICE_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_BRAKET_DEVICE_ACCESS_KEY }}
         run: |
             C_COMPILER=$(which gcc) \
             CXX_COMPILER=$(which g++) \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MK_DIR := $(dir $(MK_ABSPATH))
 DIALECTS_BUILD_DIR ?= $(MK_DIR)/mlir/build
 COVERAGE_REPORT ?= term-missing
 TEST_BACKEND ?= "lightning.qubit"
-TEST_BRAKET ?= OFF
+TEST_BRAKET ?= NONE
 
 .PHONY: help
 help:
@@ -67,11 +67,7 @@ lit:
 
 pytest:
 	@echo "check the Catalyst PyTest suite"
-ifdef remotetests
 	$(PYTHON) pytest frontend/test/pytest --tb=native --backend=$(TEST_BACKEND) --runbraket=$(TEST_BRAKET) -n auto
-else
-	$(PYTHON) pytest frontend/test/pytest --tb=native --backend=$(TEST_BACKEND) --runbraket=$(TEST_BRAKET) -k "not remotetests" -n auto
-endif
 test-demos:
 	@echo "check the Catalyst demos"
 	MDD_BENCHMARK_PRECISION=1 \

--- a/conftest.py
+++ b/conftest.py
@@ -15,8 +15,9 @@ def pytest_addoption(parser):
     parser.addoption(
         "--runbraket",
         action="store",
-        default="OFF",
-        help="Run AWS Braket tests; runtime must be compiled with `ENABLE_OPENQASM=ON`",
+        default="NONE",
+        help="Run AWS Braket ['ALL', 'LOCAL', 'REMOTE'] tests;"
+        " runtime must be compiled with `ENABLE_OPENQASM=ON`",
     )
 
 
@@ -31,23 +32,32 @@ def pytest_configure(config):
     """A pytest configure helper method"""
 
     config.addinivalue_line(
-        "markers", "braket: run on aws-braket devices using `OpenQasmDevice` in the runtime"
+        "markers",
+        "braketlocal: run on local aws-braket devices backed by `OpenQasmDevice` in the runtime",
+    )
+
+    config.addinivalue_line(
+        "markers",
+        "braketremote: run on remote aws-braket devices backed by `OpenQasmDevice` in the runtime",
     )
 
 
 def pytest_collection_modifyitems(config, items):
     """A pytest items modifier method"""
 
-    if config.getoption("--runbraket") == "ON":
+    braket_val = config.getoption("--runbraket")
+    if braket_val in ["ALL", "LOCAL", "REMOTE"]:
         # only runs test with the braket marker
         braket_tests = []
         for item in items:
-            if item.get_closest_marker("braket"):
+            if (braket_val in ["ALL", "LOCAL"] and item.get_closest_marker("braketlocal")) or (
+                braket_val in ["ALL", "REMOTE"] and item.get_closest_marker("braketremote")
+            ):
                 braket_tests.append(item)
         items[:] = braket_tests
     else:
         # skip braket tests
         skipper = pytest.mark.skip()
         for item in items:
-            if "braket" in item.keywords:
+            if "braketlocal" in item.keywords or "braketremote" in item.keywords:
                 item.add_marker(skipper)

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -8,11 +8,18 @@
   distribution.
   [#198](https://github.com/PennyLaneAI/catalyst/pull/198)
 
+<h3>Improvements</h3>
+
+* When using OpenQASM-based devices the string representation of the circuit is printed on
+  exception.
+  [#199](https://github.com/PennyLaneAI/catalyst/pull/199)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
-David Ittah
+Ali Asadi,
+David Ittah.
 
 # Release 0.2.0
 

--- a/frontend/test/pytest/test_braket_local_devices.py
+++ b/frontend/test/pytest/test_braket_local_devices.py
@@ -1,0 +1,828 @@
+# Copyright 2023 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for `OpenQasmDevice` on "local" Amazon Braket devices
+"""
+import numpy as np
+import pennylane as qml
+import pytest
+
+from catalyst import grad, qjit
+
+try:
+    qml.device("braket.local.qubit", backend="default", wires=1)
+except qml._device.DeviceError:
+    pytest.skip(
+        "skipping Braket local tests because ``amazon-braket-pennylane-plugin`` is not installed",
+        allow_module_level=True,
+    )
+
+
+@pytest.mark.braketlocal
+class TestBraketGates:
+    """Unit tests for quantum gates."""
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="default",
+                wires=3,
+            ),
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=3,
+            ),
+        ],
+    )
+    def test_no_parameters_braket(self, device):
+        """Test no-param operations on braket devices."""
+
+        def circuit():
+            qml.Identity(wires=1)
+            qml.PauliX(wires=1)
+            qml.PauliY(wires=2)
+            qml.PauliZ(wires=0)
+
+            qml.Hadamard(wires=0)
+            qml.Hadamard(wires=1)
+            qml.Hadamard(wires=2)
+
+            qml.S(wires=0)
+            qml.T(wires=0)
+
+            qml.CNOT(wires=[0, 1])
+            qml.CNOT(wires=[1, 0])
+
+            qml.CY(wires=[0, 1])
+            qml.CY(wires=[0, 2])
+
+            qml.CZ(wires=[0, 1])
+            qml.CZ(wires=[0, 2])
+
+            qml.SWAP(wires=[0, 1])
+            qml.SWAP(wires=[0, 2])
+            qml.SWAP(wires=[1, 2])
+
+            U1 = 1 / np.sqrt(2) * np.array([[1.0, 1.0], [1.0, -1.0]], dtype=complex)
+            qml.QubitUnitary(U1, wires=0)
+
+            U2 = np.array(
+                [
+                    [0.99500417 - 0.09983342j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+                    [0.0 + 0.0j, 0.99500417 + 0.09983342j, 0.0 + 0.0j, 0.0 + 0.0j],
+                    [0.0 + 0.0j, 0.0 + 0.0j, 0.99500417 + 0.09983342j, 0.0 + 0.0j],
+                    [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.99500417 - 0.09983342j],
+                ]
+            )
+            qml.QubitUnitary(U2, wires=[1, 2])
+
+            qml.ISWAP(wires=[0, 1])
+            qml.CSWAP(wires=[0, 1, 2])
+            qml.SX(wires=0)
+            qml.MultiControlledX(wires=[0, 1, 2])
+            qml.Toffoli(wires=[0, 1, 2])
+
+            return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
+
+        qjit_fn = qjit()(qml.qnode(device)(circuit))
+        qml_fn = qml.qnode(qml.device("default.qubit", wires=3))(circuit)
+
+        assert np.allclose(qjit_fn(), qml_fn())
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=3,
+            ),
+        ],
+    )
+    def test_unsupported_gate_braket(self, device):
+        """Test an unsupported gate on braket devices."""
+
+        def circuit():
+            qml.MultiRZ(np.pi / 2, wires=[0, 1, 2])
+            return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
+
+        qjit_fn = qjit()(qml.qnode(device)(circuit))
+
+        with pytest.raises(
+            RuntimeError, match="The given QIR gate name is not supported by the OpenQASM builder."
+        ):
+            qjit_fn()
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=3,
+            ),
+        ],
+    )
+    def test_param_braket(self, device):
+        """Test param operations on braket devices."""
+
+        def circuit(x: float, y: float):
+            qml.Rot(x, y, x + y, wires=0)
+
+            qml.RX(x, wires=0)
+            qml.RY(y, wires=1)
+            qml.RZ(x, wires=2)
+
+            qml.RZ(y, wires=0)
+            qml.RY(x, wires=1)
+            qml.RX(y, wires=2)
+
+            qml.PhaseShift(x, wires=0)
+            qml.PhaseShift(y, wires=1)
+
+            return qml.var(qml.PauliZ(0) @ qml.PauliZ(1) @ qml.PauliZ(2))
+
+        qjit_fn = qjit()(qml.qnode(device)(circuit))
+        qml_fn = qml.qnode(qml.device("default.qubit", wires=3))(circuit)
+
+        assert np.allclose(qjit_fn(3.14, 0.6), qml_fn(3.14, 0.6))
+
+
+@pytest.mark.braketlocal
+class TestBraketSample:
+    """Unit tests for ``qml.sample``."""
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=1,
+                shots=1000,
+            ),
+        ],
+    )
+    def test_sample_on_1qbit_braket(self, device):
+        """Test sample on 1 qubit on braket devices."""
+
+        @qjit()
+        @qml.qnode(device)
+        def sample_1qbit(x: float):
+            qml.RX(x, wires=0)
+            return qml.sample()
+
+        expected = np.array([[0.0]] * 1000)
+        observed = sample_1qbit(0.0)
+        assert np.array_equal(observed, expected)
+
+        expected = np.array([[1.0]] * 1000)
+        observed = sample_1qbit(np.pi)
+        assert np.array_equal(observed, expected)
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=2,
+                shots=1000,
+            ),
+        ],
+    )
+    def test_sample_on_2qbits_braket(self, device):
+        """Test sample on 2 qubits on braket devices."""
+
+        @qjit()
+        @qml.qnode(device)
+        def sample_2qbits(x: float):
+            qml.RX(x, wires=0)
+            qml.RY(x, wires=1)
+            return qml.sample()
+
+        expected = np.array([[0.0, 0.0]] * 1000)
+        observed = sample_2qbits(0.0)
+        assert np.array_equal(observed, expected)
+        expected = np.array([[1.0, 1.0]] * 1000)
+        observed = sample_2qbits(np.pi)
+        assert np.array_equal(observed, expected)
+
+
+@pytest.mark.braketlocal
+class TestBraketProbs:
+    """Unit tests for ``qml.probs``."""
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=1,
+                shots=1000,
+            ),
+        ],
+    )
+    def test_probs_on_1qbit_braket(self, device):
+        """Test probs on 1 qubit on braket devices."""
+
+        @qjit()
+        @qml.qnode(device)
+        def probs_1qbit(x: float):
+            qml.RX(x, wires=0)
+            return qml.probs()
+
+        observed = probs_1qbit(np.pi / 2)
+        assert np.allclose(np.sum(observed), 1.0)
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=2,
+                shots=1000,
+            ),
+        ],
+    )
+    def test_probs_on_2qbits_braket(self, device):
+        """Test probs on 2 qubits on braket devices."""
+
+        @qjit()
+        @qml.qnode(device)
+        def probs_2qbits(x: float):
+            qml.RX(x, wires=0)
+            qml.RY(x, wires=1)
+            return qml.probs()
+
+        observed = probs_2qbits(np.pi / 3)
+        assert np.allclose(np.sum(observed), 1.0)
+
+
+@pytest.mark.braketlocal
+class TestBraketCounts:
+    """Unit tests for ``qml.counts``."""
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=1,
+                shots=1000,
+            ),
+        ],
+    )
+    def test_count_on_1qbit_braket(self, device):
+        """Test counts on 1 qubits on braket devices."""
+
+        @qjit()
+        @qml.qnode(device)
+        def counts_1qbit(x: float):
+            qml.RX(x, wires=0)
+            return qml.counts()
+
+        expected = [np.array([0, 1]), np.array([1000, 0])]
+        observed = counts_1qbit(0.0)
+        assert np.array_equal(observed, expected)
+
+        expected = [np.array([0, 1]), np.array([0, 1000])]
+        observed = counts_1qbit(np.pi)
+        assert np.array_equal(observed, expected)
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=2,
+                shots=1000,
+            ),
+        ],
+    )
+    def test_count_on_2qbits_braket(self, device):
+        """Test counts on 2 qubits on braket devices."""
+
+        @qjit()
+        @qml.qnode(device)
+        def counts_2qbit(x: float):
+            qml.RX(x, wires=0)
+            qml.RY(x, wires=1)
+            return qml.counts()
+
+        expected = [np.array([0, 1, 2, 3]), np.array([1000, 0, 0, 0])]
+        observed = counts_2qbit(0.0)
+        assert np.array_equal(observed, expected)
+
+        expected = [np.array([0, 1, 2, 3]), np.array([0, 0, 0, 1000])]
+        observed = counts_2qbit(np.pi)
+        assert np.array_equal(observed, expected)
+
+
+@pytest.mark.braketlocal
+class TestBraketExpval:
+    """Unit tests for ``qml.expval``."""
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=1,
+            ),
+        ],
+    )
+    def test_named(self, device):
+        """Test expval for named observables on braket devices."""
+
+        @qjit()
+        @qml.qnode(device)
+        def expval(x: float):
+            qml.RX(x, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        expected = np.array(1.0)
+        observed = expval(0.0)
+        assert np.isclose(observed, expected)
+
+        expected = np.array(-1.0)
+        observed = expval(np.pi)
+        assert np.isclose(observed, expected)
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=1,
+            ),
+        ],
+    )
+    def test_hermitian_1(self, device):
+        """Test expval for Hermitian observable on braket devices."""
+
+        @qjit()
+        @qml.qnode(device)
+        def expval(x: float):
+            qml.RY(x, wires=0)
+            A = np.array(
+                [[complex(1.0, 0.0), complex(2.0, 0.0)], [complex(2.0, 0.0), complex(1.0, 0.0)]]
+            )
+            return qml.expval(qml.Hermitian(A, wires=0))
+
+        expected = np.array(1.0)
+        observed = expval(0.0)
+        assert np.isclose(observed, expected)
+
+        expected = np.array(3.0)
+        observed = expval(np.pi / 2)
+        assert np.isclose(observed, expected)
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=2,
+            ),
+        ],
+    )
+    def test_hermitian_2(self, device):
+        """Test expval for Hermitian observable on braket devices."""
+
+        @qjit()
+        @qml.qnode(device)
+        def expval(x: float):
+            qml.RX(x, wires=0)
+            B = np.array(
+                [
+                    [complex(1.0, 0.0), complex(2.0, 0.0), complex(1.0, 0.0), complex(2.0, 0.0)],
+                    [complex(2.0, 0.0), complex(2.0, 0.0), complex(1.0, 0.0), complex(2.0, 0.0)],
+                    [complex(1.0, 0.0), complex(1.0, 0.0), complex(1.0, 0.0), complex(2.0, 0.0)],
+                    [complex(2.0, 0.0), complex(2.0, 0.0), complex(2.0, 0.0), complex(2.0, 0.0)],
+                ]
+            )
+            return qml.expval(qml.Hermitian(B, wires=[0, 1]))
+
+        expected = np.array(1.0)
+        observed = expval(0.0)
+        assert np.isclose(observed, expected)
+
+        expected = np.array(1.0)
+        observed = expval(np.pi)
+        assert np.isclose(observed, expected)
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=2,
+            ),
+        ],
+    )
+    def test_tensor_1(self, device):
+        """Test expval for Tensor observable on braket devices."""
+
+        @qjit()
+        @qml.qnode(device)
+        def expval(x: float, y: float):
+            qml.RX(x, wires=0)
+            qml.RX(y, wires=1)
+            qml.CNOT(wires=[0, 1])
+            return qml.expval(qml.PauliX(0) @ qml.PauliY(1))
+
+        expected = np.array(-0.35355339)
+        observed = expval(np.pi / 4, np.pi / 3)
+        assert np.isclose(observed, expected)
+
+        expected = np.array(-0.49999788)
+        observed = expval(np.pi / 2, np.pi / 3)
+        assert np.isclose(observed, expected)
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=3,
+            ),
+        ],
+    )
+    def test_tensor_2(self, device):
+        """Test expval for Tensor observable including hermitian observable on braket devices."""
+
+        @qjit()
+        @qml.qnode(device)
+        def expval(x: float, y: float):
+            qml.RX(x, wires=0)
+            qml.RX(y, wires=1)
+            qml.CNOT(wires=[0, 2])
+            qml.CNOT(wires=[1, 2])
+            A = np.array(
+                [[complex(1.0, 0.0), complex(2.0, 0.0)], [complex(2.0, 0.0), complex(-1.0, 0.0)]]
+            )
+            return qml.expval(qml.PauliX(0) @ qml.Hadamard(1) @ qml.Hermitian(A, wires=2))
+
+        expected = np.array(-0.4330127)
+        observed = expval(np.pi / 4, np.pi / 3)
+        assert np.isclose(observed, expected)
+
+        expected = np.array(-0.70710678)
+        observed = expval(np.pi / 2, np.pi / 2)
+        assert np.isclose(observed, expected)
+
+
+@pytest.mark.braketlocal
+class TestBraketVar:
+    """Unit tests for ``qml.var``."""
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=1,
+            ),
+        ],
+    )
+    def test_rx(self, device):
+        """Test var with RX on braket devices."""
+
+        @qjit()
+        @qml.qnode(device)
+        def var(x: float):
+            qml.RX(x, wires=0)
+            return qml.var(qml.PauliZ(0))
+
+        expected = np.array(0.0)
+        observed = var(0.0)
+        assert np.isclose(observed, expected)
+        observed = var(np.pi)
+        assert np.isclose(observed, expected)
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=1,
+            ),
+        ],
+    )
+    def test_hadamard(self, device):
+        """Test var with Hadamard on braket devices."""
+
+        @qjit()
+        @qml.qnode(device)
+        def var(x: float):
+            qml.Hadamard(wires=0)
+            qml.RX(x, wires=0)
+            return qml.var(qml.PauliZ(0))
+
+        expected = np.array(1.0)
+        observed = var(0.0)
+        assert np.isclose(observed, expected)
+        observed = var(np.pi)
+        assert np.isclose(observed, expected)
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=2,
+            ),
+        ],
+    )
+    def test_tensor_1(self, device):
+        """Test variance for Tensor observable on braket devices."""
+
+        @qjit()
+        @qml.qnode(device)
+        def circuit(x: float, y: float):
+            qml.RX(x, wires=0)
+            qml.RX(y, wires=1)
+            qml.CNOT(wires=[0, 1])
+            return qml.var(qml.PauliX(0) @ qml.PauliY(1))
+
+        expected = np.array(0.875)
+        observed = circuit(np.pi / 4, np.pi / 3)
+        assert np.isclose(observed, expected)
+
+        expected = np.array(1.0)
+        observed = circuit(np.pi / 2, np.pi / 2)
+        assert np.isclose(observed, expected)
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=3,
+            ),
+        ],
+    )
+    def test_tensor_2(self, device):
+        """Test variance for Tensor observable including hermitian observable on braket devices."""
+
+        @qjit()
+        @qml.qnode(device)
+        def circuit(x: float, y: float):
+            qml.RX(x, wires=0)
+            qml.RX(y, wires=1)
+            qml.CNOT(wires=[0, 2])
+            qml.CNOT(wires=[1, 2])
+            A = np.array(
+                [[complex(1.0, 0.0), complex(2.0, 0.0)], [complex(2.0, 0.0), complex(-1.0, 0.0)]]
+            )
+            return qml.var(qml.PauliX(0) @ qml.Hadamard(1) @ qml.Hermitian(A, wires=2))
+
+        expected = np.array(4.8125)
+        observed = circuit(np.pi / 4, np.pi / 3)
+        assert np.isclose(observed, expected)
+
+        expected = np.array(4.5)
+        observed = circuit(np.pi / 2, np.pi / 2)
+        assert np.isclose(observed, expected)
+
+
+@pytest.mark.braketlocal
+class TestBraketMeasurementsProcess:
+    """Unit tests for mixing measurement processes."""
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                wires=2,
+            ),
+        ],
+    )
+    def test_multiple_return_values_braket1(self, device):
+        """Test multiple return values."""
+
+        @qjit()
+        @qml.qnode(device)
+        def all_measurements(x):
+            qml.RY(x, wires=0)
+            return (
+                qml.expval(qml.PauliZ(0) @ qml.PauliZ(1)),
+                qml.var(qml.PauliZ(1) @ qml.PauliZ(0)),
+            )
+
+        @qml.qnode(qml.device("default.qubit", wires=2))
+        def expected(x, measurement):
+            qml.RY(x, wires=0)
+            return qml.apply(measurement)
+
+        x = 0.7
+        result = all_measurements(x)
+
+        # qml.expval
+        assert np.allclose(result[0], expected(x, qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))))
+
+        # qml.var
+        assert np.allclose(result[1], expected(x, qml.var(qml.PauliZ(1) @ qml.PauliZ(0))))
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                wires=1,
+                shots=100,
+            ),
+        ],
+    )
+    def test_multiple_return_values_braket2(self, device):
+        """Test multiple return values with shots > 0."""
+
+        @qjit()
+        @qml.qnode(device)
+        def all_measurements(x):
+            qml.RY(x, wires=0)
+            return (
+                qml.sample(),
+                qml.counts(),
+                qml.probs(wires=[0]),
+                qml.expval(qml.PauliZ(0)),
+                qml.var(qml.PauliZ(0)),
+            )
+
+        @qml.qnode(qml.device("default.qubit", wires=2))
+        def expected(x, measurement):
+            qml.RY(x, wires=0)
+            return qml.apply(measurement)
+
+        x = 0.7
+        result = all_measurements(x)
+
+        # qml.sample
+        assert result[0].shape[0] == 100
+
+        # qml.counts
+        assert sum(result[2]) == 100
+
+        # qml.probs
+        assert result[3][0] > result[3][1]
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=2,
+            ),
+        ],
+    )
+    def test_unsupported_measurement_braket(self, device):
+        """Test unsupported measurement on braket devices."""
+
+        @qjit()
+        @qml.qnode(device)
+        def circuit(x: float, y: float):
+            qml.RX(x, wires=0)
+            qml.RX(y, wires=1)
+            qml.CNOT(wires=[0, 1])
+            return qml.state()
+
+        with pytest.raises(RuntimeError, match="Not implemented method"):
+            circuit(np.pi / 4, np.pi / 3)
+
+
+@pytest.mark.braketlocal
+class TestBraketGradient:
+    """Unit tests for gradient methods."""
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=1,
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("inp", [(1.0), (2.0), (3.0), (4.0)])
+    def test_fd(self, inp, device):
+        """Test the finite-diff method on braket devices."""
+
+        def f(x):
+            qml.RX(x * 2, wires=0)
+            return qml.expval(qml.PauliY(0))
+
+        @qjit()
+        def compiled(x: float):
+            g = qml.qnode(device)(f)
+            h = grad(g, method="fd", h=1e-4)
+            return h(x)
+
+        def interpreted(x):
+            device = qml.device("default.qubit", wires=1)
+            g = qml.QNode(f, device, diff_method="finite-diff")
+            h = qml.grad(g, argnum=0)
+            return h(x)
+
+        assert np.allclose(compiled(inp), interpreted(inp), rtol=1e-3)
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=2,
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("inp", [(1.0, 2.0), (2.0, 3.0)])
+    def test_fd_2qubits(self, inp, device):
+        """Test the finite-diff method on braket devices."""
+
+        def f(x, y):
+            qml.RX(y * x, wires=0)
+            qml.RX(x * 2, wires=1)
+            return qml.expval(qml.PauliY(0) @ qml.PauliZ(1))
+
+        @qjit()
+        def compiled(x: float, y: float):
+            g = qml.qnode(device)(f)
+            h = grad(g, method="fd", h=1e-4)
+            return h(x, y)
+
+        def interpreted(x, y):
+            device = qml.device("default.qubit", wires=2)
+            g = qml.QNode(f, device, diff_method="finite-diff")
+            h = qml.grad(g, argnum=0)
+            return h(x, y)
+
+        assert np.allclose(compiled(*inp), interpreted(*inp), rtol=1e-3)
+
+    @pytest.mark.parametrize(
+        "device",
+        [
+            qml.device(
+                "braket.local.qubit",
+                backend="braket_sv",
+                wires=2,
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("inp", [(1.0), (2.0), (3.0), (4.0)])
+    def test_fd_higher_order(self, inp, device):
+        """Test finite diff method on braket devices."""
+
+        def f(x):
+            qml.RX(x, wires=0)
+            return qml.expval(qml.PauliY(0))
+
+        @qjit()
+        def compiled_grad_default(x: float):
+            g = qml.qnode(device)(f)
+            h = grad(g, h=1e-4)
+            i = grad(h, h=1e-4)
+            return i(x)
+
+        def interpretted_grad_default(x):
+            device = qml.device("default.qubit", wires=1)
+            g = qml.QNode(f, device, diff_method="backprop", max_diff=2)
+            h = qml.grad(g, argnum=0)
+            i = qml.grad(h, argnum=0)
+            return i(x)
+
+        assert np.allclose(compiled_grad_default(inp), interpretted_grad_default(inp), rtol=0.1)
+
+
+if __name__ == "__main__":
+    pytest.main(["-x", __file__])

--- a/runtime/extensions/CMakeLists.txt
+++ b/runtime/extensions/CMakeLists.txt
@@ -29,12 +29,12 @@ if(ENABLE_LIGHTNING_KOKKOS)
     )
 
     FetchContent_MakeAvailable(pennylane_lightning_kokkos)
-    
+
     target_link_libraries(rt_interfaces INTERFACE pennylane_lightning_kokkos)
 endif()
 
 if(ENABLE_OPENQASM)
-    find_package(pybind11)
+    find_package(pybind11 CONFIG)
 
     if(pybind11_FOUND)
         message(STATUS "Found pybind11")

--- a/runtime/lib/backend/openqasm/OpenQasmBuilder.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmBuilder.hpp
@@ -70,6 +70,7 @@ using GateNameT = std::string_view;
  */
 constexpr std::array rt_qasm_gate_map = {
     // (RT-GateName, Qasm-GateName)
+    std::tuple<GateNameT, GateNameT>{"Identity", "i"},
     std::tuple<GateNameT, GateNameT>{"PauliX", "x"},
     std::tuple<GateNameT, GateNameT>{"PauliY", "y"},
     std::tuple<GateNameT, GateNameT>{"PauliZ", "z"},
@@ -77,6 +78,7 @@ constexpr std::array rt_qasm_gate_map = {
     std::tuple<GateNameT, GateNameT>{"S", "s"},
     std::tuple<GateNameT, GateNameT>{"T", "t"},
     std::tuple<GateNameT, GateNameT>{"CNOT", "cnot"},
+    std::tuple<GateNameT, GateNameT>{"CY", "cy"},
     std::tuple<GateNameT, GateNameT>{"CZ", "cz"},
     std::tuple<GateNameT, GateNameT>{"SWAP", "swap"},
     std::tuple<GateNameT, GateNameT>{"PhaseShift", "phaseshift"},
@@ -343,7 +345,7 @@ class QasmGate {
             oss << "#pragma braket unitary(";
             oss << MatrixBuilder::toOpenQasm(matrix, (1UL << wires.size()), precision, version);
             oss << ") ";
-            oss << qregister.toOpenQasm(RegisterMode::Slice, wires) << ";\n";
+            oss << qregister.toOpenQasm(RegisterMode::Slice, wires) << "\n";
             return oss.str();
         }
 

--- a/runtime/lib/backend/openqasm/OpenQasmRunner.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmRunner.hpp
@@ -162,6 +162,7 @@ struct BraketRunner : public OpenQasmRunner {
                     result = device.run(OpenQasmProgram(source=circuit), shots=int(shots)).result()
                 result = str(result)
             except Exception as e:
+                print(f"circuit: {circuit}")
                 msg = str(e)
               )",
             py::globals(), locals);
@@ -220,6 +221,7 @@ struct BraketRunner : public OpenQasmRunner {
                 for i in range(2 ** int(num_qubits)):
                     probs_list.append(probs_dict[i] if i in probs_dict else 0)
             except Exception as e:
+                print(f"circuit: {circuit}")
                 msg = str(e)
               )",
             py::globals(), locals);
@@ -283,6 +285,7 @@ struct BraketRunner : public OpenQasmRunner {
                     result = device.run(OpenQasmProgram(source=circuit), shots=int(shots)).result()
                 samples = np.array(result.measurements).flatten()
             except Exception as e:
+                print(f"circuit: {circuit}")
                 msg = str(e)
               )",
             py::globals(), locals);
@@ -344,6 +347,7 @@ struct BraketRunner : public OpenQasmRunner {
                     result = device.run(OpenQasmProgram(source=circuit), shots=int(shots)).result()
                 expval = result.values
             except Exception as e:
+                print(f"circuit: {circuit}")
                 msg = str(e)
               )",
             py::globals(), locals);
@@ -399,6 +403,7 @@ struct BraketRunner : public OpenQasmRunner {
                     result = device.run(OpenQasmProgram(source=circuit), shots=int(shots)).result()
                 var = result.values
             except Exception as e:
+                print(f"circuit: {circuit}")
                 msg = str(e)
               )",
             py::globals(), locals);

--- a/runtime/tests/Test_OpenQasmBuilder.cpp
+++ b/runtime/tests/Test_OpenQasmBuilder.cpp
@@ -179,7 +179,7 @@ TEST_CASE("Test QasmGate from OpenQasmBuilder", "[openqasm]")
     };
     auto gate5 = QasmGate(mat, {2}, false);
     CHECK(gate5.getMatrix() == mat);
-    std::string gate5_toqasm = "#pragma braket unitary([[0, 0-1im], [0+1im, 0]]) q[2];\n";
+    std::string gate5_toqasm = "#pragma braket unitary([[0, 0-1im], [0+1im, 0]]) q[2]\n";
     CHECK(gate5.toOpenQasm(qubits, 2) == gate5_toqasm);
 
     // Check a random gate with several params (value)

--- a/runtime/tests/Test_OpenQasmDevice.cpp
+++ b/runtime/tests/Test_OpenQasmDevice.cpp
@@ -70,8 +70,7 @@ TEST_CASE("Test BraketRunner::runCircuit()", "[openqasm]")
     auto &&circuit = builder.toOpenQasm();
 
     OpenQasm::BraketRunner runner{};
-    auto &&results =
-        runner.runCircuit(circuit, "arn:aws:braket:::device/quantum-simulator/amazon/sv1", 100);
+    auto &&results = runner.runCircuit(circuit, "default", 100);
     CHECK(results.find("GateModelQuantumTaskResult") != std::string::npos);
 }
 
@@ -90,8 +89,7 @@ TEST_CASE("Test the OpenQasmDevice constructor", "[openqasm]")
     SECTION("Braket SV1")
     {
         auto device = OpenQasmDevice(
-            false,
-            "{shots: 100, device_arn: arn:aws:braket:::device/quantum-simulator/amazon/sv1}");
+            false, "{shots: 100, device_type : braket.local.qubit, backend : default}");
         CHECK(device.GetNumQubits() == 0);
 
         REQUIRE_THROWS_WITH(device.Circuit(),
@@ -477,7 +475,7 @@ TEST_CASE("Test MatrixOperation with BuilderType::Braket", "[openqasm]")
                          "bit[5] bits;\n"
                          "x qubits[0];\n"
                          "y qubits[1];\n"
-                         "#pragma braket unitary([[0, 0-1im], [0+1im, 0]]) qubits[0];\n"
+                         "#pragma braket unitary([[0, 0-1im], [0+1im, 0]]) qubits[0]\n"
                          "bits = measure qubits;\n";
 
     CHECK(device->Circuit() == toqasm);


### PR DESCRIPTION
**Context:**
This PR addresses the following issues:
- Split all Braket/OQ3 end-to-end tests in two test files: `test_braket_local_devices.py` and `test_braket_remote_devices.py`. This would let us to properly use pytest markers and exclude/include braket tests. There are currently 3 options for testing braket tests using the Make command 
  - `make test-frontend TEST_BRAKET=LOCAL` : check local tests (no need to setup AWS credentials)
  - `make test-frontend TEST_BRAKET=REMOTE` : check remote tests (requires AWS credentials as well as the region)
  - `make test-frontend TEST_BRAKET=ALL` : check all local and remote Braket tests  
- Include end-to-end tests for remote Braket devices from `test_braket_local_devices.py`.
- Remove the `awscli` third-party GH action from CI. We only test OQ3 support on the default (sv1) local simulator.
- Fix a minor issue with generating the Braket/OQ3 equivalence of `QubitUnitary`. 
- Update runtime tests to run on the local simulator by default. Thus, there is no need to setup AWS credentials there. 
- Update the OQ3 runner class to print the generated OQ3 circuit when an exception is thrown. 