### PR TITLE
[Frontend] Add support for MultiControlledX

### DIFF
--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -1458,6 +1458,7 @@ class QJITDevice(qml.QubitDevice):
         with Patcher(
             (qml.ops.Controlled, "has_decomposition", lambda self: True),
             (qml.ops.Controlled, "decomposition", _decomp_controlled),
+            (qml.ops.MultiControlledX, "decomposition", _decomp_controlled),
         ):
             expanded_tape = super().default_expand_fn(circuit, max_expansion)
 

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -1458,6 +1458,7 @@ class QJITDevice(qml.QubitDevice):
         with Patcher(
             (qml.ops.Controlled, "has_decomposition", lambda self: True),
             (qml.ops.Controlled, "decomposition", _decomp_controlled),
+            # TODO: Remove once work_wires is no longer needed for decomposition.
             (qml.ops.MultiControlledX, "decomposition", _decomp_controlled),
         ):
             expanded_tape = super().default_expand_fn(circuit, max_expansion)

--- a/frontend/catalyst/utils/patching.py
+++ b/frontend/catalyst/utils/patching.py
@@ -34,9 +34,9 @@ class Patcher:
 
     def __enter__(self):
         for obj, attr_name, fn in self.patch_data:
-            self.backup[attr_name] = getattr(obj, attr_name)
+            self.backup[(obj, attr_name)] = getattr(obj, attr_name)
             setattr(obj, attr_name, fn)
 
     def __exit__(self, _type, _value, _traceback):
         for obj, attr_name, _ in self.patch_data:
-            setattr(obj, attr_name, self.backup[attr_name])
+            setattr(obj, attr_name, self.backup[(obj, attr_name)])

--- a/frontend/test/pytest/test_meta_ops.py
+++ b/frontend/test/pytest/test_meta_ops.py
@@ -65,6 +65,7 @@ ops = [
     qml.CRY(0.6, wires=[1, 2]),
     qml.CRZ(0.6, wires=[1, 2]),
     qml.MultiRZ(0.6, wires=[0, 1, 2, 3]),
+    qml.MultiControlledX(wires=[1, 2, 3]),
 ]
 
 

--- a/frontend/test/pytest/test_meta_ops.py
+++ b/frontend/test/pytest/test_meta_ops.py
@@ -86,14 +86,11 @@ def test_adjoint(g):
 def test_control(g, ctrls):
     def circuit():
         qml.Rot(0.3, 0.4, 0.5, wires=0)
-        if isinstance(g, qml.PauliX):
-            qml.ctrl(g, control=ctrls, work_wires=[7])
-        else:
-            qml.ctrl(g, control=ctrls)
+        qml.ctrl(g, control=ctrls)
         return qml.state()
 
-    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=8))(circuit))()
-    expected = qml.qnode(qml.device("default.qubit", 8))(circuit)()
+    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=7))(circuit))()
+    expected = qml.qnode(qml.device("default.qubit", 7))(circuit)()
 
     assert jnp.allclose(result, expected)
 
@@ -103,14 +100,11 @@ def test_control(g, ctrls):
 def test_control_variable_wires(g, ctrls):
     def circuit(ctrls):
         qml.Rot(0.3, 0.4, 0.5, wires=0)
-        if isinstance(g, qml.PauliX):
-            qml.ctrl(g, control=ctrls, work_wires=[7])
-        else:
-            qml.ctrl(g, control=ctrls)
+        qml.ctrl(g, control=ctrls)
         return qml.state()
 
-    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=8))(circuit))(jnp.array(ctrls))
-    expected = qml.qnode(qml.device("default.qubit", 8))(circuit)(ctrls)
+    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=7))(circuit))(jnp.array(ctrls))
+    expected = qml.qnode(qml.device("default.qubit", 7))(circuit)(ctrls)
 
     assert jnp.allclose(result, expected)
 

