### PR TITLE
[Frontend] Fix qubit unitary incompatibility.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -179,6 +179,10 @@ Sergei Mironov.
   distribution.
   [#198](https://github.com/PennyLaneAI/catalyst/pull/198)
 
+* Return a list of decompositions when calling the decomposition method for control operations.
+  This allows Catalyst to be compatible with upstream PennyLane.
+  [#241](https://github.com/PennyLaneAI/catalyst/pull/241)
+
 <h3>Improvements</h3>
 
 * When using OpenQASM-based devices the string representation of the circuit is printed on

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -1452,15 +1452,10 @@ class QJITDevice(qml.QubitDevice):
         # decomposition is generally faster.
         # At the moment, bypassing decomposition for controlled gates will generally have a higher
         # success rate, as complex decomposition paths can fail to trace (c.f. PL #3521, #3522).
-
-        def _decomp_controlled_unitary(self, *_args, **_kwargs):
-            return [qml.QubitUnitary(qml.matrix(self), wires=self.wires)]
-
         def _decomp_controlled(self, *_args, **_kwargs):
             return [qml.QubitUnitary(qml.matrix(self), wires=self.wires)]
 
         with Patcher(
-            (qml.ops.ControlledQubitUnitary, "compute_decomposition", _decomp_controlled_unitary),
             (qml.ops.Controlled, "has_decomposition", lambda self: True),
             (qml.ops.Controlled, "decomposition", _decomp_controlled),
         ):

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -1454,10 +1454,10 @@ class QJITDevice(qml.QubitDevice):
         # success rate, as complex decomposition paths can fail to trace (c.f. PL #3521, #3522).
 
         def _decomp_controlled_unitary(self, *_args, **_kwargs):
-            return qml.QubitUnitary(qml.matrix(self), wires=self.wires)
+            return [qml.QubitUnitary(qml.matrix(self), wires=self.wires)]
 
         def _decomp_controlled(self, *_args, **_kwargs):
-            return qml.QubitUnitary(qml.matrix(self), wires=self.wires)
+            return [qml.QubitUnitary(qml.matrix(self), wires=self.wires)]
 
         with Patcher(
             (qml.ops.ControlledQubitUnitary, "compute_decomposition", _decomp_controlled_unitary),


### PR DESCRIPTION
**Context:** PL has always required decomposition to return a list, however, we were returning a single gate.

**Description of the Change:** When decomposing control gates, return a list containing a `QubitUnitary`

**Benefits:** Compatibility with PL master.

[sc-43451]