### PR TITLE
[Frontend] Refactor call tree verification for Grad

### DIFF
--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -101,6 +101,7 @@ class Function:
         retval = func_p.bind(wrap_init(_eval_jaxpr), *args, fn=self.fn)
         return tree_unflatten(out_tree, retval)
 
+
 KNOWN_NAMED_OBS = (qml.Identity, qml.PauliX, qml.PauliY, qml.PauliZ, qml.Hadamard)
 
 FORCED_ORDER_PRIMITIVES = {qdevice_p, qextract_p, qinst_p}

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -98,7 +98,7 @@ class Function:
         def _eval_jaxpr(*args):
             return jax.core.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, *args)
 
-        retval = func_p.bind(wrap_init(_eval_jaxpr), *args, fn=self)
+        retval = func_p.bind(wrap_init(_eval_jaxpr), *args, fn=self.fn)
         return tree_unflatten(shape_tree, retval)
 
 


### PR DESCRIPTION
The primitives for Function and Grad have been changed to bind the callee, instead of the object instance itself.
Additionally, the call tree traversal of the callee has been improved to be more robust.

No (external) functional changes.