### PR TITLE
[MLIR] Guarantee quantum dialect ops are eliminated when extracting classical code from QNodes

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -18,7 +18,7 @@
 
 <h3>Improvements</h3>
 
-* ``AllocOp``, ``DeallocOp`` have now (only) value semantics. In the frontend, the last 
+* ``AllocOp``, ``DeallocOp`` have now (only) value semantics. In the frontend, the last
   quantum register is deallocated instead of the first one. This allows to return the quantum
   register in functions and can be given to another function (useful for quantum transformation).
   [(#360)](https://github.com/PennyLaneAI/catalyst/pull/360)
@@ -35,11 +35,20 @@
 
 <h3>Bug fixes</h3>
 
+* Resolve a bug in the compiler's differentiation engine that results in a crash with the Enzyme
+  error message "attempting to differentiate function without definition" (see issue
+  [#384](https://github.com/PennyLaneAI/catalyst/issues/384)).
+  The fix ensures that all current quantum operation types are removed during gradient passes that
+  extract classical from a QNode function. It also adds a verification step that will raise an error
+  if a gradient pass cannot successfully eliminate all quantum operations for such functions.
+  [(#397)](https://github.com/PennyLaneAI/catalyst/issues/397)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
 Ali Asadi,
+David Ittah,
 Romain Moyard,
 Erick Ochoa Lopez.
 
@@ -235,7 +244,7 @@ Erick Ochoa Lopez.
 
   - `qjit`: Path to the JIT compiler decorator provided by the compiler. This decorator should have
     the signature `qjit(fn, *args, **kwargs)`, where `fn` is the function to be compiled.
-  
+
 * The compiler driver diagnostic output has been improved, and now includes failing IR as well as
   the names of failing passes.
   [(#349)](https://github.com/PennyLaneAI/catalyst/pull/349)

--- a/mlir/include/Quantum/IR/QuantumInterfaces.td
+++ b/mlir/include/Quantum/IR/QuantumInterfaces.td
@@ -17,6 +17,42 @@
 
 include "mlir/IR/OpBase.td"
 
+def QuantumRegion : OpInterface<"QuantumRegion"> {
+    let description = [{
+        This interface provides a generic way to interact with instructions that are
+        considered quantum regions. These are characterized by operating on a single
+        qubit register, and returning a new register value.
+    }];
+
+    let cppNamespace = "::catalyst::quantum";
+
+    let methods = [
+        InterfaceMethod<
+            "Return the quantum register operand.",
+            "mlir::Value", "getRegisterOperand", (ins), /*methodBody=*/[{
+                return $_op->getOperand(0);
+            }]
+        >,
+        InterfaceMethod<
+            "Return the quantum register result.",
+            "mlir::Value", "getRegisterResult", (ins), /*methodBody=*/[{
+                return $_op->getResult(0);
+            }]
+        >,
+    ];
+
+    let verify = [{
+
+        if ($_op->getNumOperands() != 1)
+            return $_op->emitOpError("must have exactly one operand (quantum register)");
+
+        if ($_op->getNumResults() != 1)
+            return $_op->emitOpError("must have exactly one result (quantum register)");
+
+        return mlir::success();
+    }];
+}
+
 def QuantumGate : OpInterface<"QuantumGate"> {
     let description = [{
         This interface provides a generic way to interact with instructions that are

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -183,7 +183,7 @@ def InsertOp : Memory_Op<"insert", [NoMemoryEffect]> {
 // -----
 
 class Gate_Op<string mnemonic, list<Trait> traits = []> :
-        Quantum_Op<mnemonic, traits # [QuantumGate, Unitary]> {
+        Quantum_Op<mnemonic, traits # [NoMemoryEffect, QuantumGate, Unitary]> {
 
     code extraBaseClassDeclaration = [{
         mlir::ValueRange getQubitOperands() {
@@ -205,7 +205,7 @@ class Gate_Op<string mnemonic, list<Trait> traits = []> :
     let extraClassDeclaration = extraBaseClassDeclaration;
 }
 
-def CustomOp : Gate_Op<"custom", [NoMemoryEffect, AttrSizedOperandSegments, DifferentiableGate]> {
+def CustomOp : Gate_Op<"custom", [AttrSizedOperandSegments, DifferentiableGate]> {
     let summary = "A generic quantum gate on n qubits with m floating point parameters.";
     let description = [{
     }];
@@ -232,7 +232,7 @@ def CustomOp : Gate_Op<"custom", [NoMemoryEffect, AttrSizedOperandSegments, Diff
     }];
 }
 
-def MultiRZOp : Gate_Op<"multirz", [NoMemoryEffect, DifferentiableGate]> {
+def MultiRZOp : Gate_Op<"multirz", [DifferentiableGate]> {
     let summary = "Apply an arbitrary multi Z rotation";
     let description = [{
         The `quantum.multirz` operation applies an arbitrary multi Z rotation to the state-vector.
@@ -260,7 +260,7 @@ def MultiRZOp : Gate_Op<"multirz", [NoMemoryEffect, DifferentiableGate]> {
     }];
 }
 
-def QubitUnitaryOp : Gate_Op<"unitary", [NoMemoryEffect, ParametrizedGate]> {
+def QubitUnitaryOp : Gate_Op<"unitary", [ParametrizedGate]> {
     let summary = "Apply an arbitrary fixed unitary matrix";
     let description = [{
         The `quantum.unitary` operation applies an arbitrary fixed unitary matrix to the
@@ -295,9 +295,10 @@ def QubitUnitaryOp : Gate_Op<"unitary", [NoMemoryEffect, ParametrizedGate]> {
 
 // -----
 
-class Observable_Op<string mnemonic, list<Trait> traits = []> : Quantum_Op<mnemonic, traits>;
+class Observable_Op<string mnemonic, list<Trait> traits = []> :
+        Quantum_Op<mnemonic, traits # [Pure]>;
 
-def ComputationalBasisOp : Observable_Op<"compbasis", [Pure]> {
+def ComputationalBasisOp : Observable_Op<"compbasis"> {
     let summary = "Define a pseudo-obeservable of the computational basis for use in measurements";
     let description = [{
         The `quantum.compbasis` operation defines a quantum observable to be used by other
@@ -329,7 +330,7 @@ def ComputationalBasisOp : Observable_Op<"compbasis", [Pure]> {
     }];
 }
 
-def NamedObsOp : Observable_Op<"namedobs", [Pure]> {
+def NamedObsOp : Observable_Op<"namedobs"> {
     let summary = "Define a Named observable for use in measurements";
     let description = [{
         The `quantum.namedobs` operation defines a quantum observable to be used by measurement
@@ -362,7 +363,7 @@ def NamedObsOp : Observable_Op<"namedobs", [Pure]> {
     }];
 }
 
-def HermitianOp : Observable_Op<"hermitian", [Pure]> {
+def HermitianOp : Observable_Op<"hermitian"> {
     let summary = "Define a Hermitian observable for use in measurements";
     let description = [{
         The `quantum.hermitian` operation defines a quantum observable to be used by measurement
@@ -388,7 +389,7 @@ def HermitianOp : Observable_Op<"hermitian", [Pure]> {
     let hasVerifier = 1;
 }
 
-def TensorOp : Observable_Op<"tensor", [Pure]> {
+def TensorOp : Observable_Op<"tensor"> {
     let summary = "Define a tensor product of observables for use in measurements";
     let description = [{
         The `quantum.tensor` operation defines a quantum observable to be used by other
@@ -422,7 +423,7 @@ def TensorOp : Observable_Op<"tensor", [Pure]> {
     }];
 }
 
-def HamiltonianOp : Observable_Op<"hamiltonian", [Pure]> {
+def HamiltonianOp : Observable_Op<"hamiltonian"> {
     let summary = "Define a Hamiltonian observable for use in measurements";
     let description = [{
         The `quantum.hamiltonian` operation defines a quantum observable to be used by other

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -295,6 +295,47 @@ def QubitUnitaryOp : Gate_Op<"unitary", [ParametrizedGate]> {
 
 // -----
 
+class Region_Op<string mnemonic, list<Trait> traits = []> :
+        Quantum_Op<mnemonic, traits # [NoMemoryEffect]>;
+
+def AdjointOp : Region_Op<"adjoint", [QuantumRegion, SingleBlockImplicitTerminator<"YieldOp">]> {
+    let summary = "Calculate the adjoint of the enclosed operations";
+
+    let regions = (region SizedRegion<1>:$region);
+
+    let arguments = (ins
+        QuregType:$qreg
+    );
+
+    let results = (outs
+        QuregType:$out_qreg
+    );
+
+    let assemblyFormat = [{
+        `(` $qreg `)` attr-dict `:` type(operands) $region
+    }];
+
+    let hasVerifier = 1;
+}
+
+def YieldOp : Quantum_Op<"yield", [Pure, ReturnLike, Terminator, ParentOneOf<["AdjointOp"]>]> {
+    let summary = "Return results from quantum program regions";
+
+    let arguments = (ins
+        Variadic<AnyTypeOf<[QuregType]>>:$results
+    );
+
+    let assemblyFormat = [{
+        attr-dict ($results^ `:` type($results))?
+    }];
+
+    let builders = [
+        OpBuilder<(ins), [{ /* nothing to do */ }]>
+    ];
+}
+
+// -----
+
 class Observable_Op<string mnemonic, list<Trait> traits = []> :
         Quantum_Op<mnemonic, traits # [Pure]>;
 
@@ -764,43 +805,6 @@ def StateOp : Measurement_Op<"state"> {
     }];
 
     let hasVerifier = 1;
-}
-
-def AdjointOp : Op<QuantumDialect, "adjoint", [SingleBlockImplicitTerminator<"YieldOp">]> {
-    let summary = "Calculate the adjoint of the enclosed operations";
-
-    let regions = (region SizedRegion<1>:$region);
-
-    let arguments = (ins
-        QuregType:$qreg
-    );
-
-    let results = (outs
-        QuregType:$out_qreg
-    );
-
-    let assemblyFormat = [{
-        `(` $qreg `)` attr-dict `:` type(operands) $region
-    }];
-
-    let hasVerifier = 1;
-}
-
-def YieldOp : Op<QuantumDialect, "yield",
-                [Pure, ReturnLike, Terminator, ParentOneOf<["AdjointOp"]>]> {
-    let summary = "Return results from quantum program regions";
-
-    let arguments = (ins
-        Variadic<AnyTypeOf<[QuregType]>>:$results
-    );
-
-    let assemblyFormat = [{
-        attr-dict ($results^ `:` type($results))?
-    }];
-
-    let builders = [
-        OpBuilder<(ins), [{ /* nothing to do */ }]>
-    ];
 }
 
 #endif // QUANTUM_OPS

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -64,7 +64,7 @@ def NamedObservableAttr : EnumAttr<QuantumDialect, NamedObservable, "named_obser
 class Quantum_Op<string mnemonic, list<Trait> traits = []> : Op<QuantumDialect, mnemonic, traits>;
 
 def InitializeOp : Quantum_Op<"init"> {
-    let summary = "Initialize the quantum device in the runtime.";
+    let summary = "Initialize the quantum runtime.";
 
     let assemblyFormat = [{
         attr-dict
@@ -72,7 +72,7 @@ def InitializeOp : Quantum_Op<"init"> {
 }
 
 def FinalizeOp : Quantum_Op<"finalize"> {
-    let summary = "Teardown the quantum device in the runtime.";
+    let summary = "Teardown the quantum runtime.";
 
     let assemblyFormat = [{
         attr-dict
@@ -80,7 +80,7 @@ def FinalizeOp : Quantum_Op<"finalize"> {
 }
 
 def DeviceOp : Quantum_Op<"device"> {
-    let summary = "Set device specifications in the runtime.";
+    let summary = "Initialize a quantum device or set some device configuration options.";
 
     let arguments = (ins
         OptionalAttr<StrArrayAttr>:$specs

--- a/mlir/include/Quantum/Utils/RemoveQuantum.h
+++ b/mlir/include/Quantum/Utils/RemoveQuantum.h
@@ -20,6 +20,7 @@ namespace catalyst {
 namespace quantum {
 
 void removeQuantumMeasurements(mlir::func::FuncOp &function);
+mlir::LogicalResult verifyQuantumFree(mlir::func::FuncOp function);
 
 } // namespace quantum
 } // namespace catalyst

--- a/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
@@ -591,7 +591,6 @@ struct BackpropOpPattern : public ConvertOpToLLVMPattern<BackpropOp> {
 
         SmallVector<Value> unwrappedInputs;
         SmallVector<Value> unwrappedShadows;
-        unsigned idx = 0;
 
         auto unwrapMemRef = [&](Value wrapped, Type unwrappedType) {
             auto structType = getTypeConverter()->convertType(unwrappedType);
@@ -611,7 +610,6 @@ struct BackpropOpPattern : public ConvertOpToLLVMPattern<BackpropOp> {
                 assert(false && "non memref inputs not yet supported");
                 unwrappedInputs.push_back(arg);
             }
-            idx++;
         }
 
         SmallVector<Value> primalInputs{

--- a/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
@@ -39,7 +39,7 @@
 #include "Gradient/Utils/EinsumLinalgGeneric.h"
 #include "Gradient/Utils/GradientShape.h"
 #include "Quantum/IR/QuantumOps.h"
-#include "Quantum/Utils/RemoveQuantumMeasurements.h"
+#include "Quantum/Utils/RemoveQuantum.h"
 
 using namespace mlir;
 using namespace catalyst::gradient;

--- a/mlir/lib/Gradient/Transforms/GradMethods/ClassicalJacobian.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/ClassicalJacobian.cpp
@@ -25,7 +25,7 @@
 
 #include "Quantum/IR/QuantumInterfaces.h"
 #include "Quantum/IR/QuantumOps.h"
-#include "Quantum/Utils/RemoveQuantumMeasurements.h"
+#include "Quantum/Utils/RemoveQuantum.h"
 
 namespace catalyst {
 namespace gradient {

--- a/mlir/lib/Gradient/Transforms/GradMethods/ClassicalJacobian.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/ClassicalJacobian.cpp
@@ -111,6 +111,7 @@ func::FuncOp genParamCountFunction(PatternRewriter &rewriter, Location loc, func
         });
 
         quantum::removeQuantumMeasurements(paramCountFn);
+        paramCountFn->setAttr("QuantumFree", rewriter.getUnitAttr());
     }
 
     return paramCountFn;
@@ -195,6 +196,7 @@ func::FuncOp genSplitPreprocessed(PatternRewriter &rewriter, Location loc, func:
         });
 
         quantum::removeQuantumMeasurements(splitFn);
+        splitFn->setAttr("QuantumFree", rewriter.getUnitAttr());
     }
 
     return splitFn;
@@ -282,6 +284,7 @@ func::FuncOp genArgMapFunction(PatternRewriter &rewriter, Location loc, func::Fu
         });
 
         quantum::removeQuantumMeasurements(argMapFn);
+        argMapFn->setAttr("QuantumFree", rewriter.getUnitAttr());
     }
 
     return argMapFn;

--- a/mlir/lib/Gradient/Transforms/GradMethods/HybridGradient.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/HybridGradient.cpp
@@ -27,7 +27,7 @@
 #include "Gradient/Utils/GradientShape.h"
 #include "Quantum/IR/QuantumInterfaces.h"
 #include "Quantum/IR/QuantumOps.h"
-#include "Quantum/Utils/RemoveQuantumMeasurements.h"
+#include "Quantum/Utils/RemoveQuantum.h"
 
 using namespace mlir;
 

--- a/mlir/lib/Gradient/Transforms/GradMethods/PS_QuantumGradient.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/PS_QuantumGradient.cpp
@@ -307,6 +307,7 @@ func::FuncOp ParameterShiftLowering::genQGradFunction(PatternRewriter &rewriter,
         });
 
         quantum::removeQuantumMeasurements(gradientFn);
+        gradientFn->setAttr("QuantumFree", rewriter.getUnitAttr());
     }
 
     return gradientFn;

--- a/mlir/lib/Gradient/Transforms/GradMethods/PS_QuantumGradient.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/PS_QuantumGradient.cpp
@@ -28,7 +28,7 @@
 #include "Gradient/Utils/GradientShape.h"
 #include "Quantum/IR/QuantumDialect.h"
 #include "Quantum/IR/QuantumOps.h"
-#include "Quantum/Utils/RemoveQuantumMeasurements.h"
+#include "Quantum/Utils/RemoveQuantum.h"
 
 namespace catalyst {
 namespace gradient {

--- a/mlir/lib/Gradient/Transforms/GradMethods/PS_QuantumGradient.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/PS_QuantumGradient.cpp
@@ -290,13 +290,18 @@ func::FuncOp ParameterShiftLowering::genQGradFunction(PatternRewriter &rewriter,
 
         // Finally erase all quantum operations.
         gradientFn.walk([&](Operation *op) {
-            if (auto gate = dyn_cast<quantum::QuantumGate>(op)) {
+            if (isa<quantum::DeviceOp>(op)) {
+                rewriter.eraseOp(op);
+            }
+            else if (auto gate = dyn_cast<quantum::QuantumGate>(op)) {
                 // We are undoing the def-use chains of this gate's return values
                 // so that we can safely delete it (all quantum ops must be eliminated).
                 rewriter.replaceOp(gate, gate.getQubitOperands());
             }
-            else if (isa<quantum::DeviceOp>(op)) {
-                // Erase redundant device specifications.
+            else if (auto region = dyn_cast<quantum::QuantumRegion>(op)) {
+                rewriter.replaceOp(op, region.getRegisterOperand());
+            }
+            else if (isa<quantum::DeallocOp>(op)) {
                 rewriter.eraseOp(op);
             }
         });

--- a/mlir/lib/Quantum/Utils/CMakeLists.txt
+++ b/mlir/lib/Quantum/Utils/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_mlir_library(QuantumUtils
 	QuantumSplitting.cpp
-	RemoveQuantumMeasurements.cpp
+	RemoveQuantum.cpp
 )

--- a/mlir/test/Gradient/AdjointTest.mlir
+++ b/mlir/test/Gradient/AdjointTest.mlir
@@ -17,8 +17,8 @@
 // Check scalar to scalar function
 func.func private @funcScalarScalar(%arg0: f64) -> f64 attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    "do-not.dce-the-quantum-reg"(%0) : (!quantum.reg) -> ()
-    quantum.dealloc %0 : !quantum.reg
+    %1 = quantum.adjoint(%0) : !quantum.reg {}  // prevent folding of dealloc into alloc
+    quantum.dealloc %1 : !quantum.reg
     return %arg0 : f64
 }
 
@@ -43,8 +43,8 @@ func.func @gradCallScalarScalar(%arg0: f64) -> f64 {
 // Check scalar to tensor function
 func.func private @funcScalarTensor(%arg0: f64) -> tensor<2x3xf64> attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    "do-not.dce-the-quantum-reg"(%0) : (!quantum.reg) -> ()
-    quantum.dealloc %0 : !quantum.reg
+    %1 = quantum.adjoint(%0) : !quantum.reg {}  // prevent folding of dealloc into alloc
+    quantum.dealloc %1 : !quantum.reg
     %c0 = arith.constant 0.0 : f64
     %res = tensor.from_elements %c0, %c0, %c0, %c0, %c0, %c0 : tensor<2x3xf64>
     return %res : tensor<2x3xf64>
@@ -70,8 +70,8 @@ func.func @gradCallScalarTensor(%arg0: f64) -> tensor<2x3xf64> {
 // Check tensor to scalar
 func.func private @funcTensorScalar(%arg0: tensor<3xf64>) -> f64 attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    "do-not.dce-the-quantum-reg"(%0) : (!quantum.reg) -> ()
-    quantum.dealloc %0 : !quantum.reg
+    %1 = quantum.adjoint(%0) : !quantum.reg {}  // prevent folding of dealloc into alloc
+    quantum.dealloc %1 : !quantum.reg
     %res = arith.constant 0.0 : f64
     return %res : f64
 }
@@ -97,8 +97,8 @@ func.func @gradCallTensorScalar(%arg0: tensor<3xf64>) -> tensor<3xf64> {
 // Check tensor to tensor case
 func.func private @funcTensorTensor(%arg0: tensor<7x3x2x1xf64>) -> tensor<2xf64> attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    "do-not.dce-the-quantum-reg"(%0) : (!quantum.reg) -> ()
-    quantum.dealloc %0 : !quantum.reg
+    %1 = quantum.adjoint(%0) : !quantum.reg {}  // prevent folding of dealloc into alloc
+    quantum.dealloc %1 : !quantum.reg
     %c0 = arith.constant 0.0 : f64
     %res = tensor.from_elements %c0, %c0 : tensor<2xf64>
     return %res : tensor<2xf64>
@@ -124,8 +124,8 @@ func.func @gradCallTensorTensor(%arg0: tensor<7x3x2x1xf64>) -> tensor<2x7x3x2x1x
 // Check the multiple results case
 func.func @funcMultiRes(%arg0: f64) -> (f64, tensor<2xf64>) attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    "do-not.dce-the-quantum-reg"(%0) : (!quantum.reg) -> ()
-    quantum.dealloc %0 : !quantum.reg
+    %1 = quantum.adjoint(%0) : !quantum.reg {}  // prevent folding of dealloc into alloc
+    quantum.dealloc %1 : !quantum.reg
     %res = tensor.from_elements %arg0, %arg0 : tensor<2xf64>
     func.return %arg0, %res : f64, tensor<2xf64>
 }
@@ -151,8 +151,8 @@ func.func @gradCallMultiRes(%arg0: f64) -> (f64, tensor<2xf64>)  {
 // Check the case with multiple grad invocations with varying diffArgIndices
 func.func @funcMultiArg(%arg0: f64, %arg1: tensor<2xf64>) -> f64 attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    "do-not.dce-the-quantum-reg"(%0) : (!quantum.reg) -> ()
-    quantum.dealloc %0 : !quantum.reg
+    %1 = quantum.adjoint(%0) : !quantum.reg {}  // prevent folding of dealloc into alloc
+    quantum.dealloc %1 : !quantum.reg
     func.return %arg0 : f64
 }
 
@@ -179,8 +179,8 @@ func.func @gradCallMultiArg(%arg0: f64, %arg1: tensor<2xf64>) -> (f64, tensor<2x
 // Check multiple grad calls to same function with the same diffArgIndices
 func.func private @funcMultiCall(%arg0: f64) -> f64 attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    "do-not.dce-the-quantum-reg"(%0) : (!quantum.reg) -> ()
-    quantum.dealloc %0 : !quantum.reg
+    %1 = quantum.adjoint(%0) : !quantum.reg {}  // prevent folding of dealloc into alloc
+    quantum.dealloc %1 : !quantum.reg
     func.return %arg0 : f64
 }
 

--- a/mlir/test/Gradient/VerifierTest.mlir
+++ b/mlir/test/Gradient/VerifierTest.mlir
@@ -22,7 +22,6 @@ func.func private @foo(%arg0: f64) -> f64
 
 gradient.grad "fd" @foo(%0) : (f64) -> f64
 gradient.grad "auto" @foo(%0) : (f64) -> f64
-gradient.grad "auto" @foo(%0) : (f64) -> f64
 
 // expected-error@+1 {{got invalid differentiation method: none}}
 gradient.grad "none" @foo(%0) : (f64) -> f64

--- a/mlir/test/Quantum/AdjointTest.mlir
+++ b/mlir/test/Quantum/AdjointTest.mlir
@@ -105,13 +105,14 @@ func.func private @workflow_nested() -> tensor<4xcomplex<f64>> attributes {} {
 
 func.func @workflow_unhandled() {
   %0 = quantum.alloc(1) : !quantum.reg
-  quantum.adjoint (%0) : !quantum.reg {
+  %1 = quantum.adjoint (%0) : !quantum.reg {
   ^bb0(%arg0: !quantum.reg):
     %qb = quantum.extract %arg0[0] : !quantum.reg -> !quantum.bit
     // expected-error@+1 {{Unhandled operation in adjoint region}}
     quantum.measure %qb : i1, !quantum.bit
     quantum.yield %arg0 : !quantum.reg
   }
+  quantum.dealloc %1 : !quantum.reg
   return
 }
 


### PR DESCRIPTION
This PR addresses a regression introduced in #360. The frontend change to deallocate the final quantum register value prevented gradient transforms from removing all quantum instructions when extracting the classical part of a quantum function, due to some broken assumptions. See also issue #384.

The fix ensures more quantum ops are manually removed during such procedures (e.g. non-differentiable gates, quantum region ops, the `dealloc` operation), but it also adds verification that indeed all quantum operations are removed. Note the removal of quantum operations still relies on the folding/dce mechanism for certain ops like `insert`/`extract`, and `alloc`. The verification is thus applied at the end of the gradient lowering pass, by inspected functions marked with the `QuantumFree` unit attribute.

I will leave #384 open as the full resolution to that issue should involve raising an error message in the frontend when an unsupported gate is being differentiated.

[sc-51646]