### PR TITLE
Fix segfaults in recent C++ compiler code

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -24,14 +24,12 @@ jobs:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v3
 
-    # Build and cache LLVM / MLIR
-    - name: Cache LLVM Build
-      id: cache-llvm-build
-      uses: actions/cache@v3
-      with:
-        path:  llvm-build
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-generic-build-opt
+    - name: Set Ownership in Container
+      run: |
+        # To fix the git issue with the owner of the checkout dir
+        chown -R $(id -u):$(id -g) $PWD
 
+    # Cache external project sources
     - name: Cache LLVM Source
       id: cache-llvm-source
       uses: actions/cache@v3
@@ -40,24 +38,21 @@ jobs:
         key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-source
         enableCrossOsArchive: True
 
-    - name: Cache MHLO Build
-      id: cache-mhlo
-      uses: actions/cache@v3
-      with:
-        path:  mhlo-build
-        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-build
-
     - name: Cache MHLO Source
       id: cache-mhlo-source
       uses: actions/cache@v3
       with:
         path: mlir/mlir-hlo
         key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-source
+        enableCrossOsArchive: True
 
-    - name: Set Ownership in Container
-      run: |
-        # To fix the git issue with the owner of the checkout dir
-        chown -R $(id -u):$(id -g) $PWD
+    - name: Cache Enzyme Source
+      id: cache-enzyme-source
+      uses: actions/cache@v3
+      with:
+        path:  mlir/Enzyme
+        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-source
+        enableCrossOsArchive: True
 
     - name: Clone LLVM Submodule
       if: steps.cache-llvm-source.outputs.cache-hit != 'true'
@@ -68,20 +63,48 @@ jobs:
         path: mlir/llvm-project
 
     - name: Clone MHLO Submodule
-      if: |
-        steps.cache-mhlo.outputs.cache-hit != 'true' ||
-        steps.cache-mhlo-source.outputs.cache-hit != 'true'
+      if: steps.cache-mhlo-source.outputs.cache-hit != 'true'
       uses: actions/checkout@v3
       with:
         repository: tensorflow/mlir-hlo
         ref: ${{ needs.constants.outputs.mhlo_version }}
         path: mlir/mlir-hlo
 
+    - name: Clone Enzyme Submodule
+      if: steps.cache-enzyme-source.outputs.cache-hit != 'true'
+      uses: actions/checkout@v3
+      with:
+        repository: EnzymeAD/Enzyme
+        ref: ${{ needs.constants.outputs.enzyme_version }}
+        path: mlir/Enzyme
+
+    # Cache external project builds
+    - name: Cache LLVM Build
+      id: cache-llvm-build
+      uses: actions/cache@v3
+      with:
+        path:  llvm-build
+        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-generic-build-opt
+
+    - name: Cache MHLO Build
+      id: cache-mhlo-build
+      uses: actions/cache@v3
+      with:
+        path:  mhlo-build
+        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-build
+
+    - name: Cache Enzyme Build
+      id: cache-enzyme-build
+      uses: actions/cache@v3
+      with:
+        path:  enzyme-build
+        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-generic-build
+
     - name: Install dependencies (CentOS)
       if: |
         steps.cache-llvm-build.outputs.cache-hit != 'true' ||
-        steps.cache-mhlo.outputs.cache-hit != 'true' ||
-        steps.cache-enzyme.outputs.cache-hit != 'true'
+        steps.cache-mhlo-build.outputs.cache-hit != 'true' ||
+        steps.cache-enzyme-build.outputs.cache-hit != 'true'
       run: |
         # Reduce wait time for repos not responding
         cat /etc/yum.conf | sed "s/\[main\]/\[main\]\ntimeout=5/g" > /etc/yum.conf
@@ -100,10 +123,10 @@ jobs:
 
         # TODO: when updating LLVM, test to see if mlir/unittests/Bytecode/BytecodeTest.cpp:55 is passing
         # and remove filter
-        LIT_FILTER_OUT="Bytecode" cmake --build llvm-build --target lld check-mlir opt -j$(nproc)
+        LIT_FILTER_OUT="Bytecode" cmake --build llvm-build --target lld check-mlir opt
 
     - name: Build MHLO Dialect
