### PR TITLE
A few minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ wheel:
 clean:
 	@echo "uninstall catalyst and delete all temporary and cache files"
 	$(PYTHON) -m pip uninstall -y pennylane-catalyst
+	rm -rf $(MK_DIR)/frontend/mlir_quantum $(MK_DIR)/frontend/catalyst/lib
 	rm -rf dist __pycache__
 	rm -rf .coverage coverage_html_report
 

--- a/mlir/Makefile
+++ b/mlir/Makefile
@@ -120,7 +120,7 @@ test:
 .PHONY: clean
 clean:
 	@echo "clean build files"
-	rm -rf $(DIALECTS_BUILD_DIR) $(LLVM_BUILD_DIR) $(MHLO_BUILD_DIR)
+	rm -rf $(DIALECTS_BUILD_DIR) $(LLVM_BUILD_DIR) $(MHLO_BUILD_DIR) $(ENZYME_BUILD_DIR)
 
 .PHONY: format
 format:

--- a/mlir/include/Driver/CompilerDriver.h
+++ b/mlir/include/Driver/CompilerDriver.h
@@ -16,6 +16,7 @@
 
 #include <filesystem>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "mlir/IR/MLIRContext.h"

--- a/mlir/python/CMakeLists.txt
+++ b/mlir/python/CMakeLists.txt
@@ -54,7 +54,7 @@ add_mlir_python_common_capi_library(QuantumPythonCAPI
 add_library(compiler_driver MODULE PyCompilerDriver.cpp)
 set_target_properties(compiler_driver PROPERTIES PREFIX "")
 
-target_link_libraries(compiler_driver PRIVATE pybind11::headers pybind11::module CatalystCompilerDriver)
+target_link_libraries(compiler_driver PRIVATE pybind11::module CatalystCompilerDriver)
 
 set_target_properties(compiler_driver PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${MLIR_BINARY_DIR}/python_packages/quantum/mlir_quantum)
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -13,7 +13,7 @@ ENABLE_LIGHTNING_KOKKOS?=OFF
 ENABLE_OPENQASM?=OFF
 BUILD_QIR_STDLIB_FROM_SRC?=OFF
 # TODO: Update to latest_release after v0.33.0
-LIGHTNING_GIT_TAG_VALUE= "master"
+LIGHTNING_GIT_TAG_VALUE?="master"
 NPROC?=$(shell python -c "import os; print(os.cpu_count())")
 
 coverage: CODE_COVERAGE=ON


### PR DESCRIPTION
- Update `make clean` (Makefile) to remove `libs` and `mlir_quantum` folders
- Update `make clean` (mlir/Makefile) to remove the build directory of Enzyme
- Add the missing header to `CompilerDriver.h` (to fix the build failure on macOS x86 using clang-14) 
- Remove the unnecessary `pybind11::headers` library link for the `compiler_driver` Python bindings
- Fix the GIT tag macro in runtime/Makefile