### PR TITLE
[CI] Rework wheel packaging for compiler driver

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -327,6 +327,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python${{ matrix.python_version }} -m pip install wheel pytest pytest-xdist
+        python${{ matrix.python_version }} -m pip install tensorflow-cpu # for autograph tests
 
     - name: Install Catalyst
       run: |

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -302,11 +302,12 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python_version: ${{ fromJson(needs.constants.outputs.python_versions) }}
-        container: ["quay.io/pypa/manylinux2014_x86_64", "ubuntu-20.04", "ubuntu-22.04"]
+        container_img: ["quay.io/pypa/manylinux2014_x86_64", "ubuntu-20.04", "ubuntu-22.04"]
 
     # To check all wheels for supported python3 versions
     name: Test Wheels (Python ${{ matrix.python_version }}) on ${{ matrix.container }}
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container_img }}
 
     steps:
     - name: Checkout Catalyst repo

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -260,9 +260,7 @@ jobs:
               -DPython3_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -DPython3_NumPy_INCLUDE_DIRS=$(python${{ matrix.python_version }} -c "import numpy as np; print(np.get_include())")
 
-        # TODO: when updating LLVM, test to see if mlir/unittests/Bytecode/BytecodeTest.cpp:55 is passing
-        # and remove filter
-        LIT_FILTER_OUT="Bytecode" cmake --build llvm-build --target check-mlir opt -j$(nproc)
+        cmake --build llvm-build --target check-mlir opt -j$(nproc)
 
     # Build Quantum and Gradient Dialects
     - name: Build MLIR Dialects
@@ -278,7 +276,7 @@ jobs:
               -DMHLO_BINARY_DIR=$GITHUB_WORKSPACE/mhlo-build/bin \
               -DENZYME_SRC_DIR=$GITHUB_WORKSPACE/mlir/Enzyme \
 
-        cmake --build quantum-build --target check-dialects -j$(nproc)
+        cmake --build quantum-build --target check-dialects quantum-lsp-server compiler_driver -j$(nproc)
 
     - name: Build wheel
       run: |

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -325,7 +325,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python${{ matrix.python_version }} -m pip install wheel pytest pytest-xdist
-        python${{ matrix.python_version }} -m pip install tensorflow-cpu # for autograph tests
+        python${{ matrix.python_version }} -m pip install tensorflow-cpu  # for autograph tests
 
     - name: Install Catalyst
       run: |

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -326,7 +326,6 @@ jobs:
     - name: Install Python dependencies
       run: |
         python${{ matrix.python_version }} -m pip install wheel pytest pytest-xdist
-        python${{ matrix.python_version }} -m pip install tensorflow-cpu  # for autograph tests
 
     - name: Install Catalyst
       run: |

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -260,7 +260,9 @@ jobs:
               -DPython3_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -DPython3_NumPy_INCLUDE_DIRS=$(python${{ matrix.python_version }} -c "import numpy as np; print(np.get_include())")
 
-        cmake --build llvm-build --target check-mlir opt -j$(nproc)
+        # TODO: when updating LLVM, test to see if mlir/unittests/Bytecode/BytecodeTest.cpp:55 is passing
+        # and remove filter
+        LIT_FILTER_OUT="Bytecode" cmake --build llvm-build --target check-mlir opt -j$(nproc)
 
     # Build Quantum and Gradient Dialects
     - name: Build MLIR Dialects

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -46,6 +46,13 @@ jobs:
       with:
         path:  mhlo-build
         key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-build
+    
+    - name: Cache MHLO Source
+      id: cache-mhlo-source
+      uses: actions/cache@v3
+      with:
+        path: mlir/mlir-hlo
+        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-source
 
     - name: Set Ownership in Container
       run: |
@@ -61,7 +68,9 @@ jobs:
         path: mlir/llvm-project
 
     - name: Clone MHLO Submodule
-      if: steps.cache-mhlo.outputs.cache-hit != 'true'
+      if: |
+        steps.cache-mhlo.outputs.cache-hit != 'true' ||
+        steps.cache-mhlo-source.outputs.cache-hit != 'true'
       uses: actions/checkout@v3
       with:
         repository: tensorflow/mlir-hlo
@@ -114,9 +123,17 @@ jobs:
         path:  enzyme-build
         key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-generic-build
 
+    - name: Cache Enzyme Source
+      id: cache-enzyme-source
+      uses: actions/cache@v3
+      with:
+        path:  mlir/Enzyme
+        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-source
+
     - name: Clone Enzyme Submodule
       if:  |
-        steps.cache-enzyme.outputs.cache-hit != 'true'
+        steps.cache-enzyme.outputs.cache-hit != 'true' ||
+        steps.cache-enzyme-source.outputs.cache-hit != 'true'
       uses: actions/checkout@v3
       with:
         repository: EnzymeAD/Enzyme
@@ -179,6 +196,15 @@ jobs:
         key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-generic-build-opt
         fail-on-cache-miss: True
 
+    - name: Get Cached MHLO Source
+      id: cache-mhlo-source
+      uses: actions/cache@v3
+      with:
+        path: mlir/mlir-hlo
+        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-source
+        enableCrossOsArchive: True
+        fail-on-cache-miss: True
+
     - name: Get Cached MHLO Build
       id: cache-mhlo
       uses: actions/cache@v3
@@ -193,6 +219,14 @@ jobs:
       with:
         path:  enzyme-build
         key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-generic-build
+        fail-on-cache-miss: True
+    
+    - name: Get Cached Enzyme Source
+      id: cache-enzyme-source
+      uses: actions/cache@v3
+      with:
+        path:  mlir/Enzyme
+        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-source
         fail-on-cache-miss: True
 
     # Build Catalyst-Runtime
@@ -239,7 +273,10 @@ jobs:
               -DQUANTUM_ENABLE_BINDINGS_PYTHON=ON \
               -DPython3_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -DPython3_NumPy_INCLUDE_DIRS=$(python${{ matrix.python_version }} -c "import numpy as np; print(np.get_include())") \
-              -DMLIR_DIR=$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir
+              -DMLIR_DIR=$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir \
+              -DMHLO_DIR=$GITHUB_WORKSPACE/mhlo-build/lib/cmake/mlir-hlo \
+              -DMHLO_BINARY_DIR=$GITHUB_WORKSPACE/mhlo-build/bin \
+              -DENZYME_SRC_DIR=$GITHUB_WORKSPACE/mlir/Enzyme \
 
         cmake --build quantum-build --target check-dialects -j$(nproc)
 

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -276,7 +276,7 @@ jobs:
               -DMHLO_BINARY_DIR=$GITHUB_WORKSPACE/mhlo-build/bin \
               -DENZYME_SRC_DIR=$GITHUB_WORKSPACE/mlir/Enzyme \
 
