### PR TITLE
[Tests] Check the PyTree-compatibility of Wires

### DIFF
--- a/frontend/test/pytest/test_pytree_args.py
+++ b/frontend/test/pytest/test_pytree_args.py
@@ -22,7 +22,7 @@ import numpy as np
 import pennylane as qml
 import pytest
 
-from catalyst import cond, for_loop, grad, measure, qjit
+from catalyst import adjoint, cond, for_loop, grad, measure, qjit
 
 
 class TestPyTreesReturnValues:
@@ -489,6 +489,23 @@ class TestPyTreesFuncArgs:
         assert jnp.allclose(result, False)
         result = circuit({"wire": 1})
         assert jnp.allclose(result, True)
+
+    def test_dev_wires_have_pytree(self, backend):
+        """Device wires are pytree-compatible."""
+
+        def subroutine(wires):
+            for wire in wires:
+                qml.PauliX(wire)
+
+        dev = qml.device("lightning.qubit", wires=3)
+
+        @qjit
+        @qml.qnode(dev)
+        def test_function():
+            adjoint(subroutine)(dev.wires)
+            return qml.probs()
+
+        test_function()
 
 
 class TestAuxiliaryData:

--- a/frontend/test/pytest/test_pytree_args.py
+++ b/frontend/test/pytest/test_pytree_args.py
@@ -497,7 +497,7 @@ class TestPyTreesFuncArgs:
             for wire in wires:
                 qml.PauliX(wire)
 
-        dev = qml.device("lightning.qubit", wires=3)
+        dev = qml.device(backend, wires=3)
 
         @qjit
         @qml.qnode(dev)


### PR DESCRIPTION
Add unit-test checking that PennyLane's `Wires` supports a PyTree-serialization API.

This PR is the final stage of the workflow started by the https://github.com/PennyLaneAI/catalyst/issues/334 .
1. Add PyTree interface to the PennyLane's `Wires` class ([link](https://github.com/PennyLaneAI/pennylane/pull/4998))
2. **Add a Catalyst test, checking that `Wires` argument could be passed to the traced function**

The test added by this PR is currently failing, because the PennyLane's changes will become available after the next PL release. We did check these changes against the future PL version in a separate branch named `wires-pytree-CI`.

closes #334 

[sc-48585]