### PR TITLE
[Frontend] Reduce execution time

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -25,6 +25,17 @@
 * Eliminate redundant unflattening and flattening of PyTrees parameters in Catalyst control flow operations.
   [#215](https://github.com/PennyLaneAI/catalyst/pull/215)
 
+* Improve execution speed by:
+    * load the shared library once per compilation
+    * generate return value type only once per compilation
+    * avoiding type promotion
+    * avoiding unnecessary copies
+  This leads to a small but measurable improvement when using larger matrices as inputs or many
+  inputs.
+  [#213](https://github.com/PennyLaneAI/catalyst/pull/213)
+
+
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>
@@ -37,6 +48,7 @@
 This release contains contributions from (in alphabetical order):
 
 David Ittah,
+Erick Ochoa Lopez,
 Sergei Mironov.
 
 

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -522,7 +522,7 @@ class QJIT:
           function: an instance of ``CompiledFunction`` that may have been recompiled
           *args: arguments that may have been promoted
         """
-        args = [jax.numpy.array(arg) for arg in args]
+        args = [jax.numpy.asarray(arg) for arg in args]
         r_sig = CompiledFunction.get_runtime_signature(*args)
         is_prev_compile = self.compiled_function is not None
         can_promote = not is_prev_compile or CompiledFunction.can_promote(self.c_sig, r_sig)
@@ -536,7 +536,7 @@ class QJIT:
             function = self.compile()
         else:
             args = CompiledFunction.promote_arguments(self.c_sig, r_sig, *args)
-        args = [jax.numpy.array(arg) for arg in args]
+        args = [jax.numpy.asarray(arg) for arg in args]
 
         return function, args
 

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -165,8 +165,7 @@ class CompiledFunction:
 
         Args:
             compiled_signature: user supplied signature, obtain from either an annotation or a
-                                previously compiled
-            implementation of the compiled function
+                                previously compiled implementation of the compiled function
             runtime_signature: runtime signature
 
         Returns:

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -134,7 +134,7 @@ class SharedObjectManager:
         self.setup(ctypes.c_int(argc), array_of_char_ptrs)
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, _type, _value, _traceback):
         self.teardown()
 
 

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -85,6 +85,10 @@ class SharedObjectManager:
 
     def close(self):
         """Close the shared object"""
+        self.function = None
+        self.setup = None
+        self.teardown = None
+        self.mem_transfer = None
         dlclose = ctypes.CDLL(None).dlclose
         dlclose.argtypes = [ctypes.c_void_p]
         # pylint: disable=protected-access

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -534,9 +534,8 @@ class QJIT:
                 warnings.warn(msg, UserWarning)
             self.mlir_module = self.get_mlir(*r_sig)
             function = self.compile()
-        else:
+        elif can_promote:
             args = CompiledFunction.promote_arguments(self.c_sig, r_sig, *args)
-        args = [jax.numpy.asarray(arg) for arg in args]
 
         return function, args
 

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -89,6 +89,29 @@ class CompiledFunction:
         self.restype = restype
 
     @staticmethod
+    def can_skip_promote(compiled_signature, runtime_signature):
+        """Whether arguments can be promoted.
+
+        Args:
+            compiled_signature: user supplied signature, obtain from either an annotation or a
+                                previously compiled
+            implementation of the compiled function
+            runtime_signature: runtime signature
+
+        Returns:
+            bool.
+        """
+        len_compile = len(compiled_signature)
+        len_runtime = len(runtime_signature)
+        if len_compile != len_runtime:
+            return False
+
+        for c_param, r_param in zip(compiled_signature, runtime_signature):
+            if c_param.dtype != r_param.dtype or c_param.shape != r_param.shape:
+                return False
+        return True
+
+    @staticmethod
     def can_promote(compiled_signature, runtime_signature):
         """Whether arguments can be promoted.
 
@@ -522,9 +545,14 @@ class QJIT:
           function: an instance of ``CompiledFunction`` that may have been recompiled
           *args: arguments that may have been promoted
         """
-        args = [jax.numpy.asarray(arg) for arg in args]
+        bitmask = map(lambda x: not isinstance(x, jax.Array), args)
+        args = list(map(lambda arg, is_not_jax_array: jax.numpy.asarray(arg) if is_not_jax_array else arg, args, bitmask))
         r_sig = CompiledFunction.get_runtime_signature(*args)
         is_prev_compile = self.compiled_function is not None
+        can_skip_promote = is_prev_compile and CompiledFunction.can_skip_promote(self.c_sig, r_sig)
+        if can_skip_promote:
+            return function, args
+
         can_promote = not is_prev_compile or CompiledFunction.can_promote(self.c_sig, r_sig)
         needs_compile = not is_prev_compile or not can_promote
 

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -24,7 +24,7 @@ from jax import numpy as jnp
 from numpy import pi
 
 from catalyst import for_loop, grad, measure, qjit
-from catalyst.compilation_pipelines import CompiledFunction
+from catalyst.compilation_pipelines import CompiledFunction, TypeCompatibility
 from catalyst.jax_primitives import _scalar_abstractify
 
 
@@ -505,8 +505,8 @@ class TestSignatureErrors:
     def test_incompatible_compiled_vs_runtime(self):
         """Test incompatible compiled vs runtime."""
 
-        retval = CompiledFunction.can_promote([], [1])
-        assert not retval
+        retval = CompiledFunction.typecheck([], [1])
+        assert TypeCompatibility.NEEDS_COMPILATION == retval
 
     def test_incompatible_type_reachable_from_user_code(self):
         """Raise error message for incompatible types"""

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -493,14 +493,8 @@ class TestShots:
             # assert expected_shape == observed_shape
 
 
-class TestSignatureErrors:
-    def test_incompatible_argument(self):
-        """Test incompatible argument."""
-
-        string = "hello world"
-        with pytest.raises(TypeError) as err:
-            CompiledFunction.get_runtime_signature([string])
-        assert "Unsupported argument type:" in str(err.value)
+class TestPromotionRules:
+    """Class to test different promotion rules."""
 
     def test_incompatible_compiled_vs_runtime_different_lengths(self):
         """Test incompatible compiled vs runtime."""
@@ -531,6 +525,16 @@ class TestSignatureErrors:
 
         retval = CompiledFunction.typecheck(jnp.array([1.0]), jnp.array([1]))
         assert TypeCompatibility.NEEDS_PROMOTION == retval
+
+
+class TestSignatureErrors:
+    def test_incompatible_argument(self):
+        """Test incompatible argument."""
+
+        string = "hello world"
+        with pytest.raises(TypeError) as err:
+            CompiledFunction.get_runtime_signature([string])
+        assert "Unsupported argument type:" in str(err.value)
 
     def test_incompatible_type_reachable_from_user_code(self):
         """Raise error message for incompatible types"""

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -502,11 +502,35 @@ class TestSignatureErrors:
             CompiledFunction.get_runtime_signature([string])
         assert "Unsupported argument type:" in str(err.value)
 
-    def test_incompatible_compiled_vs_runtime(self):
+    def test_incompatible_compiled_vs_runtime_different_lengths(self):
         """Test incompatible compiled vs runtime."""
 
         retval = CompiledFunction.typecheck([], [1])
         assert TypeCompatibility.NEEDS_COMPILATION == retval
+
+    def test_incompatible_compiled_vs_runtime_different_types(self):
+        """Test incompatible compiled vs runtime with different types."""
+
+        retval = CompiledFunction.typecheck(jnp.array([1]), jnp.array([complex(1, 2)]))
+        assert TypeCompatibility.NEEDS_COMPILATION == retval
+
+    def test_incompatible_compiled_vs_runtime_different_shapes(self):
+        """Test incompatible compiled vs runtime with different shapes."""
+
+        retval = CompiledFunction.typecheck(jnp.array([1, 2]), jnp.array([1]))
+        assert TypeCompatibility.NEEDS_COMPILATION == retval
+
+    def test_can_skip_promotion(self):
+        """Test skipping promotion"""
+
+        retval = CompiledFunction.typecheck(jnp.array([1]), jnp.array([1]))
+        assert TypeCompatibility.CAN_SKIP_PROMOTION == retval
+
+    def test_needs_promotion(self):
+        """Test promotion"""
+
+        retval = CompiledFunction.typecheck(jnp.array([1.0]), jnp.array([1]))
+        assert TypeCompatibility.NEEDS_PROMOTION == retval
 
     def test_incompatible_type_reachable_from_user_code(self):
         """Raise error message for incompatible types"""


### PR DESCRIPTION
**Context:** There were some redundant computations being done in the frontend when calling the JIT compiled function. Instead of re-computing these same values / classes, compute them only once.

**Description of the Change:**
1. Do not promote arguments if it is unnecessary to promote them
2. Do not copy if unnecessary to copy
3. Load shared library only once per compilation
4. Generate the return value type only once per compilation

**Benefits:** Small speedup when sending multiple arguments and calling the same function multiple times.

**Ticket**: [sc-41429]

Time required to input an two NxN matrices into a function:

![NxN](https://github.com/PennyLaneAI/catalyst/assets/110487834/f0d8a240-b6a9-404c-b495-d171384f7a9d)

Time required to input N scalar arguments into a function:

![Args](https://github.com/PennyLaneAI/catalyst/assets/110487834/e633d9bf-7048-4185-a9c2-53b0ca3877b5)
