### PR TITLE
[Frontend] Fix pylint warnings (v3.0.0)

### DIFF
--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -40,7 +40,7 @@ from catalyst.ag_utils import run_autograph
 from catalyst.compiler import CompileOptions, Compiler
 from catalyst.jax_tracer import trace_to_mlir
 from catalyst.pennylane_extensions import QFunc
-from catalyst.utils import wrapper  # pylint: disable=no-name-in-module
+from catalyst.utils import wrapper
 from catalyst.utils.c_template import get_template, mlir_type_to_numpy_type
 from catalyst.utils.contexts import EvaluationContext
 from catalyst.utils.gen_mlir import inject_functions
@@ -776,6 +776,7 @@ class JAX_QJIT:
         return self.jaxed_function(*args, **kwargs)
 
 
+# pylint: disable=too-many-arguments
 def qjit(
     fn=None,
     *,

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -40,7 +40,7 @@ from catalyst.ag_utils import run_autograph
 from catalyst.compiler import CompileOptions, Compiler
 from catalyst.jax_tracer import trace_to_mlir
 from catalyst.pennylane_extensions import QFunc
-from catalyst.utils import wrapper
+from catalyst.utils import wrapper  # pylint: disable=no-name-in-module
 from catalyst.utils.c_template import get_template, mlir_type_to_numpy_type
 from catalyst.utils.contexts import EvaluationContext
 from catalyst.utils.gen_mlir import inject_functions

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -72,7 +72,7 @@ from catalyst.utils.extra_bindings import TensorExtractOp
 #
 # qbit
 #
-class AbstractQbit(AbstractValue):  # pylint: disable=abstract-method
+class AbstractQbit(AbstractValue):
     """Abstract Qbit"""
 
     hash_value = hash("AbstractQubit")
@@ -84,7 +84,7 @@ class AbstractQbit(AbstractValue):  # pylint: disable=abstract-method
         return self.hash_value
 
 
-class ConcreteQbit(AbstractQbit):  # pylint: disable=abstract-method
+class ConcreteQbit(AbstractQbit):
     """Concrete Qbit."""
 
 
@@ -96,7 +96,7 @@ def _qbit_lowering(aval):
 #
 # qreg
 #
-class AbstractQreg(AbstractValue):  # pylint: disable=abstract-method
+class AbstractQreg(AbstractValue):
     """Abstract quantum register."""
 
     hash_value = hash("AbstractQreg")
@@ -108,7 +108,7 @@ class AbstractQreg(AbstractValue):  # pylint: disable=abstract-method
         return self.hash_value
 
 
-class ConcreteQreg(AbstractQreg):  # pylint: disable=abstract-method
+class ConcreteQreg(AbstractQreg):
     """Concrete quantum register."""
 
 
@@ -120,7 +120,7 @@ def _qreg_lowering(aval):
 #
 # observable
 #
-class AbstractObs(AbstractValue):  # pylint: disable=abstract-method
+class AbstractObs(AbstractValue):
     """Abstract observable."""
 
     def __init__(self, num_qubits=None, primitive=None):
@@ -137,7 +137,7 @@ class AbstractObs(AbstractValue):  # pylint: disable=abstract-method
         return hash(self.primitive) + self.num_qubits
 
 
-class ConcreteObs(AbstractObs):  # pylint: disable=abstract-method
+class ConcreteObs(AbstractObs):
     """Concrete observable."""
 
 

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1262,6 +1262,7 @@ def _qfor_loop_abstract_eval(*args, body_jaxpr, **kwargs):
     return body_jaxpr.out_avals
 
 
+# pylint: disable=too-many-arguments
 @qfor_p.def_impl
 def _qfor_def_impl(
     ctx, lower_bound, upper_bound, step, *iter_args_plus_consts, body_jaxpr, body_nconsts
@@ -1269,7 +1270,7 @@ def _qfor_def_impl(
     raise NotImplementedError()
 
 
-# pylint: disable=too-many-statements
+# pylint: disable=too-many-statements, too-many-arguments
 def _qfor_lowering(
     jax_ctx: mlir.LoweringRuleContext,
     lower_bound: ir.Value,

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -673,6 +673,7 @@ def jacobian(f: DifferentiableLike, *, method=None, h=None, argnum=None):
     )
 
 
+# pylint: disable=too-many-arguments
 def jvp(f: DifferentiableLike, params, tangents, *, method=None, h=None, argnum=None):
     """A :func:`~.qjit` compatible Jacobian-vector product for PennyLane/Catalyst.
 
@@ -757,6 +758,7 @@ def jvp(f: DifferentiableLike, params, tangents, *, method=None, h=None, argnum=
     return jvp_p.bind(*params, *tangents, jaxpr=jaxpr, fn=fn, grad_params=grad_params)
 
 
+# pylint: disable=too-many-arguments
 def vjp(f: DifferentiableLike, params, cotangents, *, method=None, h=None, argnum=None):
     """A :func:`~.qjit` compatible Vector-Jacobian product for PennyLane/Catalyst.
 

--- a/frontend/catalyst/utils/extra_bindings.py
+++ b/frontend/catalyst/utils/extra_bindings.py
@@ -28,6 +28,7 @@ class TensorExtractOp(ir.OpView):
 
     _ODS_REGIONS = (0, True)
 
+    # pylint: disable=too-many-arguments
     def __init__(self, result, tensor, indices, *, loc=None, ip=None):
         operands = [get_op_result_or_value(tensor)]
         operands.extend(get_op_results_or_values(indices))

--- a/frontend/catalyst/utils/jax_extras.py
+++ b/frontend/catalyst/utils/jax_extras.py
@@ -286,11 +286,7 @@ def jaxpr_to_mlir(func_name, jaxpr, shape):
     """
 
     nrep = jaxpr_replicas(jaxpr)
-    effects = [
-        eff
-        for eff in jaxpr.effects
-        if eff in jax_ordered_effects  # pylint: disable=unsupported-membership-test
-    ]
+    effects = [eff for eff in jaxpr.effects if eff in jax_ordered_effects]
     axis_context = ReplicaAxisContext(xla.AxisEnv(nrep, (), ()))
     name_stack = new_name_stack(wrap_name("ok", "jit"))
     module, context = custom_lower_jaxpr_to_module(
@@ -338,8 +334,7 @@ def custom_lower_jaxpr_to_module(
     platforms_with_donation = ("cuda", "rocm", "tpu")
     assert platform not in platforms_with_donation
     assert all(
-        eff in lowerable_effects  # pylint: disable=unsupported-membership-test
-        for eff in jaxpr.effects
+        eff in lowerable_effects for eff in jaxpr.effects
     ), f"Unloweable effects: {jaxpr.effects}"
 
     # MHLO channels need to start at 1

--- a/frontend/catalyst/utils/jax_extras.py
+++ b/frontend/catalyst/utils/jax_extras.py
@@ -286,7 +286,11 @@ def jaxpr_to_mlir(func_name, jaxpr, shape):
     """
 
     nrep = jaxpr_replicas(jaxpr)
-    effects = [eff for eff in jaxpr.effects if eff in jax_ordered_effects]
+    effects = [
+        eff
+        for eff in jaxpr.effects
+        if eff in jax_ordered_effects  # pylint: disable=unsupported-membership-test
+    ]
     axis_context = ReplicaAxisContext(xla.AxisEnv(nrep, (), ()))
     name_stack = new_name_stack(wrap_name("ok", "jit"))
     module, context = custom_lower_jaxpr_to_module(
@@ -334,7 +338,8 @@ def custom_lower_jaxpr_to_module(
     platforms_with_donation = ("cuda", "rocm", "tpu")
     assert platform not in platforms_with_donation
     assert all(
-        eff in lowerable_effects for eff in jaxpr.effects
+        eff in lowerable_effects  # pylint: disable=unsupported-membership-test
+        for eff in jaxpr.effects
     ), f"Unloweable effects: {jaxpr.effects}"
 
     # MHLO channels need to start at 1


### PR DESCRIPTION
**Context:** Fix (Skip!) pylint warnings with v3.0.0. Those warnings are either related to JAX methods and bindings or not critical to be addressed now. The frontend will be refactored in coming months and these skips can be addressed while updating the code base.  


**Benefits:** Pass the GH action check