-        cmake --build quantum-build --target check-dialects quantum-lsp-server compiler_driver -j$(nproc)
+        cmake --build quantum-build --target check-dialects compiler_driver -j$(nproc)
 
     - name: Build wheel
       run: |

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -306,7 +306,6 @@ jobs:
     # To check all wheels for supported python3 versions
     name: Test Wheels (Python ${{ matrix.python_version }}) on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    container: ${{ matrix.container_img }}
 
     steps:
     - name: Checkout Catalyst repo

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -24,14 +24,12 @@ jobs:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v3
 
-    # Build and cache LLVM / MLIR
-    - name: Cache LLVM Build
-      id: cache-llvm-build
-      uses: actions/cache@v3
-      with:
-        path:  llvm-build
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-generic-build-opt
+    - name: Set Ownership in Container
+      run: |
+        # To fix the git issue with the owner of the checkout dir
+        chown -R $(id -u):$(id -g) $PWD
 
+    # Cache external project sources
     - name: Cache LLVM Source
       id: cache-llvm-source
       uses: actions/cache@v3
@@ -40,24 +38,21 @@ jobs:
         key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-source
         enableCrossOsArchive: True
 
-    - name: Cache MHLO Build
-      id: cache-mhlo
-      uses: actions/cache@v3
-      with:
-        path:  mhlo-build
-        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-build
-    
     - name: Cache MHLO Source
       id: cache-mhlo-source
       uses: actions/cache@v3
       with:
         path: mlir/mlir-hlo
         key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-source
+        enableCrossOsArchive: True
 
-    - name: Set Ownership in Container
-      run: |
-        # To fix the git issue with the owner of the checkout dir
-        chown -R $(id -u):$(id -g) $PWD
+    - name: Cache Enzyme Source
+      id: cache-enzyme-source
+      uses: actions/cache@v3
+      with:
+        path:  mlir/Enzyme
+        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-source
+        enableCrossOsArchive: True
 
     - name: Clone LLVM Submodule
       if: steps.cache-llvm-source.outputs.cache-hit != 'true'
@@ -68,20 +63,48 @@ jobs:
         path: mlir/llvm-project
 
     - name: Clone MHLO Submodule
-      if: |
-        steps.cache-mhlo.outputs.cache-hit != 'true' ||
-        steps.cache-mhlo-source.outputs.cache-hit != 'true'
+      if: steps.cache-mhlo-source.outputs.cache-hit != 'true'
       uses: actions/checkout@v3
       with:
         repository: tensorflow/mlir-hlo
         ref: ${{ needs.constants.outputs.mhlo_version }}
         path: mlir/mlir-hlo
 
+    - name: Clone Enzyme Submodule
+      if: steps.cache-enzyme-source.outputs.cache-hit != 'true'
+      uses: actions/checkout@v3
+      with:
+        repository: EnzymeAD/Enzyme
+        ref: ${{ needs.constants.outputs.enzyme_version }}
+        path: mlir/Enzyme
+
+    # Cache external project builds
+    - name: Cache LLVM Build
+      id: cache-llvm-build
+      uses: actions/cache@v3
+      with:
+        path:  llvm-build
+        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-generic-build-opt
+
+    - name: Cache MHLO Build
+      id: cache-mhlo-build
+      uses: actions/cache@v3
+      with:
+        path:  mhlo-build
+        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-build
+
+    - name: Cache Enzyme Build
+      id: cache-enzyme-build
+      uses: actions/cache@v3
+      with:
+        path:  enzyme-build
+        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-generic-build
+
     - name: Install dependencies (CentOS)
       if: |
         steps.cache-llvm-build.outputs.cache-hit != 'true' ||
-        steps.cache-mhlo.outputs.cache-hit != 'true' ||
-        steps.cache-enzyme.outputs.cache-hit != 'true'
+        steps.cache-mhlo-build.outputs.cache-hit != 'true' ||
+        steps.cache-enzyme-build.outputs.cache-hit != 'true'
       run: |
         # Reduce wait time for repos not responding
         cat /etc/yum.conf | sed "s/\[main\]/\[main\]\ntimeout=5/g" > /etc/yum.conf
@@ -100,10 +123,10 @@ jobs:
 
         # TODO: when updating LLVM, test to see if mlir/unittests/Bytecode/BytecodeTest.cpp:55 is passing
         # and remove filter
-        LIT_FILTER_OUT="Bytecode" cmake --build llvm-build --target lld check-mlir opt -j$(nproc)
+        LIT_FILTER_OUT="Bytecode" cmake --build llvm-build --target lld check-mlir opt
 
     - name: Build MHLO Dialect
-      if: steps.cache-mhlo.outputs.cache-hit != 'true'
+      if: steps.cache-mhlo-build.outputs.cache-hit != 'true'
       # building with LLD is a strong requirement for mhlo
       run: |
         export PATH=$GITHUB_WORKSPACE/llvm-build/bin:$PATH
@@ -113,43 +136,17 @@ jobs:
               -DMLIR_DIR=$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir \
               -DLLVM_ENABLE_LLD=ON
 
-        cmake --build mhlo-build --target check-mlir-hlo -j$(nproc)
-
-    # Build and cache Enzyme
-    - name: Cache Enzyme Build
-      id: cache-enzyme
-      uses: actions/cache@v3
-      with:
-        path:  enzyme-build
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-generic-build
-
-    - name: Cache Enzyme Source
-      id: cache-enzyme-source
-      uses: actions/cache@v3
-      with:
-        path:  mlir/Enzyme
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-source
-
-    - name: Clone Enzyme Submodule
-      if:  |
-        steps.cache-enzyme.outputs.cache-hit != 'true' ||
-        steps.cache-enzyme-source.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
-      with:
-        repository: EnzymeAD/Enzyme
-        ref: ${{ needs.constants.outputs.enzyme_version }}
-        path: mlir/Enzyme
+        cmake --build mhlo-build --target check-mlir-hlo
 
     - name: Build Enzyme
-      if: steps.cache-enzyme.outputs.cache-hit != 'true'
-
+      if: steps.cache-enzyme-build.outputs.cache-hit != 'true'
       run: |
-        export PATH=$GITHUB_WORKSPACE/llvm-build/bin:$PATH
-
         cmake -S mlir/Enzyme/enzyme -B enzyme-build -G Ninja \
-              -DLLVM_DIR=llvm-build/lib/cmake/llvm
+              -DCMAKE_BUILD_TYPE=Release \
+              -DLLVM_DIR=$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm \
+              -DENZYME_STATIC_LIB=ON
 
-        cmake --build enzyme-build
+        cmake --build enzyme-build --target EnzymeStatic-18
 
   catalyst-linux-wheels-x86-64:
     needs: [constants, build-dependencies]
