### PR TITLE
[MLIR] Removes use of ValueRange after using sanitizers.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -112,6 +112,7 @@
   The unitary matrix is later reconstructed from the array list and `QubitUnitary` can be executed
   in the `adjoint`ed context.
   [(#304)](https://github.com/PennyLaneAI/catalyst/pull/304)
+  [(#310)](https://github.com/PennyLaneAI/catalyst/pull/310)
 
 * Fix linking errors on Linux systems without a Clang installation.
   [(#276)](https://github.com/PennyLaneAI/catalyst/pull/276)

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -284,7 +284,7 @@ def QubitUnitaryOp : Gate_Op<"unitary", [NoMemoryEffect, ParametrizedGate]> {
 
     let extraClassDeclaration = extraBaseClassDeclaration # [{
         mlir::ValueRange getAllParams() {
-            return getODSOperands(0);
+            return getODSOperands(getParamOperandIdx());
         }
     }];
 

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -253,7 +253,7 @@ def MultiRZOp : Gate_Op<"multirz", [NoMemoryEffect, DifferentiableGate]> {
 
     let extraClassDeclaration = extraBaseClassDeclaration # [{
         mlir::ValueRange getAllParams() {
-            return getODSOperands(0);
+            return getODSOperands(getParamOperandIdx());
         }
     }];
 }

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -284,8 +284,7 @@ def QubitUnitaryOp : Gate_Op<"unitary", [NoMemoryEffect, ParametrizedGate]> {
 
     let extraClassDeclaration = extraBaseClassDeclaration # [{
         mlir::ValueRange getAllParams() {
-            mlir::ValueRange temp = {getMatrix()};
-            return temp;
+            return getODSOperands(0);
         }
     }];
 

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -240,7 +240,7 @@ class AdjointGenerator {
                             builder.create<index::SubOp>(loc, dim1Length, jPlusOne);
                         // Just for legibility
                         Value jTensorIndex = nMinusJMinusOne;
-                        std::vector<Value> indices = {iTensorIndex, jTensorIndex};
+                        SmallVector<Value> indices = {iTensorIndex, jTensorIndex};
 
                         Value updatedIthJthTensor = builder.create<tensor::InsertOp>(
                             loc, element, currIthJthTensor, indices);

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -240,7 +240,7 @@ class AdjointGenerator {
                             builder.create<index::SubOp>(loc, dim1Length, jPlusOne);
                         // Just for legibility
                         Value jTensorIndex = nMinusJMinusOne;
-                        ValueRange indices = {iTensorIndex, jTensorIndex};
+                        std::vector<Value> indices = {iTensorIndex, jTensorIndex};
 
                         Value updatedIthJthTensor = builder.create<tensor::InsertOp>(
                             loc, element, currIthJthTensor, indices);


### PR DESCRIPTION
**Context:** Wheels did not pass because of memory issues. After looking into it with address sanitizers, ValueRange is the culprit.

**Description of the Change:** Do not use ValueRange.

https://github.com/PennyLaneAI/catalyst/actions/runs/6495027163
