### PR TITLE
[Frontend/Runtime] Add support for nested Hamiltonian observables

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -144,6 +144,7 @@
   ```
 
 * Add support for nested Hamiltonian observables.
+  [#255](https://github.com/PennyLaneAI/catalyst/pull/255)
 
   ``` python
   @qjit

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -143,6 +143,23 @@
       return qml.expval(qml.Hamiltonian(coeffs, obs))
   ```
 
+* Add support for nested Hamiltonian observables.
+
+  ``` python
+  @qjit
+  @qml.qnode(qml.device("lightning.qubit", wires=3))
+  def circuit(x, y, coeffs1, coeffs2):
+      qml.RX(x, wires=0)
+      qml.RX(y, wires=1)
+      qml.RY(x + y, wires=2)
+
+      obs = [
+          qml.PauliX(0) @ qml.PauliZ(1),
+          qml.Hamiltonian(coeffs1, [qml.PauliZ(0) @ qml.Hadamard(2)]),
+      ]
+
+      return qml.var(qml.Hamiltonian(coeffs2, obs))
+  ```
 
 <h3>Improvements</h3>
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -125,43 +125,6 @@
   array(112936.34906843)
   ```
 
-* Add support for Hamiltonian observables with integer coefficients.
-  [#248](https://github.com/PennyLaneAI/catalyst/pull/248)
-
-  For example, compiling the following circuit wasn't allowed before, but it is
-  now supported in Catalyst:
-
-  ``` python
-  @qjit
-  @qml.qnode(qml.device("lightning.qubit", wires=2))
-  def circuit(x: float, y: float):
-      qml.RX(x, wires=0)
-      qml.RY(y, wires=1)
-
-      coeffs = [1, 2]
-      obs = [qml.PauliZ(0), qml.PauliZ(1)]
-      return qml.expval(qml.Hamiltonian(coeffs, obs))
-  ```
-
-* Add support for nested Hamiltonian observables.
-  [#255](https://github.com/PennyLaneAI/catalyst/pull/255)
-
-  ``` python
-  @qjit
-  @qml.qnode(qml.device("lightning.qubit", wires=3))
-  def circuit(x, y, coeffs1, coeffs2):
-      qml.RX(x, wires=0)
-      qml.RX(y, wires=1)
-      qml.RY(x + y, wires=2)
-
-      obs = [
-          qml.PauliX(0) @ qml.PauliZ(1),
-          qml.Hamiltonian(coeffs1, [qml.PauliZ(0) @ qml.Hadamard(2)]),
-      ]
-
-      return qml.var(qml.Hamiltonian(coeffs2, obs))
-  ```
-
 <h3>Improvements</h3>
 
 * Eliminate redundant unflattening and flattening of PyTrees parameters in Catalyst control flow operations.
@@ -213,6 +176,43 @@
   fix build wheel recipe, and remove references to QIR in runtime's Makefile.
   [#243](https://github.com/PennyLaneAI/catalyst/pull/243)
   [#247](https://github.com/PennyLaneAI/catalyst/pull/247)
+
+* Add support for Hamiltonian observables with integer coefficients.
+  [#248](https://github.com/PennyLaneAI/catalyst/pull/248)
+
+  For example, compiling the following circuit wasn't allowed before, but it is
+  now supported in Catalyst:
+
+  ``` python
+  @qjit
+  @qml.qnode(qml.device("lightning.qubit", wires=2))
+  def circuit(x: float, y: float):
+      qml.RX(x, wires=0)
+      qml.RY(y, wires=1)
+
+      coeffs = [1, 2]
+      obs = [qml.PauliZ(0), qml.PauliZ(1)]
+      return qml.expval(qml.Hamiltonian(coeffs, obs))
+  ```
+
+* Add support for nested Hamiltonian observables.
+  [#255](https://github.com/PennyLaneAI/catalyst/pull/255)
+
+  ``` python
+  @qjit
+  @qml.qnode(qml.device("lightning.qubit", wires=3))
+  def circuit(x, y, coeffs1, coeffs2):
+      qml.RX(x, wires=0)
+      qml.RX(y, wires=1)
+      qml.RY(x + y, wires=2)
+
+      obs = [
+          qml.PauliX(0) @ qml.PauliZ(1),
+          qml.Hamiltonian(coeffs1, [qml.PauliZ(0) @ qml.Hadamard(2)]),
+      ]
+
+      return qml.var(qml.Hamiltonian(coeffs2, obs))
+  ```
 
 <h3>Breaking changes</h3>
 

--- a/frontend/test/pytest/test_measurements_results.py
+++ b/frontend/test/pytest/test_measurements_results.py
@@ -207,7 +207,7 @@ class TestExpval:
 
         @qjit
         @qml.qnode(qml.device(backend, wires=3))
-        def expval6(x: float, y: float):
+        def expval(x: float, y: float):
             qml.RX(x, wires=0)
             qml.RY(y, wires=1)
             qml.RZ(0.1, wires=2)
@@ -218,11 +218,11 @@ class TestExpval:
             return qml.expval(qml.Hamiltonian(coeffs, obs))
 
         expected = np.array(-0.2715)
-        observed = expval6(np.pi / 4, np.pi / 3)
+        observed = expval(np.pi / 4, np.pi / 3)
         assert np.isclose(observed, expected)
 
         expected = np.array(-0.33695571)
-        observed = expval6(0.5, 0.8)
+        observed = expval(0.5, 0.8)
         assert np.isclose(observed, expected)
 
     def test_hamiltonian_2(self, backend):
@@ -230,7 +230,7 @@ class TestExpval:
 
         @qjit
         @qml.qnode(qml.device(backend, wires=2))
-        def expval6(x: float):
+        def expval(x: float):
             qml.RX(x, wires=0)
 
             coeff = np.array([0.8, 0.2])
@@ -247,11 +247,11 @@ class TestExpval:
             return qml.expval(qml.Hamiltonian(coeff, [obs, qml.PauliX(0)]))
 
         expected = np.array(0.2359798)
-        observed = expval6(np.pi / 4)
+        observed = expval(np.pi / 4)
         assert np.isclose(observed, expected)
 
         expected = np.array(-0.16)
-        observed = expval6(np.pi / 2)
+        observed = expval(np.pi / 2)
         assert np.isclose(observed, expected)
 
     def test_hamiltonian_3(self, backend):
@@ -259,7 +259,7 @@ class TestExpval:
 
         @qjit
         @qml.qnode(qml.device(backend, wires=2))
-        def expval6(x: float):
+        def expval(x: float):
             qml.RX(x, wires=0)
 
             coeff = np.array([0.8, 0.2])
@@ -280,11 +280,46 @@ class TestExpval:
             )
 
         expected = np.array(0.4359798)
-        observed = expval6(np.pi / 4)
+        observed = expval(np.pi / 4)
         assert np.isclose(observed, expected)
 
         expected = np.array(0.04)
-        observed = expval6(np.pi / 2)
+        observed = expval(np.pi / 2)
+        assert np.isclose(observed, expected)
+
+    def test_hamiltonian_4(self, backend):
+        """Test expval with TensorObs and nested Hamiltonian observables."""
+
+        @qjit
+        @qml.qnode(qml.device(backend, wires=3))
+        def expval(x: float):
+            qml.RX(x, wires=0)
+            qml.RX(x + 1.0, wires=2)
+
+            coeff = np.array([0.8, 0.2])
+            obs_matrix = np.array(
+                [
+                    [0.5, 1.0j, 0.0, -3j],
+                    [-1.0j, -1.1, 0.0, -0.1],
+                    [0.0, 0.0, -0.9, 12.0],
+                    [3j, -0.1, 12.0, 0.0],
+                ]
+            )
+
+            obs = qml.Hermitian(obs_matrix, wires=[0, 1])
+            return qml.expval(
+                qml.Hamiltonian(
+                    coeff, [obs, qml.Hamiltonian([1, 1], [qml.PauliX(0), qml.PauliZ(1)])]
+                )
+                @ qml.PauliZ(2)
+            )
+
+        expected = np.array(-0.09284557)
+        observed = expval(np.pi / 4)
+        assert np.isclose(observed, expected)
+
+        expected = np.array(-0.03365884)
+        observed = expval(np.pi / 2)
         assert np.isclose(observed, expected)
 
 
@@ -518,7 +553,7 @@ class TestVar:
         )
 
     def test_hamiltonian_5(self, backend):
-        """Test variance for nested Hamiltonian observable."""
+        """Test variance with nested Hamiltonian observable."""
 
         @qjit
         @qml.qnode(qml.device(backend, wires=3))
@@ -536,6 +571,35 @@ class TestVar:
 
         expected = np.array(0.1075)
         coeffs = np.array([0.2, 0.6])
+        observed = circuit(np.pi / 4, np.pi / 3, coeffs)
+        assert np.isclose(
+            observed,
+            expected,
+        )
+
+    def test_hamiltonian_6(self, backend):
+        """Test variance with TensorObs and nested Hamiltonian observables."""
+
+        @qjit
+        @qml.qnode(qml.device(backend, wires=3))
+        def circuit(x, y, coeffs):
+            qml.RX(x, wires=0)
+            qml.RY(y, wires=1)
+            qml.RZ(0.1, wires=2)
+
+            return qml.var(
+                qml.Hamiltonian(
+                    coeffs,
+                    [
+                        qml.PauliX(0)
+                        @ qml.PauliZ(1)
+                        @ qml.Hamiltonian(np.array([0.5]), [qml.Hadamard(2)])
+                    ],
+                )
+            )
+
+        expected = np.array(0.01)
+        coeffs = np.array([0.2])
         observed = circuit(np.pi / 4, np.pi / 3, coeffs)
         assert np.isclose(
             observed,

--- a/runtime/lib/backend/lightning-kokkos/LightningKokkosObsManager.hpp
+++ b/runtime/lib/backend/lightning-kokkos/LightningKokkosObsManager.hpp
@@ -145,10 +145,6 @@ template <typename PrecisionT> class LightningKokkosObsManager {
             RT_FAIL_IF(static_cast<size_t>(key) >= obs_size || key < 0, "Invalid observable key");
 
             auto &&[obs, type] = this->observables_[key];
-
-            RT_FAIL_IF(type != ObsType::Basic, "Invalid basic observable to construct TensorProd; "
-                                               "NamedObs and HermitianObs are only supported");
-
             obs_vec.push_back(obs);
         }
 

--- a/runtime/lib/backend/lightning-kokkos/LightningKokkosObsManager.hpp
+++ b/runtime/lib/backend/lightning-kokkos/LightningKokkosObsManager.hpp
@@ -46,11 +46,6 @@ template <typename PrecisionT> class LightningKokkosObsManager {
     using ObservablePairType = std::pair<std::shared_ptr<ObservableClassName>, ObsType>;
     std::vector<ObservablePairType> observables_{};
 
-    static constexpr std::array<ObsType, 2> hamiltonian_valid_obs_types = {
-        ObsType::Basic,
-        ObsType::TensorProd,
-    };
-
   public:
     LightningKokkosObsManager() = default;
     ~LightningKokkosObsManager() = default;
@@ -188,13 +183,6 @@ template <typename PrecisionT> class LightningKokkosObsManager {
             RT_FAIL_IF(static_cast<size_t>(key) >= obs_size || key < 0, "Invalid observable key");
 
             auto &&[obs, type] = this->observables_[key];
-            auto contain_obs = std::find(hamiltonian_valid_obs_types.begin(),
-                                         hamiltonian_valid_obs_types.end(), type);
-
-            RT_FAIL_IF(contain_obs == hamiltonian_valid_obs_types.end(),
-                       "Invalid observable to construct Hamiltonian; "
-                       "NamedObs, HermitianObs and TensorProdObs are only supported");
-
             obs_vec.push_back(obs);
         }
 

--- a/runtime/lib/backend/lightning/LightningObsManager.hpp
+++ b/runtime/lib/backend/lightning/LightningObsManager.hpp
@@ -142,10 +142,6 @@ template <typename PrecisionT> class LightningObsManager {
             RT_FAIL_IF(static_cast<size_t>(key) >= obs_size || key < 0, "Invalid observable key");
 
             auto &&[obs, type] = observables_[key];
-
-            RT_FAIL_IF(type != ObsType::Basic, "Invalid basic observable to construct TensorProd; "
-                                               "NamedObs and HermitianObs are only supported");
-
             obs_vec.push_back(obs);
         }
 

--- a/runtime/lib/backend/lightning/LightningObsManager.hpp
+++ b/runtime/lib/backend/lightning/LightningObsManager.hpp
@@ -43,11 +43,6 @@ template <typename PrecisionT> class LightningObsManager {
     using ObservablePairType = std::pair<std::shared_ptr<ObservableClassName>, ObsType>;
     std::vector<ObservablePairType> observables_{};
 
-    static constexpr std::array<ObsType, 2> hamiltonian_valid_obs_types = {
-        ObsType::Basic,
-        ObsType::TensorProd,
-    };
-
   public:
     LightningObsManager() = default;
     ~LightningObsManager() = default;
@@ -185,13 +180,6 @@ template <typename PrecisionT> class LightningObsManager {
             RT_FAIL_IF(static_cast<size_t>(key) >= obs_size || key < 0, "Invalid observable key");
 
             auto &&[obs, type] = observables_[key];
-            auto contain_obs = std::find(hamiltonian_valid_obs_types.begin(),
-                                         hamiltonian_valid_obs_types.end(), type);
-
-            RT_FAIL_IF(contain_obs == hamiltonian_valid_obs_types.end(),
-                       "Invalid observable to construct Hamiltonian; "
-                       "NamedObs, HermitianObs and TensorProdObs are only supported");
-
             obs_vec.push_back(obs);
         }
 

--- a/runtime/lib/backend/openqasm/OpenQasmObsManager.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmObsManager.hpp
@@ -137,10 +137,6 @@ class OpenQasmObsManager {
             RT_FAIL_IF(static_cast<size_t>(key) >= obs_size || key < 0, "Invalid observable key");
 
             auto &&[obs, type] = observables_[key];
-
-            RT_FAIL_IF(type != ObsType::Basic, "Invalid basic observable to construct TensorProd; "
-                                               "NamedObs and HermitianObs are only supported");
-
             obs_vec.push_back(obs);
         }
 

--- a/runtime/lib/backend/openqasm/OpenQasmObsManager.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmObsManager.hpp
@@ -37,6 +37,11 @@ class OpenQasmObsManager {
     using ObservablePairType = std::pair<std::shared_ptr<QasmObs>, ObsType>;
     std::vector<ObservablePairType> observables_{};
 
+    static constexpr std::array<ObsType, 2> hamiltonian_valid_obs_types = {
+        ObsType::Basic,
+        ObsType::TensorProd,
+    };
+
   public:
     OpenQasmObsManager() = default;
     ~OpenQasmObsManager() = default;
@@ -137,6 +142,10 @@ class OpenQasmObsManager {
             RT_FAIL_IF(static_cast<size_t>(key) >= obs_size || key < 0, "Invalid observable key");
 
             auto &&[obs, type] = observables_[key];
+
+            RT_FAIL_IF(type != ObsType::Basic, "Invalid basic observable to construct TensorProd; "
+                                               "NamedObs and HermitianObs are only supported");
+
             obs_vec.push_back(obs);
         }
 
@@ -171,6 +180,13 @@ class OpenQasmObsManager {
             RT_FAIL_IF(static_cast<size_t>(key) >= obs_size || key < 0, "Invalid observable key");
 
             auto &&[obs, type] = observables_[key];
+            auto contain_obs = std::find(hamiltonian_valid_obs_types.begin(),
+                                         hamiltonian_valid_obs_types.end(), type);
+
+            RT_FAIL_IF(contain_obs == hamiltonian_valid_obs_types.end(),
+                       "Invalid observable to construct Hamiltonian; "
+                       "NamedObs, HermitianObs and TensorProdObs are only supported");
+
             obs_vec.push_back(obs);
         }
 

--- a/runtime/lib/backend/openqasm/OpenQasmObsManager.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmObsManager.hpp
@@ -37,11 +37,6 @@ class OpenQasmObsManager {
     using ObservablePairType = std::pair<std::shared_ptr<QasmObs>, ObsType>;
     std::vector<ObservablePairType> observables_{};
 
-    static constexpr std::array<ObsType, 2> hamiltonian_valid_obs_types = {
-        ObsType::Basic,
-        ObsType::TensorProd,
-    };
-
   public:
     OpenQasmObsManager() = default;
     ~OpenQasmObsManager() = default;
@@ -180,13 +175,6 @@ class OpenQasmObsManager {
             RT_FAIL_IF(static_cast<size_t>(key) >= obs_size || key < 0, "Invalid observable key");
 
             auto &&[obs, type] = observables_[key];
-            auto contain_obs = std::find(hamiltonian_valid_obs_types.begin(),
-                                         hamiltonian_valid_obs_types.end(), type);
-
-            RT_FAIL_IF(contain_obs == hamiltonian_valid_obs_types.end(),
-                       "Invalid observable to construct Hamiltonian; "
-                       "NamedObs, HermitianObs and TensorProdObs are only supported");
-
             obs_vec.push_back(obs);
         }
 

--- a/runtime/tests/Test_LightningCoreQIS.cpp
+++ b/runtime/tests/Test_LightningCoreQIS.cpp
@@ -931,22 +931,23 @@ TEST_CASE("Test __quantum__qis__HamiltonianObs(h, Ham(x)) and Expval", "[CoreQIS
 
         auto obs_h = __quantum__qis__HermitianObs(h_matrix, 1, *ctrls);
         double coeffs_data[2] = {0.4, 0.7};
-        MemRefT_double_1d *coeffs = new MemRefT_double_1d;
-        coeffs->data_allocated = coeffs_data;
-        coeffs->data_aligned = coeffs_data;
-        coeffs->offset = 0;
-        coeffs->sizes[0] = 2;
-        coeffs->strides[0] = 1;
+        MemRefT_double_1d *coeffs2 = new MemRefT_double_1d;
+        coeffs2->data_allocated = coeffs_data;
+        coeffs2->data_aligned = coeffs_data;
+        coeffs2->offset = 0;
+        coeffs2->sizes[0] = 2;
+        coeffs2->strides[0] = 1;
 
-        auto obs_hamiltonian = __quantum__qis__HamiltonianObs(coeffs, 2, obs_h, obs_ham1);
+        auto obs_hamiltonian = __quantum__qis__HamiltonianObs(coeffs2, 2, obs_h, obs_ham1);
 
         CHECK(obs_hamiltonian == 3);
 
         CHECK(__quantum__qis__Expval(obs_hamiltonian) == Approx(0.7316370598).margin(1e-5));
 
         freeState(result);
+        delete coeffs1;
         delete h_matrix;
-        delete coeffs;
+        delete coeffs2;
         __quantum__rt__qubit_release_array(qs);
         __quantum__rt__finalize();
     }

--- a/runtime/tests/Test_LightningCoreQIS.cpp
+++ b/runtime/tests/Test_LightningCoreQIS.cpp
@@ -885,6 +885,73 @@ TEST_CASE("Test __quantum__qis__HamiltonianObs(t) and Expval", "[CoreQIS]")
     }
 }
 
+TEST_CASE("Test __quantum__qis__HamiltonianObs(h, Ham(x)) and Expval", "[CoreQIS]")
+{
+    for (const auto &[key, val] : getDevices()) {
+        __quantum__rt__initialize();
+        __quantum__rt__device((int8_t *)key.c_str(), (int8_t *)val.c_str());
+
+        QirArray *qs = __quantum__rt__qubit_allocate_array(2);
+
+        QUBIT **target = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(qs, 0);
+        QUBIT **ctrls = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(qs, 1);
+
+        // qml.Hadamard(wires=0)
+        __quantum__qis__Hadamard(*target, false);
+        // qml.Hadamard(wires=1)
+        __quantum__qis__Hadamard(*ctrls, false);
+        // qml.IsingYY(0.2, wires=[1,0])
+        __quantum__qis__IsingYY(0.6, *ctrls, *target, false);
+        // qml.CRX(0.4, wires=[1,0])
+        __quantum__qis__CRX(0.3, *ctrls, *target, false);
+
+        MemRefT_CplxT_double_1d result = getState(4);
+        __quantum__qis__State(&result, 0);
+
+        auto obs_x = __quantum__qis__NamedObs(ObsId::PauliX, *target);
+
+        double coeffs1_data[1] = {0.2};
+        MemRefT_double_1d *coeffs1 = new MemRefT_double_1d;
+        coeffs1->data_allocated = coeffs1_data;
+        coeffs1->data_aligned = coeffs1_data;
+        coeffs1->offset = 0;
+        coeffs1->sizes[0] = 1;
+        coeffs1->strides[0] = 1;
+        auto obs_ham1 = __quantum__qis__HamiltonianObs(coeffs1, 1, obs_x);
+
+        CplxT_double matrix_data[4] = {{1.0, 0.0}, {0.0, 3.0}, {2.0, 0.0}, {0.0, 5.0}};
+
+        MemRefT_CplxT_double_2d *h_matrix = new MemRefT_CplxT_double_2d;
+        h_matrix->data_allocated = matrix_data;
+        h_matrix->data_aligned = matrix_data;
+        h_matrix->offset = 0;
+        h_matrix->sizes[0] = 2;
+        h_matrix->sizes[1] = 2;
+        h_matrix->strides[0] = 1;
+
+        auto obs_h = __quantum__qis__HermitianObs(h_matrix, 1, *ctrls);
+        double coeffs_data[2] = {0.4, 0.7};
+        MemRefT_double_1d *coeffs = new MemRefT_double_1d;
+        coeffs->data_allocated = coeffs_data;
+        coeffs->data_aligned = coeffs_data;
+        coeffs->offset = 0;
+        coeffs->sizes[0] = 2;
+        coeffs->strides[0] = 1;
+
+        auto obs_hamiltonian = __quantum__qis__HamiltonianObs(coeffs, 2, obs_h, obs_ham1);
+
+        CHECK(obs_hamiltonian == 3);
+
+        CHECK(__quantum__qis__Expval(obs_hamiltonian) == Approx(0.7316370598).margin(1e-5));
+
+        freeState(result);
+        delete h_matrix;
+        delete coeffs;
+        __quantum__rt__qubit_release_array(qs);
+        __quantum__rt__finalize();
+    }
+}
+
 TEST_CASE("Test __quantum__qis__ Hadamard, PauliX, IsingYY, CRX, and Expval_arr", "[CoreQIS]")
 {
     for (const auto &[key, val] : getDevices()) {

--- a/runtime/tests/Test_LightningMeasures.cpp
+++ b/runtime/tests/Test_LightningMeasures.cpp
@@ -150,7 +150,7 @@ TEMPLATE_LIST_TEST_CASE("Expval(ObsT) test with invalid key for cached observabl
     REQUIRE_THROWS_WITH(sim->Expval(0), Catch::Contains("Invalid key for cached observables"));
 }
 
-TEMPLATE_LIST_TEST_CASE("Expval(NamedObs) test with numWires=1", "[Measures]", SimTypes)
+TEMPLATE_LIST_TEST_CASE("Expval(NamedObs) test", "[Measures]", SimTypes)
 {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
@@ -176,7 +176,7 @@ TEMPLATE_LIST_TEST_CASE("Expval(NamedObs) test with numWires=1", "[Measures]", S
     CHECK(sim->Expval(pz) == Approx(-1.0).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Expval(HermitianObs) test with numWires=1", "[Measures]", SimTypes)
+TEMPLATE_LIST_TEST_CASE("Expval(HermitianObs) test", "[Measures]", SimTypes)
 {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
@@ -338,6 +338,56 @@ TEMPLATE_LIST_TEST_CASE("Expval(TensorProd(Obs[]))", "[Measures]", SimTypes)
     ObsIdType tp = sim->TensorObservable({px, h, pz});
 
     CHECK(sim->Expval(tp) == Approx(-3.0).margin(1e-5));
+}
+
+TEMPLATE_LIST_TEST_CASE("Expval(Tensor(Hamiltonian(NamedObs[]), NamedObs)) test", "[Measures]",
+                        SimTypes)
+{
+    std::unique_ptr<TestType> sim = std::make_unique<TestType>();
+
+    // state-vector with #qubits = n
+    constexpr size_t n = 4;
+    std::vector<QubitIdType> Qs;
+    Qs.reserve(n);
+    for (size_t i = 0; i < n; i++) {
+        Qs.push_back(sim->AllocateQubit());
+    }
+
+    sim->NamedOperation("PauliX", {}, {Qs[0]}, false);
+    sim->NamedOperation("PauliY", {}, {Qs[1]}, false);
+    sim->NamedOperation("Hadamard", {}, {Qs[2]}, false);
+    sim->NamedOperation("PauliZ", {}, {Qs[3]}, false);
+
+    ObsIdType px = sim->Observable(ObsId::PauliX, {}, {Qs[2]});
+    ObsIdType py = sim->Observable(ObsId::PauliY, {}, {Qs[1]});
+    ObsIdType pz = sim->Observable(ObsId::PauliZ, {}, {Qs[0]});
+    ObsIdType hxy = sim->HamiltonianObservable({0.4, 0.8}, {px, py});
+    ObsIdType thz = sim->TensorObservable({hxy, pz});
+
+    CHECK(sim->Expval(thz) == Approx(-0.4).margin(1e-5));
+}
+
+TEMPLATE_LIST_TEST_CASE("Expval(Tensor(HermitianObs, Hamiltonian()) test", "[Measures]", SimTypes)
+{
+    std::unique_ptr<TestType> sim = std::make_unique<TestType>();
+
+    // state-vector with #qubits = n
+    constexpr size_t n = 3;
+    std::vector<QubitIdType> Qs = sim->AllocateQubits(n);
+
+    sim->NamedOperation("PauliX", {}, {Qs[0]}, false);
+    sim->NamedOperation("PauliY", {}, {Qs[1]}, false);
+    sim->NamedOperation("Hadamard", {}, {Qs[2]}, false);
+
+    std::vector<std::complex<double>> mat2{{1.0, 0.0}, {0.0, 0.0}, {-1.0, 0.0}, {0.0, 0.0}};
+
+    ObsIdType her = sim->Observable(ObsId::Hermitian, mat2, {Qs[0]});
+    ObsIdType px = sim->Observable(ObsId::PauliX, {}, {Qs[1]});
+    ObsIdType py = sim->Observable(ObsId::PauliY, {}, {Qs[2]});
+    ObsIdType hxy = sim->HamiltonianObservable({0.4, 0.8}, {px, py});
+    ObsIdType ten = sim->TensorObservable({her, hxy});
+
+    CHECK(sim->Expval(ten) == Approx(0.0).margin(1e-5));
 }
 
 TEMPLATE_LIST_TEST_CASE("Expval(Hamiltonian(NamedObs[])) test", "[Measures]", SimTypes)
@@ -533,7 +583,7 @@ TEMPLATE_LIST_TEST_CASE("Var(NamedObs) test with numWires=4", "[Measures]", SimT
     CHECK(sim->Var(pz) == Approx(.0).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Var(HermitianObs) test with numWires=1", "[Measures]", SimTypes)
+TEMPLATE_LIST_TEST_CASE("Var(HermitianObs) test", "[Measures]", SimTypes)
 {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
@@ -692,6 +742,55 @@ TEMPLATE_LIST_TEST_CASE("Var(TensorProd(Obs[])) test", "[Measures]", SimTypes)
     ObsIdType tp = sim->TensorObservable({px, h, pz});
 
     CHECK(sim->Var(tp) == Approx(4.0).margin(1e-5));
+}
+
+TEMPLATE_LIST_TEST_CASE("Var(Tensor(Hamiltonian(NamedObs[]), NamedObs)) test", "[Measures]",
+                        SimTypes)
+{
+    std::unique_ptr<TestType> sim = std::make_unique<TestType>();
+
+    // state-vector with #qubits = n
+    constexpr size_t n = 4;
+    std::vector<QubitIdType> Qs;
+    Qs.reserve(n);
+    for (size_t i = 0; i < n; i++) {
+        Qs.push_back(sim->AllocateQubit());
+    }
+
+    sim->NamedOperation("PauliX", {}, {Qs[0]}, false);
+    sim->NamedOperation("PauliY", {}, {Qs[1]}, false);
+    sim->NamedOperation("Hadamard", {}, {Qs[2]}, false);
+    sim->NamedOperation("PauliZ", {}, {Qs[3]}, false);
+
+    ObsIdType px = sim->Observable(ObsId::PauliX, {}, {Qs[2]});
+    ObsIdType py = sim->Observable(ObsId::PauliY, {}, {Qs[1]});
+    ObsIdType pz = sim->Observable(ObsId::PauliZ, {}, {Qs[0]});
+    ObsIdType hxy = sim->HamiltonianObservable({0.4, 0.8}, {px, py});
+    ObsIdType thz = sim->TensorObservable({hxy, pz});
+
+    CHECK(sim->Var(thz) == Approx(0.64).margin(1e-5));
+}
+
+TEMPLATE_LIST_TEST_CASE("Var(Tensor(HermitianObs, Hamiltonian()) test", "[Measures]", SimTypes)
+{
+    std::unique_ptr<TestType> sim = std::make_unique<TestType>();
+
+    // state-vector with #qubits = n
+    constexpr size_t n = 3;
+    std::vector<QubitIdType> Qs = sim->AllocateQubits(n);
+
+    sim->NamedOperation("Hadamard", {}, {Qs[0]}, false);
+    sim->NamedOperation("PauliY", {}, {Qs[1]}, false);
+
+    std::vector<std::complex<double>> mat2{{1.0, 0.0}, {0.0, 0.0}, {-1.0, 0.0}, {0.0, 0.0}};
+
+    ObsIdType her = sim->Observable(ObsId::Hermitian, mat2, {Qs[0]});
+    ObsIdType px = sim->Observable(ObsId::PauliX, {}, {Qs[1]});
+    ObsIdType py = sim->Observable(ObsId::PauliY, {}, {Qs[2]});
+    ObsIdType hxy = sim->HamiltonianObservable({0.4, 0.8}, {px, py});
+    ObsIdType ten = sim->TensorObservable({her, hxy});
+
+    CHECK(sim->Var(ten) == Approx(0.8).margin(1e-5));
 }
 
 TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian(NamedObs[])) test", "[Measures]", SimTypes)

--- a/runtime/tests/Test_LightningMeasures.cpp
+++ b/runtime/tests/Test_LightningMeasures.cpp
@@ -448,6 +448,65 @@ TEMPLATE_LIST_TEST_CASE("Expval(Hamiltonian({TensorProd, Hermitian}[])) test", "
     CHECK(sim->Expval(hhtp) == Approx(1.2).margin(1e-5));
 }
 
+TEMPLATE_LIST_TEST_CASE("Expval(Hamiltonian({Hamiltonian, Hermitian}[])) test", "[Measures]",
+                        SimTypes)
+{
+    std::unique_ptr<TestType> sim = std::make_unique<TestType>();
+
+    // state-vector with #qubits = n
+    constexpr size_t n = 4;
+    std::vector<QubitIdType> Qs;
+    Qs.reserve(n);
+    for (size_t i = 0; i < n; i++) {
+        Qs.push_back(sim->AllocateQubit());
+    }
+
+    sim->NamedOperation("PauliX", {}, {Qs[0]}, false);
+    sim->NamedOperation("PauliY", {}, {Qs[1]}, false);
+    sim->NamedOperation("Hadamard", {}, {Qs[2]}, false);
+    sim->NamedOperation("PauliZ", {}, {Qs[3]}, false);
+
+    ObsIdType px = sim->Observable(ObsId::PauliX, {}, {Qs[2]});
+    ObsIdType pz = sim->Observable(ObsId::PauliZ, {}, {Qs[1]});
+    ObsIdType hp = sim->HamiltonianObservable({0.2, 0.6}, {px, pz});
+
+    std::vector<std::complex<double>> mat2{{1.0, 0.0}, {2.0, 0.0}, {-1.0, 0.0}, {3.0, 0.0}};
+    ObsIdType h = sim->Observable(ObsId::Hermitian, mat2, {Qs[0]});
+    ObsIdType hhtp = sim->HamiltonianObservable({0.5, 0.3}, {h, hp});
+
+    CHECK(sim->Expval(hhtp) == Approx(1.38).margin(1e-5));
+}
+
+TEMPLATE_LIST_TEST_CASE("Expval(Hamiltonian({Hamiltonian(Hamiltonian), Hermitian}[])) test",
+                        "[Measures]", SimTypes)
+{
+    std::unique_ptr<TestType> sim = std::make_unique<TestType>();
+
+    // state-vector with #qubits = n
+    constexpr size_t n = 4;
+    std::vector<QubitIdType> Qs;
+    Qs.reserve(n);
+    for (size_t i = 0; i < n; i++) {
+        Qs.push_back(sim->AllocateQubit());
+    }
+
+    sim->NamedOperation("PauliX", {}, {Qs[0]}, false);
+    sim->NamedOperation("PauliY", {}, {Qs[1]}, false);
+    sim->NamedOperation("Hadamard", {}, {Qs[2]}, false);
+    sim->NamedOperation("PauliZ", {}, {Qs[3]}, false);
+
+    ObsIdType px = sim->Observable(ObsId::PauliX, {}, {Qs[2]});
+    ObsIdType pz = sim->Observable(ObsId::PauliZ, {}, {Qs[1]});
+    ObsIdType hp = sim->HamiltonianObservable({0.2, 0.6}, {px, pz});
+    ObsIdType hhp = sim->HamiltonianObservable({1}, {hp});
+
+    std::vector<std::complex<double>> mat2{{1.0, 0.0}, {2.0, 0.0}, {-1.0, 0.0}, {3.0, 0.0}};
+    ObsIdType h = sim->Observable(ObsId::Hermitian, mat2, {Qs[0]});
+    ObsIdType hhtp = sim->HamiltonianObservable({0.5, 0.3}, {hhp, h});
+
+    CHECK(sim->Expval(hhtp) == Approx(0.7).margin(1e-5));
+}
+
 TEMPLATE_LIST_TEST_CASE("Var(NamedObs) test with numWires=4", "[Measures]", SimTypes)
 {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
@@ -740,6 +799,64 @@ TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian({TensorProd, Hermitian}[])) test", "[Me
     ObsIdType hhtp = sim->HamiltonianObservable({0.5, 0.3}, {h, tp});
 
     CHECK(sim->Var(hhtp) == Approx(1.0).margin(1e-5));
+}
+
+TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian({Hamiltonian, Hermitian}[])) test", "[Measures]", SimTypes)
+{
+    std::unique_ptr<TestType> sim = std::make_unique<TestType>();
+
+    // state-vector with #qubits = n
+    constexpr size_t n = 4;
+    std::vector<QubitIdType> Qs;
+    Qs.reserve(n);
+    for (size_t i = 0; i < n; i++) {
+        Qs.push_back(sim->AllocateQubit());
+    }
+
+    sim->NamedOperation("PauliX", {}, {Qs[0]}, false);
+    sim->NamedOperation("PauliY", {}, {Qs[1]}, false);
+    sim->NamedOperation("Hadamard", {}, {Qs[2]}, false);
+    sim->NamedOperation("PauliZ", {}, {Qs[3]}, false);
+
+    ObsIdType px = sim->Observable(ObsId::PauliX, {}, {Qs[2]});
+    ObsIdType pz = sim->Observable(ObsId::PauliZ, {}, {Qs[1]});
+    ObsIdType hp = sim->HamiltonianObservable({0.2, 0.6}, {px, pz});
+
+    std::vector<std::complex<double>> mat2{{1.0, 0.0}, {2.0, 0.0}, {-1.0, 0.0}, {3.0, 0.0}};
+    ObsIdType h = sim->Observable(ObsId::Hermitian, mat2, {Qs[0]});
+    ObsIdType hhtp = sim->HamiltonianObservable({0.5, 0.3}, {h, hp});
+
+    CHECK(sim->Var(hhtp) == Approx(1.0).margin(1e-5));
+}
+
+TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian({Hamiltonian(Hamiltonian), Hermitian}[])) test",
+                        "[Measures]", SimTypes)
+{
+    std::unique_ptr<TestType> sim = std::make_unique<TestType>();
+
+    // state-vector with #qubits = n
+    constexpr size_t n = 4;
+    std::vector<QubitIdType> Qs;
+    Qs.reserve(n);
+    for (size_t i = 0; i < n; i++) {
+        Qs.push_back(sim->AllocateQubit());
+    }
+
+    sim->NamedOperation("PauliX", {}, {Qs[0]}, false);
+    sim->NamedOperation("PauliY", {}, {Qs[1]}, false);
+    sim->NamedOperation("Hadamard", {}, {Qs[2]}, false);
+    sim->NamedOperation("PauliZ", {}, {Qs[3]}, false);
+
+    ObsIdType px = sim->Observable(ObsId::PauliX, {}, {Qs[2]});
+    ObsIdType pz = sim->Observable(ObsId::PauliZ, {}, {Qs[1]});
+    ObsIdType hp = sim->HamiltonianObservable({0.2, 0.6}, {px, pz});
+    ObsIdType hhp = sim->HamiltonianObservable({1}, {hp});
+
+    std::vector<std::complex<double>> mat2{{1.0, 0.0}, {2.0, 0.0}, {-1.0, 0.0}, {3.0, 0.0}};
+    ObsIdType h = sim->Observable(ObsId::Hermitian, mat2, {Qs[0]});
+    ObsIdType hhtp = sim->HamiltonianObservable({0.5, 0.3}, {hhp, h});
+
+    CHECK(sim->Var(hhtp) == Approx(0.36).margin(1e-5));
 }
 
 TEMPLATE_LIST_TEST_CASE("State test with incorrect size", "[Measures]", SimTypes)


### PR DESCRIPTION
Update the runtime to support measurement processes with nested Hamiltonian observables. In runtime, we used to check the type of given observables for constructing the `HamiltonianObs` data-type and obs-id in the Observable Manager. This is now passed to the device to check whether those observables are supported in the `Hamiltonian` method or not.  

For Lightning simulators, these devices support nested Hamiltonians and will raise errors for unsupported observables while we still check the validity of given observables for OpenQasmDevice in the OpenQasmObsManager class as we have a limited support for this particular device at runtime

You can now JIT-compile the following circuit:  

  ``` python
  @qjit
  @qml.qnode(qml.device("lightning.qubit", wires=3))
  def circuit(x, y, coeffs1, coeffs2):
      qml.RX(x, wires=0)
      qml.RX(y, wires=1)
      qml.RY(x + y, wires=2)

      obs = [
          qml.PauliX(0) @ qml.PauliZ(1),
          qml.Hamiltonian(coeffs1, [qml.PauliZ(0) @ qml.Hadamard(2)]),
      ]

      return qml.var(qml.Hamiltonian(coeffs2, obs))
  ```

[sc-41351]