### PR TITLE
Add enzyme sources to compatibility test matrix.

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -74,6 +74,14 @@ jobs:
         key: ${{ runner.os }}-ccache-${{ github.run_id }}
         restore-keys: ${{ runner.os }}-ccache-
 
+    - name: Clone Enzyme Submodule
+      if: |
+        steps.cache-enzyme.outputs.cache-hit != 'true'
+      uses: actions/checkout@v3
+      with:
+        repository: EnzymeAD/Enzyme
+        ref: ${{ needs.constants.outputs.enzyme_version }}
+        path: mlir/Enzyme
 
     - name: Install Catalyst (latest/stable)
       run: |

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -75,8 +75,6 @@ jobs:
         restore-keys: ${{ runner.os }}-ccache-
 
     - name: Clone Enzyme Submodule
-      if: |
-        steps.cache-enzyme.outputs.cache-hit != 'true'
       uses: actions/checkout@v3
       with:
         repository: EnzymeAD/Enzyme

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -46,7 +46,6 @@
 #include "Quantum/Transforms/Passes.h"
 
 #include "Enzyme.h"
-#include "PreserveNVVM.h"
 
 using namespace mlir;
 using namespace catalyst;


### PR DESCRIPTION
**Context:** With the changes in the compiler driver we need access to Enzyme sources when building the dialects. This is because we need access Enzyme.h for the forward declaration of `augmentPassBuilder`.

**Description of the Change:** Adds sources to Github Action script.

**Benefits:** Github action passes.

**Possible Drawbacks:** Additional time taken when building tests. We could instead just do an `extern void augmentPassBuilder(llvm::PassBuilder &PB); ` and it also works. This avoids increasing time for Github Actions. I think it might be worthwhile, but some might consider it not a good practice. Another alternative is to cache Enzyme sources.
