### PR TITLE
Raising build errors if cargo is required and not found

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -65,10 +65,18 @@ if(BUILD_QIR_STDLIB_FROM_SRC OR APPLE)
     FetchContent_MakeAvailable(qir_runner)
 
     execute_process(
-        COMMAND cargo build --release --package qir-stdlib --target-dir ${qir_runner_BINARY_DIR}
+        COMMAND cargo build --release --package qir-stdlib --target-dir ${qir_runner_BINARY_DIR} RESULT_VARIABLE cargo_found_status
         COMMAND ${CMAKE_COMMAND} -E copy ./stdlib/include/qir_stdlib.h ${qir_runner_BINARY_DIR}/release/qir_stdlib.h
         WORKING_DIRECTORY ${qir_runner_SOURCE_DIR}
     )
+
+    if(NOT cargo_found_status EQUAL "0")
+        message(STATUS "-- To build runtime from source, you also need \"cargo\"")
+        message(STATUS "-- and the \"llvm-tools-preview\" rustup component.")
+        message(STATUS "-- Run the following command to install these dependencies:")
+        message(STATUS "-- $ curl https://sh.rustup.rs -sSf | sh && source \"$HOME/.cargo/env\" && rustup component add llvm-tools-preview")
+        message(FATAL_ERROR "Not found cargo")
+    endif()
 
     set(QIR_STDLIB_PATH ${qir_runner_BINARY_DIR}/release)
 elseif(NOT DEFINED QIR_STDLIB_PATH)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -71,11 +71,12 @@ if(BUILD_QIR_STDLIB_FROM_SRC OR APPLE)
     )
 
     if(NOT cargo_found_status EQUAL "0")
-        message(STATUS "-- To build runtime from source, you also need \"cargo\"")
-        message(STATUS "-- and the \"llvm-tools-preview\" rustup component.")
-        message(STATUS "-- Run the following command to install these dependencies:")
-        message(STATUS "-- $ curl https://sh.rustup.rs -sSf | sh && source \"$HOME/.cargo/env\" && rustup component add llvm-tools-preview")
-        message(FATAL_ERROR "Not found cargo")
+        message(FATAL_ERROR
+            "Missing cargo installation\n"
+            "Please install \"Rust\" and the \"llvm-tools-preview\" rustup component "
+            "for building qir-stdlib from source. See the installation guideline for details: "
+            "https://docs.pennylane.ai/projects/catalyst/en/stable/dev/installation.html"
+            )
     endif()
 
     set(QIR_STDLIB_PATH ${qir_runner_BINARY_DIR}/release)


### PR DESCRIPTION
The runtime requires an installation of `cargo` to build `qir-stdlib` from source (on macOS or by developer requires via the `BUILD_QIR_STDLIB_FROM_SRC=ON` CMake flag). Currently, if the developer forget to install cargo or the llvm rustup component, the build will be failed with the following error message:

``` console
catalyst/runtime/include/RuntimeCAPI.h:21:10: fatal error: 'qir_stdlib.h' file not found
#include "qir_stdlib.h"
```

This PR updates the build system of the runtime to throw errors at the proper build step with a clear message:

``` console
-- Building qir-stdlib from source.
CMake Error at CMakeLists.txt:74 (message):
  Missing cargo installation

  Please install "Rust" and the "llvm-tools-preview" rustup component for
  building qir-stdlib from source.  See the installation guideline for
  details:
  https://docs.pennylane.ai/projects/catalyst/en/stable/dev/installation.html
```
