### PR TITLE
[Frontend] Add AutoGraph support for Python for loops

### DIFF
--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -284,7 +284,6 @@ jobs:
       run: |
         sudo apt-get install -y python3 python3-pip libomp-dev
         python3 -m pip install -r requirements.txt
-        python3 -m pip install tensorflow-cpu  # for autograph tests
         python3 -m pip install .
 
     - name: Get Cached LLVM Build
@@ -369,7 +368,6 @@ jobs:
       run: |
         sudo apt-get install -y python3 python3-pip libomp-dev
         python3 -m pip install -r requirements.txt
-        python3 -m pip install tensorflow-cpu  # for autograph tests
         python3 -m pip install .
 
     - name: Get Cached LLVM Build

--- a/.pylintrc
+++ b/.pylintrc
@@ -37,7 +37,7 @@ enable=useless-suppression
 # it should appear only once).
 # Cyclical import checks are disabled for now as they are frequently used in
 # the code base, but this can be removed in the future once cycles are resolved.
-disable=too-few-public-methods,invalid-name,too-many-locals,cyclic-import,import-error,no-else-return
+disable=too-few-public-methods,invalid-name,too-many-locals,cyclic-import,import-error,no-else-return,unnecessary-ellipsis
 
 [MISCELLANEOUS]
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -10,7 +10,7 @@ extension-pkg-allow-list=catalyst.utils.wrapper
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=pennylane.ops,jaxlib.mlir.ir,tensorflow
+ignored-modules=pennylane.ops,jaxlib.mlir.ir,jaxlib.xla_extension,tensorflow
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work

--- a/.pylintrc
+++ b/.pylintrc
@@ -10,7 +10,7 @@ extension-pkg-allow-list=catalyst.utils.wrapper
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=pennylane.ops,jaxlib.mlir.ir
+ignored-modules=pennylane.ops,jaxlib.mlir.ir,tensorflow
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work
@@ -19,6 +19,10 @@ ignored-modules=pennylane.ops,jaxlib.mlir.ir
 
 # List of file/directory patters to ignore.
 ignore=test,llvm-project,mlir-hlo,.git,__pycache__,build,doc
