### PR TITLE
[Frontend] Remove `keep_intermediate=True` from test.

### DIFF
--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -315,7 +315,7 @@ module @workflow {
 }
 """
         with pytest.raises(CompileError) as e:
-            qjit(ir, keep_intermediate=True)(0.1)
+            qjit(ir)(0.1)
 
         assert "Failed to parse module as MLIR source" in e.value.args[0]
         assert "Failed to parse module as LLVM source" in e.value.args[0]


### PR DESCRIPTION
**Context:** We don't really test anything with `keep_intermediate=True` in this test.

**Description of the Change:** Remove `keep_intermediate=True`