### PR TITLE
Build runtime (stable) with Lightning git tag in runtime/Makefile instead of latest_release in the plugin matrix

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -106,8 +106,7 @@ jobs:
         pip install --upgrade .
 
 
-    - name: Build Lightning Runtime (latest)
-      if: ${{ inputs.lightning == 'latest' }}
+    - name: Build Catalyst Runtime (latest/stable)
       run: |
         COMPILER_LAUNCHER="" \
         C_COMPILER=$(which gcc }}) \
@@ -116,21 +115,6 @@ jobs:
         RT_BUILD_DIR="$(pwd)/runtime-build" \
         QIR_STDLIB_DIR="$(pwd)/qir-stdlib-build" \
         QIR_STDLIB_INCLUDES_DIR="$(pwd)/qir-stdlib-build/include" \
-        LIGHTNING_GIT_TAG_VALUE=master \
-        ENABLE_LIGHTNING_KOKKOS=ON \
-        ENABLE_OPENQASM=ON \
-        make runtime
-
-    - name: Build Lightning Runtime (stable)
-      if: ${{ inputs.lightning == 'stable' }}
-      run: |
-        COMPILER_LAUNCHER="" \
-        C_COMPILER=$(which gcc }}) \
-        CXX_COMPILER=$(which g++ }}) \
-        RT_BUILD_DIR="$(pwd)/runtime-build" \
-        QIR_STDLIB_DIR="$(pwd)/qir-stdlib-build" \
-        QIR_STDLIB_INCLUDES_DIR="$(pwd)/qir-stdlib-build/include" \
-        LIGHTNING_GIT_TAG_VALUE=latest_release \
         ENABLE_LIGHTNING_KOKKOS=ON \
         ENABLE_OPENQASM=ON \
         make runtime
@@ -156,7 +140,7 @@ jobs:
       if: ${{ inputs.pennylane == 'stable' }}
       run: |
         pip install --upgrade pennylane
-        
+
     - name: Install PennyLane (release-candidate)
       if: ${{ inputs.pennylane == 'release-candidate' }}
       run: |

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -106,7 +106,7 @@ jobs:
         pip install --upgrade .
 
 
-    - name: Build Lightning Runtime (latest)
+    - name: Build Catalyst Runtime (latest)
       if: ${{ inputs.lightning == 'latest' }}
       run: |
         COMPILER_LAUNCHER="" \
@@ -121,7 +121,7 @@ jobs:
         ENABLE_OPENQASM=ON \
         make runtime
 
-    - name: Build Lightning Runtime (stable)
+    - name: Build Catalyst Runtime (stable)
       if: ${{ inputs.lightning == 'stable' }}
       run: |
         COMPILER_LAUNCHER="" \
@@ -130,7 +130,6 @@ jobs:
         RT_BUILD_DIR="$(pwd)/runtime-build" \
         QIR_STDLIB_DIR="$(pwd)/qir-stdlib-build" \
         QIR_STDLIB_INCLUDES_DIR="$(pwd)/qir-stdlib-build/include" \
-        LIGHTNING_GIT_TAG_VALUE=latest_release \
         ENABLE_LIGHTNING_KOKKOS=ON \
         ENABLE_OPENQASM=ON \
         make runtime
@@ -156,7 +155,7 @@ jobs:
       if: ${{ inputs.pennylane == 'stable' }}
       run: |
         pip install --upgrade pennylane
-        
+
     - name: Install PennyLane (release-candidate)
       if: ${{ inputs.pennylane == 'release-candidate' }}
       run: |

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -106,7 +106,8 @@ jobs:
         pip install --upgrade .
 
 
-    - name: Build Catalyst Runtime (latest/stable)
+    - name: Build Lightning Runtime (latest)
+      if: ${{ inputs.lightning == 'latest' }}
       run: |
         COMPILER_LAUNCHER="" \
         C_COMPILER=$(which gcc }}) \
@@ -115,6 +116,21 @@ jobs:
         RT_BUILD_DIR="$(pwd)/runtime-build" \
         QIR_STDLIB_DIR="$(pwd)/qir-stdlib-build" \
         QIR_STDLIB_INCLUDES_DIR="$(pwd)/qir-stdlib-build/include" \
+        LIGHTNING_GIT_TAG_VALUE=master \
+        ENABLE_LIGHTNING_KOKKOS=ON \
+        ENABLE_OPENQASM=ON \
+        make runtime
+
+    - name: Build Lightning Runtime (stable)
+      if: ${{ inputs.lightning == 'stable' }}
+      run: |
+        COMPILER_LAUNCHER="" \
+        C_COMPILER=$(which gcc }}) \
+        CXX_COMPILER=$(which g++ }}) \
+        RT_BUILD_DIR="$(pwd)/runtime-build" \
+        QIR_STDLIB_DIR="$(pwd)/qir-stdlib-build" \
+        QIR_STDLIB_INCLUDES_DIR="$(pwd)/qir-stdlib-build/include" \
+        LIGHTNING_GIT_TAG_VALUE=latest_release \
         ENABLE_LIGHTNING_KOKKOS=ON \
         ENABLE_OPENQASM=ON \
         make runtime
@@ -140,7 +156,7 @@ jobs:
       if: ${{ inputs.pennylane == 'stable' }}
       run: |
         pip install --upgrade pennylane
-
+        
     - name: Install PennyLane (release-candidate)
       if: ${{ inputs.pennylane == 'release-candidate' }}
       run: |


### PR DESCRIPTION
Lightning tags have been explicitly specified in build recipes for a while, to ensure compatibility with a particular commit in the catalyst repo. Therefor it makes little sense to test configurations which are known not to work.

The plugin matrix will now build the runtime with a stable lightning config with respect to the lightning repo tag specified in our build scripts, which may be either `latest_release` or a commit in the history of the master branch.
