### PR TITLE
[Frontend] Add -scalarize and -O0.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -24,6 +24,8 @@
 
 * Eliminate redundant unflattening and flattening of PyTrees parameters in Catalyst control flow operations.
   [#215](https://github.com/PennyLaneAI/catalyst/pull/215)
+* Reduce execution and compilation times by using `-scalarize` and `-O0`.
+  [#217](https://github.com/PennyLaneAI/catalyst/pull/217)
 
 <h3>Breaking changes</h3>
 
@@ -37,6 +39,7 @@
 This release contains contributions from (in alphabetical order):
 
 David Ittah,
+Erick Ochoa Lopez,
 Sergei Mironov.
 
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -24,7 +24,9 @@
 
 * Eliminate redundant unflattening and flattening of PyTrees parameters in Catalyst control flow operations.
   [#215](https://github.com/PennyLaneAI/catalyst/pull/215)
-* Reduce execution and compilation times by using `-scalarize` and `-O0`.
+* Reduce the execution and compile times of user programs by generating more efficient code and
+  avoiding unnecessary optimizations. Specifically, a scalarization procedure was added to the MLIR
+  pass pipeline and LLVM IR compilation is now invoked with optimization level 0.
   [#217](https://github.com/PennyLaneAI/catalyst/pull/217)
 
 <h3>Breaking changes</h3>

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -161,6 +161,8 @@ class MHLOPass(PassPipeline):
         "--hlo-legalize-to-linalg",
         "--mhlo-legalize-to-std",
         "--convert-to-signless",
+        # Substitute tensors<1xf64> with tensors<f64>
+        "--scalarize",
         "--canonicalize",
     ]
 
@@ -310,6 +312,9 @@ class LLVMIRToObjectFile(PassPipeline):
     _default_flags = [
         "--filetype=obj",
         "--relocation-model=pic",
+        # -O0 is used to achieve compile times similar to -regalloc=fast and disabling
+        # -twoaddrinst. However, from the command line, one cannot disable -twoaddrinst
+        "-O0",
     ]
 
     @staticmethod

--- a/frontend/test/lit/test_tensor_ops.mlir.py
+++ b/frontend/test/lit/test_tensor_ops.mlir.py
@@ -34,7 +34,6 @@ from catalyst import measure, qjit
 @qjit(keep_intermediate=True)
 @qml.qnode(qml.device("lightning.qubit", wires=2))
 def test_ewise_arctan2(x, y):
-    # CHECK: linalg.generic
     # CHECK: math.atan2
     # CHECK-SAME: f64
     val = jnp.arctan2(x, y)
@@ -68,7 +67,6 @@ test_ewise_arctan2.print_stage("BufferizationPass")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
 # CHECK-LABEL: test_ewise_add
 def test_ewise_add(x, y):
-    # CHECK: linalg.generic
     # CHECK: arith.addf
     # CHECK-SAME: f64
     val = jnp.add(x, y)
@@ -84,7 +82,6 @@ test_ewise_add.print_stage("BufferizationPass")
 @qjit(keep_intermediate=True)
 @qml.qnode(qml.device("lightning.qubit", wires=2))
 def test_ewise_mult(x, y):
-    # CHECK: linalg.generic
     # CHECK: arith.mulf
     # CHECK-SAME: f64
     val = jnp.multiply(x, y)
@@ -100,7 +97,6 @@ test_ewise_mult.print_stage("BufferizationPass")
 @qjit(keep_intermediate=True)
 @qml.qnode(qml.device("lightning.qubit", wires=2))
 def test_ewise_div(x, y):
-    # CHECK: linalg.generic
     # CHECK: arith.divf
     # CHECK-SAME: f64
     val = jnp.divide(x, y)
@@ -116,7 +112,6 @@ test_ewise_div.print_stage("BufferizationPass")
 @qjit(keep_intermediate=True)
 @qml.qnode(qml.device("lightning.qubit", wires=2))
 def test_ewise_power(x, y):
-    # CHECK: linalg.generic
     # CHECK: math.powf
     # CHECK-SAME: f64
     val = jnp.power(x, y.astype(int))
@@ -132,7 +127,6 @@ test_ewise_power.print_stage("BufferizationPass")
 @qjit(keep_intermediate=True)
 @qml.qnode(qml.device("lightning.qubit", wires=2))
 def test_ewise_sub(x, y):
-    # CHECK: linalg.generic
     # CHECK: arith.subf
     # CHECK-SAME: f64
     val = jnp.subtract(x, y)
@@ -148,7 +142,6 @@ test_ewise_sub.print_stage("BufferizationPass")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
 # CHECK-LABEL: test_ewise_true_div
 def test_ewise_true_div(x, y):
-    # CHECK: linalg.generic
     # CHECK: arith.divf
     # CHECK-SAME: f64
     val = jnp.true_divide(x, y)
@@ -168,7 +161,6 @@ test_ewise_true_div.print_stage("BufferizationPass")
 @qjit(keep_intermediate=True)
 @qml.qnode(qml.device("lightning.qubit", wires=2))
 def test_ewise_float_power(x, y):
-    # CHECK: linalg.generic
     # CHECK: math.powf
     # CHECK-SAME: f64
     val = jnp.float_power(x, y)
@@ -194,7 +186,6 @@ test_ewise_float_power.print_stage("BufferizationPass")
 @qjit(keep_intermediate=True)
 @qml.qnode(qml.device("lightning.qubit", wires=2))
 def test_ewise_maximum(x, y):
-    # CHECK: linalg.generic
     # CHECK: arith.maxf
     # CHECK-SAME: f64
     val = jnp.maximum(x, y)
@@ -213,7 +204,6 @@ test_ewise_maximum.print_stage("BufferizationPass")
 @qjit(keep_intermediate=True)
 @qml.qnode(qml.device("lightning.qubit", wires=2))
 def test_ewise_minimum(x, y):
-    # CHECK: linalg.generic
     # CHECK: arith.minf
     # CHECK-SAME: f64
     val = jnp.minimum(x, y)


### PR DESCRIPTION
**Context:** While looking into compile time we found that the time spent in register allocation is proportional to the number of variables in the function being compiled. We also found that functions that do not use catalyst control flow may have a large quantity of variables (an example was above ~500k) leading to prohibitively long compile times.  

**Description of the Change:** Add `scalarize` to `mlir-hlo-opt` and `-O0` to `llc`.

 Scalarize will turn all tensor<1xT> to tensor\<T>. It will also hoist operations outside of if and for and fold tensor operations. This will avoid the lowering to linear algebra which will have the impact of reducing the number of variables seen in the LLVM-IR. It was possible to also use -linalg-detensorize but -linalg-detensorize actually increased overall compilation time once we take into account -linalg-detensorize compile time itself. With -scalarize, we see similar impact on the reduction of LLVM-IR variables but without the long compile time increase.

-O0 is added to llc as this will improve compilation times. The functions that are generated by catalyst (when not using catalyst control flow operations) will have many variables. From 50-500k. llc by default uses -O2 which uses a greedy register allocator. Ideally, we shouldn't need to change from -O2 to -O0 but the large number of variables is an issue. While we work on reducing the number of variables in the generated functions (either through supporting function calls or some other mechanism), we are switching to -O0. Please note that -O0 was shown to not have an impact on the generated code as the bottle neck for representative functions is in the execution of quantum operations. However, this may change as more and more classical computation happens in the workload.

With -scalarize and -O0 we see a measurable improvement from ~10s to ~4s for compile time in the ChemVQE N=16 (-scalarize reduces ~13k variables to ~5k variables and -O0 avoids compile time) and a reduction in execution time from ~191s to ~184s.

### Execution Time

![execution_time](https://github.com/PennyLaneAI/catalyst/assets/110487834/53afafc8-7f59-4d26-b29a-d9e986931079)

Before: Mean = 191.7s, Variance = 14.9
After: Mean = 184.3s, Variance = 15.3

Distributions with lower mean are better.

### Compile Time 

![compile_time](https://github.com/PennyLaneAI/catalyst/assets/110487834/68c56485-09c4-49e9-8d81-37d5f8a12bb5)

Before: Mean = 9.9s, Variance = 0.0139
After: Mean = 4.3s, Variance = 0.00167

Distributions with lower mean are better.

**Benefits:** Better quality LLVM-IR being generated, reduced compilation time, reduce execution time.

**Possible Drawbacks:** We need to be careful to avoid overfitting compile and execution times to non-representative workloads. I believe that we can switch back to -O2 and use -regalloc=fast once we reduce the number of variables in a function.

[sc-41428]