-      if: steps.cache-mhlo.outputs.cache-hit != 'true'
+      if: steps.cache-mhlo-build.outputs.cache-hit != 'true'
       # building with LLD is a strong requirement for mhlo
       run: |
         export PATH=$GITHUB_WORKSPACE/llvm-build/bin:$PATH
@@ -113,42 +136,14 @@ jobs:
               -DMLIR_DIR=$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir \
               -DLLVM_ENABLE_LLD=ON
 
-        cmake --build mhlo-build --target check-mlir-hlo -j$(nproc)
-
-    # Build and cache Enzyme
-    - name: Cache Enzyme Build
-      id: cache-enzyme
-      uses: actions/cache@v3
-      with:
-        path:  enzyme-build
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-generic-build
-
-    - name: Cache Enzyme Source
-      id: cache-enzyme-source
-      uses: actions/cache@v3
-      with:
-        path:  mlir/Enzyme
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-source
-        enableCrossOsArchive: True
-
-    - name: Clone Enzyme Submodule
-      if:  |
-        steps.cache-enzyme.outputs.cache-hit != 'true' ||
-        steps.cache-enzyme-source.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
-      with:
-        repository: EnzymeAD/Enzyme
-        ref: ${{ needs.constants.outputs.enzyme_version }}
-        path: mlir/Enzyme
+        cmake --build mhlo-build --target check-mlir-hlo
 
     - name: Build Enzyme
-      if: steps.cache-enzyme.outputs.cache-hit != 'true'
-
+      if: steps.cache-enzyme-build.outputs.cache-hit != 'true'
       run: |
-        export PATH=$GITHUB_WORKSPACE/llvm-build/bin:$PATH
-
         cmake -S mlir/Enzyme/enzyme -B enzyme-build -G Ninja \
-              -DLLVM_DIR=llvm-build/lib/cmake/llvm \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DLLVM_DIR=$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm \
               -DENZYME_STATIC_LIB=ON
 
         cmake --build enzyme-build --target EnzymeStatic-18
@@ -208,7 +203,7 @@ jobs:
         fail-on-cache-miss: True
 
     - name: Get Cached MHLO Build
-      id: cache-mhlo
+      id: cache-mhlo-build
       uses: actions/cache@v3
       with:
         path:  mhlo-build
@@ -216,7 +211,7 @@ jobs:
         fail-on-cache-miss: True
 
     - name: Get Cached Enzyme Build
-      id: cache-enzyme
+      id: cache-enzyme-build
       uses: actions/cache@v3
       with:
         path:  enzyme-build
@@ -246,7 +241,7 @@ jobs:
               -DKokkos_ENABLE_OPENMP=ON \
               -DENABLE_OPENQASM=ON
 
-        cmake --build runtime-build --target rt_capi -j$(nproc)
+        cmake --build runtime-build --target rt_capi
 
     # Build MLIR Python Bindings
     - name: Build MLIR Python Bindings
@@ -264,7 +259,7 @@ jobs:
 
         # TODO: when updating LLVM, test to see if mlir/unittests/Bytecode/BytecodeTest.cpp:55 is passing
         # and remove filter
-        LIT_FILTER_OUT="Bytecode" cmake --build llvm-build --target check-mlir opt -j$(nproc)
+        LIT_FILTER_OUT="Bytecode" cmake --build llvm-build --target check-mlir opt
 
     # Build Quantum and Gradient Dialects
     - name: Build MLIR Dialects
@@ -278,9 +273,10 @@ jobs:
               -DMLIR_DIR=$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir \
               -DMHLO_DIR=$GITHUB_WORKSPACE/mhlo-build/lib/cmake/mlir-hlo \
               -DMHLO_BINARY_DIR=$GITHUB_WORKSPACE/mhlo-build/bin \
-              -DENZYME_SRC_DIR=$GITHUB_WORKSPACE/mlir/Enzyme \
+              -DEnzyme_DIR=$GITHUB_WORKSPACE/enzyme-build \
+              -DENZYME_SRC_DIR=$GITHUB_WORKSPACE/mlir/Enzyme
 