+
+# List of decorators that change a function's signature. Will ignore certain errors
+# like 'no-value-for-parameter' on functions with these decorators.
+signature-mutators=catalyst.pennylane_extensions.for_loop
 
 [MESSAGES CONTROL]
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,6 +6,23 @@
   explicitly use the functional `catalyst.for_loop` form!
   [#258](https://github.com/PennyLaneAI/catalyst/pull/258)
 
+  This feature extends the existing AutoGraph support for Python if statements with Python for
+  loops. The following example is now supported:
+
+  ```python
+  dev = qml.device("lightning.qubit", wires=n)
+
+  @qjit(autograph=True)
+  @qml.qnode(dev)
+  def f(n):
+      for i in range(n):
+          qml.Hadamard(wires=i)
+
+      ...
+
+      return qml.expval(qml.PauliZ(0))
+  ```
+
 <h3>Improvements</h3>
 
 * Update the Lightning backend device to work with the PL-Lightning monorepo.
@@ -61,7 +78,7 @@ Ali Asadi
   TensorFlow installation be available. In addition, Python loops (`for` and `while`) are not
   yet supported, and do not work in AutoGraph mode.
 
-  Note that there are some caveats when using this feature especially around the ues of global
+  Note that there are some caveats when using this feature especially around the use of global
   variables or object mutation inside of methods. A functional style is always recommended when
   using `qjit` or AutoGraph.
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,6 +2,10 @@
 
 <h3>New features</h3>
 
+* Catalyst users can now use Python for loop statements in their programs without having to
+  explicitly use the functional `catalyst.for_loop` form!
+  [#258](https://github.com/PennyLaneAI/catalyst/pull/258)
+
 <h3>Improvements</h3>
 
 * Update the Lightning backend device to work with the PL-Lightning monorepo.

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -105,8 +105,8 @@ additionally need to install `Rust <https://www.rust-lang.org/tools/install>`_ a
   If the CMake version available in your system is too old, you can also install up-to-date
   versions of it via ``pip install cmake``.
 
-All additional build and developer depencies are managed via the repository's ``requirements.txt``
-and can be installed as follows:
+All additional build and developer dependencies are managed via the repository's
+``requirements.txt`` and can be installed as follows:
 
 .. code-block:: console
 

--- a/frontend/catalyst/__init__.py
+++ b/frontend/catalyst/__init__.py
@@ -75,6 +75,10 @@ from catalyst.pennylane_extensions import (
 )
 from catalyst.utils.exceptions import CompileError
 
+autograph_ignore_fallbacks = False
+autograph_strict_conversion = False
+
+
 __all__ = (
     "qjit",
     "QJIT",
@@ -88,6 +92,8 @@ __all__ = (
     "jvp",
     "adjoint",
     "autograph_source",
+    "autograph_ignore_fallbacks",
+    "autograph_strict_conversion",
     "AutoGraphError",
     "CompileError",
     "CompileOptions",

--- a/frontend/catalyst/ag_primitives.py
+++ b/frontend/catalyst/ag_primitives.py
@@ -110,10 +110,13 @@ def _call_catalyst_for(start, stop, step, body_fn, get_state, enum_start=None, a
     @catalyst.for_loop(start, stop, step)
     def functional_for(i):
         if enum_start is None and array_iterable is None:
+            # for i in range(..)
             body_fn(i)
         elif enum_start is None:
+            # for x in array
             body_fn(array_iterable[i])
         else:
+            # for (i, x) in enumerate(array)
             body_fn((i + enum_start, array_iterable[i]))
 
         return get_state()
@@ -123,6 +126,7 @@ def _call_catalyst_for(start, stop, step, body_fn, get_state, enum_start=None, a
 
 def _call_python_for(body_fn, get_state, non_array_iterable):
     """Fallback to a Python implementation of for loops."""
+
     for elem in non_array_iterable:
         body_fn(elem)
 
@@ -308,8 +312,7 @@ class CEnumerate(enumerate):
     """Catalyst enumeration object.
 
     Can be passed to a Python for loop for conversion into a for_loop call. The loop index, as well
-    as the iterable element will be provided to the loop body, which would otherwise not be possible
-    as unpacking is generally not supported in Catalyst for loops.
+    as the iterable element will be provided to the loop body.
     Otherwise this class behaves exactly like the Python enumerate class.
 
     Note that the iterable must be convertible to an array, otherwise the loop will be treated as a

--- a/frontend/catalyst/ag_primitives.py
+++ b/frontend/catalyst/ag_primitives.py
@@ -133,7 +133,6 @@ def _call_python_for(body_fn, get_state, non_array_iterable):
     return get_state()
 
 
-# pylint: disable=too-many-arguments
 def for_stmt(
     iteration_target: Any,
     _extra_test: Callable[[], bool] | None,
@@ -160,7 +159,7 @@ def for_stmt(
         start, stop, step = 0, len(iteration_target.iteration_target), 1
         try:
             iteration_array = jnp.asarray(iteration_target.iteration_target)
-        except:
+        except:  # pylint: disable=bare-except
             iteration_array = None
             fallback = True
 
@@ -173,7 +172,7 @@ def for_stmt(
         start, stop, step = 0, len(iteration_target), 1
         try:
             iteration_array = jnp.asarray(iteration_target)
-        except:
+        except:  # pylint: disable=bare-except
             iteration_array = None
             fallback = True
 
@@ -259,15 +258,19 @@ class CRange:
         self._step = step if step is not None else 1
 
     def get_raw_range(self):
+        """Get the raw values defining this range: start, stop, step."""
         return self._start, self._stop, self._step
 
     @property
     def py_range(self):
+        """Access the underlying Python range object. If it doesn't exist, create one."""
         if self._py_range is None:
             self._py_range = range(self._start, self._stop, self._step)
         return self._py_range
 
     # Interface of the Python range class.
+    # pylint: disable=missing-function-docstring
+
     @property
     def start(self) -> int:
         return self.py_range.start

--- a/frontend/catalyst/ag_primitives.py
+++ b/frontend/catalyst/ag_primitives.py
@@ -16,7 +16,9 @@
 functions. The purpose is to convert imperative style code to functional or graph-style code."""
 
 import functools
-from typing import Any, Callable, Tuple, SupportsIndex, Iterator
+from typing import Any, Callable, Iterator, SupportsIndex, Tuple
+
+import jax.numpy as jnp
 
 # Use tensorflow implementations for handling function scopes and calls,
 # as well as various utility objects.
@@ -34,7 +36,6 @@ from tensorflow.python.autograph.operators.variables import (
     Undefined,
     UndefinedReturnValue,
 )
-import jax.numpy as jnp
 
 import catalyst
 from catalyst.ag_utils import AutoGraphError
@@ -193,8 +194,7 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
         # `for .. in range(..)` to be converted natively to `for_loop` calls. This is beneficial
         # since the Python range function does not allow tracers as arguments.
         if fn is range:
-            assert len(args) in (1, 3)
-            return CRange(*args)
+            return CRange(*args, **(kwargs if kwargs is not None else {}))
 
         # We need to unpack nested QNode and QJIT calls as autograph will have trouble handling
         # them. Ideally, we only want the wrapped function to be transformed by autograph, rather

--- a/frontend/catalyst/ag_primitives.py
+++ b/frontend/catalyst/ag_primitives.py
@@ -53,6 +53,7 @@ __all__ = [
     "FunctionScope",
     "with_function_scope",
     "if_stmt",
+    "for_stmt",
     "converted_call",
 ]
 
@@ -169,6 +170,7 @@ def for_stmt(
     #   -> this will raise a warning to allow users to correct mistakes and allow the conversion
     #      to succeed, for example because they forgot to use a list instead of an array
     fallback = False
+    init_state = get_state()
 
     if isinstance(iteration_target, CRange):
         start, stop, step = iteration_target.get_raw_range()
@@ -205,6 +207,7 @@ def for_stmt(
     # Attempt to trace the Catalyst for loop.
     if not fallback:
         try:
+            set_state(init_state)
             results = _call_catalyst_for(
                 start, stop, step, body_fn, get_state, enum_start, iteration_array
             )
@@ -241,6 +244,7 @@ def for_stmt(
 
     # If anything goes wrong, we fall back to Python.
     if fallback:
+        set_state(init_state)
         results = _call_python_for(body_fn, get_state, iteration_target)
 
     # Sometimes we unpack the results of nested tracing scopes so that the user doesn't have to

--- a/frontend/catalyst/ag_primitives.py
+++ b/frontend/catalyst/ag_primitives.py
@@ -32,12 +32,12 @@ from tensorflow.python.autograph.core.function_wrappers import (
     FunctionScope,
     with_function_scope,
 )
+from tensorflow.python.autograph.impl.api import autograph_artifact
 from tensorflow.python.autograph.impl.api import converted_call as tf_converted_call
 from tensorflow.python.autograph.operators.variables import (
     Undefined,
     UndefinedReturnValue,
 )
-from tensorflow.python.autograph.pyct.error_utils import ErrorMetadataBase
 from tensorflow.python.autograph.pyct.origin_info import LineLocation
 
 import catalyst
@@ -49,6 +49,7 @@ __all__ = [
     "ConversionOptions",
     "Undefined",
     "UndefinedReturnValue",
+    "autograph_artifact",
     "FunctionScope",
     "with_function_scope",
     "if_stmt",

--- a/frontend/catalyst/ag_primitives.py
+++ b/frontend/catalyst/ag_primitives.py
@@ -161,9 +161,13 @@ def for_stmt(
     # - For loops over a Python enumeration use a combination of the above, providing a dynamic
     #   iteration variable and conversion of the iterable to array. If either fails, a fallback to
     #   Python is used.
-    # The fallback mechanism for tracing errors will raise a warning as the user may need to be
-    # aware that the graph conversion failed, for instance for lack of converting lists into arrays,
-    # but the conversion from iterable to array will fall back to Python silently.
+    # Note that there are two reasons a fallback to Python could have been triggered:
+    # - the iterable provided by the user is not convertible to an array
+    #   -> this will fallback to a Python loop silently (without a warning), since there isn't a
+    #      simple fix to make this loop traceable
+    # - an exception is raised during the tracing of the loop body after conversion
+    #   -> this will raise a warning to allow users to correct mistakes and allow the conversion
+    #      to succeed, for example because they forgot to use a list instead of an array
     fallback = False
 
     if isinstance(iteration_target, CRange):

--- a/frontend/catalyst/ag_primitives.py
+++ b/frontend/catalyst/ag_primitives.py
@@ -195,6 +195,7 @@ def for_stmt(
             )
         except Exception as e:  # pylint: disable=broad-exception-caught
             fallback = True
+            # pylint: disable=import-outside-toplevel
             import inspect
             import textwrap
 
@@ -235,7 +236,7 @@ def get_source_code_info(tb_frame):
     Uses introspection on the call stack to extract the source map record from within AutoGraph
     statements. However, it is not guaranteed to find the source map and may return nothing.
     """
-    import inspect
+    import inspect  # pylint: disable=import-outside-toplevel
 
     ag_source_map = None
 
@@ -249,22 +250,19 @@ def get_source_code_info(tb_frame):
                 obj = frame.frame.f_locals["converted_f"]
                 ag_source_map = obj.ag_source_map
                 break
-            elif "self" in frame.frame.f_locals:
+            if "self" in frame.frame.f_locals:
                 obj = frame.frame.f_locals["self"]
                 if isinstance(obj, qml.QNode):
                     ag_source_map = obj.ag_source_map
                     break
-                elif isinstance(obj, catalyst.QJIT):
+                if isinstance(obj, catalyst.QJIT):
                     ag_source_map = obj.user_function.ag_source_map
                     break
-    except:  # pylint: disable=bare-except
+    except:  # nosec B110 # pylint: disable=bare-except
         pass
 
-    if ag_source_map is None:
-        return ""
-
     loc = LineLocation(tb_frame.filename, tb_frame.lineno)
-    if loc in ag_source_map:
+    if ag_source_map is not None and loc in ag_source_map:
         function_name = ag_source_map[loc].function_name
         filename = ag_source_map[loc].loc.filename
         lineno = ag_source_map[loc].loc.lineno

--- a/frontend/catalyst/ag_primitives.py
+++ b/frontend/catalyst/ag_primitives.py
@@ -16,7 +16,7 @@
 functions. The purpose is to convert imperative style code to functional or graph-style code."""
 
 import functools
-from typing import Any, Callable, Tuple
+from typing import Any, Callable, Tuple, SupportsIndex, Iterator
 
 # Use tensorflow implementations for handling function scopes and calls,
 # as well as various utility objects.
@@ -144,18 +144,25 @@ def for_stmt(
 
     assert _extra_test is None
 
-    # We can attempt to convert the iteration target to an array.
-    # If this fails, we must fall back to Python.
-    try:
-        iteration_array = jnp.asarray(iteration_target)
-    except:
-        iteration_array = None
-
-    if iteration_array is not None:
-        start, stop, step = 0, len(iteration_target), 1
-        results = _call_catalyst_for(start, stop, step, body_fn, get_state, opts, iteration_array)
+    if isinstance(iteration_target, CRange):
+        # Ideally we iterate over a simple range.
+        start, stop, step = iteration_target.get_raw_range()
+        results = _call_catalyst_for(start, stop, step, body_fn, get_state, opts)
     else:
-        results = _call_python_for(body_fn, get_state, iteration_target)
+        # Otherwise we can attempt to convert the iteration target to an array.
+        # If this fails, we must fall back to Python.
+        try:
+            iteration_array = jnp.asarray(iteration_target)
+        except:
+            iteration_array = None
+
+        if iteration_array is not None:
+            start, stop, step = 0, len(iteration_target), 1
+            results = _call_catalyst_for(
+                start, stop, step, body_fn, get_state, opts, iteration_array
+            )
+        else:
+            results = _call_python_for(body_fn, get_state, iteration_target)
 
     # Sometimes we unpack the results of nested tracing scopes so that the user doesn't have to
     # manipulate tuples when they don't expect it. Ensure set_state receives a tuple regardless.
@@ -174,7 +181,7 @@ module_allowlist = (
 ) + config.CONVERSION_RULES
 
 
-def converted_call(fn, *args, **kwargs):
+def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
     """We want AutoGraph to use our own instance of the AST transformer when recursively
     transforming functions, but otherwise duplicate the same behaviour."""
 
@@ -182,6 +189,13 @@ def converted_call(fn, *args, **kwargs):
         (tf_autograph_api, "_TRANSPILER", catalyst.autograph.TRANSFORMER),
         (config, "CONVERSION_RULES", module_allowlist),
     ):
+        # Dispatch range calls to a custom range class that enables constructs like
+        # `for .. in range(..)` to be converted natively to `for_loop` calls. This is beneficial
+        # since the Python range function does not allow tracers as arguments.
+        if fn is range:
+            assert len(args) in (1, 3)
+            return CRange(*args)
+
         # We need to unpack nested QNode and QJIT calls as autograph will have trouble handling
         # them. Ideally, we only want the wrapped function to be transformed by autograph, rather
         # than the QNode or QJIT call method.
@@ -197,9 +211,75 @@ def converted_call(fn, *args, **kwargs):
 
             @functools.wraps(fn.func)
             def qnode_call_wrapper():
-                return tf_converted_call(fn.func, *args, **kwargs)
+                return tf_converted_call(fn.func, args, kwargs, caller_fn_scope, options)
 
             new_qnode = qml.QNode(qnode_call_wrapper, device=fn.device, diff_method=fn.diff_method)
             return new_qnode()
 
-        return tf_converted_call(fn, *args, **kwargs)
+        return tf_converted_call(fn, args, kwargs, caller_fn_scope, options)
+
+
+class CRange:
+    """Catalyst range object.
+
+    Can be passed to a Python for loop for native conversion to a for_loop call.
+    Otherwise this class behaves exactly like the Python range class.
+
+    Without this native conversion, all iteration targets in a Python for loop must be convertible
+    to arrays. For all other inputs the loop will be treated as a regular Python loop.
+    """
+
+    def __init__(self, start_stop, stop=None, step=None):
+        self._py_range = None
+        self._start = start_stop if stop is not None else 0
+        self._stop = stop if stop is not None else start_stop
+        self._step = step if step is not None else 1
+
+    def get_raw_range(self):
+        return self._start, self._stop, self._step
+
+    @property
+    def py_range(self):
+        if self._py_range is None:
+            self._py_range = range(self._start, self._stop, self._step)
+        return self._py_range
+
+    # Interface of the Python range class.
+    @property
+    def start(self) -> int:
+        return self.py_range.start
+
+    @property
+    def stop(self) -> int:
+        return self.py_range.stop
+
+    @property
+    def step(self) -> int:
+        return self.py_range.step
+
+    def count(self, __value: int) -> int:
+        return self.py_range.count(__value)
+
+    def index(self, __value: int) -> int:
+        return self.py_range.index(__value)
+
+    def __len__(self) -> int:
+        return self.py_range.__len__()
+
+    def __eq__(self, __value: object) -> bool:
+        return self.py_range.__eq__(__value)
+
+    def __hash__(self) -> int:
+        return self.py_range.__hash__()
+
+    def __contains__(self, __key: object) -> bool:
+        return self.py_range.__contains__(__key)
+
+    def __iter__(self) -> Iterator[int]:
+        return self.py_range.__iter__()
+
+    def __getitem__(self, __key: SupportsIndex | slice) -> int | range:
+        self.py_range.__getitem__(__key)
+
+    def __reversed__(self) -> Iterator[int]:
+        self.py_range.__reversed__()

--- a/frontend/catalyst/ag_primitives.py
+++ b/frontend/catalyst/ag_primitives.py
@@ -262,7 +262,7 @@ def get_source_code_info(tb_frame):
                 if isinstance(obj, catalyst.QJIT):
                     ag_source_map = obj.user_function.ag_source_map
                     break
-    except:  # nosec B110 # pylint: disable=bare-except
+    except:  # nosec B110 # pylint: disable=bare-except # pragma: nocover
         pass
 
     loc = LineLocation(tb_frame.filename, tb_frame.lineno)
@@ -362,43 +362,43 @@ class CRange:
     # pylint: disable=missing-function-docstring
 
     @property
-    def start(self) -> int:
+    def start(self) -> int:  # pragma: nocover
         return self.py_range.start
 
     @property
-    def stop(self) -> int:
+    def stop(self) -> int:  # pragma: nocover
         return self.py_range.stop
 
     @property
-    def step(self) -> int:
+    def step(self) -> int:  # pragma: nocover
         return self.py_range.step
 
-    def count(self, __value: int) -> int:
+    def count(self, __value: int) -> int:  # pragma: nocover
         return self.py_range.count(__value)
 
-    def index(self, __value: int) -> int:
+    def index(self, __value: int) -> int:  # pragma: nocover
         return self.py_range.index(__value)
 
-    def __len__(self) -> int:
+    def __len__(self) -> int:  # pragma: nocover
         return self.py_range.__len__()
 
-    def __eq__(self, __value: object) -> bool:
+    def __eq__(self, __value: object) -> bool:  # pragma: nocover
         return self.py_range.__eq__(__value)
 
-    def __hash__(self) -> int:
+    def __hash__(self) -> int:  # pragma: nocover
         return self.py_range.__hash__()
 
-    def __contains__(self, __key: object) -> bool:
+    def __contains__(self, __key: object) -> bool:  # pragma: nocover
         return self.py_range.__contains__(__key)
 
-    def __iter__(self) -> Iterator[int]:
+    def __iter__(self) -> Iterator[int]:  # pragma: nocover
         return self.py_range.__iter__()
 
-    def __getitem__(self, __key: SupportsIndex | slice) -> int | range:
-        self.py_range.__getitem__(__key)
+    def __getitem__(self, __key: SupportsIndex | slice) -> int | range:  # pragma: nocover
+        return self.py_range.__getitem__(__key)
 
-    def __reversed__(self) -> Iterator[int]:
-        self.py_range.__reversed__()
+    def __reversed__(self) -> Iterator[int]:  # pragma: nocover
+        return self.py_range.__reversed__()
 
 
 class CEnumerate(enumerate):

--- a/frontend/catalyst/autograph.py
+++ b/frontend/catalyst/autograph.py
@@ -56,7 +56,7 @@ class CFTransformer(transpiler.PyToPy):
 
         return new_obj, module, source_map
 
-    def transform_ast(self, node, user_context):
+    def transform_ast(self, node, ctx):
         """This method must be overwritten to run all desired transformations. AutoGraph provides
         several existing transforms, but we can all also provide our own in the future."""
 
@@ -64,13 +64,13 @@ class CFTransformer(transpiler.PyToPy):
         unsupported_features_checker.verify(node)
 
         # First transform the top-level function to avoid infinite recursion.
-        node = functions.transform(node, user_context)
+        node = functions.transform(node, ctx)
 
         # Convert function calls. This allows us to convert these called functions as well.
-        node = call_trees.transform(node, user_context)
+        node = call_trees.transform(node, ctx)
 
         # Convert Python control flow to custom 'ag__.if_stmt' ... functions.
-        node = control_flow.transform(node, user_context)
+        node = control_flow.transform(node, ctx)
 
         return node
 

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -768,8 +768,8 @@ def qjit(
     Args:
         fn (Callable): the quantum or classical function
         autograph (bool): Experimental support for automatically converting Python control
-            flow statements to Catalyst-compatible control flow. Currently only supports Python
-            ``if``, ``elif``, and ``else`` statements. Note that this feature requires an
+            flow statements to Catalyst-compatible control flow. Currently supports Python ``if``,
+            ``elif``, ``else``, and ``for`` statements. Note that this feature requires an
             available TensorFlow installation.
         target (str): the compilation target
         keep_intermediate (bool): Whether or not to store the intermediate files throughout the

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -79,7 +79,7 @@ class Qbit:
         self.aval = AbstractQbit()
 
 
-class AbstractQbit(AbstractValue):
+class AbstractQbit(AbstractValue):  # pylint: disable=abstract-method
     """Abstract Qbit"""
 
     hash_value = hash("AbstractQubit")
@@ -91,7 +91,7 @@ class AbstractQbit(AbstractValue):
         return self.hash_value
 
 
-class ConcreteQbit(AbstractQbit):
+class ConcreteQbit(AbstractQbit):  # pylint: disable=abstract-method
     """Concrete Qbit."""
 
 
@@ -110,7 +110,7 @@ class Qreg:
         self.aval = AbstractQreg()
 
 
-class AbstractQreg(AbstractValue):
+class AbstractQreg(AbstractValue):  # pylint: disable=abstract-method
     """Abstract quantum register."""
 
     hash_value = hash("AbstractQreg")
@@ -122,7 +122,7 @@ class AbstractQreg(AbstractValue):
         return self.hash_value
 
 
-class ConcreteQreg(AbstractQreg):
+class ConcreteQreg(AbstractQreg):  # pylint: disable=abstract-method
     """Concrete quantum register."""
 
 
@@ -141,7 +141,7 @@ class Obs:
         self.aval = AbstractObs(num_qubits, primitive)
 
 
-class AbstractObs(AbstractValue):
+class AbstractObs(AbstractValue):  # pylint: disable=abstract-method
     """Abstract observable."""
 
     def __init__(self, num_qubits=None, primitive=None):
@@ -158,7 +158,7 @@ class AbstractObs(AbstractValue):
         return hash(self.primitive) + self.num_qubits
 
 
-class ConcreteObs(AbstractObs):
+class ConcreteObs(AbstractObs):  # pylint: disable=abstract-method
     """Concrete observable."""
 
 

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -595,16 +595,16 @@ def custom_lower_jaxpr_to_module(
     Copyright 2021 The JAX Authors.
     """
     platform = xb.canonicalize_platform(platform)
-    if not xb.is_known_platform(platform):
+    if not xb.is_known_platform(platform):  # pragma: no cover
         raise ValueError(f"Unknown platform {platform}")
     assert arg_shardings is None
     assert result_shardings is None
     platforms_with_donation = ("cuda", "rocm", "tpu")
     assert platform not in platforms_with_donation
     unlowerable_effects = lowerable_effects.filter_not_in(jaxpr.effects)
-    if unlowerable_effects:
+    if unlowerable_effects:  # pragma: no cover
         raise ValueError(f"Cannot lower jaxpr with effects: {jaxpr.effects}")
-    if any(donated_args):
+    if any(donated_args):  # pragma: no cover
         msg = "See an explanation at https://jax.readthedocs.io/en/latest/faq.html#buffer-donation."
         raise ValueError(f"Donation is not implemented for platform {platform}.\n{msg}")
 

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -18,6 +18,7 @@ import jax
 import pennylane as qml
 from jax._src import source_info_util
 from jax._src.dispatch import jaxpr_replicas
+from jax._src.effects import ordered_effects
 from jax._src.interpreters.mlir import _module_name_regex
 from jax._src.lax.lax import xb, xla
 from jax._src.util import wrap_name
@@ -74,7 +75,7 @@ def get_mlir(func, *args, **kwargs):
         jaxpr, shape = jax.make_jaxpr(func, return_shape=True)(*args, **kwargs)
 
     nrep = jaxpr_replicas(jaxpr)
-    effects = [eff for eff in jaxpr.effects if eff in jax.core.ordered_effects]
+    effects = list(ordered_effects.filter_in(jaxpr.effects))
     axis_context = ReplicaAxisContext(xla.AxisEnv(nrep, (), ()))
     name_stack = source_info_util.new_name_stack(wrap_name("ok", "jit"))
     module, context = custom_lower_jaxpr_to_module(
@@ -596,18 +597,16 @@ def custom_lower_jaxpr_to_module(
     platform = xb.canonicalize_platform(platform)
     if not xb.is_known_platform(platform):
         raise ValueError(f"Unknown platform {platform}")
-    in_avals = jaxpr.in_avals
     assert arg_shardings is None
     assert result_shardings is None
     platforms_with_donation = ("cuda", "rocm", "tpu")
     assert platform not in platforms_with_donation
-    if any(eff not in lowerable_effects for eff in jaxpr.effects):
+    unlowerable_effects = lowerable_effects.filter_not_in(jaxpr.effects)
+    if unlowerable_effects:
         raise ValueError(f"Cannot lower jaxpr with effects: {jaxpr.effects}")
     if any(donated_args):
-        unused_donations = [str(a) for a, d in zip(in_avals, donated_args) if d]
         msg = "See an explanation at https://jax.readthedocs.io/en/latest/faq.html#buffer-donation."
-        if platform not in platforms_with_donation:
-            msg = f"Donation is not implemented for {platform}.\n{msg}"
+        raise ValueError(f"Donation is not implemented for platform {platform}.\n{msg}")
 
     # MHLO channels need to start at 1
     channel_iter = 1
@@ -624,9 +623,6 @@ def custom_lower_jaxpr_to_module(
         # XLA computation preserves the module name.
         module_name = _module_name_regex.sub("_", module_name)
         ctx.module.operation.attributes["sym_name"] = ir.StringAttr.get(module_name)
-        unlowerable_effects = {eff for eff in jaxpr.effects if eff not in lowerable_effects}
-        if unlowerable_effects:
-            raise ValueError(f"Cannot lower jaxpr with unlowerable effects: {unlowerable_effects}")
         lower_jaxpr_to_fun(
             ctx,
             func_name,

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -1389,6 +1389,11 @@ class ForLoopCallable:
 def for_loop(lower_bound, upper_bound, step):
     """A :func:`~.qjit` compatible for-loop decorator for PennyLane/Catalyst.
 
+    .. note::
+
+        Catalyst can now automatically convert Python for loop statements for you. Requires setting
+        ``autograph=True``, see the :func:`~.qjit` function or documentation page for more details.
+
     This for-loop representation is a functional version of the traditional
     for-loop, similar to ``jax.cond.fori_loop``. That is, any variables that
     are modified across iterations need to be provided as inputs/outputs to

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -1391,7 +1391,7 @@ def for_loop(lower_bound, upper_bound, step):
 
     .. note::
 
-        Catalyst can now automatically convert Python for loop statements for you. Requires setting
+        Catalyst can automatically convert Python for loop statements for you. Requires setting
         ``autograph=True``, see the :func:`~.qjit` function or documentation page for more details.
 
     This for-loop representation is a functional version of the traditional

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -53,18 +53,18 @@ from catalyst.utils.tracing import TracingContext
 def _trace_quantum_tape(
     cargs, ckwargs, qargs, _callee: Callable, _allow_quantum_measurements: bool = True
 ) -> Tuple[Any, Any]:
-    """Jax-trace the ``_callee`` function accepting positional and keyword arguments and containig
+    """Jax-trace the ``_callee`` function accepting positional and keyword arguments and containing
     quantum calls by running it under the PennyLane's quantum tape recorder.
 
     Args:
-        cargs (Jaxpr): classical positional arguemnts to be passed to ``_callee``
-        kwargs (Jaxpr): classical keyword arguemnts to be passed to ``_callee``
+        cargs (Jaxpr): classical positional arguments to be passed to ``_callee``
+        kwargs (Jaxpr): classical keyword arguments to be passed to ``_callee``
         qargs (Jaxpr): quantum arguments to consume in the course of tracing
         _callee (Callable): function to trace
         _allow_quantum_measurements (bool): If set to False, raise an exception if quantum
                                             measurements are detected
     Returns (Tuple[Any,Any]):
-        - Jax representaion of classical return values of ``_callee``
+        - Jax representation of classical return values of ``_callee``
         - Jax representation of quantum return values obtained in the course of tracing
     """
     assert len(qargs) == 1, f"A single quantum argument was expected, got {qargs}"

--- a/frontend/test/pytest/mock/tensorflow/__init__.py
+++ b/frontend/test/pytest/mock/tensorflow/__init__.py
@@ -1,3 +1,0 @@
-"""Fake a missing tensorflow installation."""
-
-raise ModuleNotFoundError("No module named 'tensorflow'")

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -14,6 +14,8 @@
 
 """PyTests for the AutoGraph source-to-source transformation feature."""
 
+import sys
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -28,9 +30,9 @@ from catalyst.ag_utils import AutoGraphError, autograph_source, check_cache
 # pylint: disable=too-many-public-methods
 
 
-def test_unavailable(mocker):
+def test_unavailable(monkeypatch):
     """Check the error produced in the absence of tensorflow."""
-    mocker.patch.dict("sys.modules", {"tensorflow": None})
+    monkeypatch.setitem(sys.modules, "tensorflow", None)
 
     def fn(x):
         return x**2
@@ -56,7 +58,7 @@ class TestSourceCodeInfo:
         with pytest.warns(
             UserWarning,
             match=(
-                f'  File "{__file__}", line {"51"}, in {main.__name__}\n'
+                f'  File "{__file__}", line {"53"}, in {main.__name__}\n'
                 r"    for _ in range\(5\):"
             ),
         ):
@@ -77,7 +79,7 @@ class TestSourceCodeInfo:
         with pytest.warns(
             UserWarning,
             match=(
-                f'  File "{__file__}", line {"72"}, in {main.__name__}\n'
+                f'  File "{__file__}", line {"74"}, in {main.__name__}\n'
                 r"    for _ in range\(5\):"
             ),
         ):
@@ -100,7 +102,7 @@ class TestSourceCodeInfo:
         with pytest.warns(
             UserWarning,
             match=(
-                f'  File "{__file__}", line {"92"}, in {inner.__name__}\n'
+                f'  File "{__file__}", line {"94"}, in {inner.__name__}\n'
                 r"    for _ in range\(5\):"
             ),
         ):

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -27,9 +27,9 @@ from catalyst import cond, for_loop, measure, qjit
 from catalyst.ag_utils import AutoGraphError, autograph_source, check_cache
 
 # pylint: disable=import-outside-toplevel
-# pylint: disable=missing-function-docstring
 # pylint: disable=unnecessary-lambda-assignment
 # pylint: disable=too-many-public-methods
+# pylint: disable=too-many-lines
 
 
 def test_unavailable(monkeypatch):
@@ -53,6 +53,7 @@ class TestSourceCodeInfo:
         from catalyst.ag_primitives import get_source_code_info
 
         try:
+            result = ""
             raise RuntimeError("Test failure")
         except RuntimeError as e:
             result = get_source_code_info(traceback.extract_tb(e.__traceback__, limit=1)[0])
@@ -481,6 +482,7 @@ class TestConditionals:
 
             return measure(wires=0)
 
+        # pylint: disable=singleton-comparison
         assert circuit(3) == False
         assert circuit(6) == True
 
@@ -488,6 +490,7 @@ class TestConditionals:
         """Test that an exception is raised when the true branch returns a value without an else
         branch.
         """
+        # pylint: disable=using-constant-test
 
         def circuit():
             if True:
@@ -502,6 +505,7 @@ class TestConditionals:
 
     def test_branch_multi_return_mismatch(self, backend):
         """Test that an exception is raised when the return types of all branches do not match."""
+        # pylint: disable=using-constant-test
 
         def circuit():
             if True:
@@ -525,6 +529,8 @@ class TestForLoops:
     def test_python_range_fallback(self):
         """Test that the custom CRange wrapper correctly falls back to Python."""
         from catalyst.ag_primitives import CRange
+
+        # pylint: disable=protected-access
 
         c_range = CRange(0, 5, 1)
         assert c_range._py_range is None
@@ -1058,6 +1064,8 @@ class TestMixed:
     def test_cond_if_for_loop_for(self, monkeypatch):
         """Test Python conditionals and loops together with their Catalyst counterparts."""
         monkeypatch.setattr("catalyst.autograph_strict_conversion", True)
+
+        # pylint: disable=cell-var-from-loop
 
         @qjit(autograph=True)
         def f(x):

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -41,7 +41,6 @@ def test_unavailable(monkeypatch):
         qjit(autograph=True)(fn)
 
 
-# Keep this class first due to hardcoded line numbers.
 @pytest.mark.tf
 class TestSourceCodeInfo:
     """Unit tests for exception utilities that retrieves traceback information for the original
@@ -58,7 +57,7 @@ class TestSourceCodeInfo:
         with pytest.warns(
             UserWarning,
             match=(
-                f'  File "{__file__}", line {"53"}, in {main.__name__}\n'
+                f'  File "{__file__}", line [0-9]+, in {main.__name__}\n'
                 r"    for _ in range\(5\):"
             ),
         ):
@@ -79,7 +78,7 @@ class TestSourceCodeInfo:
         with pytest.warns(
             UserWarning,
             match=(
-                f'  File "{__file__}", line {"74"}, in {main.__name__}\n'
+                f'  File "{__file__}", line [0-9]+, in {main.__name__}\n'
                 r"    for _ in range\(5\):"
             ),
         ):
@@ -102,7 +101,7 @@ class TestSourceCodeInfo:
         with pytest.warns(
             UserWarning,
             match=(
-                f'  File "{__file__}", line {"94"}, in {inner.__name__}\n'
+                f'  File "{__file__}", line [0-9]+, in {inner.__name__}\n'
                 r"    for _ in range\(5\):"
             ),
         ):

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -25,6 +25,7 @@ from catalyst.ag_utils import AutoGraphError, autograph_source, check_cache
 
 # pylint: disable=missing-function-docstring
 # pylint: disable=unnecessary-lambda-assignment
+# pylint: disable=too-many-public-methods
 
 
 def test_unavailable(mocker):
@@ -818,8 +819,8 @@ class TestForLoops:
         @qjit(autograph=True)
         def f():
             @for_loop(0, 3, 1)
-            def loop(i, sum):
-                return sum + i
+            def loop(i, acc):
+                return acc + i
 
             return loop(0)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ isort
 # testing
 lit
 pytest
-pytest-mock
 pytest-xdist
 pytest-cov
 nbmake

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,22 @@
+# build dependencies
 numpy
 pybind11>=2.8.0
 PyYAML
 
+# formatting/linting
 black[jupyter]
 clang-format==14.*
 clang-tidy==14.*
 pylint
 isort
 
+# testing
 lit
 pytest
 pytest-mock
 pytest-xdist
 pytest-cov
 nbmake
+
+# optional rt dependencies
+tensorflow-cpu


### PR DESCRIPTION
Introduces support for Python `for .. in ...:` statement capture as part of the compiled program.
Similar to PR #235, AutoGraph is used to convert such statements into the equivalent Catalyst version before tracing occurs. Specifically, the following constructs are supported via AutoGraph:
- `for elem in iterable:` - These get converted into a `for_loop(0, len(iterable), 1)` with `elem = iterable[i]` automatically assigned using the iteration index, assuming `iterable` is convertible to a JAX array.  If this is not the case, the loop is executed as is in Python.
- `for i in range(start, stop, step):` These are converted directly into their equivalent `for_loop(start, stop, step)`. Contrary to the default Python `range`, when AutoGraph is enabled `range` can also accept dynamic tracers as `start`, `stop`, `step` values. If _any_ exception is raised during the tracing of the `for_loop` body, Catalyst will fall back to Python with a warning.
- `for i, elem in enemurate(iterable):` - These get converted into `for_loop(0, len(iterable), 1)` with the iteration index assigned to the variable chosen by the user (in this case `i`), and `elem = iterable[i]`. This also assumes that `iterable` is convertible to an array, and that the loop body traces without exception, otherwise the loop is executed in Python.

Note that a warning is raised when when a Python fallback is triggered due to a tracing exception. Python fallbacks caused by the iterable not being convertible to array are silent.

[sc-41287]