### PR TITLE
Enable differentiation of `qml.probs` with the parameter-shift method (fixes #73)

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -26,10 +26,14 @@
 
 <h3>Bug fixes</h3>
 
+* Fix issue preventing the differentiation of ``qml.probs`` with the parameter-shift method.
+  [#211](https://github.com/PennyLaneAI/catalyst/pull/211)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
+David Ittah,
 Sergei Mironov.
 
 # Release 0.2.0
@@ -48,7 +52,7 @@ Sergei Mironov.
 
   ```python
   dev = qml.device("lightning.qubit", wires=1)
-  
+
   @qjit
   @qml.qnode(dev)
   def circuit(x):
@@ -56,13 +60,13 @@ Sergei Mironov.
       qml.RY(x[1] ** 2, wires=0)
       qml.RX(x[1] * x[2], wires=0)
       return qml.probs(wires=0)
-  
+
   @jax.jit
   def cost_fn(weights):
       x = jnp.sin(weights)
       return jnp.sum(jnp.cos(circuit(x)) ** 2)
   ```
-  
+
   ```pycon
   >>> cost_fn(jnp.array([0.1, 0.2, 0.3]))
   Array(1.32269195, dtype=float64)
@@ -145,25 +149,25 @@ Sergei Mironov.
 
   ```python
   dev = qml.device("lightning.qubit", wires=1)
-  
+
   @qjit
   @qml.qnode(dev)
   def circuit(x):
-  
+
       @catalyst.cond(x > 2.7)
       def cond_fn():
           qml.RX(x, wires=0)
-  
+
       @cond_fn.else_if(x > 1.4)
       def cond_elif():
           qml.RY(x, wires=0)
-  
+
       @cond_fn.otherwise
       def cond_else():
           qml.RX(x ** 2, wires=0)
-  
+
       cond_fn()
-  
+
       return qml.probs(wires=0)
   ```
 
@@ -251,17 +255,17 @@ Sergei Mironov.
 
   @qml.qnode(dev2)
   def circuit2(x):
-  
+
       @catalyst.cond(x > 2.7)
       def cond_fn():
           qml.RX(x, wires=0)
-  
+
       @cond_fn.otherwise
       def cond_else():
           qml.RX(x ** 2, wires=0)
-  
+
       cond_fn()
-  
+
       return qml.probs(wires=0)
 
   @qjit
@@ -349,7 +353,7 @@ Sergei Mironov.
   - Passes are now classes. This allows developers/users looking to change
 
     flags to inherit from these passes and change the flags.
-  
+
   - Passes are now passed as arguments to the compiler. Custom passes can just
     be passed to the compiler as an argument, as long as they implement a run
     method which takes an input and the output of this method can be fed to

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -189,6 +189,10 @@ class BufferizationPass(PassPipeline):
 
     _executable = get_executable_path("quantum", "quantum-opt")
     _default_flags = [
+        # The following pass allows differentiation of qml.probs with the parameter-shift method,
+        # as it performs the bufferization of `memref.tensor_op` (for which no dialect bufferization
+        # exists).
+        "--one-shot-bufferize=dialect-filter=memref",  # must run before any dialect bufferization
         "--inline",
         "--gradient-bufferize",
         "--scf-bufferize",

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -37,7 +37,7 @@ def test_adjoint_func():
         qml.PauliY(wires=0)
         qml.PauliZ(wires=1)
 
-    @qjit()
+    @qjit
     @qml.qnode(qml.device("lightning.qubit", wires=2))
     def C_workflow():
         qml.PauliX(wires=0)
@@ -61,7 +61,7 @@ def test_adjoint_func():
 def test_adjoint_op(theta, val):
     """Ensures that catalyst.adjoint accepts single PennyLane operators classes as argument."""
 
-    @qjit()
+    @qjit
     @qml.qnode(qml.device("lightning.qubit", wires=2))
     def C_workflow(theta, val):
         C_adjoint(qml.RY)(jnp.pi, val)
@@ -83,7 +83,7 @@ def test_adjoint_op(theta, val):
 def test_adjoint_bound_op(theta, val):
     """Ensures that catalyst.adjoint accepts single PennyLane operators objects as argument."""
 
-    @qjit()
+    @qjit
     @qml.qnode(qml.device("lightning.qubit", wires=3))
     def C_workflow(theta, val):
         C_adjoint(qml.RX(jnp.pi, val))
@@ -105,14 +105,14 @@ def test_adjoint_bound_op(theta, val):
 
 @pytest.mark.parametrize("w, p", [(0, 0.5), (0, -100.0), (1, 123.22)])
 def test_adjoint_param_fun(w, p):
-    """Ensures that catalyst.adjoint accepts paramethrized Python functions as arguments."""
+    """Ensures that catalyst.adjoint accepts parameterized Python functions as arguments."""
 
     def func(w, theta1, theta2, theta3=1):
         qml.RX(theta1 * pnp.pi / 2, wires=w)
         qml.RY(theta2 / 2, wires=w)
         qml.RZ(theta3, wires=1)
 
-    @qjit()
+    @qjit
     @qml.qnode(qml.device("lightning.qubit", wires=2))
     def C_workflow(w, theta):
         qml.PauliX(wires=0)
@@ -142,7 +142,7 @@ def test_adjoint_nested_fun():
             I = I + 1
             A(partial(func, A=A, I=I))()
 
-    @qjit(verbose=True, keep_intermediate=True)
+    @qjit
     @qml.qnode(qml.device("lightning.qubit", wires=2))
     def C_workflow():
         qml.RX(pnp.pi / 2, wires=0)
@@ -178,7 +178,7 @@ def test_adjoint_qubitunitary():
             wires=[0, 1],
         )
 
-    @qjit()
+    @qjit
     @qml.qnode(qml.device("lightning.qubit", wires=2))
     def C_workflow():
         C_adjoint(func)()
@@ -201,7 +201,7 @@ def test_adjoint_multirz():
         qml.PauliX(0)
         qml.MultiRZ(theta=pnp.pi / 2, wires=[0, 1])
 
-    @qjit()
+    @qjit
     @qml.qnode(qml.device("lightning.qubit", wires=2))
     def C_workflow():
         C_adjoint(func)()
@@ -226,7 +226,7 @@ def test_adjoint_no_measurements():
 
     with pytest.raises(ValueError, match="no measurements"):
 
-        @qjit()
+        @qjit
         @qml.qnode(qml.device("lightning.qubit", wires=2))
         def C_workflow():
             C_adjoint(func)()
@@ -239,7 +239,7 @@ def test_adjoint_invalid_argument():
     """Checks that catalyst.adjoint rejects non-quantum program arguments."""
     with pytest.raises(ValueError, match="Expected a callable"):
 
-        @qjit()
+        @qjit
         @qml.qnode(qml.device("lightning.qubit", wires=2))
         def C_workflow():
             C_adjoint(33)()
@@ -259,7 +259,7 @@ def test_adjoint_classical_loop():
         qml.PauliX(wires=loop(w))
         qml.RX(pnp.pi / 2, wires=w)
 
-    @qjit()
+    @qjit
     @qml.qnode(qml.device("lightning.qubit", wires=3))
     def C_workflow():
         C_adjoint(func)(0)

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -448,7 +448,6 @@ def test_ps_qft(inp, backend):
     assert np.allclose(compiled(inp, 2, 2), interpreted(inp, 2, 2))
 
 
-@pytest.mark.xfail(reason="https://github.com/PennyLaneAI/catalyst/issues/73")
 def test_ps_probs(backend):
     """Check that the parameter-shift method works for qml.probs."""
 
@@ -461,7 +460,10 @@ def test_ps_probs(backend):
     def workflow(p: float):
         return grad(func, method="defer")(p)
 
-    assert np.allclose(workflow(0.5), [0.93879128, 0.06120872])
+    result = workflow(0.5)
+    reference = qml.jacobian(func, argnum=0)(0.5)
+
+    assert np.allclose(result, reference)
 
 
 @pytest.mark.parametrize("inp", [(1.0), (2.0), (3.0), (4.0)])


### PR DESCRIPTION
The lowering rules for `catalyst.grad` with the parameter-shift method make use of the `memref.tensor_store` op whenever the output of the quantum function is not a scalar tensor. This is the case when differentiating `qml.probs` rather than `qml.expval`.

The bufferization for this op has previously been broken, but was fixed upstream (see issue #73). However, the fix was only implemented for the one-shot-bufferization framework, rather than the outdated (partial) dialect bufferization framework we currently use. This is another argument to switch to one-shot-bufferization in the future, but for now the fix invokes the one-shot-bufferization restricted to the `memref` dialect.

@erick-xanadu turns out we indeed already had a test for this that was marked xfail

closes #73 
[sc-41706]