-        cmake --build quantum-build --target check-dialects compiler_driver -j$(nproc)
+        cmake --build quantum-build --target check-dialects compiler_driver
 
     - name: Build wheel
       run: |

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -150,7 +150,7 @@ jobs:
               -DLLVM_DIR=llvm-build/lib/cmake/llvm \
               -DENZYME_STATIC_LIB=ON
 
-        cmake --build enzyme-build
+        cmake --build enzyme-build --target EnzymeStatic-18
 
   catalyst-linux-wheels-x86-64:
     needs: [constants, build-dependencies]

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -46,7 +46,7 @@ jobs:
       with:
         path:  mhlo-build
         key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-build
-    
+
     - name: Cache MHLO Source
       id: cache-mhlo-source
       uses: actions/cache@v3
@@ -147,7 +147,8 @@ jobs:
         export PATH=$GITHUB_WORKSPACE/llvm-build/bin:$PATH
 
         cmake -S mlir/Enzyme/enzyme -B enzyme-build -G Ninja \
-              -DLLVM_DIR=llvm-build/lib/cmake/llvm
+              -DLLVM_DIR=llvm-build/lib/cmake/llvm \
+              -DENZYME_STATIC_LIB=ON
 
         cmake --build enzyme-build
 
@@ -220,7 +221,7 @@ jobs:
         path:  enzyme-build
         key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-generic-build
         fail-on-cache-miss: True
-    
+
     - name: Get Cached Enzyme Source
       id: cache-enzyme-source
       uses: actions/cache@v3

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -129,6 +129,7 @@ jobs:
       with:
         path:  mlir/Enzyme
         key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-source
+        enableCrossOsArchive: True
 
     - name: Clone Enzyme Submodule
       if:  |

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -104,7 +104,7 @@ jobs:
     steps:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v3
-    
+
     - name: Cache MHLO Source
       id: cache-mhlo-source
       uses: actions/cache@v3
@@ -171,16 +171,34 @@ jobs:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v3
 
+    - name: Cache Enzyme Source
+      id: cache-enzyme-source
+      uses: actions/cache@v3
+      with:
+        path:  mlir/Enzyme
+        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-source
+        enableCrossOsArchive: True
+
     - name: Cache Enzyme Build
-      id: cache-enzyme
+      id: cache-enzyme-build
       uses: actions/cache@v3
       with:
         path: enzyme-build
         key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-build
 
+    - name: Clone Enzyme Submodule
+      if: |
+        steps.cache-enzyme-source.outputs.cache-hit != 'true' ||
+        steps.cache-enzyme-build.outputs.cache-hit != 'true'
+      uses: actions/checkout@v3
+      with:
+        repository: EnzymeAD/Enzyme
+        ref: ${{ needs.constants.outputs.enzyme_version }}
+        path: mlir/Enzyme
+
     - name: Get Cached LLVM Source
       id: cache-llvm-source
-      if: steps.cache-enzyme.outputs.cache-hit != 'true'
+      if: steps.cache-enzyme-build.outputs.cache-hit != 'true'
       uses: actions/cache@v3
       with:
         path: mlir/llvm-project
@@ -190,29 +208,20 @@ jobs:
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build
-      if: steps.cache-enzyme.outputs.cache-hit != 'true'
+      if: steps.cache-enzyme-build.outputs.cache-hit != 'true'
       uses: actions/cache@v3
       with:
         path: llvm-build
         key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
         fail-on-cache-miss: True
 
-    - name: Clone Enzyme Submodule
-      if: |
-        steps.cache-enzyme.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
-      with:
-        repository: EnzymeAD/Enzyme
-        ref: ${{ needs.constants.outputs.enzyme_version }}
-        path: mlir/Enzyme
-
     - name: Install Deps
-      if: steps.cache-enzyme.outputs.cache-hit != 'true'
+      if: steps.cache-enzyme-build.outputs.cache-hit != 'true'
       run: |
         sudo apt-get install -y cmake ninja-build clang lld
 
     - name: Build Enzyme
-      if: steps.cache-enzyme.outputs.cache-hit != 'true'
+      if: steps.cache-enzyme-build.outputs.cache-hit != 'true'
       run: |
         LLVM_BUILD_DIR="$(pwd)/llvm-build" \
         ENZYME_BUILD_DIR="$(pwd)/enzyme-build" \
