### PR TITLE
[CI] Implement a matrix strategy for the compiler

### DIFF
--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -375,7 +375,7 @@ jobs:
 
     - name: Install Deps
       run: |
-        sudo apt-get install -y python3 python3-pip libomp-dev
+        sudo apt-get install -y python3 python3-pip libomp-dev libasan5
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
         python3 -m pip install .
@@ -443,7 +443,7 @@ jobs:
 
     - name: Install Deps
       run: |
-        sudo apt-get install -y python3 python3-pip libomp-dev
+        sudo apt-get install -y python3 python3-pip libomp-dev libasan5
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
         python3 -m pip install .
@@ -496,7 +496,7 @@ jobs:
 
     - name: Install Deps
       run: |
-        sudo apt-get install -y python3 python3-pip libomp-dev ninja-build make cmake clang
+        sudo apt-get install -y python3 python3-pip libomp-dev libasan5
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
         python3 -m pip install .

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -375,7 +375,7 @@ jobs:
 
     - name: Install Deps
       run: |
-        sudo apt-get install -y python3 python3-pip libomp-dev libasan5
+        sudo apt-get install -y python3 python3-pip libomp-dev libasan6
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
         python3 -m pip install .
@@ -443,7 +443,7 @@ jobs:
 
     - name: Install Deps
       run: |
-        sudo apt-get install -y python3 python3-pip libomp-dev libasan5
+        sudo apt-get install -y python3 python3-pip libomp-dev libasan6
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
         python3 -m pip install .
@@ -496,7 +496,7 @@ jobs:
 
     - name: Install Deps
       run: |
-        sudo apt-get install -y python3 python3-pip libomp-dev libasan5
+        sudo apt-get install -y python3 python3-pip libomp-dev libasan6
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
         python3 -m pip install .
@@ -566,8 +566,8 @@ jobs:
       - name: Build Runtime test suite for Lightning simulator
         if: ${{ matrix.backend == 'lightning' }}
         run: |
-          C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
-          CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
+          C_COMPILER=$(which gcc) \
+          CXX_COMPILER=$(which g++) \
           COMPILER_LAUNCHER="" \
           make coverage-runtime
           mv runtime/build/coverage.info coverage-${{ github.job }}.info

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -40,7 +40,7 @@ jobs:
           CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
           RT_BUILD_DIR="$(pwd)/runtime-build" \
           ENABLE_LIGHTNING_KOKKOS=ON \
-          CMAKE_ARGS="-DENABLE_SANITIZER=ON" \
+          ENABLE_ASAN=ON \
           ENABLE_OPENQASM=ON \
           make runtime
 
@@ -579,7 +579,7 @@ jobs:
           CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
           COMPILER_LAUNCHER="" \
           ENABLE_LIGHTNING_KOKKOS=ON \
-          CMAKE_ARGS="-DENABLE_SANITIZER=ON" \
+          ENABLE_ASAN=ON \
           make test-runtime
 
       - name: Build Runtime test suite for OpenQasm device

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -40,7 +40,7 @@ jobs:
           C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
           CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
           RT_BUILD_DIR="$(pwd)/runtime-build" \
-          ENABLE_LIGHTNING_KOKKOS=OFF \
+          ENABLE_LIGHTNING_KOKKOS=ON \
           CMAKE_ARGS="-DENABLE_SANITIZER=ON" \
           ENABLE_OPENQASM=ON \
           make runtime
@@ -52,7 +52,7 @@ jobs:
           C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
           CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
           RT_BUILD_DIR="$(pwd)/runtime-build" \
-          ENABLE_LIGHTNING_KOKKOS=OFF \
+          ENABLE_LIGHTNING_KOKKOS=ON \
           ENABLE_OPENQASM=ON \
           make dummy_device
 
@@ -437,7 +437,6 @@ jobs:
     strategy:
       matrix:
         compiler: ${{ fromJson(needs.constants.outputs.compilers) }}
