### PR TITLE
[Runtime] Remove nested directories for shared libs

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -207,7 +207,7 @@ jobs:
       run: |
         cmake -S runtime -B runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=runtime-build/lib \
+              -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$PWD/runtime-build/lib \
               -DPYTHON_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -Dpybind11_DIR=$(python${{ matrix.python_version }} -c "import pybind11; print(pybind11.get_cmake_dir())") \
               -DENABLE_LIGHTNING_KOKKOS=ON \

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -202,13 +202,17 @@ jobs:
         fail-on-cache-miss: True
 
     # Build Catalyst-Runtime
+    # TODO: remove v0.31.0 after lightning monorepo upgrade
     - name: Build Catalyst-Runtime
       run: |
         cmake -S runtime -B runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=runtime-build/lib \
               -DPYTHON_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -Dpybind11_DIR=$(python${{ matrix.python_version }} -c "import pybind11; print(pybind11.get_cmake_dir())") \
               -DENABLE_LIGHTNING_KOKKOS=ON \
+              -DLIGHTNING_GIT_TAG=v0.31.0 \
+              -DLIGHTNING_KOKKOS_GIT_TAG=latest_release \
               -DKokkos_ENABLE_SERIAL=ON \
               -DKokkos_ENABLE_OPENMP=ON \
               -DENABLE_OPENQASM=ON

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -41,8 +41,7 @@ jobs:
         with:
           name: runtime-build
           path: |
