### PR TITLE
[MLIR] Extend `adjoint` to support `QubitUnitary`

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -93,6 +93,14 @@
 
 <h3>Bug fixes</h3>
 
+* Add support for applying the `adjoint` operation to `QubitUnitary` gates.
+  `QubitUnitary` was not able to be `adjoint`ed when the variable holding the unitary matrix might
+  change. This can happen, for instance, inside of a for loop.
+  To solve this issue, the unitary matrix gets stored in the array list via push and pops.
+  The unitary matrix is later reconstructed from the array list and `QubitUnitary` can be executed
+  in the `adjoint`ed context.
+  [(#304)](https://github.com/PennyLaneAI/catalyst/pull/304)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -16,7 +16,6 @@
 
 from functools import partial
 
-import jax
 import jax.numpy as jnp
 import pennylane as qml
 import pennylane.numpy as pnp

--- a/mlir/include/Quantum/IR/QuantumInterfaces.td
+++ b/mlir/include/Quantum/IR/QuantumInterfaces.td
@@ -58,7 +58,24 @@ def QuantumGate : OpInterface<"QuantumGate"> {
     }];
 }
 
-def DifferentiableGate : OpInterface<"DifferentiableGate", [QuantumGate]> {
+def ParametrizedGate : OpInterface<"ParametrizedGate", [QuantumGate]> {
+    let description = [{
+        This interface provides a generic way to interact with parametrized
+        quantum instructions. These are quantum operations with differentiable
+        gate parameters.
+    }];
+
+    let cppNamespace = "::catalyst::quantum";
+
+    let methods = [
+        InterfaceMethod<
+            "Return all operands which are considered gate parameters.",
+            "mlir::ValueRange", "getAllParams"
+        >,
+    ];
+}
+
+def DifferentiableGate : OpInterface<"DifferentiableGate", [ParametrizedGate]> {
     let description = [{
         This interface provides a generic way to interact with differentiable
         quantum instructions. These are quantum operations with differentiable
@@ -70,7 +87,10 @@ def DifferentiableGate : OpInterface<"DifferentiableGate", [QuantumGate]> {
     let methods = [
         InterfaceMethod<
             "Return all operands which are considered differentiable gate parameters.",
-            "mlir::ValueRange", "getDiffParams"
+            "mlir::ValueRange", "getDiffParams", (ins), /*methodBody=*/[{}],
+            /*defaultImplementation=*/[{
+                return $_op.getAllParams();
+            }]
         >,
         InterfaceMethod<
             "Return the starting index at which to find differentiable operands in the Operation*."

--- a/mlir/include/Quantum/IR/QuantumInterfaces.td
+++ b/mlir/include/Quantum/IR/QuantumInterfaces.td
@@ -72,6 +72,11 @@ def ParametrizedGate : OpInterface<"ParametrizedGate", [QuantumGate]> {
             "Return all operands which are considered gate parameters.",
             "mlir::ValueRange", "getAllParams"
         >,
+        InterfaceMethod<
+            "Return the starting index at which to find gate parameter operands.",
+            "size_t", "getParamOperandIdx", (ins), /*methodBody=*/[{}],
+            /*defaultImplementation=*/[{ return 0; }]
+        >,
     ];
 }
 
@@ -96,7 +101,10 @@ def DifferentiableGate : OpInterface<"DifferentiableGate", [ParametrizedGate]> {
             "Return the starting index at which to find differentiable operands in the Operation*."
             "Differentiable gate parameter operands do not need to be stored in a single ODS "
             "argument or be located in a particular position, but are assumed to be contiguous.",
-            "size_t", "getDiffOperandIdx"
+            "size_t", "getDiffOperandIdx", (ins), /*methodBody=*/[{}],
+            /*defaultImplementation=*/[{
+               return $_op.getParamOperandIdx();
+            }]
         >,
     ];
 }

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -290,7 +290,8 @@ def QubitUnitaryOp : Gate_Op<"unitary", [NoMemoryEffect, ParametrizedGate]> {
 
     let extraClassDeclaration = extraBaseClassDeclaration # [{
         mlir::ValueRange getAllParams() {
-            return getMatrix();
+            mlir::ValueRange temp = {getMatrix()};
+            return temp;
         }
     }];
 

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -227,9 +227,6 @@ def CustomOp : Gate_Op<"custom", [NoMemoryEffect, AttrSizedOperandSegments, Diff
         mlir::ValueRange getAllParams() {
             return getParams();
         }
-        size_t getDiffOperandIdx() {
-            return 0;
-        }
     }];
 }
 
@@ -257,9 +254,6 @@ def MultiRZOp : Gate_Op<"multirz", [NoMemoryEffect, DifferentiableGate]> {
     let extraClassDeclaration = extraBaseClassDeclaration # [{
         mlir::ValueRange getAllParams() {
             return getODSOperands(0);
-        }
-        size_t getDiffOperandIdx() {
-            return 0;
         }
     }];
 }
@@ -292,6 +286,10 @@ def QubitUnitaryOp : Gate_Op<"unitary", [NoMemoryEffect, ParametrizedGate]> {
         mlir::ValueRange getAllParams() {
             mlir::ValueRange temp = {getMatrix()};
             return temp;
+        }
+
+        size_t getParamOperandIdx() {
+            return 0;
         }
     }];
 

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -287,10 +287,6 @@ def QubitUnitaryOp : Gate_Op<"unitary", [NoMemoryEffect, ParametrizedGate]> {
             mlir::ValueRange temp = {getMatrix()};
             return temp;
         }
-
-        size_t getParamOperandIdx() {
-            return 0;
-        }
     }];
 
     let hasVerifier = 1;

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -224,7 +224,7 @@ def CustomOp : Gate_Op<"custom", [NoMemoryEffect, AttrSizedOperandSegments, Diff
     }];
 
     let extraClassDeclaration = extraBaseClassDeclaration # [{
