### PR TITLE
[Frontend] `typing` in Python3.9 does not support `|` operator

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -18,6 +18,7 @@
 
 * Support for dynamically-shaped arrays has been added.
   [(#366)](https://github.com/PennyLaneAI/catalyst/pull/366)
+  [(#386)](https://github.com/PennyLaneAI/catalyst/pull/385)
 
   Catalyst now accepts tensors whose dimensions are not known at compile time.
   Standard tensor initialisation functions `jax.numpy.ones`, `jnp.zeros`, and

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -25,7 +25,7 @@ import warnings
 from copy import deepcopy
 from dataclasses import dataclass
 from io import TextIOWrapper
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from mlir_quantum.compiler_driver import run_compiler_driver
 
@@ -63,7 +63,7 @@ class CompileOptions:
     pipelines: Optional[List[Any]] = None
     autograph: Optional[bool] = False
     lower_to_llvm: Optional[bool] = True
-    abstracted_axes: Optional[Iterable[Iterable[str]] | Dict[int, str]] = None
+    abstracted_axes: Optional[Union[Iterable[Iterable[str]], Dict[int, str]]] = None
 
     def __deepcopy__(self, memo):
         """Make a deep copy of all fields of a CompileOptions object except the logfile, which is


### PR DESCRIPTION
**Context:** Python3.9 does not support `|` operator for types in the `typing` module.

**Description of the Change:** Use `Union`.

**Benefits:** Tests for 3.9 succeed.

**Possible Drawbacks:** None

**Related GitHub Issues:**
