### PR TITLE
Add tests vs pennylane rc branch

### DIFF
--- a/.github/workflows/CPL_latest-rc-latest.yaml
+++ b/.github/workflows/CPL_latest-rc-latest.yaml
@@ -2,7 +2,7 @@ name: Check CPL latest/rc/latest
 
 on:
   schedule:
-    - cron: "20 10 * * 1-5"
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/CPL_latest-rc-latest.yaml
+++ b/.github/workflows/CPL_latest-rc-latest.yaml
@@ -1,4 +1,4 @@
-name: Check CPL latest/latest/latest
+name: Check CPL latest/rc/latest
 
 on:
   schedule:

--- a/.github/workflows/CPL_latest-rc-latest.yaml
+++ b/.github/workflows/CPL_latest-rc-latest.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-config:
-    name: CPL latest/latest/latest
+    name: CPL latest/rc/latest
     uses: ./.github/workflows/check-pl-compat.yaml
     with:
       catalyst: latest

--- a/.github/workflows/CPL_latest-rc-latest.yaml
+++ b/.github/workflows/CPL_latest-rc-latest.yaml
@@ -1,0 +1,15 @@
+name: Check CPL latest/latest/latest
+
+on:
+  schedule:
+    - cron: "20 10 * * 1-5"
+  workflow_dispatch:
+
+jobs:
+  build-config:
+    name: CPL latest/latest/latest
+    uses: ./.github/workflows/check-pl-compat.yaml
+    with:
+      catalyst: latest
+      pennylane: release-candidate
+      lightning: latest

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -156,6 +156,11 @@ jobs:
       if: ${{ inputs.pennylane == 'stable' }}
       run: |
         pip install --upgrade pennylane
+        
+    - name: Install PennyLane (release-candidate)
+      if: ${{ inputs.pennylane == 'release-candidate' }}
+      run: |
+        pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.33.0-rc0
 
 
     - name: Add Frontend Dependencies to PATH


### PR DESCRIPTION
**Context:**
We have this test matrix [here](https://github.com/PennyLaneAI/plugin-test-matrix#feature-freeze-testing-matrix) that runs the tests every day for each plugin against the release candidate branch of Pennylane. It's a way to make sure nothing is broken between the release branch and the other relevant repositories as we prepare for the release. Since Catalyst is part of the release now, it should also be included.

**Description of the Change:**
Added an additional install option for pennylane in the main comparison workflow for Pennylane, Catalyst and Lightning. It's currently set to the previous release candidate branch. Also added a workflow with `pennylane: release-candidate` that runs this. 

**Benefits:**
We can add this workflow to the matrix linked above, and easily monitor compatibility with the release candidate branch and catalyst throughout feature freeze.

**Possible Drawbacks:**
We will need to update the release candidate branch name in the workflow on the Monday of feature freeze every release cycle. Also it adds another CI workflow.