@@ -206,7 +203,7 @@ jobs:
         fail-on-cache-miss: True
 
     - name: Get Cached MHLO Build
-      id: cache-mhlo
+      id: cache-mhlo-build
       uses: actions/cache@v3
       with:
         path:  mhlo-build
@@ -214,13 +211,13 @@ jobs:
         fail-on-cache-miss: True
 
     - name: Get Cached Enzyme Build
-      id: cache-enzyme
+      id: cache-enzyme-build
       uses: actions/cache@v3
       with:
         path:  enzyme-build
         key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-generic-build
         fail-on-cache-miss: True
-    
+
     - name: Get Cached Enzyme Source
       id: cache-enzyme-source
       uses: actions/cache@v3
@@ -244,7 +241,7 @@ jobs:
               -DKokkos_ENABLE_OPENMP=ON \
               -DENABLE_OPENQASM=ON
 
-        cmake --build runtime-build --target rt_capi -j$(nproc)
+        cmake --build runtime-build --target rt_capi
 
     # Build MLIR Python Bindings
     - name: Build MLIR Python Bindings
@@ -262,7 +259,7 @@ jobs:
 
         # TODO: when updating LLVM, test to see if mlir/unittests/Bytecode/BytecodeTest.cpp:55 is passing
         # and remove filter
-        LIT_FILTER_OUT="Bytecode" cmake --build llvm-build --target check-mlir opt -j$(nproc)
+        LIT_FILTER_OUT="Bytecode" cmake --build llvm-build --target check-mlir opt
 
     # Build Quantum and Gradient Dialects
     - name: Build MLIR Dialects
@@ -276,9 +273,10 @@ jobs:
               -DMLIR_DIR=$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir \
               -DMHLO_DIR=$GITHUB_WORKSPACE/mhlo-build/lib/cmake/mlir-hlo \
               -DMHLO_BINARY_DIR=$GITHUB_WORKSPACE/mhlo-build/bin \
-              -DENZYME_SRC_DIR=$GITHUB_WORKSPACE/mlir/Enzyme \
+              -DEnzyme_DIR=$GITHUB_WORKSPACE/enzyme-build \
+              -DENZYME_SRC_DIR=$GITHUB_WORKSPACE/mlir/Enzyme
 
-        cmake --build quantum-build --target check-dialects compiler_driver -j$(nproc)
+        cmake --build quantum-build --target check-dialects compiler_driver
 
     - name: Build wheel
       run: |

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -300,12 +300,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, ubuntu-20.04]
         python_version: ${{ fromJson(needs.constants.outputs.python_versions) }}
-        container_img: ["quay.io/pypa/manylinux2014_x86_64", "ubuntu-20.04", "ubuntu-22.04"]
 
     # To check all wheels for supported python3 versions
-    name: Test Wheels (Python ${{ matrix.python_version }}) on ${{ matrix.container }}
+    name: Test Wheels (Python ${{ matrix.python_version }}) on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     container: ${{ matrix.container_img }}
 

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -56,13 +56,6 @@ jobs:
     # Both the LLVM source and build folder are required for further dialect builds.
     # Caching is significantly faster than git cloning since LLVM is such a large repository.
 
-    - name: Cache LLVM Build
-      id: cache-llvm-build
-      uses: actions/cache@v3
-      with:
-        path: llvm-build
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
-
     - name: Cache LLVM Source
       id: cache-llvm-source
       uses: actions/cache@v3
@@ -78,6 +71,13 @@ jobs:
         repository: llvm/llvm-project
         ref: ${{ needs.constants.outputs.llvm_version }}
         path: mlir/llvm-project
+
+    - name: Cache LLVM Build
+      id: cache-llvm-build
+      uses: actions/cache@v3
+      with:
+        path: llvm-build
+        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
 
     - name: Install Deps
       if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -104,7 +104,7 @@ jobs:
     steps:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v3
-    
+
     - name: Cache MHLO Source
       id: cache-mhlo-source
       uses: actions/cache@v3
@@ -112,6 +112,14 @@ jobs:
         path: mlir/mlir-hlo
         key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-source
         enableCrossOsArchive: True
+
+    - name: Clone MHLO Submodule
+      if: steps.cache-mhlo-source.outputs.cache-hit != 'true'
+      uses: actions/checkout@v3
+      with:
+        repository: tensorflow/mlir-hlo
+        ref: ${{ needs.constants.outputs.mhlo_version }}
+        path: mlir/mlir-hlo
 
     - name: Cache MHLO Build
       id: cache-mhlo
@@ -139,16 +147,6 @@ jobs:
         key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
         fail-on-cache-miss: True
 
-    - name: Clone MHLO Submodule
-      if: |
-        steps.cache-mhlo.outputs.cache-hit != 'true' ||
-        steps.cache-mhlo-source.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
-      with:
-        repository: tensorflow/mlir-hlo
-        ref: ${{ needs.constants.outputs.mhlo_version }}
-        path: mlir/mlir-hlo
-
     - name: Install Deps
       if: steps.cache-mhlo.outputs.cache-hit != 'true'
       run: |
@@ -171,8 +169,24 @@ jobs:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v3
 
+    - name: Cache Enzyme Source
+      id: cache-enzyme-source
+      uses: actions/cache@v3
+      with:
+        path:  mlir/Enzyme
+        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-source
+        enableCrossOsArchive: True
+
+    - name: Clone Enzyme Submodule
+      if: steps.cache-enzyme-build.outputs.cache-hit != 'true'
+      uses: actions/checkout@v3
+      with:
+        repository: EnzymeAD/Enzyme
+        ref: ${{ needs.constants.outputs.enzyme_version }}
+        path: mlir/Enzyme
+
     - name: Cache Enzyme Build
-      id: cache-enzyme
+      id: cache-enzyme-build
       uses: actions/cache@v3
       with:
         path: enzyme-build
@@ -180,7 +194,7 @@ jobs:
 
     - name: Get Cached LLVM Source
       id: cache-llvm-source
-      if: steps.cache-enzyme.outputs.cache-hit != 'true'
+      if: steps.cache-enzyme-build.outputs.cache-hit != 'true'
       uses: actions/cache@v3
       with:
         path: mlir/llvm-project
@@ -190,29 +204,20 @@ jobs:
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build
-      if: steps.cache-enzyme.outputs.cache-hit != 'true'
+      if: steps.cache-enzyme-build.outputs.cache-hit != 'true'
       uses: actions/cache@v3
       with:
         path: llvm-build
         key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
         fail-on-cache-miss: True
 
-    - name: Clone Enzyme Submodule
-      if: |
-        steps.cache-enzyme.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
-      with:
-        repository: EnzymeAD/Enzyme
-        ref: ${{ needs.constants.outputs.enzyme_version }}
-        path: mlir/Enzyme
-
     - name: Install Deps
