### PR TITLE
Update the clang-format config file to ensure consistency with PL code style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,8 +1,62 @@
+# Generic definitions
+Language: Cpp
 BasedOnStyle: LLVM
-UseTab: Never
+PointerAlignment: Left
 IndentWidth: 4
 TabWidth: 4
-AccessModifierOffset: -2
-BreakBeforeBraces: Stroustrup
-FixNamespaceComments: true
+Standard: Latest
+
+# Identify common pointer style, and use throughout.
+DerivePointerAlignment: false
+
+AlignAfterOpenBracket: Align
+
+# Allow single-line definitions and contracted definitions
+AllowShortBlocksOnASingleLine: Always
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLambdasOnASingleLine: All
+
+# Add appropriate line-breaks and spacing
+AlwaysBreakTemplateDeclarations: true
+BitFieldColonSpacing: Both
+BreakBeforeBraces: Attach
+BreakBeforeConceptDeclarations: true
+BreakConstructorInitializers: AfterColon
+BreakInheritanceList: AfterComma
+BreakStringLiterals: true
+
+# Match Python code column limit
 ColumnLimit: 100
+Cpp11BracedListStyle: true
+FixNamespaceComments: true
+
+# Include structure rules for ordering.
+# System, then user-defined system, then local.
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex:           '<[[:alnum:]]+?\.*>'
+    Priority:        3
+  - Regex:           '<[[:alnum:]].+(hpp|hh|h|cuh)>'
+    Priority:        2
+  - Regex:           '\"[[:alnum:]].+(hpp|hh|h|cuh)\"'
+    Priority:        1
+
+IndentCaseLabels: true
+IndentPPDirectives: None
+
+PackConstructorInitializers: NextLine
+
+QualifierAlignment: Left
+ReferenceAlignment: Left
+
+# Sorting rules
+SortIncludes: true
+SortUsingDeclarations: true
+
+SpaceAfterLogicalNot: false
+SpaceBeforeAssignmentOperators: true
+
+UseTab: Never
+

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -776,6 +776,7 @@ class JAX_QJIT:
         return self.jaxed_function(*args, **kwargs)
 
 
+# pylint: disable=too-many-arguments
 def qjit(
     fn=None,
     *,

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1270,7 +1270,7 @@ def _qfor_def_impl(
     raise NotImplementedError()
 
 
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments, too-many-statements
 def _qfor_lowering(
     jax_ctx: mlir.LoweringRuleContext,
     lower_bound: ir.Value,

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -72,7 +72,7 @@ from catalyst.utils.extra_bindings import TensorExtractOp
 #
 # qbit
 #
-class AbstractQbit(AbstractValue):  # pylint: disable=abstract-method
+class AbstractQbit(AbstractValue):
     """Abstract Qbit"""
 
     hash_value = hash("AbstractQubit")
@@ -84,7 +84,7 @@ class AbstractQbit(AbstractValue):  # pylint: disable=abstract-method
         return self.hash_value
 
 
-class ConcreteQbit(AbstractQbit):  # pylint: disable=abstract-method
+class ConcreteQbit(AbstractQbit):
     """Concrete Qbit."""
 
 
@@ -96,7 +96,7 @@ def _qbit_lowering(aval):
 #
 # qreg
 #
-class AbstractQreg(AbstractValue):  # pylint: disable=abstract-method
+class AbstractQreg(AbstractValue):
     """Abstract quantum register."""
 
     hash_value = hash("AbstractQreg")
@@ -108,7 +108,7 @@ class AbstractQreg(AbstractValue):  # pylint: disable=abstract-method
         return self.hash_value
 
 
-class ConcreteQreg(AbstractQreg):  # pylint: disable=abstract-method
+class ConcreteQreg(AbstractQreg):
     """Concrete quantum register."""
 
 
@@ -120,7 +120,7 @@ def _qreg_lowering(aval):
 #
 # observable
 #
-class AbstractObs(AbstractValue):  # pylint: disable=abstract-method
+class AbstractObs(AbstractValue):
     """Abstract observable."""
 
     def __init__(self, num_qubits=None, primitive=None):
@@ -137,7 +137,7 @@ class AbstractObs(AbstractValue):  # pylint: disable=abstract-method
         return hash(self.primitive) + self.num_qubits
 
 
-class ConcreteObs(AbstractObs):  # pylint: disable=abstract-method
+class ConcreteObs(AbstractObs):
     """Concrete observable."""
 
 
@@ -1262,6 +1262,7 @@ def _qfor_loop_abstract_eval(*args, body_jaxpr, **kwargs):
     return body_jaxpr.out_avals
 
 
+# pylint: disable=too-many-arguments
 @qfor_p.def_impl
 def _qfor_def_impl(
     ctx, lower_bound, upper_bound, step, *iter_args_plus_consts, body_jaxpr, body_nconsts
@@ -1269,7 +1270,7 @@ def _qfor_def_impl(
     raise NotImplementedError()
 
 
-# pylint: disable=too-many-statements
+# pylint: disable=too-many-arguments
 def _qfor_lowering(
     jax_ctx: mlir.LoweringRuleContext,
     lower_bound: ir.Value,

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -673,6 +673,7 @@ def jacobian(f: DifferentiableLike, *, method=None, h=None, argnum=None):
     )
 
 
+# pylint: disable=too-many-arguments
 def jvp(f: DifferentiableLike, params, tangents, *, method=None, h=None, argnum=None):
     """A :func:`~.qjit` compatible Jacobian-vector product for PennyLane/Catalyst.
 
@@ -757,6 +758,7 @@ def jvp(f: DifferentiableLike, params, tangents, *, method=None, h=None, argnum=
     return jvp_p.bind(*params, *tangents, jaxpr=jaxpr, fn=fn, grad_params=grad_params)
 
 
+# pylint: disable=too-many-arguments
 def vjp(f: DifferentiableLike, params, cotangents, *, method=None, h=None, argnum=None):
     """A :func:`~.qjit` compatible Vector-Jacobian product for PennyLane/Catalyst.
 

--- a/frontend/catalyst/utils/extra_bindings.py
+++ b/frontend/catalyst/utils/extra_bindings.py
@@ -28,6 +28,7 @@ class TensorExtractOp(ir.OpView):
 
     _ODS_REGIONS = (0, True)
 
+    # pylint: disable=too-many-arguments
     def __init__(self, result, tensor, indices, *, loc=None, ip=None):
         operands = [get_op_result_or_value(tensor)]
         operands.extend(get_op_results_or_values(indices))

--- a/frontend/catalyst/utils/wrapper.cpp
+++ b/frontend/catalyst/utils/wrapper.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
 #include <pybind11/pybind11.h>
+
+#include <iostream>
 
 // Emit a compile time warning if we are using numpy
 // functions that are not compatible with numpy 1.22
@@ -28,64 +29,54 @@
 namespace py = pybind11;
 
 struct memref_beginning_t {
-    char *allocated;
-    char *aligned;
+    char* allocated;
+    char* aligned;
     size_t offset;
 };
 
-size_t memref_size_based_on_rank(size_t rank)
-{
-    size_t allocated = sizeof(void *);
-    size_t aligned = sizeof(void *);
+size_t memref_size_based_on_rank(size_t rank) {
+    size_t allocated = sizeof(void*);
+    size_t aligned = sizeof(void*);
     size_t offset = sizeof(size_t);
     size_t sizes = rank * sizeof(size_t);
     size_t strides = rank * sizeof(size_t);
     return allocated + aligned + offset + sizes + strides;
 }
 
-size_t *to_sizes(char *base, size_t rank)
-{
-    if (rank == 0) {
-        return NULL;
-    }
+size_t* to_sizes(char* base, size_t rank) {
+    if (rank == 0) { return NULL; }
 
-    size_t allocated = sizeof(void *);
-    size_t aligned = sizeof(void *);
+    size_t allocated = sizeof(void*);
+    size_t aligned = sizeof(void*);
     size_t offset = sizeof(size_t);
     size_t bytes_offset = allocated + aligned + offset;
-    return (size_t *)(base + bytes_offset);
+    return (size_t*)(base + bytes_offset);
 }
 
-size_t *to_strides(char *base, size_t rank)
-{
-    if (rank == 0) {
-        return NULL;
-    }
+size_t* to_strides(char* base, size_t rank) {
+    if (rank == 0) { return NULL; }
 
-    size_t allocated = sizeof(void *);
-    size_t aligned = sizeof(void *);
+    size_t allocated = sizeof(void*);
+    size_t aligned = sizeof(void*);
     size_t offset = sizeof(size_t);
     size_t sizes = rank * sizeof(size_t);
     size_t bytes_offset = allocated + aligned + offset + sizes;
-    return (size_t *)(base + bytes_offset);
+    return (size_t*)(base + bytes_offset);
 }
 
-void free_wrap(PyObject *capsule)
-{
-    void *obj = PyCapsule_GetPointer(capsule, NULL);
+void free_wrap(PyObject* capsule) {
+    void* obj = PyCapsule_GetPointer(capsule, NULL);
     free(obj);
 }
 
-const npy_intp *npy_get_dimensions(char *memref, size_t rank)
-{
-    size_t *sizes = to_sizes(memref, rank);
-    const npy_intp *dims = (npy_intp *)sizes;
+const npy_intp* npy_get_dimensions(char* memref, size_t rank) {
+    size_t* sizes = to_sizes(memref, rank);
+    const npy_intp* dims = (npy_intp*)sizes;
     return dims;
 }
 
-const npy_intp *npy_get_strides(char *memref, size_t element_size, size_t rank)
-{
-    size_t *strides = to_strides(memref, rank);
+const npy_intp* npy_get_strides(char* memref, size_t element_size, size_t rank) {
+    size_t* strides = to_strides(memref, rank);
     for (unsigned int idx = 0; idx < rank; idx++) {
         // memref strides are in terms of elements.
         // numpy strides are in terms of bytes.
@@ -93,21 +84,18 @@ const npy_intp *npy_get_strides(char *memref, size_t element_size, size_t rank)
         strides[idx] *= (size_t)element_size;
     }
 
-    npy_intp *npy_strides = (npy_intp *)strides;
+    npy_intp* npy_strides = (npy_intp*)strides;
     return npy_strides;
 }
 
-py::list move_returns(void *memref_array_ptr, py::object result_desc, py::object transfer,
-                      py::dict numpy_arrays)
-{
+py::list move_returns(void* memref_array_ptr, py::object result_desc, py::object transfer,
+                      py::dict numpy_arrays) {
     py::list returns;
-    if (result_desc.is_none()) {
-        return returns;
-    }
+    if (result_desc.is_none()) { return returns; }
 
     auto ctypes = py::module::import("ctypes");
-    using f_ptr_t = bool (*)(void *);
-    f_ptr_t f_transfer_ptr = *((f_ptr_t *)ctypes.attr("addressof")(transfer).cast<size_t>());
+    using f_ptr_t = bool (*)(void*);
+    f_ptr_t f_transfer_ptr = *((f_ptr_t*)ctypes.attr("addressof")(transfer).cast<size_t>());
 
     /* Data from the result description */
     auto ranks = result_desc.attr("_ranks_");
@@ -117,14 +105,14 @@ py::list move_returns(void *memref_array_ptr, py::object result_desc, py::object
     size_t memref_len = ranks.attr("__len__")().cast<size_t>();
     size_t offset = 0;
 
-    char *memref_array_bytes = (char *)(memref_array_ptr);
+    char* memref_array_bytes = (char*)(memref_array_ptr);
 
     for (size_t idx = 0; idx < memref_len; idx++) {
         unsigned int rank_i = ranks.attr("__getitem__")(idx).cast<unsigned int>();
-        char *memref_i_beginning = memref_array_bytes + offset;
+        char* memref_i_beginning = memref_array_bytes + offset;
         offset += memref_size_based_on_rank(rank_i);
 
-        struct memref_beginning_t *memref = (struct memref_beginning_t *)memref_i_beginning;
+        struct memref_beginning_t* memref = (struct memref_beginning_t*)memref_i_beginning;
         bool is_in_rt_heap = f_transfer_ptr(memref->allocated);
 
         if (!is_in_rt_heap) {
@@ -142,35 +130,27 @@ py::list move_returns(void *memref_array_ptr, py::object result_desc, py::object
             continue;
         }
 
-        const npy_intp *dims = npy_get_dimensions(memref_i_beginning, rank_i);
+        const npy_intp* dims = npy_get_dimensions(memref_i_beginning, rank_i);
 
         size_t element_size = sizes.attr("__getitem__")(idx).cast<size_t>();
-        const npy_intp *strides = npy_get_strides(memref_i_beginning, element_size, rank_i);
+        const npy_intp* strides = npy_get_strides(memref_i_beginning, element_size, rank_i);
 
         auto etype_i = etypes.attr("__getitem__")(idx);
-        PyArray_Descr *descr = PyArray_DescrFromTypeObject(etype_i.ptr());
-        if (!descr) {
-            throw std::runtime_error("PyArray_Descr failed.");
-        }
+        PyArray_Descr* descr = PyArray_DescrFromTypeObject(etype_i.ptr());
+        if (!descr) { throw std::runtime_error("PyArray_Descr failed."); }
 
-        void *aligned = memref->aligned;
-        PyObject *new_array =
+        void* aligned = memref->aligned;
+        PyObject* new_array =
             PyArray_NewFromDescr(&PyArray_Type, descr, rank_i, dims, strides, aligned, 0, NULL);
-        if (!new_array) {
-            throw std::runtime_error("PyArray_NewFromDescr failed.");
-        }
+        if (!new_array) { throw std::runtime_error("PyArray_NewFromDescr failed."); }
 
-        PyObject *capsule =
+        PyObject* capsule =
             PyCapsule_New(memref->allocated, NULL, (PyCapsule_Destructor)&free_wrap);
-        if (!capsule) {
-            throw std::runtime_error("PyCapsule_New failed.");
-        }
+        if (!capsule) { throw std::runtime_error("PyCapsule_New failed."); }
 
-        int retval = PyArray_SetBaseObject((PyArrayObject *)new_array, capsule);
+        int retval = PyArray_SetBaseObject((PyArrayObject*)new_array, capsule);
         bool success = 0 == retval;
-        if (!success) {
-            throw std::runtime_error("PyArray_SetBaseObject failed.");
-        }
+        if (!success) { throw std::runtime_error("PyArray_SetBaseObject failed."); }
 
         returns.append(new_array);
 
@@ -182,10 +162,8 @@ py::list move_returns(void *memref_array_ptr, py::object result_desc, py::object
         // sent as an input to the generated function.
         // Upon following entries it is extended with the numpy.arrays
         // which are the output of the generated function.
-        PyObject *pyLong = PyLong_FromLong((size_t)memref->allocated);
-        if (!pyLong) {
-            throw std::runtime_error("PyLong_FromLong failed.");
-        }
+        PyObject* pyLong = PyLong_FromLong((size_t)memref->allocated);
+        if (!pyLong) { throw std::runtime_error("PyLong_FromLong failed."); }
 
         numpy_arrays[pyLong] = new_array;
 
@@ -196,23 +174,20 @@ py::list move_returns(void *memref_array_ptr, py::object result_desc, py::object
 }
 
 py::list wrap(py::object func, py::tuple py_args, py::object result_desc, py::object transfer,
-              py::dict numpy_arrays)
-{
+              py::dict numpy_arrays) {
     py::list returns;
 
     size_t length = py_args.attr("__len__")().cast<size_t>();
-    if (length != 2) {
-        throw std::invalid_argument("Invalid number of arguments.");
-    }
+    if (length != 2) { throw std::invalid_argument("Invalid number of arguments."); }
 
     auto ctypes = py::module::import("ctypes");
-    using f_ptr_t = void (*)(void *, void *);
-    f_ptr_t f_ptr = *reinterpret_cast<f_ptr_t *>(ctypes.attr("addressof")(func).cast<size_t>());
+    using f_ptr_t = void (*)(void*, void*);
+    f_ptr_t f_ptr = *reinterpret_cast<f_ptr_t*>(ctypes.attr("addressof")(func).cast<size_t>());
 
     auto value0 = py_args.attr("__getitem__")(0);
-    void *value0_ptr = *reinterpret_cast<void **>(ctypes.attr("addressof")(value0).cast<size_t>());
+    void* value0_ptr = *reinterpret_cast<void**>(ctypes.attr("addressof")(value0).cast<size_t>());
     auto value1 = py_args.attr("__getitem__")(1);
-    void *value1_ptr = *reinterpret_cast<void **>(ctypes.attr("addressof")(value1).cast<size_t>());
+    void* value1_ptr = *reinterpret_cast<void**>(ctypes.attr("addressof")(value1).cast<size_t>());
 
     f_ptr(value0_ptr, value1_ptr);
     returns = move_returns(value0_ptr, result_desc, transfer, numpy_arrays);
@@ -220,13 +195,10 @@ py::list wrap(py::object func, py::tuple py_args, py::object result_desc, py::ob
     return returns;
 }
 
-PYBIND11_MODULE(wrapper, m)
-{
+PYBIND11_MODULE(wrapper, m) {
     m.doc() = "wrapper module";
     m.def("wrap", &wrap, "A wrapper function.");
     int retval = _import_array();
     bool success = retval >= 0;
-    if (!success) {
-        throw pybind11::import_error("Couldn't import numpy array C-API.");
-    }
+    if (!success) { throw pybind11::import_error("Couldn't import numpy array C-API."); }
 }

--- a/mlir/include/Catalyst/IR/CatalystOps.h
+++ b/mlir/include/Catalyst/IR/CatalystOps.h
@@ -14,13 +14,12 @@
 
 #pragma once
 
+#include "Catalyst/IR/CatalystDialect.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
-
-#include "Catalyst/IR/CatalystDialect.h"
 
 #define GET_OP_CLASSES
 #include "Catalyst/IR/CatalystOps.h.inc"

--- a/mlir/include/Catalyst/Transforms/Passes.h
+++ b/mlir/include/Catalyst/Transforms/Passes.h
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <memory>
-
 #include "mlir/Pass/Pass.h"
+
+#include <memory>
 
 namespace catalyst {
 

--- a/mlir/include/Catalyst/Utils/CallGraph.h
+++ b/mlir/include/Catalyst/Utils/CallGraph.h
@@ -18,7 +18,7 @@ namespace catalyst {
 
 /// Traverse the call graph and execute the `processFunc` callback for each `func.func` op
 /// encountered.
-void traverseCallGraph(mlir::func::FuncOp start, mlir::SymbolTableCollection *symbolTable,
+void traverseCallGraph(mlir::func::FuncOp start, mlir::SymbolTableCollection* symbolTable,
                        mlir::function_ref<void(mlir::func::FuncOp)> processFunc);
 
 } // namespace catalyst

--- a/mlir/include/Driver/CatalystLLVMTarget.h
+++ b/mlir/include/Driver/CatalystLLVMTarget.h
@@ -14,20 +14,19 @@
 
 #pragma once
 
-#include "mlir/IR/DialectRegistry.h"
-#include "mlir/Support/LogicalResult.h"
+#include "CompilerDriver.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/Module.h"
-
-#include "CompilerDriver.h"
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/Support/LogicalResult.h"
 
 namespace catalyst {
 namespace driver {
 
 /// Register the translations needed to convert to LLVM IR.
-void registerLLVMTranslations(mlir::DialectRegistry &registry);
+void registerLLVMTranslations(mlir::DialectRegistry& registry);
 
-mlir::LogicalResult compileObjectFile(const CompilerOptions &options,
+mlir::LogicalResult compileObjectFile(const CompilerOptions& options,
                                       std::shared_ptr<llvm::Module> module,
                                       llvm::StringRef filename);
 

--- a/mlir/include/Driver/CompilerDriver.h
+++ b/mlir/include/Driver/CompilerDriver.h
@@ -14,14 +14,14 @@
 
 #pragma once
 
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Support/LogicalResult.h"
+
 #include <filesystem>
 #include <string>
 #include <vector>
-
-#include "mlir/IR/MLIRContext.h"
-#include "mlir/Support/LogicalResult.h"
-#include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/raw_ostream.h"
 
 namespace catalyst {
 namespace driver {
@@ -45,9 +45,7 @@ enum class Verbosity { Silent = 0, Urgent = 1, Debug = 2, All = 3 };
 /// Helper verbose reporting macro.
 #define CO_MSG(opt, level, op)                                                                     \
     do {                                                                                           \
-        if ((opt).verbosity >= (level)) {                                                          \
-            (opt).diagnosticStream << op;                                                          \
-        }                                                                                          \
+        if ((opt).verbosity >= (level)) { (opt).diagnosticStream << op; }                          \
     } while (0)
 
 /// Pipeline descriptor
@@ -67,7 +65,7 @@ struct CompilerOptions {
     /// The name of the module to compile. This is usually the same as the Python function.
     mlir::StringRef moduleName;
     /// The stream to output any error messages from MLIR/LLVM passes and translation.
-    llvm::raw_ostream &diagnosticStream;
+    llvm::raw_ostream& diagnosticStream;
     /// If true, the driver will output the module at intermediate points.
     bool keepIntermediate;
     /// Sets the verbosity level to use when printing messages.
@@ -79,8 +77,7 @@ struct CompilerOptions {
     bool lowerToLLVM;
 
     /// Get the destination of the object file at the end of compilation.
-    std::string getObjectFile() const
-    {
+    std::string getObjectFile() const {
         using path = std::filesystem::path;
         return path(workspace.str()) / path(moduleName.str()).replace_extension(".o");
     }
@@ -99,16 +96,15 @@ struct CompilerOutput {
 }; // namespace catalyst
 
 /// Entry point to the MLIR portion of the compiler.
-mlir::LogicalResult QuantumDriverMain(const catalyst::driver::CompilerOptions &options,
-                                      catalyst::driver::CompilerOutput &output);
+mlir::LogicalResult QuantumDriverMain(const catalyst::driver::CompilerOptions& options,
+                                      catalyst::driver::CompilerOutput& output);
 
 namespace llvm {
 
-inline raw_ostream &operator<<(raw_ostream &oss, const catalyst::driver::Pipeline &p)
-{
+inline raw_ostream& operator<<(raw_ostream& oss, const catalyst::driver::Pipeline& p) {
     oss << "Pipeline('" << p.name << "', [";
     bool first = true;
-    for (const auto &i : p.passes) {
+    for (const auto& i : p.passes) {
         oss << (first ? "" : ", ") << i;
         first = false;
     }

--- a/mlir/include/Driver/Support.h
+++ b/mlir/include/Driver/Support.h
@@ -14,21 +14,19 @@
 
 #pragma once
 
+#include "CompilerDriver.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/Support/LogicalResult.h"
+
 #include <filesystem>
 #include <string>
-
-#include "mlir/Support/LogicalResult.h"
-#include "llvm/Support/raw_ostream.h"
-
-#include "CompilerDriver.h"
 
 namespace catalyst {
 namespace driver {
 
 template <typename Obj>
-mlir::LogicalResult dumpToFile(const CompilerOptions &options, mlir::StringRef fileName,
-                               const Obj &obj)
-{
+mlir::LogicalResult dumpToFile(const CompilerOptions& options, mlir::StringRef fileName,
+                               const Obj& obj) {
     using std::filesystem::path;
     std::error_code errCode;
     std::string outFileName = path(options.workspace.str()) / path(fileName.str());

--- a/mlir/include/Gradient/Transforms/Passes.h
+++ b/mlir/include/Gradient/Transforms/Passes.h
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <memory>
-
 #include "mlir/Pass/Pass.h"
+
+#include <memory>
 
 namespace catalyst {
 

--- a/mlir/include/Gradient/Transforms/Patterns.h
+++ b/mlir/include/Gradient/Transforms/Patterns.h
@@ -21,9 +21,9 @@
 namespace catalyst {
 namespace gradient {
 
-void populateBufferizationPatterns(mlir::TypeConverter &, mlir::RewritePatternSet &);
-void populateLoweringPatterns(mlir::RewritePatternSet &);
-void populateConversionPatterns(mlir::LLVMTypeConverter &, mlir::RewritePatternSet &);
+void populateBufferizationPatterns(mlir::TypeConverter&, mlir::RewritePatternSet&);
+void populateLoweringPatterns(mlir::RewritePatternSet&);
+void populateConversionPatterns(mlir::LLVMTypeConverter&, mlir::RewritePatternSet&);
 
 } // namespace gradient
 } // namespace catalyst

--- a/mlir/include/Gradient/Utils/DestinationPassingStyle.h
+++ b/mlir/include/Gradient/Utils/DestinationPassingStyle.h
@@ -17,5 +17,5 @@
 namespace catalyst {
 /// Convert every MemRef-typed return value in `callee` to writing to a new argument in
 /// destination-passing style.
-void convertToDestinationPassingStyle(mlir::func::FuncOp callee, mlir::OpBuilder &builder);
+void convertToDestinationPassingStyle(mlir::func::FuncOp callee, mlir::OpBuilder& builder);
 } // namespace catalyst

--- a/mlir/include/Gradient/Utils/DifferentialQNode.h
+++ b/mlir/include/Gradient/Utils/DifferentialQNode.h
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "llvm/ADT/StringRef.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 
 namespace catalyst {
 namespace gradient {

--- a/mlir/include/Gradient/Utils/EinsumLinalgGeneric.h
+++ b/mlir/include/Gradient/Utils/EinsumLinalgGeneric.h
@@ -14,9 +14,9 @@
 
 #pragma once
 
+#include "llvm/ADT/SmallVector.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Value.h"
-#include "llvm/ADT/SmallVector.h"
 
 namespace catalyst {
 
@@ -29,7 +29,7 @@ namespace catalyst {
 /// found e.g. in the `numpy.einsum` funciton. The items of these arrays encode axis of `a`,
 /// `b` and the `result` correspondingly. For example, the `([0,1,2,3], [2,3], [0,1])` codes would
 /// be equivalent to the following `np.einsum` format string: `"abcd,cd->ab"`.
-mlir::Value einsumLinalgGeneric(mlir::OpBuilder &builder, mlir::Location loc,
+mlir::Value einsumLinalgGeneric(mlir::OpBuilder& builder, mlir::Location loc,
                                 llvm::ArrayRef<int64_t> axisCodesA,
                                 llvm::ArrayRef<int64_t> axisCodesB,
                                 llvm::ArrayRef<int64_t> axisCodesResult, mlir::Value a,

--- a/mlir/include/Gradient/Utils/GradientShape.h
+++ b/mlir/include/Gradient/Utils/GradientShape.h
@@ -14,10 +14,10 @@
 
 #pragma once
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+
 #include <optional>
 #include <vector>
-
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 
 namespace catalyst {
 namespace gradient {
@@ -25,12 +25,12 @@ namespace gradient {
 bool isDifferentiable(mlir::Type type);
 
 std::vector<mlir::Type> computeResultTypes(mlir::func::FuncOp callee,
-                                           const std::vector<size_t> &diffArgIndices);
+                                           const std::vector<size_t>& diffArgIndices);
 
 std::vector<mlir::Type> computeQGradTypes(mlir::func::FuncOp callee);
 
 std::vector<mlir::Type> computeBackpropTypes(mlir::func::FuncOp callee,
-                                             const std::vector<size_t> &diffArgIndices);
+                                             const std::vector<size_t>& diffArgIndices);
 
 std::vector<size_t> computeDiffArgIndices(std::optional<mlir::DenseIntElementsAttr> indices);
 

--- a/mlir/include/Quantum/IR/QuantumOps.h
+++ b/mlir/include/Quantum/IR/QuantumOps.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include "Quantum/IR/QuantumInterfaces.h"
+#include "llvm/ADT/StringRef.h"
 #include "mlir/Dialect/Bufferization/IR/AllocationOpInterface.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
@@ -22,10 +24,8 @@
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
 #include "mlir/Support/LogicalResult.h"
-#include "llvm/ADT/StringRef.h"
-#include <optional>
 
-#include "Quantum/IR/QuantumInterfaces.h"
+#include <optional>
 
 //===----------------------------------------------------------------------===//
 // Quantum trait declarations.
@@ -34,12 +34,11 @@
 namespace mlir {
 namespace OpTrait {
 
-template <typename ConcreteType> class UnitaryTrait : public TraitBase<ConcreteType, UnitaryTrait> {
-};
+template <typename ConcreteType>
+class UnitaryTrait : public TraitBase<ConcreteType, UnitaryTrait> {};
 
 template <typename ConcreteType>
-class HermitianTrait : public TraitBase<ConcreteType, HermitianTrait> {
-};
+class HermitianTrait : public TraitBase<ConcreteType, HermitianTrait> {};
 
 } // namespace OpTrait
 } // namespace mlir
@@ -53,6 +52,7 @@ class QuantumMemory : public mlir::SideEffects::Resource::Base<QuantumMemory> {
 //===----------------------------------------------------------------------===//
 
 #include "Quantum/IR/QuantumDialect.h"
+
 #include "Quantum/IR/QuantumEnums.h.inc"
 #define GET_ATTRDEF_CLASSES
 #include "Quantum/IR/QuantumAttributes.h.inc"

--- a/mlir/include/Quantum/Transforms/Passes.h
+++ b/mlir/include/Quantum/Transforms/Passes.h
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <memory>
-
 #include "mlir/Pass/Pass.h"
+
+#include <memory>
 
 namespace catalyst {
 

--- a/mlir/include/Quantum/Transforms/Patterns.h
+++ b/mlir/include/Quantum/Transforms/Patterns.h
@@ -20,11 +20,11 @@
 namespace catalyst {
 namespace quantum {
 
-void populateBufferizationLegality(mlir::TypeConverter &, mlir::ConversionTarget &);
-void populateBufferizationPatterns(mlir::TypeConverter &, mlir::RewritePatternSet &);
-void populateQIRConversionPatterns(mlir::TypeConverter &, mlir::RewritePatternSet &);
-void populateAdjointPatterns(mlir::RewritePatternSet &);
-void populateScatterPatterns(mlir::RewritePatternSet &);
+void populateBufferizationLegality(mlir::TypeConverter&, mlir::ConversionTarget&);
+void populateBufferizationPatterns(mlir::TypeConverter&, mlir::RewritePatternSet&);
+void populateQIRConversionPatterns(mlir::TypeConverter&, mlir::RewritePatternSet&);
+void populateAdjointPatterns(mlir::RewritePatternSet&);
+void populateScatterPatterns(mlir::RewritePatternSet&);
 
 } // namespace quantum
 } // namespace catalyst

--- a/mlir/include/Quantum/Utils/QuantumSplitting.h
+++ b/mlir/include/Quantum/Utils/QuantumSplitting.h
@@ -14,6 +14,16 @@
 
 #pragma once
 
+#include "Catalyst/IR/CatalystOps.h"
+#include "Quantum/IR/QuantumOps.h"
+#include "mlir/Dialect/Index/IR/IndexOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+using namespace mlir;
+
 namespace catalyst {
 namespace quantum {
 

--- a/mlir/include/Quantum/Utils/RemoveQuantumMeasurements.h
+++ b/mlir/include/Quantum/Utils/RemoveQuantumMeasurements.h
@@ -19,7 +19,7 @@
 namespace catalyst {
 namespace quantum {
 
-void removeQuantumMeasurements(mlir::func::FuncOp &function);
+void removeQuantumMeasurements(mlir::func::FuncOp& function);
 
 } // namespace quantum
 } // namespace catalyst

--- a/mlir/lib/Catalyst/IR/CatalystDialect.cpp
+++ b/mlir/lib/Catalyst/IR/CatalystDialect.cpp
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 #include "Catalyst/IR/CatalystDialect.h"
+
 #include "Catalyst/IR/CatalystOps.h"
+#include "llvm/ADT/TypeSwitch.h" // needed for generated type parser
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/DialectImplementation.h" // needed for generated type parser
 #include "mlir/Transforms/InliningUtils.h"
-#include "llvm/ADT/TypeSwitch.h" // needed for generated type parser
 
 using namespace mlir;
 using namespace catalyst;
@@ -28,8 +29,7 @@ using namespace catalyst;
 // Catalyst dialect.
 //===----------------------------------------------------------------------===//
 
-void CatalystDialect::initialize()
-{
+void CatalystDialect::initialize() {
     addTypes<
 #define GET_TYPEDEF_LIST
 #include "Catalyst/IR/CatalystOpsTypes.cpp.inc"

--- a/mlir/lib/Catalyst/IR/CatalystOps.cpp
+++ b/mlir/lib/Catalyst/IR/CatalystOps.cpp
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "mlir/IR/Builders.h"
-#include "mlir/IR/OpImplementation.h"
-
-#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "Catalyst/IR/CatalystOps.h"
 
 #include "Catalyst/IR/CatalystDialect.h"
-#include "Catalyst/IR/CatalystOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/OpImplementation.h"
 
 using namespace mlir;
 using namespace catalyst;

--- a/mlir/lib/Catalyst/Transforms/RegisterAllPasses.cpp
+++ b/mlir/lib/Catalyst/Transforms/RegisterAllPasses.cpp
@@ -16,8 +16,7 @@
 #include "Gradient/Transforms/Passes.h"
 #include "Quantum/Transforms/Passes.h"
 
-void catalyst::registerAllCatalystPasses()
-{
+void catalyst::registerAllCatalystPasses() {
     mlir::registerPass(catalyst::createArrayListToMemRefPass);
     mlir::registerPass(catalyst::createGradientBufferizationPass);
     mlir::registerPass(catalyst::createGradientLoweringPass);

--- a/mlir/lib/Catalyst/Utils/CallGraph.cpp
+++ b/mlir/lib/Catalyst/Utils/CallGraph.cpp
@@ -11,19 +11,18 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <deque>
-
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+
+#include <deque>
 
 using namespace mlir;
 
 namespace catalyst {
 
-void traverseCallGraph(func::FuncOp start, SymbolTableCollection *symbolTable,
-                       function_ref<void(func::FuncOp)> processFunc)
-{
-    DenseSet<Operation *> visited{start};
-    std::deque<Operation *> frontier{start};
+void traverseCallGraph(func::FuncOp start, SymbolTableCollection* symbolTable,
+                       function_ref<void(func::FuncOp)> processFunc) {
+    DenseSet<Operation*> visited{start};
+    std::deque<Operation*> frontier{start};
 
     while (!frontier.empty()) {
         auto callable = cast<func::FuncOp>(frontier.front());

--- a/mlir/lib/Driver/CatalystLLVMTarget.cpp
+++ b/mlir/lib/Driver/CatalystLLVMTarget.cpp
@@ -12,12 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "mlir/IR/FunctionInterfaces.h"
-#include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
-#include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
-#include "mlir/Target/LLVMIR/Export.h"
-#include "mlir/Target/LLVMIR/LLVMTranslationInterface.h"
-#include "mlir/Target/LLVMIR/ModuleTranslation.h"
+#include "Driver/CatalystLLVMTarget.h"
+
+#include "Gradient/IR/GradientDialect.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Support/FileSystem.h"
@@ -25,22 +22,23 @@
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetOptions.h"
 #include "llvm/TargetParser/Host.h"
-
-#include "Driver/CatalystLLVMTarget.h"
-#include "Gradient/IR/GradientDialect.h"
+#include "mlir/IR/FunctionInterfaces.h"
+#include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
+#include "mlir/Target/LLVMIR/Export.h"
+#include "mlir/Target/LLVMIR/LLVMTranslationInterface.h"
+#include "mlir/Target/LLVMIR/ModuleTranslation.h"
 
 using namespace mlir;
 
-void catalyst::driver::registerLLVMTranslations(DialectRegistry &registry)
-{
+void catalyst::driver::registerLLVMTranslations(DialectRegistry& registry) {
     registerLLVMDialectTranslation(registry);
     registerBuiltinDialectTranslation(registry);
 }
 
-LogicalResult catalyst::driver::compileObjectFile(const CompilerOptions &options,
+LogicalResult catalyst::driver::compileObjectFile(const CompilerOptions& options,
                                                   std::shared_ptr<llvm::Module> llvmModule,
-                                                  StringRef filename)
-{
+                                                  StringRef filename) {
     using namespace llvm;
 
     std::string targetTriple = sys::getDefaultTargetTriple();
@@ -61,8 +59,8 @@ LogicalResult catalyst::driver::compileObjectFile(const CompilerOptions &options
     }
 
     // Target a generic CPU without any additional features, options, or relocation model
-    const char *cpu = "generic";
-    const char *features = "";
+    const char* cpu = "generic";
+    const char* features = "";
 
     TargetOptions opt;
     auto targetMachine =

--- a/mlir/lib/Gradient/IR/GradientDialect.cpp
+++ b/mlir/lib/Gradient/IR/GradientDialect.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "mlir/Transforms/InliningUtils.h"
-
 #include "Gradient/IR/GradientDialect.h"
+
 #include "Gradient/IR/GradientOps.h"
+#include "mlir/Transforms/InliningUtils.h"
 
 using namespace mlir;
 using namespace catalyst::gradient;
@@ -31,8 +31,7 @@ struct GradientInlinerInterface : public DialectInlinerInterface {
     using DialectInlinerInterface::DialectInlinerInterface;
 
     /// Operations in Gradient dialect are always legal to inline.
-    bool isLegalToInline(Operation *, Region *, bool, IRMapping &valueMapping) const final
-    {
+    bool isLegalToInline(Operation*, Region*, bool, IRMapping& valueMapping) const final {
         return true;
     }
 };
@@ -42,8 +41,7 @@ struct GradientInlinerInterface : public DialectInlinerInterface {
 // Gradient dialect.
 //===----------------------------------------------------------------------===//
 
-void GradientDialect::initialize()
-{
+void GradientDialect::initialize() {
     addOperations<
 #define GET_OP_LIST
 #include "Gradient/IR/GradientOps.cpp.inc"

--- a/mlir/lib/Gradient/Transforms/GradMethods/Adjoint.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/Adjoint.cpp
@@ -14,30 +14,26 @@
 
 #include "Adjoint.hpp"
 
-#include <algorithm>
-#include <sstream>
-#include <vector>
-
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-
 #include "Gradient/IR/GradientOps.h"
 #include "Gradient/Utils/DifferentialQNode.h"
 #include "Gradient/Utils/GradientShape.h"
 #include "Quantum/IR/QuantumOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+
+#include <algorithm>
+#include <sstream>
+#include <vector>
 
 namespace catalyst {
 namespace gradient {
 
-LogicalResult AdjointLowering::match(func::FuncOp op) const
-{
-    if (getQNodeDiffMethod(op) == "adjoint" && requiresCustomGradient(op))
-        return success();
+LogicalResult AdjointLowering::match(func::FuncOp op) const {
+    if (getQNodeDiffMethod(op) == "adjoint" && requiresCustomGradient(op)) return success();
 
     return failure();
 }
 
-void AdjointLowering::rewrite(func::FuncOp op, PatternRewriter &rewriter) const
-{
+void AdjointLowering::rewrite(func::FuncOp op, PatternRewriter& rewriter) const {
     Location loc = op.getLoc();
     rewriter.setInsertionPointAfter(op);
 
@@ -49,9 +45,8 @@ void AdjointLowering::rewrite(func::FuncOp op, PatternRewriter &rewriter) const
     registerCustomGradient(op, FlatSymbolRefAttr::get(qGradFn));
 }
 
-func::FuncOp AdjointLowering::discardAndReturnReg(PatternRewriter &rewriter, Location loc,
-                                                  func::FuncOp callee)
-{
+func::FuncOp AdjointLowering::discardAndReturnReg(PatternRewriter& rewriter, Location loc,
+                                                  func::FuncOp callee) {
     SmallVector<quantum::DeallocOp> deallocs;
     for (auto op : callee.getOps<quantum::DeallocOp>()) {
         deallocs.push_back(op);
@@ -100,9 +95,8 @@ func::FuncOp AdjointLowering::discardAndReturnReg(PatternRewriter &rewriter, Loc
     return unallocFn;
 }
 
-func::FuncOp AdjointLowering::genQGradFunction(PatternRewriter &rewriter, Location loc,
-                                               func::FuncOp callee)
-{
+func::FuncOp AdjointLowering::genQGradFunction(PatternRewriter& rewriter, Location loc,
+                                               func::FuncOp callee) {
 
     func::FuncOp unallocFn = discardAndReturnReg(rewriter, loc, callee);
 

--- a/mlir/lib/Gradient/Transforms/GradMethods/Adjoint.hpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/Adjoint.hpp
@@ -26,12 +26,12 @@ struct AdjointLowering : public OpRewritePattern<func::FuncOp> {
     using OpRewritePattern<func::FuncOp>::OpRewritePattern;
 
     LogicalResult match(func::FuncOp op) const override;
-    void rewrite(func::FuncOp op, PatternRewriter &rewriter) const override;
+    void rewrite(func::FuncOp op, PatternRewriter& rewriter) const override;
 
   private:
-    static func::FuncOp genQGradFunction(PatternRewriter &rewriter, Location loc,
+    static func::FuncOp genQGradFunction(PatternRewriter& rewriter, Location loc,
                                          func::FuncOp callee);
-    static func::FuncOp discardAndReturnReg(PatternRewriter &rewriter, Location loc,
+    static func::FuncOp discardAndReturnReg(PatternRewriter& rewriter, Location loc,
                                             func::FuncOp callee);
 };
 

--- a/mlir/lib/Gradient/Transforms/GradMethods/ClassicalJacobian.hpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/ClassicalJacobian.hpp
@@ -22,17 +22,17 @@ using namespace mlir;
 namespace catalyst {
 namespace gradient {
 
-func::FuncOp genParamCountFunction(PatternRewriter &rewriter, Location loc, func::FuncOp callee);
+func::FuncOp genParamCountFunction(PatternRewriter& rewriter, Location loc, func::FuncOp callee);
 
 /// Generate a new mlir function that splits out classical preprocessing from any quantum
 /// operations, then calls a modified QNode that explicitly takes the saved parameters. This allows
 /// a classical automatic differentiation tool like Enzyme to process this function without needing
 /// to know how to differentiate any quantum operations, as those derivatives will be handled
 /// separately.
-func::FuncOp genSplitPreprocessed(PatternRewriter &rewriter, Location loc, func::FuncOp qnode,
+func::FuncOp genSplitPreprocessed(PatternRewriter& rewriter, Location loc, func::FuncOp qnode,
                                   func::FuncOp qnodeQuantum);
 
-func::FuncOp genArgMapFunction(PatternRewriter &rewriter, Location loc, func::FuncOp callee);
+func::FuncOp genArgMapFunction(PatternRewriter& rewriter, Location loc, func::FuncOp callee);
 
 } // namespace gradient
 } // namespace catalyst

--- a/mlir/lib/Gradient/Transforms/GradMethods/FiniteDifference.hpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/FiniteDifference.hpp
@@ -14,12 +14,11 @@
 
 #pragma once
 
-#include <vector>
-
+#include "Gradient/IR/GradientOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/PatternMatch.h"
 
-#include "Gradient/IR/GradientOps.h"
+#include <vector>
 
 using namespace mlir;
 
@@ -30,11 +29,11 @@ struct FiniteDiffLowering : public OpRewritePattern<GradOp> {
     using OpRewritePattern<GradOp>::OpRewritePattern;
 
     LogicalResult match(GradOp op) const override;
-    void rewrite(GradOp op, PatternRewriter &rewriter) const override;
+    void rewrite(GradOp op, PatternRewriter& rewriter) const override;
 
   private:
-    static void computeFiniteDiff(PatternRewriter &rewriter, Location loc, func::FuncOp gradFn,
-                                  func::FuncOp callee, const std::vector<size_t> &diffArgIndices,
+    static void computeFiniteDiff(PatternRewriter& rewriter, Location loc, func::FuncOp gradFn,
+                                  func::FuncOp callee, const std::vector<size_t>& diffArgIndices,
                                   double hValue);
 };
 

--- a/mlir/lib/Gradient/Transforms/GradMethods/HybridGradient.hpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/HybridGradient.hpp
@@ -14,10 +14,9 @@
 
 #pragma once
 
+#include "Gradient/IR/GradientOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/PatternMatch.h"
-
-#include "Gradient/IR/GradientOps.h"
 
 namespace catalyst {
 namespace gradient {
@@ -27,22 +26,22 @@ namespace gradient {
 struct HybridGradientLowering : public mlir::OpRewritePattern<GradOp> {
     using OpRewritePattern<GradOp>::OpRewritePattern;
 
-    mlir::LogicalResult matchAndRewrite(GradOp op, mlir::PatternRewriter &rewriter) const override;
+    mlir::LogicalResult matchAndRewrite(GradOp op, mlir::PatternRewriter& rewriter) const override;
 
   private:
     /// Recursively process all the QNodes of the `callee` being differentiated. The resulting
     /// BackpropOps will be called with `backpropArgs`.
     static mlir::FailureOr<mlir::func::FuncOp>
-    cloneCallee(mlir::PatternRewriter &rewriter, GradOp gradOp, mlir::func::FuncOp callee,
-                mlir::SmallVectorImpl<Value> &backpropArgs);
+    cloneCallee(mlir::PatternRewriter& rewriter, GradOp gradOp, mlir::func::FuncOp callee,
+                mlir::SmallVectorImpl<Value>& backpropArgs);
 
     /// Generate a version of the QNode that accepts the parameter buffer. This is so Enzyme will
     /// see that the gate parameters flow into the custom quantum function.
-    static mlir::func::FuncOp genQNodeQuantumOnly(mlir::PatternRewriter &rewriter,
+    static mlir::func::FuncOp genQNodeQuantumOnly(mlir::PatternRewriter& rewriter,
                                                   mlir::Location loc, mlir::func::FuncOp qnode);
 
     /// Generate a function that computes a Jacobian row-by-row using one or more BackpropOps.
-    static mlir::func::FuncOp genFullGradFunction(mlir::PatternRewriter &rewriter,
+    static mlir::func::FuncOp genFullGradFunction(mlir::PatternRewriter& rewriter,
                                                   mlir::Location loc, GradOp gradOp,
                                                   mlir::func::FuncOp callee, FunctionType fnType);
 };

--- a/mlir/lib/Gradient/Transforms/GradMethods/HybridGradient.hpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/HybridGradient.hpp
@@ -18,6 +18,8 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/PatternMatch.h"
 
+using namespace mlir;
+
 namespace catalyst {
 namespace gradient {
 

--- a/mlir/lib/Gradient/Transforms/GradMethods/JVPVJPPatterns.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/JVPVJPPatterns.cpp
@@ -14,22 +14,20 @@
 
 #define DEBUG_TYPE "jvpvjp"
 
-#include <algorithm>
-#include <memory>
-#include <vector>
-
-#include "llvm/Support/Debug.h"
-#include "llvm/Support/Errc.h"
-
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/IR/SymbolTable.h"
+#include "JVPVJPPatterns.hpp"
 
 #include "Gradient/Utils/EinsumLinalgGeneric.h"
 #include "Gradient/Utils/GradientShape.h"
 #include "Quantum/IR/QuantumOps.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Errc.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/IR/SymbolTable.h"
 
-#include "JVPVJPPatterns.hpp"
+#include <algorithm>
+#include <memory>
+#include <vector>
 
 using namespace mlir;
 using namespace catalyst::gradient;
@@ -37,8 +35,8 @@ using llvm::dbgs;
 
 namespace llvm {
 
-template <class T> raw_ostream &operator<<(raw_ostream &oss, const std::vector<T> &v)
-{
+template <class T>
+raw_ostream& operator<<(raw_ostream& oss, const std::vector<T>& v) {
     oss << "[";
     bool first = true;
     for (auto i : v) {
@@ -53,14 +51,13 @@ template <class T> raw_ostream &operator<<(raw_ostream &oss, const std::vector<T
 namespace catalyst {
 namespace gradient {
 
-template <class T> std::vector<int64_t> _tovec(const T &x)
-{
+template <class T>
+std::vector<int64_t> _tovec(const T& x) {
     return std::vector<int64_t>(x.begin(), x.end());
 };
 
-LogicalResult JVPLoweringPattern::matchAndRewrite(JVPOp op, PatternRewriter &rewriter) const
-{
-    MLIRContext *ctx = getContext();
+LogicalResult JVPLoweringPattern::matchAndRewrite(JVPOp op, PatternRewriter& rewriter) const {
+    MLIRContext* ctx = getContext();
 
     Location loc = op.getLoc();
 
@@ -152,8 +149,7 @@ LogicalResult JVPLoweringPattern::matchAndRewrite(JVPOp op, PatternRewriter &rew
 
             if (!acc.has_value()) {
                 acc = res;
-            }
-            else {
+            } else {
                 assert(acc.value().getType() == res.getType());
 
                 auto add_op = rewriter.create<linalg::ElemwiseBinaryOp>(
@@ -175,9 +171,8 @@ LogicalResult JVPLoweringPattern::matchAndRewrite(JVPOp op, PatternRewriter &rew
     return success();
 }
 
-LogicalResult VJPLoweringPattern::matchAndRewrite(VJPOp op, PatternRewriter &rewriter) const
-{
-    MLIRContext *ctx = getContext();
+LogicalResult VJPLoweringPattern::matchAndRewrite(VJPOp op, PatternRewriter& rewriter) const {
+    MLIRContext* ctx = getContext();
 
     Location loc = op.getLoc();
 
@@ -266,8 +261,7 @@ LogicalResult VJPLoweringPattern::matchAndRewrite(VJPOp op, PatternRewriter &rew
 
             if (!acc.has_value()) {
                 acc = res;
-            }
-            else {
+            } else {
                 assert(acc.value().getType() == res.getType());
 
                 auto add_op = rewriter.create<linalg::ElemwiseBinaryOp>(

--- a/mlir/lib/Gradient/Transforms/GradMethods/JVPVJPPatterns.hpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/JVPVJPPatterns.hpp
@@ -14,9 +14,8 @@
 
 #pragma once
 
-#include "mlir/IR/PatternMatch.h"
-
 #include "Gradient/IR/GradientOps.h"
+#include "mlir/IR/PatternMatch.h"
 
 namespace catalyst {
 namespace gradient {
@@ -24,13 +23,13 @@ namespace gradient {
 struct JVPLoweringPattern : public mlir::OpRewritePattern<JVPOp> {
     using mlir::OpRewritePattern<JVPOp>::OpRewritePattern;
 
-    mlir::LogicalResult matchAndRewrite(JVPOp op, mlir::PatternRewriter &rewriter) const override;
+    mlir::LogicalResult matchAndRewrite(JVPOp op, mlir::PatternRewriter& rewriter) const override;
 };
 
 struct VJPLoweringPattern : public mlir::OpRewritePattern<VJPOp> {
     using mlir::OpRewritePattern<VJPOp>::OpRewritePattern;
 
-    mlir::LogicalResult matchAndRewrite(VJPOp op, mlir::PatternRewriter &rewriter) const override;
+    mlir::LogicalResult matchAndRewrite(VJPOp op, mlir::PatternRewriter& rewriter) const override;
 };
 
 } // namespace gradient

--- a/mlir/lib/Gradient/Transforms/GradMethods/ParameterShift.hpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/ParameterShift.hpp
@@ -14,12 +14,11 @@
 
 #pragma once
 
-#include <utility>
-
+#include "Gradient/IR/GradientOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/PatternMatch.h"
 
-#include "Gradient/IR/GradientOps.h"
+#include <utility>
 
 constexpr double PI = 3.14159265358979323846;
 
@@ -32,14 +31,14 @@ struct ParameterShiftLowering : public OpRewritePattern<func::FuncOp> {
     using OpRewritePattern<func::FuncOp>::OpRewritePattern;
 
     LogicalResult match(func::FuncOp op) const override;
-    void rewrite(func::FuncOp op, PatternRewriter &rewriter) const override;
+    void rewrite(func::FuncOp op, PatternRewriter& rewriter) const override;
 
   private:
     static std::pair<int64_t, int64_t> analyzeFunction(func::FuncOp callee);
-    static func::FuncOp genShiftFunction(PatternRewriter &rewriter, Location loc,
+    static func::FuncOp genShiftFunction(PatternRewriter& rewriter, Location loc,
                                          func::FuncOp callee, const int64_t numShifts,
                                          const int64_t loopDepth);
-    static func::FuncOp genQGradFunction(PatternRewriter &rewriter, Location loc,
+    static func::FuncOp genQGradFunction(PatternRewriter& rewriter, Location loc,
                                          func::FuncOp callee, func::FuncOp shiftedFn,
                                          const int64_t numShifts, const int64_t loopDepth);
 };

--- a/mlir/lib/Gradient/Transforms/LoweringPatterns.cpp
+++ b/mlir/lib/Gradient/Transforms/LoweringPatterns.cpp
@@ -17,10 +17,8 @@
 #include "GradMethods/HybridGradient.hpp"
 #include "GradMethods/JVPVJPPatterns.hpp"
 #include "GradMethods/ParameterShift.hpp"
-
-#include "mlir/IR/PatternMatch.h"
-
 #include "Gradient/Transforms/Patterns.h"
+#include "mlir/IR/PatternMatch.h"
 
 using namespace mlir;
 using namespace catalyst::gradient;
@@ -28,8 +26,7 @@ using namespace catalyst::gradient;
 namespace catalyst {
 namespace gradient {
 
-void populateLoweringPatterns(RewritePatternSet &patterns)
-{
+void populateLoweringPatterns(RewritePatternSet& patterns) {
     patterns.add<HybridGradientLowering>(patterns.getContext());
     patterns.add<FiniteDiffLowering>(patterns.getContext(), 1);
     patterns.add<ParameterShiftLowering>(patterns.getContext(), 1);

--- a/mlir/lib/Gradient/Transforms/gradient_bufferize.cpp
+++ b/mlir/lib/Gradient/Transforms/gradient_bufferize.cpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "Gradient/IR/GradientOps.h"
+#include "Gradient/Transforms/Passes.h"
+#include "Gradient/Transforms/Patterns.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Bufferization/Transforms/Bufferize.h"
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
@@ -19,10 +22,6 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
-
-#include "Gradient/IR/GradientOps.h"
-#include "Gradient/Transforms/Passes.h"
-#include "Gradient/Transforms/Patterns.h"
 
 using namespace mlir;
 using namespace catalyst::gradient;
@@ -36,9 +35,8 @@ namespace gradient {
 struct GradientBufferizationPass : impl::GradientBufferizationPassBase<GradientBufferizationPass> {
     using GradientBufferizationPassBase::GradientBufferizationPassBase;
 
-    void runOnOperation() final
-    {
-        MLIRContext *context = &getContext();
+    void runOnOperation() final {
+        MLIRContext* context = &getContext();
         bufferization::BufferizeTypeConverter typeConverter;
 
         RewritePatternSet patterns(context);
@@ -47,7 +45,7 @@ struct GradientBufferizationPass : impl::GradientBufferizationPassBase<GradientB
         ConversionTarget target(*context);
         bufferization::populateBufferizeMaterializationLegality(target);
         // Default to operations being legal with the exception of the ones below.
-        target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
+        target.markUnknownOpDynamicallyLegal([](Operation*) { return true; });
         // Gradient ops which return arrays need to be marked illegal when the type is a tensor.
         target.addDynamicallyLegalOp<AdjointOp>(
             [&](AdjointOp op) { return typeConverter.isLegal(op); });
@@ -63,8 +61,7 @@ struct GradientBufferizationPass : impl::GradientBufferizationPassBase<GradientB
 
 } // namespace gradient
 
-std::unique_ptr<Pass> createGradientBufferizationPass()
-{
+std::unique_ptr<Pass> createGradientBufferizationPass() {
     return std::make_unique<gradient::GradientBufferizationPass>();
 }
 

--- a/mlir/lib/Gradient/Transforms/gradient_lowering.cpp
+++ b/mlir/lib/Gradient/Transforms/gradient_lowering.cpp
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <memory>
-#include <vector>
-
+#include "Catalyst/IR/CatalystDialect.h"
+#include "Gradient/IR/GradientOps.h"
+#include "Gradient/Transforms/Passes.h"
+#include "Gradient/Transforms/Patterns.h"
+#include "Quantum/IR/QuantumOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
@@ -27,11 +29,8 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
-#include "Catalyst/IR/CatalystDialect.h"
-#include "Gradient/IR/GradientOps.h"
-#include "Gradient/Transforms/Passes.h"
-#include "Gradient/Transforms/Patterns.h"
-#include "Quantum/IR/QuantumOps.h"
+#include <memory>
+#include <vector>
 
 using namespace mlir;
 using namespace catalyst::gradient;
@@ -46,8 +45,7 @@ namespace gradient {
 struct GradientLoweringPass : impl::GradientLoweringPassBase<GradientLoweringPass> {
     using GradientLoweringPassBase::GradientLoweringPassBase;
 
-    void runOnOperation() final
-    {
+    void runOnOperation() final {
         RewritePatternSet gradientPatterns(&getContext());
         populateLoweringPatterns(gradientPatterns);
 
@@ -66,8 +64,7 @@ struct GradientLoweringPass : impl::GradientLoweringPassBase<GradientLoweringPas
 
 } // namespace gradient
 
-std::unique_ptr<Pass> createGradientLoweringPass()
-{
+std::unique_ptr<Pass> createGradientLoweringPass() {
     return std::make_unique<gradient::GradientLoweringPass>();
 }
 

--- a/mlir/lib/Gradient/Transforms/gradient_to_llvm.cpp
+++ b/mlir/lib/Gradient/Transforms/gradient_to_llvm.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "Gradient/IR/GradientDialect.h"
+#include "Gradient/Transforms/Passes.h"
+#include "Gradient/Transforms/Patterns.h"
+#include "Quantum/IR/QuantumDialect.h"
 #include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -21,11 +25,6 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinOps.h"
-
-#include "Gradient/IR/GradientDialect.h"
-#include "Gradient/Transforms/Passes.h"
-#include "Gradient/Transforms/Patterns.h"
-#include "Quantum/IR/QuantumDialect.h"
 
 using namespace mlir;
 using namespace catalyst::gradient;
@@ -40,9 +39,8 @@ namespace gradient {
 struct GradientConversionPass : impl::GradientConversionPassBase<GradientConversionPass> {
     using GradientConversionPassBase::GradientConversionPassBase;
 
-    void runOnOperation() final
-    {
-        MLIRContext *context = &getContext();
+    void runOnOperation() final {
+        MLIRContext* context = &getContext();
         LowerToLLVMOptions options(context);
         options.useGenericFunctions = useGenericFunctions;
 
@@ -65,8 +63,7 @@ struct GradientConversionPass : impl::GradientConversionPassBase<GradientConvers
 
 } // namespace gradient
 
-std::unique_ptr<Pass> createGradientConversionPass()
-{
+std::unique_ptr<Pass> createGradientConversionPass() {
     return std::make_unique<gradient::GradientConversionPass>();
 }
 

--- a/mlir/lib/Gradient/Utils/DestinationPassingStyle.cpp
+++ b/mlir/lib/Gradient/Utils/DestinationPassingStyle.cpp
@@ -12,31 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "Gradient/Utils/DestinationPassingStyle.h"
+
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 
-#include "Gradient/Utils/DestinationPassingStyle.h"
-
 using namespace mlir;
 
-void catalyst::convertToDestinationPassingStyle(func::FuncOp callee, OpBuilder &builder)
-{
+void catalyst::convertToDestinationPassingStyle(func::FuncOp callee, OpBuilder& builder) {
     if (callee.getNumResults() == 0) {
         // Callee is already in destination-passing style
         return;
     }
 
-    MLIRContext *ctx = callee.getContext();
+    MLIRContext* ctx = callee.getContext();
     SmallVector<Type> memRefReturnTypes;
     SmallVector<unsigned> outputIndices;
     SmallVector<Type> nonMemRefReturns;
 
-    for (const auto &[idx, resultType] : llvm::enumerate(callee.getResultTypes())) {
+    for (const auto& [idx, resultType] : llvm::enumerate(callee.getResultTypes())) {
         if (isa<MemRefType>(resultType)) {
             memRefReturnTypes.push_back(resultType);
             outputIndices.push_back(idx);
-        }
-        else {
+        } else {
             nonMemRefReturns.push_back(resultType);
         }
     }
@@ -76,8 +74,7 @@ void catalyst::convertToDestinationPassingStyle(func::FuncOp callee, OpBuilder &
                 // type information at the LLVM level for Enzyme.
                 builder.create<linalg::CopyOp>(returnOp.getLoc(), operand, output);
                 idx++;
-            }
-            else {
+            } else {
                 nonMemRefReturns.push_back(operand);
             }
         }

--- a/mlir/lib/Gradient/Utils/DifferentialQNode.cpp
+++ b/mlir/lib/Gradient/Utils/DifferentialQNode.cpp
@@ -12,44 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "Gradient/Utils/DifferentialQNode.h"
+
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/SymbolTable.h"
 
-#include "Gradient/Utils/DifferentialQNode.h"
-
 using namespace mlir;
 
-constexpr const char *diffMethodKey = "diff_method";
-constexpr const char *pureQuantumKey = "purequantum";
+constexpr const char* diffMethodKey = "diff_method";
+constexpr const char* pureQuantumKey = "purequantum";
 
-bool catalyst::gradient::isQNode(func::FuncOp funcOp)
-{
+bool catalyst::gradient::isQNode(func::FuncOp funcOp) {
     return funcOp->hasAttrOfType<UnitAttr>("qnode");
 }
 
-StringRef catalyst::gradient::getQNodeDiffMethod(func::FuncOp funcOp)
-{
+StringRef catalyst::gradient::getQNodeDiffMethod(func::FuncOp funcOp) {
     bool hasDiffMethod = isQNode(funcOp) && funcOp->hasAttrOfType<StringAttr>(diffMethodKey);
-    if (hasDiffMethod) {
-        return funcOp->getAttrOfType<StringAttr>(diffMethodKey).strref();
-    }
+    if (hasDiffMethod) { return funcOp->getAttrOfType<StringAttr>(diffMethodKey).strref(); }
     return "";
 }
 
 void catalyst::gradient::setRequiresCustomGradient(func::FuncOp funcOp,
-                                                   FlatSymbolRefAttr pureQuantumFunc)
-{
+                                                   FlatSymbolRefAttr pureQuantumFunc) {
     funcOp->setAttr(pureQuantumKey, pureQuantumFunc);
 }
 
-bool catalyst::gradient::requiresCustomGradient(func::FuncOp funcOp)
-{
+bool catalyst::gradient::requiresCustomGradient(func::FuncOp funcOp) {
     return funcOp->hasAttrOfType<FlatSymbolRefAttr>(pureQuantumKey);
 }
 
-void catalyst::gradient::registerCustomGradient(func::FuncOp qnode, FlatSymbolRefAttr qgradFn)
-{
-    Operation *pureQuantumFunc = SymbolTable::lookupNearestSymbolFrom(
+void catalyst::gradient::registerCustomGradient(func::FuncOp qnode, FlatSymbolRefAttr qgradFn) {
+    Operation* pureQuantumFunc = SymbolTable::lookupNearestSymbolFrom(
         qnode, qnode->getAttrOfType<FlatSymbolRefAttr>(pureQuantumKey));
     pureQuantumFunc->setAttr("gradient.qgrad", qgradFn);
 

--- a/mlir/lib/Gradient/Utils/GradientShape.cpp
+++ b/mlir/lib/Gradient/Utils/GradientShape.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
-
 #include "Gradient/Utils/GradientShape.h"
+
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 
 using namespace mlir;
 
@@ -27,8 +27,8 @@ namespace gradient {
 /// whereas the result signature is the set of shape unions for each combination of differentiable
 /// argument function result.
 ///
-std::vector<Type> computeResultTypes(func::FuncOp callee, const std::vector<size_t> &diffArgIndices)
-{
+std::vector<Type> computeResultTypes(func::FuncOp callee,
+                                     const std::vector<size_t>& diffArgIndices) {
     std::vector<Type> gradResultTypes;
     FunctionType fnType = callee.getFunctionType();
 
@@ -77,8 +77,7 @@ std::vector<Type> computeResultTypes(func::FuncOp callee, const std::vector<size
     return gradResultTypes;
 }
 
-std::vector<Type> computeQGradTypes(func::FuncOp callee)
-{
+std::vector<Type> computeQGradTypes(func::FuncOp callee) {
     std::vector<Type> qGradResTypes;
     qGradResTypes.reserve(callee.getNumResults());
 
@@ -103,8 +102,7 @@ std::vector<Type> computeQGradTypes(func::FuncOp callee)
 /// The non differentiable params are filtered out.
 ///
 std::vector<Type> computeBackpropTypes(func::FuncOp callee,
-                                       const std::vector<size_t> &diffArgIndices)
-{
+                                       const std::vector<size_t>& diffArgIndices) {
     std::vector<Type> backpropResTypes;
     FunctionType fnType = callee.getFunctionType();
 
@@ -122,12 +120,9 @@ std::vector<Type> computeBackpropTypes(func::FuncOp callee,
     return backpropResTypes;
 }
 
-bool isDifferentiable(Type type)
-{
+bool isDifferentiable(Type type) {
     // Only real-numbers are supported for differentiation
-    if (isa<FloatType>(type)) {
-        return true;
-    }
+    if (isa<FloatType>(type)) { return true; }
     if (auto shapedType = dyn_cast<ShapedType>(type)) {
         return isDifferentiable(shapedType.getElementType());
     }
@@ -139,8 +134,7 @@ bool isDifferentiable(Type type)
 /// This is typically based on an attribute attached to gradient operations, but in the
 /// absence thereof it is assumed that the first argument is differentiable.
 ///
-std::vector<size_t> computeDiffArgIndices(std::optional<DenseIntElementsAttr> indices)
-{
+std::vector<size_t> computeDiffArgIndices(std::optional<DenseIntElementsAttr> indices) {
     // By default only the first argument is differentiated, otherwise gather indices.
     std::vector<size_t> diffArgIndices{0};
     if (indices.has_value()) {
@@ -153,9 +147,8 @@ std::vector<size_t> computeDiffArgIndices(std::optional<DenseIntElementsAttr> in
 /// Produce a filtered list of arguments which are differentiable.
 ///
 std::vector<mlir::Value> computeDiffArgs(ValueRange args,
-                                         std::optional<mlir::DenseIntElementsAttr> indices)
-{
-    const std::vector<size_t> &diffArgIndices = computeDiffArgIndices(indices);
+                                         std::optional<mlir::DenseIntElementsAttr> indices) {
+    const std::vector<size_t>& diffArgIndices = computeDiffArgIndices(indices);
 
     std::vector<Value> diffArgs;
     diffArgs.reserve(diffArgIndices.size());

--- a/mlir/lib/Quantum/IR/QuantumDialect.cpp
+++ b/mlir/lib/Quantum/IR/QuantumDialect.cpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "mlir/IR/DialectImplementation.h" // needed for generated type parser
-#include "llvm/ADT/TypeSwitch.h"           // needed for generated type parser
-
 #include "Quantum/IR/QuantumDialect.h"
+
 #include "Quantum/IR/QuantumOps.h"
+#include "llvm/ADT/TypeSwitch.h"           // needed for generated type parser
+#include "mlir/IR/DialectImplementation.h" // needed for generated type parser
 
 using namespace mlir;
 using namespace catalyst::quantum;
@@ -27,8 +27,7 @@ using namespace catalyst::quantum;
 
 #include "Quantum/IR/QuantumOpsDialect.cpp.inc"
 
-void QuantumDialect::initialize()
-{
+void QuantumDialect::initialize() {
     addTypes<
 #define GET_TYPEDEF_LIST
 #include "Quantum/IR/QuantumOpsTypes.cpp.inc"

--- a/mlir/lib/Quantum/Transforms/adjoint_lowering.cpp
+++ b/mlir/lib/Quantum/Transforms/adjoint_lowering.cpp
@@ -14,12 +14,11 @@
 
 #define DEBUG_TYPE "adjoint"
 
-#include <memory>
-#include <vector>
-
+#include "Catalyst/IR/CatalystDialect.h"
+#include "Quantum/IR/QuantumOps.h"
+#include "Quantum/Transforms/Patterns.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Errc.h"
-
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
@@ -32,9 +31,8 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
-#include "Catalyst/IR/CatalystDialect.h"
-#include "Quantum/IR/QuantumOps.h"
-#include "Quantum/Transforms/Patterns.h"
+#include <memory>
+#include <vector>
 
 using namespace llvm;
 using namespace mlir;
@@ -49,8 +47,7 @@ namespace quantum {
 struct AdjointLoweringPass : impl::AdjointLoweringPassBase<AdjointLoweringPass> {
     using AdjointLoweringPassBase::AdjointLoweringPassBase;
 
-    void runOnOperation() final
-    {
+    void runOnOperation() final {
         LLVM_DEBUG(dbgs() << "adjoint lowering pass"
                           << "\n");
 
@@ -64,8 +61,7 @@ struct AdjointLoweringPass : impl::AdjointLoweringPassBase<AdjointLoweringPass> 
 
 } // namespace quantum
 
-std::unique_ptr<Pass> createAdjointLoweringPass()
-{
+std::unique_ptr<Pass> createAdjointLoweringPass() {
     return std::make_unique<quantum::AdjointLoweringPass>();
 }
 

--- a/mlir/lib/Quantum/Transforms/quantum_bufferize.cpp
+++ b/mlir/lib/Quantum/Transforms/quantum_bufferize.cpp
@@ -12,16 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "Quantum/IR/QuantumOps.h"
+#include "Quantum/Transforms/Passes.h"
+#include "Quantum/Transforms/Patterns.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Bufferization/Transforms/Bufferize.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
-
-#include "Quantum/IR/QuantumOps.h"
-#include "Quantum/Transforms/Passes.h"
-#include "Quantum/Transforms/Patterns.h"
 
 using namespace mlir;
 using namespace catalyst::quantum;
@@ -35,9 +34,8 @@ namespace quantum {
 struct QuantumBufferizationPass : impl::QuantumBufferizationPassBase<QuantumBufferizationPass> {
     using QuantumBufferizationPassBase::QuantumBufferizationPassBase;
 
-    void runOnOperation() final
-    {
-        MLIRContext *context = &getContext();
+    void runOnOperation() final {
+        MLIRContext* context = &getContext();
         bufferization::BufferizeTypeConverter typeConverter;
 
         RewritePatternSet patterns(context);
@@ -55,8 +53,7 @@ struct QuantumBufferizationPass : impl::QuantumBufferizationPassBase<QuantumBuff
 
 } // namespace quantum
 
-std::unique_ptr<Pass> createQuantumBufferizationPass()
-{
+std::unique_ptr<Pass> createQuantumBufferizationPass() {
     return std::make_unique<quantum::QuantumBufferizationPass>();
 }
 

--- a/mlir/lib/Quantum/Transforms/quantum_to_llvm.cpp
+++ b/mlir/lib/Quantum/Transforms/quantum_to_llvm.cpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "Quantum/IR/QuantumDialect.h"
+#include "Quantum/Transforms/Passes.h"
+#include "Quantum/Transforms/Patterns.h"
 #include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
 #include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
@@ -20,10 +23,6 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
-
-#include "Quantum/IR/QuantumDialect.h"
-#include "Quantum/Transforms/Passes.h"
-#include "Quantum/Transforms/Patterns.h"
 
 using namespace mlir;
 using namespace catalyst::quantum;
@@ -36,8 +35,7 @@ namespace quantum {
 
 struct QIRTypeConverter : public LLVMTypeConverter {
 
-    QIRTypeConverter(MLIRContext *ctx) : LLVMTypeConverter(ctx)
-    {
+    QIRTypeConverter(MLIRContext* ctx) : LLVMTypeConverter(ctx) {
         addConversion([&](QubitType type) { return convertQubitType(type); });
         addConversion([&](QuregType type) { return convertQuregType(type); });
         addConversion([&](ObservableType type) { return convertObservableType(type); });
@@ -45,23 +43,19 @@ struct QIRTypeConverter : public LLVMTypeConverter {
     }
 
   private:
-    Type convertQubitType(Type mlirType)
-    {
+    Type convertQubitType(Type mlirType) {
         return LLVM::LLVMPointerType::get(LLVM::LLVMStructType::getOpaque("Qubit", &getContext()));
     }
 
-    Type convertQuregType(Type mlirType)
-    {
+    Type convertQuregType(Type mlirType) {
         return LLVM::LLVMPointerType::get(LLVM::LLVMStructType::getOpaque("Array", &getContext()));
     }
 
-    Type convertObservableType(Type mlirType)
-    {
+    Type convertObservableType(Type mlirType) {
         return this->convertType(IntegerType::get(&getContext(), 64));
     }
 
-    Type convertResultType(Type mlirType)
-    {
+    Type convertResultType(Type mlirType) {
         return LLVM::LLVMPointerType::get(LLVM::LLVMStructType::getOpaque("Result", &getContext()));
     }
 };
@@ -69,9 +63,8 @@ struct QIRTypeConverter : public LLVMTypeConverter {
 struct QuantumConversionPass : impl::QuantumConversionPassBase<QuantumConversionPass> {
     using QuantumConversionPassBase::QuantumConversionPassBase;
 
-    void runOnOperation() final
-    {
-        MLIRContext *context = &getContext();
+    void runOnOperation() final {
+        MLIRContext* context = &getContext();
         QIRTypeConverter typeConverter(context);
 
         RewritePatternSet patterns(context);
@@ -90,8 +83,7 @@ struct QuantumConversionPass : impl::QuantumConversionPassBase<QuantumConversion
 
 } // namespace quantum
 
-std::unique_ptr<Pass> createQuantumConversionPass()
-{
+std::unique_ptr<Pass> createQuantumConversionPass() {
     return std::make_unique<quantum::QuantumConversionPass>();
 }
 

--- a/mlir/lib/Quantum/Transforms/scatter_lowering.cpp
+++ b/mlir/lib/Quantum/Transforms/scatter_lowering.cpp
@@ -14,18 +14,15 @@
 
 #define DEBUG_TYPE "scatter"
 
-#include <vector>
-
+#include "Quantum/Transforms/Patterns.h"
 #include "llvm/Support/Debug.h"
-
 #include "mhlo/IR/hlo_ops.h"
 #include "mhlo/transforms/passes.h"
-
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
-#include "Quantum/Transforms/Patterns.h"
+#include <vector>
 
 using namespace llvm;
 using namespace mlir;
@@ -40,8 +37,7 @@ namespace quantum {
 struct ScatterLoweringPass : impl::ScatterLoweringPassBase<ScatterLoweringPass> {
     using ScatterLoweringPassBase::ScatterLoweringPassBase;
 
-    void runOnOperation() final
-    {
+    void runOnOperation() final {
         LLVM_DEBUG(dbgs() << "scatter lowering pass"
                           << "\n");
 
@@ -55,8 +51,7 @@ struct ScatterLoweringPass : impl::ScatterLoweringPassBase<ScatterLoweringPass> 
 
 } // namespace quantum
 
-std::unique_ptr<Pass> createScatterLoweringPass()
-{
+std::unique_ptr<Pass> createScatterLoweringPass() {
     return std::make_unique<quantum::ScatterLoweringPass>();
 }
 

--- a/mlir/lib/Quantum/Utils/QuantumSplitting.cpp
+++ b/mlir/lib/Quantum/Utils/QuantumSplitting.cpp
@@ -14,14 +14,6 @@
 
 #include "Quantum/Utils/QuantumSplitting.h"
 
-#include "Catalyst/IR/CatalystOps.h"
-#include "Quantum/IR/QuantumOps.h"
-#include "mlir/Dialect/Index/IR/IndexOps.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/IR/IRMapping.h"
-#include "mlir/Transforms/DialectConversion.h"
-
 using namespace mlir;
 using namespace catalyst;
 

--- a/mlir/python/PyCompilerDriver.cpp
+++ b/mlir/python/PyCompilerDriver.cpp
@@ -12,23 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <iostream>
-#include <string>
-#include <vector>
+#include "Driver/CompilerDriver.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/IR/BuiltinTypes.h"
 
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-#include "mlir/IR/BuiltinTypes.h"
-#include "llvm/Support/raw_ostream.h"
-
-#include "Driver/CompilerDriver.h"
+#include <iostream>
+#include <string>
+#include <vector>
 
 namespace py = pybind11;
 using namespace catalyst::driver;
 
-std::vector<Pipeline> parseCompilerSpec(const py::list &pipelines)
-{
+std::vector<Pipeline> parseCompilerSpec(const py::list& pipelines) {
     std::vector<Pipeline> out;
     for (py::handle obj : pipelines) {
         py::tuple t = obj.cast<py::tuple>();
@@ -45,37 +43,36 @@ std::vector<Pipeline> parseCompilerSpec(const py::list &pipelines)
     return out;
 }
 
-PYBIND11_MODULE(compiler_driver, m)
-{
+PYBIND11_MODULE(compiler_driver, m) {
     //===--------------------------------------------------------------------===//
     // Catalyst Compiler Driver
     //===--------------------------------------------------------------------===//
     py::class_<FunctionAttributes> funcattrs_class(m, "FunctionAttributes");
     funcattrs_class.def(py::init<>())
         .def("get_function_name",
-             [](const FunctionAttributes &fa) -> std::string { return fa.functionName; })
+             [](const FunctionAttributes& fa) -> std::string { return fa.functionName; })
         .def("get_return_type",
-             [](const FunctionAttributes &fa) -> std::string { return fa.returnType; });
+             [](const FunctionAttributes& fa) -> std::string { return fa.returnType; });
 
     py::class_<CompilerOutput> compout_class(m, "CompilerOutput");
     compout_class.def(py::init<>())
         .def("get_pipeline_output",
-             [](const CompilerOutput &co, const std::string &name) -> std::optional<std::string> {
+             [](const CompilerOutput& co, const std::string& name) -> std::optional<std::string> {
                  auto res = co.pipelineOutputs.find(name);
                  return res != co.pipelineOutputs.end() ? res->second
                                                         : std::optional<std::string>();
              })
-        .def("get_output_ir", [](const CompilerOutput &co) -> std::string { return co.outIR; })
+        .def("get_output_ir", [](const CompilerOutput& co) -> std::string { return co.outIR; })
         .def("get_object_filename",
-             [](const CompilerOutput &co) -> std::string { return co.objectFilename; })
+             [](const CompilerOutput& co) -> std::string { return co.objectFilename; })
         .def("get_function_attributes",
-             [](const CompilerOutput &co) -> FunctionAttributes { return co.inferredAttributes; })
+             [](const CompilerOutput& co) -> FunctionAttributes { return co.inferredAttributes; })
         .def("get_diagnostic_messages",
-             [](const CompilerOutput &co) -> std::string { return co.diagnosticMessages; });
+             [](const CompilerOutput& co) -> std::string { return co.diagnosticMessages; });
 
     m.def(
         "run_compiler_driver",
-        [](const char *source, const char *workspace, const char *moduleName, bool keepIntermediate,
+        [](const char* source, const char* workspace, const char* moduleName, bool keepIntermediate,
            bool verbose, py::list pipelines,
            bool lower_to_llvm) -> std::unique_ptr<CompilerOutput> {
             std::unique_ptr<CompilerOutput> output(new CompilerOutput());

--- a/mlir/python/QuantumExtension.cpp
+++ b/mlir/python/QuantumExtension.cpp
@@ -18,8 +18,7 @@
 namespace py = pybind11;
 using namespace mlir::python::adaptors;
 
-PYBIND11_MODULE(_quantumDialects, m)
-{
+PYBIND11_MODULE(_quantumDialects, m) {
     //===--------------------------------------------------------------------===//
     // quantum dialect
     //===--------------------------------------------------------------------===//
@@ -30,9 +29,7 @@ PYBIND11_MODULE(_quantumDialects, m)
         [](MlirContext context, bool load) {
             MlirDialectHandle handle = mlirGetDialectHandle__quantum__();
             mlirDialectHandleRegisterDialect(handle, context);
-            if (load) {
-                mlirDialectHandleLoadDialect(handle, context);
-            }
+            if (load) { mlirDialectHandleLoadDialect(handle, context); }
         },
         py::arg("context") = py::none(), py::arg("load") = true);
 
@@ -43,9 +40,7 @@ PYBIND11_MODULE(_quantumDialects, m)
         [](MlirContext context, bool load) {
             MlirDialectHandle handle = mlirGetDialectHandle__gradient__();
             mlirDialectHandleRegisterDialect(handle, context);
-            if (load) {
-                mlirDialectHandleLoadDialect(handle, context);
-            }
+            if (load) { mlirDialectHandleLoadDialect(handle, context); }
         },
         py::arg("context") = py::none(), py::arg("load") = true);
 }

--- a/mlir/tools/quantum-lsp-server/quantum-lsp-server.cpp
+++ b/mlir/tools/quantum-lsp-server/quantum-lsp-server.cpp
@@ -12,19 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "mlir/IR/DialectRegistry.h"
-#include "mlir/InitAllDialects.h"
-#include "mlir/Tools/mlir-lsp-server/MlirLspServerMain.h"
-
 #include "Catalyst/IR/CatalystDialect.h"
 #include "Gradient/IR/GradientDialect.h"
 #include "Quantum/IR/QuantumDialect.h"
-
 #include "mhlo/IR/register.h"
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/InitAllDialects.h"
+#include "mlir/Tools/mlir-lsp-server/MlirLspServerMain.h"
 #include "stablehlo/dialect/Register.h"
 
-int main(int argc, char **argv)
-{
+int main(int argc, char** argv) {
     mlir::DialectRegistry registry;
     mlir::registerAllDialects(registry);
     registry.insert<catalyst::CatalystDialect>();

--- a/mlir/tools/quantum-opt/quantum-opt.cpp
+++ b/mlir/tools/quantum-opt/quantum-opt.cpp
@@ -12,6 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "Catalyst/IR/CatalystDialect.h"
+#include "Catalyst/Transforms/Passes.h"
+#include "Gradient/IR/GradientDialect.h"
+#include "Gradient/Transforms/Passes.h"
+#include "Quantum/IR/QuantumDialect.h"
+#include "Quantum/Transforms/Passes.h"
+#include "mhlo/IR/hlo_ops.h"
 #include "mhlo/IR/register.h"
 #include "mhlo/transforms/passes.h"
 #include "mlir/Dialect/Func/Extensions/AllExtensions.h"
@@ -22,17 +29,7 @@
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 #include "stablehlo/dialect/Register.h"
 
-#include "mhlo/IR/hlo_ops.h"
-
-#include "Catalyst/IR/CatalystDialect.h"
-#include "Catalyst/Transforms/Passes.h"
-#include "Gradient/IR/GradientDialect.h"
-#include "Gradient/Transforms/Passes.h"
-#include "Quantum/IR/QuantumDialect.h"
-#include "Quantum/Transforms/Passes.h"
-
-int main(int argc, char **argv)
-{
+int main(int argc, char** argv) {
     mlir::registerAllPasses();
     catalyst::registerAllCatalystPasses();
     mlir::mhlo::registerAllMhloPasses();

--- a/runtime/extensions/StateVectorLQubitDynamic.hpp
+++ b/runtime/extensions/StateVectorLQubitDynamic.hpp
@@ -13,19 +13,17 @@
 // limitations under the License.
 #pragma once
 
-#include <numeric>
-#include <utility>
-#include <vector>
-
 #include "BitUtil.hpp"
+#include "Error.hpp"
 #include "LinearAlgebra.hpp"
 #include "Util.hpp"
-
-#include "Error.hpp"
 
 #include <StateVectorLQubit.hpp>
 
 #include <iostream>
+#include <numeric>
+#include <utility>
+#include <vector>
 
 namespace {
 using Pennylane::Util::AlignedAllocator;
@@ -61,8 +59,7 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
     static constexpr PrecisionT epsilon_ = std::numeric_limits<PrecisionT>::epsilon() * 100;
 
     template <class IIter, class OIter>
-    inline OIter _move_data_elements(IIter first, size_t distance, OIter second)
-    {
+    inline OIter _move_data_elements(IIter first, size_t distance, OIter second) {
         *second++ = std::move(*first);
         for (size_t i = 1; i < distance; i++) {
             *second++ = std::move(*++first);
@@ -71,8 +68,7 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
     }
 
     template <class IIter, class OIter>
-    inline OIter _shallow_move_data_elements(IIter first, size_t distance, OIter second)
-    {
+    inline OIter _shallow_move_data_elements(IIter first, size_t distance, OIter second) {
         for (size_t i = 0; i < distance; i++) {
             *second++ = std::move(*first);
             *first = ZERO<PrecisionT>();
@@ -81,15 +77,13 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
         return second;
     }
 
-    inline void _scalar_mul_data(std::vector<ComplexT, AlignedAllocator<ComplexT>> &data,
-                                 ComplexT scalar)
-    {
+    inline void _scalar_mul_data(std::vector<ComplexT, AlignedAllocator<ComplexT>>& data,
+                                 ComplexT scalar) {
         std::transform(data.begin(), data.end(), data.begin(),
-                       [scalar](const ComplexT &elem) { return elem * scalar; });
+                       [scalar](const ComplexT& elem) { return elem * scalar; });
     }
 
-    inline void _normalize_data(std::vector<ComplexT, AlignedAllocator<ComplexT>> &data)
-    {
+    inline void _normalize_data(std::vector<ComplexT, AlignedAllocator<ComplexT>>& data) {
         _scalar_mul_data(data,
                          ONE<PrecisionT>() / std::sqrt(squaredNorm(data.data(), data.size())));
     }
@@ -104,12 +98,11 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
      */
     explicit StateVectorLQubitDynamic(size_t num_qubits,
                                       Threading threading = Threading::SingleThread,
-                                      CPUMemoryModel memory_model = bestCPUMemoryModel())
-        : BaseType{num_qubits, threading, memory_model},
-          data_{exp2(num_qubits), ZERO<PrecisionT>(),
-                getAllocator<ComplexT>( // LCOV_EXCL_LINE
-                    this->memory_model_)}
-    {
+                                      CPUMemoryModel memory_model = bestCPUMemoryModel()) :
+        BaseType{num_qubits, threading, memory_model},
+        data_{exp2(num_qubits), ZERO<PrecisionT>(),
+              getAllocator<ComplexT>( // LCOV_EXCL_LINE
+                  this->memory_model_)} {
         data_[0] = ONE<PrecisionT>();
     }
 
@@ -121,12 +114,10 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
      * @param other Another statevector to construct the statevector from
      */
     template <class OtherDerived>
-    explicit StateVectorLQubitDynamic(const StateVectorLQubit<PrecisionT, OtherDerived> &other)
-        : BaseType(other.getNumQubits(), other.threading(), other.memoryModel()),
-          data_{other.getData(), other.getData() + other.getLength(),
-                getAllocator<ComplexT>(this->memory_model_)}
-    {
-    }
+    explicit StateVectorLQubitDynamic(const StateVectorLQubit<PrecisionT, OtherDerived>& other) :
+        BaseType(other.getNumQubits(), other.threading(), other.memoryModel()),
+        data_{other.getData(), other.getData() + other.getLength(),
+              getAllocator<ComplexT>(this->memory_model_)} {}
 
     /**
      * @brief Construct a statevector from data pointer
@@ -136,12 +127,11 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
      * @param threading Threading option the statevector to use
      * @param memory_model Memory model the statevector will use
      */
-    StateVectorLQubitDynamic(const ComplexT *other_data, size_t other_size,
+    StateVectorLQubitDynamic(const ComplexT* other_data, size_t other_size,
                              Threading threading = Threading::SingleThread,
-                             CPUMemoryModel memory_model = bestCPUMemoryModel())
-        : BaseType(log2PerfectPower(other_size), threading, memory_model),
-          data_{other_data, other_data + other_size, getAllocator<ComplexT>(this->memory_model_)}
-    {
+                             CPUMemoryModel memory_model = bestCPUMemoryModel()) :
+        BaseType(log2PerfectPower(other_size), threading, memory_model),
+        data_{other_data, other_data + other_size, getAllocator<ComplexT>(this->memory_model_)} {
         PL_ABORT_IF_NOT(isPerfectPowerOf2(other_size),
                         "The size of provided data must be a power of 2.");
     }
@@ -156,18 +146,16 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
      * @param memory_model Memory model the statevector will use
      */
     template <class Alloc>
-    explicit StateVectorLQubitDynamic(const std::vector<std::complex<PrecisionT>, Alloc> &other,
+    explicit StateVectorLQubitDynamic(const std::vector<std::complex<PrecisionT>, Alloc>& other,
                                       Threading threading = Threading::SingleThread,
-                                      CPUMemoryModel memory_model = bestCPUMemoryModel())
-        : StateVectorLQubitDynamic(other.data(), other.size(), threading, memory_model)
-    {
-    }
+                                      CPUMemoryModel memory_model = bestCPUMemoryModel()) :
+        StateVectorLQubitDynamic(other.data(), other.size(), threading, memory_model) {}
 
-    StateVectorLQubitDynamic(const StateVectorLQubitDynamic &rhs) = default;
-    StateVectorLQubitDynamic(StateVectorLQubitDynamic &&) noexcept = default;
+    StateVectorLQubitDynamic(const StateVectorLQubitDynamic& rhs) = default;
+    StateVectorLQubitDynamic(StateVectorLQubitDynamic&&) noexcept = default;
 
-    StateVectorLQubitDynamic &operator=(const StateVectorLQubitDynamic &) = default;
-    StateVectorLQubitDynamic &operator=(StateVectorLQubitDynamic &&) noexcept = default;
+    StateVectorLQubitDynamic& operator=(const StateVectorLQubitDynamic&) = default;
+    StateVectorLQubitDynamic& operator=(StateVectorLQubitDynamic&&) noexcept = default;
 
     ~StateVectorLQubitDynamic() = default;
 
@@ -181,18 +169,17 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
     /**
      * @brief Get underlying C-style data of the state-vector.
      */
-    [[nodiscard]] auto getData() -> ComplexT * { return data_.data(); }
+    [[nodiscard]] auto getData() -> ComplexT* { return data_.data(); }
 
     /**
      * @brief Get underlying C-style data of the state-vector.
      */
-    [[nodiscard]] auto getData() const -> const ComplexT * { return data_.data(); }
+    [[nodiscard]] auto getData() const -> const ComplexT* { return data_.data(); }
 
     /**
      * @brief Get underlying data vector.
      */
-    [[nodiscard]] auto getDataVector() -> std::vector<ComplexT, AlignedAllocator<ComplexT>> &
-    {
+    [[nodiscard]] auto getDataVector() -> std::vector<ComplexT, AlignedAllocator<ComplexT>>& {
         return data_;
     }
 
@@ -200,8 +187,7 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
      * @brief Get underlying data vector.
      */
     [[nodiscard]] auto getDataVector() const
-        -> const std::vector<ComplexT, AlignedAllocator<ComplexT>> &
-    {
+        -> const std::vector<ComplexT, AlignedAllocator<ComplexT>>& {
         return data_;
     }
 
@@ -211,8 +197,7 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
      * @param new_data data pointer to new data.
      * @param new_size size of underlying data storage.
      */
-    void updateData(const ComplexT *new_data, size_t new_size)
-    {
+    void updateData(const ComplexT* new_data, size_t new_size) {
         PL_ASSERT(data_.size() == new_size);
         std::copy(new_data, new_data + new_size, data_.data());
     }
@@ -223,8 +208,8 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
      * @tparam Alloc Allocator type of std::vector to use for updating data.
      * @param new_data std::vector contains data.
      */
-    template <class Alloc> void updateData(const std::vector<ComplexT, Alloc> &new_data)
-    {
+    template <class Alloc>
+    void updateData(const std::vector<ComplexT, Alloc>& new_data) {
         updateData(new_data.data(), new_data.size());
     }
 
@@ -242,8 +227,7 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
      * @param wire Index of the wire.
      * @return ComplexT
      */
-    auto getSubsystemPurity(size_t wire) -> ComplexT
-    {
+    auto getSubsystemPurity(size_t wire) -> ComplexT {
         PL_ABORT_IF_NOT(isValidWire(wire), "Invalid wire: The wire must be in the range of wires");
 
         const size_t sv_size = data_.size();
@@ -288,8 +272,7 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
      * @param eps The comparing precision threshold.
      * @return bool
      */
-    [[nodiscard]] auto checkSubsystemPurity(size_t wire, double eps = epsilon_) -> bool
-    {
+    [[nodiscard]] auto checkSubsystemPurity(size_t wire, double eps = epsilon_) -> bool {
         ComplexT purity = getSubsystemPurity(wire);
         return (std::abs(1.0 - purity.real()) < eps) && (purity.imag() < eps);
     }
@@ -300,8 +283,7 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
      * @return It updates the state-vector and the number of qubits,
      * and returns index of the activated wire.
      */
-    auto allocateWire() -> size_t
-    {
+    auto allocateWire() -> size_t {
         const size_t next_idx = this->getNumQubits();
         const size_t dsize = data_.size();
         data_.resize(dsize << 1UL);
@@ -322,8 +304,7 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
      *
      * @param wire Index of the wire to be released
      */
-    void releaseWire(size_t wire)
-    {
+    void releaseWire(size_t wire) {
         PL_ABORT_IF_NOT(checkSubsystemPurity(wire),
                         "Invalid wire: "
                         "The state-vector must remain pure after releasing a wire")
@@ -336,16 +317,12 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
         bool is_first_half = false;
         for (auto src = dst; src < data_.end(); std::advance(src, 2 * distance)) {
             is_first_half = std::any_of(src, src + static_cast<long long>(distance),
-                                        [](ComplexT &e) { return e != ZERO<PrecisionT>(); });
-            if (is_first_half) {
-                break;
-            }
+                                        [](ComplexT& e) { return e != ZERO<PrecisionT>(); });
+            if (is_first_half) { break; }
         }
 
         auto src = dst;
-        if (!is_first_half) {
-            std::advance(src, distance);
-        }
+        if (!is_first_half) { std::advance(src, distance); }
 
         for (; src < data_.end(); std::advance(src, 2 * distance), std::advance(dst, distance)) {
             _move_data_elements(src, distance, dst);
@@ -360,8 +337,7 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
     /**
      * @brief Update the state-vector to the initial state with 0-qubit.
      */
-    void clearData()
-    {
+    void clearData() {
         data_.clear();
         this->setNumQubits(0);
 

--- a/runtime/include/DataView.hpp
+++ b/runtime/include/DataView.hpp
@@ -14,7 +14,9 @@
 
 #pragma once
 
-#include <Exception.hpp>
+#include "Exception.hpp"
+
+#include <vector>
 
 /**
  * A multi-dimensional view for MemRef-like and std::vector<T> types.

--- a/runtime/include/DataView.hpp
+++ b/runtime/include/DataView.hpp
@@ -28,9 +28,10 @@
  * in the following order:
  * (0, 0), ..., (0, sizes[1]-1), (1, 0), ..., (1, sizes[1]-1), ... (sizes[0]-1, sizes[1]-1).
  */
-template <typename T, size_t R> class DataView {
+template <typename T, size_t R>
+class DataView {
   private:
-    T *data_aligned;
+    T* data_aligned;
     size_t offset;
     size_t sizes[R] = {0};
     size_t strides[R] = {0};
@@ -38,7 +39,7 @@ template <typename T, size_t R> class DataView {
   public:
     class iterator {
       private:
-        const DataView<T, R> &view;
+        const DataView<T, R>& view;
 
         int64_t loc; // physical index
         size_t indices[R] = {0};
@@ -47,14 +48,13 @@ template <typename T, size_t R> class DataView {
         using iterator_category = std::forward_iterator_tag; // LCOV_EXCL_LINE
         using value_type = T;                                // LCOV_EXCL_LINE
         using difference_type = std::ptrdiff_t;              // LCOV_EXCL_LINE
-        using pointer = T *;                                 // LCOV_EXCL_LINE
-        using reference = T &;                               // LCOV_EXCL_LINE
+        using pointer = T*;                                  // LCOV_EXCL_LINE
+        using reference = T&;                                // LCOV_EXCL_LINE
 
-        iterator(const DataView<T, R> &_view, int64_t begin_idx) : view(_view), loc(begin_idx) {}
+        iterator(const DataView<T, R>& _view, int64_t begin_idx) : view(_view), loc(begin_idx) {}
         pointer operator->() const { return &view.data_aligned[loc]; }
         reference operator*() const { return view.data_aligned[loc]; }
-        iterator &operator++()
-        {
+        iterator& operator++() {
             int64_t next_axis = -1;
             int64_t idx;
             for (int64_t i = R; i > 0; --i) {
@@ -70,8 +70,7 @@ template <typename T, size_t R> class DataView {
             loc = next_axis == -1 ? -1 : loc + view.strides[next_axis];
             return *this;
         }
-        iterator operator++(int)
-        {
+        iterator operator++(int) {
             auto tmp = *this;
             int64_t next_axis = -1;
             int64_t idx;
@@ -88,23 +87,20 @@ template <typename T, size_t R> class DataView {
             loc = next_axis == -1 ? -1 : loc + view.strides[next_axis];
             return tmp;
         }
-        bool operator==(const iterator &other) const
-        {
+        bool operator==(const iterator& other) const {
             return (loc == other.loc && view.data_aligned == other.view.data_aligned);
         }
-        bool operator!=(const iterator &other) const { return !(*this == other); }
+        bool operator!=(const iterator& other) const { return !(*this == other); }
     };
 
-    explicit DataView(std::vector<T> &buffer) : data_aligned(buffer.data()), offset(0)
-    {
+    explicit DataView(std::vector<T>& buffer) : data_aligned(buffer.data()), offset(0) {
         static_assert(R == 1, "[Class: DataView] Assertion: R == 1");
         sizes[0] = buffer.size();
         strides[0] = 1;
     }
 
-    explicit DataView(T *_data_aligned, size_t _offset, size_t *_sizes, size_t *_strides)
-        : data_aligned(_data_aligned), offset(_offset)
-    {
+    explicit DataView(T* _data_aligned, size_t _offset, size_t* _sizes, size_t* _strides) :
+        data_aligned(_data_aligned), offset(_offset) {
         static_assert(R > 0, "[Class: DataView] Assertion: R > 0");
         if (_sizes && _strides) {
             for (size_t i = 0; i < R; i++) {
@@ -114,11 +110,8 @@ template <typename T, size_t R> class DataView {
         } // else sizes = {0}, strides = {0}
     }
 
-    [[nodiscard]] auto size() const -> size_t
-    {
-        if (!data_aligned) {
-            return 0;
-        }
+    [[nodiscard]] auto size() const -> size_t {
+        if (!data_aligned) { return 0; }
 
         size_t tsize = 1;
         for (size_t i = 0; i < R; i++) {
@@ -127,8 +120,8 @@ template <typename T, size_t R> class DataView {
         return tsize;
     }
 
-    template <typename... I> T &operator()(I... idxs) const
-    {
+    template <typename... I>
+    T& operator()(I... idxs) const {
         static_assert(sizeof...(idxs) == R,
                       "[Class: DataView] Error in Catalyst Runtime: Wrong number of indices");
         size_t indices[] = {static_cast<size_t>(idxs)...};

--- a/runtime/include/Exception.hpp
+++ b/runtime/include/Exception.hpp
@@ -16,7 +16,6 @@
 
 #include <exception>
 #include <iostream>
-
 #include <sstream>
 #include <string>
 #include <type_traits>
@@ -32,9 +31,7 @@
  * to true.
  */
 #define RT_FAIL_IF(expression, message)                                                            \
-    if ((expression)) {                                                                            \
-        RT_FAIL(message);                                                                          \
-    }
+    if ((expression)) { RT_FAIL(message); }
 
 /**
  * @brief Macro that throws `RuntimeException` with the given expression
@@ -53,18 +50,17 @@ class RuntimeException : public std::exception {
     const std::string err_msg;
 
   public:
-    explicit RuntimeException(std::string msg) noexcept
-        : err_msg{std::move(msg)} {}        // LCOV_EXCL_LINE
+    explicit RuntimeException(std::string msg) noexcept :
+        err_msg{std::move(msg)} {}          // LCOV_EXCL_LINE
     ~RuntimeException() override = default; // LCOV_EXCL_LINE
 
-    RuntimeException(const RuntimeException &) = default;
-    RuntimeException(RuntimeException &&) noexcept = default;
+    RuntimeException(const RuntimeException&) = default;
+    RuntimeException(RuntimeException&&) noexcept = default;
 
-    RuntimeException &operator=(const RuntimeException &) = delete;
-    RuntimeException &operator=(RuntimeException &&) = delete;
+    RuntimeException& operator=(const RuntimeException&) = delete;
+    RuntimeException& operator=(RuntimeException&&) = delete;
 
-    [[nodiscard]] auto what() const noexcept -> const char * override
-    {
+    [[nodiscard]] auto what() const noexcept -> const char* override {
         return err_msg.c_str();
     } // LCOV_EXCL_LINE
 };
@@ -74,9 +70,8 @@ class RuntimeException : public std::exception {
  *
  * @note This is not supposed to be called directly.
  */
-[[noreturn]] inline void _abort(const char *message, const char *file_name, size_t line,
-                                const char *function_name)
-{
+[[noreturn]] inline void _abort(const char* message, const char* file_name, size_t line,
+                                const char* function_name) {
     std::stringstream sstream;
     sstream << "[" << file_name << "][Line:" << line << "][Function:" << function_name
             << "] Error in Catalyst Runtime: " << message;

--- a/runtime/include/QuantumDevice.hpp
+++ b/runtime/include/QuantumDevice.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
+#include "DataView.hpp"
+#include "Types.h"
+
 #include <complex>
 #include <memory>
 #include <vector>
-
-#include "DataView.hpp"
-#include "Types.h"
 
 namespace Catalyst::Runtime {
 
@@ -39,10 +39,10 @@ struct QuantumDevice {
     QuantumDevice() = default;          // LCOV_EXCL_LINE
     virtual ~QuantumDevice() = default; // LCOV_EXCL_LINE
 
-    QuantumDevice &operator=(const QuantumDevice &) = delete;
-    QuantumDevice(const QuantumDevice &) = delete;
-    QuantumDevice(QuantumDevice &&) = delete;
-    QuantumDevice &operator=(QuantumDevice &&) = delete;
+    QuantumDevice& operator=(const QuantumDevice&) = delete;
+    QuantumDevice(const QuantumDevice&) = delete;
+    QuantumDevice(QuantumDevice&&) = delete;
+    QuantumDevice& operator=(QuantumDevice&&) = delete;
 
     /**
      * @brief Allocate a qubit.
@@ -131,8 +131,8 @@ struct QuantumDevice {
      * @param wires Wires to apply gate to
      * @param inverse Indicates whether to use inverse of gate
      */
-    virtual void NamedOperation(const std::string &name, const std::vector<double> &params,
-                                const std::vector<QubitIdType> &wires, bool inverse) = 0;
+    virtual void NamedOperation(const std::string& name, const std::vector<double>& params,
+                                const std::vector<QubitIdType>& wires, bool inverse) = 0;
 
     /**
      * @brief Apply a given matrix directly to the state vector of a device.
@@ -141,8 +141,8 @@ struct QuantumDevice {
      * @param wires Wires to apply gate to
      * @param inverse Indicates whether to use inverse of gate
      */
-    virtual void MatrixOperation(const std::vector<std::complex<double>> &matrix,
-                                 const std::vector<QubitIdType> &wires, bool inverse) = 0;
+    virtual void MatrixOperation(const std::vector<std::complex<double>>& matrix,
+                                 const std::vector<QubitIdType>& wires, bool inverse) = 0;
 
     /**
      * @brief Construct a named (Identity, PauliX, PauliY, PauliZ, and Hadamard)
@@ -154,8 +154,8 @@ struct QuantumDevice {
      *
      * @return `ObsIdType` Index of the constructed observable
      */
-    virtual auto Observable(ObsId id, const std::vector<std::complex<double>> &matrix,
-                            const std::vector<QubitIdType> &wires) -> ObsIdType = 0;
+    virtual auto Observable(ObsId id, const std::vector<std::complex<double>>& matrix,
+                            const std::vector<QubitIdType>& wires) -> ObsIdType = 0;
 
     /**
      * @brief Construct a tensor product of observables.
@@ -164,7 +164,7 @@ struct QuantumDevice {
      *
      * @return `ObsIdType` Index of the constructed observable
      */
-    virtual auto TensorObservable(const std::vector<ObsIdType> &obs) -> ObsIdType = 0;
+    virtual auto TensorObservable(const std::vector<ObsIdType>& obs) -> ObsIdType = 0;
 
     /**
      * @brief Construct a Hamiltonian observable.
@@ -174,8 +174,8 @@ struct QuantumDevice {
      *
      * @return `ObsIdType` Index of the constructed observable
      */
-    virtual auto HamiltonianObservable(const std::vector<double> &coeffs,
-                                       const std::vector<ObsIdType> &obs) -> ObsIdType = 0;
+    virtual auto HamiltonianObservable(const std::vector<double>& coeffs,
+                                       const std::vector<ObsIdType>& obs) -> ObsIdType = 0;
 
     /**
      * @brief Compute the expected value of an observable.
@@ -200,14 +200,14 @@ struct QuantumDevice {
      *
      * @param state The pre-allocated `DataView<complex<double>, 1>`
      */
-    virtual void State(DataView<std::complex<double>, 1> &state) = 0;
+    virtual void State(DataView<std::complex<double>, 1>& state) = 0;
 
     /**
      * @brief Compute the probabilities of each computational basis state.
 
      * @param probs The pre-allocated `DataView<double, 1>`
      */
-    virtual void Probs(DataView<double, 1> &probs) = 0;
+    virtual void Probs(DataView<double, 1>& probs) = 0;
 
     /**
      * @brief Compute the probabilities for a subset of the full system.
@@ -215,8 +215,8 @@ struct QuantumDevice {
      * @param probs The pre-allocated `DataView<double, 1>`
      * @param wires Wires will restrict probabilities to a subset of the full system
      */
-    virtual void PartialProbs(DataView<double, 1> &probs,
-                              const std::vector<QubitIdType> &wires) = 0;
+    virtual void PartialProbs(DataView<double, 1>& probs,
+                              const std::vector<QubitIdType>& wires) = 0;
 
     /**
      * @brief Compute samples with the number of shots on the entire wires,
@@ -227,7 +227,7 @@ struct QuantumDevice {
      * iterates over all elements of `samples` row-wise.
      * @param shots The number of shots
      */
-    virtual void Sample(DataView<double, 2> &samples, size_t shots) = 0;
+    virtual void Sample(DataView<double, 2>& samples, size_t shots) = 0;
 
     /**
      * @brief Compute partial samples with the number of shots on `wires`,
@@ -239,7 +239,7 @@ struct QuantumDevice {
      * @param wires Wires to compute samples on
      * @param shots The number of shots
      */
-    virtual void PartialSample(DataView<double, 2> &samples, const std::vector<QubitIdType> &wires,
+    virtual void PartialSample(DataView<double, 2>& samples, const std::vector<QubitIdType>& wires,
                                size_t shots) = 0;
 
     /**
@@ -250,7 +250,7 @@ struct QuantumDevice {
      * @param counts The pre-allocated `DataView<int64_t, 1>`
      * @param shots The number of shots
      */
-    virtual void Counts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts,
+    virtual void Counts(DataView<double, 1>& eigvals, DataView<int64_t, 1>& counts,
                         size_t shots) = 0;
 
     /**
@@ -262,8 +262,8 @@ struct QuantumDevice {
      * @param wires Wires to compute samples on
      * @param shots The number of shots
      */
-    virtual void PartialCounts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts,
-                               const std::vector<QubitIdType> &wires, size_t shots) = 0;
+    virtual void PartialCounts(DataView<double, 1>& eigvals, DataView<int64_t, 1>& counts,
+                               const std::vector<QubitIdType>& wires, size_t shots) = 0;
 
     /**
      * @brief A general measurement method that acts on a single wire.
@@ -285,7 +285,7 @@ struct QuantumDevice {
      * would be assumed trainable
      *
      */
-    virtual void Gradient(std::vector<DataView<double, 1>> &gradients,
-                          const std::vector<size_t> &trainParams) = 0;
+    virtual void Gradient(std::vector<DataView<double, 1>>& gradients,
+                          const std::vector<size_t>& trainParams) = 0;
 };
 } // namespace Catalyst::Runtime

--- a/runtime/include/RuntimeCAPI.h
+++ b/runtime/include/RuntimeCAPI.h
@@ -17,7 +17,6 @@
 #define RUNTIMECAPI_H
 
 #include "Types.h"
-
 #include "qir_stdlib.h"
 
 #ifdef __cplusplus
@@ -25,76 +24,76 @@ extern "C" {
 #endif
 
 // Quantum Runtime Instructions
-void __quantum__rt__fail_cstr(const char *);
+void __quantum__rt__fail_cstr(const char*);
 void __quantum__rt__initialize();
-void __quantum__rt__device(int8_t *, int8_t *);
+void __quantum__rt__device(int8_t*, int8_t*);
 void __quantum__rt__finalize();
 void __quantum__rt__toggle_recorder(bool);
 void __quantum__rt__print_state();
 
-QUBIT *__quantum__rt__qubit_allocate();
-QirArray *__quantum__rt__qubit_allocate_array(int64_t);
-void __quantum__rt__qubit_release(QUBIT *);
-void __quantum__rt__qubit_release_array(QirArray *);
+QUBIT* __quantum__rt__qubit_allocate();
+QirArray* __quantum__rt__qubit_allocate_array(int64_t);
+void __quantum__rt__qubit_release(QUBIT*);
+void __quantum__rt__qubit_release_array(QirArray*);
 
 int64_t __quantum__rt__num_qubits();
-QirString *__quantum__rt__qubit_to_string(QUBIT *);
+QirString* __quantum__rt__qubit_to_string(QUBIT*);
 
-bool __quantum__rt__result_equal(RESULT *, RESULT *);
-RESULT *__quantum__rt__result_get_one();
-RESULT *__quantum__rt__result_get_zero();
-QirString *__quantum__rt__result_to_string(RESULT *);
+bool __quantum__rt__result_equal(RESULT*, RESULT*);
+RESULT* __quantum__rt__result_get_one();
+RESULT* __quantum__rt__result_get_zero();
+QirString* __quantum__rt__result_to_string(RESULT*);
 
 // Quantum Gate Set Instructions
-void __quantum__qis__Identity(QUBIT *, bool);
-void __quantum__qis__PauliX(QUBIT *, bool);
-void __quantum__qis__PauliY(QUBIT *, bool);
-void __quantum__qis__PauliZ(QUBIT *, bool);
-void __quantum__qis__Hadamard(QUBIT *, bool);
-void __quantum__qis__S(QUBIT *, bool);
-void __quantum__qis__T(QUBIT *, bool);
-void __quantum__qis__PhaseShift(double, QUBIT *, bool);
-void __quantum__qis__RX(double, QUBIT *, bool);
-void __quantum__qis__RY(double, QUBIT *, bool);
-void __quantum__qis__RZ(double, QUBIT *, bool);
-void __quantum__qis__Rot(double, double, double, QUBIT *, bool);
-void __quantum__qis__CNOT(QUBIT *, QUBIT *, bool);
-void __quantum__qis__CY(QUBIT *, QUBIT *, bool);
-void __quantum__qis__CZ(QUBIT *, QUBIT *, bool);
-void __quantum__qis__SWAP(QUBIT *, QUBIT *, bool);
-void __quantum__qis__IsingXX(double, QUBIT *, QUBIT *, bool);
-void __quantum__qis__IsingYY(double, QUBIT *, QUBIT *, bool);
-void __quantum__qis__IsingXY(double, QUBIT *, QUBIT *, bool);
-void __quantum__qis__IsingZZ(double, QUBIT *, QUBIT *, bool);
-void __quantum__qis__ControlledPhaseShift(double, QUBIT *, QUBIT *, bool);
-void __quantum__qis__CRX(double, QUBIT *, QUBIT *, bool);
-void __quantum__qis__CRY(double, QUBIT *, QUBIT *, bool);
-void __quantum__qis__CRZ(double, QUBIT *, QUBIT *, bool);
-void __quantum__qis__CRot(double, double, double, QUBIT *, QUBIT *, bool);
-void __quantum__qis__CSWAP(QUBIT *, QUBIT *, QUBIT *, bool);
-void __quantum__qis__Toffoli(QUBIT *, QUBIT *, QUBIT *, bool);
+void __quantum__qis__Identity(QUBIT*, bool);
+void __quantum__qis__PauliX(QUBIT*, bool);
+void __quantum__qis__PauliY(QUBIT*, bool);
+void __quantum__qis__PauliZ(QUBIT*, bool);
+void __quantum__qis__Hadamard(QUBIT*, bool);
+void __quantum__qis__S(QUBIT*, bool);
+void __quantum__qis__T(QUBIT*, bool);
+void __quantum__qis__PhaseShift(double, QUBIT*, bool);
+void __quantum__qis__RX(double, QUBIT*, bool);
+void __quantum__qis__RY(double, QUBIT*, bool);
+void __quantum__qis__RZ(double, QUBIT*, bool);
+void __quantum__qis__Rot(double, double, double, QUBIT*, bool);
+void __quantum__qis__CNOT(QUBIT*, QUBIT*, bool);
+void __quantum__qis__CY(QUBIT*, QUBIT*, bool);
+void __quantum__qis__CZ(QUBIT*, QUBIT*, bool);
+void __quantum__qis__SWAP(QUBIT*, QUBIT*, bool);
+void __quantum__qis__IsingXX(double, QUBIT*, QUBIT*, bool);
+void __quantum__qis__IsingYY(double, QUBIT*, QUBIT*, bool);
+void __quantum__qis__IsingXY(double, QUBIT*, QUBIT*, bool);
+void __quantum__qis__IsingZZ(double, QUBIT*, QUBIT*, bool);
+void __quantum__qis__ControlledPhaseShift(double, QUBIT*, QUBIT*, bool);
+void __quantum__qis__CRX(double, QUBIT*, QUBIT*, bool);
+void __quantum__qis__CRY(double, QUBIT*, QUBIT*, bool);
+void __quantum__qis__CRZ(double, QUBIT*, QUBIT*, bool);
+void __quantum__qis__CRot(double, double, double, QUBIT*, QUBIT*, bool);
+void __quantum__qis__CSWAP(QUBIT*, QUBIT*, QUBIT*, bool);
+void __quantum__qis__Toffoli(QUBIT*, QUBIT*, QUBIT*, bool);
 void __quantum__qis__MultiRZ(double, bool /*adjoint*/, int64_t, /*qubits*/...);
 
 // Struct pointer arguments for these instructions represent real arguments,
 // as passing structs by value is too unreliable / compiler dependant.
-void __quantum__qis__QubitUnitary(MemRefT_CplxT_double_2d *, bool /*adjoint*/, int64_t,
+void __quantum__qis__QubitUnitary(MemRefT_CplxT_double_2d*, bool /*adjoint*/, int64_t,
                                   /*qubits*/...);
 
-ObsIdType __quantum__qis__NamedObs(int64_t, QUBIT *);
-ObsIdType __quantum__qis__HermitianObs(MemRefT_CplxT_double_2d *, int64_t, /*qubits*/...);
+ObsIdType __quantum__qis__NamedObs(int64_t, QUBIT*);
+ObsIdType __quantum__qis__HermitianObs(MemRefT_CplxT_double_2d*, int64_t, /*qubits*/...);
 ObsIdType __quantum__qis__TensorObs(int64_t, /*obsKeys*/...);
-ObsIdType __quantum__qis__HamiltonianObs(MemRefT_double_1d *, int64_t, /*obsKeys*/...);
+ObsIdType __quantum__qis__HamiltonianObs(MemRefT_double_1d*, int64_t, /*obsKeys*/...);
 
 // Struct pointers arguments here represent return values.
-RESULT *__quantum__qis__Measure(QUBIT *);
+RESULT* __quantum__qis__Measure(QUBIT*);
 double __quantum__qis__Expval(ObsIdType);
 double __quantum__qis__Variance(ObsIdType);
-void __quantum__qis__Probs(MemRefT_double_1d *, int64_t, /*qubits*/...);
-void __quantum__qis__Sample(MemRefT_double_2d *, int64_t, int64_t, /*qubits*/...);
-void __quantum__qis__Counts(PairT_MemRefT_double_int64_1d *, int64_t, int64_t, /*qubits*/...);
-void __quantum__qis__State(MemRefT_CplxT_double_1d *, int64_t, /*qubits*/...);
+void __quantum__qis__Probs(MemRefT_double_1d*, int64_t, /*qubits*/...);
+void __quantum__qis__Sample(MemRefT_double_2d*, int64_t, int64_t, /*qubits*/...);
+void __quantum__qis__Counts(PairT_MemRefT_double_int64_1d*, int64_t, int64_t, /*qubits*/...);
+void __quantum__qis__State(MemRefT_CplxT_double_1d*, int64_t, /*qubits*/...);
 void __quantum__qis__Gradient(int64_t, /*results*/...);
-void __quantum__qis__Gradient_params(MemRefT_int64_1d *, int64_t, /*results*/...);
+void __quantum__qis__Gradient_params(MemRefT_int64_1d*, int64_t, /*results*/...);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/runtime/include/Types.h
+++ b/runtime/include/Types.h
@@ -17,6 +17,7 @@
 #define TYPES_H
 
 #include <cmath>
+
 #include <cstdint>
 #include <limits>
 
@@ -29,7 +30,7 @@ struct QUBIT;
 typedef intptr_t QubitIdType;
 
 typedef bool RESULT;
-typedef RESULT *Result;
+typedef RESULT* Result;
 
 typedef intptr_t ObsIdType;
 
@@ -56,8 +57,8 @@ struct CplxT_double {
 
 // MemRefT<complex<double>, dimension=1> type
 struct MemRefT_CplxT_double_1d {
-    CplxT_double *data_allocated;
-    CplxT_double *data_aligned;
+    CplxT_double* data_allocated;
+    CplxT_double* data_aligned;
     size_t offset;
     size_t sizes[1];
     size_t strides[1];
@@ -65,8 +66,8 @@ struct MemRefT_CplxT_double_1d {
 
 // MemRefT<complex<double>, dimension=2> type
 struct MemRefT_CplxT_double_2d {
-    CplxT_double *data_allocated;
-    CplxT_double *data_aligned;
+    CplxT_double* data_allocated;
+    CplxT_double* data_aligned;
     size_t offset;
     size_t sizes[2];
     size_t strides[2];
@@ -74,8 +75,8 @@ struct MemRefT_CplxT_double_2d {
 
 // MemRefT<double, dimension=1> type
 struct MemRefT_double_1d {
-    double *data_allocated;
-    double *data_aligned;
+    double* data_allocated;
+    double* data_aligned;
     size_t offset;
     size_t sizes[1];
     size_t strides[1];
@@ -83,8 +84,8 @@ struct MemRefT_double_1d {
 
 // MemRefT<double, dimension=2> type
 struct MemRefT_double_2d {
-    double *data_allocated;
-    double *data_aligned;
+    double* data_allocated;
+    double* data_aligned;
     size_t offset;
     size_t sizes[2];
     size_t strides[2];
@@ -92,8 +93,8 @@ struct MemRefT_double_2d {
 
 // MemRefT<int64_t, dimension=1> type
 struct MemRefT_int64_1d {
-    int64_t *data_allocated;
-    int64_t *data_aligned;
+    int64_t* data_allocated;
+    int64_t* data_aligned;
     size_t offset;
     size_t sizes[1];
     size_t strides[1];

--- a/runtime/lib/backend/common/CacheManager.hpp
+++ b/runtime/lib/backend/common/CacheManager.hpp
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include <string>
-#include <vector>
-
 #include "Types.h"
 #include "Utils.hpp"
+
+#include <string>
+#include <vector>
 
 namespace Catalyst::Runtime::Simulator {
 /**
@@ -48,16 +48,15 @@ class CacheManager {
     CacheManager() = default;
     ~CacheManager() = default;
 
-    CacheManager(const CacheManager &) = delete;
-    CacheManager &operator=(const CacheManager &) = delete;
-    CacheManager(CacheManager &&) = delete;
-    CacheManager &operator=(CacheManager &&) = delete;
+    CacheManager(const CacheManager&) = delete;
+    CacheManager& operator=(const CacheManager&) = delete;
+    CacheManager(CacheManager&&) = delete;
+    CacheManager& operator=(CacheManager&&) = delete;
 
     /**
      * Reset cached gates
      */
-    void Reset()
-    {
+    void Reset() {
         this->ops_names_.clear();
         this->ops_params_.clear();
         this->ops_wires_.clear();
@@ -77,9 +76,8 @@ class CacheManager {
      * @param wires Wires the gate acts on
      * @param inverse If true, inverse of the gate is applied
      */
-    void addOperation(const std::string &name, const std::vector<double> &params,
-                      const std::vector<size_t> &dev_wires, bool inverse)
-    {
+    void addOperation(const std::string& name, const std::vector<double>& params,
+                      const std::vector<size_t>& dev_wires, bool inverse) {
         this->ops_names_.push_back(name);
         this->ops_params_.push_back(params);
 
@@ -101,8 +99,7 @@ class CacheManager {
      * @param callee The measurement operation
      */
     void addObservable(const ObsIdType id,
-                       const Lightning::Measurements &callee = Lightning::Measurements::None)
-    {
+                       const Lightning::Measurements& callee = Lightning::Measurements::None) {
         this->obs_keys_.push_back(id);
         this->obs_callees_.push_back(callee);
     }
@@ -110,47 +107,43 @@ class CacheManager {
     /**
      * @brief Get a reference to observables keys.
      */
-    auto getObservablesKeys() -> const std::vector<ObsIdType> & { return this->obs_keys_; }
+    auto getObservablesKeys() -> const std::vector<ObsIdType>& { return this->obs_keys_; }
 
     /**
      * @brief Get a reference to observables callees.
      */
-    auto getObservablesCallees() -> const std::vector<Lightning::Measurements> &
-    {
+    auto getObservablesCallees() -> const std::vector<Lightning::Measurements>& {
         return this->obs_callees_;
     }
 
     /**
      * @brief Get a reference to operations names.
      */
-    auto getOperationsNames() -> const std::vector<std::string> & { return this->ops_names_; }
+    auto getOperationsNames() -> const std::vector<std::string>& { return this->ops_names_; }
 
     /**
      * @brief Get a a reference to operations parameters.
      */
-    auto getOperationsParameters() -> const std::vector<std::vector<double>> &
-    {
+    auto getOperationsParameters() -> const std::vector<std::vector<double>>& {
         return this->ops_params_;
     }
 
     /**
      * @brief Get a a reference to operations wires.
      */
-    auto getOperationsWires() -> const std::vector<std::vector<size_t>> &
-    {
+    auto getOperationsWires() -> const std::vector<std::vector<size_t>>& {
         return this->ops_wires_;
     }
 
     /**
      * @brief Get a reference to operations inverses.
      */
-    auto getOperationsInverses() -> const std::vector<bool> & { return this->ops_inverses_; }
+    auto getOperationsInverses() -> const std::vector<bool>& { return this->ops_inverses_; }
 
     /**
      * @brief Get total number of cached gates.
      */
-    [[nodiscard]] auto getNumGates() const -> size_t
-    {
+    [[nodiscard]] auto getNumGates() const -> size_t {
         return this->ops_names_.size() + this->obs_keys_.size();
     }
 

--- a/runtime/lib/backend/common/QubitManager.hpp
+++ b/runtime/lib/backend/common/QubitManager.hpp
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <algorithm>
-#include <map>
-
 #include "Exception.hpp"
 #include "Types.h"
 #include "Utils.hpp"
+
+#include <algorithm>
+#include <map>
 
 namespace Catalyst::Runtime::Simulator {
 
@@ -41,17 +41,15 @@ class QubitManager {
     LQMapT qubits_map{};
 
     template <class OIter = typename LQMapT::iterator>
-    [[nodiscard]] inline OIter _remove_simulator_qubit_id(SimQubitIdType s_idx)
-    {
-        const auto &&s_idx_iter = this->qubits_map.find(s_idx);
+    [[nodiscard]] inline OIter _remove_simulator_qubit_id(SimQubitIdType s_idx) {
+        const auto&& s_idx_iter = this->qubits_map.find(s_idx);
         RT_FAIL_IF(s_idx_iter == this->qubits_map.end(), "Invalid simulator qubit index");
 
         return this->qubits_map.erase(s_idx_iter);
     }
 
     template <class IIter = typename LQMapT::iterator>
-    inline void _update_qubits_mapfrom(IIter s_idx_iter)
-    {
+    inline void _update_qubits_mapfrom(IIter s_idx_iter) {
         for (; s_idx_iter != this->qubits_map.end(); s_idx_iter++) {
             s_idx_iter->second--;
         }
@@ -61,68 +59,60 @@ class QubitManager {
     QubitManager() = default;
     ~QubitManager() = default;
 
-    QubitManager(const QubitManager &) = delete;
-    QubitManager &operator=(const QubitManager &) = delete;
-    QubitManager(QubitManager &&) = delete;
-    QubitManager &operator=(QubitManager &&) = delete;
+    QubitManager(const QubitManager&) = delete;
+    QubitManager& operator=(const QubitManager&) = delete;
+    QubitManager(QubitManager&&) = delete;
+    QubitManager& operator=(QubitManager&&) = delete;
 
-    [[nodiscard]] auto isValidQubitId(SimQubitIdType s_idx) -> bool
-    {
+    [[nodiscard]] auto isValidQubitId(SimQubitIdType s_idx) -> bool {
         return this->qubits_map.contains(s_idx);
     }
 
-    [[nodiscard]] auto isValidQubitId(const std::vector<SimQubitIdType> &ss_idx) -> bool
-    {
+    [[nodiscard]] auto isValidQubitId(const std::vector<SimQubitIdType>& ss_idx) -> bool {
         return std::all_of(ss_idx.begin(), ss_idx.end(),
                            [this](SimQubitIdType s) { return isValidQubitId(s); });
     }
 
-    [[nodiscard]] auto getAllQubitIds() -> std::vector<SimQubitIdType>
-    {
+    [[nodiscard]] auto getAllQubitIds() -> std::vector<SimQubitIdType> {
         std::vector<SimQubitIdType> ids;
         ids.reserve(this->qubits_map.size());
-        for (const auto &it : this->qubits_map) {
+        for (const auto& it : this->qubits_map) {
             ids.push_back(it.first);
         }
 
         return ids;
     }
 
-    [[nodiscard]] auto getDeviceId(SimQubitIdType s_idx) -> DevQubitIdType
-    {
+    [[nodiscard]] auto getDeviceId(SimQubitIdType s_idx) -> DevQubitIdType {
         RT_FAIL_IF(!isValidQubitId(s_idx), "Invalid device qubit index");
 
         return this->qubits_map[s_idx];
     }
 
-    auto getDeviceIds(const std::vector<SimQubitIdType> &ss_idx) -> std::vector<DevQubitIdType>
-    {
+    auto getDeviceIds(const std::vector<SimQubitIdType>& ss_idx) -> std::vector<DevQubitIdType> {
         std::vector<DevQubitIdType> dd_idx;
         dd_idx.reserve(ss_idx.size());
-        for (const auto &s : ss_idx) {
+        for (const auto& s : ss_idx) {
             dd_idx.push_back(getDeviceId(s));
         }
         return dd_idx;
     }
 
-    [[nodiscard]] auto getSimulatorId(DevQubitIdType d_idx) -> SimQubitIdType
-    {
+    [[nodiscard]] auto getSimulatorId(DevQubitIdType d_idx) -> SimQubitIdType {
         auto s_idx = std::find_if(this->qubits_map.begin(), this->qubits_map.end(),
-                                  [&d_idx](auto &&p) { return p.second == d_idx; });
+                                  [&d_idx](auto&& p) { return p.second == d_idx; });
 
         RT_FAIL_IF(s_idx == this->qubits_map.end(), "Invalid simulator qubit index");
 
         return s_idx->first;
     }
 
-    [[nodiscard]] auto Allocate(DevQubitIdType d_next_idx) -> SimQubitIdType
-    {
+    [[nodiscard]] auto Allocate(DevQubitIdType d_next_idx) -> SimQubitIdType {
         this->qubits_map[this->next_idx++] = d_next_idx;
         return this->next_idx - 1;
     }
 
-    auto AllocateRange(DevQubitIdType start_idx, size_t size) -> std::vector<SimQubitIdType>
-    {
+    auto AllocateRange(DevQubitIdType start_idx, size_t size) -> std::vector<SimQubitIdType> {
         std::vector<SimQubitIdType> ids;
         ids.reserve(size);
         for (DevQubitIdType i = start_idx; i < start_idx + size; i++) {
@@ -132,13 +122,11 @@ class QubitManager {
         return ids;
     }
 
-    void Release(SimQubitIdType s_idx)
-    {
+    void Release(SimQubitIdType s_idx) {
         _update_qubits_mapfrom(_remove_simulator_qubit_id(s_idx));
     }
 
-    void ReleaseAll()
-    {
+    void ReleaseAll() {
         // Release all qubits by clearing the map.
         this->qubits_map.clear();
     }

--- a/runtime/lib/backend/common/Utils.hpp
+++ b/runtime/lib/backend/common/Utils.hpp
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include "Exception.hpp"
+#include "Types.h"
+
 #include <algorithm>
 #include <array>
 #include <sstream>
@@ -23,20 +26,15 @@
 #include <unordered_map>
 #include <utility>
 
-#include "Exception.hpp"
-#include "Types.h"
-
 #if __has_include("StateVectorLQubitDynamic.hpp")
 #include "Util.hpp"
 #endif
 
 namespace Catalyst::Runtime::Simulator {
-static inline auto parse_kwargs(std::string kwargs) -> std::unordered_map<std::string, std::string>
-{
+static inline auto parse_kwargs(std::string kwargs)
+    -> std::unordered_map<std::string, std::string> {
     // cleaning kwargs
-    if (kwargs.empty()) {
-        return {};
-    }
+    if (kwargs.empty()) { return {}; }
 
     std::unordered_map<std::string, std::string> map;
     size_t s3_pos = kwargs.find("\'s3_destination_folder\'");
@@ -53,13 +51,11 @@ static inline auto parse_kwargs(std::string kwargs) -> std::unordered_map<std::s
     kwargs.erase(std::remove_if(kwargs.begin(), kwargs_end_iter,
                                 [](char c) {
                                     switch (c) {
-                                    case '{':
-                                    case '}':
-                                    case ' ':
-                                    case '\'':
-                                        return true;
-                                    default:
-                                        return false;
+                                        case '{':
+                                        case '}':
+                                        case ' ':
+                                        case '\'': return true;
+                                        default: return false;
                                     }
                                 }),
                  kwargs.end());
@@ -176,38 +172,29 @@ template <size_t size = simulator_gate_info_size>
 using SimulatorGateInfoDataT = std::array<GateInfoTupleT, size>;
 
 template <size_t size = simulator_observable_support_size>
-constexpr auto lookup_obs(const std::array<std::tuple<ObsId, std::string_view, bool>, size> &arr,
-                          const ObsId key) -> std::string_view
-{
+constexpr auto lookup_obs(const std::array<std::tuple<ObsId, std::string_view, bool>, size>& arr,
+                          const ObsId key) -> std::string_view {
     for (size_t idx = 0; idx < size; idx++) {
-        auto &&[op_id, op_str, op_support] = arr[idx];
-        if (op_id == key && op_support) {
-            return op_str;
-        }
+        auto&& [op_id, op_str, op_support] = arr[idx];
+        if (op_id == key && op_support) { return op_str; }
     }
     throw std::range_error("The given observable is not supported by the simulator");
 }
 
 template <size_t size = simulator_gate_info_size>
-constexpr auto lookup_gates(const SimulatorGateInfoDataT<size> &arr, const std::string &key)
-    -> std::pair<size_t, size_t>
-{
+constexpr auto lookup_gates(const SimulatorGateInfoDataT<size>& arr, const std::string& key)
+    -> std::pair<size_t, size_t> {
     for (size_t idx = 0; idx < size; idx++) {
-        auto &&[op, op_str, op_num_wires, op_num_params] = arr[idx];
-        if (op_str == key) {
-            return std::make_pair(op_num_wires, op_num_params);
-        }
+        auto&& [op, op_str, op_num_wires, op_num_params] = arr[idx];
+        if (op_str == key) { return std::make_pair(op_num_wires, op_num_params); }
     }
     throw std::range_error("The given operation is not supported by the simulator");
 }
 
 template <size_t size = simulator_gate_info_size>
-constexpr auto has_gate(const SimulatorGateInfoDataT<size> &arr, const std::string &key) -> bool
-{
+constexpr auto has_gate(const SimulatorGateInfoDataT<size>& arr, const std::string& key) -> bool {
     for (size_t idx = 0; idx < size; idx++) {
-        if (std::get<1>(arr[idx]) == key) {
-            return true;
-        }
+        if (std::get<1>(arr[idx]) == key) { return true; }
     }
     return false;
 }

--- a/runtime/lib/backend/lightning-kokkos/LightningKokkosSimulator.hpp
+++ b/runtime/lib/backend/lightning-kokkos/LightningKokkosSimulator.hpp
@@ -19,26 +19,26 @@ throw std::logic_error("StateVectorKokkos.hpp: No such header file");
 
 #define __device_lightning_kokkos
 
-#include <bitset>
+#include "AdjointJacobianKokkos.hpp"
+#include "CacheManager.hpp"
+#include "Exception.hpp"
+#include "LightningKokkosObsManager.hpp"
+#include "LinearAlgebra.hpp"
+#include "MeasurementsKokkos.hpp"
+#include "QuantumDevice.hpp"
+#include "QubitManager.hpp"
+#include "StateVectorKokkos.hpp"
+#include "Utils.hpp"
+
 #include <cmath>
+
+#include <bitset>
 #include <cstdint>
 #include <iostream>
 #include <limits>
 #include <random>
 #include <span>
 #include <stdexcept>
-
-#include "AdjointJacobianKokkos.hpp"
-#include "LinearAlgebra.hpp"
-#include "MeasurementsKokkos.hpp"
-#include "StateVectorKokkos.hpp"
-
-#include "CacheManager.hpp"
-#include "Exception.hpp"
-#include "LightningKokkosObsManager.hpp"
-#include "QuantumDevice.hpp"
-#include "QubitManager.hpp"
-#include "Utils.hpp"
 
 namespace Catalyst::Runtime::Simulator {
 class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
@@ -60,25 +60,21 @@ class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
     std::unique_ptr<StateVectorT> device_sv = std::make_unique<StateVectorT>(0);
     LightningKokkosObsManager<double> obs_manager{};
 
-    inline auto isValidQubit(QubitIdType wire) -> bool
-    {
+    inline auto isValidQubit(QubitIdType wire) -> bool {
         return this->qubit_manager.isValidQubitId(wire);
     }
 
-    inline auto isValidQubits(const std::vector<QubitIdType> &wires) -> bool
-    {
+    inline auto isValidQubits(const std::vector<QubitIdType>& wires) -> bool {
         return std::all_of(wires.begin(), wires.end(),
                            [this](QubitIdType w) { return this->isValidQubit(w); });
     }
 
-    inline auto isValidQubits(size_t numWires, const QubitIdType *wires) -> bool
-    {
+    inline auto isValidQubits(size_t numWires, const QubitIdType* wires) -> bool {
         return std::all_of(wires, wires + numWires,
                            [this](QubitIdType w) { return this->isValidQubit(w); });
     }
 
-    inline auto getDeviceWires(size_t numWires, const QubitIdType *wires) -> std::vector<size_t>
-    {
+    inline auto getDeviceWires(size_t numWires, const QubitIdType* wires) -> std::vector<size_t> {
         std::vector<size_t> res;
         res.reserve(numWires);
         std::transform(wires, wires + numWires, std::back_inserter(res),
@@ -86,8 +82,7 @@ class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
         return res;
     }
 
-    inline auto getDeviceWires(const std::vector<QubitIdType> &wires) -> std::vector<size_t>
-    {
+    inline auto getDeviceWires(const std::vector<QubitIdType>& wires) -> std::vector<size_t> {
         std::vector<size_t> res;
         res.reserve(wires.size());
         std::transform(wires.begin(), wires.end(), std::back_inserter(res),
@@ -96,19 +91,18 @@ class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
     }
 
   public:
-    explicit LightningKokkosSimulator(bool status = false, const std::string &kwargs = "{}")
-        : tape_recording(status)
-    {
-        auto &&args = parse_kwargs(kwargs);
+    explicit LightningKokkosSimulator(bool status = false, const std::string& kwargs = "{}") :
+        tape_recording(status) {
+        auto&& args = parse_kwargs(kwargs);
         device_shots = args.contains("shots") ? static_cast<size_t>(std::stoll(args["shots"]))
                                               : default_device_shots;
     }
     ~LightningKokkosSimulator() = default;
 
-    LightningKokkosSimulator(const LightningKokkosSimulator &) = delete;
-    LightningKokkosSimulator &operator=(const LightningKokkosSimulator &) = delete;
-    LightningKokkosSimulator(LightningKokkosSimulator &&) = delete;
-    LightningKokkosSimulator &operator=(LightningKokkosSimulator &&) = delete;
+    LightningKokkosSimulator(const LightningKokkosSimulator&) = delete;
+    LightningKokkosSimulator& operator=(const LightningKokkosSimulator&) = delete;
+    LightningKokkosSimulator(LightningKokkosSimulator&&) = delete;
+    LightningKokkosSimulator& operator=(LightningKokkosSimulator&&) = delete;
 
     // RT
     auto AllocateQubit() -> QubitIdType override;
@@ -128,28 +122,28 @@ class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
         -> std::tuple<size_t, size_t, size_t, std::vector<std::string>, std::vector<ObsIdType>>;
 
     // QIS
-    void NamedOperation(const std::string &name, const std::vector<double> &params,
-                        const std::vector<QubitIdType> &wires, bool inverse) override;
-    void MatrixOperation(const std::vector<std::complex<double>> &matrix,
-                         const std::vector<QubitIdType> &wires, bool inverse) override;
-    auto Observable(ObsId id, const std::vector<std::complex<double>> &matrix,
-                    const std::vector<QubitIdType> &wires) -> ObsIdType override;
-    auto TensorObservable(const std::vector<ObsIdType> &obs) -> ObsIdType override;
-    auto HamiltonianObservable(const std::vector<double> &coeffs, const std::vector<ObsIdType> &obs)
+    void NamedOperation(const std::string& name, const std::vector<double>& params,
+                        const std::vector<QubitIdType>& wires, bool inverse) override;
+    void MatrixOperation(const std::vector<std::complex<double>>& matrix,
+                         const std::vector<QubitIdType>& wires, bool inverse) override;
+    auto Observable(ObsId id, const std::vector<std::complex<double>>& matrix,
+                    const std::vector<QubitIdType>& wires) -> ObsIdType override;
+    auto TensorObservable(const std::vector<ObsIdType>& obs) -> ObsIdType override;
+    auto HamiltonianObservable(const std::vector<double>& coeffs, const std::vector<ObsIdType>& obs)
         -> ObsIdType override;
     auto Expval(ObsIdType obsKey) -> double override;
     auto Var(ObsIdType obsKey) -> double override;
-    void State(DataView<std::complex<double>, 1> &state) override;
-    void Probs(DataView<double, 1> &probs) override;
-    void PartialProbs(DataView<double, 1> &probs, const std::vector<QubitIdType> &wires) override;
-    void Sample(DataView<double, 2> &samples, size_t shots) override;
-    void PartialSample(DataView<double, 2> &samples, const std::vector<QubitIdType> &wires,
+    void State(DataView<std::complex<double>, 1>& state) override;
+    void Probs(DataView<double, 1>& probs) override;
+    void PartialProbs(DataView<double, 1>& probs, const std::vector<QubitIdType>& wires) override;
+    void Sample(DataView<double, 2>& samples, size_t shots) override;
+    void PartialSample(DataView<double, 2>& samples, const std::vector<QubitIdType>& wires,
                        size_t shots) override;
-    void Counts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts, size_t shots) override;
-    void PartialCounts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts,
-                       const std::vector<QubitIdType> &wires, size_t shots) override;
+    void Counts(DataView<double, 1>& eigvals, DataView<int64_t, 1>& counts, size_t shots) override;
+    void PartialCounts(DataView<double, 1>& eigvals, DataView<int64_t, 1>& counts,
+                       const std::vector<QubitIdType>& wires, size_t shots) override;
     auto Measure(QubitIdType wire) -> Result override;
-    void Gradient(std::vector<DataView<double, 1>> &gradients,
-                  const std::vector<size_t> &trainParams) override;
+    void Gradient(std::vector<DataView<double, 1>>& gradients,
+                  const std::vector<size_t>& trainParams) override;
 };
 } // namespace Catalyst::Runtime::Simulator

--- a/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
+++ b/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
@@ -16,50 +16,40 @@
 
 namespace Catalyst::Runtime::Device {
 
-auto OpenQasmDevice::AllocateQubit() -> QubitIdType
-{
+auto OpenQasmDevice::AllocateQubit() -> QubitIdType {
     RT_FAIL("Unsupported functionality");
     return QubitIdType{};
 }
 
-auto OpenQasmDevice::AllocateQubits(size_t num_qubits) -> std::vector<QubitIdType>
-{
-    if (num_qubits == 0U) {
-        return {};
-    }
+auto OpenQasmDevice::AllocateQubits(size_t num_qubits) -> std::vector<QubitIdType> {
+    if (num_qubits == 0U) { return {}; }
 
     const size_t cur_num_qubits = builder->getNumQubits();
     const size_t new_num_qubits = cur_num_qubits + num_qubits;
-    if (cur_num_qubits) {
-        builder = std::make_unique<OpenQasm::OpenQasmBuilder>();
-    }
+    if (cur_num_qubits) { builder = std::make_unique<OpenQasm::OpenQasmBuilder>(); }
 
     builder->Register(OpenQasm::RegisterType::Qubit, "qubits", new_num_qubits);
 
     return qubit_manager.AllocateRange(cur_num_qubits, new_num_qubits);
 }
 
-void OpenQasmDevice::ReleaseAllQubits()
-{
+void OpenQasmDevice::ReleaseAllQubits() {
     // do nothing
 }
 
-void OpenQasmDevice::ReleaseQubit([[maybe_unused]] QubitIdType q)
-{
+void OpenQasmDevice::ReleaseQubit([[maybe_unused]] QubitIdType q) {
     RT_FAIL("Unsupported functionality");
 }
 
 auto OpenQasmDevice::GetNumQubits() const -> size_t { return builder->getNumQubits(); }
 
-void OpenQasmDevice::StartTapeRecording()
-{
+void OpenQasmDevice::StartTapeRecording() {
     RT_FAIL_IF(tape_recording, "Cannot re-activate the cache manager");
     tape_recording = true;
     cache_manager.Reset();
 }
 
-void OpenQasmDevice::StopTapeRecording()
-{
+void OpenQasmDevice::StopTapeRecording() {
     RT_FAIL_IF(!tape_recording, "Cannot stop an already stopped cache manager");
     tape_recording = false;
 }
@@ -68,14 +58,13 @@ void OpenQasmDevice::SetDeviceShots([[maybe_unused]] size_t shots) { device_shot
 
 auto OpenQasmDevice::GetDeviceShots() const -> size_t { return device_shots; }
 
-void OpenQasmDevice::PrintState()
-{
+void OpenQasmDevice::PrintState() {
     using std::cout;
     using std::endl;
 
     std::ostringstream oss;
     oss << "#pragma braket result state_vector";
-    auto &&circuit = builder->toOpenQasmWithCustomInstructions(oss.str());
+    auto&& circuit = builder->toOpenQasmWithCustomInstructions(oss.str());
 
     std::string s3_folder_str{};
     if (device_kwargs.contains("s3_destination_folder")) {
@@ -85,12 +74,11 @@ void OpenQasmDevice::PrintState()
     std::string device_info{};
     if (builder_type == OpenQasm::BuilderType::BraketRemote) {
         device_info = device_kwargs["device_arn"];
-    }
-    else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
+    } else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
         device_info = device_kwargs["backend"];
     }
 
-    auto &&state = runner->State(circuit, device_info, device_shots, GetNumQubits(), s3_folder_str);
+    auto&& state = runner->State(circuit, device_info, device_shots, GetNumQubits(), s3_folder_str);
 
     const size_t num_qubits = GetNumQubits();
     const size_t size = 1UL << num_qubits;
@@ -104,83 +92,74 @@ void OpenQasmDevice::PrintState()
     cout << state[idx] << "]" << endl;
 }
 
-auto OpenQasmDevice::Zero() const -> Result
-{
+auto OpenQasmDevice::Zero() const -> Result {
     return const_cast<Result>(&GLOBAL_RESULT_FALSE_CONST);
 }
 
 auto OpenQasmDevice::One() const -> Result { return const_cast<Result>(&GLOBAL_RESULT_TRUE_CONST); }
 
-void OpenQasmDevice::NamedOperation(const std::string &name, const std::vector<double> &params,
-                                    const std::vector<QubitIdType> &wires, bool inverse)
-{
+void OpenQasmDevice::NamedOperation(const std::string& name, const std::vector<double>& params,
+                                    const std::vector<QubitIdType>& wires, bool inverse) {
     using namespace Catalyst::Runtime::Simulator::Lightning;
 
     // First, check operation specifications
-    auto &&[op_num_wires, op_num_params] = lookup_gates(simulator_gate_info, name);
+    auto&& [op_num_wires, op_num_params] = lookup_gates(simulator_gate_info, name);
 
     // Check the validity of number of qubits and parameters
     RT_FAIL_IF((!wires.size() && wires.size() != op_num_wires), "Invalid number of qubits");
     RT_FAIL_IF(params.size() != op_num_params, "Invalid number of parameters");
 
     // Convert wires to device wires
-    auto &&dev_wires = getDeviceWires(wires);
+    auto&& dev_wires = getDeviceWires(wires);
 
     builder->Gate(name, params, {}, dev_wires, inverse);
 }
 
 void OpenQasmDevice::MatrixOperation(
-    [[maybe_unused]] const std::vector<std::complex<double>> &matrix,
-    [[maybe_unused]] const std::vector<QubitIdType> &wires, [[maybe_unused]] bool inverse)
-{
+    [[maybe_unused]] const std::vector<std::complex<double>>& matrix,
+    [[maybe_unused]] const std::vector<QubitIdType>& wires, [[maybe_unused]] bool inverse) {
     RT_FAIL_IF(builder_type == OpenQasm::BuilderType::Common, "Unsupported functionality");
 
     // Convert wires to device wires
     // with checking validity of wires
-    auto &&dev_wires = getDeviceWires(wires);
+    auto&& dev_wires = getDeviceWires(wires);
 
     builder->Gate(matrix, dev_wires, inverse);
 }
 
-auto OpenQasmDevice::Observable(ObsId id, const std::vector<std::complex<double>> &matrix,
-                                const std::vector<QubitIdType> &wires) -> ObsIdType
-{
+auto OpenQasmDevice::Observable(ObsId id, const std::vector<std::complex<double>>& matrix,
+                                const std::vector<QubitIdType>& wires) -> ObsIdType {
     RT_FAIL_IF(wires.size() > GetNumQubits(), "Invalid number of wires");
     RT_FAIL_IF(!isValidQubits(wires), "Invalid given wires");
 
-    auto &&dev_wires = getDeviceWires(wires);
+    auto&& dev_wires = getDeviceWires(wires);
 
-    if (id == ObsId::Hermitian) {
-        return obs_manager.createHermitianObs(matrix, dev_wires);
-    }
+    if (id == ObsId::Hermitian) { return obs_manager.createHermitianObs(matrix, dev_wires); }
 
     return obs_manager.createNamedObs(id, dev_wires);
 }
 
-auto OpenQasmDevice::TensorObservable([[maybe_unused]] const std::vector<ObsIdType> &obs)
-    -> ObsIdType
-{
+auto OpenQasmDevice::TensorObservable([[maybe_unused]] const std::vector<ObsIdType>& obs)
+    -> ObsIdType {
     return obs_manager.createTensorProdObs(obs);
 }
 
-auto OpenQasmDevice::HamiltonianObservable([[maybe_unused]] const std::vector<double> &coeffs,
-                                           [[maybe_unused]] const std::vector<ObsIdType> &obs)
-    -> ObsIdType
-{
+auto OpenQasmDevice::HamiltonianObservable([[maybe_unused]] const std::vector<double>& coeffs,
+                                           [[maybe_unused]] const std::vector<ObsIdType>& obs)
+    -> ObsIdType {
     return obs_manager.createHamiltonianObs(coeffs, obs);
 }
 
-auto OpenQasmDevice::Expval([[maybe_unused]] ObsIdType obsKey) -> double
-{
+auto OpenQasmDevice::Expval([[maybe_unused]] ObsIdType obsKey) -> double {
     RT_ASSERT(builder->getQubits().size());
     RT_FAIL_IF(!obs_manager.isValidObservables({obsKey}), "Invalid key for cached observables");
-    auto &&obs = obs_manager.getObservable(obsKey);
+    auto&& obs = obs_manager.getObservable(obsKey);
     RT_FAIL_IF(obs->getName() == "QasmHamiltonianObs",
                "Unsupported observable: QasmHamiltonianObs");
 
     std::ostringstream oss;
     oss << "#pragma braket result expectation " << obs->toOpenQasm(builder->getQubits()[0]);
-    auto &&circuit = builder->toOpenQasmWithCustomInstructions(oss.str(), 9);
+    auto&& circuit = builder->toOpenQasmWithCustomInstructions(oss.str(), 9);
 
     // update tape caching
     if (tape_recording) {
@@ -196,25 +175,23 @@ auto OpenQasmDevice::Expval([[maybe_unused]] ObsIdType obsKey) -> double
     std::string device_info{};
     if (builder_type == OpenQasm::BuilderType::BraketRemote) {
         device_info = device_kwargs["device_arn"];
-    }
-    else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
+    } else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
         device_info = device_kwargs["backend"];
     }
 
     return runner->Expval(circuit, device_info, device_shots, s3_folder_str);
 }
 
-auto OpenQasmDevice::Var([[maybe_unused]] ObsIdType obsKey) -> double
-{
+auto OpenQasmDevice::Var([[maybe_unused]] ObsIdType obsKey) -> double {
     RT_ASSERT(builder->getQubits().size());
     RT_FAIL_IF(!obs_manager.isValidObservables({obsKey}), "Invalid key for cached observables");
-    auto &&obs = obs_manager.getObservable(obsKey);
+    auto&& obs = obs_manager.getObservable(obsKey);
     RT_FAIL_IF(obs->getName() == "QasmHamiltonianObs",
                "Unsupported observable: QasmHamiltonianObs");
 
     std::ostringstream oss;
     oss << "#pragma braket result variance " << obs->toOpenQasm(builder->getQubits()[0]);
-    auto &&circuit = builder->toOpenQasmWithCustomInstructions(oss.str(), 9);
+    auto&& circuit = builder->toOpenQasmWithCustomInstructions(oss.str(), 9);
 
     // update tape caching
     if (tape_recording) {
@@ -230,19 +207,17 @@ auto OpenQasmDevice::Var([[maybe_unused]] ObsIdType obsKey) -> double
     std::string device_info{};
     if (builder_type == OpenQasm::BuilderType::BraketRemote) {
         device_info = device_kwargs["device_arn"];
-    }
-    else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
+    } else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
         device_info = device_kwargs["backend"];
     }
 
     return runner->Var(circuit, device_info, device_shots, s3_folder_str);
 }
 
-void OpenQasmDevice::State([[maybe_unused]] DataView<std::complex<double>, 1> &state)
-{
+void OpenQasmDevice::State([[maybe_unused]] DataView<std::complex<double>, 1>& state) {
     std::ostringstream oss;
     oss << "#pragma braket result state_vector";
-    auto &&circuit = builder->toOpenQasmWithCustomInstructions(oss.str());
+    auto&& circuit = builder->toOpenQasmWithCustomInstructions(oss.str());
 
     std::string s3_folder_str{};
     if (device_kwargs.contains("s3_destination_folder")) {
@@ -252,20 +227,18 @@ void OpenQasmDevice::State([[maybe_unused]] DataView<std::complex<double>, 1> &s
     std::string device_info{};
     if (builder_type == OpenQasm::BuilderType::BraketRemote) {
         device_info = device_kwargs["device_arn"];
-    }
-    else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
+    } else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
         device_info = device_kwargs["backend"];
     }
 
-    auto &&dv_state =
+    auto&& dv_state =
         runner->State(circuit, device_info, device_shots, GetNumQubits(), s3_folder_str);
     RT_FAIL_IF(state.size() != dv_state.size(), "Invalid size for the pre-allocated state vector");
 
     std::move(dv_state.begin(), dv_state.end(), state.begin());
 }
 
-void OpenQasmDevice::Probs(DataView<double, 1> &probs)
-{
+void OpenQasmDevice::Probs(DataView<double, 1>& probs) {
     std::string s3_folder_str{};
     if (device_kwargs.contains("s3_destination_folder")) {
         s3_folder_str = device_kwargs["s3_destination_folder"];
@@ -274,12 +247,11 @@ void OpenQasmDevice::Probs(DataView<double, 1> &probs)
     std::string device_info{};
     if (builder_type == OpenQasm::BuilderType::BraketRemote) {
         device_info = device_kwargs["device_arn"];
-    }
-    else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
+    } else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
         device_info = device_kwargs["backend"];
     }
 
-    auto &&dv_probs = runner->Probs(builder->toOpenQasm(), device_info, device_shots,
+    auto&& dv_probs = runner->Probs(builder->toOpenQasm(), device_info, device_shots,
                                     GetNumQubits(), s3_folder_str);
 
     RT_FAIL_IF(probs.size() != dv_probs.size(), "Invalid size for the pre-allocated probabilities");
@@ -287,16 +259,15 @@ void OpenQasmDevice::Probs(DataView<double, 1> &probs)
     std::move(dv_probs.begin(), dv_probs.end(), probs.begin());
 }
 
-void OpenQasmDevice::PartialProbs([[maybe_unused]] DataView<double, 1> &probs,
-                                  [[maybe_unused]] const std::vector<QubitIdType> &wires)
-{
+void OpenQasmDevice::PartialProbs([[maybe_unused]] DataView<double, 1>& probs,
+                                  [[maybe_unused]] const std::vector<QubitIdType>& wires) {
     // get device wires
-    auto &&dev_wires = getDeviceWires(wires);
+    auto&& dev_wires = getDeviceWires(wires);
 
     std::ostringstream oss;
     oss << "#pragma braket result probability "
         << builder->getQubits()[0].toOpenQasm(OpenQasm::RegisterMode::Slice, dev_wires);
-    auto &&circuit = builder->toOpenQasmWithCustomInstructions(oss.str());
+    auto&& circuit = builder->toOpenQasmWithCustomInstructions(oss.str());
 
     std::string s3_folder_str{};
     if (device_kwargs.contains("s3_destination_folder")) {
@@ -306,12 +277,11 @@ void OpenQasmDevice::PartialProbs([[maybe_unused]] DataView<double, 1> &probs,
     std::string device_info{};
     if (builder_type == OpenQasm::BuilderType::BraketRemote) {
         device_info = device_kwargs["device_arn"];
-    }
-    else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
+    } else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
         device_info = device_kwargs["backend"];
     }
 
-    auto &&dv_probs =
+    auto&& dv_probs =
         runner->Probs(circuit, device_info, device_shots, wires.size(), s3_folder_str);
 
     RT_FAIL_IF(probs.size() != dv_probs.size(), "Invalid size for the pre-allocated probabilities");
@@ -319,8 +289,7 @@ void OpenQasmDevice::PartialProbs([[maybe_unused]] DataView<double, 1> &probs,
     std::move(dv_probs.begin(), dv_probs.end(), probs.begin());
 }
 
-void OpenQasmDevice::Sample(DataView<double, 2> &samples, size_t shots)
-{
+void OpenQasmDevice::Sample(DataView<double, 2>& samples, size_t shots) {
     std::string s3_folder_str{};
     if (device_kwargs.contains("s3_destination_folder")) {
         s3_folder_str = device_kwargs["s3_destination_folder"];
@@ -329,12 +298,11 @@ void OpenQasmDevice::Sample(DataView<double, 2> &samples, size_t shots)
     std::string device_info{};
     if (builder_type == OpenQasm::BuilderType::BraketRemote) {
         device_info = device_kwargs["device_arn"];
-    }
-    else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
+    } else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
         device_info = device_kwargs["backend"];
     }
 
-    auto &&li_samples = runner->Sample(builder->toOpenQasm(), device_info, device_shots,
+    auto&& li_samples = runner->Sample(builder->toOpenQasm(), device_info, device_shots,
                                        GetNumQubits(), s3_folder_str);
     RT_FAIL_IF(samples.size() != li_samples.size(), "Invalid size for the pre-allocated samples");
 
@@ -348,9 +316,8 @@ void OpenQasmDevice::Sample(DataView<double, 2> &samples, size_t shots)
     }
 }
 
-void OpenQasmDevice::PartialSample(DataView<double, 2> &samples,
-                                   const std::vector<QubitIdType> &wires, size_t shots)
-{
+void OpenQasmDevice::PartialSample(DataView<double, 2>& samples,
+                                   const std::vector<QubitIdType>& wires, size_t shots) {
     const size_t numWires = wires.size();
     const size_t numQubits = GetNumQubits();
 
@@ -360,7 +327,7 @@ void OpenQasmDevice::PartialSample(DataView<double, 2> &samples,
                "Invalid size for the pre-allocated partial-samples");
 
     // // get device wires
-    auto &&dev_wires = getDeviceWires(wires);
+    auto&& dev_wires = getDeviceWires(wires);
 
     std::string s3_folder_str{};
     if (device_kwargs.contains("s3_destination_folder")) {
@@ -370,12 +337,11 @@ void OpenQasmDevice::PartialSample(DataView<double, 2> &samples,
     std::string device_info{};
     if (builder_type == OpenQasm::BuilderType::BraketRemote) {
         device_info = device_kwargs["device_arn"];
-    }
-    else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
+    } else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
         device_info = device_kwargs["backend"];
     }
 
-    auto &&li_samples = runner->Sample(builder->toOpenQasm(), device_info, device_shots,
+    auto&& li_samples = runner->Sample(builder->toOpenQasm(), device_info, device_shots,
                                        GetNumQubits(), s3_folder_str);
 
     auto samplesIter = samples.begin();
@@ -386,9 +352,8 @@ void OpenQasmDevice::PartialSample(DataView<double, 2> &samples,
     }
 }
 
-void OpenQasmDevice::Counts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts,
-                            size_t shots)
-{
+void OpenQasmDevice::Counts(DataView<double, 1>& eigvals, DataView<int64_t, 1>& counts,
+                            size_t shots) {
     const size_t numQubits = GetNumQubits();
     const size_t numElements = 1U << numQubits;
 
@@ -403,12 +368,11 @@ void OpenQasmDevice::Counts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &
     std::string device_info{};
     if (builder_type == OpenQasm::BuilderType::BraketRemote) {
         device_info = device_kwargs["device_arn"];
-    }
-    else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
+    } else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
         device_info = device_kwargs["backend"];
     }
 
-    auto &&li_samples = runner->Sample(builder->toOpenQasm(), device_info, device_shots,
+    auto&& li_samples = runner->Sample(builder->toOpenQasm(), device_info, device_shots,
                                        GetNumQubits(), s3_folder_str);
 
     std::iota(eigvals.begin(), eigvals.end(), 0);
@@ -424,9 +388,8 @@ void OpenQasmDevice::Counts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &
     }
 }
 
-void OpenQasmDevice::PartialCounts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts,
-                                   const std::vector<QubitIdType> &wires, size_t shots)
-{
+void OpenQasmDevice::PartialCounts(DataView<double, 1>& eigvals, DataView<int64_t, 1>& counts,
+                                   const std::vector<QubitIdType>& wires, size_t shots) {
     const size_t numWires = wires.size();
     const size_t numQubits = GetNumQubits();
     const size_t numElements = 1U << numWires;
@@ -436,7 +399,7 @@ void OpenQasmDevice::PartialCounts(DataView<double, 1> &eigvals, DataView<int64_
     RT_FAIL_IF((eigvals.size() != numElements || counts.size() != numElements),
                "Invalid size for the pre-allocated partial-counts");
 
-    auto &&dev_wires = getDeviceWires(wires);
+    auto&& dev_wires = getDeviceWires(wires);
 
     std::string s3_folder_str{};
     if (device_kwargs.contains("s3_destination_folder")) {
@@ -446,12 +409,11 @@ void OpenQasmDevice::PartialCounts(DataView<double, 1> &eigvals, DataView<int64_
     std::string device_info{};
     if (builder_type == OpenQasm::BuilderType::BraketRemote) {
         device_info = device_kwargs["device_arn"];
-    }
-    else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
+    } else if (builder_type == OpenQasm::BuilderType::BraketLocal) {
         device_info = device_kwargs["backend"];
     }
 
-    auto &&li_samples = runner->Sample(builder->toOpenQasm(), device_info, device_shots,
+    auto&& li_samples = runner->Sample(builder->toOpenQasm(), device_info, device_shots,
                                        GetNumQubits(), s3_folder_str);
 
     std::iota(eigvals.begin(), eigvals.end(), 0);
@@ -467,15 +429,14 @@ void OpenQasmDevice::PartialCounts(DataView<double, 1> &eigvals, DataView<int64_
     }
 }
 
-auto OpenQasmDevice::Measure([[maybe_unused]] QubitIdType wire) -> Result
-{
+auto OpenQasmDevice::Measure([[maybe_unused]] QubitIdType wire) -> Result {
     if (builder_type != OpenQasm::BuilderType::Common) {
         RT_FAIL("Unsupported functionality");
         return Result{};
     }
 
     // Convert wire to device wire
-    auto &&dev_wire = getDeviceWires({wire});
+    auto&& dev_wire = getDeviceWires({wire});
 
     auto num_qubits = GetNumQubits();
     if (builder->getNumBits() != num_qubits) {
@@ -487,9 +448,8 @@ auto OpenQasmDevice::Measure([[maybe_unused]] QubitIdType wire) -> Result
 }
 
 // Gradient
-void OpenQasmDevice::Gradient([[maybe_unused]] std::vector<DataView<double, 1>> &gradients,
-                              [[maybe_unused]] const std::vector<size_t> &trainParams)
-{
+void OpenQasmDevice::Gradient([[maybe_unused]] std::vector<DataView<double, 1>>& gradients,
+                              [[maybe_unused]] const std::vector<size_t>& trainParams) {
     // TODO: custom implementation
     RT_FAIL("Unsupported functionality");
 }

--- a/runtime/lib/backend/openqasm/OpenQasmDevice.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmDevice.hpp
@@ -16,23 +16,21 @@
 
 #define __device_openqasm
 
+#include "CacheManager.hpp"
+#include "Exception.hpp"
+#include "OpenQasmBuilder.hpp"
+#include "OpenQasmObsManager.hpp"
+#include "OpenQasmRunner.hpp"
+#include "QuantumDevice.hpp"
+#include "QubitManager.hpp"
+#include "Utils.hpp"
+
 #include <algorithm>
 #include <bitset>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#include "Exception.hpp"
-#include "QuantumDevice.hpp"
-
-#include "CacheManager.hpp"
-#include "QubitManager.hpp"
-#include "Utils.hpp"
-
-#include "OpenQasmBuilder.hpp"
-#include "OpenQasmObsManager.hpp"
-#include "OpenQasmRunner.hpp"
 
 namespace Catalyst::Runtime::Device {
 class OpenQasmDevice final : public Catalyst::Runtime::QuantumDevice {
@@ -55,8 +53,7 @@ class OpenQasmDevice final : public Catalyst::Runtime::QuantumDevice {
     OpenQasm::BuilderType builder_type;
     std::unordered_map<std::string, std::string> device_kwargs;
 
-    inline auto getDeviceWires(const std::vector<QubitIdType> &wires) -> std::vector<size_t>
-    {
+    inline auto getDeviceWires(const std::vector<QubitIdType>& wires) -> std::vector<size_t> {
         std::vector<size_t> res;
         res.reserve(wires.size());
         std::transform(wires.begin(), wires.end(), std::back_inserter(res),
@@ -64,8 +61,7 @@ class OpenQasmDevice final : public Catalyst::Runtime::QuantumDevice {
         return res;
     }
 
-    inline auto isValidQubits(const std::vector<QubitIdType> &wires) -> bool
-    {
+    inline auto isValidQubits(const std::vector<QubitIdType>& wires) -> bool {
         return std::all_of(wires.begin(), wires.end(),
                            [this](QubitIdType w) { return qubit_manager.isValidQubitId(w); });
     }
@@ -73,9 +69,8 @@ class OpenQasmDevice final : public Catalyst::Runtime::QuantumDevice {
   public:
     explicit OpenQasmDevice(
         [[maybe_unused]] bool status = false,
-        const std::string &kwargs = "{device_type : braket.local.qubit, backend : default}")
-        : tape_recording(status)
-    {
+        const std::string& kwargs = "{device_type : braket.local.qubit, backend : default}") :
+        tape_recording(status) {
         device_kwargs = Simulator::parse_kwargs(kwargs);
         device_shots = device_kwargs.contains("shots")
                            ? static_cast<size_t>(std::stoll(device_kwargs["shots"]))
@@ -88,18 +83,13 @@ class OpenQasmDevice final : public Catalyst::Runtime::QuantumDevice {
                     device_kwargs["device_arn"] =
                         "arn:aws:braket:::device/quantum-simulator/amazon/sv1";
                 }
-            }
-            else if (device_kwargs["device_type"] == "braket.local.qubit") {
+            } else if (device_kwargs["device_type"] == "braket.local.qubit") {
                 builder_type = OpenQasm::BuilderType::BraketLocal;
-                if (!device_kwargs.contains("backend")) {
-                    device_kwargs["backend"] = "default";
-                }
-            }
-            else {
+                if (!device_kwargs.contains("backend")) { device_kwargs["backend"] = "default"; }
+            } else {
                 RT_ASSERT("Invalid OpenQasm device type");
             }
-        }
-        else {
+        } else {
             builder_type = OpenQasm::BuilderType::Common;
             builder = std::make_unique<OpenQasm::OpenQasmBuilder>();
             runner = std::make_unique<OpenQasm::OpenQasmRunner>();
@@ -112,10 +102,10 @@ class OpenQasmDevice final : public Catalyst::Runtime::QuantumDevice {
     }
     ~OpenQasmDevice() = default;
 
-    OpenQasmDevice(const OpenQasmDevice &) = delete;
-    OpenQasmDevice &operator=(const OpenQasmDevice &) = delete;
-    OpenQasmDevice(OpenQasmDevice &&) = delete;
-    OpenQasmDevice &operator=(OpenQasmDevice &&) = delete;
+    OpenQasmDevice(const OpenQasmDevice&) = delete;
+    OpenQasmDevice& operator=(const OpenQasmDevice&) = delete;
+    OpenQasmDevice(OpenQasmDevice&&) = delete;
+    OpenQasmDevice& operator=(OpenQasmDevice&&) = delete;
 
     // RT
     auto AllocateQubit() -> QubitIdType override;
@@ -135,28 +125,28 @@ class OpenQasmDevice final : public Catalyst::Runtime::QuantumDevice {
     [[nodiscard]] auto Circuit() const -> std::string { return builder->toOpenQasm(); }
 
     // QIS
-    void NamedOperation(const std::string &name, const std::vector<double> &params,
-                        const std::vector<QubitIdType> &wires, bool inverse) override;
-    void MatrixOperation(const std::vector<std::complex<double>> &matrix,
-                         const std::vector<QubitIdType> &wires, bool inverse) override;
-    auto Observable(ObsId id, const std::vector<std::complex<double>> &matrix,
-                    const std::vector<QubitIdType> &wires) -> ObsIdType override;
-    auto TensorObservable(const std::vector<ObsIdType> &obs) -> ObsIdType override;
-    auto HamiltonianObservable(const std::vector<double> &coeffs, const std::vector<ObsIdType> &obs)
+    void NamedOperation(const std::string& name, const std::vector<double>& params,
+                        const std::vector<QubitIdType>& wires, bool inverse) override;
+    void MatrixOperation(const std::vector<std::complex<double>>& matrix,
+                         const std::vector<QubitIdType>& wires, bool inverse) override;
+    auto Observable(ObsId id, const std::vector<std::complex<double>>& matrix,
+                    const std::vector<QubitIdType>& wires) -> ObsIdType override;
+    auto TensorObservable(const std::vector<ObsIdType>& obs) -> ObsIdType override;
+    auto HamiltonianObservable(const std::vector<double>& coeffs, const std::vector<ObsIdType>& obs)
         -> ObsIdType override;
     auto Expval(ObsIdType obsKey) -> double override;
     auto Var(ObsIdType obsKey) -> double override;
-    void State(DataView<std::complex<double>, 1> &state) override;
-    void Probs(DataView<double, 1> &probs) override;
-    void PartialProbs(DataView<double, 1> &probs, const std::vector<QubitIdType> &wires) override;
-    void Sample(DataView<double, 2> &samples, size_t shots) override;
-    void PartialSample(DataView<double, 2> &samples, const std::vector<QubitIdType> &wires,
+    void State(DataView<std::complex<double>, 1>& state) override;
+    void Probs(DataView<double, 1>& probs) override;
+    void PartialProbs(DataView<double, 1>& probs, const std::vector<QubitIdType>& wires) override;
+    void Sample(DataView<double, 2>& samples, size_t shots) override;
+    void PartialSample(DataView<double, 2>& samples, const std::vector<QubitIdType>& wires,
                        size_t shots) override;
-    void Counts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts, size_t shots) override;
-    void PartialCounts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts,
-                       const std::vector<QubitIdType> &wires, size_t shots) override;
+    void Counts(DataView<double, 1>& eigvals, DataView<int64_t, 1>& counts, size_t shots) override;
+    void PartialCounts(DataView<double, 1>& eigvals, DataView<int64_t, 1>& counts,
+                       const std::vector<QubitIdType>& wires, size_t shots) override;
     auto Measure(QubitIdType wire) -> Result override;
-    void Gradient(std::vector<DataView<double, 1>> &gradients,
-                  const std::vector<size_t> &trainParams) override;
+    void Gradient(std::vector<DataView<double, 1>>& gradients,
+                  const std::vector<size_t>& trainParams) override;
 };
 } // namespace Catalyst::Runtime::Device

--- a/runtime/lib/backend/openqasm/OpenQasmObsManager.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmObsManager.hpp
@@ -14,16 +14,15 @@
 
 #pragma once
 
+#include "Exception.hpp"
+#include "OpenQasmBuilder.hpp"
+#include "Types.h"
+#include "Utils.hpp"
+
 #include <array>
 #include <stdexcept>
 #include <tuple>
 #include <utility>
-
-#include "Exception.hpp"
-#include "OpenQasmBuilder.hpp"
-#include "Utils.hpp"
-
-#include "Types.h"
 
 namespace Catalyst::Runtime::Device::OpenQasm {
 
@@ -46,10 +45,10 @@ class OpenQasmObsManager {
     OpenQasmObsManager() = default;
     ~OpenQasmObsManager() = default;
 
-    OpenQasmObsManager(const OpenQasmObsManager &) = delete;
-    OpenQasmObsManager &operator=(const OpenQasmObsManager &) = delete;
-    OpenQasmObsManager(OpenQasmObsManager &&) = delete;
-    OpenQasmObsManager &operator=(OpenQasmObsManager &&) = delete;
+    OpenQasmObsManager(const OpenQasmObsManager&) = delete;
+    OpenQasmObsManager& operator=(const OpenQasmObsManager&) = delete;
+    OpenQasmObsManager(OpenQasmObsManager&&) = delete;
+    OpenQasmObsManager& operator=(OpenQasmObsManager&&) = delete;
 
     /**
      * @brief A helper function to clear constructed observables in the program.
@@ -62,8 +61,7 @@ class OpenQasmObsManager {
      * @param obsKeys The vector of observable keys
      * @return bool
      */
-    [[nodiscard]] auto isValidObservables(const std::vector<ObsIdType> &obsKeys) const -> bool
-    {
+    [[nodiscard]] auto isValidObservables(const std::vector<ObsIdType>& obsKeys) const -> bool {
         return std::all_of(obsKeys.begin(), obsKeys.end(), [this](auto i) {
             return (i >= 0 && static_cast<size_t>(i) < observables_.size());
         });
@@ -75,8 +73,7 @@ class OpenQasmObsManager {
      * @param key The observable key
      * @return std::shared_ptr<ObservableClassName>
      */
-    [[nodiscard]] auto getObservable(ObsIdType key) -> std::shared_ptr<QasmObs>
-    {
+    [[nodiscard]] auto getObservable(ObsIdType key) -> std::shared_ptr<QasmObs> {
         RT_FAIL_IF(!isValidObservables({key}), "Invalid observable key");
         return std::get<0>(observables_[key]);
     }
@@ -95,11 +92,10 @@ class OpenQasmObsManager {
      * @param wires The vector of wires the observable acts on
      * @return ObsIdType
      */
-    [[nodiscard]] auto createNamedObs(ObsId obsId, const std::vector<size_t> &wires) -> ObsIdType
-    {
+    [[nodiscard]] auto createNamedObs(ObsId obsId, const std::vector<size_t>& wires) -> ObsIdType {
         using namespace Catalyst::Runtime::Simulator::Lightning;
 
-        auto &&obs_str = std::string(
+        auto&& obs_str = std::string(
             lookup_obs<simulator_observable_support_size>(simulator_observable_support, obsId));
 
         observables_.push_back(
@@ -115,9 +111,8 @@ class OpenQasmObsManager {
      * @return ObsIdType
      */
     [[nodiscard]] auto
-    createHermitianObs([[maybe_unused]] const std::vector<std::complex<double>> &matrix,
-                       [[maybe_unused]] const std::vector<size_t> &wires) -> ObsIdType
-    {
+    createHermitianObs([[maybe_unused]] const std::vector<std::complex<double>>& matrix,
+                       [[maybe_unused]] const std::vector<size_t>& wires) -> ObsIdType {
         observables_.push_back(std::make_pair(
             std::make_shared<QasmHermitianObs>(QasmHermitianObs{matrix, wires}), ObsType::Basic));
 
@@ -130,18 +125,17 @@ class OpenQasmObsManager {
      * @param obsKeys The vector of observable keys
      * @return ObsIdType
      */
-    [[nodiscard]] auto createTensorProdObs(const std::vector<ObsIdType> &obsKeys) -> ObsIdType
-    {
+    [[nodiscard]] auto createTensorProdObs(const std::vector<ObsIdType>& obsKeys) -> ObsIdType {
         const auto key_size = obsKeys.size();
         const auto obs_size = observables_.size();
 
         std::vector<std::shared_ptr<QasmObs>> obs_vec;
         obs_vec.reserve(key_size);
 
-        for (const auto &key : obsKeys) {
+        for (const auto& key : obsKeys) {
             RT_FAIL_IF(static_cast<size_t>(key) >= obs_size || key < 0, "Invalid observable key");
 
-            auto &&[obs, type] = observables_[key];
+            auto&& [obs, type] = observables_[key];
 
             RT_FAIL_IF(type != ObsType::Basic, "Invalid basic observable to construct TensorProd; "
                                                "NamedObs and HermitianObs are only supported");
@@ -163,9 +157,8 @@ class OpenQasmObsManager {
      * @param obsKeys The vector of observable keys
      * @return ObsIdType
      */
-    [[nodiscard]] auto createHamiltonianObs(const std::vector<double> &coeffs,
-                                            const std::vector<ObsIdType> &obsKeys) -> ObsIdType
-    {
+    [[nodiscard]] auto createHamiltonianObs(const std::vector<double>& coeffs,
+                                            const std::vector<ObsIdType>& obsKeys) -> ObsIdType {
         const auto key_size = obsKeys.size();
         const auto obs_size = observables_.size();
 
@@ -179,7 +172,7 @@ class OpenQasmObsManager {
         for (auto key : obsKeys) {
             RT_FAIL_IF(static_cast<size_t>(key) >= obs_size || key < 0, "Invalid observable key");
 
-            auto &&[obs, type] = observables_[key];
+            auto&& [obs, type] = observables_[key];
             auto contain_obs = std::find(hamiltonian_valid_obs_types.begin(),
                                          hamiltonian_valid_obs_types.end(), type);
 

--- a/runtime/lib/backend/openqasm/OpenQasmRunner.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmRunner.hpp
@@ -14,16 +14,16 @@
 
 #pragma once
 
+#include "Exception.hpp"
+
+#include <pybind11/embed.h>
+
 #include <complex>
 #include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-
-#include "Exception.hpp"
-
-#include <pybind11/embed.h>
 
 namespace Catalyst::Runtime::Device::OpenQasm {
 
@@ -39,10 +39,10 @@ struct PythonInterpreterGuard {
     PythonInterpreterGuard() { pybind11::initialize_interpreter(); }
     ~PythonInterpreterGuard() { pybind11::finalize_interpreter(); }
 
-    PythonInterpreterGuard(const PythonInterpreterGuard &) = delete;
-    PythonInterpreterGuard(PythonInterpreterGuard &&) = delete;
-    PythonInterpreterGuard &operator=(const PythonInterpreterGuard &) = delete;
-    PythonInterpreterGuard &operator=(PythonInterpreterGuard &&) = delete;
+    PythonInterpreterGuard(const PythonInterpreterGuard&) = delete;
+    PythonInterpreterGuard(PythonInterpreterGuard&&) = delete;
+    PythonInterpreterGuard& operator=(const PythonInterpreterGuard&) = delete;
+    PythonInterpreterGuard& operator=(PythonInterpreterGuard&&) = delete;
 };
 
 /**
@@ -51,63 +51,56 @@ struct PythonInterpreterGuard {
 struct OpenQasmRunner {
     explicit OpenQasmRunner() = default;
     virtual ~OpenQasmRunner() = default;
-    [[nodiscard]] virtual auto runCircuit([[maybe_unused]] const std::string &circuit,
-                                          [[maybe_unused]] const std::string &device,
+    [[nodiscard]] virtual auto runCircuit([[maybe_unused]] const std::string& circuit,
+                                          [[maybe_unused]] const std::string& device,
                                           [[maybe_unused]] size_t shots,
-                                          [[maybe_unused]] const std::string &kwargs = "") const
-        -> std::string
-    {
+                                          [[maybe_unused]] const std::string& kwargs = "") const
+        -> std::string {
         RT_FAIL("Not implemented method");
         return {};
     }
     [[nodiscard]] virtual auto
-    Probs([[maybe_unused]] const std::string &circuit, [[maybe_unused]] const std::string &device,
+    Probs([[maybe_unused]] const std::string& circuit, [[maybe_unused]] const std::string& device,
           [[maybe_unused]] size_t shots, [[maybe_unused]] size_t num_qubits,
-          [[maybe_unused]] const std::string &kwargs = "") const -> std::vector<double>
-    {
+          [[maybe_unused]] const std::string& kwargs = "") const -> std::vector<double> {
         RT_FAIL("Not implemented method");
         return {};
     }
     [[nodiscard]] virtual auto
-    Sample([[maybe_unused]] const std::string &circuit, [[maybe_unused]] const std::string &device,
+    Sample([[maybe_unused]] const std::string& circuit, [[maybe_unused]] const std::string& device,
            [[maybe_unused]] size_t shots, [[maybe_unused]] size_t num_qubits,
-           [[maybe_unused]] const std::string &kwargs = "") const -> std::vector<size_t>
-    {
+           [[maybe_unused]] const std::string& kwargs = "") const -> std::vector<size_t> {
         RT_FAIL("Not implemented method");
         return {};
     }
     [[nodiscard]] virtual auto
-    Expval([[maybe_unused]] const std::string &circuit, [[maybe_unused]] const std::string &device,
-           [[maybe_unused]] size_t shots, [[maybe_unused]] const std::string &kwargs = "") const
-        -> double
-    {
-        RT_FAIL("Not implemented method");
-        return {};
-    }
-    [[nodiscard]] virtual auto Var([[maybe_unused]] const std::string &circuit,
-                                   [[maybe_unused]] const std::string &device,
-                                   [[maybe_unused]] size_t shots,
-                                   [[maybe_unused]] const std::string &kwargs = "") const -> double
-    {
+    Expval([[maybe_unused]] const std::string& circuit, [[maybe_unused]] const std::string& device,
+           [[maybe_unused]] size_t shots, [[maybe_unused]] const std::string& kwargs = "") const
+        -> double {
         RT_FAIL("Not implemented method");
         return {};
     }
     [[nodiscard]] virtual auto
-    State([[maybe_unused]] const std::string &circuit, [[maybe_unused]] const std::string &device,
+    Var([[maybe_unused]] const std::string& circuit, [[maybe_unused]] const std::string& device,
+        [[maybe_unused]] size_t shots, [[maybe_unused]] const std::string& kwargs = "") const
+        -> double {
+        RT_FAIL("Not implemented method");
+        return {};
+    }
+    [[nodiscard]] virtual auto
+    State([[maybe_unused]] const std::string& circuit, [[maybe_unused]] const std::string& device,
           [[maybe_unused]] size_t shots, [[maybe_unused]] size_t num_qubits,
-          [[maybe_unused]] const std::string &kwargs = "") const
-        -> std::vector<std::complex<double>>
-    {
+          [[maybe_unused]] const std::string& kwargs = "") const
+        -> std::vector<std::complex<double>> {
         RT_FAIL("Not implemented method");
         return {};
     }
-    [[nodiscard]] virtual auto Gradient([[maybe_unused]] const std::string &circuit,
-                                        [[maybe_unused]] const std::string &device,
+    [[nodiscard]] virtual auto Gradient([[maybe_unused]] const std::string& circuit,
+                                        [[maybe_unused]] const std::string& device,
                                         [[maybe_unused]] size_t shots,
                                         [[maybe_unused]] size_t num_qubits,
-                                        [[maybe_unused]] const std::string &kwargs = "") const
-        -> std::vector<double>
-    {
+                                        [[maybe_unused]] const std::string& kwargs = "") const
+        -> std::vector<double> {
         RT_FAIL("Not implemented method");
         return {};
     }
@@ -118,10 +111,9 @@ struct OpenQasmRunner {
  * Amazon Braket Python SDK.
  */
 struct BraketRunner : public OpenQasmRunner {
-    [[nodiscard]] auto runCircuit(const std::string &circuit, const std::string &device,
-                                  size_t shots, const std::string &kwargs = "") const
-        -> std::string override
-    {
+    [[nodiscard]] auto runCircuit(const std::string& circuit, const std::string& device,
+                                  size_t shots, const std::string& kwargs = "") const
+        -> std::string override {
         namespace py = pybind11;
         using namespace py::literals;
 
@@ -166,16 +158,15 @@ struct BraketRunner : public OpenQasmRunner {
               )",
             py::globals(), locals);
 
-        auto &&msg = locals["msg"].cast<std::string>();
+        auto&& msg = locals["msg"].cast<std::string>();
         RT_FAIL_IF(!msg.empty(), msg.c_str());
 
         return locals["result"].cast<std::string>();
     }
 
-    [[nodiscard]] auto Probs(const std::string &circuit, const std::string &device, size_t shots,
-                             size_t num_qubits, const std::string &kwargs = "") const
-        -> std::vector<double> override
-    {
+    [[nodiscard]] auto Probs(const std::string& circuit, const std::string& device, size_t shots,
+                             size_t num_qubits, const std::string& kwargs = "") const
+        -> std::vector<double> override {
         namespace py = pybind11;
         using namespace py::literals;
 
@@ -224,7 +215,7 @@ struct BraketRunner : public OpenQasmRunner {
               )",
             py::globals(), locals);
 
-        auto &&msg = locals["msg"].cast<std::string>();
+        auto&& msg = locals["msg"].cast<std::string>();
         RT_FAIL_IF(!msg.empty(), msg.c_str());
 
         py::list results = locals["probs_list"];
@@ -238,10 +229,9 @@ struct BraketRunner : public OpenQasmRunner {
         return probs;
     }
 
-    [[nodiscard]] auto Sample(const std::string &circuit, const std::string &device, size_t shots,
-                              size_t num_qubits, const std::string &kwargs = "") const
-        -> std::vector<size_t> override
-    {
+    [[nodiscard]] auto Sample(const std::string& circuit, const std::string& device, size_t shots,
+                              size_t num_qubits, const std::string& kwargs = "") const
+        -> std::vector<size_t> override {
         namespace py = pybind11;
         using namespace py::literals;
 
@@ -287,7 +277,7 @@ struct BraketRunner : public OpenQasmRunner {
               )",
             py::globals(), locals);
 
-        auto &&msg = locals["msg"].cast<std::string>();
+        auto&& msg = locals["msg"].cast<std::string>();
         RT_FAIL_IF(!msg.empty(), msg.c_str());
 
         py::list results = locals["samples"];
@@ -301,9 +291,8 @@ struct BraketRunner : public OpenQasmRunner {
         return samples;
     }
 
-    [[nodiscard]] auto Expval(const std::string &circuit, const std::string &device, size_t shots,
-                              const std::string &kwargs = "") const -> double override
-    {
+    [[nodiscard]] auto Expval(const std::string& circuit, const std::string& device, size_t shots,
+                              const std::string& kwargs = "") const -> double override {
         namespace py = pybind11;
         using namespace py::literals;
 
@@ -348,7 +337,7 @@ struct BraketRunner : public OpenQasmRunner {
               )",
             py::globals(), locals);
 
-        auto &&msg = locals["msg"].cast<std::string>();
+        auto&& msg = locals["msg"].cast<std::string>();
         RT_FAIL_IF(!msg.empty(), msg.c_str());
 
         py::list results = locals["expval"];
@@ -356,9 +345,8 @@ struct BraketRunner : public OpenQasmRunner {
         return results[0].cast<double>();
     }
 
-    [[nodiscard]] auto Var(const std::string &circuit, const std::string &device, size_t shots,
-                           const std::string &kwargs = "") const -> double override
-    {
+    [[nodiscard]] auto Var(const std::string& circuit, const std::string& device, size_t shots,
+                           const std::string& kwargs = "") const -> double override {
         namespace py = pybind11;
         using namespace py::literals;
 
@@ -403,7 +391,7 @@ struct BraketRunner : public OpenQasmRunner {
               )",
             py::globals(), locals);
 
-        auto &&msg = locals["msg"].cast<std::string>();
+        auto&& msg = locals["msg"].cast<std::string>();
         RT_FAIL_IF(!msg.empty(), msg.c_str());
 
         py::list results = locals["var"];

--- a/runtime/lib/capi/MemRefUtils.hpp
+++ b/runtime/lib/capi/MemRefUtils.hpp
@@ -17,16 +17,17 @@
 #include <cstddef>
 
 extern "C" {
-void *_mlir_memref_to_llvm_alloc(size_t size);
-void *_mlir_memref_to_llvm_aligned_alloc(size_t alignment, size_t size);
-bool _mlir_memory_transfer(void *);
-void _mlir_memref_to_llvm_free(void *ptr);
+void* _mlir_memref_to_llvm_alloc(size_t size);
+void* _mlir_memref_to_llvm_aligned_alloc(size_t alignment, size_t size);
+bool _mlir_memory_transfer(void*);
+void _mlir_memref_to_llvm_free(void* ptr);
 }
 
 // MemRef type definition
-template <typename T, size_t R> struct MemRefT {
-    T *data_allocated;
-    T *data_aligned;
+template <typename T, size_t R>
+struct MemRefT {
+    T* data_allocated;
+    T* data_aligned;
     size_t offset;
     size_t sizes[R];
     size_t strides[R];

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -12,24 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "RuntimeCAPI.h"
+
+#include "Exception.hpp"
+#include "ExecutionContext.hpp"
+#include "MemRefUtils.hpp"
+#include "QuantumDevice.hpp"
+
+#include <bitset>
 #include <cstdarg>
 #include <cstdlib>
 #include <ctime>
-
-#include <bitset>
-#include <stdexcept>
-
 #include <iostream>
 #include <memory>
 #include <ostream>
-
-#include "Exception.hpp"
-#include "QuantumDevice.hpp"
-
-#include "ExecutionContext.hpp"
-#include "MemRefUtils.hpp"
-
-#include "RuntimeCAPI.h"
+#include <stdexcept>
 
 namespace Catalyst::Runtime {
 
@@ -42,56 +39,47 @@ thread_local static std::unique_ptr<ExecutionContext> CTX = nullptr;
 
 extern "C" {
 
-void *_mlir_memref_to_llvm_alloc(size_t size)
-{
-    void *ptr = malloc(size);
+void* _mlir_memref_to_llvm_alloc(size_t size) {
+    void* ptr = malloc(size);
     Catalyst::Runtime::CTX->getMemoryManager()->insert(ptr);
     return ptr;
 }
 
-void *_mlir_memref_to_llvm_aligned_alloc(size_t alignment, size_t size)
-{
-    void *ptr = aligned_alloc(alignment, size);
+void* _mlir_memref_to_llvm_aligned_alloc(size_t alignment, size_t size) {
+    void* ptr = aligned_alloc(alignment, size);
     Catalyst::Runtime::CTX->getMemoryManager()->insert(ptr);
     return ptr;
 }
 
-bool _mlir_memory_transfer(void *ptr)
-{
-    if (!Catalyst::Runtime::CTX->getMemoryManager()->contains(ptr)) {
-        return false;
-    }
+bool _mlir_memory_transfer(void* ptr) {
+    if (!Catalyst::Runtime::CTX->getMemoryManager()->contains(ptr)) { return false; }
     Catalyst::Runtime::CTX->getMemoryManager()->erase(ptr);
     return true;
 }
 
-void _mlir_memref_to_llvm_free(void *ptr)
-{
+void _mlir_memref_to_llvm_free(void* ptr) {
     Catalyst::Runtime::CTX->getMemoryManager()->erase(ptr);
     free(ptr);
 }
 
-void __quantum__rt__fail_cstr(const char *cstr) { RT_FAIL(cstr); }
+void __quantum__rt__fail_cstr(const char* cstr) { RT_FAIL(cstr); }
 
-void __quantum__rt__initialize()
-{
+void __quantum__rt__initialize() {
     Catalyst::Runtime::CTX = std::make_unique<Catalyst::Runtime::ExecutionContext>();
 }
 
 void __quantum__rt__finalize() { Catalyst::Runtime::CTX.reset(nullptr); }
 
-void __quantum__rt__device(int8_t *spec, int8_t *value)
-{
+void __quantum__rt__device(int8_t* spec, int8_t* value) {
     RT_FAIL_IF((!spec || !value), "Invalid device specification");
     RT_FAIL_IF(!Catalyst::Runtime::CTX, "Invalid use of the global driver before initialization");
 
-    const std::vector<std::string_view> args{reinterpret_cast<char *>(spec),
-                                             reinterpret_cast<char *>(value)};
+    const std::vector<std::string_view> args{reinterpret_cast<char*>(spec),
+                                             reinterpret_cast<char*>(value)};
     if (args[0] == "kwargs") {
         Catalyst::Runtime::CTX->setDeviceKwArgs(args[1]);
         return;
-    }
-    else if (args[0] == "backend") {
+    } else if (args[0] == "backend") {
         RT_FAIL_IF(!Catalyst::Runtime::CTX->initDevice(args[1]),
                    "Failed initialization of the backend device");
         return;
@@ -102,51 +90,43 @@ void __quantum__rt__device(int8_t *spec, int8_t *value)
 
 void __quantum__rt__print_state() { Catalyst::Runtime::CTX->getDevice()->PrintState(); }
 
-void __quantum__rt__toggle_recorder(bool status)
-{
+void __quantum__rt__toggle_recorder(bool status) {
     Catalyst::Runtime::CTX->setDeviceRecorder(status);
-    if (!Catalyst::Runtime::CTX->getDevice()) {
-        return;
-    }
+    if (!Catalyst::Runtime::CTX->getDevice()) { return; }
 
     if (status) {
         Catalyst::Runtime::CTX->getDevice()->StartTapeRecording();
-    }
-    else {
+    } else {
         Catalyst::Runtime::CTX->getDevice()->StopTapeRecording();
     }
 }
 
-QUBIT *__quantum__rt__qubit_allocate()
-{
+QUBIT* __quantum__rt__qubit_allocate() {
     RT_ASSERT(Catalyst::Runtime::CTX->getDevice() != nullptr);
     RT_ASSERT(Catalyst::Runtime::CTX->getMemoryManager() != nullptr);
 
-    return reinterpret_cast<QUBIT *>(Catalyst::Runtime::CTX->getDevice()->AllocateQubit());
+    return reinterpret_cast<QUBIT*>(Catalyst::Runtime::CTX->getDevice()->AllocateQubit());
 }
 
-QirArray *__quantum__rt__qubit_allocate_array(int64_t num_qubits)
-{
+QirArray* __quantum__rt__qubit_allocate_array(int64_t num_qubits) {
     RT_ASSERT(Catalyst::Runtime::CTX->getDevice() != nullptr);
     RT_ASSERT(Catalyst::Runtime::CTX->getMemoryManager() != nullptr);
     RT_ASSERT(num_qubits >= 0);
 
-    QirArray *qubit_array = __quantum__rt__array_create_1d(sizeof(QubitIdType), num_qubits);
-    const auto &&qubit_vector = Catalyst::Runtime::CTX->getDevice()->AllocateQubits(num_qubits);
+    QirArray* qubit_array = __quantum__rt__array_create_1d(sizeof(QubitIdType), num_qubits);
+    const auto&& qubit_vector = Catalyst::Runtime::CTX->getDevice()->AllocateQubits(num_qubits);
     for (int64_t idx = 0; idx < num_qubits; idx++) {
-        *reinterpret_cast<QUBIT **>(__quantum__rt__array_get_element_ptr_1d(qubit_array, idx)) =
-            reinterpret_cast<QUBIT *>(qubit_vector[idx]);
+        *reinterpret_cast<QUBIT**>(__quantum__rt__array_get_element_ptr_1d(qubit_array, idx)) =
+            reinterpret_cast<QUBIT*>(qubit_vector[idx]);
     }
     return qubit_array;
 }
 
-void __quantum__rt__qubit_release(QUBIT *qubit)
-{
+void __quantum__rt__qubit_release(QUBIT* qubit) {
     return Catalyst::Runtime::CTX->getDevice()->ReleaseQubit(reinterpret_cast<QubitIdType>(qubit));
 }
 
-void __quantum__rt__qubit_release_array(QirArray *qubit_array)
-{
+void __quantum__rt__qubit_release_array(QirArray* qubit_array) {
     // Update the reference count of qubit_array by -1
     // It will deallocates it iff the reference count becomes 0
     // The behavior is undefined if the reference count becomes < 0
@@ -155,47 +135,43 @@ void __quantum__rt__qubit_release_array(QirArray *qubit_array)
     Catalyst::Runtime::CTX->getDevice()->ReleaseAllQubits();
 }
 
-int64_t __quantum__rt__num_qubits()
-{
+int64_t __quantum__rt__num_qubits() {
     return static_cast<int64_t>(Catalyst::Runtime::CTX->getDevice()->GetNumQubits());
 }
 
-QirString *__quantum__rt__qubit_to_string(QUBIT *qubit)
-{
+QirString* __quantum__rt__qubit_to_string(QUBIT* qubit) {
     return __quantum__rt__string_create(
         std::to_string(reinterpret_cast<QubitIdType>(qubit)).c_str());
 }
 
-bool __quantum__rt__result_equal(RESULT *r0, RESULT *r1) { return (r0 == r1) || (*r0 == *r1); }
+bool __quantum__rt__result_equal(RESULT* r0, RESULT* r1) { return (r0 == r1) || (*r0 == *r1); }
 
-RESULT *__quantum__rt__result_get_one() { return Catalyst::Runtime::CTX->getDevice()->One(); }
+RESULT* __quantum__rt__result_get_one() { return Catalyst::Runtime::CTX->getDevice()->One(); }
 
-RESULT *__quantum__rt__result_get_zero() { return Catalyst::Runtime::CTX->getDevice()->Zero(); }
+RESULT* __quantum__rt__result_get_zero() { return Catalyst::Runtime::CTX->getDevice()->Zero(); }
 
-QirString *__quantum__rt__result_to_string(RESULT *result)
-{
+QirString* __quantum__rt__result_to_string(RESULT* result) {
     return __quantum__rt__result_equal(result, __quantum__rt__result_get_one())
                ? __quantum__rt__string_create("true")   // one
                : __quantum__rt__string_create("false"); // zero
 }
 
-void __quantum__qis__Gradient(int64_t numResults, /* results = */...)
-{
+void __quantum__qis__Gradient(int64_t numResults, /* results = */...) {
     RT_ASSERT(numResults >= 0);
     using ResultType = MemRefT<double, 1>;
 
-    std::vector<ResultType *> mem_ptrs;
+    std::vector<ResultType*> mem_ptrs;
     mem_ptrs.reserve(numResults);
     va_list args;
     va_start(args, numResults);
     for (int64_t i = 0; i < numResults; i++) {
-        mem_ptrs.push_back(va_arg(args, ResultType *));
+        mem_ptrs.push_back(va_arg(args, ResultType*));
     }
     va_end(args);
 
     std::vector<DataView<double, 1>> mem_views;
     mem_views.reserve(numResults);
-    for (auto *mr : mem_ptrs) {
+    for (auto* mr : mem_ptrs) {
         mem_views.emplace_back(mr->data_aligned, mr->offset, mr->sizes, mr->strides);
     }
 
@@ -203,10 +179,9 @@ void __quantum__qis__Gradient(int64_t numResults, /* results = */...)
     Catalyst::Runtime::CTX->getDevice()->Gradient(mem_views, {});
 }
 
-void __quantum__qis__Gradient_params([[maybe_unused]] MemRefT_int64_1d *params,
+void __quantum__qis__Gradient_params([[maybe_unused]] MemRefT_int64_1d* params,
                                      [[maybe_unused]] int64_t numResults,
-                                     /* results = */...)
-{
+                                     /* results = */...) {
     RT_ASSERT(numResults >= 0);
     using ResultType = MemRefT<double, 1>;
 
@@ -218,7 +193,7 @@ void __quantum__qis__Gradient_params([[maybe_unused]] MemRefT_int64_1d *params,
 
     // create a vector of custom trainable parameters
     std::vector<size_t> train_params;
-    auto *params_data = params->data_aligned;
+    auto* params_data = params->data_aligned;
     train_params.reserve(tp_size);
     for (size_t i = 0; i < tp_size; i++) {
         auto p = params_data[i];
@@ -226,18 +201,18 @@ void __quantum__qis__Gradient_params([[maybe_unused]] MemRefT_int64_1d *params,
         train_params.push_back(p);
     }
 
-    std::vector<ResultType *> mem_ptrs;
+    std::vector<ResultType*> mem_ptrs;
     mem_ptrs.reserve(numResults);
     va_list args;
     va_start(args, numResults);
     for (int64_t i = 0; i < numResults; i++) {
-        mem_ptrs.push_back(va_arg(args, ResultType *));
+        mem_ptrs.push_back(va_arg(args, ResultType*));
     }
     va_end(args);
 
     std::vector<DataView<double, 1>> mem_views;
     mem_views.reserve(numResults);
-    for (auto *mr : mem_ptrs) {
+    for (auto* mr : mem_ptrs) {
         mem_views.emplace_back(mr->data_aligned, mr->offset, mr->sizes, mr->strides);
     }
 
@@ -245,92 +220,79 @@ void __quantum__qis__Gradient_params([[maybe_unused]] MemRefT_int64_1d *params,
     Catalyst::Runtime::CTX->getDevice()->Gradient(mem_views, train_params);
 }
 
-void __quantum__qis__Identity(QUBIT *qubit, bool adjoint)
-{
+void __quantum__qis__Identity(QUBIT* qubit, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation("Identity", {},
                                                         {reinterpret_cast<QubitIdType>(qubit)},
                                                         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__PauliX(QUBIT *qubit, bool adjoint)
-{
+void __quantum__qis__PauliX(QUBIT* qubit, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation("PauliX", {},
                                                         {reinterpret_cast<QubitIdType>(qubit)},
                                                         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__PauliY(QUBIT *qubit, bool adjoint)
-{
+void __quantum__qis__PauliY(QUBIT* qubit, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation("PauliY", {},
                                                         {reinterpret_cast<QubitIdType>(qubit)},
                                                         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__PauliZ(QUBIT *qubit, bool adjoint)
-{
+void __quantum__qis__PauliZ(QUBIT* qubit, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation("PauliZ", {},
                                                         {reinterpret_cast<QubitIdType>(qubit)},
                                                         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__Hadamard(QUBIT *qubit, bool adjoint)
-{
+void __quantum__qis__Hadamard(QUBIT* qubit, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation("Hadamard", {},
                                                         {reinterpret_cast<QubitIdType>(qubit)},
                                                         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__S(QUBIT *qubit, bool adjoint)
-{
+void __quantum__qis__S(QUBIT* qubit, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation("S", {},
                                                         {reinterpret_cast<QubitIdType>(qubit)},
                                                         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__T(QUBIT *qubit, bool adjoint)
-{
+void __quantum__qis__T(QUBIT* qubit, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation("T", {},
                                                         {reinterpret_cast<QubitIdType>(qubit)},
                                                         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__PhaseShift(double theta, QUBIT *qubit, bool adjoint)
-{
+void __quantum__qis__PhaseShift(double theta, QUBIT* qubit, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation("PhaseShift", {theta},
                                                         {reinterpret_cast<QubitIdType>(qubit)},
                                                         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__RX(double theta, QUBIT *qubit, bool adjoint)
-{
+void __quantum__qis__RX(double theta, QUBIT* qubit, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation("RX", {theta},
                                                         {reinterpret_cast<QubitIdType>(qubit)},
                                                         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__RY(double theta, QUBIT *qubit, bool adjoint)
-{
+void __quantum__qis__RY(double theta, QUBIT* qubit, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation("RY", {theta},
                                                         {reinterpret_cast<QubitIdType>(qubit)},
                                                         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__RZ(double theta, QUBIT *qubit, bool adjoint)
-{
+void __quantum__qis__RZ(double theta, QUBIT* qubit, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation("RZ", {theta},
                                                         {reinterpret_cast<QubitIdType>(qubit)},
                                                         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__Rot(double phi, double theta, double omega, QUBIT *qubit, bool adjoint)
-{
+void __quantum__qis__Rot(double phi, double theta, double omega, QUBIT* qubit, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation("Rot", {phi, theta, omega},
                                                         {reinterpret_cast<QubitIdType>(qubit)},
                                                         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__CNOT(QUBIT *control, QUBIT *target, bool adjoint)
-{
+void __quantum__qis__CNOT(QUBIT* control, QUBIT* target, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation(
         "CNOT", {},
         {/* control = */ reinterpret_cast<QubitIdType>(control),
@@ -338,8 +300,7 @@ void __quantum__qis__CNOT(QUBIT *control, QUBIT *target, bool adjoint)
         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__CY(QUBIT *control, QUBIT *target, bool adjoint)
-{
+void __quantum__qis__CY(QUBIT* control, QUBIT* target, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation(
         "CY", {},
         {/* control = */ reinterpret_cast<QubitIdType>(control),
@@ -347,8 +308,7 @@ void __quantum__qis__CY(QUBIT *control, QUBIT *target, bool adjoint)
         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__CZ(QUBIT *control, QUBIT *target, bool adjoint)
-{
+void __quantum__qis__CZ(QUBIT* control, QUBIT* target, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation(
         "CZ", {},
         {/* control = */ reinterpret_cast<QubitIdType>(control),
@@ -356,8 +316,7 @@ void __quantum__qis__CZ(QUBIT *control, QUBIT *target, bool adjoint)
         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__SWAP(QUBIT *control, QUBIT *target, bool adjoint)
-{
+void __quantum__qis__SWAP(QUBIT* control, QUBIT* target, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation(
         "SWAP", {},
         {/* control = */ reinterpret_cast<QubitIdType>(control),
@@ -365,8 +324,7 @@ void __quantum__qis__SWAP(QUBIT *control, QUBIT *target, bool adjoint)
         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__IsingXX(double theta, QUBIT *control, QUBIT *target, bool adjoint)
-{
+void __quantum__qis__IsingXX(double theta, QUBIT* control, QUBIT* target, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation(
         "IsingXX", {theta},
         {/* control = */ reinterpret_cast<QubitIdType>(control),
@@ -374,8 +332,7 @@ void __quantum__qis__IsingXX(double theta, QUBIT *control, QUBIT *target, bool a
         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__IsingYY(double theta, QUBIT *control, QUBIT *target, bool adjoint)
-{
+void __quantum__qis__IsingYY(double theta, QUBIT* control, QUBIT* target, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation(
         "IsingYY", {theta},
         {/* control = */ reinterpret_cast<QubitIdType>(control),
@@ -383,8 +340,7 @@ void __quantum__qis__IsingYY(double theta, QUBIT *control, QUBIT *target, bool a
         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__IsingXY(double theta, QUBIT *control, QUBIT *target, bool adjoint)
-{
+void __quantum__qis__IsingXY(double theta, QUBIT* control, QUBIT* target, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation(
         "IsingXY", {theta},
         {/* control = */ reinterpret_cast<QubitIdType>(control),
@@ -392,8 +348,7 @@ void __quantum__qis__IsingXY(double theta, QUBIT *control, QUBIT *target, bool a
         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__IsingZZ(double theta, QUBIT *control, QUBIT *target, bool adjoint)
-{
+void __quantum__qis__IsingZZ(double theta, QUBIT* control, QUBIT* target, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation(
         "IsingZZ", {theta},
         {/* control = */ reinterpret_cast<QubitIdType>(control),
@@ -401,8 +356,8 @@ void __quantum__qis__IsingZZ(double theta, QUBIT *control, QUBIT *target, bool a
         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__ControlledPhaseShift(double theta, QUBIT *control, QUBIT *target, bool adjoint)
-{
+void __quantum__qis__ControlledPhaseShift(double theta, QUBIT* control, QUBIT* target,
+                                          bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation(
         "ControlledPhaseShift", {theta},
         {/* control = */ reinterpret_cast<QubitIdType>(control),
@@ -410,8 +365,7 @@ void __quantum__qis__ControlledPhaseShift(double theta, QUBIT *control, QUBIT *t
         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__CRX(double theta, QUBIT *control, QUBIT *target, bool adjoint)
-{
+void __quantum__qis__CRX(double theta, QUBIT* control, QUBIT* target, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation(
         "CRX", {theta},
         {/* control = */ reinterpret_cast<QubitIdType>(control),
@@ -419,8 +373,7 @@ void __quantum__qis__CRX(double theta, QUBIT *control, QUBIT *target, bool adjoi
         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__CRY(double theta, QUBIT *control, QUBIT *target, bool adjoint)
-{
+void __quantum__qis__CRY(double theta, QUBIT* control, QUBIT* target, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation(
         "CRY", {theta},
         {/* control = */ reinterpret_cast<QubitIdType>(control),
@@ -428,8 +381,7 @@ void __quantum__qis__CRY(double theta, QUBIT *control, QUBIT *target, bool adjoi
         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__CRZ(double theta, QUBIT *control, QUBIT *target, bool adjoint)
-{
+void __quantum__qis__CRZ(double theta, QUBIT* control, QUBIT* target, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation(
         "CRZ", {theta},
         {/* control = */ reinterpret_cast<QubitIdType>(control),
@@ -437,9 +389,8 @@ void __quantum__qis__CRZ(double theta, QUBIT *control, QUBIT *target, bool adjoi
         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__CRot(double phi, double theta, double omega, QUBIT *control, QUBIT *target,
-                          bool adjoint)
-{
+void __quantum__qis__CRot(double phi, double theta, double omega, QUBIT* control, QUBIT* target,
+                          bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation(
         "CRot", {phi, theta, omega},
         {/* control = */ reinterpret_cast<QubitIdType>(control),
@@ -447,8 +398,7 @@ void __quantum__qis__CRot(double phi, double theta, double omega, QUBIT *control
         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__CSWAP(QUBIT *control, QUBIT *aswap, QUBIT *bswap, bool adjoint)
-{
+void __quantum__qis__CSWAP(QUBIT* control, QUBIT* aswap, QUBIT* bswap, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation("CSWAP", {},
                                                         {reinterpret_cast<QubitIdType>(control),
                                                          reinterpret_cast<QubitIdType>(aswap),
@@ -456,8 +406,7 @@ void __quantum__qis__CSWAP(QUBIT *control, QUBIT *aswap, QUBIT *bswap, bool adjo
                                                         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__Toffoli(QUBIT *wire0, QUBIT *wire1, QUBIT *wire2, bool adjoint)
-{
+void __quantum__qis__Toffoli(QUBIT* wire0, QUBIT* wire1, QUBIT* wire2, bool adjoint) {
     Catalyst::Runtime::CTX->getDevice()->NamedOperation("Toffoli", {},
                                                         {reinterpret_cast<QubitIdType>(wire0),
                                                          reinterpret_cast<QubitIdType>(wire1),
@@ -465,8 +414,7 @@ void __quantum__qis__Toffoli(QUBIT *wire0, QUBIT *wire1, QUBIT *wire2, bool adjo
                                                         /* inverse = */ adjoint);
 }
 
-void __quantum__qis__MultiRZ(double theta, bool adjoint, int64_t numQubits, ...)
-{
+void __quantum__qis__MultiRZ(double theta, bool adjoint, int64_t numQubits, ...) {
     RT_ASSERT(numQubits >= 0);
 
     va_list args;
@@ -481,10 +429,9 @@ void __quantum__qis__MultiRZ(double theta, bool adjoint, int64_t numQubits, ...)
                                                         /* inverse = */ adjoint);
 }
 
-static void _qubitUnitary_impl(MemRefT_CplxT_double_2d *matrix, int64_t numQubits,
-                               std::vector<std::complex<double>> &coeffs,
-                               std::vector<QubitIdType> &wires, va_list *args)
-{
+static void _qubitUnitary_impl(MemRefT_CplxT_double_2d* matrix, int64_t numQubits,
+                               std::vector<std::complex<double>>& coeffs,
+                               std::vector<QubitIdType>& wires, va_list* args) {
     const size_t num_rows = matrix->sizes[0];
     const size_t num_col = matrix->sizes[1];
     const size_t expected_size = std::pow(2, numQubits);
@@ -506,18 +453,13 @@ static void _qubitUnitary_impl(MemRefT_CplxT_double_2d *matrix, int64_t numQubit
     }
 }
 
-void __quantum__qis__QubitUnitary(MemRefT_CplxT_double_2d *matrix, bool adjoint, int64_t numQubits,
-                                  /*qubits*/...)
-{
+void __quantum__qis__QubitUnitary(MemRefT_CplxT_double_2d* matrix, bool adjoint, int64_t numQubits,
+                                  /*qubits*/...) {
     RT_ASSERT(numQubits >= 0);
 
-    if (matrix == nullptr) {
-        RT_FAIL("The QubitUnitary matrix must be initialized");
-    }
+    if (matrix == nullptr) { RT_FAIL("The QubitUnitary matrix must be initialized"); }
 
-    if (numQubits > __quantum__rt__num_qubits()) {
-        RT_FAIL("Invalid number of wires");
-    }
+    if (numQubits > __quantum__rt__num_qubits()) { RT_FAIL("Invalid number of wires"); }
 
     va_list args;
     std::vector<std::complex<double>> coeffs;
@@ -529,19 +471,15 @@ void __quantum__qis__QubitUnitary(MemRefT_CplxT_double_2d *matrix, bool adjoint,
                                                                 /*inverse = */ adjoint);
 }
 
-ObsIdType __quantum__qis__NamedObs(int64_t obsId, QUBIT *wire)
-{
+ObsIdType __quantum__qis__NamedObs(int64_t obsId, QUBIT* wire) {
     return Catalyst::Runtime::CTX->getDevice()->Observable(static_cast<ObsId>(obsId), {},
                                                            {reinterpret_cast<QubitIdType>(wire)});
 }
 
-ObsIdType __quantum__qis__HermitianObs(MemRefT_CplxT_double_2d *matrix, int64_t numQubits, ...)
-{
+ObsIdType __quantum__qis__HermitianObs(MemRefT_CplxT_double_2d* matrix, int64_t numQubits, ...) {
     RT_ASSERT(numQubits >= 0);
 
-    if (matrix == nullptr) {
-        RT_FAIL("The Hermitian matrix must be initialized");
-    }
+    if (matrix == nullptr) { RT_FAIL("The Hermitian matrix must be initialized"); }
 
     const size_t num_rows = matrix->sizes[0];
     const size_t num_col = matrix->sizes[1];
@@ -560,9 +498,7 @@ ObsIdType __quantum__qis__HermitianObs(MemRefT_CplxT_double_2d *matrix, int64_t 
     }
     va_end(args);
 
-    if (numQubits > __quantum__rt__num_qubits()) {
-        RT_FAIL("Invalid number of wires");
-    }
+    if (numQubits > __quantum__rt__num_qubits()) { RT_FAIL("Invalid number of wires"); }
 
     const size_t matrix_size = num_rows * num_col;
     std::vector<std::complex<double>> coeffs;
@@ -574,11 +510,8 @@ ObsIdType __quantum__qis__HermitianObs(MemRefT_CplxT_double_2d *matrix, int64_t 
     return Catalyst::Runtime::CTX->getDevice()->Observable(ObsId::Hermitian, coeffs, wires);
 }
 
-ObsIdType __quantum__qis__TensorObs(int64_t numObs, /*obsKeys*/...)
-{
-    if (numObs < 1) {
-        RT_FAIL("Invalid number of observables to create TensorProdObs");
-    }
+ObsIdType __quantum__qis__TensorObs(int64_t numObs, /*obsKeys*/...) {
+    if (numObs < 1) { RT_FAIL("Invalid number of observables to create TensorProdObs"); }
 
     va_list args;
     va_start(args, numObs);
@@ -592,9 +525,8 @@ ObsIdType __quantum__qis__TensorObs(int64_t numObs, /*obsKeys*/...)
     return Catalyst::Runtime::CTX->getDevice()->TensorObservable(obsKeys);
 }
 
-ObsIdType __quantum__qis__HamiltonianObs(MemRefT_double_1d *coeffs, int64_t numObs,
-                                         /*obsKeys*/...)
-{
+ObsIdType __quantum__qis__HamiltonianObs(MemRefT_double_1d* coeffs, int64_t numObs,
+                                         /*obsKeys*/...) {
     RT_ASSERT(numObs >= 0);
 
     if (coeffs == nullptr) {
@@ -622,25 +554,21 @@ ObsIdType __quantum__qis__HamiltonianObs(MemRefT_double_1d *coeffs, int64_t numO
     return Catalyst::Runtime::CTX->getDevice()->HamiltonianObservable(coeffs_vec, obsKeys);
 }
 
-RESULT *__quantum__qis__Measure(QUBIT *wire)
-{
+RESULT* __quantum__qis__Measure(QUBIT* wire) {
     return Catalyst::Runtime::CTX->getDevice()->Measure(reinterpret_cast<QubitIdType>(wire));
 }
 
-double __quantum__qis__Expval(ObsIdType obsKey)
-{
+double __quantum__qis__Expval(ObsIdType obsKey) {
     return Catalyst::Runtime::CTX->getDevice()->Expval(obsKey);
 }
 
-double __quantum__qis__Variance(ObsIdType obsKey)
-{
+double __quantum__qis__Variance(ObsIdType obsKey) {
     return Catalyst::Runtime::CTX->getDevice()->Var(obsKey);
 }
 
-void __quantum__qis__State(MemRefT_CplxT_double_1d *result, int64_t numQubits, ...)
-{
+void __quantum__qis__State(MemRefT_CplxT_double_1d* result, int64_t numQubits, ...) {
     RT_ASSERT(numQubits >= 0);
-    MemRefT<std::complex<double>, 1> *result_p = (MemRefT<std::complex<double>, 1> *)result;
+    MemRefT<std::complex<double>, 1>* result_p = (MemRefT<std::complex<double>, 1>*)result;
 
     va_list args;
     va_start(args, numQubits);
@@ -655,18 +583,16 @@ void __quantum__qis__State(MemRefT_CplxT_double_1d *result, int64_t numQubits, .
 
     if (wires.empty()) {
         Catalyst::Runtime::CTX->getDevice()->State(view);
-    }
-    else {
+    } else {
         RT_FAIL("Partial State-Vector not supported yet");
         // Catalyst::Runtime::CTX->getDevice()->PartialState(stateVec,
         // numElements, wires);
     }
 }
 
-void __quantum__qis__Probs(MemRefT_double_1d *result, int64_t numQubits, ...)
-{
+void __quantum__qis__Probs(MemRefT_double_1d* result, int64_t numQubits, ...) {
     RT_ASSERT(numQubits >= 0);
-    MemRefT<double, 1> *result_p = (MemRefT<double, 1> *)result;
+    MemRefT<double, 1>* result_p = (MemRefT<double, 1>*)result;
 
     va_list args;
     va_start(args, numQubits);
@@ -681,17 +607,15 @@ void __quantum__qis__Probs(MemRefT_double_1d *result, int64_t numQubits, ...)
 
     if (wires.empty()) {
         Catalyst::Runtime::CTX->getDevice()->Probs(view);
-    }
-    else {
+    } else {
         Catalyst::Runtime::CTX->getDevice()->PartialProbs(view, wires);
     }
 }
 
-void __quantum__qis__Sample(MemRefT_double_2d *result, int64_t shots, int64_t numQubits, ...)
-{
+void __quantum__qis__Sample(MemRefT_double_2d* result, int64_t shots, int64_t numQubits, ...) {
     RT_ASSERT(shots >= 0);
     RT_ASSERT(numQubits >= 0);
-    MemRefT<double, 2> *result_p = (MemRefT<double, 2> *)result;
+    MemRefT<double, 2>* result_p = (MemRefT<double, 2>*)result;
 
     va_list args;
     va_start(args, numQubits);
@@ -706,19 +630,17 @@ void __quantum__qis__Sample(MemRefT_double_2d *result, int64_t shots, int64_t nu
 
     if (wires.empty()) {
         Catalyst::Runtime::CTX->getDevice()->Sample(view, shots);
-    }
-    else {
+    } else {
         Catalyst::Runtime::CTX->getDevice()->PartialSample(view, wires, shots);
     }
 }
 
-void __quantum__qis__Counts(PairT_MemRefT_double_int64_1d *result, int64_t shots, int64_t numQubits,
-                            ...)
-{
+void __quantum__qis__Counts(PairT_MemRefT_double_int64_1d* result, int64_t shots, int64_t numQubits,
+                            ...) {
     RT_ASSERT(shots >= 0);
     RT_ASSERT(numQubits >= 0);
-    MemRefT<double, 1> *result_eigvals_p = (MemRefT<double, 1> *)&result->first;
-    MemRefT<int64_t, 1> *result_counts_p = (MemRefT<int64_t, 1> *)&result->second;
+    MemRefT<double, 1>* result_eigvals_p = (MemRefT<double, 1>*)&result->first;
+    MemRefT<int64_t, 1>* result_counts_p = (MemRefT<int64_t, 1>*)&result->second;
 
     va_list args;
     va_start(args, numQubits);
@@ -735,8 +657,7 @@ void __quantum__qis__Counts(PairT_MemRefT_double_int64_1d *result, int64_t shots
 
     if (wires.empty()) {
         Catalyst::Runtime::CTX->getDevice()->Counts(eigvals_view, counts_view, shots);
-    }
-    else {
+    } else {
         Catalyst::Runtime::CTX->getDevice()->PartialCounts(eigvals_view, counts_view, wires, shots);
     }
 }

--- a/runtime/tests/TestUtils.hpp
+++ b/runtime/tests/TestUtils.hpp
@@ -18,13 +18,12 @@
  */
 #pragma once
 
+#include "LightningSimulator.hpp"
+#include "catch2/catch.hpp"
+
 #include <string>
 #include <tuple>
 #include <vector>
-
-#include "catch2/catch.hpp"
-
-#include "LightningSimulator.hpp"
 
 /**
  * A tuple of available backend devices to be tested using TEMPLATE_LIST_TEST_CASE in Catch2
@@ -44,8 +43,7 @@ using SimTypes = std::tuple<Catalyst::Runtime::Simulator::LightningSimulator>;
  *
  * @return `std::vector<std::pair<std::string, std::string>>`
  */
-static inline auto getDevices() -> std::vector<std::pair<std::string, std::string>>
-{
+static inline auto getDevices() -> std::vector<std::pair<std::string, std::string>> {
     std::vector<std::pair<std::string, std::string>> devices{{"backend", "lightning.qubit"}};
 #ifdef __device_lightning_kokkos
     devices.emplace_back("backend", "lightning.kokkos");

--- a/runtime/tests/Test_CacheManager.cpp
+++ b/runtime/tests/Test_CacheManager.cpp
@@ -15,23 +15,20 @@
 #include "CacheManager.hpp"
 #include "QuantumDevice.hpp"
 #include "RuntimeCAPI.h"
-#include "Utils.hpp"
-
 #include "TestUtils.hpp"
+#include "Utils.hpp"
 
 using namespace Catalyst::Runtime;
 using namespace Catalyst::Runtime::Simulator;
 
-TEST_CASE("Test the constructor with a naive example", "[CacheManager]")
-{
+TEST_CASE("Test the constructor with a naive example", "[CacheManager]") {
     CacheManager cm = CacheManager();
 
     CHECK(cm.getNumOperations() == 0);
     CHECK(cm.getNumObservables() == 0);
 }
 
-TEST_CASE("Test addOperation with a naive example", "[CacheManager]")
-{
+TEST_CASE("Test addOperation with a naive example", "[CacheManager]") {
     CacheManager cm = CacheManager();
 
     cm.addOperation("H", {0}, {0}, false);
@@ -40,8 +37,7 @@ TEST_CASE("Test addOperation with a naive example", "[CacheManager]")
     CHECK(cm.getNumObservables() == 0);
 }
 
-TEST_CASE("Test addOperations with a naive example", "[CacheManager]")
-{
+TEST_CASE("Test addOperations with a naive example", "[CacheManager]") {
     CacheManager cm = CacheManager();
 
     cm.addOperation("H", {0}, {0}, false);
@@ -54,8 +50,7 @@ TEST_CASE("Test addOperations with a naive example", "[CacheManager]")
 }
 
 TEMPLATE_LIST_TEST_CASE("Test edge cases of the cache manager in QuantumDevice methods",
-                        "[CacheManager]", SimTypes)
-{
+                        "[CacheManager]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     sim->StartTapeRecording();
@@ -68,8 +63,7 @@ TEMPLATE_LIST_TEST_CASE("Test edge cases of the cache manager in QuantumDevice m
 }
 
 TEMPLATE_LIST_TEST_CASE("Test a LightningSimulator circuit with num_qubits=2 ", "[CacheManager]",
-                        SimTypes)
-{
+                        SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -85,7 +79,7 @@ TEMPLATE_LIST_TEST_CASE("Test a LightningSimulator circuit with num_qubits=2 ", 
     sim->NamedOperation("PauliX", {}, {Qs[0]}, false);
     sim->NamedOperation("CNOT", {}, {Qs[0], Qs[1]}, false);
 
-    auto &&[num_ops, num_obs, num_params, op_names, _] = sim->CacheManagerInfo();
+    auto&& [num_ops, num_obs, num_params, op_names, _] = sim->CacheManagerInfo();
     CHECK((num_ops == 2 && num_obs == 0));
     CHECK(num_params == 0);
     CHECK(op_names[0] == "PauliX");
@@ -93,8 +87,7 @@ TEMPLATE_LIST_TEST_CASE("Test a LightningSimulator circuit with num_qubits=2 ", 
 }
 
 TEMPLATE_LIST_TEST_CASE("Test a LightningSimulator circuit with num_qubits=4", "[CacheManager]",
-                        SimTypes)
-{
+                        SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubit = n
@@ -116,7 +109,7 @@ TEMPLATE_LIST_TEST_CASE("Test a LightningSimulator circuit with num_qubits=4", "
     sim->NamedOperation("CRZ", {0.789}, {Qs[0], Qs[3]}, false);
     sim->StopTapeRecording();
 
-    auto &&[num_ops, num_obs, num_params, op_names, _] = sim->CacheManagerInfo();
+    auto&& [num_ops, num_obs, num_params, op_names, _] = sim->CacheManagerInfo();
     CHECK((num_ops == 4 && num_obs == 0));
     CHECK(num_params == 3);
     CHECK(op_names[0] == "Hadamard");
@@ -126,8 +119,7 @@ TEMPLATE_LIST_TEST_CASE("Test a LightningSimulator circuit with num_qubits=4", "
 }
 
 TEMPLATE_LIST_TEST_CASE("Test a LightningSimulator circuit with num_qubits=4 and observables",
-                        "[CacheManager]", SimTypes)
-{
+                        "[CacheManager]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -153,7 +145,7 @@ TEMPLATE_LIST_TEST_CASE("Test a LightningSimulator circuit with num_qubits=4 and
     sim->Var(px);
     sim->Expval(pz);
 
-    auto &&[num_ops, num_obs, num_params, op_names, obs_keys] = sim->CacheManagerInfo();
+    auto&& [num_ops, num_obs, num_params, op_names, obs_keys] = sim->CacheManagerInfo();
     CHECK(num_ops == 4);
     CHECK(num_params == 0);
     CHECK(op_names[0] == "PauliX");
@@ -167,16 +159,15 @@ TEMPLATE_LIST_TEST_CASE("Test a LightningSimulator circuit with num_qubits=4 and
     CHECK(obs_keys[2] == pz);
 }
 
-TEST_CASE("Test __quantum__qis__ circuit with observables", "[CacheManager]")
-{
+TEST_CASE("Test __quantum__qis__ circuit with observables", "[CacheManager]") {
     __quantum__rt__initialize();
-    for (const auto &[key, val] : getDevices()) {
-        __quantum__rt__device((int8_t *)key.c_str(), (int8_t *)val.c_str());
+    for (const auto& [key, val] : getDevices()) {
+        __quantum__rt__device((int8_t*)key.c_str(), (int8_t*)val.c_str());
 
-        QUBIT *target = __quantum__rt__qubit_allocate();              // id = 0
-        QirArray *ctrls_arr = __quantum__rt__qubit_allocate_array(1); // id = 1
+        QUBIT* target = __quantum__rt__qubit_allocate();              // id = 0
+        QirArray* ctrls_arr = __quantum__rt__qubit_allocate_array(1); // id = 1
 
-        QUBIT **ctrls = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(ctrls_arr, 0);
+        QUBIT** ctrls = (QUBIT**)__quantum__rt__array_get_element_ptr_1d(ctrls_arr, 0);
 
         // qml.Hadamard(wires=0)
         __quantum__qis__Hadamard(target, false);
@@ -188,10 +179,10 @@ TEST_CASE("Test __quantum__qis__ circuit with observables", "[CacheManager]")
         __quantum__qis__CRX(0.4, target, *ctrls, false);
 
         size_t buffer_len = 4;
-        CplxT_double *buffer = new CplxT_double[buffer_len];
+        CplxT_double* buffer = new CplxT_double[buffer_len];
         MemRefT_CplxT_double_1d result = {buffer, buffer, 0, {buffer_len}, {1}};
         __quantum__qis__State(&result, 0);
-        CplxT_double *state = result.data_allocated;
+        CplxT_double* state = result.data_allocated;
 
         CHECK((state[0].real == Approx(0.70357419).margin(1e-5) &&
                state[0].imag == Approx(0.0).margin(1e-5)));
@@ -202,7 +193,7 @@ TEST_CASE("Test __quantum__qis__ circuit with observables", "[CacheManager]")
         CHECK((state[3].real == Approx(0.0).margin(1e-5) &&
                state[3].imag == Approx(-0.0705929).margin(1e-5)));
         // qml.expval(qml.PauliZ(wires=1))
-        QUBIT **qubit = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(ctrls_arr, 0);
+        QUBIT** qubit = (QUBIT**)__quantum__rt__array_get_element_ptr_1d(ctrls_arr, 0);
         auto obs = __quantum__qis__NamedObs(ObsId::PauliZ, *qubit);
 
         CHECK(__quantum__qis__Expval(obs) == Approx(0.9800665778).margin(1e-5));
@@ -215,17 +206,16 @@ TEST_CASE("Test __quantum__qis__ circuit with observables", "[CacheManager]")
 }
 
 TEST_CASE("Test __quantum__qis__ circuit with observables using deactiveCacheManager",
-          "[CacheManager]")
-{
+          "[CacheManager]") {
 
     __quantum__rt__initialize();
-    for (const auto &[key, val] : getDevices()) {
-        __quantum__rt__device((int8_t *)key.c_str(), (int8_t *)val.c_str());
+    for (const auto& [key, val] : getDevices()) {
+        __quantum__rt__device((int8_t*)key.c_str(), (int8_t*)val.c_str());
 
-        QUBIT *target = __quantum__rt__qubit_allocate();              // id = 0
-        QirArray *ctrls_arr = __quantum__rt__qubit_allocate_array(1); // id = 1
+        QUBIT* target = __quantum__rt__qubit_allocate();              // id = 0
+        QirArray* ctrls_arr = __quantum__rt__qubit_allocate_array(1); // id = 1
 
-        QUBIT **ctrls = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(ctrls_arr, 0);
+        QUBIT** ctrls = (QUBIT**)__quantum__rt__array_get_element_ptr_1d(ctrls_arr, 0);
 
         __quantum__rt__toggle_recorder(/* activate_cm */ true);
 
@@ -239,10 +229,10 @@ TEST_CASE("Test __quantum__qis__ circuit with observables using deactiveCacheMan
         __quantum__qis__CRX(0.4, target, *ctrls, false);
 
         size_t buffer_len = 4;
-        CplxT_double *buffer = new CplxT_double[buffer_len];
+        CplxT_double* buffer = new CplxT_double[buffer_len];
         MemRefT_CplxT_double_1d result = {buffer, buffer, 0, {buffer_len}, {1}};
         __quantum__qis__State(&result, 0);
-        CplxT_double *state = result.data_allocated;
+        CplxT_double* state = result.data_allocated;
 
         CHECK((state[0].real == Approx(0.70357419).margin(1e-5) &&
                state[0].imag == Approx(0.0).margin(1e-5)));
@@ -253,7 +243,7 @@ TEST_CASE("Test __quantum__qis__ circuit with observables using deactiveCacheMan
         CHECK((state[3].real == Approx(0.0).margin(1e-5) &&
                state[3].imag == Approx(-0.0705929).margin(1e-5)));
         // qml.expval(qml.PauliZ(wires=1))
-        QUBIT **qubit = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(ctrls_arr, 0);
+        QUBIT** qubit = (QUBIT**)__quantum__rt__array_get_element_ptr_1d(ctrls_arr, 0);
         auto obs = __quantum__qis__NamedObs(ObsId::PauliZ, *qubit);
 
         CHECK(__quantum__qis__Expval(obs) == Approx(0.9800665778).margin(1e-5));

--- a/runtime/tests/Test_LightningDriver.cpp
+++ b/runtime/tests/Test_LightningDriver.cpp
@@ -13,21 +13,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <numeric>
-#include <string>
-
 #include "ExecutionContext.hpp"
 #include "QuantumDevice.hpp"
 #include "RuntimeCAPI.h"
+#include "TestUtils.hpp"
 #include "Utils.hpp"
 
-#include "TestUtils.hpp"
+#include <numeric>
+#include <string>
 
 using namespace Catalyst::Runtime;
 using namespace Catalyst::Runtime::Simulator;
 
-TEST_CASE("Test parse_kwargs coverage", "[Utils]")
-{
+TEST_CASE("Test parse_kwargs coverage", "[Utils]") {
     std::string case1{""};
     CHECK(parse_kwargs(case1).empty());
 
@@ -55,8 +53,7 @@ TEST_CASE("Test parse_kwargs coverage", "[Utils]")
            res6["s3_destination_folder"] == "('catalyst-op3-s3', 'prefix')"));
 }
 
-TEST_CASE("Test Driver", "[Driver]")
-{
+TEST_CASE("Test Driver", "[Driver]") {
     std::unique_ptr<ExecutionContext> driver = std::make_unique<ExecutionContext>("default");
 
     // check the scope of memory-manager
@@ -74,8 +71,7 @@ TEST_CASE("Test Driver", "[Driver]")
     CHECK(driver->getDeviceRecorderStatus() == true);
 }
 
-TEMPLATE_LIST_TEST_CASE("lightning Basis vector", "[Driver]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("lightning Basis vector", "[Driver]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     QubitIdType q = sim->AllocateQubit();
@@ -98,8 +94,7 @@ TEMPLATE_LIST_TEST_CASE("lightning Basis vector", "[Driver]", SimTypes)
     CHECK(view(3).imag() == Approx(0.0).epsilon(1e-5));
 }
 
-TEMPLATE_TEST_CASE("Qubit allocatation and deallocation", "[Driver]", LightningSimulator)
-{
+TEMPLATE_TEST_CASE("Qubit allocatation and deallocation", "[Driver]", LightningSimulator) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     constexpr size_t n = 1;
@@ -139,13 +134,12 @@ TEMPLATE_TEST_CASE("Qubit allocatation and deallocation", "[Driver]", LightningS
     }
 }
 
-TEMPLATE_LIST_TEST_CASE("test AllocateQubits", "[Driver]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("test AllocateQubits", "[Driver]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     CHECK(sim->AllocateQubits(0).size() == 0);
 
-    auto &&q = sim->AllocateQubits(2);
+    auto&& q = sim->AllocateQubits(2);
 
     sim->ReleaseQubit(q[0]);
 
@@ -156,8 +150,7 @@ TEMPLATE_LIST_TEST_CASE("test AllocateQubits", "[Driver]", SimTypes)
     CHECK(state[0].real() == Approx(1.0).epsilon(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("test DeviceShots", "[Driver]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("test DeviceShots", "[Driver]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     CHECK(sim->GetDeviceShots() == 1000);
@@ -167,8 +160,7 @@ TEMPLATE_LIST_TEST_CASE("test DeviceShots", "[Driver]", SimTypes)
     CHECK(sim->GetDeviceShots() == 500);
 }
 
-TEMPLATE_LIST_TEST_CASE("compute register tests", "[Driver]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("compute register tests", "[Driver]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     constexpr size_t n = 10;
@@ -195,15 +187,13 @@ TEMPLATE_LIST_TEST_CASE("compute register tests", "[Driver]", SimTypes)
     }
 }
 
-TEMPLATE_LIST_TEST_CASE("Check an unsupported operation", "[Driver]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Check an unsupported operation", "[Driver]", SimTypes) {
     REQUIRE_THROWS_WITH(
         Lightning::lookup_gates(Lightning::simulator_gate_info, "UnsupportedGateName"),
         Catch::Contains("The given operation is not supported by the simulator"));
 }
 
-TEMPLATE_TEST_CASE("QuantumDevice object test [lightning.qubit]", "[Driver]", LightningSimulator)
-{
+TEMPLATE_TEST_CASE("QuantumDevice object test [lightning.qubit]", "[Driver]", LightningSimulator) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n

--- a/runtime/tests/Test_LightningGateSet.cpp
+++ b/runtime/tests/Test_LightningGateSet.cpp
@@ -12,21 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cmath>
-
 #include "QuantumDevice.hpp"
 #include "RuntimeCAPI.h"
+#include "TestUtils.hpp"
 #include "Utils.hpp"
 
-#include "TestUtils.hpp"
+#include <cmath>
 
 using namespace Pennylane;
 
 using namespace Catalyst::Runtime;
 using namespace Catalyst::Runtime::Simulator;
 
-TEMPLATE_LIST_TEST_CASE("Identity Gate tests", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Identity Gate tests", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -57,8 +55,7 @@ TEMPLATE_LIST_TEST_CASE("Identity Gate tests", "[GateSet]", SimTypes)
     CHECK(sum == std::complex<double>{0, 0});
 }
 
-TEMPLATE_LIST_TEST_CASE("PauliX Gate tests num_qubits=1", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("PauliX Gate tests num_qubits=1", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -81,8 +78,7 @@ TEMPLATE_LIST_TEST_CASE("PauliX Gate tests num_qubits=1", "[GateSet]", SimTypes)
 }
 
 // 1-qubit operations
-TEMPLATE_LIST_TEST_CASE("PauliX Gate tests num_qubits=3", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("PauliX Gate tests num_qubits=3", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -116,8 +112,7 @@ TEMPLATE_LIST_TEST_CASE("PauliX Gate tests num_qubits=3", "[GateSet]", SimTypes)
     CHECK(sum == std::complex<double>{0, 0});
 }
 
-TEMPLATE_LIST_TEST_CASE("PauliY Gate tests num_qubits=1", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("PauliY Gate tests num_qubits=1", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -139,8 +134,7 @@ TEMPLATE_LIST_TEST_CASE("PauliY Gate tests num_qubits=1", "[GateSet]", SimTypes)
     CHECK(state.at(1) == std::complex<double>{0, 1});
 }
 
-TEMPLATE_LIST_TEST_CASE("PauliY Gate tests num_qubits=2", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("PauliY Gate tests num_qubits=2", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -165,8 +159,7 @@ TEMPLATE_LIST_TEST_CASE("PauliY Gate tests num_qubits=2", "[GateSet]", SimTypes)
     CHECK(state.at(3) == std::complex<double>{-1, 0});
 }
 
-TEMPLATE_LIST_TEST_CASE("PauliZ Gate tests num_qubits=2", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("PauliZ Gate tests num_qubits=2", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -191,8 +184,7 @@ TEMPLATE_LIST_TEST_CASE("PauliZ Gate tests num_qubits=2", "[GateSet]", SimTypes)
     CHECK(state.at(3) == std::complex<double>{0, 0});
 }
 
-TEMPLATE_LIST_TEST_CASE("Hadamard Gate tests num_qubits=2", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Hadamard Gate tests num_qubits=2", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -218,8 +210,7 @@ TEMPLATE_LIST_TEST_CASE("Hadamard Gate tests num_qubits=2", "[GateSet]", SimType
     CHECK(state.at(3) == state.at(0));
 }
 
-TEMPLATE_LIST_TEST_CASE("Hadamard Gate tests num_qubits=3", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Hadamard Gate tests num_qubits=3", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -245,8 +236,7 @@ TEMPLATE_LIST_TEST_CASE("Hadamard Gate tests num_qubits=3", "[GateSet]", SimType
     CHECK(state.at(3) == state.at(0));
 }
 
-TEMPLATE_LIST_TEST_CASE("MIX Gate test R(X,Y,Z) num_qubits=1,4", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("MIX Gate test R(X,Y,Z) num_qubits=1,4", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubit = n
@@ -293,8 +283,7 @@ TEMPLATE_LIST_TEST_CASE("MIX Gate test R(X,Y,Z) num_qubits=1,4", "[GateSet]", Si
     CHECK(state.at(15) == std::complex<double>{0, 0});
 }
 
-TEMPLATE_LIST_TEST_CASE("test PhaseShift num_qubits=2", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("test PhaseShift num_qubits=2", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubit = n
@@ -328,8 +317,7 @@ TEMPLATE_LIST_TEST_CASE("test PhaseShift num_qubits=2", "[GateSet]", SimTypes)
 }
 
 // 2-qubit operations
-TEMPLATE_LIST_TEST_CASE("CNOT Gate tests num_qubits=2 [0,1]", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("CNOT Gate tests num_qubits=2 [0,1]", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -354,8 +342,7 @@ TEMPLATE_LIST_TEST_CASE("CNOT Gate tests num_qubits=2 [0,1]", "[GateSet]", SimTy
     CHECK(state.at(3) == std::complex<double>{1, 0});
 }
 
-TEMPLATE_LIST_TEST_CASE("CNOT Gate tests num_qubits=2 [1,0]", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("CNOT Gate tests num_qubits=2 [1,0]", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -380,8 +367,7 @@ TEMPLATE_LIST_TEST_CASE("CNOT Gate tests num_qubits=2 [1,0]", "[GateSet]", SimTy
     CHECK(state.at(3) == std::complex<double>{0, 0});
 }
 
-TEMPLATE_LIST_TEST_CASE("MIX Gate test CR(X, Y, Z) num_qubits=1,4", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("MIX Gate test CR(X, Y, Z) num_qubits=1,4", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubit = n
@@ -425,8 +411,7 @@ TEMPLATE_LIST_TEST_CASE("MIX Gate test CR(X, Y, Z) num_qubits=1,4", "[GateSet]",
     CHECK(state.at(15) == std::complex<double>{0, 0});
 }
 
-TEMPLATE_LIST_TEST_CASE("CRot", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("CRot", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -454,8 +439,7 @@ TEMPLATE_LIST_TEST_CASE("CRot", "[GateSet]", SimTypes)
     CHECK(state[3].imag() == Approx(-0.4844562109).epsilon(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("CSWAP test", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("CSWAP test", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -478,8 +462,7 @@ TEMPLATE_LIST_TEST_CASE("CSWAP test", "[GateSet]", SimTypes)
     CHECK(state[5].imag() == Approx(0).epsilon(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("IsingXY Gate tests num_qubits=2 [1,0]", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("IsingXY Gate tests num_qubits=2 [1,0]", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -510,8 +493,7 @@ TEMPLATE_LIST_TEST_CASE("IsingXY Gate tests num_qubits=2 [1,0]", "[GateSet]", Si
     CHECK(state[3].imag() == Approx(0).epsilon(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Toffoli test", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Toffoli test", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -543,8 +525,7 @@ TEMPLATE_LIST_TEST_CASE("Toffoli test", "[GateSet]", SimTypes)
     CHECK(state[7].imag() == Approx(0).epsilon(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("MultiRZ test", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("MultiRZ test", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -570,8 +551,7 @@ TEMPLATE_LIST_TEST_CASE("MultiRZ test", "[GateSet]", SimTypes)
     CHECK(state[2].imag() == Approx(0).epsilon(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("MatrixOperation test with 2-qubit", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("MatrixOperation test with 2-qubit", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -612,8 +592,7 @@ TEMPLATE_LIST_TEST_CASE("MatrixOperation test with 2-qubit", "[GateSet]", SimTyp
     CHECK(state[3].imag() == Approx(-0.187075).epsilon(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("MatrixOperation test with 3-qubit", "[GateSet]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("MatrixOperation test with 3-qubit", "[GateSet]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -657,8 +636,7 @@ TEMPLATE_LIST_TEST_CASE("MatrixOperation test with 3-qubit", "[GateSet]", SimTyp
     CHECK(state[6].imag() == Approx(0.162104).epsilon(1e-5));
 }
 
-TEMPLATE_TEST_CASE("MatrixOperation test with 4-qubit", "[GateSet]", LightningSimulator)
-{
+TEMPLATE_TEST_CASE("MatrixOperation test with 4-qubit", "[GateSet]", LightningSimulator) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubit = n

--- a/runtime/tests/Test_LightningGradient.cpp
+++ b/runtime/tests/Test_LightningGradient.cpp
@@ -14,28 +14,25 @@
 
 #include "QuantumDevice.hpp"
 #include "RuntimeCAPI.h"
-#include "Utils.hpp"
-
 #include "TestUtils.hpp"
+#include "Utils.hpp"
 
 using namespace Catalyst::Runtime;
 
-TEST_CASE("Test __quantum__qis__Gradient with numAlloc=0", "[Gradient]")
-{
+TEST_CASE("Test __quantum__qis__Gradient with numAlloc=0", "[Gradient]") {
     __quantum__rt__initialize();
-    for (const auto &[key, val] : getDevices()) {
-        __quantum__rt__device((int8_t *)key.c_str(), (int8_t *)val.c_str());
+    for (const auto& [key, val] : getDevices()) {
+        __quantum__rt__device((int8_t*)key.c_str(), (int8_t*)val.c_str());
 
         REQUIRE_NOTHROW(__quantum__qis__Gradient(0, nullptr));
     }
     __quantum__rt__finalize();
 }
 
-TEST_CASE("Test __quantum__qis__Gradient_params with numAlloc=0", "[Gradient]")
-{
+TEST_CASE("Test __quantum__qis__Gradient_params with numAlloc=0", "[Gradient]") {
     __quantum__rt__initialize();
-    for (const auto &[key, val] : getDevices()) {
-        __quantum__rt__device((int8_t *)key.c_str(), (int8_t *)val.c_str());
+    for (const auto& [key, val] : getDevices()) {
+        __quantum__rt__device((int8_t*)key.c_str(), (int8_t*)val.c_str());
 
         REQUIRE_THROWS_WITH(__quantum__qis__Gradient_params(nullptr, 0, nullptr),
                             Catch::Contains("Invalid number of trainable parameters"));
@@ -43,20 +40,19 @@ TEST_CASE("Test __quantum__qis__Gradient_params with numAlloc=0", "[Gradient]")
     __quantum__rt__finalize();
 }
 
-TEST_CASE("Test __quantum__qis__Gradient_params for zero number of obs", "[Gradient]")
-{
+TEST_CASE("Test __quantum__qis__Gradient_params for zero number of obs", "[Gradient]") {
     std::vector<int64_t> trainParams{0};
     size_t J = 1;
-    double *buffer = new double[J];
+    double* buffer = new double[J];
     MemRefT_double_1d results = {buffer, buffer, 0, {J}, {1}};
-    int64_t *buffer_tp = trainParams.data();
+    int64_t* buffer_tp = trainParams.data();
     MemRefT_int64_1d tp = {buffer_tp, buffer_tp, 0, {trainParams.size()}, {1}};
 
     __quantum__rt__initialize();
-    for (const auto &[key, val] : getDevices()) {
-        __quantum__rt__device((int8_t *)key.c_str(), (int8_t *)val.c_str());
+    for (const auto& [key, val] : getDevices()) {
+        __quantum__rt__device((int8_t*)key.c_str(), (int8_t*)val.c_str());
 
-        QUBIT *q = __quantum__rt__qubit_allocate();
+        QUBIT* q = __quantum__rt__qubit_allocate();
 
         __quantum__rt__toggle_recorder(/* activate_cm */ true);
 
@@ -74,24 +70,23 @@ TEST_CASE("Test __quantum__qis__Gradient_params for zero number of obs", "[Gradi
 
 TEST_CASE("Test __quantum__qis__Gradient and __quantum__qis__Gradient_params "
           "with Var",
-          "[Gradient]")
-{
+          "[Gradient]") {
     std::vector<int64_t> trainParams{0};
     size_t J = 1;
-    double *buffer = new double[J];
+    double* buffer = new double[J];
     MemRefT_double_1d results = {buffer, buffer, 0, {J}, {1}};
-    int64_t *buffer_tp = trainParams.data();
+    int64_t* buffer_tp = trainParams.data();
     MemRefT_int64_1d tp = {buffer_tp, buffer_tp, 0, {trainParams.size()}, {1}};
 
-    for (const auto &[key, val] : getDevices()) {
+    for (const auto& [key, val] : getDevices()) {
         __quantum__rt__initialize();
 
         // To check toggle_recorder before device initialization
         __quantum__rt__toggle_recorder(/* activate_cm */ true);
 
-        __quantum__rt__device((int8_t *)key.c_str(), (int8_t *)val.c_str());
+        __quantum__rt__device((int8_t*)key.c_str(), (int8_t*)val.c_str());
 
-        QUBIT *q = __quantum__rt__qubit_allocate();
+        QUBIT* q = __quantum__rt__qubit_allocate();
 
         __quantum__qis__RX(-M_PI / 7, q, false);
 
@@ -116,22 +111,21 @@ TEST_CASE("Test __quantum__qis__Gradient and __quantum__qis__Gradient_params "
 
 TEST_CASE("Test __quantum__qis__Gradient and __quantum__qis__Gradient_params "
           "Op=RX, Obs=Z",
-          "[Gradient]")
-{
+          "[Gradient]") {
     std::vector<int64_t> trainParams{0};
     size_t J = trainParams.size();
-    double *buffer = new double[J];
+    double* buffer = new double[J];
     MemRefT_double_1d result = {buffer, buffer, 0, {J}, {1}};
-    double *buffer_tp = new double[J];
+    double* buffer_tp = new double[J];
     MemRefT_double_1d result_tp = {buffer_tp, buffer_tp, 0, {J}, {1}};
-    int64_t *buffer_memref = trainParams.data();
+    int64_t* buffer_memref = trainParams.data();
     MemRefT_int64_1d tp_memref = {buffer_memref, buffer_memref, 0, {trainParams.size()}, {1}};
 
-    for (const auto &[key, val] : getDevices()) {
+    for (const auto& [key, val] : getDevices()) {
         __quantum__rt__initialize();
-        __quantum__rt__device((int8_t *)key.c_str(), (int8_t *)val.c_str());
+        __quantum__rt__device((int8_t*)key.c_str(), (int8_t*)val.c_str());
 
-        QUBIT *q = __quantum__rt__qubit_allocate();
+        QUBIT* q = __quantum__rt__qubit_allocate();
 
         __quantum__rt__toggle_recorder(/* activate_cm */ true);
 
@@ -160,22 +154,21 @@ TEST_CASE("Test __quantum__qis__Gradient and __quantum__qis__Gradient_params "
 
 TEST_CASE("Test __quantum__qis__Gradient and __quantum__qis__Gradient_params "
           "Op=RX, Obs=Hermitian",
-          "[Gradient]")
-{
+          "[Gradient]") {
     std::vector<int64_t> trainParams{0};
     size_t J = trainParams.size();
-    double *buffer = new double[J];
+    double* buffer = new double[J];
     MemRefT_double_1d result = {buffer, buffer, 0, {J}, {1}};
-    double *buffer_tp = new double[J];
+    double* buffer_tp = new double[J];
     MemRefT_double_1d result_tp = {buffer_tp, buffer_tp, 0, {J}, {1}};
-    int64_t *buffer_tp_memref = trainParams.data();
+    int64_t* buffer_tp_memref = trainParams.data();
     MemRefT_int64_1d tp_memref = {buffer_tp_memref, buffer_tp_memref, 0, {trainParams.size()}, {1}};
 
-    for (const auto &[key, val] : getDevices()) {
+    for (const auto& [key, val] : getDevices()) {
         __quantum__rt__initialize();
-        __quantum__rt__device((int8_t *)key.c_str(), (int8_t *)val.c_str());
+        __quantum__rt__device((int8_t*)key.c_str(), (int8_t*)val.c_str());
 
-        QUBIT *q = __quantum__rt__qubit_allocate();
+        QUBIT* q = __quantum__rt__qubit_allocate();
 
         __quantum__rt__toggle_recorder(/* activate_cm */ true);
 
@@ -183,7 +176,7 @@ TEST_CASE("Test __quantum__qis__Gradient and __quantum__qis__Gradient_params "
 
         CplxT_double matrix_data[4] = {{1.0, 0.0}, {0.0, 0.0}, {2.0, 0.0}, {0.0, 0.0}};
 
-        MemRefT_CplxT_double_2d *h_matrix = new MemRefT_CplxT_double_2d;
+        MemRefT_CplxT_double_2d* h_matrix = new MemRefT_CplxT_double_2d;
         h_matrix->data_allocated = matrix_data;
         h_matrix->data_aligned = matrix_data;
         h_matrix->offset = 0;
@@ -216,27 +209,26 @@ TEST_CASE("Test __quantum__qis__Gradient and __quantum__qis__Gradient_params "
 
 TEST_CASE("Test __quantum__qis__Gradient_params and __quantum__qis__Gradient "
           "Op=RY, Obs=X [lightning.qubit]",
-          "[Gradient]")
-{
+          "[Gradient]") {
     const std::vector<double> param{-M_PI / 7, M_PI / 5, 2 * M_PI / 3};
 
     std::vector<int64_t> trainParams{0};
     size_t J = trainParams.size();
-    double *buffer = new double[J];
+    double* buffer = new double[J];
     MemRefT_double_1d result = {buffer, buffer, 0, {J}, {1}};
-    double *buffer_tp = new double[J];
+    double* buffer_tp = new double[J];
     MemRefT_double_1d result_tp = {buffer_tp, buffer_tp, 0, {J}, {1}};
-    int64_t *buffer_tp_memref = trainParams.data();
+    int64_t* buffer_tp_memref = trainParams.data();
     MemRefT_int64_1d tp_memref = {buffer_tp_memref, buffer_tp_memref, 0, {trainParams.size()}, {1}};
 
     const std::string dev("backend");
     const std::string dev_value("lightning.qubit");
 
-    for (const auto &p : param) {
+    for (const auto& p : param) {
         __quantum__rt__initialize();
-        __quantum__rt__device((int8_t *)dev.c_str(), (int8_t *)dev_value.c_str());
+        __quantum__rt__device((int8_t*)dev.c_str(), (int8_t*)dev_value.c_str());
 
-        QUBIT *q = __quantum__rt__qubit_allocate();
+        QUBIT* q = __quantum__rt__qubit_allocate();
 
         __quantum__rt__toggle_recorder(/* activate_cm */ true);
 
@@ -265,8 +257,7 @@ TEST_CASE("Test __quantum__qis__Gradient_params and __quantum__qis__Gradient "
 
 TEST_CASE("Test __quantum__qis__Gradient_params Op=[Hadamard,RZ,RY,RZ,S,T,ParamShift], "
           "Obs=[X]",
-          "[Gradient]")
-{
+          "[Gradient]") {
     const std::vector<double> param{0.3, 0.7, 0.4};
     const std::vector<double> expected{
         -0.1496908292,
@@ -276,19 +267,19 @@ TEST_CASE("Test __quantum__qis__Gradient_params Op=[Hadamard,RZ,RY,RZ,S,T,ParamS
 
     std::vector<int64_t> trainParams{0, 1, 2};
     size_t J = trainParams.size();
-    double *buffer = new double[J];
+    double* buffer = new double[J];
     MemRefT_double_1d result = {buffer, buffer, 0, {J}, {1}};
-    double *buffer_tp = new double[J];
+    double* buffer_tp = new double[J];
     MemRefT_double_1d result_tp = {buffer_tp, buffer_tp, 0, {J}, {1}};
-    int64_t *buffer_tp_memref = trainParams.data();
+    int64_t* buffer_tp_memref = trainParams.data();
     MemRefT_int64_1d tp_memref = {buffer_tp_memref, buffer_tp_memref, 0, {trainParams.size()}, {1}};
 
     __quantum__rt__initialize();
-    for (const auto &[key, val] : getDevices()) {
-        __quantum__rt__device((int8_t *)key.c_str(), (int8_t *)val.c_str());
+    for (const auto& [key, val] : getDevices()) {
+        __quantum__rt__device((int8_t*)key.c_str(), (int8_t*)val.c_str());
 
-        QUBIT *q0 = __quantum__rt__qubit_allocate();
-        QUBIT *q1 = __quantum__rt__qubit_allocate();
+        QUBIT* q0 = __quantum__rt__qubit_allocate();
+        QUBIT* q1 = __quantum__rt__qubit_allocate();
 
         __quantum__rt__toggle_recorder(/* activate_cm */ true);
 
@@ -326,23 +317,22 @@ TEST_CASE("Test __quantum__qis__Gradient_params Op=[Hadamard,RZ,RY,RZ,S,T,ParamS
     delete[] buffer_tp;
 }
 
-TEST_CASE("Test __quantum__qis__Gradient Op=[RX,CY], Obs=[Z,Z]", "[Gradient]")
-{
+TEST_CASE("Test __quantum__qis__Gradient Op=[RX,CY], Obs=[Z,Z]", "[Gradient]") {
     std::vector<int64_t> trainParams{0};
     const std::vector<double> expected{-sin(-M_PI / 7), 0.4338837391};
     size_t J = trainParams.size();
-    double *buffer0 = new double[J];
+    double* buffer0 = new double[J];
     MemRefT_double_1d result0 = {buffer0, buffer0, 0, {J}, {1}};
-    double *buffer1 = new double[J];
+    double* buffer1 = new double[J];
     MemRefT_double_1d result1 = {buffer1, buffer1, 0, {J}, {1}};
 
-    for (const auto &[key, val] : getDevices()) {
+    for (const auto& [key, val] : getDevices()) {
         __quantum__rt__initialize();
-        __quantum__rt__device((int8_t *)key.c_str(), (int8_t *)val.c_str());
+        __quantum__rt__device((int8_t*)key.c_str(), (int8_t*)val.c_str());
 
-        QirArray *qs = __quantum__rt__qubit_allocate_array(2);
-        QUBIT **q0 = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(qs, 0);
-        QUBIT **q1 = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(qs, 1);
+        QirArray* qs = __quantum__rt__qubit_allocate_array(2);
+        QUBIT** q0 = (QUBIT**)__quantum__rt__array_get_element_ptr_1d(qs, 0);
+        QUBIT** q1 = (QUBIT**)__quantum__rt__array_get_element_ptr_1d(qs, 1);
 
         __quantum__rt__toggle_recorder(/* activate_cm */ true);
 
@@ -370,30 +360,29 @@ TEST_CASE("Test __quantum__qis__Gradient Op=[RX,CY], Obs=[Z,Z]", "[Gradient]")
     delete[] buffer1;
 }
 
-TEST_CASE("Test __quantum__qis__Gradient_params Op=[RX,RX,RX,CZ], Obs=[Z,Z,Z]", "[Gradient]")
-{
+TEST_CASE("Test __quantum__qis__Gradient_params Op=[RX,RX,RX,CZ], Obs=[Z,Z,Z]", "[Gradient]") {
     const std::vector<double> param{-M_PI / 7, M_PI / 5, 2 * M_PI / 3};
     const std::vector<double> expected{-sin(param[0]), -sin(param[1]), -sin(param[2])};
 
     std::vector<int64_t> trainParams{0, 1, 2};
     size_t J = trainParams.size();
-    double *buffer0 = new double[J];
+    double* buffer0 = new double[J];
     MemRefT_double_1d result0 = {buffer0, buffer0, 0, {J}, {1}};
-    double *buffer1 = new double[J];
+    double* buffer1 = new double[J];
     MemRefT_double_1d result1 = {buffer1, buffer1, 0, {J}, {1}};
-    double *buffer2 = new double[J];
+    double* buffer2 = new double[J];
     MemRefT_double_1d result2 = {buffer2, buffer2, 0, {J}, {1}};
-    int64_t *buffer_tp_memref = trainParams.data();
+    int64_t* buffer_tp_memref = trainParams.data();
     MemRefT_int64_1d tp_memref = {buffer_tp_memref, buffer_tp_memref, 0, {trainParams.size()}, {1}};
 
-    for (const auto &[key, val] : getDevices()) {
+    for (const auto& [key, val] : getDevices()) {
         __quantum__rt__initialize();
-        __quantum__rt__device((int8_t *)key.c_str(), (int8_t *)val.c_str());
+        __quantum__rt__device((int8_t*)key.c_str(), (int8_t*)val.c_str());
 
-        QirArray *qs = __quantum__rt__qubit_allocate_array(3);
-        QUBIT **q0 = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(qs, 0);
-        QUBIT **q1 = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(qs, 1);
-        QUBIT **q2 = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(qs, 2);
+        QirArray* qs = __quantum__rt__qubit_allocate_array(3);
+        QUBIT** q0 = (QUBIT**)__quantum__rt__array_get_element_ptr_1d(qs, 0);
+        QUBIT** q1 = (QUBIT**)__quantum__rt__array_get_element_ptr_1d(qs, 1);
+        QUBIT** q2 = (QUBIT**)__quantum__rt__array_get_element_ptr_1d(qs, 2);
 
         __quantum__rt__toggle_recorder(/* activate_cm */ true);
 
@@ -429,29 +418,28 @@ TEST_CASE("Test __quantum__qis__Gradient_params Op=[RX,RX,RX,CZ], Obs=[Z,Z,Z]", 
 
 TEST_CASE("Test __quantum__qis__Gradient and __quantum__qis__Gradient_params "
           "Op=Mixed, Obs=X@X@X",
-          "[Gradient]")
-{
+          "[Gradient]") {
     const std::vector<double> param{-M_PI / 7, M_PI / 5, 2 * M_PI / 3};
     const std::vector<double> expected{0.0,         -0.6742144271, 0.275139672,
                                        0.275139672, -0.0129093062, 0.3238461564};
 
     std::vector<int64_t> trainParams{0, 1, 2, 3, 4, 5};
     size_t J = trainParams.size();
-    double *buffer = new double[J];
+    double* buffer = new double[J];
     MemRefT_double_1d result = {buffer, buffer, 0, {J}, {1}};
-    double *buffer_tp = new double[J];
+    double* buffer_tp = new double[J];
     MemRefT_double_1d result_tp = {buffer_tp, buffer_tp, 0, {J}, {1}};
-    int64_t *buffer_tp_memref = trainParams.data();
+    int64_t* buffer_tp_memref = trainParams.data();
     MemRefT_int64_1d tp_memref = {buffer_tp_memref, buffer_tp_memref, 0, {trainParams.size()}, {1}};
 
-    for (const auto &[key, val] : getDevices()) {
+    for (const auto& [key, val] : getDevices()) {
         __quantum__rt__initialize();
-        __quantum__rt__device((int8_t *)key.c_str(), (int8_t *)val.c_str());
+        __quantum__rt__device((int8_t*)key.c_str(), (int8_t*)val.c_str());
 
-        QirArray *qs = __quantum__rt__qubit_allocate_array(3);
-        QUBIT **q0 = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(qs, 0);
-        QUBIT **q1 = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(qs, 1);
-        QUBIT **q2 = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(qs, 2);
+        QirArray* qs = __quantum__rt__qubit_allocate_array(3);
+        QUBIT** q0 = (QUBIT**)__quantum__rt__array_get_element_ptr_1d(qs, 0);
+        QUBIT** q1 = (QUBIT**)__quantum__rt__array_get_element_ptr_1d(qs, 1);
+        QUBIT** q2 = (QUBIT**)__quantum__rt__array_get_element_ptr_1d(qs, 2);
 
         __quantum__rt__toggle_recorder(/* activate_cm */ true);
 
@@ -501,29 +489,28 @@ TEST_CASE("Test __quantum__qis__Gradient and __quantum__qis__Gradient_params "
 
 TEST_CASE("Test __quantum__qis__Gradient and __quantum__qis__Gradient_params "
           "Op=Mixed, Obs=Z@Z@Z",
-          "[Gradient]")
-{
+          "[Gradient]") {
     const std::vector<double> param{-M_PI / 7, M_PI / 5, 2 * M_PI / 3};
     const std::vector<double> expected{0.0, -0.414506421, 0.0, 0.0, -0.4643270456, 0.0210905264};
 
     std::vector<int64_t> trainParams{0, 1, 2, 3, 4, 5};
     size_t J = 8;
-    double *buffer = new double[J];
+    double* buffer = new double[J];
     MemRefT_double_1d result = {buffer, buffer, 0, {J}, {1}};
     size_t J_tp = trainParams.size();
-    double *buffer_tp = new double[J_tp];
+    double* buffer_tp = new double[J_tp];
     MemRefT_double_1d result_tp = {buffer_tp, buffer_tp, 0, {J_tp}, {1}};
-    int64_t *buffer_tp_memref = trainParams.data();
+    int64_t* buffer_tp_memref = trainParams.data();
     MemRefT_int64_1d tp_memref = {buffer_tp_memref, buffer_tp_memref, 0, {trainParams.size()}, {0}};
 
-    for (const auto &[key, val] : getDevices()) {
+    for (const auto& [key, val] : getDevices()) {
         __quantum__rt__initialize();
-        __quantum__rt__device((int8_t *)key.c_str(), (int8_t *)val.c_str());
+        __quantum__rt__device((int8_t*)key.c_str(), (int8_t*)val.c_str());
 
-        QirArray *qs = __quantum__rt__qubit_allocate_array(3);
-        QUBIT **q0 = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(qs, 0);
-        QUBIT **q1 = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(qs, 1);
-        QUBIT **q2 = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(qs, 2);
+        QirArray* qs = __quantum__rt__qubit_allocate_array(3);
+        QUBIT** q0 = (QUBIT**)__quantum__rt__array_get_element_ptr_1d(qs, 0);
+        QUBIT** q1 = (QUBIT**)__quantum__rt__array_get_element_ptr_1d(qs, 1);
+        QUBIT** q2 = (QUBIT**)__quantum__rt__array_get_element_ptr_1d(qs, 2);
 
         __quantum__rt__toggle_recorder(/* activate_cm */ true);
 
@@ -576,28 +563,27 @@ TEST_CASE("Test __quantum__qis__Gradient and __quantum__qis__Gradient_params "
 TEST_CASE("Test __quantum__qis__Gradient and __quantum__qis__Gradient_params "
           "Op=Mixed, "
           "Obs=Hamiltonian([Z@Z, H], {0.2, 0.6})",
-          "[Gradient]")
-{
+          "[Gradient]") {
     const std::vector<double> param{-M_PI / 7, M_PI / 5, 2 * M_PI / 3};
     const std::vector<double> expected{0.0, -0.2493761627, 0.0, 0.0, -0.1175570505, 0.0};
 
     std::vector<int64_t> trainParams{0, 1, 2, 3, 4, 5};
     size_t J = trainParams.size();
-    double *buffer = new double[J];
+    double* buffer = new double[J];
     MemRefT_double_1d result = {buffer, buffer, 0, {J}, {1}};
-    double *buffer_tp = new double[J];
+    double* buffer_tp = new double[J];
     MemRefT_double_1d result_tp = {buffer_tp, buffer_tp, 0, {J}, {1}};
-    int64_t *buffer_tp_memref = trainParams.data();
+    int64_t* buffer_tp_memref = trainParams.data();
     MemRefT_int64_1d tp_memref = {buffer_tp_memref, buffer_tp_memref, 0, {trainParams.size()}, {1}};
 
-    for (const auto &[key, val] : getDevices()) {
+    for (const auto& [key, val] : getDevices()) {
         __quantum__rt__initialize();
-        __quantum__rt__device((int8_t *)key.c_str(), (int8_t *)val.c_str());
+        __quantum__rt__device((int8_t*)key.c_str(), (int8_t*)val.c_str());
 
-        QirArray *qs = __quantum__rt__qubit_allocate_array(3);
-        QUBIT **q0 = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(qs, 0);
-        QUBIT **q1 = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(qs, 1);
-        QUBIT **q2 = (QUBIT **)__quantum__rt__array_get_element_ptr_1d(qs, 2);
+        QirArray* qs = __quantum__rt__qubit_allocate_array(3);
+        QUBIT** q0 = (QUBIT**)__quantum__rt__array_get_element_ptr_1d(qs, 0);
+        QUBIT** q1 = (QUBIT**)__quantum__rt__array_get_element_ptr_1d(qs, 1);
+        QUBIT** q2 = (QUBIT**)__quantum__rt__array_get_element_ptr_1d(qs, 2);
 
         __quantum__rt__toggle_recorder(/* activate_cm */ true);
 
@@ -651,30 +637,29 @@ TEST_CASE("Test __quantum__qis__Gradient and __quantum__qis__Gradient_params "
 
 TEST_CASE("Test __quantum__qis__Gradient and __quantum__qis__Gradient_params "
           "for a nontrivial qubits map in the qubit-manager Op=RX, Obs=Hermitian",
-          "[Gradient]")
-{
+          "[Gradient]") {
     std::vector<int64_t> trainParams{0};
     size_t J = trainParams.size();
-    double *buffer = new double[J];
+    double* buffer = new double[J];
     MemRefT_double_1d result = {buffer, buffer, 0, {J}, {1}};
-    double *buffer_tp = new double[J];
+    double* buffer_tp = new double[J];
     MemRefT_double_1d result_tp = {buffer_tp, buffer_tp, 0, {J}, {1}};
-    int64_t *buffer_tp_memref = trainParams.data();
+    int64_t* buffer_tp_memref = trainParams.data();
     MemRefT_int64_1d tp_memref = {buffer_tp_memref, buffer_tp_memref, 0, {1}, {1}};
 
-    for (const auto &[key, val] : getDevices()) {
+    for (const auto& [key, val] : getDevices()) {
         __quantum__rt__initialize();
-        __quantum__rt__device((int8_t *)key.c_str(), (int8_t *)val.c_str());
+        __quantum__rt__device((int8_t*)key.c_str(), (int8_t*)val.c_str());
 
-        QirArray *qubit_arr = __quantum__rt__qubit_allocate_array(2);
+        QirArray* qubit_arr = __quantum__rt__qubit_allocate_array(2);
 
         __quantum__rt__qubit_release_array(qubit_arr);
 
-        QUBIT *q = __quantum__rt__qubit_allocate();
+        QUBIT* q = __quantum__rt__qubit_allocate();
 
-        QirString *qstr = __quantum__rt__qubit_to_string(q);
+        QirString* qstr = __quantum__rt__qubit_to_string(q);
 
-        QirString *expected_str = __quantum__rt__int_to_string(2);
+        QirString* expected_str = __quantum__rt__int_to_string(2);
 
         CHECK(__quantum__rt__string_equal(qstr, expected_str));
         __quantum__rt__string_update_reference_count(qstr, -1);
@@ -686,7 +671,7 @@ TEST_CASE("Test __quantum__qis__Gradient and __quantum__qis__Gradient_params "
 
         CplxT_double matrix_data[4] = {{1.0, 0.0}, {0.0, 0.0}, {2.0, 0.0}, {0.0, 0.0}};
 
-        MemRefT_CplxT_double_2d *h_matrix = new MemRefT_CplxT_double_2d;
+        MemRefT_CplxT_double_2d* h_matrix = new MemRefT_CplxT_double_2d;
         h_matrix->data_allocated = matrix_data;
         h_matrix->data_aligned = matrix_data;
         h_matrix->offset = 0;

--- a/runtime/tests/Test_LightningMeasures.cpp
+++ b/runtime/tests/Test_LightningMeasures.cpp
@@ -12,23 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "cmath"
-
-#include "RuntimeCAPI.h"
-#include "Types.h"
-
 #include "CacheManager.hpp"
 #include "MemRefUtils.hpp"
 #include "QuantumDevice.hpp"
-#include "Utils.hpp"
-
+#include "RuntimeCAPI.h"
 #include "TestUtils.hpp"
+#include "Types.h"
+#include "Utils.hpp"
+#include "cmath"
 
 using namespace Catalyst::Runtime;
 using namespace Catalyst::Runtime::Simulator;
 
-TEMPLATE_LIST_TEST_CASE("NameObs test with invalid number of wires", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("NameObs test with invalid number of wires", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     REQUIRE_THROWS_WITH(sim->Observable(ObsId::PauliX, {}, {1}),
@@ -36,8 +32,7 @@ TEMPLATE_LIST_TEST_CASE("NameObs test with invalid number of wires", "[Measures]
 }
 
 TEMPLATE_LIST_TEST_CASE("NameObs test with invalid given wires for NamedObs", "[Measures]",
-                        SimTypes)
-{
+                        SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     sim->AllocateQubit();
@@ -46,8 +41,7 @@ TEMPLATE_LIST_TEST_CASE("NameObs test with invalid given wires for NamedObs", "[
                         Catch::Contains("Invalid given wires"));
 }
 
-TEMPLATE_LIST_TEST_CASE("HermitianObs test with invalid number of wires", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("HermitianObs test with invalid number of wires", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     REQUIRE_THROWS_WITH(sim->Observable(ObsId::Hermitian, {}, {1}),
@@ -55,8 +49,7 @@ TEMPLATE_LIST_TEST_CASE("HermitianObs test with invalid number of wires", "[Meas
 }
 
 TEMPLATE_LIST_TEST_CASE("HermitianObs test with invalid given wires for HermitianObs", "[Measures]",
-                        SimTypes)
-{
+                        SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
     sim->AllocateQubit();
 
@@ -64,15 +57,13 @@ TEMPLATE_LIST_TEST_CASE("HermitianObs test with invalid given wires for Hermitia
                         Catch::Contains("Invalid given wires"));
 }
 
-TEMPLATE_LIST_TEST_CASE("Check an unsupported observable", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Check an unsupported observable", "[Measures]", SimTypes) {
     REQUIRE_THROWS_WITH(Lightning::lookup_obs<Lightning::simulator_observable_support_size>(
                             Lightning::simulator_observable_support, static_cast<ObsId>(10)),
                         Catch::Contains("The given observable is not supported by the simulator"));
 }
 
-TEMPLATE_LIST_TEST_CASE("Measurement collapse test with 2 wires", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Measurement collapse test with 2 wires", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     constexpr size_t n = 2;
@@ -89,8 +80,7 @@ TEMPLATE_LIST_TEST_CASE("Measurement collapse test with 2 wires", "[Measures]", 
     if (*m) {
         CHECK(pow(std::abs(std::real(state[2])), 2) + pow(std::abs(std::imag(state[2])), 2) ==
               Approx(1.0).margin(1e-5));
-    }
-    else {
+    } else {
         CHECK(pow(std::abs(std::real(state[0])), 2) + pow(std::abs(std::imag(state[0])), 2) ==
               Approx(1.0).margin(1e-5));
     }
@@ -98,8 +88,7 @@ TEMPLATE_LIST_TEST_CASE("Measurement collapse test with 2 wires", "[Measures]", 
 }
 
 TEMPLATE_LIST_TEST_CASE("Measurement collapse concrete logical qubit difference", "[Measures]",
-                        SimTypes)
-{
+                        SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     constexpr size_t n = 1;
@@ -127,8 +116,7 @@ TEMPLATE_LIST_TEST_CASE("Measurement collapse concrete logical qubit difference"
     // LCOV_EXCL_STOP
 }
 
-TEMPLATE_LIST_TEST_CASE("Mid-circuit measurement naive test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Mid-circuit measurement naive test", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     QubitIdType q;
@@ -143,15 +131,13 @@ TEMPLATE_LIST_TEST_CASE("Mid-circuit measurement naive test", "[Measures]", SimT
 }
 
 TEMPLATE_LIST_TEST_CASE("Expval(ObsT) test with invalid key for cached observables", "[Measures]",
-                        SimTypes)
-{
+                        SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     REQUIRE_THROWS_WITH(sim->Expval(0), Catch::Contains("Invalid key for cached observables"));
 }
 
-TEMPLATE_LIST_TEST_CASE("Expval(NamedObs) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Expval(NamedObs) test", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -176,8 +162,7 @@ TEMPLATE_LIST_TEST_CASE("Expval(NamedObs) test", "[Measures]", SimTypes)
     CHECK(sim->Expval(pz) == Approx(-1.0).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Expval(HermitianObs) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Expval(HermitianObs) test", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -201,8 +186,7 @@ TEMPLATE_LIST_TEST_CASE("Expval(HermitianObs) test", "[Measures]", SimTypes)
     CHECK(sim->Expval(h2) == Approx(.0).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Expval(TensorProd(NamedObs)) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Expval(TensorProd(NamedObs)) test", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -230,8 +214,7 @@ TEMPLATE_LIST_TEST_CASE("Expval(TensorProd(NamedObs)) test", "[Measures]", SimTy
     CHECK(sim->Expval(tpz) == Approx(-1.0).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Expval(TensorProd(NamedObs[])) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Expval(TensorProd(NamedObs[])) test", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -260,8 +243,7 @@ TEMPLATE_LIST_TEST_CASE("Expval(TensorProd(NamedObs[])) test", "[Measures]", Sim
     CHECK(sim->Expval(tpxz) == Approx(-1.0).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Expval(TensorProd(HermitianObs))", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Expval(TensorProd(HermitianObs))", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -287,8 +269,7 @@ TEMPLATE_LIST_TEST_CASE("Expval(TensorProd(HermitianObs))", "[Measures]", SimTyp
     CHECK(sim->Expval(tph2) == Approx(.0).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Expval(TensorProd(HermitianObs[]))", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Expval(TensorProd(HermitianObs[]))", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -312,8 +293,7 @@ TEMPLATE_LIST_TEST_CASE("Expval(TensorProd(HermitianObs[]))", "[Measures]", SimT
     CHECK(sim->Expval(tp) == Approx(.0).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Expval(TensorProd(Obs[]))", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Expval(TensorProd(Obs[]))", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -341,8 +321,7 @@ TEMPLATE_LIST_TEST_CASE("Expval(TensorProd(Obs[]))", "[Measures]", SimTypes)
 }
 
 TEMPLATE_LIST_TEST_CASE("Expval(Tensor(Hamiltonian(NamedObs[]), NamedObs)) test", "[Measures]",
-                        SimTypes)
-{
+                        SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -367,8 +346,7 @@ TEMPLATE_LIST_TEST_CASE("Expval(Tensor(Hamiltonian(NamedObs[]), NamedObs)) test"
     CHECK(sim->Expval(thz) == Approx(-0.4).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Expval(Tensor(HermitianObs, Hamiltonian()) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Expval(Tensor(HermitianObs, Hamiltonian()) test", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -390,8 +368,7 @@ TEMPLATE_LIST_TEST_CASE("Expval(Tensor(HermitianObs, Hamiltonian()) test", "[Mea
     CHECK(sim->Expval(ten) == Approx(0.0).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Expval(Hamiltonian(NamedObs[])) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Expval(Hamiltonian(NamedObs[])) test", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -415,8 +392,7 @@ TEMPLATE_LIST_TEST_CASE("Expval(Hamiltonian(NamedObs[])) test", "[Measures]", Si
     CHECK(sim->Expval(hxyz) == Approx(0.2).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Expval(Hamiltonian(TensorObs[])) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Expval(Hamiltonian(TensorObs[])) test", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -442,8 +418,7 @@ TEMPLATE_LIST_TEST_CASE("Expval(Hamiltonian(TensorObs[])) test", "[Measures]", S
     CHECK(sim->Expval(hxyz) == Approx(-.6).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Expval(Hamiltonian(Hermitian[])) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Expval(Hamiltonian(Hermitian[])) test", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -470,8 +445,7 @@ TEMPLATE_LIST_TEST_CASE("Expval(Hamiltonian(Hermitian[])) test", "[Measures]", S
 }
 
 TEMPLATE_LIST_TEST_CASE("Expval(Hamiltonian({TensorProd, Hermitian}[])) test", "[Measures]",
-                        SimTypes)
-{
+                        SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -499,8 +473,7 @@ TEMPLATE_LIST_TEST_CASE("Expval(Hamiltonian({TensorProd, Hermitian}[])) test", "
 }
 
 TEMPLATE_LIST_TEST_CASE("Expval(Hamiltonian({Hamiltonian, Hermitian}[])) test", "[Measures]",
-                        SimTypes)
-{
+                        SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -528,8 +501,7 @@ TEMPLATE_LIST_TEST_CASE("Expval(Hamiltonian({Hamiltonian, Hermitian}[])) test", 
 }
 
 TEMPLATE_LIST_TEST_CASE("Expval(Hamiltonian({Hamiltonian(Hamiltonian), Hermitian}[])) test",
-                        "[Measures]", SimTypes)
-{
+                        "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -557,8 +529,7 @@ TEMPLATE_LIST_TEST_CASE("Expval(Hamiltonian({Hamiltonian(Hamiltonian), Hermitian
     CHECK(sim->Expval(hhtp) == Approx(0.7).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Var(NamedObs) test with numWires=4", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Var(NamedObs) test with numWires=4", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -583,8 +554,7 @@ TEMPLATE_LIST_TEST_CASE("Var(NamedObs) test with numWires=4", "[Measures]", SimT
     CHECK(sim->Var(pz) == Approx(.0).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Var(HermitianObs) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Var(HermitianObs) test", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -608,8 +578,7 @@ TEMPLATE_LIST_TEST_CASE("Var(HermitianObs) test", "[Measures]", SimTypes)
     CHECK(sim->Var(h2) == Approx(1.0).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Var(TensorProd(NamedObs)) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Var(TensorProd(NamedObs)) test", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -637,8 +606,7 @@ TEMPLATE_LIST_TEST_CASE("Var(TensorProd(NamedObs)) test", "[Measures]", SimTypes
     CHECK(sim->Var(tpz) == Approx(.0).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Var(TensorProd(NamedObs[])) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Var(TensorProd(NamedObs[])) test", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -664,8 +632,7 @@ TEMPLATE_LIST_TEST_CASE("Var(TensorProd(NamedObs[])) test", "[Measures]", SimTyp
     CHECK(sim->Var(tpxz) == Approx(0.0).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Var(TensorProd(HermitianObs)) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Var(TensorProd(HermitianObs)) test", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -691,8 +658,7 @@ TEMPLATE_LIST_TEST_CASE("Var(TensorProd(HermitianObs)) test", "[Measures]", SimT
     CHECK(sim->Var(tph2) == Approx(1.0).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Var(TensorProd(HermitianObs[])) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Var(TensorProd(HermitianObs[])) test", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -716,8 +682,7 @@ TEMPLATE_LIST_TEST_CASE("Var(TensorProd(HermitianObs[])) test", "[Measures]", Si
     CHECK(sim->Var(tp) == Approx(2.0).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Var(TensorProd(Obs[])) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Var(TensorProd(Obs[])) test", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -745,8 +710,7 @@ TEMPLATE_LIST_TEST_CASE("Var(TensorProd(Obs[])) test", "[Measures]", SimTypes)
 }
 
 TEMPLATE_LIST_TEST_CASE("Var(Tensor(Hamiltonian(NamedObs[]), NamedObs)) test", "[Measures]",
-                        SimTypes)
-{
+                        SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -771,8 +735,7 @@ TEMPLATE_LIST_TEST_CASE("Var(Tensor(Hamiltonian(NamedObs[]), NamedObs)) test", "
     CHECK(sim->Var(thz) == Approx(0.64).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Var(Tensor(HermitianObs, Hamiltonian()) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Var(Tensor(HermitianObs, Hamiltonian()) test", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -793,8 +756,7 @@ TEMPLATE_LIST_TEST_CASE("Var(Tensor(HermitianObs, Hamiltonian()) test", "[Measur
     CHECK(sim->Var(ten) == Approx(0.8).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian(NamedObs[])) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian(NamedObs[])) test", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -818,8 +780,7 @@ TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian(NamedObs[])) test", "[Measures]", SimTy
     CHECK(sim->Var(hxyz) == Approx(0.64).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian(TensorObs[])) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian(TensorObs[])) test", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -845,8 +806,7 @@ TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian(TensorObs[])) test", "[Measures]", SimT
     CHECK(sim->Var(hxyz) == Approx(0.04).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian(Hermitian[])) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian(Hermitian[])) test", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -872,8 +832,8 @@ TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian(Hermitian[])) test", "[Measures]", SimT
     CHECK(sim->Var(hxhz) == Approx(0.36).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian({TensorProd, Hermitian}[])) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian({TensorProd, Hermitian}[])) test", "[Measures]",
+                        SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -900,8 +860,8 @@ TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian({TensorProd, Hermitian}[])) test", "[Me
     CHECK(sim->Var(hhtp) == Approx(1.0).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian({Hamiltonian, Hermitian}[])) test", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian({Hamiltonian, Hermitian}[])) test", "[Measures]",
+                        SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -929,8 +889,7 @@ TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian({Hamiltonian, Hermitian}[])) test", "[M
 }
 
 TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian({Hamiltonian(Hamiltonian), Hermitian}[])) test",
-                        "[Measures]", SimTypes)
-{
+                        "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -958,8 +917,7 @@ TEMPLATE_LIST_TEST_CASE("Var(Hamiltonian({Hamiltonian(Hamiltonian), Hermitian}[]
     CHECK(sim->Var(hhtp) == Approx(0.36).margin(1e-5));
 }
 
-TEMPLATE_LIST_TEST_CASE("State test with incorrect size", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("State test with incorrect size", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -972,8 +930,7 @@ TEMPLATE_LIST_TEST_CASE("State test with incorrect size", "[Measures]", SimTypes
                         Catch::Contains("Invalid size for the pre-allocated state vector"));
 }
 
-TEMPLATE_LIST_TEST_CASE("State test with numWires=4", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("State test with numWires=4", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -993,8 +950,7 @@ TEMPLATE_LIST_TEST_CASE("State test with numWires=4", "[Measures]", SimTypes)
         if (i == 4 || i == 6 || i == 12 || i == 14) {
             CHECK(std::real(state[i]) == Approx(0.).margin(1e-5));
             CHECK(std::imag(state[i]) == Approx(0.5).margin(1e-5));
-        }
-        else {
+        } else {
             CHECK(std::real(state[i]) == Approx(0.).margin(1e-5));
             CHECK(std::imag(state[i]) == Approx(0.).margin(1e-5));
         }
@@ -1002,8 +958,7 @@ TEMPLATE_LIST_TEST_CASE("State test with numWires=4", "[Measures]", SimTypes)
 }
 
 TEMPLATE_LIST_TEST_CASE("PartialProbs test with incorrect numWires and numAlloc", "[Measures]",
-                        SimTypes)
-{
+                        SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -1033,8 +988,7 @@ TEMPLATE_LIST_TEST_CASE("PartialProbs test with incorrect numWires and numAlloc"
                         Catch::Contains("Invalid given wires to measure"));
 }
 
-TEMPLATE_LIST_TEST_CASE("Probs and PartialProbs tests with numWires=0-4", "[Measures]", SimTypes)
-{
+TEMPLATE_LIST_TEST_CASE("Probs and PartialProbs tests with numWires=0-4", "[Measures]", SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -1077,8 +1031,7 @@ TEMPLATE_LIST_TEST_CASE("Probs and PartialProbs tests with numWires=0-4", "[Meas
     for (size_t i = 0; i < 4; i++) {
         if (i == 0 || i == 2) {
             CHECK(probs2[i] == Approx(0.5).margin(1e-5));
-        }
-        else {
+        } else {
             CHECK(probs2[i] == Approx(0.).margin(1e-5));
         }
     }
@@ -1086,8 +1039,7 @@ TEMPLATE_LIST_TEST_CASE("Probs and PartialProbs tests with numWires=0-4", "[Meas
         if (i == 4 || i == 6 || i == 12 || i == 14) {
             CHECK(probs3[i] == Approx(0.25).margin(1e-5));
             CHECK(probs4[i] == Approx(0.25).margin(1e-5));
-        }
-        else {
+        } else {
             CHECK(probs3[i] == Approx(0.).margin(1e-5));
             CHECK(probs4[i] == Approx(0.).margin(1e-5));
         }
@@ -1095,8 +1047,7 @@ TEMPLATE_LIST_TEST_CASE("Probs and PartialProbs tests with numWires=0-4", "[Meas
 }
 
 TEMPLATE_LIST_TEST_CASE("PartialSample test with incorrect numWires and numAlloc", "[Measures]",
-                        SimTypes)
-{
+                        SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -1128,8 +1079,7 @@ TEMPLATE_LIST_TEST_CASE("PartialSample test with incorrect numWires and numAlloc
 }
 
 TEMPLATE_LIST_TEST_CASE("PartialCounts test with incorrect numWires and numAlloc", "[Measures]",
-                        SimTypes)
-{
+                        SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -1163,8 +1113,7 @@ TEMPLATE_LIST_TEST_CASE("PartialCounts test with incorrect numWires and numAlloc
 }
 
 TEMPLATE_LIST_TEST_CASE("Sample and PartialSample tests with numWires=0-4 shots=100", "[Measures]",
-                        SimTypes)
-{
+                        SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n
@@ -1212,8 +1161,7 @@ TEMPLATE_LIST_TEST_CASE("Sample and PartialSample tests with numWires=0-4 shots=
 }
 
 TEMPLATE_LIST_TEST_CASE("Counts and PartialCounts tests with numWires=0-4 shots=100", "[Measures]",
-                        SimTypes)
-{
+                        SimTypes) {
     std::unique_ptr<TestType> sim = std::make_unique<TestType>();
 
     // state-vector with #qubits = n

--- a/runtime/tests/Test_OpenQasmBuilder.cpp
+++ b/runtime/tests/Test_OpenQasmBuilder.cpp
@@ -12,20 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <memory>
-#include <string>
-#include <typeinfo>
-
 #include "OpenQasmBuilder.hpp"
 
 #include <catch2/catch.hpp>
+
+#include <memory>
+#include <string>
+#include <typeinfo>
 
 #define TYPE_INFO(x) std::string(typeid(x).name())
 
 using namespace Catalyst::Runtime::Device::OpenQasm;
 
-TEST_CASE("Test lookup openqasm gate names from QIR -> OpenQasm map", "[openqasm]")
-{
+TEST_CASE("Test lookup openqasm gate names from QIR -> OpenQasm map", "[openqasm]") {
     // Check lookup supported gates
     CHECK(lookup_qasm_gate_name("PauliX") == "x");
     CHECK(lookup_qasm_gate_name("Hadamard") == "h");
@@ -39,8 +38,7 @@ TEST_CASE("Test lookup openqasm gate names from QIR -> OpenQasm map", "[openqasm
         Catch::Contains("The given QIR gate name is not supported by the OpenQASM builder"));
 }
 
-TEST_CASE("Test QasmVariable(type=Float) from OpenQasmBuilder", "[openqasm]")
-{
+TEST_CASE("Test QasmVariable(type=Float) from OpenQasmBuilder", "[openqasm]") {
     auto var = QasmVariable(VariableType::Float, "alpha");
     CHECK(var.getType() == VariableType::Float);
     CHECK(var.getName() == "alpha");
@@ -56,8 +54,7 @@ TEST_CASE("Test QasmVariable(type=Float) from OpenQasmBuilder", "[openqasm]")
             "[Function:toOpenQasm] Error in Catalyst Runtime: Unsupported OpenQasm variable type"));
 }
 
-TEST_CASE("Test QasmRegister(type=Qubit) from OpenQasmBuilder", "[openqasm]")
-{
+TEST_CASE("Test QasmRegister(type=Qubit) from OpenQasmBuilder", "[openqasm]") {
     auto reg = QasmRegister(RegisterType::Qubit, "qubits", 5);
     CHECK(reg.getName() == "qubits");
     CHECK(reg.getSize() == 5);
@@ -93,8 +90,7 @@ TEST_CASE("Test QasmRegister(type=Qubit) from OpenQasmBuilder", "[openqasm]")
                                         "Unsupported OpenQasm register mode"));
 }
 
-TEST_CASE("Test QasmRegister(type=Bit) from OpenQasmBuilder", "[openqasm]")
-{
+TEST_CASE("Test QasmRegister(type=Bit) from OpenQasmBuilder", "[openqasm]") {
     auto reg = QasmRegister(RegisterType::Bit, "bits", 5);
     CHECK(reg.getName() == "bits");
     CHECK(reg.getSize() == 5);
@@ -135,8 +131,7 @@ TEST_CASE("Test QasmRegister(type=Bit) from OpenQasmBuilder", "[openqasm]")
                                         "Unsupported OpenQasm register mode"));
 }
 
-TEST_CASE("Test QasmGate from OpenQasmBuilder", "[openqasm]")
-{
+TEST_CASE("Test QasmGate from OpenQasmBuilder", "[openqasm]") {
     auto qubits = QasmRegister(RegisterType::Qubit, "q", 5);
 
     // Check a supported gate without params
@@ -207,8 +202,7 @@ TEST_CASE("Test QasmGate from OpenQasmBuilder", "[openqasm]")
                         "currently supported via either their values or names but not both."));
 }
 
-TEST_CASE("Test QasmMeasure from OpenQasmBuilder", "[openqasm]")
-{
+TEST_CASE("Test QasmMeasure from OpenQasmBuilder", "[openqasm]") {
     auto qubits = QasmRegister(RegisterType::Qubit, "q", 5);
 
     auto mz1 = QasmMeasure(0, 0);
@@ -234,10 +228,8 @@ TEST_CASE("Test QasmMeasure from OpenQasmBuilder", "[openqasm]")
     CHECK(mz2.toOpenQasm(bits, qubits) == mz2_res_toqasm);
 }
 
-TEST_CASE("Test MatrixBuilder", "[openqasm]")
-{
-    SECTION("matrix(2 * 2) vector(complex(double))")
-    {
+TEST_CASE("Test MatrixBuilder", "[openqasm]") {
+    SECTION("matrix(2 * 2) vector(complex(double))") {
         std::vector<std::complex<double>> mat{
             {0, 0},
             {-0.1488, 0.360849},
@@ -250,8 +242,7 @@ TEST_CASE("Test MatrixBuilder", "[openqasm]")
         CHECK(result == expected);
     }
 
-    SECTION("matrix(4 * 2) vector(complex(double))")
-    {
+    SECTION("matrix(4 * 2) vector(complex(double))") {
         std::vector<std::complex<double>> mat{
             {-0.67094, -0.63044}, {-0.148854, 0.36084}, {-0.23763, 0.309679}, {-0.88183, -0.26456},
             {-0.67094, -0.63044}, {-0.148854, 0.36084}, {-0.23763, 0.309679}, {-0.88183, -0.26456},
@@ -263,8 +254,7 @@ TEST_CASE("Test MatrixBuilder", "[openqasm]")
         CHECK(result == expected);
     }
 
-    SECTION("matrix(2 * 2) vector(double)")
-    {
+    SECTION("matrix(2 * 2) vector(double)") {
         std::vector<double> mat{
             -0.670,
             0.1488,
@@ -277,8 +267,7 @@ TEST_CASE("Test MatrixBuilder", "[openqasm]")
         CHECK(result == expected);
     }
 
-    SECTION("matrix(4 * 4) vector(double)")
-    {
+    SECTION("matrix(4 * 4) vector(double)") {
         std::vector<double> mat{
             -0.67094, 0.63044,  -0.148854, 0.36084, -0.23763, 0.309679, -0.88183, 0.26456,
             0.67094,  -0.63044, -0.148854, 0.36084, -0.23763, 0.309679, -0.88183, 0.26456,
@@ -291,8 +280,7 @@ TEST_CASE("Test MatrixBuilder", "[openqasm]")
     }
 }
 
-TEST_CASE("Test QasmNamedObs from OpenQasmBuilder", "[openqasm]")
-{
+TEST_CASE("Test QasmNamedObs from OpenQasmBuilder", "[openqasm]") {
     auto qubits = QasmRegister(RegisterType::Qubit, "q", 5);
 
     auto obs_x = QasmNamedObs("PauliX", {0});
@@ -306,8 +294,7 @@ TEST_CASE("Test QasmNamedObs from OpenQasmBuilder", "[openqasm]")
     CHECK(obs_h.toOpenQasm(qubits) == "h(q[3])");
 }
 
-TEST_CASE("Test QasmTensorObs from OpenQasmBuilder", "[openqasm]")
-{
+TEST_CASE("Test QasmTensorObs from OpenQasmBuilder", "[openqasm]") {
     auto qubits = QasmRegister(RegisterType::Qubit, "q", 5);
 
     auto obs_x = std::shared_ptr<QasmNamedObs>{new QasmNamedObs("PauliX", {0})};
@@ -333,8 +320,7 @@ TEST_CASE("Test QasmTensorObs from OpenQasmBuilder", "[openqasm]")
             "[Function:QasmTensorObs] Error in Catalyst Runtime: Invalid list of total wires"));
 }
 
-TEST_CASE("Test QasmHamiltonianObs from OpenQasmBuilder", "[openqasm]")
-{
+TEST_CASE("Test QasmHamiltonianObs from OpenQasmBuilder", "[openqasm]") {
     auto qubits = QasmRegister(RegisterType::Qubit, "q", 5);
 
     auto obs_x = std::shared_ptr<QasmObs>{new QasmNamedObs("PauliX", {0})};
@@ -363,8 +349,7 @@ TEST_CASE("Test QasmHamiltonianObs from OpenQasmBuilder", "[openqasm]")
 }
 
 TEMPLATE_TEST_CASE("Test OpenQasmBuilder with dumping the circuit header", "[openqasm]",
-                   OpenQasmBuilder, BraketBuilder)
-{
+                   OpenQasmBuilder, BraketBuilder) {
     auto builder = TestType();
     builder.Register(RegisterType::Qubit, "qubits", 5);
 
@@ -373,8 +358,7 @@ TEMPLATE_TEST_CASE("Test OpenQasmBuilder with dumping the circuit header", "[ope
         toqasm = "OPENQASM 3.0;\n"
                  "qubit[5] qubits;\n"
                  "reset qubits;\n";
-    }
-    else if (TYPE_INFO(TestType) == TYPE_INFO(BraketBuilder)) {
+    } else if (TYPE_INFO(TestType) == TYPE_INFO(BraketBuilder)) {
         toqasm = "OPENQASM 3.0;\n"
                  "qubit[5] qubits;\n"
                  "bit[5] bits;\n"
@@ -392,8 +376,7 @@ TEMPLATE_TEST_CASE("Test OpenQasmBuilder with dumping the circuit header", "[ope
 }
 
 TEMPLATE_TEST_CASE("Test OpenQasmBuilder with invalid number of measurement results registers",
-                   "[openqasm]", OpenQasmBuilder, BraketBuilder)
-{
+                   "[openqasm]", OpenQasmBuilder, BraketBuilder) {
     auto builder = OpenQasmBuilder();
     CHECK(builder.getNumQubits() == 0);
     CHECK(builder.getNumBits() == 0);
@@ -418,8 +401,7 @@ TEMPLATE_TEST_CASE("Test OpenQasmBuilder with invalid number of measurement resu
 }
 
 TEMPLATE_TEST_CASE("Test OpenQasmBuilder with dumping the circuit header, gates, and measure",
-                   "[openqasm]", OpenQasmBuilder, BraketBuilder)
-{
+                   "[openqasm]", OpenQasmBuilder, BraketBuilder) {
     auto builder = TestType();
 
     builder.Register(RegisterType::Qubit, "q", 2);
@@ -449,8 +431,7 @@ TEMPLATE_TEST_CASE("Test OpenQasmBuilder with dumping the circuit header, gates,
                  "b[0] = measure q[0];\n"
                  "b[1] = measure q[1];\n"
                  "reset q;\n";
-    }
-    else if (TYPE_INFO(TestType) == TYPE_INFO(BraketBuilder)) {
+    } else if (TYPE_INFO(TestType) == TYPE_INFO(BraketBuilder)) {
         toqasm = "OPENQASM 3.0;\n"
                  "input float alpha;\n"
                  "qubit[2] q;\n"
@@ -467,8 +448,7 @@ TEMPLATE_TEST_CASE("Test OpenQasmBuilder with dumping the circuit header, gates,
 }
 
 TEMPLATE_TEST_CASE("Test OpenQasmBuilder with dumping a circuit without measurement results",
-                   "[openqasm]", OpenQasmBuilder, BraketBuilder)
-{
+                   "[openqasm]", OpenQasmBuilder, BraketBuilder) {
     auto builder = TestType();
 
     builder.Register(RegisterType::Qubit, "q", 2);
@@ -488,8 +468,7 @@ TEMPLATE_TEST_CASE("Test OpenQasmBuilder with dumping a circuit without measurem
                  "measure q[0];\n"
                  "measure q[1];\n"
                  "reset q;\n";
-    }
-    else if (TYPE_INFO(TestType) == TYPE_INFO(BraketBuilder)) {
+    } else if (TYPE_INFO(TestType) == TYPE_INFO(BraketBuilder)) {
         toqasm = "OPENQASM 3.0;\n"
                  "qubit[2] q;\n"
                  "bit[2] bits;\n"
@@ -502,8 +481,7 @@ TEMPLATE_TEST_CASE("Test OpenQasmBuilder with dumping a circuit without measurem
 }
 
 TEMPLATE_TEST_CASE("Test OpenQasmBuilder with custom instructions", "[openqasm]", OpenQasmBuilder,
-                   BraketBuilder)
-{
+                   BraketBuilder) {
     auto builder = TestType();
 
     builder.Register(RegisterType::Qubit, "q", 2);
@@ -518,8 +496,7 @@ TEMPLATE_TEST_CASE("Test OpenQasmBuilder with custom instructions", "[openqasm]"
         REQUIRE_THROWS_WITH(
             builder.toOpenQasmWithCustomInstructions(""),
             Catch::Contains("Error in Catalyst Runtime: Unsupported functionality"));
-    }
-    else if (TYPE_INFO(TestType) == TYPE_INFO(BraketBuilder)) {
+    } else if (TYPE_INFO(TestType) == TYPE_INFO(BraketBuilder)) {
         std::string toqasm = "OPENQASM 3.0;\n"
                              "qubit[2] q;\n"
                              "x q[0];\n"

--- a/runtime/tests/Test_OpenQasmDevice.cpp
+++ b/runtime/tests/Test_OpenQasmDevice.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "MemRefUtils.hpp"
-
 #include "OpenQasmBuilder.hpp"
 #include "OpenQasmDevice.hpp"
 #include "OpenQasmRunner.hpp"
@@ -25,8 +24,7 @@ using BType = OpenQasm::BuilderType;
 
 OpenQasm::PythonInterpreterGuard guard{};
 
-TEST_CASE("Test OpenQasmRunner base class", "[openqasm]")
-{
+TEST_CASE("Test OpenQasmRunner base class", "[openqasm]") {
     // check the coverage support
     OpenQasm::OpenQasmRunner runner{};
     REQUIRE_THROWS_WITH(runner.runCircuit("", "", 0),
@@ -58,8 +56,7 @@ TEST_CASE("Test OpenQasmRunner base class", "[openqasm]")
                                         "Not implemented method"));
 }
 
-TEST_CASE("Test BraketRunner::runCircuit()", "[openqasm]")
-{
+TEST_CASE("Test BraketRunner::runCircuit()", "[openqasm]") {
     OpenQasm::BraketBuilder builder{};
 
     builder.Register(OpenQasm::RegisterType::Qubit, "q", 2);
@@ -67,17 +64,15 @@ TEST_CASE("Test BraketRunner::runCircuit()", "[openqasm]")
     builder.Gate("Hadamard", {}, {}, {0}, false);
     builder.Gate("CNOT", {}, {}, {0, 1}, false);
 
-    auto &&circuit = builder.toOpenQasm();
+    auto&& circuit = builder.toOpenQasm();
 
     OpenQasm::BraketRunner runner{};
-    auto &&results = runner.runCircuit(circuit, "default", 100);
+    auto&& results = runner.runCircuit(circuit, "default", 100);
     CHECK(results.find("GateModelQuantumTaskResult") != std::string::npos);
 }
 
-TEST_CASE("Test the OpenQasmDevice constructor", "[openqasm]")
-{
-    SECTION("Common")
-    {
+TEST_CASE("Test the OpenQasmDevice constructor", "[openqasm]") {
+    SECTION("Common") {
         auto device = OpenQasmDevice(false, "{shots : 100}");
         CHECK(device.GetNumQubits() == 0);
 
@@ -86,8 +81,7 @@ TEST_CASE("Test the OpenQasmDevice constructor", "[openqasm]")
                                             "Invalid number of quantum register"));
     }
 
-    SECTION("Braket SV1")
-    {
+    SECTION("Braket SV1") {
         auto device = OpenQasmDevice(
             false, "{shots: 100, device_type : braket.local.qubit, backend : default}");
         CHECK(device.GetNumQubits() == 0);
@@ -98,8 +92,7 @@ TEST_CASE("Test the OpenQasmDevice constructor", "[openqasm]")
     }
 }
 
-TEST_CASE("Test qubits allocation OpenQasmDevice", "[openqasm]")
-{
+TEST_CASE("Test qubits allocation OpenQasmDevice", "[openqasm]") {
     std::unique_ptr<OpenQasmDevice> device =
         std::make_unique<OpenQasmDevice>(false, "{shots : 100}");
 
@@ -114,8 +107,7 @@ TEST_CASE("Test qubits allocation OpenQasmDevice", "[openqasm]")
     CHECK(wires[n - 1] == n);
 }
 
-TEST_CASE("Test the bell pair circuit with BuilderType::Common", "[openqasm]")
-{
+TEST_CASE("Test the bell pair circuit with BuilderType::Common", "[openqasm]") {
     std::unique_ptr<OpenQasmDevice> device =
         std::make_unique<OpenQasmDevice>(false, "{shots : 100}");
 
@@ -139,8 +131,7 @@ TEST_CASE("Test the bell pair circuit with BuilderType::Common", "[openqasm]")
 }
 
 TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::Braket",
-          "[openqasm]")
-{
+          "[openqasm]") {
     constexpr size_t shots{1000};
     constexpr bool status{false};
     std::unique_ptr<OpenQasmDevice> device = std::make_unique<OpenQasmDevice>(
@@ -162,8 +153,7 @@ TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::B
 
     CHECK(device->Circuit() == toqasm);
 
-    SECTION("Probs")
-    {
+    SECTION("Probs") {
         std::vector<double> probs(size);
         DataView<double, 1> view(probs);
         device->Probs(view);
@@ -172,8 +162,7 @@ TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::B
         CHECK(probs[0] + probs[3] == Approx(1.f).margin(1e-5));
     }
 
-    SECTION("PartialProbs")
-    {
+    SECTION("PartialProbs") {
         std::vector<double> probs(size);
         DataView<double, 1> view(probs);
         device->PartialProbs(view, std::vector<QubitIdType>{0, 1});
@@ -181,8 +170,7 @@ TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::B
         CHECK(probs[0] + probs[3] == Approx(1.f).margin(1e-5));
     }
 
-    SECTION("Samples")
-    {
+    SECTION("Samples") {
         std::vector<double> samples(shots * n);
         MemRefT<double, 2> buffer{samples.data(), samples.data(), 0, {shots, n}, {1, 1}};
         DataView<double, 2> view(buffer.data_aligned, buffer.offset, buffer.sizes, buffer.strides);
@@ -193,8 +181,7 @@ TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::B
         }
     }
 
-    SECTION("PartialSamples")
-    {
+    SECTION("PartialSamples") {
         std::vector<double> samples(shots);
         MemRefT<double, 2> buffer{samples.data(), samples.data(), 0, {shots, 1}, {1, 1}};
         DataView<double, 2> view(buffer.data_aligned, buffer.offset, buffer.sizes, buffer.strides);
@@ -205,8 +192,7 @@ TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::B
         }
     }
 
-    SECTION("Counts")
-    {
+    SECTION("Counts") {
         std::vector<double> eigvals(size);
         std::vector<int64_t> counts(size);
         DataView<double, 1> eview(eigvals);
@@ -221,8 +207,7 @@ TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::B
         CHECK(sum == shots);
     }
 
-    SECTION("PartialCounts")
-    {
+    SECTION("PartialCounts") {
         size_t size = (1UL << 1);
         std::vector<double> eigvals(size);
         std::vector<int64_t> counts(size);
@@ -238,16 +223,14 @@ TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::B
         CHECK(sum == shots);
     }
 
-    SECTION("Expval(h(1))")
-    {
+    SECTION("Expval(h(1))") {
         device->SetDeviceShots(0); // to get deterministic results
         auto obs = device->Observable(ObsId::Hadamard, {}, std::vector<QubitIdType>{1});
         auto expval = device->Expval(obs);
         CHECK(expval == Approx(0.0).margin(1e-5));
     }
 
-    SECTION("Expval(x(0) @ h(1))")
-    {
+    SECTION("Expval(x(0) @ h(1))") {
         device->SetDeviceShots(0); // to get deterministic results
         auto obs_x = device->Observable(ObsId::PauliX, {}, std::vector<QubitIdType>{0});
         auto obs_h = device->Observable(ObsId::Hadamard, {}, std::vector<QubitIdType>{1});
@@ -256,16 +239,14 @@ TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::B
         CHECK(expval == Approx(0.7071067812).margin(1e-5));
     }
 
-    SECTION("Var(h(1))")
-    {
+    SECTION("Var(h(1))") {
         device->SetDeviceShots(0); // to get deterministic results
         auto obs = device->Observable(ObsId::Hadamard, {}, std::vector<QubitIdType>{1});
         auto expval = device->Var(obs);
         CHECK(expval == Approx(1.0).margin(1e-5));
     }
 
-    SECTION("Var(x(0) @ h(1))")
-    {
+    SECTION("Var(x(0) @ h(1))") {
         device->SetDeviceShots(0); // to get deterministic results
         auto obs_x = device->Observable(ObsId::PauliX, {}, std::vector<QubitIdType>{0});
         auto obs_h = device->Observable(ObsId::Hadamard, {}, std::vector<QubitIdType>{1});
@@ -275,8 +256,7 @@ TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::B
     }
 }
 
-TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket", "[openqasm]")
-{
+TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket", "[openqasm]") {
     std::unique_ptr<OpenQasmDevice> device = std::make_unique<OpenQasmDevice>();
 
     constexpr size_t shots{1000};
@@ -304,8 +284,7 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
 
     CHECK(device->Circuit() == toqasm);
 
-    SECTION("Probs")
-    {
+    SECTION("Probs") {
         std::vector<double> probs(size);
         DataView<double, 1> view(probs);
         device->Probs(view);
@@ -313,8 +292,7 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
         CHECK(probs[27] + probs[26] == Approx(1.f).margin(1e-5));
     }
 
-    SECTION("PartialProbs")
-    {
+    SECTION("PartialProbs") {
         std::vector<double> probs(size);
         DataView<double, 1> view(probs);
         device->PartialProbs(view, std::vector<QubitIdType>{0, 1, 2, 3, 4});
@@ -322,8 +300,7 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
         CHECK(probs[27] + probs[26] == Approx(1.f).margin(1e-5));
     }
 
-    SECTION("Samples")
-    {
+    SECTION("Samples") {
         std::vector<double> samples(shots * n);
         MemRefT<double, 2> buffer{samples.data(), samples.data(), 0, {shots, n}, {1, 1}};
         DataView<double, 2> view(buffer.data_aligned, buffer.offset, buffer.sizes, buffer.strides);
@@ -334,8 +311,7 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
         }
     }
 
-    SECTION("PartialSamples")
-    {
+    SECTION("PartialSamples") {
         std::vector<double> samples(shots);
         MemRefT<double, 2> buffer{samples.data(), samples.data(), 0, {shots, 1}, {1, 1}};
         DataView<double, 2> view(buffer.data_aligned, buffer.offset, buffer.sizes, buffer.strides);
@@ -346,8 +322,7 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
         }
     }
 
-    SECTION("Counts")
-    {
+    SECTION("Counts") {
         std::vector<double> eigvals(size);
         std::vector<int64_t> counts(size);
         DataView<double, 1> eview(eigvals);
@@ -362,8 +337,7 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
         CHECK(sum == shots);
     }
 
-    SECTION("PartialCounts")
-    {
+    SECTION("PartialCounts") {
         size_t size = (1UL << 1);
         std::vector<double> eigvals(size);
         std::vector<int64_t> counts(size);
@@ -379,16 +353,14 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
         CHECK(sum == shots);
     }
 
-    SECTION("Expval(h(1))")
-    {
+    SECTION("Expval(h(1))") {
         device->SetDeviceShots(0); // to get deterministic results
         auto obs = device->Observable(ObsId::Hadamard, {}, std::vector<QubitIdType>{1});
         auto expval = device->Expval(obs);
         CHECK(expval == Approx(-0.7071067812).margin(1e-5));
     }
 
-    SECTION("Expval(hermitian(1))")
-    {
+    SECTION("Expval(hermitian(1))") {
         device->SetDeviceShots(0); // to get deterministic results
         std::vector<std::complex<double>> matrix{
             {0, 0},
@@ -401,8 +373,7 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
         CHECK(expval == Approx(0).margin(1e-5));
     }
 
-    SECTION("Expval(x(0) @ h(1))")
-    {
+    SECTION("Expval(x(0) @ h(1))") {
         device->SetDeviceShots(0); // to get deterministic results
         auto obs_z = device->Observable(ObsId::PauliZ, {}, std::vector<QubitIdType>{0});
         auto obs_h = device->Observable(ObsId::Hadamard, {}, std::vector<QubitIdType>{1});
@@ -415,16 +386,14 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
                             Catch::Contains("Unsupported observable: QasmHamiltonianObs"));
     }
 
-    SECTION("Var(h(1))")
-    {
+    SECTION("Var(h(1))") {
         device->SetDeviceShots(0); // to get deterministic results
         auto obs = device->Observable(ObsId::Hadamard, {}, std::vector<QubitIdType>{1});
         auto var = device->Var(obs);
         CHECK(var == Approx(0.5).margin(1e-5));
     }
 
-    SECTION("Var(hermitian(1))")
-    {
+    SECTION("Var(hermitian(1))") {
         device->SetDeviceShots(0); // to get deterministic results
         std::vector<std::complex<double>> matrix{
             {0, 0},
@@ -437,8 +406,7 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
         CHECK(var == Approx(1).margin(1e-5));
     }
 
-    SECTION("Var(x(0) @ h(1))")
-    {
+    SECTION("Var(x(0) @ h(1))") {
         device->SetDeviceShots(0); // to get deterministic results
         auto obs_z = device->Observable(ObsId::PauliZ, {}, std::vector<QubitIdType>{0});
         auto obs_h = device->Observable(ObsId::Hadamard, {}, std::vector<QubitIdType>{1});
@@ -452,8 +420,7 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
     }
 }
 
-TEST_CASE("Test MatrixOperation with BuilderType::Braket", "[openqasm]")
-{
+TEST_CASE("Test MatrixOperation with BuilderType::Braket", "[openqasm]") {
     std::unique_ptr<OpenQasmDevice> device = std::make_unique<OpenQasmDevice>();
 
     constexpr size_t n{5};
@@ -480,16 +447,14 @@ TEST_CASE("Test MatrixOperation with BuilderType::Braket", "[openqasm]")
 
     CHECK(device->Circuit() == toqasm);
 
-    SECTION("Probs")
-    {
+    SECTION("Probs") {
         std::vector<double> probs(size);
         DataView<double, 1> view(probs);
         device->Probs(view);
         CHECK(probs[1] == Approx(1.f).margin(1e-5));
     }
 
-    SECTION("Expval(h(1))")
-    {
+    SECTION("Expval(h(1))") {
         device->SetDeviceShots(0); // to get deterministic results
         auto obs = device->Observable(ObsId::Hadamard, {}, std::vector<QubitIdType>{1});
         auto expval = device->Expval(obs);
@@ -497,8 +462,7 @@ TEST_CASE("Test MatrixOperation with BuilderType::Braket", "[openqasm]")
     }
 }
 
-TEST_CASE("Test MatrixOperation with OpenQasmDevice and BuilderType::Common", "[openqasm]")
-{
+TEST_CASE("Test MatrixOperation with OpenQasmDevice and BuilderType::Common", "[openqasm]") {
     auto device = OpenQasmDevice(false, "{shots : 100}");
     auto wires = device.AllocateQubits(2);
     std::vector<std::complex<double>> matrix{

--- a/runtime/tests/Test_QubitManager.cpp
+++ b/runtime/tests/Test_QubitManager.cpp
@@ -12,21 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <numeric>
-
-#include "RuntimeCAPI.h"
-
 #include "QuantumDevice.hpp"
 #include "QubitManager.hpp"
+#include "RuntimeCAPI.h"
 #include "Utils.hpp"
 
 #include <catch2/catch.hpp>
 
+#include <numeric>
+
 using namespace Catalyst::Runtime;
 using namespace Catalyst::Runtime::Simulator;
 
-TEST_CASE("Simple allocation and release of one qubit", "[QubitManager]")
-{
+TEST_CASE("Simple allocation and release of one qubit", "[QubitManager]") {
     QubitManager qm = QubitManager();
     QubitIdType idx = qm.Allocate(0);
     CHECK(qm.isValidQubitId(idx));
@@ -35,8 +33,7 @@ TEST_CASE("Simple allocation and release of one qubit", "[QubitManager]")
     CHECK(!qm.isValidQubitId(idx));
 }
 
-TEST_CASE("Allocation and reallocation of one qubit multiple times", "[QubitManager]")
-{
+TEST_CASE("Allocation and reallocation of one qubit multiple times", "[QubitManager]") {
     QubitManager qm = QubitManager();
 
     QubitIdType q = qm.Allocate(0);
@@ -48,8 +45,7 @@ TEST_CASE("Allocation and reallocation of one qubit multiple times", "[QubitMana
     qm.Release(q0);
 }
 
-TEST_CASE("Allocation and reallocation of two qubit", "[QubitManager]")
-{
+TEST_CASE("Allocation and reallocation of two qubit", "[QubitManager]") {
     QubitManager qm = QubitManager();
     QubitIdType idx0 = qm.Allocate(0);
     QubitIdType idx1 = qm.Allocate(1);
@@ -63,8 +59,7 @@ TEST_CASE("Allocation and reallocation of two qubit", "[QubitManager]")
     REQUIRE_THROWS_WITH(qm.getDeviceId(idx0), Catch::Contains("Invalid device qubit"));
 }
 
-TEST_CASE("multiple release of qubits", "[QubitManager]")
-{
+TEST_CASE("multiple release of qubits", "[QubitManager]") {
     QubitManager qm = QubitManager();
 
     QubitIdType idx0 = qm.Allocate(0);
@@ -97,8 +92,7 @@ TEST_CASE("multiple release of qubits", "[QubitManager]")
     CHECK(qm.getDeviceId(idx6) == 3);
 }
 
-TEST_CASE("Test isFreeQubitId for a vector of wires", "[QubitManager]")
-{
+TEST_CASE("Test isFreeQubitId for a vector of wires", "[QubitManager]") {
     QubitManager qm = QubitManager();
 
     QubitIdType idx0 = qm.Allocate(0);
@@ -125,8 +119,7 @@ TEST_CASE("Test isFreeQubitId for a vector of wires", "[QubitManager]")
     CHECK(!qm.isValidQubitId({idx0, idx5, idx6, idx2}));
 }
 
-TEST_CASE("Test getSimulatorId for a vector of wires", "[QubitManager]")
-{
+TEST_CASE("Test getSimulatorId for a vector of wires", "[QubitManager]") {
     QubitManager qm = QubitManager();
 
     QubitIdType idx0 = qm.Allocate(0);

--- a/runtime/tests/Test_SVDynamicCPU_Allocation.cpp
+++ b/runtime/tests/Test_SVDynamicCPU_Allocation.cpp
@@ -12,6 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "LinearAlgebra.hpp"
+#include "StateVectorLQubitDynamic.hpp"
+#include "TestHelpers.hpp"
+#include "Util.hpp"
+#include "cpu_kernels/GateImplementationsPI.hpp"
+
+#include <StateVectorLQubit.hpp>
+
 #include <algorithm>
 #include <complex>
 #include <iostream>
@@ -21,23 +29,13 @@
 #include <utility>
 #include <vector>
 
-#include "LinearAlgebra.hpp"
-#include "StateVectorLQubitDynamic.hpp"
-#include "Util.hpp"
-#include "cpu_kernels/GateImplementationsPI.hpp"
-#include <StateVectorLQubit.hpp>
-
-#include "TestHelpers.hpp"
-
 using namespace Pennylane::LightningQubit;
 
 TEMPLATE_TEST_CASE("StateVectorLQubitDynamic::getSubsystemPurity /allocation",
-                   "[StateVectorLQubitDynamic]", float, double)
-{
+                   "[StateVectorLQubitDynamic]", float, double) {
     using PrecisionT = TestType;
 
-    SECTION("Test getSubsystemPurity for a state-vector with RX-RY")
-    {
+    SECTION("Test getSubsystemPurity for a state-vector with RX-RY") {
         constexpr size_t num_qubits = 3;
         StateVectorLQubitDynamic<PrecisionT> sv1(num_qubits);
 
@@ -48,8 +46,7 @@ TEMPLATE_TEST_CASE("StateVectorLQubitDynamic::getSubsystemPurity /allocation",
         CHECK(sv1.getSubsystemPurity(2) == approx(std::complex<PrecisionT>{1, 0}));
     }
 
-    SECTION("Test checkSubsystemPurity for a state-vector with RX-RY")
-    {
+    SECTION("Test checkSubsystemPurity for a state-vector with RX-RY") {
         constexpr size_t num_qubits = 3;
         StateVectorLQubitDynamic<PrecisionT> sv1(num_qubits);
 
@@ -58,8 +55,7 @@ TEMPLATE_TEST_CASE("StateVectorLQubitDynamic::getSubsystemPurity /allocation",
         CHECK(sv1.checkSubsystemPurity(2));
     }
 
-    SECTION("Test getSubsystemPurity for a state-vector with CNOT-RY")
-    {
+    SECTION("Test getSubsystemPurity for a state-vector with CNOT-RY") {
         constexpr size_t num_qubits = 3;
         StateVectorLQubitDynamic<PrecisionT> sv1(num_qubits);
 
@@ -70,8 +66,7 @@ TEMPLATE_TEST_CASE("StateVectorLQubitDynamic::getSubsystemPurity /allocation",
         CHECK(sv1.checkSubsystemPurity(2));
     }
 
-    SECTION("Test getSubsystemPurity for a custom state-vector")
-    {
+    SECTION("Test getSubsystemPurity for a custom state-vector") {
         constexpr size_t num_qubits = 2;
         StateVectorLQubitDynamic<PrecisionT> sv1(num_qubits);
 
@@ -86,12 +81,10 @@ TEMPLATE_TEST_CASE("StateVectorLQubitDynamic::getSubsystemPurity /allocation",
 }
 
 TEMPLATE_TEST_CASE("StateVectorLQubitDynamic::allocateWire /allocation",
-                   "[StateVectorLQubitDynamic]", float, double)
-{
+                   "[StateVectorLQubitDynamic]", float, double) {
     using PrecisionT = TestType;
 
-    SECTION("applyOperations with released wires")
-    {
+    SECTION("applyOperations with released wires") {
         constexpr size_t num_qubits = 3;
         StateVectorLQubitDynamic<PrecisionT> sv1(num_qubits);
         size_t new_idx = sv1.allocateWire();
@@ -103,8 +96,7 @@ TEMPLATE_TEST_CASE("StateVectorLQubitDynamic::allocateWire /allocation",
             sv1.applyOperations({"PauliX", "PauliY"}, {{new_idx + 1}, {1}}, {false, false}));
     }
 
-    SECTION("Test counting wires for a simple state-vector")
-    {
+    SECTION("Test counting wires for a simple state-vector") {
         constexpr size_t num_qubits = 10;
         StateVectorLQubitDynamic<PrecisionT> sv1(num_qubits);
 
@@ -120,8 +112,7 @@ TEMPLATE_TEST_CASE("StateVectorLQubitDynamic::allocateWire /allocation",
         CHECK(sv1.getNumQubits() == 10);
     }
 
-    SECTION("Test the validity of the shranked state vector in the second half")
-    {
+    SECTION("Test the validity of the shranked state vector in the second half") {
         constexpr size_t num_qubits = 4;
         StateVectorLQubitDynamic<PrecisionT> sv1(num_qubits);
         std::vector<std::complex<PrecisionT>> data(1 << num_qubits, {0.0, 0.0});
@@ -133,8 +124,7 @@ TEMPLATE_TEST_CASE("StateVectorLQubitDynamic::allocateWire /allocation",
         CHECK(sv1.getNumQubits() == 3);
     }
 
-    SECTION("Test allocation/deallocation of a customed state-vector")
-    {
+    SECTION("Test allocation/deallocation of a customed state-vector") {
         StateVectorLQubitDynamic<PrecisionT> sv1(0);
         size_t idx_0 = sv1.allocateWire(); // 1, 0
 
@@ -177,8 +167,7 @@ TEMPLATE_TEST_CASE("StateVectorLQubitDynamic::allocateWire /allocation",
     }
 
     SECTION("Test allocation/deallocation of wires for a state-vector with "
-            "num_qubits=0")
-    {
+            "num_qubits=0") {
         StateVectorLQubitDynamic<PrecisionT> sv1(0);
 
         std::vector<std::complex<PrecisionT>> expected_data{{1, 0}};
@@ -202,8 +191,7 @@ TEMPLATE_TEST_CASE("StateVectorLQubitDynamic::allocateWire /allocation",
     }
 
     SECTION("Test allocation/deallocation of wires for a state-vector with "
-            "num_qubits=1")
-    {
+            "num_qubits=1") {
         constexpr size_t num_qubits = 1;
         StateVectorLQubitDynamic<PrecisionT> sv1(num_qubits);
         sv1.applyOperation("Hadamard", {0}, false, {});
@@ -218,8 +206,7 @@ TEMPLATE_TEST_CASE("StateVectorLQubitDynamic::allocateWire /allocation",
     }
 
     SECTION("Test allocation/deallocation of wires for a state-vector with "
-            "num_qubits=2")
-    {
+            "num_qubits=2") {
         constexpr size_t num_qubits = 2;
         StateVectorLQubitDynamic<PrecisionT> sv1(num_qubits);
         sv1.applyOperations({"RX", "CNOT"}, {{0}, {0, 1}}, {false, false}, {{0.4}, {}});
@@ -235,8 +222,7 @@ TEMPLATE_TEST_CASE("StateVectorLQubitDynamic::allocateWire /allocation",
     }
 
     SECTION("Test allocation/deallocation of wires for a state-vector with "
-            "num_qubits=3")
-    {
+            "num_qubits=3") {
         constexpr size_t num_qubits = 3;
         StateVectorLQubitDynamic<PrecisionT> sv1(num_qubits);
 
@@ -250,8 +236,7 @@ TEMPLATE_TEST_CASE("StateVectorLQubitDynamic::allocateWire /allocation",
     }
 
     SECTION("Test allocation/deallocation of wires for a state-vector with "
-            "num_qubits=4")
-    {
+            "num_qubits=4") {
         constexpr size_t num_qubits = 4;
         StateVectorLQubitDynamic<PrecisionT> sv1(num_qubits);
 

--- a/runtime/tests/coverage_helper.cpp
+++ b/runtime/tests/coverage_helper.cpp
@@ -16,9 +16,8 @@
 
 // This is a hack around analyzing CAPI and
 // simulators C++ implementation code by lcov
-#include "RuntimeCAPI.cpp"
-
 #include "LightningSimulator.cpp"
+#include "RuntimeCAPI.cpp"
 
 #ifdef __device_lightning_kokkos
 #include "LightningKokkosSimulator.cpp"


### PR DESCRIPTION
This PR includes following updates in the code-base, 
- Update the C++ clang-format config file to ensure consistency with PL code style introduced [here](https://github.com/PennyLaneAI/dev_guidelines).
- Add a missing std library to the `DataView` class.
- Add missing headers to a few dialects files.
- Fix pylint warnings and useless-suppression 