### PR TITLE
Enable address sanitizers on macOS in our build scripts

### DIFF
--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -413,7 +413,6 @@ jobs:
 
     - name: Run Python Pytest Tests
       run: |
-        # export ASAN_OPTIONS=detect_odr_violation=0
         COVERAGE_REPORT="xml:coverage.xml -p no:warnings" \
         make coverage-frontend
         mv coverage.xml coverage-${{ github.job }}.xml
@@ -582,8 +581,6 @@ jobs:
       - name: Build Runtime test suite for OpenQasm device
         if: ${{ matrix.backend == 'openqasm' }}
         run: |
-          # Disabling leak detection is usually required when running Python.
-          ASAN_OPTIONS=detect_leaks=0 \
           C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
           CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
           COMPILER_LAUNCHER="" \

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,10 @@ dialects:
 	$(MAKE) -C mlir dialects
 
 runtime:
-	$(MAKE) -C runtime all
+	$(MAKE) -C runtime runtime
+
+runtime-all:
+	$(MAKE) -C runtime runtime ENABLE_LIGHTNING_KOKKOS=ON ENABLE_OPENQASM=ON
 
 dummy_device:
 	$(MAKE) -C runtime dummy_device
@@ -86,6 +89,9 @@ test: test-runtime test-frontend test-demos
 
 test-runtime:
 	$(MAKE) -C runtime test
+
+test-runtime-all:
+	$(MAKE) -C runtime test ENABLE_LIGHTNING_KOKKOS=ON ENABLE_OPENQASM=ON
 
 test-frontend: lit pytest
 

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,9 @@ test-runtime:
 test-runtime-all:
 	$(MAKE) -C runtime test ENABLE_LIGHTNING_KOKKOS=ON ENABLE_OPENQASM=ON
 
+test-mlir:
+	$(MAKE) -C mlir test
+
 test-frontend: lit pytest
 
 lit:

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ all: runtime mlir frontend
 frontend:
 	@echo "install Catalyst Frontend"
 	$(PYTHON) -m pip install -e .
+	rm -r frontend/pennylane_catalyst.egg-info
 
 .PHONY: mlir llvm mhlo enzyme dialects runtime
 mlir:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,12 @@ ENABLE_ASAN ?= OFF
 PLATFORM := $(shell uname -s)
 ifeq ($(PLATFORM),Linux)
 COPY_FLAGS := --dereference
+endif
+
+ifeq ($(PLATFORM) $(findstring clang,$(C_COMPILER)),Linux clang)
 ASAN_FLAGS := LD_PRELOAD="$(shell clang  -print-file-name=libclang_rt.asan-x86_64.so)"
+else ifeq ($(PLATFORM) $(findstring gcc,$(C_COMPILER)),Linux gcc)
+ASAN_FLAGS := LD_PRELOAD="$(shell gcc  -print-file-name=libasan.so)"
 else ifeq ($(PLATFORM),Darwin)
 ASAN_FLAGS := DYLD_INSERT_LIBRARIES="$(shell clang -print-file-name=libclang_rt.asan_osx_dynamic.dylib)"
 endif

--- a/frontend/test/lit/lit.cfg.py
+++ b/frontend/test/lit/lit.cfg.py
@@ -32,19 +32,25 @@ config.test_source_root = path.dirname(__file__)
 config.test_exec_root = getattr(config, "frontend_test_dir", ".lit")
 
 # TODO: Ideally we would test with leak detection, but this may not be possible from Python.
-config.environment["ASAN_OPTIONS"] = "detect_leaks=0"
+# TODO: Find out why we have container overflow on macOS.
+config.environment["ASAN_OPTIONS"] = "detect_leaks=0,detect_container_overflow=0"
 
 # Define substitutions used at the top of lit test files, e.g. %PYTHON.
 python_executable = getattr(config, "python_executable", "python3.10")
 
 if "Address" in getattr(config, "llvm_use_sanitizer", ""):
     # With sanitized builds, Python tests require some preloading magic to run.
-    assert "Linux" in config.host_os, "Testing with sanitized builds requires Linux/Clang"
-
-    python_executable = (
-        f"LD_PRELOAD=$({config.host_cxx} -print-file-name=libclang_rt.asan-{config.host_arch}.so)"
-        f" {python_executable}"
-    )
+    if "Linux" in config.host_os:
+        python_executable = f"LD_PRELOAD=$({config.host_cxx} -print-file-name=libclang_rt.asan-{config.host_arch}.so) {python_executable}"
+    elif "Darwin" in config.host_os:
+        # It's important that the python executable discovered by CMake is the true interpreter
+        # binary. On macOS, it appears that there can be multiple "python" executables which are
+        # just wrappers around the actual interpreter. In that case, the DYLD_INSERT_LIBRARIES trick
+        # will not work, as it will not be forwarded to the final process.
+        # See https://stackoverflow.com/a/47853433 for more information.
+        python_executable = f"DYLD_INSERT_LIBRARIES=$({config.host_cxx} -print-file-name=libclang_rt.asan_osx_dynamic.dylib) {python_executable}"
+    else:
+        assert False, "Testing with sanitized builds requires Linux or MacOS"
 
 config.substitutions.append(("%PYTHON", python_executable))
 