-        mlir::ValueRange getDiffParams() {
+        mlir::ValueRange getAllParams() {
             return getParams();
         }
         size_t getDiffOperandIdx() {
@@ -255,7 +255,7 @@ def MultiRZOp : Gate_Op<"multirz", [NoMemoryEffect, DifferentiableGate]> {
     }];
 
     let extraClassDeclaration = extraBaseClassDeclaration # [{
-        mlir::ValueRange getDiffParams() {
+        mlir::ValueRange getAllParams() {
             return getODSOperands(0);
         }
         size_t getDiffOperandIdx() {
@@ -264,7 +264,7 @@ def MultiRZOp : Gate_Op<"multirz", [NoMemoryEffect, DifferentiableGate]> {
     }];
 }
 
-def QubitUnitaryOp : Gate_Op<"unitary", [NoMemoryEffect]> {
+def QubitUnitaryOp : Gate_Op<"unitary", [NoMemoryEffect, ParametrizedGate]> {
     let summary = "Apply an arbitrary fixed unitary matrix";
     let description = [{
         The `quantum.unitary` operation applies an arbitrary fixed unitary matrix to the
@@ -286,6 +286,12 @@ def QubitUnitaryOp : Gate_Op<"unitary", [NoMemoryEffect]> {
 
     let assemblyFormat = [{
         `(` $matrix `:` type($matrix) `)` $in_qubits attr-dict `:` type($out_qubits)
+    }];
+
+    let extraClassDeclaration = extraBaseClassDeclaration # [{
+        mlir::ValueRange getAllParams() {
+            return getMatrix();
+        }
     }];
 
     let hasVerifier = 1;

--- a/mlir/include/Quantum/Transforms/Passes.td
+++ b/mlir/include/Quantum/Transforms/Passes.td
@@ -62,7 +62,9 @@ def AdjointLoweringPass : Pass<"adjoint-lowering"> {
 
     let dependentDialects = [
         "catalyst::CatalystDialect",
-        "index::IndexDialect"
+        "index::IndexDialect",
+        "tensor::TensorDialect",
+        "complex::ComplexDialect"
     ];
 
     let constructor = "catalyst::createAdjointLoweringPass()";

--- a/mlir/include/Quantum/Transforms/Passes.td
+++ b/mlir/include/Quantum/Transforms/Passes.td
@@ -64,7 +64,8 @@ def AdjointLoweringPass : Pass<"adjoint-lowering"> {
         "catalyst::CatalystDialect",
         "index::IndexDialect",
         "tensor::TensorDialect",
-        "complex::ComplexDialect"
+        "complex::ComplexDialect",
+        "scf::SCFDialect"
     ];
 
     let constructor = "catalyst::createAdjointLoweringPass()";

--- a/mlir/include/Quantum/Utils/QuantumSplitting.h
+++ b/mlir/include/Quantum/Utils/QuantumSplitting.h
@@ -72,7 +72,7 @@ class AugmentedCircuitGenerator {
     }
 };
 
-void verifyTypeIsCacheable(mlir::Type ty, mlir::Operation &op);
+void verifyTypeIsCacheable(mlir::Type ty, mlir::Operation *gate);
 
 } // namespace quantum
 } // namespace catalyst

--- a/mlir/include/Quantum/Utils/QuantumSplitting.h
+++ b/mlir/include/Quantum/Utils/QuantumSplitting.h
@@ -71,5 +71,8 @@ class AugmentedCircuitGenerator {
         }
     }
 };
+
+void verifyTypeIsCacheable(mlir::Type ty, mlir::Operation &op);
+
 } // namespace quantum
 } // namespace catalyst

--- a/mlir/include/Quantum/Utils/QuantumSplitting.h
+++ b/mlir/include/Quantum/Utils/QuantumSplitting.h
@@ -70,6 +70,8 @@ class AugmentedCircuitGenerator {
                                        cache.wireVector);
         }
     }
