### PR TITLE
Refactor jax tracing of quantum functions

### DIFF
--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1525,7 +1525,7 @@ def _adjoint_lowering(
     output_types = util.flatten(map(mlir.aval_to_ir_types, jax_ctx.avals_out))
 
     # Build an adjoint operation with a single-block region.
-    op = AdjointOp(output_types[0], qargs[0])
+    op = AdjointOp(output_types[-1], qargs[0])
     adjoint_block = op.regions[0].blocks.append(*[mlir.aval_to_ir_types(a)[0] for a in aqargs])
     with ir.InsertionPoint(adjoint_block):
         source_info_util.extend_name_stack("adjoint")

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -274,7 +274,7 @@ def trace_quantum_tape(
                 op.branch_jaxprs,
                 *header_and_branch_args_plus_consts,
             )
-            qregs, v = tree_unflatten(op.out_trees[0], outs)
+            v, qregs = tree_unflatten(op.out_trees[0], outs)
             qreg = qregs[0]
             p.send_partial_input(v)
             # We don't know if the conditional modified any of the qubits

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -274,7 +274,8 @@ def trace_quantum_tape(
                 op.branch_jaxprs,
                 *header_and_branch_args_plus_consts,
             )
-            v, qreg = tree_unflatten(op.out_trees[0], outs)
+            qregs, v = tree_unflatten(op.out_trees[0], outs)
+            qreg = qregs[0]
             p.send_partial_input(v)
             # We don't know if the conditional modified any of the qubits
             # So let's load them all...

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -299,14 +299,11 @@ def trace_quantum_tape(
             qubit_states.clear()
         elif op.__class__.__name__ == "ForLoop":
             loop_bounds, body_consts, iter_args = op_args
-            print(f"{body_consts=}")
-            print(f"{iter_args=}")
             qreg = insert_to_qreg(qubit_states, qreg)
             header_and_iter_args_plus_consts = loop_bounds + body_consts + iter_args + [qreg]
             outs = jprim.qfor(op.body_jaxpr, len(body_consts), *header_and_iter_args_plus_consts)
             v, qregs = tree_unflatten(op.body_tree, outs)
             qreg = qregs[0]
-            print(f"{v=}, {qreg=}")
             p.send_partial_input(v)
             # We don't know if the loop modified any of the qubits
             # So let's load them all...

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -283,7 +283,7 @@ def trace_quantum_tape(
         elif op.__class__.__name__ == "WhileLoop":
             cond_consts, body_consts, iter_args = op_args
             qreg = insert_to_qreg(qubit_states, qreg)
-            iter_args_plus_consts = cond_consts + body_consts + iter_args + [qreg]
+            iter_args_plus_consts = cond_consts + body_consts + [qreg] + iter_args
             outs = jprim.qwhile(
                 op.cond_jaxpr,
                 op.body_jaxpr,
@@ -291,7 +291,8 @@ def trace_quantum_tape(
                 len(body_consts),
                 *iter_args_plus_consts,
             )
-            v, qreg = tree_unflatten(op.body_tree, outs)
+            qregs, v = tree_unflatten(op.body_tree, outs)
+            qreg = qregs[0]
             p.send_partial_input(v)
             # We don't know if the loop modified any of the qubits
             # So let's load them all...

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -299,10 +299,14 @@ def trace_quantum_tape(
             qubit_states.clear()
         elif op.__class__.__name__ == "ForLoop":
             loop_bounds, body_consts, iter_args = op_args
+            print(f"{body_consts=}")
+            print(f"{iter_args=}")
             qreg = insert_to_qreg(qubit_states, qreg)
             header_and_iter_args_plus_consts = loop_bounds + body_consts + iter_args + [qreg]
             outs = jprim.qfor(op.body_jaxpr, len(body_consts), *header_and_iter_args_plus_consts)
             v, qreg = tree_unflatten(op.body_tree, outs)
+            print(f"{v=}, {qreg=}")
+            # qreg = qregs[0]
             p.send_partial_input(v)
             # We don't know if the loop modified any of the qubits
             # So let's load them all...

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -722,7 +722,7 @@ class CondCallable:
         Cond(self.preds, consts, branch_jaxprs, args_tree, out_trees)
 
         # Create tracers for any non-qreg return values (if there are any).
-        _, ret_vals = tree_unflatten(out_trees[0], branch_jaxprs[0].out_avals)
+        ret_vals, _ = tree_unflatten(out_trees[0], branch_jaxprs[0].out_avals)
         print(f"{ret_vals=}, {branch_jaxprs[0].out_avals=}")
         a, t = tree_flatten(ret_vals)
         return ctx.jax_tape.create_tracer(t, a)

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -224,7 +224,7 @@ def test_adjoint_no_measurements():
         qml.RX(pnp.pi / 2, wires=0)
         qml.sample()
 
-    with pytest.raises(ValueError, match="no measurements"):
+    with pytest.raises(ValueError, match="Quantum measurements are not allowed"):
 
         @qjit()
         @qml.qnode(qml.device("lightning.qubit", wires=2))


### PR DESCRIPTION
In this PR we refactor jax tracing of quantum functions by moving the common code into a unified function.