-            runtime-build/lib/capi/*.so
-            runtime-build/lib/backend/*.so
+            runtime-build/lib/*.so
           retention-days: 1
 
   llvm:

--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,8 @@ wheel:
 	cp $(MHLO_BUILD_DIR)/bin/mlir-hlo-opt $(MK_DIR)/frontend/catalyst/bin
 	cp $(DIALECTS_BUILD_DIR)/bin/quantum-opt $(MK_DIR)/frontend/catalyst/bin
 	# Copy libs to frontend/catalyst/lib
-	mkdir -p $(MK_DIR)/frontend/catalyst/lib/backend/ $(MK_DIR)/frontend/catalyst/lib/capi
-	cp $(RT_BUILD_DIR)/lib/backend/librt_backend.* $(MK_DIR)/frontend/catalyst/lib/backend/
-	cp $(RT_BUILD_DIR)/lib/capi/librt_capi.* $(MK_DIR)/frontend/catalyst/lib/capi
+	cp $(RT_BUILD_DIR)/lib/librt_backend.* $(MK_DIR)/frontend/catalyst/lib
+	cp $(RT_BUILD_DIR)/lib/librt_capi.* $(MK_DIR)/frontend/catalyst/lib
 	cp $(COPY_FLAGS) $(LLVM_BUILD_DIR)/lib/libmlir_float16_utils.* $(MK_DIR)/frontend/catalyst/lib
 	cp $(COPY_FLAGS) $(LLVM_BUILD_DIR)/lib/libmlir_c_runner_utils.* $(MK_DIR)/frontend/catalyst/lib
 	# Copy enzyme to frontend

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ wheel:
 	cp $(MHLO_BUILD_DIR)/bin/mlir-hlo-opt $(MK_DIR)/frontend/catalyst/bin
 	cp $(DIALECTS_BUILD_DIR)/bin/quantum-opt $(MK_DIR)/frontend/catalyst/bin
 	# Copy libs to frontend/catalyst/lib
+	mkdir -p $(MK_DIR)/frontend/catalyst/lib
 	cp $(RT_BUILD_DIR)/lib/librt_backend.* $(MK_DIR)/frontend/catalyst/lib
 	cp $(RT_BUILD_DIR)/lib/librt_capi.* $(MK_DIR)/frontend/catalyst/lib
 	cp $(COPY_FLAGS) $(LLVM_BUILD_DIR)/lib/libmlir_float16_utils.* $(MK_DIR)/frontend/catalyst/lib

--- a/frontend/catalyst/_configuration.py
+++ b/frontend/catalyst/_configuration.py
@@ -1,1 +1,6 @@
-INSTALLED = True
+""" When catalyst is packaged into a python wheel
+    the contents of this file will be overridden with:
+    INSTALLED = True
+"""
+
+INSTALLED = False

--- a/frontend/catalyst/_configuration.py
+++ b/frontend/catalyst/_configuration.py
@@ -1,7 +1,1 @@
-""" When catalyst is packaged into a python wheel
-    the contents of this file will be overridden with:
-
-    INSTALLED = True
-"""
-
-INSTALLED = False
+INSTALLED = True

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -370,8 +370,6 @@ class CompilerDriver:
         """
         mlir_lib_path = get_lib_path("llvm", "MLIR_LIB_DIR")
         rt_lib_path = get_lib_path("runtime", "RUNTIME_LIB_DIR")
-        rt_capi_path = os.path.join(rt_lib_path, "capi")
-        rt_backend_path = os.path.join(rt_lib_path, "backend")
         error_flag_apple = "-Wl,-arch_errors_fatal"
         error_flag_linux = ""
         error_flag = error_flag_linux if platform.system() == "Linux" else error_flag_apple
@@ -379,12 +377,10 @@ class CompilerDriver:
         default_flags = [
             "-shared",
             "-rdynamic",
-            f"-Wl,-rpath,{rt_capi_path}",
-            f"-Wl,-rpath,{rt_backend_path}",
+            f"-Wl,-rpath,{rt_lib_path}",
             f"-Wl,-rpath,{mlir_lib_path}",
             f"-L{mlir_lib_path}",
-            f"-L{rt_capi_path}",
-            f"-L{rt_backend_path}",
+            f"-L{rt_lib_path}",
             "-lrt_backend",
             "-lrt_capi",
             "-lpthread",

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -43,6 +43,7 @@ configure:
 	@echo "Configure Catalyst Runtime"
 	cmake -G Ninja -B $(RT_BUILD_DIR) . \
 		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
+		-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(RT_BUILD_DIR)/lib \
 		-DLIGHTNING_GIT_TAG=$(LIGHTNING_GIT_TAG_VALUE) \
 		-DLIGHTNING_KOKKOS_GIT_TAG=$(LIGHTNING_KOKKOS_GIT_TAG_VALUE) \
 		-DENABLE_LIGHTNING_KOKKOS=$(ENABLE_LIGHTNING_KOKKOS) \
@@ -86,9 +87,7 @@ examples: runtime
 .PHONY: clean
 clean:
 	@echo "clean build files"
-	rm -rf $(RT_BUILD_DIR)
-	rm -rf cov coverage.info
-	rm -rf $(MK_DIR)/BuildTidy
+	rm -rf $(RT_BUILD_DIR) cov coverage.info $(MK_DIR)/BuildTidy
 	$(MAKE) -C examples clean
 
 .PHONY: format

--- a/runtime/examples/Makefile
+++ b/runtime/examples/Makefile
@@ -2,8 +2,8 @@ COMPILER := clang
 
 BUILD_DIR := $(if ,$(BUILD_DIR),../build)
 
-QIR_LINK := -L$(BUILD_DIR)/lib/capi -L$(BUILD_DIR)/lib/backend
-QIR_RPATH := -Wl,-rpath,$(BUILD_DIR)/lib/capi:$(BUILD_DIR)/lib/backend
+QIR_LINK := -L$(BUILD_DIR)/lib
+QIR_RPATH := -Wl,-rpath,$(BUILD_DIR)/lib
 QIR_LIBS := -lrt_capi -lrt_backend
 
 .PHONY: all

--- a/runtime/lib/capi/CMakeLists.txt
+++ b/runtime/lib/capi/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(catalyst_qir_qis_obj OBJECT RuntimeCAPI.cpp)
 
 # link to rt_backend
 target_link_libraries(catalyst_qir_qis_obj ${CMAKE_DL_LIBS}
-                                            "-L${CMAKE_BINARY_DIR}/lib/backend"
+                                            "-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
                                             -lrt_backend
                                             rt_interfaces)
 


### PR DESCRIPTION
**Context:**
Remove nested directories `./lib/backend` and `./lib/capi` for the runtime shared libraries by adding `CMAKE_LIBRARY_OUTPUT_DIRECTORY`.

**Benefits:**
This is generally a better practice which also leads to a cleaner cmake calls. 
