### PR TITLE
[Build system] Allow the runtime to be compiled on macOS in parallel and using `ld64`.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -116,6 +116,10 @@
   to prevent a mismatch in machines which compile using ILP32 mode.
   [#229](https://github.com/PennyLaneAI/catalyst/pull/230)
 
+* Allow runtime to be compiled on macOS. Substitute ``nproc`` with a call to ``os.cpu_count()`` and
+  use correct flags for ``ld.64``.
+  [#232](https://github.com/PennyLaneAI/catalyst/pull/232)
+
 <h3>Breaking changes</h3>
 
 * Since we are now using PyTrees, python lists are no longer automatically converted into JAX

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -16,6 +16,18 @@ ENABLE_OPENQASM?=OFF
 LIGHTNING_GIT_TAG_VALUE?=latest_release
 LIGHTNING_KOKKOS_GIT_TAG_VALUE?=latest_release
 
+# Assumption: uname is installed in the machine
+# building Catalyst. This assumption will not hold
+# on windows machines, for that we will need to have
+# an extra condition before trying to run uname.
+UNAME := $(shell uname)
+ifeq ($(UNAME),Linux)
+  NPROC = $(shell nproc)
+else ifeq ($(UNAME),Darwin)
+  NPROC = $(shell sysctl -n hw.physicalcpu)
+else
+  NPROC = 1
+endif
 
 coverage: CODE_COVERAGE=ON
 coverage: BUILD_TYPE=Debug
@@ -63,7 +75,7 @@ $(QIR_STDLIB_DIR)/libqir_stdlib.a $(QIR_STDLIB_INCLUDES_DIR)/qir_stdlib.h:
 	$(MAKE) -C qir-stdlib all
 
 $(RT_BUILD_DIR)/lib/backend/librt_backend.so $(RT_BUILD_DIR)/lib/librt_capi.so: configure
-	cmake --build $(RT_BUILD_DIR) --target rt_capi -j$(if $(nprocs:-=),$(nprocs),$$(nproc))
+	cmake --build $(RT_BUILD_DIR) --target rt_capi -j$(NPROC)
 
 .PHONY: qir
 qir: $(QIR_STDLIB_DIR)/libqir_stdlib.a $(QIR_STDLIB_INCLUDES_DIR)/qir_stdlib.h
@@ -72,7 +84,7 @@ qir: $(QIR_STDLIB_DIR)/libqir_stdlib.a $(QIR_STDLIB_INCLUDES_DIR)/qir_stdlib.h
 runtime: qir $(RT_BUILD_DIR)/lib/backend/librt_backend.so $(RT_BUILD_DIR)/lib/librt_capi.so
 
 $(RT_BUILD_DIR)/tests/runner_tests: configure
-	cmake --build $(RT_BUILD_DIR) --target runner_tests -j$(if $(nprocs:-=),$(nprocs),$$(nproc))
+	cmake --build $(RT_BUILD_DIR) --target runner_tests -j$(NPROC)
 
 .PHONY: test
 test: $(RT_BUILD_DIR)/tests/runner_tests
@@ -120,4 +132,4 @@ check-tidy: | qir
 		-DQIR_STDLIB_INCLUDES=$(QIR_STDLIB_INCLUDES_DIR) \
 		-DRUNTIME_CLANG_TIDY=ON
 
-	cmake --build $(MK_DIR)/BuildTidy --target rt_capi -j$(if $(nprocs:-=),$(nprocs),$$(nproc))
+	cmake --build $(MK_DIR)/BuildTidy --target rt_capi -j$(NPROC)

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -15,19 +15,7 @@ ENABLE_LIGHTNING_KOKKOS?=OFF
 ENABLE_OPENQASM?=OFF
 LIGHTNING_GIT_TAG_VALUE?=latest_release
 LIGHTNING_KOKKOS_GIT_TAG_VALUE?=latest_release
-
-# Assumption: uname is installed in the machine
-# building Catalyst. This assumption will not hold
-# on windows machines, for that we will need to have
-# an extra condition before trying to run uname.
-UNAME := $(shell uname)
-ifeq ($(UNAME),Linux)
-  NPROC = $(shell nproc)
-else ifeq ($(UNAME),Darwin)
-  NPROC = $(shell sysctl -n hw.physicalcpu)
-else
-  NPROC = 1
-endif
+NPROC?=$(shell python -c "import os; print(os.cpu_count())")
 
 coverage: CODE_COVERAGE=ON
 coverage: BUILD_TYPE=Debug

--- a/runtime/lib/capi/CMakeLists.txt
+++ b/runtime/lib/capi/CMakeLists.txt
@@ -10,11 +10,20 @@ target_link_libraries(catalyst_qir_qis_obj ${CMAKE_DL_LIBS}
                                             -lrt_backend
                                             rt_interfaces)
 
-# link to qir_stdlib
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set(LINKER_FLAGS_1, "-Wl,-all_load")
+  # We can technically use "-Wl,-noall_load", but the linker
+  # raises a warning saying that it is a no-op.
+  set(LINKER_FLAGS_2, "")
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  set(LINKER_FLAGS_1, "-Wl,--whole-archive")
+  set(LINKER_FLAGS_2, "-Wl,--no-whole-archive")
+endif()
+
 target_link_libraries(catalyst_qir_qis_obj "-L${QIR_STDLIB_LIB}"
-                                            "-Wl,--whole-archive"
+                                            ${LINKER_FLAGS_1}
                                             qir_stdlib
-                                            "-Wl,--no-whole-archive"
+                                            ${LINKER_FLAGS_2}
                                             pthread
                                             dl)
 


### PR DESCRIPTION
**Context:** macOS lacks `nproc` and uses a different loader. 

**Description of the Change:** Determine how many processors are available on an Apple machine via `sysctl`) to replace `nproc`. Use an `-all_load` instead of `--whole-archive`.

**Benefits:** Improved portability, we can compile the runtime on macOS.