### PR TITLE
[MLIR] Fix issue when quantum measurement is used by an op multiple times

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -158,6 +158,10 @@
 * Fix incorrect return value data-type with functions returning ``qml.counts``.
   [#221](https://github.com/PennyLaneAI/catalyst/pull/221)
 
+* Fix segmentation fault when differentiating a function where a quantum measurement is used
+  multiple times by the same operation.
+  [#242](https://github.com/PennyLaneAI/catalyst/pull/242)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/mlir/test/Gradient/PS_QuantumGradientTest.mlir
+++ b/mlir/test/Gradient/PS_QuantumGradientTest.mlir
@@ -383,10 +383,12 @@ func.func @tensor_circuit(%arg0: f64) -> tensor<2x3xf64> attributes {qnode, diff
     //
     // CHECK-NOT: quantum.custom
     %q_1 = quantum.custom "rx"(%arg0) %q_0 : !quantum.bit
+    %obs = quantum.namedobs %q_1[PauliX] : !quantum.obs
+    %expval = quantum.expval %obs : f64
 
     // CHECK: [[ret:%[a-zA-Z0-9_]+]] = bufferization.to_tensor [[grad]]
     // CHECK: return [[ret]] : tensor<?x2x3xf64>
-    %res = tensor.from_elements %arg0, %arg0, %arg0, %arg0, %arg0, %arg0 : tensor<2x3xf64>
+    %res = tensor.from_elements %expval, %expval, %expval, %expval, %expval, %expval : tensor<2x3xf64>
     func.return %res : tensor<2x3xf64>
 }
 


### PR DESCRIPTION
**Context:** In `removeQuantumMeasurements`, there is a segmentation fault when the same measurement value is used multiple times by the same op. For instance:

```mlir
%expval = quantum.expval ...
%packed = tensor.from_elements %expval, %expval : tensor<2xf64>
```

This is due to `tensor.from_elements` being marked for deletion multiple times.

**Description of the Change:** Keep track of operations marked for deletion explicitly to make sure they are not processed more than once.

**Benefits:** This allows us to write more flexible tests that return tensors that actually have quantum instructions that are used. This is necessary for some of the tests that need to have quantum operations that may otherwise be folded away by `applyPatternsAndFoldGreedily`.

**Possible Drawbacks:** Minimal memory overhead of the additional set data structure.
