### PR TITLE
Update wheels: Addressing changes in PR #279

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -261,6 +261,7 @@ jobs:
               -DLIGHTNING_GIT_TAG="latest_release" \
               -DKokkos_ENABLE_SERIAL=ON \
               -DKokkos_ENABLE_OPENMP=ON \
+              -DENABLE_WARNINGS=OFF \
               -DENABLE_OPENQASM=ON
 
         cmake --build runtime-build --target rt_capi

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -245,6 +245,7 @@ jobs:
               -DLIGHTNING_GIT_TAG="latest_release" \
               -DKokkos_ENABLE_SERIAL=ON \
               -DKokkos_ENABLE_COMPLEX_ALIGN=OFF \
+              -DENABLE_WARNINGS=OFF \
               -DENABLE_OPENQASM=ON
 
         cmake --build runtime-build --target rt_capi

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -248,6 +248,7 @@ jobs:
               -DKokkos_ENABLE_SERIAL=ON \
               -DKokkos_ENABLE_COMPLEX_ALIGN=OFF \
               -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
+              -DENABLE_WARNINGS=OFF \
               -DENABLE_OPENQASM=ON
 
         cmake --build runtime-build --target rt_capi

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 env:
-  MACOSX_DEPLOYMENT_TARGET: 11.7
+  MACOSX_DEPLOYMENT_TARGET: 12
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ wheel:
 	# Copy mlir bindings & compiler driver to frontend/mlir_quantum
 	mkdir -p $(MK_DIR)/frontend/mlir_quantum/dialects
 	cp -R $(COPY_FLAGS) $(DIALECTS_BUILD_DIR)/python_packages/quantum/mlir_quantum/runtime $(MK_DIR)/frontend/mlir_quantum/runtime
-	for file in gradient quantum _ods_common ; do \
+	for file in gradient quantum _ods_common catalyst ; do \
 		cp $(COPY_FLAGS) $(DIALECTS_BUILD_DIR)/python_packages/quantum/mlir_quantum/dialects/*$${file}* $(MK_DIR)/frontend/mlir_quantum/dialects ; \
 	done
 	cp $(COPY_FLAGS) $(DIALECTS_BUILD_DIR)/python_packages/quantum/mlir_quantum/compiler_driver.so $(MK_DIR)/frontend/mlir_quantum/

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -4,6 +4,7 @@
 
 * Debug compiled programs and print dynamic values at runtime with ``debug.print``
   [(#279)](https://github.com/PennyLaneAI/catalyst/pull/279)
+  [(#356)](https://github.com/PennyLaneAI/catalyst/pull/356)
 
   You can now print arbitrary values from your running program, whether they are arrays, constants,
   strings, or abitrary Python objects. Note that while non-array Python objects

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -77,6 +77,7 @@ void __quantum__rt__print_string(char *string)
 {
     if (!string) {
         std::cout << "None" << std::endl;
+        return;
     }
     std::cout << string << std::endl;
 }

--- a/runtime/tests/Test_LightningCoreQIS.cpp
+++ b/runtime/tests/Test_LightningCoreQIS.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Test __quantum__rt__print_string", "[qir_lightning_core]")
     char *str_null = nullptr;
     __quantum__rt__print_string(str_null);
 
-    CHECK(true)
+    CHECK(true);
 }
 
 TEST_CASE("Test __quantum__rt__print_tensor i1, i8, i16, i32, f32, and c64", "[qir_lightning_core]")

--- a/runtime/tests/Test_LightningCoreQIS.cpp
+++ b/runtime/tests/Test_LightningCoreQIS.cpp
@@ -37,8 +37,6 @@ TEST_CASE("Test __quantum__rt__print_string", "[qir_lightning_core]")
 
     char *str_null = nullptr;
     __quantum__rt__print_string(str_null);
-
-    CHECK(true);
 }
 
 TEST_CASE("Test __quantum__rt__print_tensor i1, i8, i16, i32, f32, and c64", "[qir_lightning_core]")

--- a/runtime/tests/Test_LightningCoreQIS.cpp
+++ b/runtime/tests/Test_LightningCoreQIS.cpp
@@ -37,6 +37,8 @@ TEST_CASE("Test __quantum__rt__print_string", "[qir_lightning_core]")
 
     char *str_null = nullptr;
     __quantum__rt__print_string(str_null);
+
+    CHECK(true)
 }
 
 TEST_CASE("Test __quantum__rt__print_tensor i1, i8, i16, i32, f32, and c64", "[qir_lightning_core]")

--- a/runtime/tests/Test_LightningCoreQIS.cpp
+++ b/runtime/tests/Test_LightningCoreQIS.cpp
@@ -32,9 +32,11 @@ using namespace Catalyst::Runtime;
 
 TEST_CASE("Test __quantum__rt__print_string", "[qir_lightning_core]")
 {
-    std::string str{"print_string_test"};
-    __quantum__rt__print_string(const_cast<char *>(str.c_str()));
-    __quantum__rt__print_string(nullptr);
+    char str[] = "print_string_test";
+    __quantum__rt__print_string(str);
+
+    char *str_null = nullptr;
+    __quantum__rt__print_string(str_null);
 }
 
 TEST_CASE("Test __quantum__rt__print_tensor i1, i8, i16, i32, f32, and c64", "[qir_lightning_core]")


### PR DESCRIPTION
With Changes in PR #279, 
- [X] Disable the warning-as-error build option for 3rd-party backend devices on wheels recipes.
- [X] Add the new `catalyst` module to the wheels
- [x] Fix segfaults with debug_print tests on macOS