### PR TITLE
[Runtime] Fixes the issue with missing `CFP_t`

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -14,7 +14,6 @@
 
 * Fixes the issue with missing `CFP_t` in `StateVectorLQubitDynamic` when building against the master
   branch of PennyLane-Lightning. This issue introduced in [PR 499](https://github.com/PennyLaneAI/pennylane-lightning/pull/499).
-  
   [(#322)](https://github.com/PennyLaneAI/catalyst/pull/322)
 
 <h3>Contributors</h3>

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -12,6 +12,11 @@
 
 <h3>Bug fixes</h3>
 
+* Fixes the issue with missing `CFP_t` in `StateVectorLQubitDynamic` when building against the master
+  branch of PennyLane-Lightning. This issue introduced in [PR 499](https://github.com/PennyLaneAI/pennylane-lightning/pull/499).
+  
+  [(#322)](https://github.com/PennyLaneAI/catalyst/pull/322)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -13,7 +13,7 @@ ENABLE_LIGHTNING_KOKKOS?=OFF
 ENABLE_OPENQASM?=OFF
 BUILD_QIR_STDLIB_FROM_SRC?=OFF
 # TODO: Update to latest_release after v0.33.0
-LIGHTNING_GIT_TAG_VALUE?="master"
+LIGHTNING_GIT_TAG_VALUE= "0bce777"
 NPROC?=$(shell python -c "import os; print(os.cpu_count())")
 
 coverage: CODE_COVERAGE=ON

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -13,7 +13,7 @@ ENABLE_LIGHTNING_KOKKOS?=OFF
 ENABLE_OPENQASM?=OFF
 BUILD_QIR_STDLIB_FROM_SRC?=OFF
 # TODO: Update to latest_release after v0.33.0
-LIGHTNING_GIT_TAG_VALUE= "0bce777"
+LIGHTNING_GIT_TAG_VALUE?="0bce777"
 NPROC?=$(shell python -c "import os; print(os.cpu_count())")
 
 coverage: CODE_COVERAGE=ON

--- a/runtime/extensions/StateVectorLQubitDynamic.hpp
+++ b/runtime/extensions/StateVectorLQubitDynamic.hpp
@@ -52,6 +52,7 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
   public:
     using PrecisionT = fp_t;
     using ComplexT = std::complex<PrecisionT>;
+    using CFP_t = ComplexT;
     using MemoryStorageT = Pennylane::Util::MemoryStorageLocation::Internal;
 
   private:


### PR DESCRIPTION
This fixes the issue with building `StateVectorLQubitDynamic` against the master branch of the lightning monorepo after merging PR https://github.com/PennyLaneAI/pennylane-lightning/pull/499.