### PR TITLE
[Frontend] Hotfix for error flag on ubuntu machine without clang.

### DIFF
--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -386,7 +386,7 @@ class CompilerDriver:
             "-lmlir_c_runner_utils",  # required for memref.copy
         ]
 
-        if platform.system() != "Linux":
+        if platform.system() != "Linux":  # pragma: no cover
             default_flags += [error_flag_apple]
 
         return default_flags

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -372,8 +372,6 @@ class CompilerDriver:
         mlir_lib_path = get_lib_path("llvm", "MLIR_LIB_DIR")
         rt_lib_path = get_lib_path("runtime", "RUNTIME_LIB_DIR")
         error_flag_apple = "-Wl,-arch_errors_fatal"
-        error_flag_linux = ""
-        error_flag = error_flag_linux if platform.system() == "Linux" else error_flag_apple
 
         default_flags = [
             "-shared",
@@ -385,9 +383,11 @@ class CompilerDriver:
             "-lrt_backend",
             "-lrt_capi",
             "-lpthread",
-            f"{error_flag}",
             "-lmlir_c_runner_utils",  # required for memref.copy
         ]
+
+        if platform.system() != "Linux":
+            default_flags += [error_flag_apple]
 
         return default_flags
 

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -386,7 +386,7 @@ class CompilerDriver:
             "-lmlir_c_runner_utils",  # required for memref.copy
         ]
 
-        if platform.system() != "Linux":  # pragma: no cover
+        if platform.system() == "Darwin":  # pragma: no cover
             default_flags += [error_flag_apple]
 
         return default_flags


### PR DESCRIPTION
**Context:** The empty argument in the flags causes the ld failure when invoking gcc via subprocess (and inter-process communication) but not clang

**Description of the Change:** Only add flag when in macOS.

**Benefits:** User can avoid install clang.

**Related GitHub Issues:**
