### PR TITLE
[MLIR] Disable printing stack traces on the entry point search remark

### DIFF
--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -99,6 +99,15 @@ struct CatalystPassInstrumentation : public PassInstrumentation {
     }
 };
 
+
+// Run the callback with stack printing disabled
+void withoutStackTrace(MLIRContext *ctx, std::function<void()> callback) {
+    auto old = ctx->shouldPrintStackTraceOnDiagnostic();
+    ctx->printStackTraceOnDiagnostic(false);
+    callback();
+    ctx->printStackTraceOnDiagnostic(old);
+}
+
 } // namespace
 
 namespace {
@@ -142,13 +151,18 @@ void registerAllCatalystDialects(DialectRegistry &registry)
 FailureOr<llvm::Function *> getJITFunction(MLIRContext *ctx, llvm::Module &llvmModule)
 {
     Location loc = NameLoc::get(StringAttr::get(ctx, llvmModule.getName()));
+    std::list<StringRef> visited;
     for (auto &function : llvmModule.functions()) {
-        emitRemark(loc) << "Found LLVM function: " << function.getName() << "\n";
+        visited.push_back(function.getName());
         if (function.getName().starts_with("catalyst.entry_point")) {
             return &function;
         }
     }
-    emitError(loc, "Failed to find JIT function");
+    withoutStackTrace(ctx, [&]() {
+        auto noteStream = emitRemark(loc, "Failed to find entry-point function among the following: ");
+        llvm::interleaveComma(visited, noteStream, [&](StringRef t) { noteStream << t; });
+    });
+
     return failure();
 }
 
@@ -474,7 +488,7 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
             }
         }
         else {
-            CO_MSG(options, Verbosity::Urgent, "Unable to infer jit_* function attributes\n");
+            CO_MSG(options, Verbosity::Urgent, "Unable to infer catalyst.entry_point* function attributes\n");
         }
 
         auto outfile = options.getObjectFile();

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -99,9 +99,9 @@ struct CatalystPassInstrumentation : public PassInstrumentation {
     }
 };
 
-
 // Run the callback with stack printing disabled
-void withoutStackTrace(MLIRContext *ctx, std::function<void()> callback) {
+void withoutStackTrace(MLIRContext *ctx, std::function<void()> callback)
+{
     auto old = ctx->shouldPrintStackTraceOnDiagnostic();
     ctx->printStackTraceOnDiagnostic(false);
     callback();
@@ -159,7 +159,8 @@ FailureOr<llvm::Function *> getJITFunction(MLIRContext *ctx, llvm::Module &llvmM
         }
     }
     withoutStackTrace(ctx, [&]() {
-        auto noteStream = emitRemark(loc, "Failed to find entry-point function among the following: ");
+        auto noteStream =
+            emitRemark(loc, "Failed to find entry-point function among the following: ");
         llvm::interleaveComma(visited, noteStream, [&](StringRef t) { noteStream << t; });
     });
 
@@ -488,7 +489,8 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
             }
         }
         else {
-            CO_MSG(options, Verbosity::Urgent, "Unable to infer catalyst.entry_point* function attributes\n");
+            CO_MSG(options, Verbosity::Urgent,
+                   "Unable to infer catalyst.entry_point* function attributes\n");
         }
 
         auto outfile = options.getObjectFile();


### PR DESCRIPTION
By default, MLIR prints stack traces for all messages including remarks. By this PR we alter the remarks found in the IR entry-point detection algorithm of the compiler driver and also disable printing the traces. So, the changes are:

* Simplify and correct the entry point search result message
* Disable printing stack traces for this message.