### PR TITLE
[Frontend] Add compatibility in the frontend for macOS and Linux.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -120,6 +120,10 @@
   use correct flags for ``ld.64``.
   [#232](https://github.com/PennyLaneAI/catalyst/pull/232)
 
+* Improve portability on the frontend to be available on macOS. Use ``.dylib``, remove unnecessary flags,
+  and address behaviour difference in flags.
+  [#233](https://github.com/PennyLaneAI/catalyst/pull/233)
+
 <h3>Breaking changes</h3>
 
 * Since we are now using PyTrees, python lists are no longer automatically converted into JAX

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -17,6 +17,7 @@ MLIR/LLVM representations.
 
 import abc
 import os
+import platform
 import pathlib
 import shutil
 import subprocess
@@ -303,8 +304,11 @@ class Enzyme(PassPipeline):
 
     _executable = get_executable_path("llvm", "opt")
     enzyme_path = get_lib_path("enzyme", "ENZYME_LIB_DIR")
+    apple_ext = "dylib"
+    linux_ext = "so"
+    ext = linux_ext if platform.system() == "Linux" else apple_ext
     _default_flags = [
-        f"-load-pass-plugin={enzyme_path}/LLVMEnzyme-17.so",
+        f"-load-pass-plugin={enzyme_path}/LLVMEnzyme-17.{ext}",
         # preserve-nvvm transforms certain global arrays to LLVM metadata that Enzyme will recognize
         "-passes=preserve-nvvm,enzyme",
         "-S",
@@ -371,8 +375,9 @@ class CompilerDriver:
         default_flags = [
             "-shared",
             "-rdynamic",
-            "-Wl,-no-as-needed",
-            f"-Wl,-rpath,{rt_capi_path}:{rt_backend_path}:{mlir_lib_path}",
+            f"-Wl,-rpath,{rt_capi_path}",
+            f"-Wl,-rpath,{rt_backend_path}",
+            f"-Wl,-rpath,{mlir_lib_path}",
             f"-L{mlir_lib_path}",
             f"-L{rt_capi_path}",
             f"-L{rt_backend_path}",

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -17,8 +17,8 @@ MLIR/LLVM representations.
 
 import abc
 import os
-import platform
 import pathlib
+import platform
 import shutil
 import subprocess
 import sys


### PR DESCRIPTION
**Context:** There are some small differences between macOS and Linux in the frontend.

**Description of the Change:** Use `.dylib` instead of `.so`. Split `-Wl,rpath` across multiple options. Remove `--no-as-needed` as it is the default behaviour on linux and unavailable on macOS.

**Benefits:** Portability.
