### PR TITLE
[Frontend] Invoke Catalyst gradient functions from outside of `@qjit`

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -42,6 +42,12 @@
 
 <h3>Improvements</h3>
 
+* Catalyst gradient functions ``grad``, ``jacobian``, ``jvp``, and ``vjp`` can now be invoked from
+  outside a ``@qjit`` context. This simplifies the process of writing functions where compilation
+  can be turned on and off easily by adding or removing the decorator. The functions dispatch to
+  their JAX equivalents when the compilation is turned off.
+  [(#375)](https://github.com/PennyLaneAI/catalyst/pull/375)
+
 * ``AllocOp``, ``DeallocOp`` have now (only) value semantics. In the frontend, the last
   quantum register is deallocated instead of the first one. This allows to return the quantum
   register in functions and can be given to another function (useful for quantum transformation).

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -42,8 +42,8 @@
 
 <h3>Improvements</h3>
 
-* Catalyst gradient functions ``grad``, ``jacobian``, ``jvp``, and ``vjp`` can now be invoked from
-  outside a ``@qjit`` context. This simplifies the process of writing functions where compilation
+* Catalyst gradient functions `grad`, `jacobian`, `jvp`, and `vjp` can now be invoked from
+  outside a `@qjit` context. This simplifies the process of writing functions where compilation
   can be turned on and off easily by adding or removing the decorator. The functions dispatch to
   their JAX equivalents when the compilation is turned off.
   [(#375)](https://github.com/PennyLaneAI/catalyst/pull/375)

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -15,7 +15,7 @@
 of quantum operations, measurements, and observables to JAXPR.
 """
 
-from dataclasses import dataclass
+from dataclasses import astuple, dataclass
 from itertools import chain
 from typing import Dict, Iterable, List
 
@@ -310,6 +310,9 @@ class GradParams:
     scalar_out: bool
     h: float
     argnum: List[int]
+
+    def __iter__(self):
+        return iter(astuple(self))
 
 
 @grad_p.def_impl

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -27,7 +27,13 @@ import jax.numpy as jnp
 import pennylane as qml
 from jax._src.api_util import shaped_abstractify
 from jax._src.lax.lax import _abstractify
-from jax._src.tree_util import PyTreeDef, tree_flatten, tree_unflatten, treedef_is_leaf
+from jax._src.tree_util import (
+    PyTreeDef,
+    flatten_one_level,
+    tree_flatten,
+    tree_unflatten,
+    treedef_is_leaf,
+)
 from jax.core import eval_jaxpr, get_aval
 from pennylane import QNode, QueuingManager
 from pennylane.measurements import MidMeasureMP
@@ -419,7 +425,7 @@ def _check_grad_params(
     if method == "fd" and h is None:
         h = 1e-7
     if not (h is None or isinstance(h, numbers.Number)):
-        raise ValueError(f"Invalid h value ({h}). None or number was excpected.")
+        raise ValueError(f"Invalid h value ({h}). None or number was expected.")
     if argnum is None:
         argnum = [0]
     elif isinstance(argnum, int):
@@ -448,9 +454,9 @@ class Grad:
         TypeError: Non-differentiable object was passed as `fn` argument.
     """
 
-    def __init__(self, fn: Differentiable, *, grad_params: GradParams):
+    def __init__(self, fn: Differentiable, grad_params: GradParams):
         self.fn = fn
-        self.__name__ = f"grad.{fn.__name__}"
+        self.__name__ = f"grad.{getattr(fn, '__name__', 'unknown')}"
         self.grad_params = grad_params
 
     def __call__(self, *args, **kwargs):
@@ -458,15 +464,25 @@ class Grad:
         Args:
             args: the arguments to the differentiated function
         """
-        EvaluationContext.check_is_tracing(
-            "catalyst.grad can only be used from within @qjit decorated code."
-        )
-        jaxpr = _make_jaxpr_check_differentiable(self.fn, self.grad_params, *args)
+        if EvaluationContext.is_tracing():
+            fn = _ensure_differentiable(self.fn)
+            grad_params = _check_grad_params(*self.grad_params)
 
-        args_data, _ = tree_flatten(args)
+            jaxpr = _make_jaxpr_check_differentiable(fn, grad_params, *args)
 
-        # It always returns list as required by catalyst control-flows
-        return grad_p.bind(*args_data, jaxpr=jaxpr, fn=self.fn, grad_params=self.grad_params)
+            args_data, _ = tree_flatten(args)
+
+            # It always returns list as required by catalyst control-flows
+            results = grad_p.bind(*args_data, jaxpr=jaxpr, fn=fn, grad_params=grad_params)
+        else:
+            if argnums := self.grad_params.argnum is None:
+                argnums = 0
+            if self.grad_params.scalar_out:
+                results = jax.grad(self.fn, argnums=argnums)(*args)
+            else:
+                results = jax.jacobian(self.fn, argnums=argnums)(*args)
+
+        return results
 
 
 def grad(f: DifferentiableLike, *, method=None, h=None, argnum=None):
@@ -595,9 +611,7 @@ def grad(f: DifferentiableLike, *, method=None, h=None, argnum=None):
     array(4.6)
     """
     scalar_out = True
-    return Grad(
-        _ensure_differentiable(f), grad_params=_check_grad_params(method, scalar_out, h, argnum)
-    )
+    return Grad(f, GradParams(method, scalar_out, h, argnum))
 
 
 def jacobian(f: DifferentiableLike, *, method=None, h=None, argnum=None):
@@ -661,9 +675,7 @@ def jacobian(f: DifferentiableLike, *, method=None, h=None, argnum=None):
            [-4.20735506e-01,  4.20735506e-01]])
     """
     scalar_out = False
-    return Grad(
-        _ensure_differentiable(f), grad_params=_check_grad_params(method, scalar_out, h, argnum)
-    )
+    return Grad(f, GradParams(method, scalar_out, h, argnum))
 
 
 # pylint: disable=too-many-arguments
@@ -733,22 +745,26 @@ def jvp(f: DifferentiableLike, params, tangents, *, method=None, h=None, argnum=
     >>> workflow(params, dy)
     [array(0.78766064), array(-0.7011436)]
     """
-    EvaluationContext.check_is_tracing(
-        "catalyst.jvp can only be used from within @qjit decorated code."
-    )
 
-    def _check(x, hint):
+    def check_is_iterable(x, hint):
         if not isinstance(x, Iterable):
             raise ValueError(f"vjp '{hint}' argument must be an iterable, not {type(x)}")
-        return x
 
-    params = _check(params, "params")
-    tangents = _check(tangents, "tangents")
-    fn: Differentiable = _ensure_differentiable(f)
-    scalar_out = False
-    grad_params = _check_grad_params(method, scalar_out, h, argnum)
-    jaxpr = _make_jaxpr_check_differentiable(fn, grad_params, *params)
-    return jvp_p.bind(*params, *tangents, jaxpr=jaxpr, fn=fn, grad_params=grad_params)
+    check_is_iterable(params, "params")
+    check_is_iterable(tangents, "tangents")
+
+    if EvaluationContext.is_tracing():
+        scalar_out = False
+        fn = _ensure_differentiable(f)
+        grad_params = _check_grad_params(method, scalar_out, h, argnum)
+
+        jaxpr = _make_jaxpr_check_differentiable(fn, grad_params, *params)
+
+        results = jvp_p.bind(*params, *tangents, jaxpr=jaxpr, fn=fn, grad_params=grad_params)
+    else:
+        results = jax.jvp(f, params, tangents)
+
+    return results
 
 
 # pylint: disable=too-many-arguments
@@ -794,22 +810,37 @@ def vjp(f: DifferentiableLike, params, cotangents, *, method=None, h=None, argnu
     [array([0.09983342, 0.04      , 0.02      ]),
     array([-0.43750208,  0.07000001])]
     """
-    EvaluationContext.check_is_tracing(
-        "catalyst.vjp can only be used from within @qjit decorated code."
-    )
 
-    def _check(x, hint):
+    def check_is_iterable(x, hint):
         if not isinstance(x, Iterable):
             raise ValueError(f"vjp '{hint}' argument must be an iterable, not {type(x)}")
-        return x
 
-    params = _check(params, "params")
-    cotangents = _check(cotangents, "cotangents")
-    fn: Differentiable = _ensure_differentiable(f)
-    scalar_out = False
-    grad_params = _check_grad_params(method, scalar_out, h, argnum)
-    jaxpr = _make_jaxpr_check_differentiable(fn, grad_params, *params)
-    return vjp_p.bind(*params, *cotangents, jaxpr=jaxpr, fn=fn, grad_params=grad_params)
+    check_is_iterable(params, "params")
+    check_is_iterable(cotangents, "cotangents")
+
+    if EvaluationContext.is_tracing():
+        scalar_out = False
+        fn = _ensure_differentiable(f)
+        grad_params = _check_grad_params(method, scalar_out, h, argnum)
+
+        jaxpr = _make_jaxpr_check_differentiable(fn, grad_params, *params)
+
+        results = vjp_p.bind(*params, *cotangents, jaxpr=jaxpr, fn=fn, grad_params=grad_params)
+    else:
+        primal_outputs, vjp_fn = jax.vjp(f, *params)
+
+        # JAX requires that the PyTree shape of cotangents matches that of the function results.
+        # Generally, the user is responsible for this, except when the function returns a "bare"
+        # array, since we do force users to provide cotangents as an iterable.
+        # TODO: Add support for PyTrees in the compiled branch, then we can remove this special
+        # handling here by relaxing the input type restriction.
+        if len(cotangents) == 1 and isinstance(primal_outputs, jax.Array):
+            children, _ = flatten_one_level(cotangents)
+            cotangents = children[0]
+
+        results = vjp_fn(cotangents)
+
+    return results
 
 
 def _aval_to_primitive_type(aval):

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -488,8 +488,9 @@ class Grad:
 def grad(f: DifferentiableLike, *, method=None, h=None, argnum=None):
     """A :func:`~.qjit` compatible gradient transformation for PennyLane/Catalyst.
 
-    This function allows the gradient of a hybrid quantum-classical function
-    to be computed within the compiled program.
+    This function allows the gradient of a hybrid quantum-classical function to be computed within
+    the compiled program. Outside of a compiled function, this function will simply dispatch to its
+    JAX counterpart ``jax.grad``.
 
     .. warning::
 
@@ -617,8 +618,9 @@ def grad(f: DifferentiableLike, *, method=None, h=None, argnum=None):
 def jacobian(f: DifferentiableLike, *, method=None, h=None, argnum=None):
     """A :func:`~.qjit` compatible Jacobian transformation for PennyLane/Catalyst.
 
-    This function allows the Jacobian of a hybrid quantum-classical function
-    to be computed within the compiled program.
+    This function allows the Jacobian of a hybrid quantum-classical function to be computed within
+    the compiled program. Outside of a compiled function, this function will simply dispatch to its
+    JAX counterpart ``jax.jacobian``.
 
     Args:
         f (Callable): a function or a function object to differentiate
@@ -683,7 +685,8 @@ def jvp(f: DifferentiableLike, params, tangents, *, method=None, h=None, argnum=
     """A :func:`~.qjit` compatible Jacobian-vector product for PennyLane/Catalyst.
 
     This function allows the Jacobian-vector Product of a hybrid quantum-classical function to be
-    computed within the compiled program.
+    computed within the compiled program. Outside of a compiled function, this function will simply
+    dispatch to its JAX counterpart ``jax.jvp``.
 
     Args:
         f (Callable): Function-like object to calculate JVP for
@@ -772,7 +775,8 @@ def vjp(f: DifferentiableLike, params, cotangents, *, method=None, h=None, argnu
     """A :func:`~.qjit` compatible Vector-Jacobian product for PennyLane/Catalyst.
 
     This function allows the Vector-Jacobian Product of a hybrid quantum-classical function to be
-    computed within the compiled program.
+    computed within the compiled program. Outside of a compiled function, this function will simply
+    dispatch to its JAX counterpart ``jax.vjp``.
 
     Args:
         f(Callable): Function-like object to calculate JVP for

--- a/frontend/test/pytest/test_jvpvjp.py
+++ b/frontend/test/pytest/test_jvpvjp.py
@@ -59,6 +59,96 @@ def assert_elements_allclose(a, b, **kwargs):
 diff_methods = ["auto", "fd"]
 
 
+def test_vjp_outside_qjit_scalar_scalar():
+    """Test that vjp can be used outside of a jitting context on a scalar-scalar function."""
+
+    def f(x):
+        return x**2
+
+    x = (4.0,)
+    ct = (1.0,)
+
+    expected = jax.vjp(f, *x)[1](*ct)
+    result = C_vjp(f, x, ct)
+
+    assert_allclose(expected, result)
+
+
+def test_vjp_outside_qjit_tuple_scalar():
+    """Test that vjp can be used outside of a jitting context on a tuple-scalar function."""
+
+    def f(x, y):
+        return x**2 + y**2
+
+    x = (4.0, 4.0)
+    ct = (1.0,)
+
+    expected = jax.vjp(f, *x)[1](*ct)
+    result = C_vjp(f, x, ct)
+
+    assert_allclose(expected, result)
+
+
+def test_vjp_outside_qjit_tuple_tuple():
+    """Test that vjp can be used outside of a jitting context on a tuple-tuple function."""
+
+    def f(x, y):
+        return x**2, y**2
+
+    x = (4.0, 4.0)
+    ct = (1.0, 1.0)
+
+    expected = jax.vjp(f, *x)[1](ct)
+    result = C_vjp(f, x, ct)
+
+    assert_allclose(expected, result)
+
+
+def test_jvp_outside_qjit_scalar_scalar():
+    """Test that jvp can be used outside of a jitting context on a scalar-scalar function."""
+
+    def f(x):
+        return x**2
+
+    x = (4.0,)
+    t = (1.0,)
+
+    expected = jax.jvp(f, x, t)
+    result = C_jvp(f, x, t)
+
+    assert_allclose(expected, result)
+
+
+def test_jvp_outside_qjit_tuple_scalar():
+    """Test that jvp can be used outside of a jitting context on a tuple-scalar function."""
+
+    def f(x, y):
+        return x**2 + y**2
+
+    x = (4.0, 4.0)
+    t = (1.0, 1.0)
+
+    expected = jax.jvp(f, x, t)
+    result = C_jvp(f, x, t)
+
+    assert_allclose(expected, result)
+
+
+def test_jvp_outside_qjit_tuple_tuple():
+    """Test that jvp can be used outside of a jitting context on a tuple-tuple function."""
+
+    def f(x, y):
+        return x**2, y**2
+
+    x = (4.0, 4.0)
+    t = (1.0, 1.0)
+
+    expected = jax.jvp(f, x, t)
+    result = C_jvp(f, x, t)
+
+    assert_allclose(expected, result)
+
+
 @pytest.mark.parametrize("diff_method", diff_methods)
 def test_jvp_against_jax_full_argnum_case_S_SS(diff_method):
     """Numerically tests Catalyst's jvp against the JAX version."""


### PR DESCRIPTION
The following is now supported:

```py
from catalyst import *

def f(x):
    return x**2

>>> grad(f)(4)
Array(8., dtype=float64, weak_type=True)
```

Support has been added to: `grad`, `jacobian`, `jvp`, `jvp`

[sc-46393]