-    if: false
 
     steps:
     - name: Checkout Catalyst repo

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -14,10 +14,16 @@ jobs:
   constants:
     name: "Set build matrix"
     uses: ./.github/workflows/constants.yaml
+    with:
+      multiple_compilers: ${{ github.trigger == 'push' && github.ref_name == 'main' }}
 
   runtime:
     name: Catalyst-Runtime Build
+    needs: [constants]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: ${{ fromJson(needs.constants.outputs.compilers) }}
 
     steps:
       - name: Checkout Catalyst repo
@@ -31,6 +37,8 @@ jobs:
         run: |
           # TODO: reenable kokkos builds
           COMPILER_LAUNCHER="" \
+          C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
+          CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
           RT_BUILD_DIR="$(pwd)/runtime-build" \
           ENABLE_LIGHTNING_KOKKOS=OFF \
           CMAKE_ARGS="-DENABLE_SANITIZER=ON" \
@@ -41,6 +49,8 @@ jobs:
           # Note the lack of sanitizers.
           # Left other flags the same.
           COMPILER_LAUNCHER="" \
+          C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
+          CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
           RT_BUILD_DIR="$(pwd)/runtime-build" \
           ENABLE_LIGHTNING_KOKKOS=OFF \
           ENABLE_OPENQASM=ON \
@@ -50,7 +60,7 @@ jobs:
       - name: Upload Catalyst-Runtime Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: runtime-build
