### PR TITLE
Add MHLO sources as dependency for matrix compatibility action.

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -58,6 +58,14 @@ jobs:
         path: llvm-build
         key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
         fail-on-cache-miss: True
+    - name: Get Cached MHLO Source
+      id: cache-mhlo-source
+      uses: actions/cache@v3
+      with:
+        path: mlir/mlir-hlo
+        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-source
+        enableCrossOsArchive: True
+        fail-on-cache-miss: True
     - uses: actions/cache@v3
       with:
         path: mhlo-build


### PR DESCRIPTION
**Context:** MHLO Sources are also needed for building the compiler driver.

**Description of the Change:** Use cached MHLO sources for the compiler driver.
