### PR TITLE
Add libmlir_async_runtime to wheels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,7 @@ wheel:
 	cp $(RT_BUILD_DIR)/lib/backend/*.toml $(MK_DIR)/frontend/catalyst/lib/backend
 	cp $(COPY_FLAGS) $(LLVM_BUILD_DIR)/lib/libmlir_float16_utils.* $(MK_DIR)/frontend/catalyst/lib
 	cp $(COPY_FLAGS) $(LLVM_BUILD_DIR)/lib/libmlir_c_runner_utils.* $(MK_DIR)/frontend/catalyst/lib
+	cp $(COPY_FLAGS) $(LLVM_BUILD_DIR)/lib/libmlir_async_runtime.* $(MK_DIR)/frontend/catalyst/lib
 
 	# Copy mlir bindings & compiler driver to frontend/mlir_quantum
 	mkdir -p $(MK_DIR)/frontend/mlir_quantum/dialects

--- a/runtime/lib/capi/ExecutionContext.hpp
+++ b/runtime/lib/capi/ExecutionContext.hpp
@@ -208,7 +208,7 @@ class RTDevice {
     std::string rtd_kwargs;
 
     std::unique_ptr<SharedLibraryManager> rtd_dylib{nullptr};
-    std::shared_ptr<QuantumDevice> rtd_qdevice{nullptr};
+    QuantumDevice *rtd_qdevice{nullptr};
 
     RTDeviceStatus status{RTDeviceStatus::Inactive};
 
@@ -263,7 +263,7 @@ class RTDevice {
                this->rtd_kwargs == other.rtd_kwargs;
     }
 
-    [[nodiscard]] auto getQuantumDevicePtr() -> std::shared_ptr<QuantumDevice>
+    [[nodiscard]] auto getQuantumDevicePtr() -> QuantumDevice *
     {
         if (rtd_qdevice) {
             return rtd_qdevice;
@@ -272,11 +272,10 @@ class RTDevice {
         rtd_dylib = std::make_unique<SharedLibraryManager>(rtd_lib);
         std::string factory_name{rtd_name + "Factory"};
         void *f_ptr = rtd_dylib->getSymbol(factory_name);
-        QuantumDevice *impl =
+        rtd_qdevice =
             f_ptr ? reinterpret_cast<decltype(GenericDeviceFactory) *>(f_ptr)(rtd_kwargs.c_str())
                   : nullptr;
 
-        rtd_qdevice.reset(impl);
         return rtd_qdevice;
     }
 

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -64,10 +64,7 @@ thread_local static RTDevice *RTD_PTR = nullptr;
 /**
  * @brief get the active device.
  */
-auto getQuantumDevicePtr() -> std::shared_ptr<QuantumDevice>
-{
-    return RTD_PTR->getQuantumDevicePtr();
-}
+auto getQuantumDevicePtr() -> QuantumDevice * { return RTD_PTR->getQuantumDevicePtr(); }
 
 /**
  * @brief Inactivate the active device instance.


### PR DESCRIPTION
- Add the missing `libmlir_async_runtime` to wheels
- Remove unnecessary shared_ptr in `CAPI::getQuantumDevicePtr` 