--- a/frontend/test/pytest/test_meta_ops.py
+++ b/frontend/test/pytest/test_meta_ops.py
@@ -86,11 +86,14 @@ def test_adjoint(g):
 def test_control(g, ctrls):
     def circuit():
         qml.Rot(0.3, 0.4, 0.5, wires=0)
-        qml.ctrl(g, control=ctrls)
+        if isinstance(g, qml.PauliX):
+            qml.ctrl(g, control=ctrls, work_wires=[7])
+        else:
+            qml.ctrl(g, control=ctrls)
         return qml.state()
 
-    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=7))(circuit))()
-    expected = qml.qnode(qml.device("default.qubit", 7))(circuit)()
+    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=8))(circuit))()
+    expected = qml.qnode(qml.device("default.qubit", 8))(circuit)()
 
     assert jnp.allclose(result, expected)
 
@@ -100,11 +103,14 @@ def test_control(g, ctrls):
 def test_control_variable_wires(g, ctrls):
     def circuit(ctrls):
         qml.Rot(0.3, 0.4, 0.5, wires=0)
-        qml.ctrl(g, control=ctrls)
+        if isinstance(g, qml.PauliX):
+            qml.ctrl(g, control=ctrls, work_wires=[7])
+        else:
+            qml.ctrl(g, control=ctrls)
         return qml.state()
 
-    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=7))(circuit))(jnp.array(ctrls))
-    expected = qml.qnode(qml.device("default.qubit", 7))(circuit)(ctrls)
+    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=8))(circuit))(jnp.array(ctrls))
+    expected = qml.qnode(qml.device("default.qubit", 8))(circuit)(ctrls)
 
     assert jnp.allclose(result, expected)
 

--- a/frontend/test/pytest/test_operations.py
+++ b/frontend/test/pytest/test_operations.py
@@ -72,18 +72,19 @@ def test_no_parameters(backend):
         # and `quantum-opt` doesn't fail to materialize conversion for the result
         qml.CZ(wires=[1, 2])
 
+        qml.MultiControlledX(wires=[0, 1, 2, 3])
+
         # Unsupported:
         # qml.SX(wires=0)
         # qml.ISWAP(wires=[0,1])
         # qml.ECR(wires=[0,1])
         # qml.SISWAP(wires=[0,1])
         # qml.Toffoli(wires=[0,1,2])
-        # qml.MultiControlledX(wires=[0,1,2,3])
 
         return qml.state()
 
-    qjit_fn = qjit()(qml.qnode(qml.device(backend, wires=3))(circuit))
-    qml_fn = qml.qnode(qml.device("default.qubit", wires=3))(circuit)
+    qjit_fn = qjit()(qml.qnode(qml.device(backend, wires=4))(circuit))
+    qml_fn = qml.qnode(qml.device("default.qubit", wires=4))(circuit)
 
     assert np.allclose(qjit_fn(), qml_fn())
 


### PR DESCRIPTION
**Context:** Previously `qml.ctrl(qml.PauliX)` would return `qml.Controlled(qml.PauliX)`. `qml.Controlled(qml.PauliX)` would then decompose according to the decomposition rules for the `qml.Controlled` operator.

Recent changes in PL upstream introduced the behaviour that `qml.ctrl(qml.PauliX)` would return `qml.MultiControlledX` instead. This is essentially a form of decomposition; however happening during the instantiation of the gate, as opposed of decomposition time.

Catalyst does not support `qml.MultiControlledX` and will attempt to decompose it. Since there are no work wires specified, this will raise an exception. Raising this exception matches PennyLane's behaviour.

There are a couple of solutions:

1. just add work wires only when PauliX is used in the test for control operations.
2. add a custom decomposition for `qml.MultiControlled` to QubitUnitary
3. Monkey patch `qml.ctrl` to avoid returning `qml.MultiControlledX` and instead return `qml.matrix(op.matrix(), ...)`

**Description of the Change:** Change to add custom decomposition for `qml.MultiControlled` to `QubitUnitary`

**Benefits:** No error on the test.

**Possible Drawbacks:** Different logic than PL upstream.

[sc-42184]