### PR TITLE
Disable ZLIB and ZSTD in wheels

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -119,7 +119,9 @@ jobs:
               -DLLVM_TARGETS_TO_BUILD="host" \
               -DLLVM_ENABLE_PROJECTS="lld;mlir" \
               -DLLVM_ENABLE_ASSERTIONS=ON \
-              -DLLVM_INSTALL_UTILS=ON
+              -DLLVM_INSTALL_UTILS=ON \
+              -DLLVM_ENABLE_ZLIB=OFF \
+              -DLLVM_ENABLE_ZSTD=OFF
 
         # TODO: when updating LLVM, test to see if mlir/unittests/Bytecode/BytecodeTest.cpp:55 is passing
         # and remove filter
@@ -134,7 +136,9 @@ jobs:
               -DCMAKE_BUILD_TYPE=Release \
               -DLLVM_ENABLE_ASSERTIONS=ON \
               -DMLIR_DIR=$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir \
-              -DLLVM_ENABLE_LLD=ON
+              -DLLVM_ENABLE_LLD=ON \
+              -DLLVM_ENABLE_ZLIB=OFF \
+              -DLLVM_ENABLE_ZSTD=OFF
 
         cmake --build mhlo-build --target check-mlir-hlo
 
@@ -239,7 +243,9 @@ jobs:
               -DLIGHTNING_GIT_TAG="master" \
               -DKokkos_ENABLE_SERIAL=ON \
               -DKokkos_ENABLE_OPENMP=ON \
-              -DENABLE_OPENQASM=ON
+              -DENABLE_OPENQASM=ON \
+              -DLLVM_ENABLE_ZLIB=OFF \
+              -DLLVM_ENABLE_ZSTD=OFF
 
         cmake --build runtime-build --target rt_capi
 
@@ -255,7 +261,9 @@ jobs:
               -DLLVM_INSTALL_UTILS=ON \
               -DMLIR_ENABLE_BINDINGS_PYTHON=ON \
               -DPython3_EXECUTABLE=$(which python${{ matrix.python_version }}) \
-              -DPython3_NumPy_INCLUDE_DIRS=$(python${{ matrix.python_version }} -c "import numpy as np; print(np.get_include())")
+              -DPython3_NumPy_INCLUDE_DIRS=$(python${{ matrix.python_version }} -c "import numpy as np; print(np.get_include())") \
+              -DLLVM_ENABLE_ZLIB=OFF \
+              -DLLVM_ENABLE_ZSTD=OFF
 
         # TODO: when updating LLVM, test to see if mlir/unittests/Bytecode/BytecodeTest.cpp:55 is passing
         # and remove filter
@@ -274,7 +282,9 @@ jobs:
               -DMHLO_DIR=$GITHUB_WORKSPACE/mhlo-build/lib/cmake/mlir-hlo \
               -DMHLO_BINARY_DIR=$GITHUB_WORKSPACE/mhlo-build/bin \
               -DEnzyme_DIR=$GITHUB_WORKSPACE/enzyme-build \
-              -DENZYME_SRC_DIR=$GITHUB_WORKSPACE/mlir/Enzyme
+              -DENZYME_SRC_DIR=$GITHUB_WORKSPACE/mlir/Enzyme \
+              -DLLVM_ENABLE_ZLIB=OFF \
+              -DLLVM_ENABLE_ZSTD=OFF
 
         cmake --build quantum-build --target check-dialects compiler_driver
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -6,7 +6,7 @@
   [(#273)](https://github.com/PennyLaneAI/catalyst/pull/273)
 
   ```python
-  
+
   @qjit
   def add_multiply(l: jax.core.ShapedArray((3,), dtype=float), idx: int):
       res = l.at[idx].multiply(3)
@@ -97,6 +97,9 @@
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>
+
+* Remove undocumented package dependency on the zlib/zstd compression library.
+  [(#308)](https://github.com/PennyLaneAI/catalyst/pull/308)
 
 * Add support for applying the `adjoint` operation to `QubitUnitary` gates.
   `QubitUnitary` was not able to be `adjoint`ed when the variable holding the unitary matrix might


### PR DESCRIPTION
We decided to disable the ZLIB and ZSTD libraries in the wheels, as we didn't find any specific drawbacks associated with this action yet. However, we continue to build and test Catalyst with the default values for LLVM_ENABLE_ZLIB=ON and LLVM_ENABLE_ZSTD=ON in `check-catalyst.yaml`.