### PR TITLE
Add the PL default tolerance and number of shots for measurement tests

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -45,6 +45,7 @@
 * Add support for finite-shot measurement statistics (`expval`, `var`, and `probs`)
   for `lightning.qubit` and `lightning.kokkos` devices.
   [(#392)](https://github.com/PennyLaneAI/catalyst/pull/392)
+  [(#410)](https://github.com/PennyLaneAI/catalyst/pull/410)
 
 * The runtime now supports multiple active devices managed via a device pool.
   The new `RTDevice` data-class and `RTDeviceStatus` along with the `thread_local`

--- a/frontend/test/pytest/conftest.py
+++ b/frontend/test/pytest/conftest.py
@@ -25,6 +25,15 @@ except (ImportError, ModuleNotFoundError) as e:
 else:
     tf_available = True
 
+# Default from PennyLane
+TOL_STOCHASTIC = 0.05
+
+
+@pytest.fixture(scope="session")
+def tol_stochastic():
+    """Numerical tolerance for equality tests of stochastic values."""
+    return TOL_STOCHASTIC
+
 
 def pytest_addoption(parser):
     """Add pytest custom options."""

--- a/frontend/test/pytest/test_measurements_results.py
+++ b/frontend/test/pytest/test_measurements_results.py
@@ -623,64 +623,6 @@ class TestOtherMeasurements:
         observed = state(0.0)
         assert np.array_equal(observed, expected)
 
-    def test_multiple_return_values(self, backend, tol_stochastic):
-        """Test multiple return values."""
-
-        @qjit
-        @qml.qnode(qml.device(backend, wires=2, shots=10000))
-        def all_measurements(x):
-            qml.RY(x, wires=0)
-            return (
-                qml.sample(),
-                qml.counts(),
-                qml.expval(qml.PauliZ(0)),
-                qml.var(qml.PauliZ(0)),
-                qml.probs(wires=[0, 1]),
-                qml.state(),
-            )
-
-        @qml.qnode(qml.device("lightning.qubit", wires=2, shots=10000))
-        def expected(x, measurement):
-            qml.RY(x, wires=0)
-            return qml.apply(measurement)
-
-        x = 0.7
-        result = all_measurements(x)
-
-        # qml.sample
-        assert result[0].shape == expected(x, qml.sample(wires=[0, 1]), shots=10000).shape
-
-        # qml.counts
-        for r, e in zip(
-            result[1][0], expected(x, qml.counts(all_outcomes=True), shots=10000).keys()
-        ):
-            assert format(int(r), "02b") == e
-        assert sum(result[1][1]) == 10000
-
-        # qml.expval
-        assert np.allclose(
-            result[2],
-            expected(x, qml.expval(qml.PauliZ(0))),
-            atol=tol_stochastic,
-            rtol=tol_stochastic,
-        )
-
-        # qml.var
-        assert np.allclose(
-            result[3], expected(x, qml.var(qml.PauliZ(0))), atol=tol_stochastic, rtol=tol_stochastic
-        )
-
-        # qml.probs
-        assert np.allclose(
-            result[4],
-            expected(x, qml.probs(wires=[0, 1])),
-            atol=tol_stochastic,
-            rtol=tol_stochastic,
-        )
-
-        # qml.state
-        assert np.allclose(result[5], expected(x, qml.state()))
-
 
 class TestNewArithmeticOps:
     "Test PennyLane new arithmetic operators"

--- a/frontend/test/pytest/test_measurements_results.py
+++ b/frontend/test/pytest/test_measurements_results.py
@@ -623,11 +623,11 @@ class TestOtherMeasurements:
         observed = state(0.0)
         assert np.array_equal(observed, expected)
 
-    def test_multiple_return_values(self, backend):
+    def test_multiple_return_values(self, backend, tol_stochastic):
         """Test multiple return values."""
 
         @qjit
-        @qml.qnode(qml.device(backend, wires=2, shots=5000))
+        @qml.qnode(qml.device(backend, wires=2, shots=10000))
         def all_measurements(x):
             qml.RY(x, wires=0)
             return (
@@ -639,7 +639,7 @@ class TestOtherMeasurements:
                 qml.state(),
             )
 
-        @qml.qnode(qml.device("lightning.qubit", wires=2, shots=5000))
+        @qml.qnode(qml.device("lightning.qubit", wires=2, shots=10000))
         def expected(x, measurement):
             qml.RY(x, wires=0)
             return qml.apply(measurement)
@@ -648,23 +648,35 @@ class TestOtherMeasurements:
         result = all_measurements(x)
 
         # qml.sample
-        assert result[0].shape == expected(x, qml.sample(wires=[0, 1]), shots=5000).shape
+        assert result[0].shape == expected(x, qml.sample(wires=[0, 1]), shots=10000).shape
 
         # qml.counts
         for r, e in zip(
-            result[1][0], expected(x, qml.counts(all_outcomes=True), shots=5000).keys()
+            result[1][0], expected(x, qml.counts(all_outcomes=True), shots=10000).keys()
         ):
             assert format(int(r), "02b") == e
-        assert sum(result[1][1]) == 5000
+        assert sum(result[1][1]) == 10000
 
         # qml.expval
-        assert np.allclose(result[2], expected(x, qml.expval(qml.PauliZ(0))), atol=0.05)
+        assert np.allclose(
+            result[2],
+            expected(x, qml.expval(qml.PauliZ(0))),
+            atol=tol_stochastic,
+            rtol=tol_stochastic,
+        )
 
         # qml.var
-        assert np.allclose(result[3], expected(x, qml.var(qml.PauliZ(0))), atol=0.05)
+        assert np.allclose(
+            result[3], expected(x, qml.var(qml.PauliZ(0))), atol=tol_stochastic, rtol=tol_stochastic
+        )
 
         # qml.probs
-        assert np.allclose(result[4], expected(x, qml.probs(wires=[0, 1])), atol=0.05)
+        assert np.allclose(
+            result[4],
+            expected(x, qml.probs(wires=[0, 1])),
+            atol=tol_stochastic,
+            rtol=tol_stochastic,
+        )
 
         # qml.state
         assert np.allclose(result[5], expected(x, qml.state()))

--- a/frontend/test/pytest/test_measurements_shots_results.py
+++ b/frontend/test/pytest/test_measurements_shots_results.py
@@ -24,10 +24,10 @@ from catalyst import qjit
 class TestExpval:
     "Test expval with shots > 0"
 
-    def test_identity(self, backend):
+    def test_identity(self, backend, tol_stochastic):
         """Test that identity expectation value (i.e. the trace) is 1."""
         n_wires = 2
-        n_shots = 5000
+        n_shots = 10000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         theta = 0.432
@@ -42,12 +42,12 @@ class TestExpval:
 
         expected = circuit()
         result = qjit(circuit)()
-        assert np.allclose(result, expected, atol=0.05)
+        assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
-    def test_pauliz(self, backend):
+    def test_pauliz(self, backend, tol_stochastic):
         """Test that PauliZ expectation value is correct"""
         n_wires = 2
-        n_shots = 5000
+        n_shots = 10000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         theta = 0.432
@@ -62,12 +62,12 @@ class TestExpval:
 
         expected = circuit()
         result = qjit(circuit)()
-        assert np.allclose(result, expected, atol=0.05)
+        assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
-    def test_paulix(self, backend):
+    def test_paulix(self, backend, tol_stochastic):
         """Test that PauliX expectation value is correct"""
         n_wires = 2
-        n_shots = 5000
+        n_shots = 10000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         theta = 0.432
@@ -82,12 +82,12 @@ class TestExpval:
 
         expected = circuit()
         result = qjit(circuit)()
-        assert np.allclose(result, expected, atol=0.05)
+        assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
-    def test_pauliy(self, backend):
+    def test_pauliy(self, backend, tol_stochastic):
         """Test that PauliY expectation value is correct"""
         n_wires = 2
-        n_shots = 5000
+        n_shots = 10000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         theta = 0.432
@@ -102,12 +102,12 @@ class TestExpval:
 
         expected = circuit()
         result = qjit(circuit)()
-        assert np.allclose(result, expected, atol=0.05)
+        assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
-    def test_hadamard(self, backend):
+    def test_hadamard(self, backend, tol_stochastic):
         """Test that Hadamard expectation value is correct"""
         n_wires = 2
-        n_shots = 5000
+        n_shots = 10000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         theta = 0.432
@@ -122,13 +122,13 @@ class TestExpval:
 
         expected = circuit()
         result = qjit(circuit)()
-        assert np.allclose(result, expected, atol=0.05)
+        assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
-    def test_hermitian(self, backend):
+    def test_hermitian(self, backend, tol_stochastic):
         """Test expval Hermitian observables with shots."""
 
         @qjit
-        @qml.qnode(qml.device(backend, wires=3, shots=5000))
+        @qml.qnode(qml.device(backend, wires=3, shots=10000))
         def circuit(x, y):
             qml.RX(x, wires=0)
             qml.RX(y, wires=1)
@@ -144,10 +144,10 @@ class TestExpval:
         ):
             circuit(np.pi / 4, np.pi / 4)
 
-    def test_paulix_pauliy(self, backend):
+    def test_paulix_pauliy(self, backend, tol_stochastic):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
         n_wires = 3
-        n_shots = 50000
+        n_shots = 100000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         theta = 0.432
@@ -165,12 +165,12 @@ class TestExpval:
 
         expected = circuit()
         result = qjit(circuit)()
-        assert np.allclose(result, expected, atol=0.05)
+        assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
-    def test_pauliz_pauliy_prod(self, backend):
+    def test_pauliz_pauliy_prod(self, backend, tol_stochastic):
         """Test that a tensor product involving PauliZ and PauliY works correctly"""
         n_wires = 3
-        n_shots = 5000
+        n_shots = 10000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         @qml.qnode(dev)
@@ -184,12 +184,12 @@ class TestExpval:
 
         expected = circuit(0.432, 0.123, -0.543)
         result = qjit(circuit)(0.432, 0.123, -0.543)
-        assert np.allclose(result, expected, atol=0.05)
+        assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
-    def test_pauliz_hamiltonian(self, backend):
+    def test_pauliz_hamiltonian(self, backend, tol_stochastic):
         """Test that a hamiltonian involving PauliZ and PauliY and hadamard works correctly"""
         n_wires = 3
-        n_shots = 5000
+        n_shots = 10000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         @qml.qnode(dev)
@@ -205,12 +205,12 @@ class TestExpval:
 
         expected = circuit(0.432, 0.123, -0.543)
         result = qjit(circuit)(0.432, 0.123, -0.543)
-        assert np.allclose(result, expected, atol=0.05)
+        assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
-    def test_prod_hamiltonian(self, backend):
+    def test_prod_hamiltonian(self, backend, tol_stochastic):
         """Test that a hamiltonian involving PauliZ and Hadamard @ PauliX works correctly"""
         n_wires = 3
-        n_shots = 5000
+        n_shots = 10000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         @qml.qnode(dev)
@@ -226,16 +226,16 @@ class TestExpval:
 
         expected = circuit(0.432, 0.123, -0.543)
         result = qjit(circuit)(0.432, 0.123, -0.543)
-        assert np.allclose(result, expected, atol=0.05)
+        assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
 
 class TestVar:
     "Test var with shots > 0"
 
-    def test_identity(self, backend):
+    def test_identity(self, backend, tol_stochastic):
         """Test that identity variance value (i.e. the trace) is 1."""
         n_wires = 2
-        n_shots = 5000
+        n_shots = 10000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         theta = 0.432
@@ -250,12 +250,12 @@ class TestVar:
 
         expected = circuit()
         result = qjit(circuit)()
-        assert np.allclose(result, expected, atol=0.05)
+        assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
-    def test_pauliz(self, backend):
+    def test_pauliz(self, backend, tol_stochastic):
         """Test that PauliZ variance value is correct"""
         n_wires = 2
-        n_shots = 5000
+        n_shots = 10000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         theta = 0.432
@@ -270,12 +270,12 @@ class TestVar:
 
         expected = circuit()
         result = qjit(circuit)()
-        assert np.allclose(result, expected, atol=0.05)
+        assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
-    def test_paulix(self, backend):
+    def test_paulix(self, backend, tol_stochastic):
         """Test that PauliX variance value is correct"""
         n_wires = 2
-        n_shots = 5000
+        n_shots = 10000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         theta = 0.432
@@ -290,12 +290,12 @@ class TestVar:
 
         expected = circuit()
         result = qjit(circuit)()
-        assert np.allclose(result, expected, atol=0.05)
+        assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
-    def test_pauliy(self, backend):
+    def test_pauliy(self, backend, tol_stochastic):
         """Test that PauliY variance value is correct"""
         n_wires = 2
-        n_shots = 5000
+        n_shots = 10000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         theta = 0.432
@@ -310,12 +310,12 @@ class TestVar:
 
         expected = circuit()
         result = qjit(circuit)()
-        assert np.allclose(result, expected, atol=0.05)
+        assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
-    def test_hadamard(self, backend):
+    def test_hadamard(self, backend, tol_stochastic):
         """Test that Hadamard variance value is correct"""
         n_wires = 2
-        n_shots = 5000
+        n_shots = 10000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         theta = 0.432
@@ -330,13 +330,13 @@ class TestVar:
 
         expected = circuit()
         result = qjit(circuit)()
-        assert np.allclose(result, expected, atol=0.05)
+        assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
-    def test_hermitian_shots(self, backend):
+    def test_hermitian_shots(self, backend, tol_stochastic):
         """Test var Hermitian observables with shots."""
 
         @qjit
-        @qml.qnode(qml.device(backend, wires=3, shots=5000))
+        @qml.qnode(qml.device(backend, wires=3, shots=10000))
         def circuit(x, y):
             qml.RX(x, wires=0)
             qml.RX(y, wires=1)
@@ -352,10 +352,10 @@ class TestVar:
         ):
             circuit(np.pi / 4, np.pi / 4)
 
-    def test_paulix_pauliy(self, backend):
+    def test_paulix_pauliy(self, backend, tol_stochastic):
         """Test that a tensor product involving PauliX and PauliY works correctly"""
         n_wires = 3
-        n_shots = 5000
+        n_shots = 10000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         theta = 0.432
@@ -373,12 +373,12 @@ class TestVar:
 
         expected = circuit()
         result = qjit(circuit)()
-        assert np.allclose(result, expected, atol=0.05)
+        assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
-    def test_hadamard_pauliy_prod(self, backend):
+    def test_hadamard_pauliy_prod(self, backend, tol_stochastic):
         """Test that a tensor product involving Hadamard and PauliY works correctly"""
         n_wires = 3
-        n_shots = 5000
+        n_shots = 10000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         @qml.qnode(dev)
@@ -392,12 +392,12 @@ class TestVar:
 
         expected = circuit(0.432, 0.123, -0.543)
         result = qjit(circuit)(0.432, 0.123, -0.543)
-        assert np.allclose(result, expected, atol=0.05)
+        assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
-    def test_pauliz_pauliy_prod(self, backend):
+    def test_pauliz_pauliy_prod(self, backend, tol_stochastic):
         """Test that a tensor product involving PauliZ and PauliY works correctly"""
         n_wires = 3
-        n_shots = 5000
+        n_shots = 10000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         @qml.qnode(dev)
@@ -411,12 +411,12 @@ class TestVar:
 
         expected = circuit(0.432, 0.123, -0.543)
         result = qjit(circuit)(0.432, 0.123, -0.543)
-        assert np.allclose(result, expected, atol=0.05)
+        assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
-    def test_pauliz_hamiltonian(self, backend):
+    def test_pauliz_hamiltonian(self, backend, tol_stochastic):
         """Test that a hamiltonian involving PauliZ and PauliY and hadamard works correctly"""
         n_wires = 3
-        n_shots = 5000
+        n_shots = 10000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         @qml.qnode(dev)
@@ -438,11 +438,11 @@ class TestVar:
 class TestProbs:
     "Test var with shots > 0"
 
-    def test_probs(self, backend):
+    def test_probs(self, backend, tol_stochastic):
         """Test probs on all wires"""
 
         n_wires = 2
-        n_shots = 5000
+        n_shots = 10000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         @qml.qnode(dev)
@@ -453,13 +453,13 @@ class TestProbs:
 
         expected = circuit(0.432)
         result = qjit(circuit)(0.432)
-        assert np.allclose(result, expected, atol=0.05)
+        assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
-    def test_probs_wire(self, backend):
+    def test_probs_wire(self, backend, tol_stochastic):
         """Test probs on subset of wires"""
 
         n_wires = 2
-        n_shots = 5000
+        n_shots = 10000
         dev = qml.device(backend, wires=n_wires, shots=n_shots)
 
         @qml.qnode(dev)
@@ -470,4 +470,4 @@ class TestProbs:
 
         expected = circuit(0.432)
         result = qjit(circuit)(0.432)
-        assert np.allclose(result, expected, atol=0.05)
+        assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)

--- a/frontend/test/pytest/test_pytree_args.py
+++ b/frontend/test/pytest/test_pytree_args.py
@@ -83,7 +83,7 @@ class TestPyTreesReturnValues:
         assert jnp.allclose(result[0], jnp.pi)
         assert jnp.allclose(result[1], ip_result)
 
-    def test_return_value_tuples(self, backend):
+    def test_return_value_tuples(self, backend, tol_stochastic):
         """Test tuples."""
 
         @qml.qnode(qml.device(backend, wires=2))
@@ -133,7 +133,7 @@ class TestPyTreesReturnValues:
         assert isinstance(result, tuple)
         assert isinstance(result[0], tuple)
         assert len(result[1]) == 4
-        assert jnp.allclose(result[2], expected_expval, atol=0.05)
+        assert jnp.allclose(result[2], expected_expval, atol=tol_stochastic, rtol=tol_stochastic)
 
         @qjit
         def workflow(x):
@@ -216,7 +216,7 @@ class TestPyTreesReturnValues:
         assert res5["cond"][1] == (125, 625)
         assert res5["const"] == 5
 
-    def test_return_value_dict(self, backend):
+    def test_return_value_dict(self, backend, tol_stochastic):
         """Test dictionaries."""
 
         @qml.qnode(qml.device(backend, wires=2))
@@ -257,7 +257,9 @@ class TestPyTreesReturnValues:
         assert isinstance(result, dict)
         assert isinstance(result["counts"], tuple)
         assert len(result["state"]) == 4
-        assert jnp.allclose(result["expval"]["z0"], expected_expval, atol=0.05)
+        assert jnp.allclose(
+            result["expval"]["z0"], expected_expval, atol=tol_stochastic, rtol=tol_stochastic
+        )
 
         @qjit
         def workflow1(param):


### PR DESCRIPTION
The shot tests are randomly failing due to a low number of shots and floating-point comparison tolerance. This PR fixes random failures with adding the PL default stochastic tolerance and number of shots.

All frontend tests passed using the PL tolerance (`0.05`) and shots (`10000`) in 200 runs.