-      if: steps.cache-enzyme.outputs.cache-hit != 'true'
+      if: steps.cache-enzyme-build.outputs.cache-hit != 'true'
       run: |
         sudo apt-get install -y cmake ninja-build clang lld
 
     - name: Build Enzyme
-      if: steps.cache-enzyme.outputs.cache-hit != 'true'
+      if: steps.cache-enzyme-build.outputs.cache-hit != 'true'
       run: |
         LLVM_BUILD_DIR="$(pwd)/llvm-build" \
         ENZYME_BUILD_DIR="$(pwd)/enzyme-build" \
@@ -221,7 +226,7 @@ jobs:
 
   quantum:
     name: Quantum Dialects Build
-    needs: [constants, mhlo, llvm]
+    needs: [constants, llvm, mhlo, enzyme]
     runs-on: ubuntu-latest
 
     steps:
@@ -249,7 +254,7 @@ jobs:
         path: llvm-build
         key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
         fail-on-cache-miss: True
-    
+
     - name: Get Cached MHLO Source
       id: cache-mhlo-source
       uses: actions/cache@v3
@@ -258,13 +263,30 @@ jobs:
         key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-source
         enableCrossOsArchive: True
         fail-on-cache-miss: True
-    
+
     - name: Get Cached MHLO Build
       id: cache-mhlo
       uses: actions/cache@v3
       with:
         path: mhlo-build
         key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-build
+        fail-on-cache-miss: True
+
+    - name: Get Cached Enzyme Source
+      id: cache-enzyme-source
+      uses: actions/cache@v3
+      with:
+        path:  mlir/Enzyme
+        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-source
+        enableCrossOsArchive: True
+        fail-on-cache-miss: True
+
+    - name: Get Cached Enzyme Build
+      id: cache-enzyme-build
+      uses: actions/cache@v3
+      with:
+        path: enzyme-build
+        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-build
         fail-on-cache-miss: True
 
     - name: Cache CCache
@@ -278,21 +300,12 @@ jobs:
         key: ${{ runner.os }}-ccache-${{ github.run_id }}
         restore-keys: ${{ runner.os }}-ccache-
 
-    - name: Clone Enzyme Submodule
-      if: |
-        steps.cache-enzyme.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
-      with:
-        repository: EnzymeAD/Enzyme
-        ref: ${{ needs.constants.outputs.enzyme_version }}
-        path: mlir/Enzyme
-
     - name: Build MLIR Dialects
       run: |
         CCACHE_DIR="$(pwd)/.ccache" \
         LLVM_BUILD_DIR="$(pwd)/llvm-build" \
         MHLO_BUILD_DIR="$(pwd)/mhlo-build" \
-        ENZYME_SRC_DIR="$(pwd)/Enzyme" \
+        ENZYME_BUILD_DIR="$(pwd)/enzyme-build" \
         DIALECTS_BUILD_DIR="$(pwd)/quantum-build" \
         make dialects
 
@@ -308,7 +321,7 @@ jobs:
 
   frontend-tests:
     name: Frontend Tests
-    needs: [constants, runtime, mhlo, quantum]
+    needs: [constants, llvm, runtime, quantum]
     runs-on: ubuntu-latest
 
     steps:
@@ -329,22 +342,6 @@ jobs:
         key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
         fail-on-cache-miss: True
 
-    - name: Get Cached MHLO Build
-      id: cache-mhlo
-      uses: actions/cache@v3
-      with:
-        path: mhlo-build
-        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-build
-        fail-on-cache-miss: True
-
-    - name: Get Cached Enzyme Build
-      id: cache-enzyme
-      uses: actions/cache@v3
-      with:
-        path: enzyme-build
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-build
-        fail-on-cache-miss: True
-
     - name: Download Quantum Build Artifact
       uses: actions/download-artifact@v3
       with:
@@ -360,12 +357,9 @@ jobs:
     - name: Add Frontend Dependencies to PATH
       run: |
         echo "$(pwd)/llvm-build/bin" >> $GITHUB_PATH
-        echo "$(pwd)/mhlo-build/bin" >> $GITHUB_PATH
-        echo "$(pwd)/quantum-build/bin" >> $GITHUB_PATH
         echo "PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum" >> $GITHUB_ENV
         echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
         echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
-        chmod +x quantum-build/bin/quantum-opt  # artifact upload does not preserve permissions
 
     - name: Run Python Lit Tests
       run: |
@@ -391,7 +385,7 @@ jobs:
 
   frontend-tests-lightning-kokkos:
     name: Frontend Tests (backend="lightning.kokkos")
-    needs: [constants, runtime, mhlo, quantum]
+    needs: [constants, llvm, runtime, quantum]
     runs-on: ubuntu-latest
 
     steps:
@@ -412,22 +406,6 @@ jobs:
         key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
         fail-on-cache-miss: True
 
-    - name: Get Cached MHLO Build
-      id: cache-mhlo
-      uses: actions/cache@v3
-      with:
-        path: mhlo-build
-        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-build
-        fail-on-cache-miss: True
-
-    - name: Get Cached Enzyme Build
-      id: cache-enzyme
-      uses: actions/cache@v3
-      with:
-        path: enzyme-build
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-build
-        fail-on-cache-miss: True
-
     - name: Download Quantum Build Artifact
       uses: actions/download-artifact@v3
       with:
@@ -442,13 +420,9 @@ jobs:
 
     - name: Add Frontend Dependencies to PATH
       run: |
-        echo "$(pwd)/llvm-build/bin" >> $GITHUB_PATH
-        echo "$(pwd)/mhlo-build/bin" >> $GITHUB_PATH
-        echo "$(pwd)/quantum-build/bin" >> $GITHUB_PATH
         echo "PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum" >> $GITHUB_ENV
         echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
         echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
-        chmod +x quantum-build/bin/quantum-opt  # artifact upload does not preserve permissions
 
     - name: Install lightning.kokkos used in Python tests
       run: |
@@ -460,7 +434,7 @@ jobs:
 
   frontend-tests-openqasm-device:
     name: Frontend Tests (backend="openqasm3")
-    needs: [constants, mhlo, quantum, llvm]
+    needs: [constants, llvm, runtime, quantum]
     runs-on: ubuntu-latest
 
     steps:
@@ -479,22 +453,6 @@ jobs:
       with:
         path: llvm-build
         key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
-        fail-on-cache-miss: True
-
-    - name: Get Cached MHLO Build
-      id: cache-mhlo
-      uses: actions/cache@v3
-      with:
-        path: mhlo-build
-        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-build
-        fail-on-cache-miss: True
-
-    - name: Get Cached Enzyme Build
-      id: cache-enzyme
-      uses: actions/cache@v3
-      with:
-        path: enzyme-build
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-build
         fail-on-cache-miss: True
 
     - name: Download Quantum Build Artifact