@@ -249,7 +258,7 @@ jobs:
         path: llvm-build
         key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
         fail-on-cache-miss: True
-    
+
     - name: Get Cached MHLO Source
       id: cache-mhlo-source
       uses: actions/cache@v3
@@ -258,13 +267,30 @@ jobs:
         key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-source
         enableCrossOsArchive: True
         fail-on-cache-miss: True
-    
+
     - name: Get Cached MHLO Build
       id: cache-mhlo
       uses: actions/cache@v3
       with:
         path: mhlo-build
         key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-build
+        fail-on-cache-miss: True
+
+    - name: Get Cached Enzyme Source
+      id: cache-enzyme-source
+      uses: actions/cache@v3
+      with:
+        path:  mlir/Enzyme
+        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-source
+        enableCrossOsArchive: True
+        fail-on-cache-miss: True
+
+    - name: Get Cached Enzyme Build
+      id: cache-enzyme-build
+      uses: actions/cache@v3
+      with:
+        path: enzyme-build
+        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-build
         fail-on-cache-miss: True
 
     - name: Cache CCache
@@ -278,21 +304,12 @@ jobs:
         key: ${{ runner.os }}-ccache-${{ github.run_id }}
         restore-keys: ${{ runner.os }}-ccache-
 
-    - name: Clone Enzyme Submodule
-      if: |
-        steps.cache-enzyme.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
-      with:
-        repository: EnzymeAD/Enzyme
-        ref: ${{ needs.constants.outputs.enzyme_version }}
-        path: mlir/Enzyme
-
     - name: Build MLIR Dialects
       run: |
         CCACHE_DIR="$(pwd)/.ccache" \
         LLVM_BUILD_DIR="$(pwd)/llvm-build" \
         MHLO_BUILD_DIR="$(pwd)/mhlo-build" \
-        ENZYME_SRC_DIR="$(pwd)/Enzyme" \
+        ENZYME_BUILD_DIR="$(pwd)/enzyme-build" \
         DIALECTS_BUILD_DIR="$(pwd)/quantum-build" \
         make dialects
 

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -56,13 +56,6 @@ jobs:
     # Both the LLVM source and build folder are required for further dialect builds.
     # Caching is significantly faster than git cloning since LLVM is such a large repository.
 
-    - name: Cache LLVM Build
-      id: cache-llvm-build
-      uses: actions/cache@v3
-      with:
-        path: llvm-build
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
-
     - name: Cache LLVM Source
       id: cache-llvm-source
       uses: actions/cache@v3
@@ -78,6 +71,13 @@ jobs:
         repository: llvm/llvm-project
         ref: ${{ needs.constants.outputs.llvm_version }}
         path: mlir/llvm-project
+
+    - name: Cache LLVM Build
+      id: cache-llvm-build
+      uses: actions/cache@v3
+      with:
+        path: llvm-build
+        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
 
     - name: Install Deps
       if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -113,6 +113,14 @@ jobs:
         key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-source
         enableCrossOsArchive: True
 
+    - name: Clone MHLO Submodule
+      if: steps.cache-mhlo-source.outputs.cache-hit != 'true'
+      uses: actions/checkout@v3
+      with:
+        repository: tensorflow/mlir-hlo
+        ref: ${{ needs.constants.outputs.mhlo_version }}
+        path: mlir/mlir-hlo
+
     - name: Cache MHLO Build
       id: cache-mhlo
       uses: actions/cache@v3
@@ -138,16 +146,6 @@ jobs:
         path: llvm-build
         key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
         fail-on-cache-miss: True
-
-    - name: Clone MHLO Submodule
-      if: |
-        steps.cache-mhlo.outputs.cache-hit != 'true' ||
-        steps.cache-mhlo-source.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
-      with:
-        repository: tensorflow/mlir-hlo
-        ref: ${{ needs.constants.outputs.mhlo_version }}
-        path: mlir/mlir-hlo
 
     - name: Install Deps
       if: steps.cache-mhlo.outputs.cache-hit != 'true'
@@ -179,22 +177,20 @@ jobs:
         key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-source
         enableCrossOsArchive: True
 
