### PR TITLE
[Middle-end] Fix type mismatch.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -107,6 +107,9 @@
   until the end of the call to the JIT compiled function.
   [#201](https://github.com/PennyLaneAI/catalyst/pull/201)
 
+* Avoid a type mismatch. This allows dialects to compile with older versions of clang.
+  [#228](https://github.com/PennyLaneAI/catalyst/pull/228)
+
 
 <h3>Breaking changes</h3>
 

--- a/mlir/include/Gradient/Utils/GradientShape.h
+++ b/mlir/include/Gradient/Utils/GradientShape.h
@@ -25,12 +25,12 @@ namespace gradient {
 bool isDifferentiable(mlir::Type type);
 
 std::vector<mlir::Type> computeResultTypes(mlir::func::FuncOp callee,
-                                           const std::vector<uint64_t> &diffArgIndices);
+                                           const std::vector<size_t> &diffArgIndices);
 
 std::vector<mlir::Type> computeQGradTypes(mlir::func::FuncOp callee);
 
 std::vector<mlir::Type> computeBackpropTypes(mlir::func::FuncOp callee,
-                                             const std::vector<uint64_t> &diffArgIndices);
+                                             const std::vector<size_t> &diffArgIndices);
 
 std::vector<size_t> computeDiffArgIndices(std::optional<mlir::DenseIntElementsAttr> indices);
 

--- a/mlir/lib/Gradient/Utils/GradientShape.cpp
+++ b/mlir/lib/Gradient/Utils/GradientShape.cpp
@@ -27,8 +27,7 @@ namespace gradient {
 /// whereas the result signature is the set of shape unions for each combination of differentiable
 /// argument function result.
 ///
-std::vector<Type> computeResultTypes(func::FuncOp callee,
-                                     const std::vector<size_t> &diffArgIndices)
+std::vector<Type> computeResultTypes(func::FuncOp callee, const std::vector<size_t> &diffArgIndices)
 {
     std::vector<Type> gradResultTypes;
     FunctionType fnType = callee.getFunctionType();

--- a/mlir/lib/Gradient/Utils/GradientShape.cpp
+++ b/mlir/lib/Gradient/Utils/GradientShape.cpp
@@ -28,7 +28,7 @@ namespace gradient {
 /// argument function result.
 ///
 std::vector<Type> computeResultTypes(func::FuncOp callee,
-                                     const std::vector<uint64_t> &diffArgIndices)
+                                     const std::vector<size_t> &diffArgIndices)
 {
     std::vector<Type> gradResultTypes;
     FunctionType fnType = callee.getFunctionType();
@@ -104,7 +104,7 @@ std::vector<Type> computeQGradTypes(func::FuncOp callee)
 /// The non differentiable params are filtered out.
 ///
 std::vector<Type> computeBackpropTypes(func::FuncOp callee,
-                                       const std::vector<uint64_t> &diffArgIndices)
+                                       const std::vector<size_t> &diffArgIndices)
 {
     std::vector<Type> backpropResTypes;
     FunctionType fnType = callee.getFunctionType();


### PR DESCRIPTION
**Context:** When building using clang version  14.0.3 (clang-1403.0.22.14.1) there's an error due to a type mismatch. ` candidate function not viable: no known conversion from 'const vector<size_t>' to 'const vector<uint64_t>'`

**Description of the Change:** Change `uint64_t` to `size_t`.

**Benefits:** No type mismatch, dialects build with older versions of clang.
