### PR TITLE
[Frontend] calling `qjit(keep_intermediate=True)` multiple times

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,7 +6,7 @@
   [(#273)](https://github.com/PennyLaneAI/catalyst/pull/273)
 
   ```python
-  
+
   @qjit
   def add_multiply(l: jax.core.ShapedArray((3,), dtype=float), idx: int):
       res = l.at[idx].multiply(3)
@@ -92,6 +92,13 @@
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>
+
+* Fix filesystem issue when compiling multiple functions with the same name and
+  `keep_intermediate=True`.
+  [(#306)](https://github.com/PennyLaneAI/catalyst/pull/306)
+
+* Fix linking errors on Linux systems without a Clang installation.
+  [(#276)](https://github.com/PennyLaneAI/catalyst/pull/276)
 
 <h3>Contributors</h3>
 

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -474,8 +474,7 @@ class Directory:
         return self._impl.is_dir()
 
     def cleanup(self):
-        """Remove the contents of the directory.
-        """
+        """Remove the contents of the directory."""
         if isinstance(self._impl, tempfile.TemporaryDirectory):
             # The temporary directory can clean up
             # after itself...

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -44,11 +44,10 @@ from catalyst.pennylane_extensions import QFunc
 from catalyst.utils import wrapper  # pylint: disable=no-name-in-module
 from catalyst.utils.c_template import get_template, mlir_type_to_numpy_type
 from catalyst.utils.contexts import EvaluationContext
-from catalyst.utils.filesystem import Directory, WorkspaceManager
+from catalyst.utils.filesystem import WorkspaceManager
 from catalyst.utils.gen_mlir import inject_functions
 from catalyst.utils.patching import Patcher
 
-# pylint: disable=too-many-lines
 # Required for JAX tracer objects as PennyLane wires.
 # pylint: disable=unnecessary-lambda
 setattr(jax.interpreters.partial_eval.DynamicJaxprTracer, "__hash__", lambda x: id(x))
@@ -796,7 +795,6 @@ class JAX_QJIT:
         return self.jaxed_function(*args, **kwargs)
 
 
-# pylint: disable=too-many-arguments
 def qjit(
     fn=None,
     *,

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -580,12 +580,13 @@ class QJIT:
             pathlib.Path.cwd() if self.compile_options.keep_intermediate else None
         )
         # If we are compiling from textual ir, just use this as the name of the function.
-        preferred_workspace_name = (
-            "compiled_function" if self.compiling_from_textual_ir else self.__name__
-        )
-        self.workspace = WorkspaceManager.get_or_create_workspace(
-            preferred_workspace_name, preferred_workspace_dir
-        )
+        name = "compiled_function"
+        if not self.compiling_from_textual_ir:
+            # pylint: disable=no-member
+            # Guaranteed to exist after functools.update_wrapper AND not compiling from textual IR
+            name = self.__name__
+
+        self.workspace = WorkspaceManager.get_or_create_workspace(name, preferred_workspace_dir)
 
         if self.compiling_from_textual_ir:
             EvaluationContext.check_is_not_tracing("Cannot compile from IR in tracing context.")

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -19,8 +19,6 @@ import ctypes
 import functools
 import inspect
 import pathlib
-import shutil
-import tempfile
 import typing
 import warnings
 from enum import Enum
@@ -46,6 +44,7 @@ from catalyst.pennylane_extensions import QFunc
 from catalyst.utils import wrapper  # pylint: disable=no-name-in-module
 from catalyst.utils.c_template import get_template, mlir_type_to_numpy_type
 from catalyst.utils.contexts import EvaluationContext
+from catalyst.utils.filesystem import Directory, WorkspaceManager
 from catalyst.utils.gen_mlir import inject_functions
 from catalyst.utils.patching import Patcher
 
@@ -446,97 +445,6 @@ class CompiledFunction:
         )
 
         return result
-
-
-class Directory:
-    """Abstracts over pathlib and tempfile."""
-
-    def __init__(self, pathlibOrTempfile):
-        is_tempdir = isinstance(pathlibOrTempfile, tempfile.TemporaryDirectory)
-        is_path = isinstance(pathlibOrTempfile, pathlib.Path)
-        is_valid = is_tempdir or is_path
-        assert is_valid, "Invalid initialization of Directory"
-        self._impl = pathlibOrTempfile
-
-    def __str__(self):
-        if isinstance(self._impl, tempfile.TemporaryDirectory):
-            return self._impl.name
-        return str(self._impl)
-
-    def is_dir(self):
-        """Returns True if it is a directory.
-
-        Should always return True for both, however, we leave it to the implementation to actually
-        confirm it.
-        """
-        if isinstance(self._impl, tempfile.TemporaryDirectory):
-            return True
-        return self._impl.is_dir()
-
-    def cleanup(self):
-        """Remove the contents of the directory."""
-        if isinstance(self._impl, tempfile.TemporaryDirectory):
-            # The temporary directory can clean up
-            # after itself...
-            return
-        shutil.rmtree(str(self))
-
-
-class WorkspaceManager:
-    """Singleton object that manages the output files for the IR.
-
-    A good motivation for this is whether or not we are allowed to overwrite
-    folders in the user's directory if they match the preferred name.
-
-    This happens whenever we want to compile a function with the same name
-    multiple times and we have used the user facing option keep_intermediates=True.
-    """
-
-    # Operating System agnostic way of finding out what is the temporary
-    # directory. See https://docs.python.org/3.10/library/tempfile.html#tempfile.gettempdir
-    tempdir = pathlib.Path(tempfile.gettempdir())
-
-    @staticmethod
-    def get_or_create_workspace(name, path=None):
-        """
-        Args:
-            name (str): Directory name
-            path (Optional(str)): Directory path
-                                If path is None, then it will be a temporary directory
-                                stored in whatever temporary directory is specific to the
-                                operating system.
-        """
-        path, name = WorkspaceManager._get_preferred_abspath(name, path)
-        return Directory(WorkspaceManager._get_or_create_directory(path, name))
-
-    @staticmethod
-    def _get_preferred_abspath(name, path=None):
-        preferred_path = pathlib.Path(path) if path is not None else WorkspaceManager.tempdir
-        preferred_name = pathlib.Path(name)
-        return preferred_path, preferred_name
-
-    @staticmethod
-    def _get_or_create_directory(path, name):
-        if path == WorkspaceManager.tempdir:
-            # TODO: Once Python 3.12 becomes the least supported version of python, consider
-            # setting the fields: delete and delete_on_close.
-            # This can likely avoid having all the code below.
-            return tempfile.TemporaryDirectory(dir=path.resolve(), prefix=name.name)
-
-        count = 1
-        curr_preferred_abspath = path / name
-        preferred_name = name.name
-
-        # TODO: Maybe just look for the last one?
-        while curr_preferred_abspath.exists():
-            curr_preferred_name_str = preferred_name + "_" + str(count)
-            curr_preferred_name = pathlib.Path(curr_preferred_name_str)
-            curr_preferred_abspath = path / curr_preferred_name
-            count += 1
-
-        free_preferred_abspath = pathlib.Path(curr_preferred_abspath)
-        free_preferred_abspath.mkdir()
-        return free_preferred_abspath
 
 
 # pylint: disable=too-many-instance-attributes

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -478,7 +478,7 @@ class Directory:
         if isinstance(self._impl, tempfile.TemporaryDirectory):
             # The temporary directory can clean up
             # after itself...
-            ...
+            return
         shutil.rmtree(str(self))
 
 

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -466,7 +466,9 @@ class Directory:
 
     def cleanup(self):
         if isinstance(self._impl, tempfile.TemporaryDirectory):
-            self._impl.cleanup()
+            # The temporary directory can clean up
+            # after itself...
+            ...
         shutil.rmtree(str(self))
 
 

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -538,20 +538,20 @@ class QJIT:
         self._mlir = None
         self._llvmir = None
 
+        functools.update_wrapper(self, fn)
+
+        if compile_options.autograph:
+            self.user_function = run_autograph(fn)
+
         # QJIT is the owner of workspace.
         # do not move to compiler.
         preferred_workspace_dir = (
             pathlib.Path.cwd() if self.compile_options.keep_intermediate else None
         )
-        preferred_workspace_name = self.original_function.__name__
+        preferred_workspace_name = self.__name__
         self.workspace = WorkspaceManager.get_or_create_workspace(
             preferred_workspace_name, preferred_workspace_dir
         )
-
-        functools.update_wrapper(self, fn)
-
-        if compile_options.autograph:
-            self.user_function = run_autograph(fn)
 
         if self.compiling_from_textual_ir:
             EvaluationContext.check_is_not_tracing("Cannot compile from IR in tracing context.")
@@ -621,6 +621,7 @@ class QJIT:
 
     def compile(self):
         """Compile the current MLIR module."""
+
         if self.compiled_function and self.compiled_function.shared_object:
             self.compiled_function.shared_object.close()
 

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -20,6 +20,7 @@ import functools
 import inspect
 import os
 import pathlib
+import shutil
 import tempfile
 import typing
 import warnings
@@ -456,8 +457,17 @@ class Directory:
     def __str__(self):
         if isinstance(self._impl, tempfile.TemporaryDirectory):
             return self._impl.name
-        if isinstance(self._impl, pathlib.Path):
-            return str(self._impl)
+        return str(self._impl)
+
+    def is_dir(self):
+        if isinstance(self._impl, tempfile.TemporaryDirectory):
+            return True
+        return self._impl.is_dir()
+
+    def cleanup(self):
+        if isinstance(self._impl, tempfile.TemporaryDirectory):
+            self._impl.cleanup()
+        shutil.rmtree(str(self))
 
 
 class WorkspaceManager:
@@ -502,6 +512,7 @@ class WorkspaceManager:
             curr_preferred_name_str = preferred_name + "_" + str(count)
             curr_preferred_name = pathlib.Path(curr_preferred_name_str)
             curr_preferred_abspath = path / curr_preferred_name
+            count += 1
 
         free_preferred_abspath = pathlib.Path(curr_preferred_abspath)
         free_preferred_abspath.mkdir()

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -452,6 +452,10 @@ class Directory:
     """Abstracts over pathlib and tempfile."""
 
     def __init__(self, pathlibOrTempfile):
+        is_tempdir = isinstance(pathlibOrTempfile, tempfile.TemporaryDirectory)
+        is_path = isinstance(pathlibOrTempfile, pathlib.Path)
+        is_valid = is_tempdir or is_path
+        assert is_valid, "Invalid initialization of Directory"
         self._impl = pathlibOrTempfile
 
     def __str__(self):

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -474,6 +474,16 @@ class QJIT:
         self._mlir = None
         self._llvmir = None
 
+        # QJIT is the owner of workspace.
+        # do not move to compiler.
+        self.workspace = None
+
+        if self.compile_options.keep_intermediate:
+            workspace_name = os.path.abspath(os.path.join(os.getcwd(), self.user_function.__name__))
+            self.workspace = tempfile.NamedTemporaryFile(prefix=workspace_name, dir=os.getcwd(), delete=False, delete_on_close=False)
+        else:
+            self.workspace = tempfile.NamedTemporaryFile()
+
         functools.update_wrapper(self, fn)
 
         if compile_options.autograph:

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -18,7 +18,6 @@ compiling of hybrid quantum-classical functions using Catalyst.
 import ctypes
 import functools
 import inspect
-import os
 import pathlib
 import shutil
 import tempfile
@@ -50,6 +49,7 @@ from catalyst.utils.contexts import EvaluationContext
 from catalyst.utils.gen_mlir import inject_functions
 from catalyst.utils.patching import Patcher
 
+# pylint: disable=too-many-lines
 # Required for JAX tracer objects as PennyLane wires.
 # pylint: disable=unnecessary-lambda
 setattr(jax.interpreters.partial_eval.DynamicJaxprTracer, "__hash__", lambda x: id(x))
@@ -464,11 +464,18 @@ class Directory:
         return str(self._impl)
 
     def is_dir(self):
+        """Returns True if it is a directory.
+
+        Should always return True for both, however, we leave it to the implementation to actually
+        confirm it.
+        """
         if isinstance(self._impl, tempfile.TemporaryDirectory):
             return True
         return self._impl.is_dir()
 
     def cleanup(self):
+        """Remove the contents of the directory.
+        """
         if isinstance(self._impl, tempfile.TemporaryDirectory):
             # The temporary directory can clean up
             # after itself...
@@ -492,6 +499,14 @@ class WorkspaceManager:
 
     @staticmethod
     def get_or_create_workspace(name, path=None):
+        """
+        Args:
+            name (str): Directory name
+            path (Optional(str)): Directory path
+                                If path is None, then it will be a temporary directory
+                                stored in whatever temporary directory is specific to the
+                                operating system.
+        """
         path, name = WorkspaceManager._get_preferred_abspath(name, path)
         return Directory(WorkspaceManager._get_or_create_directory(path, name))
 

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -21,7 +21,6 @@ import platform
 import shutil
 import subprocess
 import sys
-import tempfile
 import warnings
 from dataclasses import dataclass
 from io import TextIOWrapper
@@ -311,6 +310,7 @@ class Compiler:
         self.options = options if options is not None else CompileOptions
         self.last_compiler_output = None
 
+    # pylint: disable=too-many-arguments
     def run_from_ir(
         self,
         ir: str,
@@ -406,6 +406,8 @@ class Compiler:
         Returns
             (Optional[str]): output IR
         """
+        # Here to avoid circular dependency
+        # pylint: disable=import-outside-toplevel
         from catalyst.compilation_pipelines import Directory
 
         assert isinstance(workspace, Directory), "get_output_of expects a Directory type."

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -400,11 +400,19 @@ class Compiler:
     def get_output_of(self, workspace, pipeline) -> Optional[str]:
         """Get the output IR of a pipeline.
         Args:
+            workspace (Directory): directory that holds data.
             pipeline (str): name of pass class
 
         Returns
             (Optional[str]): output IR
         """
+        from catalyst.compilation_pipelines import Directory
+
+        assert isinstance(workspace, Directory), "get_output_of expects a Directory type."
+
+        if not self.last_compiler_output:
+            return None
+
         return self.last_compiler_output.get_pipeline_output(pipeline)
 
     def print(self, workspace, pipeline):

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -409,6 +409,7 @@ class Compiler:
         from catalyst.compilation_pipelines import Directory
 
         assert isinstance(workspace, Directory), "get_output_of expects a Directory type."
+        assert workspace.is_dir(), "We expect a directory."
 
         if not self.last_compiler_output:
             return None

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -408,7 +408,7 @@ class Compiler:
         """
         # Here to avoid circular dependency
         # pylint: disable=import-outside-toplevel
-        from catalyst.compilation_pipelines import Directory
+        from catalyst.utils.filesystem import Directory
 
         assert isinstance(workspace, Directory), "get_output_of expects a Directory type."
         assert workspace.is_dir(), "We expect a directory."

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -30,6 +30,7 @@ from mlir_quantum.compiler_driver import run_compiler_driver
 
 from catalyst._configuration import INSTALLED
 from catalyst.utils.exceptions import CompileError
+from catalyst.utils.filesystem import Directory
 
 package_root = os.path.dirname(__file__)
 
@@ -406,10 +407,6 @@ class Compiler:
         Returns
             (Optional[str]): output IR
         """
-        # Here to avoid circular dependency
-        # pylint: disable=import-outside-toplevel
-        from catalyst.utils.filesystem import Directory
-
         assert isinstance(workspace, Directory), "get_output_of expects a Directory type."
         assert workspace.is_dir(), "We expect a directory."
 

--- a/frontend/catalyst/utils/filesystem.py
+++ b/frontend/catalyst/utils/filesystem.py
@@ -1,0 +1,111 @@
+# Copyright 2023 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Functions to interface with the filesystem.
+"""
+
+import pathlib
+import shutil
+import tempfile
+
+
+class Directory:
+    """Abstracts over pathlib and tempfile."""
+
+    def __init__(self, pathlibOrTempfile):
+        is_tempdir = isinstance(pathlibOrTempfile, tempfile.TemporaryDirectory)
+        is_path = isinstance(pathlibOrTempfile, pathlib.Path)
+        is_valid = is_tempdir or is_path
+        assert is_valid, "Invalid initialization of Directory"
+        self._impl = pathlibOrTempfile
+
+    def __str__(self):
+        if isinstance(self._impl, tempfile.TemporaryDirectory):
+            return self._impl.name
+        return str(self._impl)
+
+    def is_dir(self):
+        """Returns True if it is a directory.
+
+        Should always return True for both, however, we leave it to the implementation to actually
+        confirm it.
+        """
+        if isinstance(self._impl, tempfile.TemporaryDirectory):
+            return True
+        return self._impl.is_dir()
+
+    def cleanup(self):
+        """Remove the contents of the directory."""
+        if isinstance(self._impl, tempfile.TemporaryDirectory):
+            # The temporary directory can clean up
+            # after itself...
+            return
+        shutil.rmtree(str(self))
+
+
+class WorkspaceManager:
+    """Singleton object that manages the output files for the IR.
+
+    A good motivation for this is whether or not we are allowed to overwrite
+    folders in the user's directory if they match the preferred name.
+
+    This happens whenever we want to compile a function with the same name
+    multiple times and we have used the user facing option keep_intermediates=True.
+    """
+
+    # Operating System agnostic way of finding out what is the temporary
+    # directory. See https://docs.python.org/3.10/library/tempfile.html#tempfile.gettempdir
+    tempdir = pathlib.Path(tempfile.gettempdir())
+
+    @staticmethod
+    def get_or_create_workspace(name, path=None):
+        """
+        Args:
+            name (str): Directory name
+            path (Optional(str)): Directory path
+                                If path is None, then it will be a temporary directory
+                                stored in whatever temporary directory is specific to the
+                                operating system.
+        """
+        path, name = WorkspaceManager._get_preferred_abspath(name, path)
+        return Directory(WorkspaceManager._get_or_create_directory(path, name))
+
+    @staticmethod
+    def _get_preferred_abspath(name, path=None):
+        preferred_path = pathlib.Path(path) if path is not None else WorkspaceManager.tempdir
+        preferred_name = pathlib.Path(name)
+        return preferred_path, preferred_name
+
+    @staticmethod
+    def _get_or_create_directory(path, name):
+        if path == WorkspaceManager.tempdir:
+            # TODO: Once Python 3.12 becomes the least supported version of python, consider
+            # setting the fields: delete and delete_on_close.
+            # This can likely avoid having all the code below.
+            return tempfile.TemporaryDirectory(dir=path.resolve(), prefix=name.name)
+
+        count = 1
+        curr_preferred_abspath = path / name
+        preferred_name = name.name
+
+        # TODO: Maybe just look for the last one?
+        while curr_preferred_abspath.exists():
+            curr_preferred_name_str = preferred_name + "_" + str(count)
+            curr_preferred_name = pathlib.Path(curr_preferred_name_str)
+            curr_preferred_abspath = path / curr_preferred_name
+            count += 1
+
+        free_preferred_abspath = pathlib.Path(curr_preferred_abspath)
+        free_preferred_abspath.mkdir()
+        return free_preferred_abspath

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -129,7 +129,6 @@ class TestSourceCodeInfo:
 class TestIntegration:
     """Test that the autograph transformations trigger correctly in different settings."""
 
-    @pytest.mark.xfail(reason="temp")
     def test_unsupported_object(self):
         """Check the error produced when attempting to convert an unsupported object (neither of
         QNode, function, or method)."""

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -129,6 +129,7 @@ class TestSourceCodeInfo:
 class TestIntegration:
     """Test that the autograph transformations trigger correctly in different settings."""
 
+    @pytest.mark.xfail(reason="temp")
     def test_unsupported_object(self):
         """Check the error produced when attempting to convert an unsupported object (neither of
         QNode, function, or method)."""

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -52,6 +52,7 @@ class TestCompilerOptions:
             compilers = LinkerDriver._get_compiler_fallback_order([])
             assert compiler in compilers
 
+    @pytest.mark.skip(reason="temp")
     @pytest.mark.parametrize(
         "logfile,keep_intermediate", [("stdout", True), ("stderr", False), (None, False)]
     )
@@ -108,6 +109,7 @@ class TestCompilerErrors:
             with pytest.raises(CompileError, match="Unable to link .*"):
                 LinkerDriver.run(invalid_file.name, fallback_compilers=["cc"])
 
+    @pytest.mark.xfail(reason="temp")
     def test_attempts_to_get_inexistent_intermediate_file(self):
         """Test return value if user request intermediate file that doesn't exist."""
         compiler = Compiler()
@@ -173,6 +175,7 @@ void _catalyst_pyface_jit_cpp_exception_test(void*, void*) {
 class TestCompilerState:
     """Test states that the compiler can reach."""
 
+    @pytest.mark.xfail(reason="temp")
     def test_print_stages(self, backend):
         """Test that after compiling the intermediate files exist."""
 
@@ -198,6 +201,7 @@ class TestCompilerState:
         assert compiler.get_output_of("MHLOPass") is None
         assert compiler.get_output_of("None-existing-pipeline") is None
 
+    @pytest.mark.xfail(reason="fail")
     def test_workspace_keep_intermediate(self, backend):
         """Test cwd's has been modified with folder containing intermediate results"""
 
@@ -220,6 +224,7 @@ class TestCompilerState:
         assert files
         shutil.rmtree(directory)
 
+    @pytest.mark.xfail(reason="fail")
     def test_workspace_temporary(self):
         """Test temporary directory has been modified with folder containing intermediate results"""
 
@@ -269,6 +274,7 @@ class TestCompilerState:
             assert observed_outfilename == expected_outfilename
             assert os.path.exists(observed_outfilename)
 
+    @pytest.mark.xfail(reason="temp")
     def test_compiler_from_textual_ir(self):
         """Test the textual IR compilation."""
 

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -29,9 +29,8 @@ import pennylane as qml
 import pytest
 
 from catalyst import qjit
-from catalyst.compilation_pipelines import Directory
+from catalyst.compilation_pipelines import Directory, WorkspaceManager
 from catalyst.compiler import CompileOptions, Compiler, LinkerDriver
-from catalyst.jax_tracer import trace_to_mlir
 from catalyst.pennylane_extensions import measure, qfunc
 from catalyst.utils.exceptions import CompileError
 
@@ -113,14 +112,15 @@ class TestCompilerErrors:
         """
         compiler = Compiler()
         with pytest.raises(AssertionError, match="expects a Directory type"):
-            result = compiler.get_output_of(None, "inexistent-file")
+            compiler.get_output_of(None, "inexistent-file")
 
     def test_attempts_to_get_inexistent_intermediate_file(self):
         """Test return value if user request intermediate file that doesn't exist."""
         compiler = Compiler()
-        workspace = tempfile.TemporaryDirectory()
-        result = compiler.get_output_of(Directory(workspace), "inexistent-file")
+        workspace = WorkspaceManager.get_or_create_workspace("a-name")
+        result = compiler.get_output_of(workspace, "inexistent-file")
         assert result is None
+        workspace.cleanup()
 
     def test_runtime_error(self, backend):
         """Test with non-default flags."""

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -19,7 +19,6 @@ Unit tests for LinkerDriver class
 import os
 import pathlib
 import platform
-import shutil
 import subprocess
 import sys
 import tempfile

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -141,9 +141,6 @@ void _catalyst_pyface_jit_cpp_exception_test(void*, void*) {
         class MockCompiler(Compiler):
             """Mock compiler class"""
 
-            def __init__(self, co):
-                super().__init__(co)
-
             def run_from_ir(self, *_args, **_kwargs):
                 with tempfile.TemporaryDirectory() as workspace:
                     filename = workspace + "a.cpp"

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -257,7 +257,6 @@ class TestCompilerState:
             assert observed_outfilename == expected_outfilename
             assert os.path.exists(observed_outfilename)
 
-    @pytest.mark.xfail(reason="temp")
     def test_compiler_from_textual_ir(self):
         """Test the textual IR compilation."""
 

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -53,7 +53,6 @@ class TestCompilerOptions:
             compilers = LinkerDriver._get_compiler_fallback_order([])
             assert compiler in compilers
 
-    @pytest.mark.skip(reason="temp")
     @pytest.mark.parametrize(
         "logfile,keep_intermediate", [("stdout", True), ("stderr", False), (None, False)]
     )
@@ -77,9 +76,7 @@ class TestCompilerOptions:
         assert ("[SYSTEM]" in capture) if verbose else ("[SYSTEM]" not in capture)
         assert ("[LIB]" in capture) if verbose else ("[LIB]" not in capture)
         assert ("Dumping" in capture) if (verbose and keep_intermediate) else True
-        if keep_intermediate:
-            directory = os.path.join(os.getcwd(), workflow.__name__)
-            shutil.rmtree(directory)
+        workflow.workspace.cleanup()
 
 
 class TestCompilerWarnings:

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -233,22 +233,16 @@ class TestCompilerState:
         assert files
         shutil.rmtree(directory)
 
-    @pytest.mark.xfail(reason="fail")
-    def test_workspace_temporary(self):
-        """Test temporary directory has been modified with folder containing intermediate results"""
+    def test_workspace(self):
+        """Test directory has been modified with folder containing intermediate results"""
 
-        @qjit
+        @qjit(keep_intermediate=True, target="mlir")
         @qml.qnode(qml.device("lightning.qubit", wires=1))
         def workflow():
             qml.PauliX(wires=0)
             return qml.state()
 
-        mlir_module, _, _, _ = trace_to_mlir(workflow)
-        # This means that we are not running any pass.
-        identity_compiler = Compiler(CompileOptions(keep_intermediate=True))
-        identity_compiler.run(mlir_module, pipelines=[], lower_to_llvm=False)
         directory = os.path.join(os.getcwd(), workflow.__name__)
-        assert directory == identity_compiler.last_workspace
         files = os.listdir(directory)
         # The directory is non-empty. Should at least contain the original .mlir file
         assert files

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -210,29 +210,6 @@ class TestCompilerState:
         assert compiler.get_output_of("MHLOPass") is None
         assert compiler.get_output_of("None-existing-pipeline") is None
 
-    @pytest.mark.xfail(reason="fail")
-    def test_workspace_keep_intermediate(self, backend):
-        """Test cwd's has been modified with folder containing intermediate results"""
-
-        @qjit
-        @qml.qnode(qml.device(backend, wires=1))
-        def workflow():
-            qml.PauliX(wires=0)
-            return qml.state()
-
-        mlir_module, _, _, _ = trace_to_mlir(workflow)
-        # This means that we are not running any pass.
-        pipelines = []
-        identity_compiler = Compiler(CompileOptions(keep_intermediate=True))
-        identity_compiler.run(mlir_module, pipelines=pipelines, lower_to_llvm=False)
-        directory = os.path.join(os.getcwd(), workflow.__name__)
-        assert directory == identity_compiler.last_workspace
-        assert os.path.exists(directory)
-        files = os.listdir(directory)
-        # The directory is non-empty. Should at least contain the original .mlir file
-        assert files
-        shutil.rmtree(directory)
-
     def test_workspace(self):
         """Test directory has been modified with folder containing intermediate results"""
 

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -29,7 +29,7 @@ import pennylane as qml
 import pytest
 
 from catalyst import qjit
-from catalyst.compilation_pipelines import Directory, WorkspaceManager
+from catalyst.compilation_pipelines import WorkspaceManager
 from catalyst.compiler import CompileOptions, Compiler, LinkerDriver
 from catalyst.pennylane_extensions import measure, qfunc
 from catalyst.utils.exceptions import CompileError

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -220,7 +220,7 @@ class TestCompilerState:
         files = os.listdir(directory)
         # The directory is non-empty. Should at least contain the original .mlir file
         assert files
-        shutil.rmtree(directory)
+        workflow.workspace.cleanup()
 
     def test_compiler_driver_with_output_name(self):
         """Test with non-default output name."""

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -905,17 +905,18 @@ class TestAvoidVerification:
 class TestTwoQJITsOneName:
     """Test two QJITs with the same name."""
 
+    # pylint: disable=disallowed-name
+    # pylint: disable=function-redefined
+
     def test_two_qjit(self):
         """Test two qjits with the same name"""
 
-        # pylint: disable=disallowed-name
         def foo():
             """Returns 1"""
             return 1
 
         foo_1 = qjit(foo)
 
-        # pylint: disable=function-redefined
         def foo():
             """Returns 2"""
             return 2
@@ -928,14 +929,12 @@ class TestTwoQJITsOneName:
     def test_two_qjit_keep_intermediate(self):
         """Test two qjits with the same name but also keep intermediate=True"""
 
-        # pylint: disable=disallowed-name
         def foo():
             """Returns 1"""
             return 1
 
         foo_1 = qjit(keep_intermediate=True)(foo)
 
-        # pylint: disable=function-redefined
         def foo():
             """Returns 2"""
             return 2

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -903,7 +903,7 @@ class TestAvoidVerification:
 
 
 class TestTwoQJITsOneName:
-    @pytest.mark.skip(reason="temp")
+
     def test_two_qjit(self, backend):
         def foo():
             return 1
@@ -918,7 +918,6 @@ class TestTwoQJITsOneName:
         assert foo_1() == 1
         assert foo_2() == 2
 
-    @pytest.mark.skip(reason="temp")
     def test_two_qjit_keep_intermediate(self, backend):
         def foo():
             return 1

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -903,6 +903,8 @@ class TestAvoidVerification:
 
 
 class TestTwoQJITsOneName:
+    """Test two QJITs with the same name."""
+
     def test_two_qjit(self):
         """Test two qjits with the same name"""
 

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -944,6 +944,8 @@ class TestTwoQJITsOneName:
 
         assert foo_1() == 1
         assert foo_2() == 2
+        foo_1.workspace.cleanup()
+        foo_2.workspace.cleanup()
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -903,6 +903,7 @@ class TestAvoidVerification:
 
 
 class TestTwoQJITsOneName:
+    @pytest.mark.skip(reason="temp")
     def test_two_qjit(self, backend):
         def foo():
             return 1
@@ -917,6 +918,7 @@ class TestTwoQJITsOneName:
         assert foo_1() == 1
         assert foo_2() == 2
 
+    @pytest.mark.skip(reason="temp")
     def test_two_qjit_keep_intermediate(self, backend):
         def foo():
             return 1

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -903,14 +903,19 @@ class TestAvoidVerification:
 
 
 class TestTwoQJITsOneName:
+    def test_two_qjit(self):
+        """Test two qjits with the same name"""
 
-    def test_two_qjit(self, backend):
+        # pylint: disable=disallowed-name
         def foo():
+            """Returns 1"""
             return 1
 
         foo_1 = qjit(foo)
 
+        # pylint: disable=function-redefined
         def foo():
+            """Returns 2"""
             return 2
 
         foo_2 = qjit(foo)
@@ -918,13 +923,19 @@ class TestTwoQJITsOneName:
         assert foo_1() == 1
         assert foo_2() == 2
 
-    def test_two_qjit_keep_intermediate(self, backend):
+    def test_two_qjit_keep_intermediate(self):
+        """Test two qjits with the same name but also keep intermediate=True"""
+
+        # pylint: disable=disallowed-name
         def foo():
+            """Returns 1"""
             return 1
 
         foo_1 = qjit(keep_intermediate=True)(foo)
 
+        # pylint: disable=function-redefined
         def foo():
+            """Returns 2"""
             return 2
 
         foo_2 = qjit(keep_intermediate=True)(foo)

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -902,5 +902,35 @@ class TestAvoidVerification:
         assert "does not reference a valid function" not in capture_string.err
 
 
+class TestTwoQJITsOneName:
+    def test_two_qjit(self, backend):
+        def foo():
+            return 1
+
+        foo_1 = qjit(foo)
+
+        def foo():
+            return 2
+
+        foo_2 = qjit(foo)
+
+        assert foo_1() == 1
+        assert foo_2() == 2
+
+    def test_two_qjit_keep_intermediate(self, backend):
+        def foo():
+            return 1
+
+        foo_1 = qjit(keep_intermediate=True)(foo)
+
+        def foo():
+            return 2
+
+        foo_2 = qjit(keep_intermediate=True)(foo)
+
+        assert foo_1() == 1
+        assert foo_2() == 2
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])


### PR DESCRIPTION
**Context:** Having a single workspace for a single python function to be compiled could lead to an error when the same function was compiled multiple times or another function with the same name was compiled. It also wasn't entirely clear what the behaviour should be when using `keep_intermediate` and a function was recompiled.

**Description of the Change:** Now when two functions of the request the same name, a new directory will be created appending `_$NUM`. 

**Benefits:** No issues with compiling functions with the same name.

**Possible Drawbacks:**

**Related GitHub Issues:** closes #291 

[sc-47499]