### PR TITLE
Fix GCC support in Catalyst with `-no-as-needed`

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -98,6 +98,15 @@
 
 <h3>Bug fixes</h3>
 
+* Fix incompatibilities with GCC on Linux introduced in v0.3.0 when compiling user programs.
+  Due to these, Catalyst v0.3.0 only works when clang is installed in the user environment.
+
+  - Resolve an issue with an empty linker flag, causing `ld` to error.
+    [(#276)](https://github.com/PennyLaneAI/catalyst/pull/276)
+
+  - Resolve an issue with undefined symbols provided the Catalyst runtime.
+    [(#316)](https://github.com/PennyLaneAI/catalyst/pull/316)
+
 * Remove undocumented package dependency on the zlib/zstd compression library.
   [(#308)](https://github.com/PennyLaneAI/catalyst/pull/308)
 
@@ -114,14 +123,12 @@
   [(#304)](https://github.com/PennyLaneAI/catalyst/pull/304)
   [(#310)](https://github.com/PennyLaneAI/catalyst/pull/310)
 
-* Fix linking errors on Linux systems without a Clang installation.
-  [(#276)](https://github.com/PennyLaneAI/catalyst/pull/276)
-
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
 Ali Asadi,
+David Ittah,
 Erick Ochoa Lopez,
 Jacob Mai Peng,
 Sergei Mironov,
@@ -511,7 +518,7 @@ Romain Moyard.
   [(#211)](https://github.com/PennyLaneAI/catalyst/pull/211)
 
 * Fixed the incorrect return value data-type with functions returning `qml.counts`.
- [(#221)](https://github.com/PennyLaneAI/catalyst/pull/221)
+  [(#221)](https://github.com/PennyLaneAI/catalyst/pull/221)
 
 * Fix segmentation fault when differentiating a function where a quantum measurement is used
   multiple times by the same operation.

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -200,33 +200,34 @@ class LinkerDriver:
         """
         mlir_lib_path = get_lib_path("llvm", "MLIR_LIB_DIR")
         rt_lib_path = get_lib_path("runtime", "RUNTIME_LIB_DIR")
-        error_flag_apple = "-Wl,-arch_errors_fatal"
 
-        lib_path = [
+        lib_path_flags = [
             f"-Wl,-rpath,{mlir_lib_path}",
             f"-L{mlir_lib_path}",
         ]
 
         if rt_lib_path != mlir_lib_path:
-            lib_path.extend(
-                [
-                    f"-Wl,-rpath,{rt_lib_path}",
-                    f"-L{rt_lib_path}",
-                ]
-            )
+            lib_path_flags += [
+                f"-Wl,-rpath,{rt_lib_path}",
+                f"-L{rt_lib_path}",
+            ]
+
+        system_flags = []
+        if platform.system() == "Linux":
+            system_flags += ["-Wl,-no-as-needed"]
+        elif platform.system() == "Darwin":  # pragma: no cover
+            system_flags += ["-Wl,-arch_errors_fatal"]
 
         default_flags = [
             "-shared",
             "-rdynamic",
-            *lib_path,
+            *system_flags,
+            *lib_path_flags,
             "-lrt_backend",
             "-lrt_capi",
             "-lpthread",
             "-lmlir_c_runner_utils",  # required for memref.copy
         ]
-
-        if platform.system() == "Darwin":  # pragma: no cover
-            default_flags += [error_flag_apple]
 
         return default_flags
 


### PR DESCRIPTION
With the introduction of macOS the linker flag `-no-as-needed` was removed when compiling user programs, since it doesn't exist it on macOS. However, GCC defaults to including libraries during linking only "as-needed", meaning if they contain definitions for undefined symbols. For the `librt_backend.so` library, the user program doesn't actually reference any of its symbols, leading the linker to ignore it, which generates undefined symbol errors when the user program is loaded.

This fix reenables `-Wl,-no-as-needed` on Linux systems, although alternative might be to set up the runtime libraries such that they can correctly load each other transitively in a dependency chain.