+          name: runtime-build-${{ matrix.compiler }}
           path: |
             runtime-build/lib/*.so
           retention-days: 1
@@ -59,6 +69,9 @@ jobs:
     name: LLVM Build
     needs: [constants]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: ${{ fromJson(needs.constants.outputs.compilers) }}
 
     steps:
     - name: Checkout Catalyst repo
@@ -88,7 +101,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: llvm-build
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
+        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-${{ matrix.compiler }}
 
     - name: Install Deps
       if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -104,6 +117,8 @@ jobs:
       run: |
         # echo 'target_compile_options(mlir_c_runner_utils PRIVATE "-fno-sanitize=all")' \
         #       >> mlir/llvm-project/mlir/lib/ExecutionEngine/CMakeLists.txt
+        C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
+        CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
         LLVM_BUILD_DIR="$(pwd)/llvm-build" \
         COMPILER_LAUNCHER="" \
         make llvm
@@ -112,6 +127,9 @@ jobs:
     name: MHLO Dialect Build
     needs: [constants, llvm]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: ${{ fromJson(needs.constants.outputs.compilers) }}
 
     steps:
     - name: Checkout Catalyst repo
@@ -138,7 +156,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: mhlo-build
-        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-build
+        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-build-${{ matrix.compiler }}
 
     - name: Get Cached LLVM Source
       id: cache-llvm-source
@@ -156,7 +174,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: llvm-build
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
+        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-${{ matrix.compiler }}
         fail-on-cache-miss: True
 
     - name: Install Deps
@@ -167,6 +185,8 @@ jobs:
     - name: Build MHLO Dialect
       if: steps.cache-mhlo.outputs.cache-hit != 'true'
       run: |
+        C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
+        CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
         LLVM_BUILD_DIR="$(pwd)/llvm-build" \
         MHLO_BUILD_DIR="$(pwd)/mhlo-build" \
         COMPILER_LAUNCHER="" \
@@ -176,6 +196,9 @@ jobs:
     name: Enzyme Build
     needs: [constants, llvm]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: ${{ fromJson(needs.constants.outputs.compilers) }}
 
     steps:
     - name: Checkout Catalyst repo
@@ -202,7 +225,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: enzyme-build
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-build
+        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-build-${{ matrix.compiler }}
 
     - name: Get Cached LLVM Source
       id: cache-llvm-source
@@ -220,7 +243,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: llvm-build
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
+        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-${{ matrix.compiler }}
         fail-on-cache-miss: True
 
     - name: Install Deps
@@ -231,6 +254,8 @@ jobs:
     - name: Build Enzyme
       if: steps.cache-enzyme-build.outputs.cache-hit != 'true'
       run: |
+        C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
+        CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
         LLVM_BUILD_DIR="$(pwd)/llvm-build" \
         ENZYME_BUILD_DIR="$(pwd)/enzyme-build" \
         COMPILER_LAUNCHER="" \
@@ -240,6 +265,9 @@ jobs:
     name: Quantum Dialects Build
     needs: [constants, llvm, mhlo, enzyme]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: ${{ fromJson(needs.constants.outputs.compilers) }}
 
     steps:
     - name: Checkout Catalyst repo
@@ -265,7 +293,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: llvm-build
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
+        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-${{ matrix.compiler }}
         fail-on-cache-miss: True
 
     - name: Get Cached MHLO Source
@@ -282,7 +310,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: mhlo-build
-        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-build
+        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-build-${{ matrix.compiler }}
         fail-on-cache-miss: True
 
     - name: Get Cached Enzyme Source
@@ -299,7 +327,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: enzyme-build
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-build
+        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-build-${{ matrix.compiler }}
         fail-on-cache-miss: True
 
     - name: Cache CCache
@@ -316,6 +344,8 @@ jobs:
     - name: Build MLIR Dialects
       run: |
         CCACHE_DIR="$(pwd)/.ccache" \
+        C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
+        CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
         LLVM_BUILD_DIR="$(pwd)/llvm-build" \
         MHLO_BUILD_DIR="$(pwd)/mhlo-build" \
         ENZYME_BUILD_DIR="$(pwd)/enzyme-build" \
@@ -325,7 +355,7 @@ jobs:
     - name: Upload Quantum Build Artifact
       uses: actions/upload-artifact@v3
       with:
-        name: quantum-build
+        name: quantum-build-${{ matrix.compiler }}
         path: |
           quantum-build/bin
           quantum-build/lib/lib*.so*
@@ -336,6 +366,9 @@ jobs:
     name: Frontend Tests
     needs: [constants, llvm, runtime, quantum]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: ${{ fromJson(needs.constants.outputs.compilers) }}
 
     steps:
     - name: Checkout Catalyst repo
@@ -353,19 +386,19 @@ jobs:
       uses: actions/cache@v3
       with:
         path: llvm-build
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
+        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-${{ matrix.compiler }}
         fail-on-cache-miss: True
 
     - name: Download Quantum Build Artifact
       uses: actions/download-artifact@v3
       with:
-        name: quantum-build
+        name: quantum-build-${{ matrix.compiler }}
         path: quantum-build
 
     - name: Download Catalyst-Runtime Artifact
       uses: actions/download-artifact@v3
       with:
-        name: runtime-build
+        name: runtime-build-${{ matrix.compiler }}
         path: runtime-build/lib
 
     - name: Add Frontend Dependencies to PATH
@@ -401,6 +434,9 @@ jobs:
     name: Frontend Tests (backend="lightning.kokkos")
     needs: [constants, llvm, runtime, quantum]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: ${{ fromJson(needs.constants.outputs.compilers) }}
     if: false
 
     steps:
@@ -419,19 +455,19 @@ jobs:
       uses: actions/cache@v3
       with:
         path: llvm-build
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
+        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-${{ matrix.compiler }}
         fail-on-cache-miss: True
 
     - name: Download Quantum Build Artifact
       uses: actions/download-artifact@v3
       with:
-        name: quantum-build
+        name: quantum-build-${{ matrix.compiler }}
         path: quantum-build
 
     - name: Download Catalyst-Runtime Artifact
       uses: actions/download-artifact@v3
       with:
-        name: runtime-build
+        name: runtime-build-${{ matrix.compiler }}
         path: runtime-build/lib
 
     - name: Add Frontend Dependencies to PATH
@@ -452,6 +488,9 @@ jobs:
     name: Frontend Tests (backend="openqasm3")
     needs: [constants, llvm, runtime, quantum]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        compiler: ${{ fromJson(needs.constants.outputs.compilers) }}
 
     steps:
     - name: Checkout Catalyst repo
@@ -469,19 +508,19 @@ jobs:
       uses: actions/cache@v3
       with:
         path: llvm-build
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
+        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-${{ matrix.compiler }}
         fail-on-cache-miss: True
 
     - name: Download Quantum Build Artifact
       uses: actions/download-artifact@v3
       with:
-        name: quantum-build
+        name: quantum-build-${{ matrix.compiler }}
         path: quantum-build
 
     - name: Download Catalyst-Runtime Artifact
       uses: actions/download-artifact@v3
       with:
-        name: runtime-build
+        name: runtime-build-${{ matrix.compiler }}
         path: runtime-build/lib
 
     - name: Install additional dependencies (OpenQasm device)
@@ -510,6 +549,7 @@ jobs:
       fail-fast: false
       matrix:
         backend: ${{ fromJson(needs.constants.outputs.rt_backends) }}
+        compiler: ${{ fromJson(needs.constants.outputs.compilers) }}
 
     steps:
       - name: Checkout the repo
@@ -528,30 +568,30 @@ jobs:
       - name: Build Runtime test suite for Lightning simulator
         if: ${{ matrix.backend == 'lightning' }}
         run: |
-            C_COMPILER=$(which gcc) \
-            CXX_COMPILER=$(which g++) \
-            COMPILER_LAUNCHER="" \
-            make coverage-runtime
-            mv runtime/build/coverage.info coverage-${{ github.job }}.info
+          C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
+          CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
+          COMPILER_LAUNCHER="" \
+          make coverage-runtime
+          mv runtime/build/coverage.info coverage-${{ github.job }}.info
 
       - name: Build Runtime test suite with both Lightning and Lightning-Kokkos simulators
         if: ${{ matrix.backend == 'lightning-kokkos' }}
         run: |
-            C_COMPILER=$(which gcc) \
-            CXX_COMPILER=$(which g++) \
-            COMPILER_LAUNCHER="" \
-            ENABLE_LIGHTNING_KOKKOS=ON \
-            CMAKE_ARGS="-DENABLE_SANITIZER=ON" \
-            make test-runtime
+          C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
+          CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
+          COMPILER_LAUNCHER="" \
+          ENABLE_LIGHTNING_KOKKOS=ON \
+          CMAKE_ARGS="-DENABLE_SANITIZER=ON" \
+          make test-runtime
 
       - name: Build Runtime test suite for OpenQasm device
         if: ${{ matrix.backend == 'openqasm' }}
         run: |
-            C_COMPILER=$(which gcc) \
-            CXX_COMPILER=$(which g++) \
-            COMPILER_LAUNCHER="" \
-            ENABLE_OPENQASM=ON \
-            make test-runtime
+          C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
+          CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
+          COMPILER_LAUNCHER="" \
+          ENABLE_OPENQASM=ON \
+          make test-runtime
 
       - name: Upload to Codecov
         if: ${{ matrix.backend == 'lightning' }}
@@ -563,7 +603,7 @@ jobs:
       - name: Build examples
         if: ${{ matrix.backend == 'lightning' }}
         run: |
-          C_COMPILER=$(which gcc) \
-          CXX_COMPILER=$(which g++) \
+          C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
+          CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
           COMPILER_LAUNCHER="" \
           make examples-runtime

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -40,8 +40,8 @@ jobs:
           CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
           RT_BUILD_DIR="$(pwd)/runtime-build" \
           ENABLE_LIGHTNING_KOKKOS=ON \
-          ENABLE_ASAN=ON \
           ENABLE_OPENQASM=ON \
+          ENABLE_ASAN=OFF \
           make runtime
 
           # This is needed in the artifact for the pytests

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -585,10 +585,13 @@ jobs:
       - name: Build Runtime test suite for OpenQasm device
         if: ${{ matrix.backend == 'openqasm' }}
         run: |
+          # Disabling leak detection is usually required when running Python.
+          ASAN_OPTIONS=detect_leaks=0 \
           C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
           CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
           COMPILER_LAUNCHER="" \
           ENABLE_OPENQASM=ON \
+          ENABLE_ASAN=ON \
           make test-runtime
 
       - name: Upload to Codecov

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -35,7 +35,6 @@ jobs:
 
       - name: Build Catalyst-Runtime
         run: |
-          # TODO: reenable kokkos builds
           COMPILER_LAUNCHER="" \
           C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
           CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Install deps
       run: |
-        sudo apt-get install -y cmake ninja-build ccache clang lld libomp-dev
+        sudo apt-get install -y cmake ninja-build ccache libomp-dev libasan5
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
         # TODO: Use the latest version of boto3 after fixing the issue with
@@ -101,6 +101,7 @@ jobs:
         CCACHE_DIR="$(pwd)/.ccache" \
         C_COMPILER=$(which gcc }}) \
         CXX_COMPILER=$(which g++ }}) \
+        ENABLE_LLD=OFF \
         LLVM_BUILD_DIR="$(pwd)/llvm-build" \
         MHLO_BUILD_DIR="$(pwd)/mhlo-build" \
         ENZYME_BUILD_DIR="$(pwd)/enzyme-build" \
@@ -115,6 +116,7 @@ jobs:
         COMPILER_LAUNCHER="" \
         C_COMPILER=$(which gcc }}) \
         CXX_COMPILER=$(which g++ }}) \
+        ENABLE_LLD=OFF \
         RT_BUILD_DIR="$(pwd)/runtime-build" \
         QIR_STDLIB_DIR="$(pwd)/qir-stdlib-build" \
         QIR_STDLIB_INCLUDES_DIR="$(pwd)/qir-stdlib-build/include" \

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Install deps
       run: |
-        sudo apt-get install -y cmake ninja-build ccache libomp-dev libasan5
+        sudo apt-get install -y cmake ninja-build ccache libomp-dev libasan6
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
         # TODO: Use the latest version of boto3 after fixing the issue with

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -63,7 +63,7 @@ jobs:
     - uses: actions/cache@v3
       with:
         path: llvm-build
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-opt
+        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-gcc
         fail-on-cache-miss: True
     - name: Get Cached MHLO Source
       id: cache-mhlo-source
@@ -76,12 +76,12 @@ jobs:
     - uses: actions/cache@v3
       with:
         path: mhlo-build
-        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-build
+        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-default-build-gcc
         fail-on-cache-miss: True
     - uses: actions/cache@v3
       with:
         path: enzyme-build
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-build
+        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-default-build-gcc
         fail-on-cache-miss: True
     - uses: actions/cache@v3
       with:
@@ -99,6 +99,8 @@ jobs:
     - name: Install Catalyst (latest/stable)
       run: |
         CCACHE_DIR="$(pwd)/.ccache" \
+        C_COMPILER=$(which gcc }}) \
+        CXX_COMPILER=$(which g++ }}) \
         LLVM_BUILD_DIR="$(pwd)/llvm-build" \
         MHLO_BUILD_DIR="$(pwd)/mhlo-build" \
         ENZYME_BUILD_DIR="$(pwd)/enzyme-build" \
@@ -111,6 +113,8 @@ jobs:
       if: ${{ inputs.lightning == 'latest' }}
       run: |
         COMPILER_LAUNCHER="" \
+        C_COMPILER=$(which gcc }}) \
+        CXX_COMPILER=$(which g++ }}) \
         RT_BUILD_DIR="$(pwd)/runtime-build" \
         QIR_STDLIB_DIR="$(pwd)/qir-stdlib-build" \
         QIR_STDLIB_INCLUDES_DIR="$(pwd)/qir-stdlib-build/include" \
@@ -123,6 +127,8 @@ jobs:
       if: ${{ inputs.lightning == 'stable' }}
       run: |
         COMPILER_LAUNCHER="" \
+        C_COMPILER=$(which gcc }}) \
+        CXX_COMPILER=$(which g++ }}) \
         RT_BUILD_DIR="$(pwd)/runtime-build" \
         QIR_STDLIB_DIR="$(pwd)/qir-stdlib-build" \
         QIR_STDLIB_INCLUDES_DIR="$(pwd)/qir-stdlib-build/include" \

--- a/.github/workflows/constants.yaml
+++ b/.github/workflows/constants.yaml
@@ -2,6 +2,11 @@ name: Set constants
 
 on:
   workflow_call:
+    inputs:
+      multiple_compilers:
+        required: false
+        default: false
+        type: boolean
     outputs:
       llvm_version:
         description: "LLVM version"
@@ -21,6 +26,17 @@ on:
       rt_backends:
         description: "List of backends."
         value: ${{ jobs.set-constants.outputs.rt_backends }}
+      compilers:
+        description: "List of compilers to test Catalyst builds with."
+        value: ${{ jobs.set-constants.outputs.compilers }}
+      c_compiler.gcc:
+        value: gcc
+      c_compiler.clang:
+        value: clang
+      cxx_compiler.gcc:
+        value: g++
+      cxx_compiler.clang:
+        value: clang++
 
 jobs:
   set-constants:
@@ -56,6 +72,18 @@ jobs:
         id: rt_backends
         run: echo 'rt_backends=["lightning", "lightning-kokkos", "openqasm"]' >> $GITHUB_OUTPUT
 
+      - name: Compilers (All)
+        id: compilers
+        run: |
+          # TODO: add Clang after https://github.com/actions/runner-images/issues/8659 is fixed
+          if [[ $MULTIPLE ]]; then
+            echo 'compilers=["gcc"]' >> $GITHUB_OUTPUT
+          else
+            echo 'compilers=["gcc"]' >> $GITHUB_OUTPUT
+          fi
+        env:
+          MULTIPLE: ${{ inputs.multiple_compilers }}
+
     outputs:
       llvm_version: ${{ steps.llvm_version.outputs.llvm_version }}
       mhlo_version: ${{ steps.mhlo_version.outputs.mhlo_version }}
@@ -63,3 +91,4 @@ jobs:
       python_versions: ${{ steps.python_versions.outputs.python_versions }}
       primary_python_version: ${{ steps.primary_python_version.outputs.primary_python_version }}
       rt_backends: ${{ steps.rt_backends.outputs.rt_backends }}
+      compilers: ${{ steps.compilers.outputs.compilers }}

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -2,6 +2,7 @@ PYTHON := python3
 C_COMPILER?=clang
 CXX_COMPILER?=clang++
 COMPILER_LAUNCHER?=ccache
+ENABLE_ASAN?=OFF
 MK_ABSPATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MK_DIR := $(dir $(MK_ABSPATH))
 RT_BUILD_DIR?=$(MK_DIR)/build
@@ -53,6 +54,7 @@ configure:
 		-DENABLE_WARNINGS=$(ENABLE_WARNINGS) \
 		-DENABLE_CODE_COVERAGE=$(CODE_COVERAGE) \
 		-DBUILD_QIR_STDLIB_FROM_SRC=$(BUILD_QIR_STDLIB_FROM_SRC) \
+		-DENABLE_SANITIZER=$(ENABLE_ASAN) \
 		$(CMAKE_ARGS)
 
 $(RT_BUILD_DIR)/lib/backend/librt_backend.so $(RT_BUILD_DIR)/lib/librt_capi.so: configure


### PR DESCRIPTION
- the plugin-matrix action always builds with gcc now
- the compiler for the check-catalyst action is determined by the constants action, and can be a list of several compilers
- on push to main, all compilers are tested, whereas within PRs only the default compiler is tested
- there is now a build cache on ubuntu for each compiler

Note that at the moment, only gcc is enabled due the issue with Ubuntu runners and Clang.