### PR TITLE
Fix the Wheel macOS (arm64) recipe with name of the job dependency

### DIFF
--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -297,7 +297,7 @@ jobs:
         retention-days: 14
 
   test-wheels:
-    needs: [constants, catalyst-macos-wheels-x86-64]
+    needs: [constants, catalyst-macos-wheels-arm64]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The recipe has been failing after merging PR #363. This PR should address the issue.