### PR TITLE
Set opengraph metadata for docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -129,11 +129,15 @@ extensions = [
 intersphinx_mapping = {"https://docs.pennylane.ai/en/stable/": None}
 
 # opengraph details
-ogp_site_url = "https://docs.pennylane.ai/projects/catalyst/en/stable/"
 ogp_image = "https://docs.pennylane.ai/projects/catalyst/en/stable/_static/catalyst.png"
 ogp_type = "article"
 ogp_enable_meta_description = True
 ogp_use_first_image = True
+
+ogp_social_cards = {
+    "image": "_static/catalyst_illustration.jpg",
+    "enable": True
+}
 
 autosummary_generate = True
 autosummary_imported_members = False

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -120,12 +120,20 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
+    "sphinxext.opengraph",
     "sphinx_automodapi.automodapi",
     "sphinx_automodapi.smart_resolver",
     "m2r2",
 ]
 
 intersphinx_mapping = {"https://docs.pennylane.ai/en/stable/": None}
+
+# opengraph details
+ogp_site_url = "https://pennylane.ai/project/catalyst"
+ogp_image = "https://docs.pennylane.ai/projects/catalyst/en/stable/_static/catalyst.png"
+ogp_type = "article"
+ogp_enable_meta_description = True
+ogp_use_first_image = True
 
 autosummary_generate = True
 autosummary_imported_members = False

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -131,9 +131,13 @@ intersphinx_mapping = {"https://docs.pennylane.ai/en/stable/": None}
 # OpenGraph Metadata
 ogp_title = "Catalyst Documentation"
 ogp_type = "website"
