### PR TITLE
Update Lightning tags

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -259,7 +259,7 @@ jobs:
               -DPYTHON_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -Dpybind11_DIR=$(python${{ matrix.python_version }} -c "import pybind11; print(pybind11.get_cmake_dir())") \
               -DENABLE_LIGHTNING_KOKKOS=ON \
-              -DLIGHTNING_GIT_TAG="23ee599" \
+              -DLIGHTNING_GIT_TAG="489cff7" \
               -DKokkos_ENABLE_SERIAL=ON \
               -DKokkos_ENABLE_OPENMP=ON \
               -DENABLE_WARNINGS=OFF \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -243,7 +243,7 @@ jobs:
               -DPYTHON_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -Dpybind11_DIR=$(python${{ matrix.python_version }} -c "import pybind11; print(pybind11.get_cmake_dir())") \
               -DENABLE_LIGHTNING_KOKKOS=ON \
-              -DLIGHTNING_GIT_TAG="23ee599" \
+              -DLIGHTNING_GIT_TAG="489cff7" \
               -DKokkos_ENABLE_SERIAL=ON \
               -DKokkos_ENABLE_OPENMP=OFF \
               -DKokkos_ENABLE_COMPLEX_ALIGN=OFF \

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -244,7 +244,7 @@ jobs:
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$GITHUB_WORKSPACE/runtime-build/lib \
               -DPYTHON_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -Dpybind11_DIR=$(python${{ matrix.python_version }} -c "import pybind11; print(pybind11.get_cmake_dir())") \
-              -DLIGHTNING_GIT_TAG="23ee599" \
+              -DLIGHTNING_GIT_TAG="489cff7" \
               -DENABLE_LIGHTNING_KOKKOS=ON \
               -DKokkos_ENABLE_SERIAL=ON \
               -DKokkos_ENABLE_OPENMP=OFF \

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -14,7 +14,7 @@ ENABLE_LIGHTNING?=ON
 ENABLE_LIGHTNING_KOKKOS?=OFF
 ENABLE_OPENQASM?=OFF
 ENABLE_ASAN?=OFF
-LIGHTNING_GIT_TAG_VALUE?="23ee599" # TODO: Update to v0.34.0
+LIGHTNING_GIT_TAG_VALUE?="489cff7" # TODO: Update to v0.34.0
 NPROC?=$(shell python3 -c "import os; print(os.cpu_count())")
 
 ifeq ($(shell uname), Darwin)


### PR DESCRIPTION
Update Lightning tags to https://github.com/PennyLaneAI/pennylane-lightning/commit/489cff75f64fb1ddb706a7e6fa27d1ae15f1c1b0 as the fix https://github.com/PennyLaneAI/pennylane-lightning/pull/582 is now merged into the master branch.  

PS. This is related to the "temporary" fix in https://github.com/PennyLaneAI/catalyst/pull/412