### PR TITLE
[Build system] Remove unneeded dependencies

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -326,7 +326,7 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        python${{ matrix.python_version }} -m pip install wheel pytest pytest-xdist
+        python${{ matrix.python_version }} -m pip install pytest pytest-xdist
         python${{ matrix.python_version }} -m pip install tensorflow-cpu  # for autograph tests
 
     - name: Install Catalyst

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -123,7 +123,8 @@ jobs:
 
         # TODO: when updating LLVM, test to see if mlir/unittests/Bytecode/BytecodeTest.cpp:55 is passing
         # and remove filter
-        LIT_FILTER_OUT="Bytecode" cmake --build llvm-build --target lld check-mlir opt
+        # This tests fails on CI/CD not locally.
+        LIT_FILTER_OUT="Bytecode" cmake --build llvm-build --target lld check-mlir 
 
     - name: Build MHLO Dialect
       if: steps.cache-mhlo-build.outputs.cache-hit != 'true'
@@ -259,7 +260,8 @@ jobs:
 
         # TODO: when updating LLVM, test to see if mlir/unittests/Bytecode/BytecodeTest.cpp:55 is passing
         # and remove filter
-        LIT_FILTER_OUT="Bytecode" cmake --build llvm-build --target check-mlir opt
+        # This tests fails on CI/CD not locally.
+        LIT_FILTER_OUT="Bytecode" cmake --build llvm-build --target check-mlir
 
     # Build Quantum and Gradient Dialects
     - name: Build MLIR Dialects

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -89,6 +89,10 @@
   for AWS Braket remove devices.
   [(#278)](https://github.com/PennyLaneAI/catalyst/pull/278)
 
+* Avoid building `opt` from the build process as it is unnecessary.
+  Avoid downloading the `wheel` Python package as it is unnecessary.
+  [(#298)](https://github.com/PennyLaneAI/catalyst/pull/298)
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>

--- a/mlir/Makefile
+++ b/mlir/Makefile
@@ -28,7 +28,7 @@ help:
 	@echo "  format [version=?] to apply C++ formatter; use with 'version={version}' to run clang-format-{version} instead of clang-format"
 
 .PHONY: all
-all: llvm mhlo dialects enzyme
+all: llvm mhlo enzyme dialects
 
 .PHONY: llvm
 llvm:


### PR DESCRIPTION
**Context:** LLVM's `opt` is no longer a dependency. Python's `wheel` package is also not a dependency.

**Description of the Change:** Remove them from the build wheel action.

**Benefits:** Less time spent on the action.

**Note**: Test the wheel before merging. Wheels passed: https://github.com/PennyLaneAI/catalyst/actions/runs/6434485404

[sc-47316]
