### PR TITLE
Add macros for generating the device entry-point and declarations

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -15,6 +15,8 @@
   This provides flexibility and extensibility to Catalyst allowing users to
   load quantum devices dynamically.
   [(#343)](https://github.com/PennyLaneAI/catalyst/pull/343)
+  [(#400)](https://github.com/PennyLaneAI/catalyst/pull/400)
+
 
 * Support for dynamically-shaped arrays has been added.
   [(#366)](https://github.com/PennyLaneAI/catalyst/pull/366)
@@ -60,9 +62,6 @@
   and lowers the operation to one single device initialization call:
   `__quantum__rt__device_init(int8_t *, int8_t *, int8_t *)`.
   [(#396)](https://github.com/PennyLaneAI/catalyst/pull/396)
-
-* Add C++ macros for generating the device entry-point and declarations.
-  [(#400)](https://github.com/PennyLaneAI/catalyst/pull/400)
 
 <h3>Breaking changes</h3>
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -55,6 +55,9 @@
   operations and control flow operations.
   [(#353)](https://github.com/PennyLaneAI/catalyst/pull/353)
 
+* Add the `GENERATE_DEVICE_ENTRYPOINT` template macro for generating a device entry-point in the runtime plugin system.
+  [(#400)](https://github.com/PennyLaneAI/catalyst/pull/400)
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -61,6 +61,9 @@
   `__quantum__rt__device_init(int8_t *, int8_t *, int8_t *)`.
   [(#396)](https://github.com/PennyLaneAI/catalyst/pull/396)
 
+* Add C++ macros for generating the device entry-point and declarations.
+  [(#400)](https://github.com/PennyLaneAI/catalyst/pull/400)
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>

--- a/doc/dev/custom_devices.rst
+++ b/doc/dev/custom_devices.rst
@@ -84,7 +84,7 @@ in the C++ format. As an example, we use the identifier ``CustomDevice``:
 
 .. code-block:: c++
 
-    GENERATE_DEVICE_FACTORY(CustomDevice, /* NAMESPACE */)
+    GENERATE_DEVICE_ENTRYPOINT(CustomDevice, /* NAMESPACE */)
 
 The entry point function acts as a factory method for the device class.
 Note that a plugin library may also provide several factory methods in case it packages

--- a/doc/dev/custom_devices.rst
+++ b/doc/dev/custom_devices.rst
@@ -86,6 +86,15 @@ uniquely identify the entry point symbol. As an example, we use the identifier `
         return new CustomDevice(std::string(kwargs));
     }
 
+For simplicity, you can use the ``GENERATE_DEVICE_FACTORY(IDENTIFIER, CONSTRUCTOR)`` macro to
+define this function, where ``IDENTIFIER`` is the device identifier, and ``CONSTRUCTOR`` is the
+C++ device constructor including the namespace. For this example, both the device identifier and
+constructor are the same:
+
+.. code-block:: c++
+
+    GENERATE_DEVICE_FACTORY(CustomDevice, CustomDevice);
+
 The entry point function acts as a factory method for the device class.
 Note that a plugin library may also provide several factory methods in case it packages
 multiple devices into the same library. However, it is important that the device identifier

--- a/doc/dev/custom_devices.rst
+++ b/doc/dev/custom_devices.rst
@@ -77,14 +77,14 @@ Additionally, all measurements will always return ``true``.
 
 In addition to implementing the ``QuantumDevice`` class, one must implement an entry point for the
 device library with the name ``<DeviceIdentifier>Factory``, where ``DeviceIdentifier`` is used to
-uniquely identify the entry point symbol. As an example, we use the identifier ``CustomDevice``:
+uniquely identify the entry point symbol.
+You can use the `GENERATE_DEVICE_ENTRYPOINT(DEVICE_NAME, NAMESPACE)` template macro to define this entry
+point where `DEVICE_NAME` is the name of the device identifier and `NAMESPACE` is the device class namespace
+in the C++ format. As an example, we use the identifier ``CustomDevice``:
 
 .. code-block:: c++
 
-    extern "C" Catalyst::Runtime::QuantumDevice*
-    CustomDeviceFactory(const std::string &kwargs) {
-        return new CustomDevice(kwargs);
-    }
+    GENERATE_DEVICE_FACTORY(CustomDevice, /* NAMESPACE */)
 
 The entry point function acts as a factory method for the device class.
 Note that a plugin library may also provide several factory methods in case it packages

--- a/runtime/include/QuantumDevice.hpp
+++ b/runtime/include/QuantumDevice.hpp
@@ -21,6 +21,15 @@
 #include "DataView.hpp"
 #include "Types.h"
 
+// A helper template macro to generate the <IDENTIFIER>Factory method by
+// calling <CONSTRUCTOR>(kwargs). Check the Custom Devices guideline for details:
+// https://docs.pennylane.ai/projects/catalyst/en/stable/dev/custom_devices.html
+#define GENERATE_DEVICE_FACTORY(IDENTIFIER, CONSTRUCTOR)                                           \
+    extern "C" Catalyst::Runtime::QuantumDevice *IDENTIFIER##Factory(const char *kwargs)           \
+    {                                                                                              \
+        return new CONSTRUCTOR(std::string(kwargs));                                               \
+    }
+
 namespace Catalyst::Runtime {
 
 /**

--- a/runtime/include/QuantumDevice.hpp
+++ b/runtime/include/QuantumDevice.hpp
@@ -21,6 +21,12 @@
 #include "DataView.hpp"
 #include "Types.h"
 
+#define GENERATE_DEVICE_ENTRYPOINT(DEVICE_NAME, NAMESPACE)                                         \
+    extern "C" Catalyst::Runtime::QuantumDevice *DEVICE_NAME##Factory(const char *kwargs)          \
+    {                                                                                              \
+        return new NAMESPACE::DEVICE_NAME(std::string(kwargs));                                    \
+    }
+
 namespace Catalyst::Runtime {
 
 /**

--- a/runtime/lib/backend/common/Utils.hpp
+++ b/runtime/lib/backend/common/Utils.hpp
@@ -26,6 +26,54 @@
 #include "Exception.hpp"
 #include "Types.h"
 
+#define QUANTUM_DEVICE_DEL_DECLARATIONS(CLASSNAME)                                                 \
+    CLASSNAME(const CLASSNAME &) = delete;                                                         \
+    CLASSNAME &operator=(const CLASSNAME &) = delete;                                              \
+    CLASSNAME(CLASSNAME &&) = delete;                                                              \
+    CLASSNAME &operator=(CLASSNAME &&) = delete;
+
+#define QUANTUM_DEVICE_RT_DECLARATIONS                                                             \
+    auto AllocateQubit()->QubitIdType override;                                                    \
+    auto AllocateQubits(size_t num_qubits)->std::vector<QubitIdType> override;                     \
+    void ReleaseQubit(QubitIdType q) override;                                                     \
+    void ReleaseAllQubits() override;                                                              \
+    [[nodiscard]] auto GetNumQubits() const->size_t override;                                      \
+    void StartTapeRecording() override;                                                            \
+    void StopTapeRecording() override;                                                             \
+    void SetDeviceShots(size_t shots) override;                                                    \
+    [[nodiscard]] auto GetDeviceShots() const->size_t override;                                    \
+    void PrintState() override;                                                                    \
+    [[nodiscard]] auto Zero() const->Result override;                                              \
+    [[nodiscard]] auto One() const->Result override;
+
+#define QUANTUM_DEVICE_QIS_DECLARATIONS                                                            \
+    void NamedOperation(const std::string &name, const std::vector<double> &params,                \
+                        const std::vector<QubitIdType> &wires, bool inverse) override;             \
+    void MatrixOperation(const std::vector<std::complex<double>> &matrix,                          \
+                         const std::vector<QubitIdType> &wires, bool inverse) override;            \
+    auto Observable(ObsId id, const std::vector<std::complex<double>> &matrix,                     \
+                    const std::vector<QubitIdType> &wires)                                         \
+        ->ObsIdType override;                                                                      \
+    auto TensorObservable(const std::vector<ObsIdType> &obs)->ObsIdType override;                  \
+    auto HamiltonianObservable(const std::vector<double> &coeffs,                                  \
+                               const std::vector<ObsIdType> &obs)                                  \
+        ->ObsIdType override;                                                                      \
+    auto Expval(ObsIdType obsKey)->double override;                                                \
+    auto Var(ObsIdType obsKey)->double override;                                                   \
+    void State(DataView<std::complex<double>, 1> &state) override;                                 \
+    void Probs(DataView<double, 1> &probs) override;                                               \
+    void PartialProbs(DataView<double, 1> &probs, const std::vector<QubitIdType> &wires) override; \
+    void Sample(DataView<double, 2> &samples, size_t shots) override;                              \
+    void PartialSample(DataView<double, 2> &samples, const std::vector<QubitIdType> &wires,        \
+                       size_t shots) override;                                                     \
+    void Counts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts, size_t shots)          \
+        override;                                                                                  \
+    void PartialCounts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts,                 \
+                       const std::vector<QubitIdType> &wires, size_t shots) override;              \
+    auto Measure(QubitIdType wire)->Result override;                                               \
+    void Gradient(std::vector<DataView<double, 1>> &gradients,                                     \
+                  const std::vector<size_t> &trainParams) override;
+
 namespace Catalyst::Runtime {
 static inline auto parse_kwargs(std::string kwargs) -> std::unordered_map<std::string, std::string>
 {

--- a/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.cpp
+++ b/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.cpp
@@ -520,7 +520,4 @@ void LightningSimulator::Gradient(std::vector<DataView<double, 1>> &gradients,
 
 } // namespace Catalyst::Runtime::Simulator
 
-extern "C" Catalyst::Runtime::QuantumDevice *LightningSimulatorFactory(const char *kwargs)
-{
-    return new Catalyst::Runtime::Simulator::LightningSimulator(std::string(kwargs));
-}
+GENERATE_DEVICE_FACTORY(LightningSimulator, Catalyst::Runtime::Simulator::LightningSimulator);

--- a/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.cpp
+++ b/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.cpp
@@ -520,7 +520,4 @@ void LightningSimulator::Gradient(std::vector<DataView<double, 1>> &gradients,
 
 } // namespace Catalyst::Runtime::Simulator
 
-extern "C" Catalyst::Runtime::QuantumDevice *LightningSimulatorFactory(const std::string &kwargs)
-{
-    return new Catalyst::Runtime::Simulator::LightningSimulator(kwargs);
-}
+GENERATE_DEVICE_ENTRYPOINT(LightningSimulator, Catalyst::Runtime::Simulator)

--- a/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.hpp
+++ b/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.hpp
@@ -88,51 +88,12 @@ class LightningSimulator final : public Catalyst::Runtime::QuantumDevice {
     }
     ~LightningSimulator() override = default;
 
-    LightningSimulator(const LightningSimulator &) = delete;
-    LightningSimulator &operator=(const LightningSimulator &) = delete;
-    LightningSimulator(LightningSimulator &&) = delete;
-    LightningSimulator &operator=(LightningSimulator &&) = delete;
+    QUANTUM_DEVICE_DEL_DECLARATIONS(LightningSimulator);
 
-    // RT
-    auto AllocateQubit() -> QubitIdType override;
-    auto AllocateQubits(size_t num_qubits) -> std::vector<QubitIdType> override;
-    void ReleaseQubit(QubitIdType q) override;
-    void ReleaseAllQubits() override;
-    [[nodiscard]] auto GetNumQubits() const -> size_t override;
-    void StartTapeRecording() override;
-    void StopTapeRecording() override;
-    void SetDeviceShots(size_t shots) override;
-    [[nodiscard]] auto GetDeviceShots() const -> size_t override;
-    void PrintState() override;
-    [[nodiscard]] auto Zero() const -> Result override;
-    [[nodiscard]] auto One() const -> Result override;
+    QUANTUM_DEVICE_RT_DECLARATIONS;
+    QUANTUM_DEVICE_QIS_DECLARATIONS;
 
     auto CacheManagerInfo()
         -> std::tuple<size_t, size_t, size_t, std::vector<std::string>, std::vector<ObsIdType>>;
-
-    // QIS
-    void NamedOperation(const std::string &name, const std::vector<double> &params,
-                        const std::vector<QubitIdType> &wires, bool inverse) override;
-    void MatrixOperation(const std::vector<std::complex<double>> &matrix,
-                         const std::vector<QubitIdType> &wires, bool inverse) override;
-    auto Observable(ObsId id, const std::vector<std::complex<double>> &matrix,
-                    const std::vector<QubitIdType> &wires) -> ObsIdType override;
-    auto TensorObservable(const std::vector<ObsIdType> &obs) -> ObsIdType override;
-    auto HamiltonianObservable(const std::vector<double> &coeffs, const std::vector<ObsIdType> &obs)
-        -> ObsIdType override;
-    auto Expval(ObsIdType obsKey) -> double override;
-    auto Var(ObsIdType obsKey) -> double override;
-    void State(DataView<std::complex<double>, 1> &state) override;
-    void Probs(DataView<double, 1> &probs) override;
-    void PartialProbs(DataView<double, 1> &probs, const std::vector<QubitIdType> &wires) override;
-    void Sample(DataView<double, 2> &samples, size_t shots) override;
-    void PartialSample(DataView<double, 2> &samples, const std::vector<QubitIdType> &wires,
-                       size_t shots) override;
-    void Counts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts, size_t shots) override;
-    void PartialCounts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts,
-                       const std::vector<QubitIdType> &wires, size_t shots) override;
-    auto Measure(QubitIdType wire) -> Result override;
-    void Gradient(std::vector<DataView<double, 1>> &gradients,
-                  const std::vector<size_t> &trainParams) override;
 };
 } // namespace Catalyst::Runtime::Simulator

--- a/runtime/lib/backend/lightning/lightning_kokkos/LightningKokkosSimulator.cpp
+++ b/runtime/lib/backend/lightning/lightning_kokkos/LightningKokkosSimulator.cpp
@@ -539,7 +539,5 @@ void LightningKokkosSimulator::Gradient(std::vector<DataView<double, 1>> &gradie
 
 } // namespace Catalyst::Runtime::Simulator
 
-extern "C" Catalyst::Runtime::QuantumDevice *LightningKokkosSimulatorFactory(const char *kwargs)
-{
-    return new Catalyst::Runtime::Simulator::LightningKokkosSimulator(std::string(kwargs));
-}
+GENERATE_DEVICE_FACTORY(LightningKokkosSimulator,
+                        Catalyst::Runtime::Simulator::LightningKokkosSimulator);

--- a/runtime/lib/backend/lightning/lightning_kokkos/LightningKokkosSimulator.cpp
+++ b/runtime/lib/backend/lightning/lightning_kokkos/LightningKokkosSimulator.cpp
@@ -539,8 +539,4 @@ void LightningKokkosSimulator::Gradient(std::vector<DataView<double, 1>> &gradie
 
 } // namespace Catalyst::Runtime::Simulator
 
-extern "C" Catalyst::Runtime::QuantumDevice *
-LightningKokkosSimulatorFactory(const std::string &kwargs)
-{
-    return new Catalyst::Runtime::Simulator::LightningKokkosSimulator(kwargs);
-}
+GENERATE_DEVICE_ENTRYPOINT(LightningKokkosSimulator, Catalyst::Runtime::Simulator)

--- a/runtime/lib/backend/lightning/lightning_kokkos/LightningKokkosSimulator.hpp
+++ b/runtime/lib/backend/lightning/lightning_kokkos/LightningKokkosSimulator.hpp
@@ -91,51 +91,13 @@ class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
     }
     ~LightningKokkosSimulator() = default;
 
-    LightningKokkosSimulator(const LightningKokkosSimulator &) = delete;
-    LightningKokkosSimulator &operator=(const LightningKokkosSimulator &) = delete;
-    LightningKokkosSimulator(LightningKokkosSimulator &&) = delete;
-    LightningKokkosSimulator &operator=(LightningKokkosSimulator &&) = delete;
+    QUANTUM_DEVICE_DEL_DECLARATIONS(LightningKokkosSimulator);
 
-    // RT
-    auto AllocateQubit() -> QubitIdType override;
-    auto AllocateQubits(size_t num_qubits) -> std::vector<QubitIdType> override;
-    void ReleaseQubit(QubitIdType q) override;
-    void ReleaseAllQubits() override;
-    [[nodiscard]] auto GetNumQubits() const -> size_t override;
-    void StartTapeRecording() override;
-    void StopTapeRecording() override;
-    void SetDeviceShots(size_t shots) override;
-    [[nodiscard]] auto GetDeviceShots() const -> size_t override;
-    void PrintState() override;
-    [[nodiscard]] auto Zero() const -> Result override;
-    [[nodiscard]] auto One() const -> Result override;
+    QUANTUM_DEVICE_RT_DECLARATIONS;
+    QUANTUM_DEVICE_QIS_DECLARATIONS;
 
     auto CacheManagerInfo()
         -> std::tuple<size_t, size_t, size_t, std::vector<std::string>, std::vector<ObsIdType>>;
 
-    // QIS
-    void NamedOperation(const std::string &name, const std::vector<double> &params,
-                        const std::vector<QubitIdType> &wires, bool inverse) override;
-    void MatrixOperation(const std::vector<std::complex<double>> &matrix,
-                         const std::vector<QubitIdType> &wires, bool inverse) override;
-    auto Observable(ObsId id, const std::vector<std::complex<double>> &matrix,
-                    const std::vector<QubitIdType> &wires) -> ObsIdType override;
-    auto TensorObservable(const std::vector<ObsIdType> &obs) -> ObsIdType override;
-    auto HamiltonianObservable(const std::vector<double> &coeffs, const std::vector<ObsIdType> &obs)
-        -> ObsIdType override;
-    auto Expval(ObsIdType obsKey) -> double override;
-    auto Var(ObsIdType obsKey) -> double override;
-    void State(DataView<std::complex<double>, 1> &state) override;
-    void Probs(DataView<double, 1> &probs) override;
-    void PartialProbs(DataView<double, 1> &probs, const std::vector<QubitIdType> &wires) override;
-    void Sample(DataView<double, 2> &samples, size_t shots) override;
-    void PartialSample(DataView<double, 2> &samples, const std::vector<QubitIdType> &wires,
-                       size_t shots) override;
-    void Counts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts, size_t shots) override;
-    void PartialCounts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts,
-                       const std::vector<QubitIdType> &wires, size_t shots) override;
-    auto Measure(QubitIdType wire) -> Result override;
-    void Gradient(std::vector<DataView<double, 1>> &gradients,
-                  const std::vector<size_t> &trainParams) override;
 };
 } // namespace Catalyst::Runtime::Simulator

--- a/runtime/lib/backend/lightning/lightning_kokkos/LightningKokkosSimulator.hpp
+++ b/runtime/lib/backend/lightning/lightning_kokkos/LightningKokkosSimulator.hpp
@@ -98,6 +98,5 @@ class LightningKokkosSimulator final : public Catalyst::Runtime::QuantumDevice {
 
     auto CacheManagerInfo()
         -> std::tuple<size_t, size_t, size_t, std::vector<std::string>, std::vector<ObsIdType>>;
-
 };
 } // namespace Catalyst::Runtime::Simulator

--- a/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
+++ b/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
@@ -494,7 +494,4 @@ void OpenQasmDevice::Gradient([[maybe_unused]] std::vector<DataView<double, 1>> 
 
 } // namespace Catalyst::Runtime::Device
 
-extern "C" Catalyst::Runtime::QuantumDevice *OpenQasmDeviceFactory(const std::string &kwargs)
-{
-    return new Catalyst::Runtime::Device::OpenQasmDevice(kwargs);
-}
+GENERATE_DEVICE_ENTRYPOINT(OpenQasmDevice, Catalyst::Runtime::Device)

--- a/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
+++ b/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
@@ -494,7 +494,4 @@ void OpenQasmDevice::Gradient([[maybe_unused]] std::vector<DataView<double, 1>> 
 
 } // namespace Catalyst::Runtime::Device
 
-extern "C" Catalyst::Runtime::QuantumDevice *OpenQasmDeviceFactory(const char *kwargs)
-{
-    return new Catalyst::Runtime::Device::OpenQasmDevice(std::string(kwargs));
-}
+GENERATE_DEVICE_FACTORY(OpenQasmDevice, Catalyst::Runtime::Device::OpenQasmDevice);

--- a/runtime/lib/backend/openqasm/OpenQasmDevice.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmDevice.hpp
@@ -113,51 +113,12 @@ class OpenQasmDevice final : public Catalyst::Runtime::QuantumDevice {
     }
     ~OpenQasmDevice() = default;
 
-    OpenQasmDevice(const OpenQasmDevice &) = delete;
-    OpenQasmDevice &operator=(const OpenQasmDevice &) = delete;
-    OpenQasmDevice(OpenQasmDevice &&) = delete;
-    OpenQasmDevice &operator=(OpenQasmDevice &&) = delete;
+    QUANTUM_DEVICE_DEL_DECLARATIONS(OpenQasmDevice);
 
-    // RT
-    auto AllocateQubit() -> QubitIdType override;
-    auto AllocateQubits(size_t num_qubits) -> std::vector<QubitIdType> override;
-    void ReleaseQubit(QubitIdType q) override;
-    void ReleaseAllQubits() override;
-    [[nodiscard]] auto GetNumQubits() const -> size_t override;
-    void StartTapeRecording() override;
-    void StopTapeRecording() override;
-    void SetDeviceShots(size_t shots) override;
-    [[nodiscard]] auto GetDeviceShots() const -> size_t override;
-    void PrintState() override;
-    [[nodiscard]] auto Zero() const -> Result override;
-    [[nodiscard]] auto One() const -> Result override;
+    QUANTUM_DEVICE_RT_DECLARATIONS;
+    QUANTUM_DEVICE_QIS_DECLARATIONS;
 
     // Circuit RT
     [[nodiscard]] auto Circuit() const -> std::string { return builder->toOpenQasm(); }
-
-    // QIS
-    void NamedOperation(const std::string &name, const std::vector<double> &params,
-                        const std::vector<QubitIdType> &wires, bool inverse) override;
-    void MatrixOperation(const std::vector<std::complex<double>> &matrix,
-                         const std::vector<QubitIdType> &wires, bool inverse) override;
-    auto Observable(ObsId id, const std::vector<std::complex<double>> &matrix,
-                    const std::vector<QubitIdType> &wires) -> ObsIdType override;
-    auto TensorObservable(const std::vector<ObsIdType> &obs) -> ObsIdType override;
-    auto HamiltonianObservable(const std::vector<double> &coeffs, const std::vector<ObsIdType> &obs)
-        -> ObsIdType override;
-    auto Expval(ObsIdType obsKey) -> double override;
-    auto Var(ObsIdType obsKey) -> double override;
-    void State(DataView<std::complex<double>, 1> &state) override;
-    void Probs(DataView<double, 1> &probs) override;
-    void PartialProbs(DataView<double, 1> &probs, const std::vector<QubitIdType> &wires) override;
-    void Sample(DataView<double, 2> &samples, size_t shots) override;
-    void PartialSample(DataView<double, 2> &samples, const std::vector<QubitIdType> &wires,
-                       size_t shots) override;
-    void Counts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts, size_t shots) override;
-    void PartialCounts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts,
-                       const std::vector<QubitIdType> &wires, size_t shots) override;
-    auto Measure(QubitIdType wire) -> Result override;
-    void Gradient(std::vector<DataView<double, 1>> &gradients,
-                  const std::vector<size_t> &trainParams) override;
 };
 } // namespace Catalyst::Runtime::Device

--- a/runtime/lib/capi/ExecutionContext.hpp
+++ b/runtime/lib/capi/ExecutionContext.hpp
@@ -157,7 +157,7 @@ class SharedLibraryManager final {
     }
 };
 
-extern "C" Catalyst::Runtime::QuantumDevice *GenericDeviceFactory(const std::string &kwargs);
+extern "C" Catalyst::Runtime::QuantumDevice *GenericDeviceFactory(const char *kwargs);
 
 class ExecutionContext final {
   private:
@@ -220,7 +220,8 @@ class ExecutionContext final {
         _driver_so_ptr = std::make_unique<SharedLibraryManager>(filename);
         std::string factory_name{_device_name + "Factory"};
         void *f_ptr = _driver_so_ptr->getSymbol(factory_name);
-        return f_ptr ? reinterpret_cast<decltype(GenericDeviceFactory) *>(f_ptr)(_device_kwargs)
+        return f_ptr ? reinterpret_cast<decltype(GenericDeviceFactory) *>(f_ptr)(
+                           _device_kwargs.c_str())
                      : nullptr;
     }
 

--- a/runtime/tests/third_party/dummy_device.cpp
+++ b/runtime/tests/third_party/dummy_device.cpp
@@ -69,7 +69,4 @@ struct DummyDevice final : public Catalyst::Runtime::QuantumDevice {
     void Gradient(std::vector<DataView<double, 1>> &, const std::vector<size_t> &) override {}
 };
 
-extern "C" Catalyst::Runtime::QuantumDevice *DummyDeviceFactory(const std::string &kwargs)
-{
-    return new DummyDevice(kwargs);
-}
+GENERATE_DEVICE_ENTRYPOINT(DummyDevice, )

--- a/runtime/tests/third_party/dummy_device.cpp
+++ b/runtime/tests/third_party/dummy_device.cpp
@@ -69,7 +69,4 @@ struct DummyDevice final : public Catalyst::Runtime::QuantumDevice {
     void Gradient(std::vector<DataView<double, 1>> &, const std::vector<size_t> &) override {}
 };
 
-extern "C" Catalyst::Runtime::QuantumDevice *DummyDeviceFactory(const char *kwargs)
-{
-    return new DummyDevice(std::string(kwargs));
-}
+GENERATE_DEVICE_FACTORY(DummyDevice, DummyDevice);


### PR DESCRIPTION
This PR adds a C++ template macro to facilitate the generation of a device entry-point. For every implementation of `QuantumDevice`, there are a repeated list of methods declarations in the header file of the class. These declarations can be templated away to reduce the redundant code to write a new backend device. This PR addresses this issue with introducing a couple of macros to generate these declarations. It also updates the signature of `extern "C"` factory methods to stick to the C data-types.
