### PR TITLE
[Frontend] Add runtime warning for unexpected JAX version

### DIFF
--- a/frontend/catalyst/utils/tracing.py
+++ b/frontend/catalyst/utils/tracing.py
@@ -16,6 +16,9 @@
 Tracing module.
 """
 
+import warnings
+
+import jax
 from catalyst.utils.exceptions import CompileError
 
 
@@ -26,10 +29,16 @@ class TracingContext:
     """
 
     _is_tracing = False
+    _supported_version = "0.4.13"
 
     def __enter__(self):
         assert not TracingContext._is_tracing, "Cannot nest tracing contexts."
         TracingContext._is_tracing = True
+        jax_version = jax.version.__version__
+        supported_version = TracingContext._supported_version
+        if jax_version != supported_version:
+            msg = f"Attempting to trace with JAX version {jax_version} when supported version is {supported_version}."
+            warnings.warn(msg)
 
     def __exit__(self, *args, **kwargs):
         TracingContext._is_tracing = False

--- a/frontend/catalyst/utils/tracing.py
+++ b/frontend/catalyst/utils/tracing.py
@@ -35,13 +35,17 @@ class TracingContext:
         assert not TracingContext._is_tracing, "Cannot nest tracing contexts."
         TracingContext._is_tracing = True
         jax_version = jax.version.__version__
-        supported_version = TracingContext._supported_version
-        if jax_version != supported_version:
-            msg = f"Attempting to trace with JAX version {jax_version} when supported version is {supported_version}."
+        if not TracingContext.is_supported_jax_version(jax_version):
+            msg = f"Attempting to trace with JAX version {jax_version} when supported version is {TracingContext._supported_version}."
             warnings.warn(msg)
+        return self
 
     def __exit__(self, *args, **kwargs):
         TracingContext._is_tracing = False
+
+    @staticmethod
+    def is_supported_jax_version(version: str):
+        return version == TracingContext._supported_version
 
     @staticmethod
     def is_tracing():

--- a/frontend/catalyst/utils/tracing.py
+++ b/frontend/catalyst/utils/tracing.py
@@ -19,6 +19,7 @@ Tracing module.
 import warnings
 
 import jax
+
 from catalyst.utils.exceptions import CompileError
 
 
@@ -32,20 +33,22 @@ class TracingContext:
     _supported_version = "0.4.13"
 
     def __enter__(self):
+        if not TracingContext.is_supported_jax_version():
+            jax_version = jax.version.__version__
+            msg = f"Attempting to trace with JAX version {jax_version}"
+            msg += f" when supported version is {TracingContext._supported_version}."
+            warnings.warn(msg)
         assert not TracingContext._is_tracing, "Cannot nest tracing contexts."
         TracingContext._is_tracing = True
-        jax_version = jax.version.__version__
-        if not TracingContext.is_supported_jax_version(jax_version):
-            msg = f"Attempting to trace with JAX version {jax_version} when supported version is {TracingContext._supported_version}."
-            warnings.warn(msg)
         return self
 
-    def __exit__(self, *args, **kwargs):
+    def __exit__(self, _type, _value, _traceback):
         TracingContext._is_tracing = False
 
     @staticmethod
-    def is_supported_jax_version(version: str):
-        return version == TracingContext._supported_version
+    def is_supported_jax_version():
+        """Returns true if JAXs version string is supported."""
+        return jax.version.__version__ == TracingContext._supported_version
 
     @staticmethod
     def is_tracing():

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -25,6 +25,7 @@ import warnings
 
 import pennylane as qml
 import pytest
+
 from catalyst import qjit
 from catalyst.compiler import (
     BufferizationPass,
@@ -101,7 +102,7 @@ class TestCompilerWarnings:
 
     def test_incompatible_jax_version(self):
         """Test warning message with incompatible jax version."""
-        with Patcher((TracingContext, "is_supported_jax_version", lambda x: False)):
+        with Patcher((TracingContext, "is_supported_jax_version", lambda: False)):
             with pytest.warns(UserWarning, match="Attempting to trace with JAX version"):
                 with TracingContext():
                     pass

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -25,7 +25,6 @@ import warnings
 
 import pennylane as qml
 import pytest
-
 from catalyst import qjit
 from catalyst.compiler import (
     BufferizationPass,
@@ -42,6 +41,8 @@ from catalyst.compiler import (
 )
 from catalyst.jax_tracer import get_mlir
 from catalyst.utils.exceptions import CompileError
+from catalyst.utils.patching import Patcher
+from catalyst.utils.tracing import TracingContext
 
 # pylint: disable=missing-function-docstring
 
@@ -97,6 +98,13 @@ class TestCompilerWarnings:
         with pytest.warns(UserWarning, match="Compiler .* failed .*"):
             # pylint: disable=protected-access
             CompilerDriver._attempt_link("cc", [""], "in.o", "out.so", None)
+
+    def test_incompatible_jax_version(self):
+        """Test warning message with incompatible jax version."""
+        with Patcher((TracingContext, "is_supported_jax_version", lambda x: False)):
+            with pytest.warns(UserWarning, match="Attempting to trace with JAX version"):
+                with TracingContext():
+                    pass
 
 
 class TestCompilerErrors:


### PR DESCRIPTION
**Context:** Sometimes it is useful to install in catalyst in debug mode. This enables one to checkout different versions of the project without having to `pip install -e .` again. However, the downside is that when one checks out versions of Catalyst that change compatibility with JAX it is necessary to install JAX again. 

**Description of the Change:** This change adds a runtime warning in case catalyst is run against an unexpected version of JAX.

**Benefits:** Warning in case of running an unexpected version of JAX.

**Possible Drawbacks:** Another place to change whenever JAX version changes.