+    - name: Clone Enzyme Submodule
+      if: steps.cache-enzyme-build.outputs.cache-hit != 'true'
+      uses: actions/checkout@v3
+      with:
+        repository: EnzymeAD/Enzyme
+        ref: ${{ needs.constants.outputs.enzyme_version }}
+        path: mlir/Enzyme
+
     - name: Cache Enzyme Build
       id: cache-enzyme-build
       uses: actions/cache@v3
       with:
         path: enzyme-build
         key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-build
-
-    - name: Clone Enzyme Submodule
-      if: |
-        steps.cache-enzyme-source.outputs.cache-hit != 'true' ||
-        steps.cache-enzyme-build.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
-      with:
-        repository: EnzymeAD/Enzyme
-        ref: ${{ needs.constants.outputs.enzyme_version }}
-        path: mlir/Enzyme
 
     - name: Get Cached LLVM Source
       id: cache-llvm-source

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -230,7 +230,7 @@ jobs:
 
   quantum:
     name: Quantum Dialects Build
-    needs: [constants, mhlo, llvm]
+    needs: [constants, llvm, mhlo, enzyme]
     runs-on: ubuntu-latest
 
     steps:
@@ -325,7 +325,7 @@ jobs:
 
   frontend-tests:
     name: Frontend Tests
-    needs: [constants, runtime, mhlo, quantum]
+    needs: [constants, llvm, runtime, quantum]
     runs-on: ubuntu-latest
 
     steps:
@@ -346,22 +346,6 @@ jobs:
         key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
         fail-on-cache-miss: True
 
-    - name: Get Cached MHLO Build
-      id: cache-mhlo
-      uses: actions/cache@v3
-      with:
-        path: mhlo-build
-        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-build
-        fail-on-cache-miss: True
-
-    - name: Get Cached Enzyme Build
-      id: cache-enzyme
-      uses: actions/cache@v3
-      with:
-        path: enzyme-build
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-build
-        fail-on-cache-miss: True
-
     - name: Download Quantum Build Artifact
       uses: actions/download-artifact@v3
       with:
@@ -377,12 +361,9 @@ jobs:
     - name: Add Frontend Dependencies to PATH
       run: |
         echo "$(pwd)/llvm-build/bin" >> $GITHUB_PATH
-        echo "$(pwd)/mhlo-build/bin" >> $GITHUB_PATH
-        echo "$(pwd)/quantum-build/bin" >> $GITHUB_PATH
         echo "PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum" >> $GITHUB_ENV
         echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
         echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
-        chmod +x quantum-build/bin/quantum-opt  # artifact upload does not preserve permissions
 
     - name: Run Python Lit Tests
       run: |
@@ -408,7 +389,7 @@ jobs:
 
   frontend-tests-lightning-kokkos:
     name: Frontend Tests (backend="lightning.kokkos")
-    needs: [constants, runtime, mhlo, quantum]
+    needs: [constants, llvm, runtime, quantum]
     runs-on: ubuntu-latest
 
     steps:
@@ -429,22 +410,6 @@ jobs:
         key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
         fail-on-cache-miss: True
 
-    - name: Get Cached MHLO Build
-      id: cache-mhlo
-      uses: actions/cache@v3
-      with:
-        path: mhlo-build
-        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-build
-        fail-on-cache-miss: True
-
-    - name: Get Cached Enzyme Build
-      id: cache-enzyme
-      uses: actions/cache@v3
-      with:
-        path: enzyme-build
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-build
-        fail-on-cache-miss: True
-
     - name: Download Quantum Build Artifact
       uses: actions/download-artifact@v3
       with:
@@ -459,13 +424,9 @@ jobs:
 
     - name: Add Frontend Dependencies to PATH
       run: |
-        echo "$(pwd)/llvm-build/bin" >> $GITHUB_PATH
-        echo "$(pwd)/mhlo-build/bin" >> $GITHUB_PATH
-        echo "$(pwd)/quantum-build/bin" >> $GITHUB_PATH
         echo "PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum" >> $GITHUB_ENV
         echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
         echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
-        chmod +x quantum-build/bin/quantum-opt  # artifact upload does not preserve permissions
 
     - name: Install lightning.kokkos used in Python tests
       run: |
