### PR TITLE
[MLIR] Improve the compiler driver failure reporting

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -4,6 +4,10 @@
 
 <h3>Improvements</h3>
 
+* Improve the compiler driver diagnostic output even more. Now it dumps the failing IR as well as
+  prints names of failing passes.
+  [(#349)](https://github.com/PennyLaneAI/catalyst/pull/349)
+
 * Improve the compiler driver diagnostic output. The driver now provides more context for error
   messages and includes a verbose trace if verbose mode is enabled.
   [(#303)](https://github.com/PennyLaneAI/catalyst/pull/303)

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -364,7 +364,12 @@ LogicalResult runLowering(const CompilerOptions &options, MLIRContext *ctx, Modu
     auto afterPassFailedCallback = [&](Pass *pass, Operation *op) {
         auto res = passPipelineNames.find(pass);
         assert(res != passPipelineNames.end() && "Unexpected pass");
-        options.diagnosticStream << "While processing pipeline: " << res->second << "\n";
+        options.diagnosticStream << "While processing '" << pass->getName() << "' pass "
+                                 << "of the '" << res->second << "' pipeline\n";
+        llvm::raw_string_ostream s{outputs[res->second]};
+        s << *op;
+        dumpToFile(options, output.nextPipelineDumpFilename(res->second+"_FAILED"),
+                   outputs[res->second]);
     };
 
     // Output pipeline names on failures

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -368,8 +368,10 @@ LogicalResult runLowering(const CompilerOptions &options, MLIRContext *ctx, Modu
                                  << "of the '" << res->second << "' pipeline\n";
         llvm::raw_string_ostream s{outputs[res->second]};
         s << *op;
-        dumpToFile(options, output.nextPipelineDumpFilename(res->second + "_FAILED"),
-                   outputs[res->second]);
+        if (options.keepIntermediate) {
+            dumpToFile(options, output.nextPipelineDumpFilename(res->second + "_FAILED"),
+                       outputs[res->second]);
+        }
     };
 
     // Output pipeline names on failures

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -368,7 +368,7 @@ LogicalResult runLowering(const CompilerOptions &options, MLIRContext *ctx, Modu
                                  << "of the '" << res->second << "' pipeline\n";
         llvm::raw_string_ostream s{outputs[res->second]};
         s << *op;
-        dumpToFile(options, output.nextPipelineDumpFilename(res->second+"_FAILED"),
+        dumpToFile(options, output.nextPipelineDumpFilename(res->second + "_FAILED"),
                    outputs[res->second]);
     };
 


### PR DESCRIPTION
In this PR we add the following functionality to the CompilerDriver:
* [x] Print the name of failed pass along with the name of the pipeline
* [x] Dump the failing IR into the workspace with the "_FAILED" suffix