--- a/mlir/Makefile
+++ b/mlir/Makefile
@@ -13,13 +13,13 @@ RT_BUILD_DIR?=$(MK_DIR)/../runtime/build
 ENABLE_ASAN?=OFF
 
 ifeq ($(shell uname), Darwin)
-	DEFAULT_ENABLE_LLD := OFF
-	DEFAULT_ENABLE_ZLIB := OFF
-	DEFAULT_ENABLE_ZSTD := OFF
+DEFAULT_ENABLE_LLD := OFF
+DEFAULT_ENABLE_ZLIB := OFF
+DEFAULT_ENABLE_ZSTD := OFF
 else
-	DEFAULT_ENABLE_LLD := ON
-	DEFAULT_ENABLE_ZLIB := ON
-	DEFAULT_ENABLE_ZSTD := ON
+DEFAULT_ENABLE_LLD := ON
+DEFAULT_ENABLE_ZLIB := ON
+DEFAULT_ENABLE_ZSTD := ON
 endif
 
 ENABLE_LLD?=$(DEFAULT_ENABLE_LLD)
@@ -27,10 +27,6 @@ ENABLE_ZLIB?=$(DEFAULT_ENABLE_LLD)
 ENABLE_ZSTD?=$(DEFAULT_ENABLE_LLD)
 
 ifeq ($(ENABLE_ASAN), ON)
-ifneq ($(findstring clang,$(C_COMPILER)), clang)
-	@echo "Build and Test with Address Sanitizer are only supported by Clang, but provided $(C_COMPILER)"
-	@exit 1
-endif
 USE_SANITIZER_NAMES="Address"
 USE_SANITIZER_FLAGS="-fsanitize=address"
 else

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -21,9 +21,17 @@ python_executable = getattr(config, "python_executable", "python3.10")
 
 if "Address" in getattr(config, "llvm_use_sanitizer", ""):
     # With sanitized builds, Python tests require some preloading magic to run.
-    assert "Linux" in config.host_os, "Testing with sanitized builds requires Linux/Clang"
-
-    python_executable = f"LD_PRELOAD=$({config.host_cxx} -print-file-name=libclang_rt.asan-{config.host_arch}.so) {python_executable}"
+    if "Linux" in config.host_os:
+        python_executable = f"LD_PRELOAD=$({config.host_cxx} -print-file-name=libclang_rt.asan-{config.host_arch}.so) {python_executable}"
+    elif "Darwin" in config.host_os:
+        # It's important that the python executable discovered by CMake is the true interpreter
+        # binary. On macOS, it appears that there can be multiple "python" executables which are
+        # just wrappers around the actual interpreter. In that case, the DYLD_INSERT_LIBRARIES trick
+        # will not work, as it will not be forwarded to the final process.
+        # See https://stackoverflow.com/a/47853433 for more information.
+        python_executable = f"DYLD_INSERT_LIBRARIES=$({config.host_cxx} -print-file-name=libclang_rt.asan_osx_dynamic.dylib) {python_executable}"
+    else:
+        assert False, "Testing with sanitized builds requires Linux or MacOS"
 
 config.substitutions.append(("%PYTHON", python_executable))
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -82,7 +82,7 @@ dummy_device:
 .PHONY: test
 test: $(RT_BUILD_DIR)/tests/runner_tests
 	@echo "test the Catalyst runtime test suite"
-	$(RT_BUILD_DIR)/tests/runner_tests
+	$(ASAN_COMMAND) $(RT_BUILD_DIR)/tests/runner_tests
 
 .PHONY: coverage
 coverage: $(RT_BUILD_DIR)/tests/runner_tests


### PR DESCRIPTION
Adjusted configuration in Makefiles and lit config files to successfully run tests with ASAN on macOS.

Tested: `make dialects`, `make lit`, `make pytest`, `make test-demos` (non-functional), `make runtime`, `make runtime-all` (new), `make test-runtime`, `make test-runtime-all` (new), `make test-mlir` (new), `make coverage-frontend`

The main issue on this platform is related to the need to preload the ASAN runtime library for the process that will end up loading a sanitized shared library. Similar to `LD_PRELOAD` on Linux, this is achieved via the environment variable
```
DYLD_INSERT_LIBRARIES="$(clang -print-file-name=libclang_rt.asan_osx_dynamic.dylib)"
```

However, contrary to `LD_PRELOAD`, the preloaded library is not propagated to any subprocesses spawned by the parent process. This can also manifest when running Jupyter Notebook tests, or when running PyTests in parallel with `xdist`, both of which are **disabled** now on macOS with ASAN enabled.

Additionally, it is **necessary** that the default Python executable discoverable in the environment is the "real" executable for the Python interpreter (one that won't spawn additional processes). On macOS, there seems to exist additional Python executables which are wrappers around the interpreter executable. For example, on my system, using the official Python installer, I can find the following executables (not symlinks):
- `/Library/Frameworks/Python.framework/Versions/3.11/bin/python3.11`: seems to spawn a new process with the executable below
- `/Library/Frameworks/Python.framework/Versions/3.11/Resources/Python.app/Contents/MacOS/Python`: actual interpreter binary

Refer to this issue for more information: https://stackoverflow.com/a/47853433

I also discovered "container overflow" sanitizer errors in our tests, but fixing these is outside the scope of this PR.

[sc-50453]