@@ -477,7 +438,7 @@ jobs:
 
   frontend-tests-openqasm-device:
     name: Frontend Tests (backend="openqasm3")
-    needs: [constants, mhlo, quantum, llvm]
+    needs: [constants, llvm, runtime, quantum]
     runs-on: ubuntu-latest
 
     steps:
@@ -496,22 +457,6 @@ jobs:
       with:
         path: llvm-build
         key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
-        fail-on-cache-miss: True
-
-    - name: Get Cached MHLO Build
-      id: cache-mhlo
-      uses: actions/cache@v3
-      with:
-        path: mhlo-build
-        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-build
-        fail-on-cache-miss: True
-
-    - name: Get Cached Enzyme Build
-      id: cache-enzyme
-      uses: actions/cache@v3
-      with:
-        path: enzyme-build
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-build
         fail-on-cache-miss: True
 
     - name: Download Quantum Build Artifact
@@ -535,13 +480,9 @@ jobs:
 
     - name: Add Frontend Dependencies to PATH
       run: |
-        echo "$(pwd)/llvm-build/bin" >> $GITHUB_PATH
-        echo "$(pwd)/mhlo-build/bin" >> $GITHUB_PATH
-        echo "$(pwd)/quantum-build/bin" >> $GITHUB_PATH
         echo "PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum" >> $GITHUB_ENV
         echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
         echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
-        chmod +x quantum-build/bin/quantum-opt  # artifact upload does not preserve permissions
 
     - name: Run Python Pytest Tests
       run: |

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -523,6 +523,7 @@ class TestConditionals:
             qjit(autograph=True)(qml.qnode(qml.device(backend, wires=1))(circuit))
 
 
+@pytest.mark.tf
 class TestForLoops:
     """Test that the autograph transformations produce correct results on for loops."""
 
@@ -1076,6 +1077,7 @@ class TestForLoops:
         assert f() == 9
 
 
+@pytest.mark.tf
 class TestMixed:
     """Test a mix of supported autograph conversions and Catalyst control flow."""
 

--- a/frontend/test/pytest/test_scatter.py
+++ b/frontend/test/pytest/test_scatter.py
@@ -16,6 +16,7 @@
 
 import jax
 import numpy as np
+import pytest
 from jax import numpy as jnp
 
 from catalyst import qjit
@@ -56,3 +57,7 @@ def test_matrix():
 
     res = multiple_index_multiply(jnp.array([[0, 1, 2], [3, 4, 5], [6, 7, 8]]))
     assert np.allclose(res, jnp.array([[0, 1, 2], [9, 12, 15], [18, 21, 24]]))
+
+
+if __name__ == "__main__":
+    pytest.main(["-x", __file__])

--- a/mlir/Makefile
+++ b/mlir/Makefile
@@ -77,7 +77,7 @@ enzyme:
 		-DCMAKE_C_COMPILER_LAUNCHER=$(COMPILER_LAUNCHER) \
 		-DCMAKE_CXX_COMPILER_LAUNCHER=$(COMPILER_LAUNCHER)
 
-	cmake --build $(ENZYME_BUILD_DIR)
+	cmake --build $(ENZYME_BUILD_DIR) --target EnzymeStatic-18
 
 .PHONY: dialects
 dialects:

--- a/mlir/Makefile
+++ b/mlir/Makefile
@@ -87,8 +87,10 @@ dialects:
 		-DCMAKE_BUILD_TYPE=Release \
 		-DLLVM_ENABLE_ASSERTIONS=ON \
 		-DQUANTUM_ENABLE_BINDINGS_PYTHON=ON \
+		-DPython3_EXECUTABLE=$$(which $(PYTHON)) \
+		-DPython3_NumPy_INCLUDE_DIRS=$$($(PYTHON) -c "import numpy as np; print(np.get_include())") \
+		-DEnzyme_DIR=$(ENZYME_BUILD_DIR) \
 		-DENZYME_SRC_DIR=$(MK_DIR)/Enzyme \
-		-DPython3_EXECUTABLE="$(PYTHON)" \
 		-DMLIR_DIR=$(LLVM_BUILD_DIR)/lib/cmake/mlir \
 		-DMHLO_DIR=$(MHLO_BUILD_DIR)/lib/cmake/mlir-hlo \
 		-DMHLO_BINARY_DIR=$(MHLO_BUILD_DIR)/bin \

