### PR TITLE
[MLIR] Improve concurrency when using async.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -59,9 +59,10 @@
   [(#381)](https://github.com/PennyLaneAI/catalyst/pull/381)
 
 * Qjitted functions now support asynchronuous execution of QNodes. Simply use ``qjit(async_qnodes=True)`` to
-  enable the async execution of QNodes. It is useful for finite differences and parameter-shift, as those
-  differentiation methods can generate multiple circuit. Support for the async MLIR dialect was added.
+  enable the async execution of QNodes. It is useful for finite differences as it generates multiple circuits.
+  Support for the async MLIR dialect was added.
   [(#374)](https://github.com/PennyLaneAI/catalyst/pull/374)
+  [(#424)](https://github.com/PennyLaneAI/catalyst/pull/424)
 
   In this example below, the first and second circuit are executed in parrallel if two threads are available.
   To see a speed up in your code, you should use circuits with more gates and/or more qubits.

--- a/mlir/lib/Catalyst/Transforms/QnodeToAsyncPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/QnodeToAsyncPatterns.cpp
@@ -50,10 +50,10 @@ struct CallOpToAsyncOPRewritePattern : public mlir::OpRewritePattern<func::CallO
             rewriter.setInsertionPointToEnd(block);
         }
 
-        // TODO: Here we place an await until the very end.
+        // Here we place an await until the very end.
         // The reason for this is because if the call returns no values,
         // then we will never execute it.
-        // Potentially we could just remove the call altogether.
+        // TODO: We could just remove the call altogether.
         // But we should make sure that there are no side effects in the call.
         // One possible side effect is printing to stdout.
         rewriter.create<async::AwaitOp>(op.getLoc(), executeOp.getResults().front());

--- a/mlir/lib/Catalyst/Transforms/QnodeToAsyncPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/QnodeToAsyncPatterns.cpp
@@ -137,7 +137,7 @@ struct CallOpToAsyncOPRewritePattern : public mlir::OpRewritePattern<func::CallO
         std::vector<Value> bodyReturns(results.begin() + 1, results.end());
         // TODO: Assert/FAIL that op.getResults() and bodyReturns have the same number of elements.
         if (bodyReturns.size() == op.getResults().size()) {
-            for (auto [oldVal, newVal] : llvm::zip(op.getResults(), bodyReturns)) {
+            for (auto &&[oldVal, newVal] : llvm::zip(op.getResults(), bodyReturns)) {
                 auto _users = oldVal.getUsers();
                 // Insert users into a vector to avoid modifying users during a loop.
                 std::vector<Operation *> users(_users.begin(), _users.end());

--- a/mlir/lib/Catalyst/Transforms/QnodeToAsyncPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/QnodeToAsyncPatterns.cpp
@@ -31,8 +31,8 @@ namespace catalyst {
 struct CallOpToAsyncOPRewritePattern : public mlir::OpRewritePattern<func::CallOp> {
     using mlir::OpRewritePattern<func::CallOp>::OpRewritePattern;
 
-    void insertDropRefOp(func::CallOp op, async::ExecuteOp executeOp,
-                         PatternRewriter &rewriter) const
+    void insertDropRefOps(func::CallOp op, async::ExecuteOp executeOp,
+                          PatternRewriter &rewriter) const
     {
         PatternRewriter::InsertionGuard insertGuard(rewriter);
         // Let's first place the awaits just before the terminator of this block.
@@ -61,6 +61,92 @@ struct CallOpToAsyncOPRewritePattern : public mlir::OpRewritePattern<func::CallO
         for (auto refCountedValue : executeOp.getResults()) {
             rewriter.create<async::RuntimeDropRefOp>(op.getLoc(), refCountedValue,
                                                      rewriter.getI64IntegerAttr(1));
+        }
+    }
+
+    void insertAwaitOps(func::CallOp op, async::ExecuteOp executeOp,
+                        PatternRewriter &rewriter) const
+    {
+        // The async.execute instruction returns a promise.
+        //
+        //    %token, %promise = async.execute {
+        //       // body...
+        //       async.yield %0 : !some.type
+        //    }
+        //
+        //  Then we would wait on the promise or the token like so:
+        //
+        //     async.await %token
+        //     async.await %promise
+        //
+        //  If called async for the first time and the value is not available, the thread will wait
+        //  until the value becomes available. If the value is available, the function returns
+        //  practically immediately. For example.
+        //
+        //     %1 = async.await %promise // promise is not yet available, will wait.
+        //     %2 = async.await %promise // promise is now available, will not wait.
+        //
+        //  This makes the job of deciding where to place awaits really easy.
+        //  We just need to place awaits just before every use of the original value.
+        //  For example, take the following piece of code
+        //
+        //     %quantum_results = call @qnode
+        //
+        //     // Arbitrary control flow
+        //     // This use might be inside a different basic block.
+        //     %some_val = some.op %quantum_results
+        //
+        //  First we translate the call to an async.execute (which was performed before this
+        //  function was called) When this function was called, the transformation is not yet
+        //  complete. Because there are still uses of %quantum_results.
+        //
+        //     %async_quantum_results = call @qnode
+        //
+        //     // Arbitrary control flow
+        //     // This use might be inside a different basic block.
+        //     %some_val = some.op %quantum_results
+        //
+        //  This function will perform the following change:
+        //
+        //     %async_quantum_results = call @qnode
+        //
+        //     // Arbitrary control flow
+        //     // This use might be inside a different basic block.
+        //     %await_quantum_results = async.await %async_quantum_results
+        //     %some_val = some.op %await_quantum_results
+        //
+        //  And it will do so for every use of %quantum_results
+        //  E.g.
+        //
+        //     %async_quantum_results = call @qnode
+        //
+        //     // Arbitrary control flow
+        //     // This use might be inside a different basic block.
+        //     %await_quantum_results_0 = async.await %async_quantum_results
+        //     %some_val_0 = some.op %await_quantum_results_0
+        //     %await_quantum_results_1 = async.await %async_quantum_results_1
+        //     %some_val_1 = some.op %await_quantum_results_1
+        //
+        //  However, we can do a bit better and avoid this extra awaits that follow.
+        auto results = executeOp.getResults();
+        // The first value is just a token.
+        std::vector<Value> bodyReturns(results.begin() + 1, results.end());
+        // TODO: Assert/FAIL that op.getResults() and bodyReturns have the same number of elements.
+        if (bodyReturns.size() == op.getResults().size()) {
+            for (auto [oldVal, newVal] : llvm::zip(op.getResults(), bodyReturns)) {
+                auto _users = oldVal.getUsers();
+                // Insert users into a vector to avoid modifying users during a loop.
+                std::vector<Operation *> users(_users.begin(), _users.end());
+                for (auto user : users) {
+                    // Now we can safely modify users
+                    PatternRewriter::InsertionGuard insertGuard(rewriter);
+                    rewriter.setInsertionPoint(user);
+                    auto awaitOp = rewriter.create<async::AwaitOp>(op.getLoc(), newVal);
+                    auto awaitVal = awaitOp.getResults();
+                    rewriter.replaceUsesWithIf(
+                        oldVal, awaitVal, [&](OpOperand &use) { return use.getOwner() == user; });
+                }
+            }
         }
     }
 
@@ -103,28 +189,8 @@ struct CallOpToAsyncOPRewritePattern : public mlir::OpRewritePattern<func::CallO
             rewriter.create<async::YieldOp>(op.getLoc(), cloneOp->getResults());
         }
 
-        auto asyncValues = executeOp.getResults();
-
-        insertDropRefOp(op, executeOp, rewriter);
-
-        std::vector<Value> bodyReturns(asyncValues.begin() + 1, asyncValues.end());
-        // TODO: Assert/FAIL that op.getResults() and bodyReturns have the same number of elements.
-        if (bodyReturns.size() == op.getResults().size()) {
-            for (auto [oldVal, newVal] : llvm::zip(op.getResults(), bodyReturns)) {
-                auto _users = oldVal.getUsers();
-                // Insert users into a vector to avoid modifying users during a loop.
-                std::vector<Operation *> users(_users.begin(), _users.end());
-                for (auto user : users) {
-                    // Now we can safely modify users
-                    PatternRewriter::InsertionGuard insertGuard(rewriter);
-                    rewriter.setInsertionPoint(user);
-                    auto awaitOp = rewriter.create<async::AwaitOp>(op.getLoc(), newVal);
-                    auto awaitVal = awaitOp.getResults();
-                    rewriter.replaceUsesWithIf(
-                        oldVal, awaitVal, [&](OpOperand &use) { return use.getOwner() == user; });
-                }
-            }
-        }
+        insertDropRefOps(op, executeOp, rewriter);
+        insertAwaitOps(op, executeOp, rewriter);
 
         rewriter.eraseOp(op);
 

--- a/mlir/test/Catalyst/Async.mlir
+++ b/mlir/test/Catalyst/Async.mlir
@@ -140,3 +140,43 @@ module @workflow {
     return %0#0, %0#1 : memref<2xcomplex<f64>>, memref<2xcomplex<f64>>
   }
 }
+
+// -----
+
+
+// Test to make sure that async is placed before uses even in the presence of control flow.
+
+module @bar {
+  func.func public @jit_bar(%arg0: tensor<i1>) -> tensor<2xcomplex<f64>> attributes {llvm.emit_c_interface} {
+    %0 = stablehlo.constant dense<(1.000000e+00,0.000000e+00)> : tensor<complex<f64>>
+    %1 = call @foo() : () -> tensor<2xcomplex<f64>>
+    %extracted = tensor.extract %arg0[] : tensor<i1>
+    %2 = scf.if %extracted -> (tensor<2xcomplex<f64>>) {
+      // CHECK: scf.if
+      // CHECK: async.await
+      // CHECK: scf.yield
+      %3 = stablehlo.broadcast_in_dim %0, dims = [] : (tensor<complex<f64>>) -> tensor<2xcomplex<f64>>
+      %4 = stablehlo.add %1, %3 : tensor<2xcomplex<f64>>
+      scf.yield %4 : tensor<2xcomplex<f64>>
+    } else {
+      // CHECK: else
+      // CHECK: async.await
+      // CHECK: scf.yield
+      %3 = stablehlo.broadcast_in_dim %0, dims = [] : (tensor<complex<f64>>) -> tensor<2xcomplex<f64>>
+      %4 = stablehlo.subtract %1, %3 : tensor<2xcomplex<f64>>
+      scf.yield %4 : tensor<2xcomplex<f64>>
+    }
+    return %2 : tensor<2xcomplex<f64>>
+  }
+  func.func private @foo() -> tensor<2xcomplex<f64>> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
+    quantum.device["/home/ubuntu/code/catalyst/frontend/catalyst/utils/../../../runtime/build/lib/librtd_lightning.so", "LightningSimulator", "{'shots': 0, 'mcmc': False}"]
+    %0 = quantum.alloc( 1) : !quantum.reg
+    %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+    %2 = quantum.compbasis %1 : !quantum.obs
+    %3 = quantum.state %2 : tensor<2xcomplex<f64>>
+    quantum.dealloc %0 : !quantum.reg
+    quantum.device_release
+    return %3 : tensor<2xcomplex<f64>>
+  }
+}
+


### PR DESCRIPTION
**Context:** The initial implementation of async had a naive algorithm that serialized a lot of potentially concurrent code. This PR improves the algorithm and guarantees maximum concurrency.

**Description of the Change:**

The `async.execute` instruction returns a token and a promise.

```llvm
 %token, %promise = async.execute {
   // body...
   async.yield %0 : !some.type
}
```

We can then wait on the promise or the token

```llvm
async.await %token // doesn't return a value but waits for all execution in region to finish
%val = async.await %promise // does return a value, whatever is yielded
```

If `async.await` is used for the first time and the value is not available, the thread will wait
until the value becomes available. If the value is available, the function returns practically immediately. For example.

```llvm 
%1 = async.await %promise // promise is not yet available, will wait.
%2 = async.await %promise // promise is now available, will not wait.
```

This makes the job of deciding where to place awaits really easy.
We just need to place awaits just before every use of the original value.
For example, take the following piece of code

```llvm
%quantum_results = call @qnode

// Arbitrary control flow
// This use might be inside a different basic block.
%some_val = some.op %quantum_results
```

First we translate the call to an async.execute (which was performed before this
function was called) When this function was called, the transformation is not yet
complete. Because there are still uses of %quantum_results.

```llvm
%async_quantum_results = call @qnode

// Arbitrary control flow
// This use might be inside a different basic block.
%some_val = some.op %quantum_results
```

This function will perform the following change:
 
```llvm
%async_quantum_results = call @qnode

// Arbitrary control flow
// This use might be inside a different basic block.
%await_quantum_results = async.await %async_quantum_results
%some_val = some.op %await_quantum_results
```

And it will do so for every use of `%quantum_results`. Eg.

```llvm
%async_quantum_results = call @qnode

// Arbitrary control flow
// This use might be inside a different basic block.
%await_quantum_results_0 = async.await %async_quantum_results
%some_val_0 = some.op %await_quantum_results_0
%await_quantum_results_1 = async.await %async_quantum_results
%some_val_1 = some.op %await_quantum_results_1
```

**Benefits:** Improved concurrency.

**Possible Drawbacks:** Not really a drawback, but potential improvement point (which is independent of this commit). We could have a heuristic to decide when async is profitable locally. I believe async is always profitable in remote execution, but not locally. 

[sc-52637]