### PR TITLE
[Docs] Add instructions for installing Catalyst from src on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,15 @@ In addition, we also provide a Python frontend for [PennyLane](https://pennylane
 
 ## Installation
 
-Catalyst is officially supported on Linux (x86_64) platforms, and pre-built binaries are being
-distributed via the Python Package Index (PyPI) for Python versions 3.9 and higher. To install it,
-simply run the following ``pip`` command:
+Catalyst is officially supported on Linux (x86_64) and macOS (aarch64) platforms, and pre-built
+binaries are being distributed via the Python Package Index (PyPI) for Python versions 3.9 and
+higher. To install it, simply run the following ``pip`` command:
 
 ```console
 pip install pennylane-catalyst
 ```
 
-Pre-built packages for Windows and MacOS are not yet available, and comptability with those
+Pre-built packages for Windows are not yet available, and comptability with those
 platforms is untested and cannot be guaranteed. If you are using one of these platforms, please
 try out our Docker and Dev Container images described in the [documentation](https://docs.pennylane.ai/projects/catalyst/en/latest/dev/installation.html#dev-containers)
 or click this button:

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ higher. To install it, simply run the following ``pip`` command:
 pip install pennylane-catalyst
 ```
 
-Pre-built packages for Windows are not yet available, and comptability with those
-platforms is untested and cannot be guaranteed. If you are using one of these platforms, please
+Pre-built packages for Windows are not yet available, and comptability with Windows 
+is untested and cannot be guaranteed. If you are using one of these platforms, please
 try out our Docker and Dev Container images described in the [documentation](https://docs.pennylane.ai/projects/catalyst/en/latest/dev/installation.html#dev-containers)
 or click this button:
 

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -93,8 +93,9 @@ They can be installed on macOS via:
 
   brew install cmake ninja
 
-If you install Catalyst on a macOS system with ``ARM`` architecture (e.g. Apple M1/M2), you 
-additionally need to install the ``llvm-tools-preview`` rustup component:
+If you install Catalyst on a macOS system with ``ARM`` architecture (e.g. Apple M1/M2), you
+additionally need to install `Rust <https://www.rust-lang.org/tools/install>`_ and the
+``llvm-tools-preview`` rustup component:
 
 .. code-block:: console
 

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -2,9 +2,9 @@ Installation
 ============
 
 
-Catalyst is officially supported on Linux (x86_64) platforms, and pre-built binaries are being
-distributed via the Python Package Index (PyPI) for Python versions 3.9 and higher. To install it,
-simply run the following ``pip`` command:
+Catalyst is officially supported on Linux (x86_64) and macOS (aarch64) platforms, and pre-built binaries
+are being distributed via the Python Package Index (PyPI) for Python versions 3.9 and higher. To install
+it, simply run the following ``pip`` command:
 
 .. code-block:: console
 

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -137,13 +137,11 @@ following make target from the top level directory:
 
   make all
 
-.. Note::
+To build the project on macOS with ``ARM`` architecture (e.g. Apple M1/M2):
 
-  To install on macOS:
+.. code-block:: console
 
-  .. code-block:: console
-
-    BUILD_QIR_STDLIB_FROM_SRC=ON ENABLE_LLD=OFF make all
+  BUILD_QIR_STDLIB_FROM_SRC=ON ENABLE_LLD=OFF make all
 
 To build each component one by one starting from the runtime, you can follow
 the instructions below.

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -87,6 +87,19 @@ They can be installed on Debian/Ubuntu via:
 
   sudo apt install clang lld ccache libomp-dev ninja-build make cmake
 
+They can be installed on macOS via:
+
+.. code-block:: console
+
+  brew install cmake ninja gpatch
+
+If you install Catalyst on a macOS with an ``ARM`` architecture, you need to install
+the ``llvm-tools-preview`` rustup component:
+
+.. code-block:: console
+
+  rustup component add llvm-tools-preview
+
 .. Note::
   If the CMake version available in your system is too old, you can also install up-to-date
   versions of it via ``pip install cmake``.
@@ -122,6 +135,14 @@ following make target from the top level directory:
 .. code-block:: console
 
   make all
+
+.. Note::
+
+  To install on macOS:
+
+  .. code-block:: console
+
+    BUILD_QIR_STDLIB_FROM_SRC=ON ENABLE_LLD=OFF make all
 
 To build each component one by one starting from the runtime, you can follow
 the instructions below.

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -93,8 +93,8 @@ They can be installed on macOS via:
 
   brew install cmake ninja
 
-If you install Catalyst on a macOS system with ``ARM`` architecture, you need to install
-the ``llvm-tools-preview`` rustup component:
+If you install Catalyst on a macOS system with ``ARM`` architecture (e.g. Apple M1/M2), you 
+additionally need to install the ``llvm-tools-preview`` rustup component:
 
 .. code-block:: console
 

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -91,9 +91,9 @@ They can be installed on macOS via:
 
 .. code-block:: console
 
-  brew install cmake ninja gpatch
+  brew install cmake ninja
 
-If you install Catalyst on a macOS with an ``ARM`` architecture, you need to install
+If you install Catalyst on a macOS system with ``ARM`` architecture, you need to install
 the ``llvm-tools-preview`` rustup component:
 
 .. code-block:: console


### PR DESCRIPTION
**Context:**
Update "installation" doc page to include instructions for installing Catalyst from srouce on macOS.  