@@ -518,13 +476,9 @@ jobs:
 
     - name: Add Frontend Dependencies to PATH
       run: |
-        echo "$(pwd)/llvm-build/bin" >> $GITHUB_PATH
-        echo "$(pwd)/mhlo-build/bin" >> $GITHUB_PATH
-        echo "$(pwd)/quantum-build/bin" >> $GITHUB_PATH
         echo "PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum" >> $GITHUB_ENV
         echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
         echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
-        chmod +x quantum-build/bin/quantum-opt  # artifact upload does not preserve permissions
 
     - name: Run Python Pytest Tests
       run: |

--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,7 @@ wheel:
 	# Copy mlir bindings & compiler driver to frontend/mlir_quantum
 	mkdir -p $(MK_DIR)/frontend/mlir_quantum/dialects
 	cp -R $(COPY_FLAGS) $(DIALECTS_BUILD_DIR)/python_packages/quantum/mlir_quantum/runtime $(MK_DIR)/frontend/mlir_quantum/runtime
-	cp $(COPY_FLAGS) $(DIALECTS_BUILD_DIR)/python_packages/quantum/mlir_quantum/ir.py $(MK_DIR)/frontend/mlir_quantum/
-	for file in arith tensor scf gradient quantum _ods_common ; do \
+	for file in gradient quantum _ods_common ; do \
 		cp $(COPY_FLAGS) $(DIALECTS_BUILD_DIR)/python_packages/quantum/mlir_quantum/dialects/*$${file}* $(MK_DIR)/frontend/mlir_quantum/dialects ; \
 	done
 	cp $(COPY_FLAGS) $(DIALECTS_BUILD_DIR)/python_packages/quantum/mlir_quantum/compiler_driver.so $(MK_DIR)/frontend/mlir_quantum/

--- a/Makefile
+++ b/Makefile
@@ -80,28 +80,22 @@ test-demos:
 
 wheel:
 	echo "INSTALLED = True" > $(MK_DIR)/frontend/catalyst/_configuration.py
-	# Copy bins to frontend/catalyst/bin
-	mkdir -p $(MK_DIR)/frontend/catalyst/bin
-	cp $(LLVM_BUILD_DIR)/bin/llc $(MK_DIR)/frontend/catalyst/bin
-	cp $(LLVM_BUILD_DIR)/bin/opt $(MK_DIR)/frontend/catalyst/bin
-	cp $(LLVM_BUILD_DIR)/bin/mlir-translate $(MK_DIR)/frontend/catalyst/bin
-	cp $(MHLO_BUILD_DIR)/bin/mlir-hlo-opt $(MK_DIR)/frontend/catalyst/bin
-	cp $(DIALECTS_BUILD_DIR)/bin/quantum-opt $(MK_DIR)/frontend/catalyst/bin
+
 	# Copy libs to frontend/catalyst/lib
 	mkdir -p $(MK_DIR)/frontend/catalyst/lib
 	cp $(RT_BUILD_DIR)/lib/librt_backend.* $(MK_DIR)/frontend/catalyst/lib
 	cp $(RT_BUILD_DIR)/lib/librt_capi.* $(MK_DIR)/frontend/catalyst/lib
 	cp $(COPY_FLAGS) $(LLVM_BUILD_DIR)/lib/libmlir_float16_utils.* $(MK_DIR)/frontend/catalyst/lib
 	cp $(COPY_FLAGS) $(LLVM_BUILD_DIR)/lib/libmlir_c_runner_utils.* $(MK_DIR)/frontend/catalyst/lib
-	# Copy enzyme to frontend
-	cp $(COPY_FLAGS) $(ENZYME_BUILD_DIR)/Enzyme/LLVMEnzyme-18.* $(MK_DIR)/frontend/catalyst/lib
-	# Copy mlir bindings to frontend/mlir_quantum
+
+	# Copy mlir bindings & compiler driver to frontend/mlir_quantum
 	mkdir -p $(MK_DIR)/frontend/mlir_quantum/dialects
 	cp -R $(COPY_FLAGS) $(DIALECTS_BUILD_DIR)/python_packages/quantum/mlir_quantum/runtime $(MK_DIR)/frontend/mlir_quantum/runtime
 	cp $(COPY_FLAGS) $(DIALECTS_BUILD_DIR)/python_packages/quantum/mlir_quantum/ir.py $(MK_DIR)/frontend/mlir_quantum/
 	for file in arith tensor scf gradient quantum _ods_common ; do \
 		cp $(COPY_FLAGS) $(DIALECTS_BUILD_DIR)/python_packages/quantum/mlir_quantum/dialects/*$${file}* $(MK_DIR)/frontend/mlir_quantum/dialects ; \
 	done
+	cp $(COPY_FLAGS) $(DIALECTS_BUILD_DIR)/python_packages/quantum/mlir_quantum/compiler_driver.so $(MK_DIR)/frontend/mlir_quantum/
 	find $(MK_DIR)/frontend -type d -name __pycache__ -exec rm -rf {} +
 
 	$(PYTHON) $(MK_DIR)/setup.py bdist_wheel

--- a/frontend/catalyst/ag_primitives.py
+++ b/frontend/catalyst/ag_primitives.py
@@ -483,7 +483,7 @@ class CRange:
     def __iter__(self) -> Iterator[int]:  # pragma: nocover
         return self.py_range.__iter__()
 
-    def __getitem__(self, __key: SupportsIndex | slice) -> int | range:  # pragma: nocover
+    def __getitem__(self, __key: Union[SupportsIndex, slice]) -> Union[int, range]:  # pragma: nocover
         return self.py_range.__getitem__(__key)
 
     def __reversed__(self) -> Iterator[int]:  # pragma: nocover

--- a/frontend/catalyst/ag_primitives.py
+++ b/frontend/catalyst/ag_primitives.py
@@ -483,7 +483,9 @@ class CRange:
     def __iter__(self) -> Iterator[int]:  # pragma: nocover
         return self.py_range.__iter__()
 
-    def __getitem__(self, __key: Union[SupportsIndex, slice]) -> Union[int, range]:  # pragma: nocover
+    def __getitem__(
+        self, __key: Union[SupportsIndex, slice]
+    ) -> Union[int, range]:  # pragma: nocover
         return self.py_range.__getitem__(__key)
 
     def __reversed__(self) -> Iterator[int]:  # pragma: nocover

--- a/frontend/catalyst/ag_primitives.py
+++ b/frontend/catalyst/ag_primitives.py
@@ -17,7 +17,7 @@ functions. The purpose is to convert imperative style code to functional or grap
 
 import functools
 import warnings
-from typing import Any, Callable, Iterator, SupportsIndex, Tuple
+from typing import Any, Callable, Iterator, SupportsIndex, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -208,7 +208,7 @@ def _call_python_for(body_fn, get_state, non_array_iterable):
 
 def for_stmt(
     iteration_target: Any,
-    _extra_test: Callable[[], bool] | None,
+    _extra_test: Union[Callable[[], bool], None],
     body_fn: Callable[[int], None],
     get_state: Callable[[], Tuple],
     set_state: Callable[[Tuple], None],

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -785,7 +785,7 @@ def qjit(
     verbose=False,
     logfile=None,
     pipelines=None,
-):
+):  # pylint: disable=too-many-arguments
     """A just-in-time decorator for PennyLane and JAX programs using Catalyst.
 
     This decorator enables both just-in-time and ahead-of-time compilation,

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -74,12 +74,6 @@ def run_writing_command(command: List[str], compile_options: Optional[CompileOpt
     subprocess.run(command, check=True)
 
 
-default_bin_paths = {
-    "llvm": os.path.join(package_root, "../../mlir/llvm-project/build/bin"),
-    "mhlo": os.path.join(package_root, "../../mlir/mlir-hlo/build/bin"),
-    "quantum": os.path.join(package_root, "../../mlir/build/bin"),
-}
-
 default_lib_paths = {
     "llvm": os.path.join(package_root, "../../mlir/llvm-project/build/lib"),
     "runtime": os.path.join(package_root, "../../runtime/build/lib"),

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -751,7 +751,7 @@ def _qmeasure_lowering(jax_ctx: mlir.LoweringRuleContext, qubit: ir.Value):
     result, new_qubit = MeasureOp(result_type, qubit.type, qubit).results
 
     result_from_elements_op = ir.RankedTensorType.get((), result.type)
-    from_elements_op = FromElementsOp.build_generic([result_from_elements_op], [result])
+    from_elements_op = FromElementsOp(result_from_elements_op, result)
 
     return (
         from_elements_op.results[0],
@@ -994,7 +994,7 @@ def _expval_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shots: in
 
     mres = ExpvalOp(result_type, obs, shots=shots_attr).result
     result_from_elements_op = ir.RankedTensorType.get((), result_type)
-    from_elements_op = FromElementsOp.build_generic([result_from_elements_op], [mres])
+    from_elements_op = FromElementsOp(result_from_elements_op, mres)
     return from_elements_op.results
 
 
@@ -1026,7 +1026,7 @@ def _var_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shots: int):
 
     mres = VarianceOp(result_type, obs, shots=shots_attr).result
     result_from_elements_op = ir.RankedTensorType.get((), result_type)
-    from_elements_op = FromElementsOp.build_generic([result_from_elements_op], [mres])
+    from_elements_op = FromElementsOp(result_from_elements_op, mres)
     return from_elements_op.results
 
 
@@ -1356,7 +1356,7 @@ def _qfor_lowering(
             body_args[0] = AddIOp(start_val, MulIOp(body_args[0], step_val))
         body_args[0] = IndexCastOp(loop_index_type, body_args[0]).result
         result_from_elements_op = ir.RankedTensorType.get((), loop_index_type)
-        from_elements_op = FromElementsOp.build_generic([result_from_elements_op], [body_args[0]])
+        from_elements_op = FromElementsOp(result_from_elements_op, body_args[0])
         body_args[0] = from_elements_op.result
 
         # recursively generate the mlir for the loop body

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -71,7 +71,7 @@ from catalyst.utils.extra_bindings import FromElementsOp, TensorExtractOp
 #
 # qbit
 #
-class AbstractQbit(AbstractValue):  # pylint: disable=abstract-method
+class AbstractQbit(AbstractValue):
     """Abstract Qbit"""
 
     hash_value = hash("AbstractQubit")
@@ -83,7 +83,7 @@ class AbstractQbit(AbstractValue):  # pylint: disable=abstract-method
         return self.hash_value
 
 
-class ConcreteQbit(AbstractQbit):  # pylint: disable=abstract-method
+class ConcreteQbit(AbstractQbit):
     """Concrete Qbit."""
 
 
@@ -95,7 +95,7 @@ def _qbit_lowering(aval):
 #
 # qreg
 #
-class AbstractQreg(AbstractValue):  # pylint: disable=abstract-method
+class AbstractQreg(AbstractValue):
     """Abstract quantum register."""
 
     hash_value = hash("AbstractQreg")
@@ -107,7 +107,7 @@ class AbstractQreg(AbstractValue):  # pylint: disable=abstract-method
         return self.hash_value
 
 
-class ConcreteQreg(AbstractQreg):  # pylint: disable=abstract-method
+class ConcreteQreg(AbstractQreg):
     """Concrete quantum register."""
 
 
@@ -119,7 +119,7 @@ def _qreg_lowering(aval):
 #
 # observable
 #
-class AbstractObs(AbstractValue):  # pylint: disable=abstract-method
+class AbstractObs(AbstractValue):
     """Abstract observable."""
 
     def __init__(self, num_qubits=None, primitive=None):
@@ -136,7 +136,7 @@ class AbstractObs(AbstractValue):  # pylint: disable=abstract-method
         return hash(self.primitive) + self.num_qubits
 
 
-class ConcreteObs(AbstractObs):  # pylint: disable=abstract-method
+class ConcreteObs(AbstractObs):
     """Concrete observable."""
 
 
@@ -1261,6 +1261,7 @@ def _qfor_loop_abstract_eval(*args, body_jaxpr, **kwargs):
     return body_jaxpr.out_avals
 
 
+# pylint: disable=too-many-arguments
 @qfor_p.def_impl
 def _qfor_def_impl(
     ctx, lower_bound, upper_bound, step, *iter_args_plus_consts, body_jaxpr, body_nconsts
@@ -1268,7 +1269,7 @@ def _qfor_def_impl(
     raise NotImplementedError()
 
 
-# pylint: disable=too-many-statements
+# pylint: disable=too-many-statements,too-many-arguments
 def _qfor_lowering(
     jax_ctx: mlir.LoweringRuleContext,
     lower_bound: ir.Value,

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -56,11 +56,10 @@ from mlir_quantum.dialects.quantum import (
     VarianceOp,
 )
 from mlir_quantum.dialects.quantum import YieldOp as QYieldOp
-from mlir_quantum.dialects.tensor import FromElementsOp
 from pennylane import QNode as pennylane_QNode
 
 from catalyst.utils.calculate_grad_shape import Signature, calculate_grad_shape
-from catalyst.utils.extra_bindings import TensorExtractOp
+from catalyst.utils.extra_bindings import FromElementsOp, TensorExtractOp
 
 # pylint: disable=unused-argument,too-many-lines
 

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -673,7 +673,9 @@ def jacobian(f: DifferentiableLike, *, method=None, h=None, argnum=None):
     )
 
 
-def jvp(f: DifferentiableLike, params, tangents, *, method=None, h=None, argnum=None):
+def jvp(
+    f: DifferentiableLike, params, tangents, *, method=None, h=None, argnum=None
+):  # pylint: disable=too-many-arguments
     """A :func:`~.qjit` compatible Jacobian-vector product for PennyLane/Catalyst.
 
     This function allows the Jacobian-vector Product of a hybrid quantum-classical function to be
@@ -757,7 +759,9 @@ def jvp(f: DifferentiableLike, params, tangents, *, method=None, h=None, argnum=
     return jvp_p.bind(*params, *tangents, jaxpr=jaxpr, fn=fn, grad_params=grad_params)
 
 
-def vjp(f: DifferentiableLike, params, cotangents, *, method=None, h=None, argnum=None):
+def vjp(
+    f: DifferentiableLike, params, cotangents, *, method=None, h=None, argnum=None
+):  # pylint: disable=too-many-arguments
     """A :func:`~.qjit` compatible Vector-Jacobian product for PennyLane/Catalyst.
 
     This function allows the Vector-Jacobian Product of a hybrid quantum-classical function to be

--- a/frontend/catalyst/utils/extra_bindings.py
+++ b/frontend/catalyst/utils/extra_bindings.py
@@ -29,7 +29,7 @@ class FromElementsOp(ir.OpView):
     _ODS_REGIONS = (0, True)
 
     def __init__(self, result, elements, *, loc=None, ip=None):
-        operands = [get_op_results_or_values(elements)]
+        operands = [elements]
         super().__init__(
             self.build_generic(
                 attributes={},

--- a/frontend/catalyst/utils/extra_bindings.py
+++ b/frontend/catalyst/utils/extra_bindings.py
@@ -48,7 +48,9 @@ class TensorExtractOp(ir.OpView):
 
     _ODS_REGIONS = (0, True)
 
-    def __init__(self, result, tensor, indices, *, loc=None, ip=None):
+    def __init__(
+        self, result, tensor, indices, *, loc=None, ip=None
+    ):  # pylint: disable=too-many-arguments
         operands = [get_op_result_or_value(tensor)]
         operands.extend(get_op_results_or_values(indices))
         super().__init__(

--- a/frontend/catalyst/utils/extra_bindings.py
+++ b/frontend/catalyst/utils/extra_bindings.py
@@ -23,6 +23,26 @@ from jaxlib.mlir.dialects._ods_common import (
 # pylint: disable=missing-class-docstring
 
 
+class FromElementsOp(ir.OpView):
+    OPERATION_NAME = "tensor.from_elements"
+
+    _ODS_REGIONS = (0, True)
+
+    def __init__(self, result, elements, *, loc=None, ip=None):
+        operands = [get_op_results_or_values(elements)]
+        super().__init__(
+            self.build_generic(
+                attributes={},
+                results=[result],
+                operands=operands,
+                successors=None,
+                regions=None,
+                loc=loc,
+                ip=ip,
+            )
+        )
+
+
 class TensorExtractOp(ir.OpView):
     OPERATION_NAME = "tensor.extract"
 

--- a/frontend/test/pytest/conftest.py
+++ b/frontend/test/pytest/conftest.py
@@ -18,6 +18,7 @@ Pytest configuration file for Catalyst test suite.
 import pytest
 
 try:
+    import catalyst
     import tensorflow as tf
 except (ImportError, ModuleNotFoundError) as e:
     tf_available = False

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -523,6 +523,7 @@ class TestConditionals:
             qjit(autograph=True)(qml.qnode(qml.device(backend, wires=1))(circuit))
 
 
+@pytest.mark.tf
 class TestForLoops:
     """Test that the autograph transformations produce correct results on for loops."""
 
@@ -1076,6 +1077,7 @@ class TestForLoops:
         assert f() == 9
 
 
+@pytest.mark.tf
 class TestMixed:
     """Test a mix of supported autograph conversions and Catalyst control flow."""
 

--- a/frontend/test/pytest/test_braket_remote_devices.py
+++ b/frontend/test/pytest/test_braket_remote_devices.py
@@ -62,7 +62,7 @@ class TestBraketS3Bucket:
     def test_s3_bucket_str(self, device):
         """Test with an undefined s3 bucket name."""
 
-        @qjit(keep_intermediate=True)
+        @qjit
         @qml.qnode(device)
         def circuit():
             qml.PauliX(wires=0)

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -75,6 +75,9 @@ class TestCompilerOptions:
         assert ("[SYSTEM]" in capture) if verbose else ("[SYSTEM]" not in capture)
         assert ("[LIB]" in capture) if verbose else ("[LIB]" not in capture)
         assert ("Dumping" in capture) if (verbose and keep_intermediate) else True
+        if keep_intermediate:
+            directory = os.path.join(os.getcwd(), workflow.__name__)
+            shutil.rmtree(directory)
 
 
 class TestCompilerWarnings:
@@ -188,6 +191,7 @@ class TestCompilerState:
         assert compiler.get_output_of("PreEnzymeOpt")
         assert compiler.get_output_of("Enzyme")
         assert compiler.get_output_of("None-existing-pipeline") is None
+        shutil.rmtree(compiler.last_workspace)
 
         compiler = Compiler(CompileOptions(keep_intermediate=False))
         compiler.run(mlir_module)
@@ -209,6 +213,7 @@ class TestCompilerState:
         identity_compiler = Compiler(CompileOptions(keep_intermediate=True))
         identity_compiler.run(mlir_module, pipelines=pipelines, lower_to_llvm=False)
         directory = os.path.join(os.getcwd(), workflow.__name__)
+        assert directory == identity_compiler.last_workspace
         assert os.path.exists(directory)
         files = os.listdir(directory)
         # The directory is non-empty. Should at least contain the original .mlir file
@@ -228,9 +233,12 @@ class TestCompilerState:
         # This means that we are not running any pass.
         identity_compiler = Compiler(CompileOptions(keep_intermediate=True))
         identity_compiler.run(mlir_module, pipelines=[], lower_to_llvm=False)
-        files = os.listdir(identity_compiler.last_workspace)
+        directory = os.path.join(os.getcwd(), workflow.__name__)
+        assert directory == identity_compiler.last_workspace
+        files = os.listdir(directory)
         # The directory is non-empty. Should at least contain the original .mlir file
         assert files
+        shutil.rmtree(directory)
 
     def test_compiler_driver_with_output_name(self):
         """Test with non-default output name."""
@@ -300,8 +308,8 @@ module @workflow {
   }
 }
 """
-        out = qjit(ir, keep_intermediate=True, verbose=True)
-        out(0.1)
+        compiled_function = qjit(ir)
+        assert compiled_function(0.1) == -1
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_scatter.py
+++ b/frontend/test/pytest/test_scatter.py
@@ -16,6 +16,7 @@
 
 import jax
 import numpy as np
+import pytest
 from jax import numpy as jnp
 
 from catalyst import qjit
@@ -56,3 +57,7 @@ def test_matrix():
 
     res = multiple_index_multiply(jnp.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]]))
     assert np.allclose(res, jnp.array([[0, 1, 2], [9, 12, 15], [18, 21, 24]]))
+
+
+if __name__ == "__main__":
+    pytest.main(["-x", __file__])

--- a/mlir/Makefile
+++ b/mlir/Makefile
@@ -77,7 +77,7 @@ enzyme:
 		-DCMAKE_C_COMPILER_LAUNCHER=$(COMPILER_LAUNCHER) \
 		-DCMAKE_CXX_COMPILER_LAUNCHER=$(COMPILER_LAUNCHER)
 
-	cmake --build $(ENZYME_BUILD_DIR)
+	cmake --build $(ENZYME_BUILD_DIR) --target EnzymeStatic-18
 
 .PHONY: dialects
 dialects:
@@ -87,8 +87,10 @@ dialects:
 		-DCMAKE_BUILD_TYPE=Release \
 		-DLLVM_ENABLE_ASSERTIONS=ON \
 		-DQUANTUM_ENABLE_BINDINGS_PYTHON=ON \
+		-DPython3_EXECUTABLE=$$(which $(PYTHON)) \
+		-DPython3_NumPy_INCLUDE_DIRS=$$($(PYTHON) -c "import numpy as np; print(np.get_include())") \
+		-DEnzyme_DIR=$(ENZYME_BUILD_DIR) \
 		-DENZYME_SRC_DIR=$(MK_DIR)/Enzyme \
-		-DPython3_EXECUTABLE="$(PYTHON)" \
 		-DMLIR_DIR=$(LLVM_BUILD_DIR)/lib/cmake/mlir \
 		-DMHLO_DIR=$(MHLO_BUILD_DIR)/lib/cmake/mlir-hlo \
 		-DMHLO_BINARY_DIR=$(MHLO_BUILD_DIR)/bin \

--- a/mlir/lib/CAPI/CMakeLists.txt
+++ b/mlir/lib/CAPI/CMakeLists.txt
@@ -2,7 +2,6 @@ add_mlir_public_c_api_library(QuantumCAPI
     Dialects.cpp
 
     LINK_LIBS PRIVATE
-    CatalystCompilerDriver
     MLIRCatalyst
     MLIRCatalystTransforms
     MLIRQuantum

--- a/mlir/lib/Driver/CMakeLists.txt
+++ b/mlir/lib/Driver/CMakeLists.txt
@@ -3,8 +3,13 @@
 # along with zstd.
 # TODO: Investigate if we can depend on only one
 set(EXTERNAL_LIB z)
-set(ENZYME_STATIC_LIB ON)
-add_subdirectory(${ENZYME_SRC_DIR}/enzyme ${CMAKE_CURRENT_BINARY_DIR}/enzyme)
+
+find_package(Enzyme REQUIRED CONFIG)
+message(STATUS "Using EnzymeConfig.cmake in: ${Enzyme_DIR}")
+
+# TODO: remove this once Enzyme exports the static library target
+find_library(ENZYME_LIB EnzymeStatic-${LLVM_VERSION_MAJOR} PATHS ${Enzyme_DIR}/Enzyme/)
+message(STATUS "Found Enzyme lib: ${ENZYME_LIB}")
 
 include_directories(${ENZYME_SRC_DIR}/enzyme/Enzyme)
 
@@ -34,6 +39,7 @@ set(LIBS
     MhloRegisterDialects
     StablehloRegister
     ${ALL_MHLO_PASSES}
+    ${ENZYME_LIB}
 )
 
 add_mlir_library(CatalystCompilerDriver
@@ -41,13 +47,6 @@ add_mlir_library(CatalystCompilerDriver
     CatalystLLVMTarget.cpp
 
     LINK_LIBS PRIVATE
-    MhloRegisterDialects
-    StablehloRegister
-    ${ALL_MHLO_PASSES}
     ${EXTERNAL_LIB}
     ${LIBS}
-
-    EnzymeStatic-${LLVM_VERSION_MAJOR}
-    DEPENDS
-    EnzymeStatic-${LLVM_VERSION_MAJOR}
     )

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -298,6 +298,7 @@ LogicalResult runLowering(const CompilerOptions &options, MLIRContext *ctx, Modu
         pipelineTailMarkers[lastPass].push_back(pipeline.name);
     }
 
+    size_t pipelineIdx = 0;
     if (options.keepIntermediate) {
 
         {
@@ -314,7 +315,6 @@ LogicalResult runLowering(const CompilerOptions &options, MLIRContext *ctx, Modu
         }
 
         {
-            size_t pipelineIdx = 0;
             auto printHandler =
                 [&](Pass *pass, CatalystIRPrinterConfig::PrintCallbackFn print) -> LogicalResult {
                 // Do not print if keepIntermediate is not set.

--- a/mlir/lib/Quantum/Transforms/ScatterPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ScatterPatterns.cpp
@@ -151,7 +151,7 @@ struct ScatterOpRewritePattern : public mlir::OpRewritePattern<mhlo::ScatterOp> 
             }
 
             // Set the arguments for the call op
-            ValueRange args{resultValue, updateValue};
+            std::vector<Value> args{resultValue, updateValue};
 
             // Call the function that computes the update
             Value updated = rewriter.create<func::CallOp>(loc, updateFnOp, args).getResult(0);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ extend-exclude = '''
 
 [tool.isort]
 profile = "black"
+skip = ["frontend/test/pytest/conftest.py"]
 extend_skip_glob = ["mlir/llvm-project/*", "mlir/mlir-hlo/*", ".git/*", ".vscode/*"]
 
 [build-system]


### PR DESCRIPTION
**Description of the Change:**

- Build compiler driver
- Remove unnecessary copy of files to the wheel
- Copy compiler-driver.so in the wheels
- Add `FromElementsOp(ir.OpView)` to extra bindings
- Fixes two memory issues in the C++ code base, unearthed by some tests
failing on the recent wheel build:
- A local variable was used outside of its stack scope. The variable was
captured by a lambda function whose lifetime exceeded that of the
variable.
- A ValueRange was generated without underlying storage that persists
for the lifetime of the range.

To prevent further such errors #49 should be resolved as soon as
possible.

Some other issues that were fixed:
- CMake was reconfigured such that building the dialects no longer
builds Enzyme, since the external project is built separately.
- Missing markers were added to new tensorflow tests. Tests should no
longer fail if tensorflow is not installed.
- Import Catalyst before TF

[sc-46569]