--- a/mlir/lib/CAPI/CMakeLists.txt
+++ b/mlir/lib/CAPI/CMakeLists.txt
@@ -2,7 +2,6 @@ add_mlir_public_c_api_library(QuantumCAPI
     Dialects.cpp
 
     LINK_LIBS PRIVATE
-    CatalystCompilerDriver
     MLIRCatalyst
     MLIRCatalystTransforms
     MLIRQuantum

--- a/mlir/lib/Driver/CMakeLists.txt
+++ b/mlir/lib/Driver/CMakeLists.txt
@@ -3,8 +3,13 @@
 # along with zstd.
 # TODO: Investigate if we can depend on only one
 set(EXTERNAL_LIB z)
-set(ENZYME_STATIC_LIB ON)
-add_subdirectory(${ENZYME_SRC_DIR}/enzyme ${CMAKE_CURRENT_BINARY_DIR}/enzyme)
+
+find_package(Enzyme REQUIRED CONFIG)
+message(STATUS "Using EnzymeConfig.cmake in: ${Enzyme_DIR}")
+
+# TODO: remove this once Enzyme exports the static library target
+find_library(ENZYME_LIB EnzymeStatic-${LLVM_VERSION_MAJOR} PATHS ${Enzyme_DIR}/Enzyme/)
+message(STATUS "Found Enzyme lib: ${ENZYME_LIB}")
 
 include_directories(${ENZYME_SRC_DIR}/enzyme/Enzyme)
 
@@ -34,6 +39,7 @@ set(LIBS
     MhloRegisterDialects
     StablehloRegister
     ${ALL_MHLO_PASSES}
+    ${ENZYME_LIB}
 )
 
 add_mlir_library(CatalystCompilerDriver
@@ -41,13 +47,6 @@ add_mlir_library(CatalystCompilerDriver
     CatalystLLVMTarget.cpp
 
     LINK_LIBS PRIVATE
-    MhloRegisterDialects
-    StablehloRegister
-    ${ALL_MHLO_PASSES}
     ${EXTERNAL_LIB}
     ${LIBS}
-
-    EnzymeStatic-${LLVM_VERSION_MAJOR}
-    DEPENDS
-    EnzymeStatic-${LLVM_VERSION_MAJOR}
     )

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -298,6 +298,7 @@ LogicalResult runLowering(const CompilerOptions &options, MLIRContext *ctx, Modu
         pipelineTailMarkers[lastPass].push_back(pipeline.name);
     }
 
+    size_t pipelineIdx = 0;
     if (options.keepIntermediate) {
 
         {
@@ -314,7 +315,6 @@ LogicalResult runLowering(const CompilerOptions &options, MLIRContext *ctx, Modu
         }
 
         {
-            size_t pipelineIdx = 0;
             auto printHandler =
                 [&](Pass *pass, CatalystIRPrinterConfig::PrintCallbackFn print) -> LogicalResult {
                 // Do not print if keepIntermediate is not set.

--- a/mlir/lib/Quantum/Transforms/ScatterPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ScatterPatterns.cpp
@@ -151,7 +151,7 @@ struct ScatterOpRewritePattern : public mlir::OpRewritePattern<mhlo::ScatterOp> 
             }
 
             // Set the arguments for the call op
-            ValueRange args{resultValue, updateValue};
+            std::vector<Value> args{resultValue, updateValue};
 
             // Call the function that computes the update
             Value updated = rewriter.create<func::CallOp>(loc, updateFnOp, args).getResult(0);


### PR DESCRIPTION
Fixes two memory issues in the C++ code base, unearthed by some tests failing on the recent wheel build:
- A local variable was used outside of its stack scope. The variable was captured by a lambda function whose lifetime exceeded that of the variable. 
- A ValueRange was generated without underlying storage that persists for the lifetime of the range.

To prevent further such errors #49 should be resolved as soon as possible.

Some other issues that were fixed:
- CMake was reconfigured such that building the dialects no longer builds Enzyme, since the external project is built separately.
- Missing markers were added to new tensorflow tests. Tests should no longer fail if tensorflow is not installed.

[sc-46566]