-ogp_description = "Catalyst is an experimental package that enables just-in-time (JIT) compilation of PennyLane programs. Compile the entire quantum-classical workflow."
-ogp_use_first_image = False
-# ogp_image = "_static/catalyst_illustration.jpg"
+ogp_description = (
+    "Catalyst is an experimental package that enables just-in-time (JIT) "
+    "compilation of PennyLane programs. Compile the entire "
+    "quantum-classical workflow."
+)
+ogp_use_first_image = True  # set to False for autocards
+ogp_image = "_static/catalyst_illustration.jpg"  # comment for autocards
 
 ogp_social_cards = {
     "image": "_static/catalyst_illustration.jpg",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -136,7 +136,9 @@ ogp_use_first_image = False
 
 ogp_social_cards = {
     "image": "_static/catalyst_illustration.jpg",
-    "enable": True
+    "enable": True,
+    "site_url": "https://docs.pennylane.ai/projects/catalyst",
+    "line_color": "#03b2ff"
 }
 
 autosummary_generate = True

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -129,10 +129,10 @@ extensions = [
 intersphinx_mapping = {"https://docs.pennylane.ai/en/stable/": None}
 
 # opengraph details
-ogp_image = "https://docs.pennylane.ai/projects/catalyst/en/stable/_static/catalyst.png"
+# ogp_image = "https://docs.pennylane.ai/projects/catalyst/en/stable/_static/catalyst.png"
 ogp_type = "article"
 ogp_enable_meta_description = True
-ogp_use_first_image = True
+ogp_use_first_image = False
 
 ogp_social_cards = {
     "image": "_static/catalyst_illustration.jpg",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -129,13 +129,6 @@ extensions = [
 intersphinx_mapping = {"https://docs.pennylane.ai/en/stable/": None}
 
 # OpenGraph Metadata
-ogp_title = "Catalyst Documentation"
-ogp_type = "website"
-ogp_description = (
-    "Catalyst is an experimental package that enables just-in-time (JIT) "
-    "compilation of PennyLane programs. Compile the entire "
-    "quantum-classical workflow."
-)
 ogp_use_first_image = True  # set to False for autocards
 ogp_image = "_static/catalyst_illustration.jpg"  # comment for autocards
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -130,7 +130,7 @@ intersphinx_mapping = {"https://docs.pennylane.ai/en/stable/": None}
 
 # opengraph details
 ogp_type = "article"
-# set the following two to False to activate custom
+# Comment the folloring two lines to activate custom
 # social media cards
 ogp_use_first_image = True
 ogp_image = "_static/catalyst_illustration.jpg"

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -128,12 +128,12 @@ extensions = [
 
 intersphinx_mapping = {"https://docs.pennylane.ai/en/stable/": None}
 
-# opengraph details
-ogp_type = "article"
-# Comment the folloring two lines to activate custom
-# social media cards
-ogp_use_first_image = True
-ogp_image = "_static/catalyst_illustration.jpg"
+# OpenGraph Metadata
+ogp_title = "Catalyst Documentation"
+ogp_type = "website"
+ogp_description = "Catalyst is an experimental package that enables just-in-time (JIT) compilation of PennyLane programs. Compile the entire quantum-classical workflow."
+ogp_use_first_image = False
+# ogp_image = "_static/catalyst_illustration.jpg"
 
 ogp_social_cards = {
     "image": "_static/catalyst_illustration.jpg",
@@ -141,6 +141,7 @@ ogp_social_cards = {
     "site_url": "https://docs.pennylane.ai/projects/catalyst",
     "line_color": "#03b2ff",
 }
+
 # The base URL with a proper language and version.
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -129,7 +129,7 @@ extensions = [
 intersphinx_mapping = {"https://docs.pennylane.ai/en/stable/": None}
 
 # opengraph details
-ogp_site_url = "https://docs.pennylane.ai/projects/catalyst/en/stable"
+ogp_site_url = "https://docs.pennylane.ai/projects/catalyst/en/stable/"
 ogp_image = "https://docs.pennylane.ai/projects/catalyst/en/stable/_static/catalyst.png"
 ogp_type = "article"
 ogp_enable_meta_description = True

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -129,7 +129,7 @@ extensions = [
 intersphinx_mapping = {"https://docs.pennylane.ai/en/stable/": None}
 
 # opengraph details
-ogp_site_url = "https://pennylane.ai/project/catalyst"
+ogp_site_url = "https://docs.pennylane.ai/projects/catalyst/en/stable"
 ogp_image = "https://docs.pennylane.ai/projects/catalyst/en/stable/_static/catalyst.png"
 ogp_type = "article"
 ogp_enable_meta_description = True

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -130,8 +130,8 @@ intersphinx_mapping = {"https://docs.pennylane.ai/en/stable/": None}
 
 # opengraph details
 ogp_type = "article"
-ogp_enable_meta_description = True
-ogp_use_first_image = False
+ogp_enable_meta_description = False
+ogp_use_first_image = True
 
 ogp_social_cards = {
     "image": "_static/catalyst_illustration.jpg",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -130,8 +130,10 @@ intersphinx_mapping = {"https://docs.pennylane.ai/en/stable/": None}
 
 # opengraph details
 ogp_type = "article"
-ogp_enable_meta_description = False
+# set the following two to False to activate custom
+# social media cards
 ogp_use_first_image = True
+ogp_image = "_static/catalyst_illustration.jpg"
 
 ogp_social_cards = {
     "image": "_static/catalyst_illustration.jpg",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -137,7 +137,7 @@ ogp_social_cards = {
     "image": "_static/catalyst_illustration.jpg",
     "enable": True,
     "site_url": "https://docs.pennylane.ai/projects/catalyst",
-    "line_color": "#03b2ff"
+    "line_color": "#03b2ff",
 }
 # The base URL with a proper language and version.
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -129,7 +129,6 @@ extensions = [
 intersphinx_mapping = {"https://docs.pennylane.ai/en/stable/": None}
 
 # opengraph details
-# ogp_image = "https://docs.pennylane.ai/projects/catalyst/en/stable/_static/catalyst.png"
 ogp_type = "article"
 ogp_enable_meta_description = True
 ogp_use_first_image = False
@@ -140,6 +139,8 @@ ogp_social_cards = {
     "site_url": "https://docs.pennylane.ai/projects/catalyst",
     "line_color": "#03b2ff"
 }
+# The base URL with a proper language and version.
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
 
 autosummary_generate = True
 autosummary_imported_members = False

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,3 +1,5 @@
+:og:description: Catalyst is an experimental package that enables just-in-time (JIT) compilation of PennyLane programs. Compile the entire quantum-classical workflow.
+
 Catalyst
 ########
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -18,3 +18,4 @@ graphviz
 pybind11
 m2r2
 mistune==0.8.4
+sphinxext-opengraph

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -18,5 +18,5 @@ graphviz
 pybind11
 m2r2
 mistune==0.8.4
-sphinxext-opengraph
-matplotlib
+sphinxext-opengraph==0.9.0
+matplotlib==3.8.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -19,3 +19,4 @@ pybind11
 m2r2
 mistune==0.8.4
 sphinxext-opengraph
+matplotlib


### PR DESCRIPTION
**Context:** When posting links to the docs on social media, there is no social media preview, as there was no [OpenGraph](https://opengraph.xyz) metadata generated by Sphinx.

**Description of the Change:**

- Adds matplotlib and [sphinxext-opengraph](https://github.com/wpilibsuite/sphinxext-opengraph) as doc requirements

- configures `conf.py` to set the OpenGraph information, in particular,

  - the default social media preview image
  - if an image is used on the page, that is used as the preview image

**Benefits:** As above.

To see a preview, copy and paste the RTDs preview into opengraph.xyz:

- [home page](https://www.opengraph.xyz/url/https%3A%2F%2Fxanaduai-pennylane--344.com.readthedocs.build%2Fprojects%2Fcatalyst%2Fen%2F344%2F)
- [autograph guide](https://www.opengraph.xyz/url/https%3A%2F%2Fxanaduai-pennylane--344.com.readthedocs.build%2Fprojects%2Fcatalyst%2Fen%2F344%2Fdev%2Fautograph.html)

**Possible Drawbacks:**

Sometimes the image used on the page may not be ideal. If we set `ogp_use_first_image` to False, and delete `ogp_image`, instead Sphinx will generate social media _cards_, like the following:

<img src="https://github.com/PennyLaneAI/catalyst/assets/2959003/8e3cc611-d9d5-403c-9174-5db8a71b5f78" width=500>

Would we prefer this?

**Related GitHub Issues:** n/a