+
+    void cacheGate(quantum::ParametrizedGate, mlir::OpBuilder &builder);
 };
 
 void verifyTypeIsCacheable(mlir::Type ty, mlir::Operation *gate);

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -146,10 +146,10 @@ class AdjointGenerator {
                         bool isDim1Static = ShapedType::kDynamic != shape[1];
                         Value dim0Length =
                             isDim0Static ? (Value)builder.create<index::ConstantOp>(loc, shape[0])
-                                         : (Value)builder.create<tensor::DimOp>(loc, param);
+                                         : (Value)builder.create<tensor::DimOp>(loc, param, c0);
                         Value dim1Length =
                             isDim1Static ? (Value)builder.create<index::ConstantOp>(loc, shape[1])
-                                         : (Value)builder.create<tensor::DimOp>(loc, param);
+                                         : (Value)builder.create<tensor::DimOp>(loc, param, c1);
 
                         // Renaming for legibility
                         // Note: Since this is a square matrix, upperBound for both loops is the

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -110,121 +110,7 @@ class AdjointGenerator {
                 remappedValues.map(extractOp.getQreg(), insertOp.getResult());
             }
             else if (auto gate = dyn_cast<quantum::QuantumGate>(op)) {
-                for (const auto &[qubitResult, qubitOperand] :
-                     llvm::zip(gate.getQubitResults(), gate.getQubitOperands())) {
-                    remappedValues.map(qubitOperand, remappedValues.lookup(qubitResult));
-                }
-
-                auto clone = cast<QuantumGate>(builder.clone(*gate, remappedValues));
-                clone.setAdjointFlag(!gate.getAdjointFlag());
-
-                // Read cached parameters from the recorded parameter vector.
-                if (auto parametrizedGate = dyn_cast<quantum::ParametrizedGate>(op)) {
-                    OpBuilder::InsertionGuard insertionGuard(builder);
-                    builder.setInsertionPoint(clone);
-                    SmallVector<Value> cachedParams;
-                    ValueRange params = parametrizedGate.getAllParams();
-                    for (Value param : params) {
-                        Type paramType = param.getType();
-                        verifyTypeIsCacheable(paramType, &op);
-                        if (paramType.isF64()) {
-                            cachedParams.push_back(builder.create<ListPopOp>(
-                                parametrizedGate.getLoc(), cache.paramVector));
-                            continue;
-                        }
-
-                        // Guaranteed by verifyTypeIsPoppable above.
-                        auto aTensorType = paramType.cast<RankedTensorType>();
-                        ArrayRef<int64_t> shape = aTensorType.getShape();
-                        Type elementType = aTensorType.getElementType();
-                        // Constants
-                        auto loc = parametrizedGate.getLoc();
-                        Value c0 = builder.create<index::ConstantOp>(loc, 0);
-                        Value c1 = builder.create<index::ConstantOp>(loc, 1);
-                        // TODO: Generalize to all possible dimensions
-                        bool isDim0Static = ShapedType::kDynamic != shape[0];
-                        bool isDim1Static = ShapedType::kDynamic != shape[1];
-                        Value dim0Length =
-                            isDim0Static ? (Value)builder.create<index::ConstantOp>(loc, shape[0])
-                                         : (Value)builder.create<tensor::DimOp>(loc, param, c0);
-                        Value dim1Length =
-                            isDim1Static ? (Value)builder.create<index::ConstantOp>(loc, shape[1])
-                                         : (Value)builder.create<tensor::DimOp>(loc, param, c1);
-
-                        // Renaming for legibility
-                        // Note: Since this is a square matrix, upperBound for both loops is the
-                        // same value.
-                        Value lowerBoundDim0 = c0;
-                        Value upperBoundDim0 = dim0Length;
-                        Value stepDim0 = c1;
-                        Value lowerBoundDim1 = c0;
-                        Value upperBoundDim1 = dim1Length;
-                        Value stepDim1 = c1;
-                        Value beginningTensor =
-                            builder.create<tensor::EmptyOp>(loc, shape, elementType);
-                        // This time, we are in reverse, so we need to start
-                        // with N-1 since MLIR does not allow for loops with negative step sizes.
-                        SmallVector<Value> initialValues = {beginningTensor};
-
-                        scf::ForOp iForLoop = builder.create<scf::ForOp>(
-                            loc, lowerBoundDim0, upperBoundDim0, stepDim0, initialValues);
-                        {
-                            OpBuilder::InsertionGuard afterIForLoop(builder);
-                            builder.setInsertionPointToStart(iForLoop.getBody());
-                            auto iIterArgs = iForLoop.getRegionIterArgs();
-                            Value currIthTensor = iIterArgs.front();
-
-                            Value i = iForLoop.getInductionVar();
-                            Value iPlusOne = builder.create<index::AddOp>(loc, i, c1);
-                            Value nMinusIMinusOne =
-                                builder.create<index::SubOp>(loc, dim0Length, iPlusOne);
-                            // Just for legibility
-                            Value iTensorIndex = nMinusIMinusOne;
-
-                            scf::ForOp jForLoop = builder.create<scf::ForOp>(
-                                loc, lowerBoundDim1, upperBoundDim1, stepDim1, currIthTensor);
-                            {
-                                OpBuilder::InsertionGuard afterJForLoop(builder);
-                                builder.setInsertionPointToStart(jForLoop.getBody());
-                                auto jIterArgs = jForLoop.getRegionIterArgs();
-                                assert(jIterArgs.size() == 1 &&
-                                       "jForLoop has more induction variables than necessary.");
-                                Value currIthJthTensor = jIterArgs.front();
-
-                                Value imag = builder.create<ListPopOp>(loc, cache.paramVector);
-                                Value real = builder.create<ListPopOp>(loc, cache.paramVector);
-                                Value element =
-                                    builder.create<complex::CreateOp>(loc, elementType, real, imag);
-
-                                // TODO: Generalize to types which are not complex
-                                Value j = jForLoop.getInductionVar();
-                                Value jPlusOne = builder.create<index::AddOp>(loc, j, c1);
-                                Value nMinusJMinusOne =
-                                    builder.create<index::SubOp>(loc, dim1Length, jPlusOne);
-                                // Just for legibility
-                                Value jTensorIndex = nMinusJMinusOne;
-                                ValueRange indices = {iTensorIndex, jTensorIndex};
-
-                                Value updatedIthJthTensor = builder.create<tensor::InsertOp>(
-                                    loc, element, currIthJthTensor, indices);
-                                builder.create<scf::YieldOp>(loc, updatedIthJthTensor);
-                            }
-
-                            Value ithTensor = jForLoop.getResult(0);
-                            builder.create<scf::YieldOp>(loc, ithTensor);
-                        }
-
-                        Value recreatedTensor = iForLoop.getResult(0);
-                        cachedParams.push_back(recreatedTensor);
-                    }
-                    MutableOperandRange(clone, parametrizedGate.getParamOperandIdx(), params.size())
-                        .assign(cachedParams);
-                }
-
-                for (const auto &[qubitResult, qubitOperand] :
-                     llvm::zip(clone.getQubitResults(), gate.getQubitOperands())) {
-                    remappedValues.map(qubitOperand, qubitResult);
-                }
+                visitOperation(gate, builder);
             }
             else if (auto adjointOp = dyn_cast<quantum::AdjointOp>(&op)) {
                 BlockArgument regionArg = adjointOp.getRegion().getArgument(0);
@@ -258,6 +144,124 @@ class AdjointGenerator {
             }
         }
         return std::nullopt;
+    }
+
+    void visitOperation(quantum::QuantumGate gate, OpBuilder &builder)
+    {
+        for (const auto &[qubitResult, qubitOperand] :
+             llvm::zip(gate.getQubitResults(), gate.getQubitOperands())) {
+            remappedValues.map(qubitOperand, remappedValues.lookup(qubitResult));
+        }
+
+        auto clone = cast<QuantumGate>(builder.clone(*gate, remappedValues));
+        clone.setAdjointFlag(!gate.getAdjointFlag());
+
+        // Read cached parameters from the recorded parameter vector.
+        mlir::Operation *operation = gate;
+        if (auto parametrizedGate = dyn_cast<quantum::ParametrizedGate>(operation)) {
+            OpBuilder::InsertionGuard insertionGuard(builder);
+            builder.setInsertionPoint(clone);
+            SmallVector<Value> cachedParams;
+            ValueRange params = parametrizedGate.getAllParams();
+            for (Value param : params) {
+                Type paramType = param.getType();
+                verifyTypeIsCacheable(paramType, operation);
+                if (paramType.isF64()) {
+                    cachedParams.push_back(
+                        builder.create<ListPopOp>(parametrizedGate.getLoc(), cache.paramVector));
+                    continue;
+                }
+
+                // Guaranteed by verifyTypeIsPoppable above.
+                auto aTensorType = paramType.cast<RankedTensorType>();
+                ArrayRef<int64_t> shape = aTensorType.getShape();
+                Type elementType = aTensorType.getElementType();
+                // Constants
+                auto loc = parametrizedGate.getLoc();
+                Value c0 = builder.create<index::ConstantOp>(loc, 0);
+                Value c1 = builder.create<index::ConstantOp>(loc, 1);
+                // TODO: Generalize to all possible dimensions
+                bool isDim0Static = ShapedType::kDynamic != shape[0];
+                bool isDim1Static = ShapedType::kDynamic != shape[1];
+                Value dim0Length = isDim0Static
+                                       ? (Value)builder.create<index::ConstantOp>(loc, shape[0])
+                                       : (Value)builder.create<tensor::DimOp>(loc, param, c0);
+                Value dim1Length = isDim1Static
+                                       ? (Value)builder.create<index::ConstantOp>(loc, shape[1])
+                                       : (Value)builder.create<tensor::DimOp>(loc, param, c1);
+
+                // Renaming for legibility
+                // Note: Since this is a square matrix, upperBound for both loops is the
+                // same value.
+                Value lowerBoundDim0 = c0;
+                Value upperBoundDim0 = dim0Length;
+                Value stepDim0 = c1;
+                Value lowerBoundDim1 = c0;
+                Value upperBoundDim1 = dim1Length;
+                Value stepDim1 = c1;
+                Value beginningTensor = builder.create<tensor::EmptyOp>(loc, shape, elementType);
+                // This time, we are in reverse, so we need to start
+                // with N-1 since MLIR does not allow for loops with negative step sizes.
+                SmallVector<Value> initialValues = {beginningTensor};
+
+                scf::ForOp iForLoop = builder.create<scf::ForOp>(
+                    loc, lowerBoundDim0, upperBoundDim0, stepDim0, initialValues);
+                {
+                    OpBuilder::InsertionGuard afterIForLoop(builder);
+                    builder.setInsertionPointToStart(iForLoop.getBody());
+                    auto iIterArgs = iForLoop.getRegionIterArgs();
+                    Value currIthTensor = iIterArgs.front();
+
+                    Value i = iForLoop.getInductionVar();
+                    Value iPlusOne = builder.create<index::AddOp>(loc, i, c1);
+                    Value nMinusIMinusOne = builder.create<index::SubOp>(loc, dim0Length, iPlusOne);
+                    // Just for legibility
+                    Value iTensorIndex = nMinusIMinusOne;
+
+                    scf::ForOp jForLoop = builder.create<scf::ForOp>(
+                        loc, lowerBoundDim1, upperBoundDim1, stepDim1, currIthTensor);
+                    {
+                        OpBuilder::InsertionGuard afterJForLoop(builder);
+                        builder.setInsertionPointToStart(jForLoop.getBody());
+                        auto jIterArgs = jForLoop.getRegionIterArgs();
+                        assert(jIterArgs.size() == 1 &&
+                               "jForLoop has more induction variables than necessary.");
+                        Value currIthJthTensor = jIterArgs.front();
+
+                        Value imag = builder.create<ListPopOp>(loc, cache.paramVector);
+                        Value real = builder.create<ListPopOp>(loc, cache.paramVector);
+                        Value element =
+                            builder.create<complex::CreateOp>(loc, elementType, real, imag);
+
+                        // TODO: Generalize to types which are not complex
+                        Value j = jForLoop.getInductionVar();
+                        Value jPlusOne = builder.create<index::AddOp>(loc, j, c1);
+                        Value nMinusJMinusOne =
+                            builder.create<index::SubOp>(loc, dim1Length, jPlusOne);
+                        // Just for legibility
+                        Value jTensorIndex = nMinusJMinusOne;
+                        ValueRange indices = {iTensorIndex, jTensorIndex};
+
+                        Value updatedIthJthTensor = builder.create<tensor::InsertOp>(
+                            loc, element, currIthJthTensor, indices);
+                        builder.create<scf::YieldOp>(loc, updatedIthJthTensor);
+                    }
+
+                    Value ithTensor = jForLoop.getResult(0);
+                    builder.create<scf::YieldOp>(loc, ithTensor);
+                }
+
+                Value recreatedTensor = iForLoop.getResult(0);
+                cachedParams.push_back(recreatedTensor);
+            }
+            MutableOperandRange(clone, parametrizedGate.getParamOperandIdx(), params.size())
+                .assign(cachedParams);
+        }
+
+        for (const auto &[qubitResult, qubitOperand] :
+             llvm::zip(clone.getQubitResults(), gate.getQubitOperands())) {
+            remappedValues.map(qubitOperand, qubitResult);
+        }
     }
 
     void visitOperation(scf::ForOp forOp, OpBuilder &builder)

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -134,7 +134,6 @@ class AdjointGenerator {
                 }
 
                 else if (auto qubitUnitaryGate = dyn_cast<quantum::QubitUnitaryOp>(op)) {
-
                     OpBuilder::InsertionGuard insertionGuard(builder);
                     builder.setInsertionPoint(clone);
                     Value matrix = qubitUnitaryGate.getMatrix();

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -126,7 +126,7 @@ class AdjointGenerator {
                     ValueRange params = parametrizedGate.getAllParams();
                     for (Value param : params) {
                         Type paramType = param.getType();
-                        verifyTypeIsCacheable(paramType, op);
+                        verifyTypeIsCacheable(paramType, &op);
                         if (paramType.isF64()) {
                             cachedParams.push_back(builder.create<ListPopOp>(
                                 parametrizedGate.getLoc(), cache.paramVector));

--- a/mlir/lib/Quantum/Transforms/adjoint_lowering.cpp
+++ b/mlir/lib/Quantum/Transforms/adjoint_lowering.cpp
@@ -22,6 +22,7 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"

--- a/mlir/lib/Quantum/Utils/QuantumSplitting.cpp
+++ b/mlir/lib/Quantum/Utils/QuantumSplitting.cpp
@@ -110,6 +110,77 @@ void QuantumCache::emitDealloc(OpBuilder &builder, Location loc)
     }
 }
 
+void AugmentedCircuitGenerator::cacheGate(quantum::ParametrizedGate gate, OpBuilder &builder)
+{
+    ValueRange params = gate.getAllParams();
+
+    for (Value param : params) {
+        Location loc = gate.getLoc();
+        Value clonedParam = oldToCloned.lookupOrDefault(param);
+        Type paramType = clonedParam.getType();
+        mlir::Operation *op = gate;
+        verifyTypeIsCacheable(paramType, op);
+
+        if (paramType.isF64()) {
+            builder.create<ListPushOp>(loc, clonedParam, cache.paramVector);
+            continue;
+        }
+
+        // Sanitizing inputs.
+        // Technically we know for a fact that none of this will ever issue an error.
+        // This is because QubitUnitary is guaranteed to have a tensor<NxNxcomplex<f64>>
+        // But this code in the future may be extended to support other types.
+        // Hence the sanitization.
+        if (!isa<RankedTensorType>(paramType)) {
+            gate.emitOpError() << "Unexpected type.";
+        }
+
+        auto aTensor = paramType.cast<RankedTensorType>();
+        ArrayRef<int64_t> shape = aTensor.getShape();
+        Value c0 = builder.create<index::ConstantOp>(loc, 0);
+        Value c1 = builder.create<index::ConstantOp>(loc, 1);
+        bool isDim0Static = ShapedType::kDynamic != shape[0];
+        bool isDim1Static = ShapedType::kDynamic != shape[1];
+        Value dim0Length = isDim0Static ? (Value)builder.create<index::ConstantOp>(loc, shape[0])
+                                        : (Value)builder.create<tensor::DimOp>(loc, param, c0);
+        Value dim1Length = isDim1Static ? (Value)builder.create<index::ConstantOp>(loc, shape[1])
+                                        : (Value)builder.create<tensor::DimOp>(loc, param, c1);
+
+        Value lowerBoundDim0 = c0;
+        Value upperBoundDim0 = dim0Length;
+        Value stepDim0 = c1;
+        Value lowerBoundDim1 = c0;
+        Value upperBoundDim1 = dim1Length;
+        Value stepDim1 = c1;
+        Value matrix = clonedParam;
+
+        scf::ForOp iForLoop =
+            builder.create<scf::ForOp>(loc, lowerBoundDim0, upperBoundDim0, stepDim0);
+        {
+            OpBuilder::InsertionGuard afterIForLoop(builder);
+            builder.setInsertionPointToStart(iForLoop.getBody());
+            Value i_index = iForLoop.getInductionVar();
+
+            scf::ForOp jForLoop =
+                builder.create<scf::ForOp>(loc, lowerBoundDim1, upperBoundDim1, stepDim1);
+            {
+                OpBuilder::InsertionGuard afterJForLoop(builder);
+                builder.setInsertionPointToStart(jForLoop.getBody());
+                Value j_index = jForLoop.getInductionVar();
+                SmallVector<Value> indices = {i_index, j_index};
+                Value element = builder.create<tensor::ExtractOp>(loc, matrix, indices);
+                // element is complex!
+                // So we need to convert into {f64, f64}
+                Value real = builder.create<complex::ReOp>(loc, element);
+                Value imag = builder.create<complex::ImOp>(loc, element);
+                // Again, take note of the order.
+                builder.create<ListPushOp>(loc, real, cache.paramVector);
+                builder.create<ListPushOp>(loc, imag, cache.paramVector);
+            }
+        }
+    }
+}
+
 void AugmentedCircuitGenerator::generate(Region &region, OpBuilder &builder)
 {
     assert(region.hasOneBlock() &&
@@ -127,74 +198,7 @@ void AugmentedCircuitGenerator::generate(Region &region, OpBuilder &builder)
             cacheDynamicWire(extractOp, builder);
         }
         else if (auto gate = dyn_cast<quantum::ParametrizedGate>(op)) {
-            ValueRange params = gate.getAllParams();
-
-            for (Value param : params) {
-                Location loc = gate.getLoc();
-                Value clonedParam = oldToCloned.lookupOrDefault(param);
-                Type paramType = clonedParam.getType();
-                verifyTypeIsCacheable(paramType, &op);
-
-                if (paramType.isF64()) {
-                    builder.create<ListPushOp>(loc, clonedParam, cache.paramVector);
-                    continue;
-                }
-
-                // Sanitizing inputs.
-                // Technically we know for a fact that none of this will ever issue an error.
-                // This is because QubitUnitary is guaranteed to have a tensor<NxNxcomplex<f64>>
-                // But this code in the future may be extended to support other types.
-                // Hence the sanitization.
-                if (!isa<RankedTensorType>(paramType)) {
-                    gate.emitOpError() << "Unexpected type.";
-                }
-
-                auto aTensor = paramType.cast<RankedTensorType>();
-                ArrayRef<int64_t> shape = aTensor.getShape();
-                Value c0 = builder.create<index::ConstantOp>(loc, 0);
-                Value c1 = builder.create<index::ConstantOp>(loc, 1);
-                bool isDim0Static = ShapedType::kDynamic != shape[0];
-                bool isDim1Static = ShapedType::kDynamic != shape[1];
-                Value dim0Length = isDim0Static
-                                       ? (Value)builder.create<index::ConstantOp>(loc, shape[0])
-                                       : (Value)builder.create<tensor::DimOp>(loc, param, c0);
-                Value dim1Length = isDim1Static
-                                       ? (Value)builder.create<index::ConstantOp>(loc, shape[1])
-                                       : (Value)builder.create<tensor::DimOp>(loc, param, c1);
-
-                Value lowerBoundDim0 = c0;
-                Value upperBoundDim0 = dim0Length;
-                Value stepDim0 = c1;
-                Value lowerBoundDim1 = c0;
-                Value upperBoundDim1 = dim1Length;
-                Value stepDim1 = c1;
-                Value matrix = clonedParam;
-
-                scf::ForOp iForLoop =
-                    builder.create<scf::ForOp>(loc, lowerBoundDim0, upperBoundDim0, stepDim0);
-                {
-                    OpBuilder::InsertionGuard afterIForLoop(builder);
-                    builder.setInsertionPointToStart(iForLoop.getBody());
-                    Value i_index = iForLoop.getInductionVar();
-
-                    scf::ForOp jForLoop =
-                        builder.create<scf::ForOp>(loc, lowerBoundDim1, upperBoundDim1, stepDim1);
-                    {
-                        OpBuilder::InsertionGuard afterJForLoop(builder);
-                        builder.setInsertionPointToStart(jForLoop.getBody());
-                        Value j_index = jForLoop.getInductionVar();
-                        SmallVector<Value> indices = {i_index, j_index};
-                        Value element = builder.create<tensor::ExtractOp>(loc, matrix, indices);
-                        // element is complex!
-                        // So we need to convert into {f64, f64}
-                        Value real = builder.create<complex::ReOp>(loc, element);
-                        Value imag = builder.create<complex::ImOp>(loc, element);
-                        // Again, take note of the order.
-                        builder.create<ListPushOp>(loc, real, cache.paramVector);
-                        builder.create<ListPushOp>(loc, imag, cache.paramVector);
-                    }
-                }
-            }
+            cacheGate(gate, builder);
         }
         else if (isa<QuantumDialect>(op.getDialect())) {
             // Any quantum op other than a parametrized gate/insert/extract is ignored.

--- a/mlir/lib/Quantum/Utils/QuantumSplitting.cpp
+++ b/mlir/lib/Quantum/Utils/QuantumSplitting.cpp
@@ -91,14 +91,15 @@ void AugmentedCircuitGenerator::generate(Region &region, OpBuilder &builder)
         else if (auto extractOp = dyn_cast<quantum::ExtractOp>(op)) {
             cacheDynamicWire(extractOp, builder);
         }
-        else if (auto gate = dyn_cast<quantum::DifferentiableGate>(op)) {
-            ValueRange diffParams = gate.getDiffParams();
-            if (!diffParams.empty()) {
-                for (Value param : diffParams) {
-                    builder.create<ListPushOp>(gate.getLoc(), oldToCloned.lookupOrDefault(param),
-                                               cache.paramVector);
-                }
-            }
+        else if (auto gate = dyn_cast<quantum::ParametrizedGate>(op)) {
+            ValueRange params = gate.getAllParams();
+            // TODO: Add capability to cache tensors here
+            // if (!params.empty()) {
+            //     for (Value param : params) {
+            //         builder.create<ListPushOp>(gate.getLoc(), oldToCloned.lookupOrDefault(param),
+            //                                    cache.paramVector);
+            //     }
+            // }
         }
         else if (auto gate = dyn_cast<quantum::QubitUnitaryOp>(op)) {
             Value matrix = gate.getMatrix();
@@ -154,7 +155,7 @@ void AugmentedCircuitGenerator::generate(Region &region, OpBuilder &builder)
             }
         }
         else if (isa<QuantumDialect>(op.getDialect())) {
-            // Any quantum op other than a differentiable gate/insert/extract is ignored.
+            // Any quantum op other than a parametrized gate/insert/extract is ignored.
         }
         else if (isClassicalSCFOp(op)) {
             // Purely classical SCF ops should be treated as any other purely classical op, but

--- a/mlir/lib/Quantum/Utils/QuantumSplitting.cpp
+++ b/mlir/lib/Quantum/Utils/QuantumSplitting.cpp
@@ -93,8 +93,6 @@ void AugmentedCircuitGenerator::generate(Region &region, OpBuilder &builder)
         }
         else if (auto gate = dyn_cast<quantum::ParametrizedGate>(op)) {
             ValueRange params = gate.getAllParams();
-            if (params.empty())
-                continue;
 
             for (Value param : params) {
                 Location loc = gate.getLoc();

--- a/mlir/lib/Quantum/Utils/QuantumSplitting.cpp
+++ b/mlir/lib/Quantum/Utils/QuantumSplitting.cpp
@@ -101,7 +101,6 @@ void AugmentedCircuitGenerator::generate(Region &region, OpBuilder &builder)
             }
         }
         else if (auto gate = dyn_cast<quantum::QubitUnitaryOp>(op)) {
-
             Value matrix = gate.getMatrix();
             Value matrixCloned = oldToCloned.lookupOrDefault(matrix);
             Type aType = matrixCloned.getType();

--- a/mlir/lib/Quantum/Utils/QuantumSplitting.cpp
+++ b/mlir/lib/Quantum/Utils/QuantumSplitting.cpp
@@ -58,7 +58,7 @@ void verifyTypeIsCacheable(Type ty, Operation &op)
 
     // TODO: Generalize to unranked tensors
     if (!isa<RankedTensorType>(ty)) {
-        op.emitOpError() << "This type cannot be popped.";
+        op.emitOpError() << "Caching only supports tensors complex F64";
     }
 
     auto aTensorType = ty.cast<RankedTensorType>();
@@ -66,17 +66,17 @@ void verifyTypeIsCacheable(Type ty, Operation &op)
 
     // TODO: Generalize to arbitrary dimensions
     if (2 != shape.size()) {
-        op.emitOpError() << "This type cannot be popped.";
+        op.emitOpError() << "Caching only supports tensors complex F64";
     }
     // TODO: Generalize to other types
     Type elementType = aTensorType.getElementType();
     if (!isa<ComplexType>(elementType)) {
-        op.emitOpError() << "This type cannot be popped.";
+        op.emitOpError() << "Caching only supports tensors complex F64";
     }
     // TODO: Generalize to other types
     Type f64 = elementType.cast<ComplexType>().getElementType();
     if (!f64.isF64()) {
-        op.emitOpError() << "This type cannot be popped.";
+        op.emitOpError() << "Caching only supports tensors complex F64";
     }
 }
 

--- a/mlir/lib/Quantum/Utils/QuantumSplitting.cpp
+++ b/mlir/lib/Quantum/Utils/QuantumSplitting.cpp
@@ -110,24 +110,39 @@ void AugmentedCircuitGenerator::generate(Region &region, OpBuilder &builder)
             assert(shape.size() == 2 && "Unexpected tensor shape in QubitUnitaryOp");
             assert(shape[0] == shape[1] && "QubitUnitaryOp is not square matrix");
 
+            auto loc = gate.getLoc();
+            Value c0 = builder.create<index::ConstantOp>(loc, 0);
+            Value c1 = builder.create<index::ConstantOp>(loc, 1);
+
+            Value lowerBound = c0;
+            Value upperBound = builder.create<index::ConstantOp>(loc, shape[1]);
+            Value step = c1;
+
             // TODO:
             // Make this for loop in MLIR.
             for (int i = 0; i < shape[0]; i++) {
-                for (int j = 0; j < shape[1]; j++) {
-                    // Note the order. It will be the reverse order
-                    // when you are popping these items from the list.
-                    auto x = builder.create<index::ConstantOp>(gate.getLoc(), i);
-                    auto y = builder.create<index::ConstantOp>(gate.getLoc(), j);
-                    SmallVector<Value> indices = {x, y};
-                    auto element =
-                        builder.create<tensor::ExtractOp>(gate.getLoc(), matrixCloned, indices);
+                auto x = builder.create<index::ConstantOp>(loc, i);
+
+                // What values is the loop going to be using?
+                // None... That means we don't need iterargs.
+                // No results needed as pushOp acts on memory.
+                // This is interesting, should we change the list to be value semantics?
+                scf::ForOp innerForLoop =
+                    builder.create<scf::ForOp>(loc, lowerBound, upperBound, step);
+                {
+                    OpBuilder::InsertionGuard afterLoop(builder);
+                    builder.setInsertionPointToStart(innerForLoop.getBody());
+                    Value j_index = innerForLoop.getInductionVar();
+                    Value i_index = x;
+                    SmallVector<Value> indices = {i_index, j_index};
+                    Value element = builder.create<tensor::ExtractOp>(loc, matrixCloned, indices);
                     // element is complex!
                     // So we need to convert into {f64, f64}
-                    auto real = builder.create<complex::ReOp>(gate.getLoc(), element);
-                    auto imag = builder.create<complex::ImOp>(gate.getLoc(), element);
+                    Value real = builder.create<complex::ReOp>(loc, element);
+                    Value imag = builder.create<complex::ImOp>(loc, element);
                     // Again, take note of the order.
-                    builder.create<ListPushOp>(gate.getLoc(), real, cache.paramVector);
-                    builder.create<ListPushOp>(gate.getLoc(), imag, cache.paramVector);
+                    builder.create<ListPushOp>(loc, real, cache.paramVector);
+                    builder.create<ListPushOp>(loc, imag, cache.paramVector);
                 }
             }
         }

--- a/mlir/test/Quantum/AdjointTest.mlir
+++ b/mlir/test/Quantum/AdjointTest.mlir
@@ -114,3 +114,56 @@ func.func @workflow_unhandled() {
   }
   return
 }
+
+
+// -----
+
+func.func private @qubit_unitary_test(%arg0: tensor<4x4xcomplex<f64>>) -> tensor<4xcomplex<f64>> {
+    quantum.device ["kwargs", "{'shots': 0}"]
+    quantum.device ["backend", "lightning.qubit"]
+    %0 = quantum.alloc( 2) : !quantum.reg
+    %1 = quantum.adjoint(%0) : !quantum.reg {
+    ^bb0(%arg1: !quantum.reg):
+      %6 = quantum.extract %arg1[ 0] : !quantum.reg -> !quantum.bit
+      %7 = quantum.extract %arg1[ 1] : !quantum.reg -> !quantum.bit
+
+      // CHECK-DAG: [[idx0:%.+]] = index.constant 0
+      // CHECK-DAG: [[idx1:%.+]] = index.constant 1
+      // CHECK-DAG: [[idxN:%.+]] = index.constant
+      // CHECK: scf.for [[i:%.+]] = [[idx0]] to [[idxN]] step [[idx1]]
+      // CHECK:     scf.for [[j:%.+]] = [[idx0]] to [[idxN]] step [[idx1]]
+      // CHECK:     [[element:%.+]] = tensor.extract {{.*}}[[[i]], [[j]]
+      // CHECK:     [[real:%.+]] = complex.re [[element]]
+      // CHECK:     [[imag:%.+]] = complex.im [[element]]
+      // CHECK:     catalyst.list_push [[real]]
+      // CHECK:     catalyst.list_push [[imag]]
+
+      %8:2 = quantum.unitary(%arg0 : tensor<4x4xcomplex<f64>>) %6, %7 : !quantum.bit, !quantum.bit
+
+      // CHECK-DAG: [[result:%.+]] = tensor.empty
+      // CHECK: scf.for [[k:%.+]] = [[idx0]] to [[idxN]] step [[idx1]] iter_args([[curr_k:%.+]] = [[result]])
+      // CHECK:   [[kplus1:%.+]] = index.add [[k]], [[idx1]]
+      // CHECK:   [[k_idx:%.+]] = index.sub [[idxN]], [[kplus1]]
+      // CHECK:   [[last_tensor:%.+]] = scf.for [[l:%.+]] = [[idx0]] to [[idxN]] step [[idx1]] iter_args([[curr_l:%.+]] = [[curr_k]])
+      // CHECK:     [[imag2:%.+]] = catalyst.list_pop
+      // CHECK:     [[real2:%.+]] = catalyst.list_pop
+      // CHECK:     [[complex:%.+]] = complex.create [[real2]], [[imag2]]
+      // CHECK:     [[lplus1:%.+]] = index.add [[l]], [[idx1]]
+      // CHECK:     [[l_idx:%.+]] = index.sub [[idxN]], [[lplus1]]
+      // CHECK:     [[new_tensor:%.+]] = tensor.insert [[complex]] into [[curr_l]]
+      // CHECK:     scf.yield [[new_tensor]]
+
+      // CHECK:   scf.yield [[last_tensor]]
+
+
+      %9 = quantum.insert %arg1[ 0], %8#0 : !quantum.reg, !quantum.bit
+      %10 = quantum.insert %9[ 1], %8#1 : !quantum.reg, !quantum.bit
+      quantum.yield %10 : !quantum.reg
+    }
+    %2 = quantum.extract %1[ 0] : !quantum.reg -> !quantum.bit
+    %3 = quantum.extract %1[ 1] : !quantum.reg -> !quantum.bit
+    %4 = quantum.compbasis %2, %3 : !quantum.obs
+    %5 = quantum.state %4 : tensor<4xcomplex<f64>>
+    quantum.dealloc %0 : !quantum.reg
+    return %5 : tensor<4xcomplex<f64>>
+  }

--- a/mlir/test/Quantum/AdjointTest.mlir
+++ b/mlir/test/Quantum/AdjointTest.mlir
@@ -150,7 +150,7 @@ func.func private @qubit_unitary_test(%arg0: tensor<4x4xcomplex<f64>>) -> tensor
       // CHECK:     [[complex:%.+]] = complex.create [[real2]], [[imag2]]
       // CHECK:     [[lplus1:%.+]] = index.add [[l]], [[idx1]]
       // CHECK:     [[l_idx:%.+]] = index.sub [[idxN]], [[lplus1]]
-      // CHECK:     [[new_tensor:%.+]] = tensor.insert [[complex]] into [[curr_l]]
+      // CHECK:     [[new_tensor:%.+]] = tensor.insert [[complex]] into [[curr_l]][[[k_idx]], [[l_idx]]]
       // CHECK:     scf.yield [[new_tensor]]
 
       // CHECK:   scf.yield [[last_tensor]]


### PR DESCRIPTION
**Context:** The adjoint decomposition pass in `AugmentedCircuitGenerator::generate` makes use of the `DifferentiableGate` interface to identify parameters that need to be cached in the forwards pass. The issue is that only gates with individual float64 parameters are included in this interface, the QubitUnitary which takes a complex tensor is not.
The adjoint pass should use a new interface ParametrizedGate that includes any op with numeric parameters (so far the only additional one would be QubitUnitary).
The difficulty however is caching these more general numeric parameters. The pass right now makes use of a resizable arraylist for float64 values, and cannot straightforwardly hold other datatypes and tensors thereof.

**Description of the Change:** As an alternative, instead of storing arbitary data types in a list, types of `tensor<NxNxcomplex<T>>` are serialized into `f64` specifically to handle QubitUnitary gates. Since the `arraylist` is a Last-Input First-Output (LIFO) data structure, one must pay attention regarding the order of pushing and popping into the array list and reconstructing the `tensor<NxNxcomplex<T>>` from the `f64` cache.

**Benefits:** Handles QubitUnitary.

**Possible Drawbacks:** Does not handle arbitrary types.

**Related GitHub Issues:** [sc-46570]
