### PR TITLE
Address the issue of missing calls to device destructors at the end of programs

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -349,6 +349,9 @@
   the `debug.print` function. The issue was caused by non-null-terminated strings.
   [(#418)](https://github.com/PennyLaneAI/catalyst/pull/418)
 
+* Address the issue of missing calls to device destructors at the end of programs.
+  [(#446)](https://github.com/PennyLaneAI/catalyst/pull/446)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/runtime/lib/backend/lightning/lightning_dynamic/StateVectorLQubitDynamic.hpp
+++ b/runtime/lib/backend/lightning/lightning_dynamic/StateVectorLQubitDynamic.hpp
@@ -364,10 +364,6 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
     void clearData()
     {
         data_.clear();
-
-        // reduce allocated memory to fit in the updated size (0)
-        data_.shrink_to_fit();
-
         this->setNumQubits(0);
 
         // the init state-vector

--- a/runtime/lib/backend/lightning/lightning_dynamic/StateVectorLQubitDynamic.hpp
+++ b/runtime/lib/backend/lightning/lightning_dynamic/StateVectorLQubitDynamic.hpp
@@ -366,7 +366,7 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
         data_.clear();
 
         // reduce allocated memory to fit in the updated size (0)
-        // data_.shrink_to_fit();
+        data_.shrink_to_fit();
 
         this->setNumQubits(0);
 

--- a/runtime/lib/backend/lightning/lightning_dynamic/StateVectorLQubitDynamic.hpp
+++ b/runtime/lib/backend/lightning/lightning_dynamic/StateVectorLQubitDynamic.hpp
@@ -364,6 +364,10 @@ class StateVectorLQubitDynamic : public StateVectorLQubit<fp_t, StateVectorLQubi
     void clearData()
     {
         data_.clear();
+
+        // reduce allocated memory to fit in the updated size (0)
+        // data_.shrink_to_fit();
+
         this->setNumQubits(0);
 
         // the init state-vector

--- a/runtime/lib/capi/ExecutionContext.hpp
+++ b/runtime/lib/capi/ExecutionContext.hpp
@@ -208,7 +208,7 @@ class RTDevice {
     std::string rtd_kwargs;
 
     std::unique_ptr<SharedLibraryManager> rtd_dylib{nullptr};
-    QuantumDevice *rtd_qdevice{nullptr};
+    std::unique_ptr<QuantumDevice> rtd_qdevice{nullptr};
 
     RTDeviceStatus status{RTDeviceStatus::Inactive};
 
@@ -263,7 +263,7 @@ class RTDevice {
                this->rtd_kwargs == other.rtd_kwargs;
     }
 
-    [[nodiscard]] auto getQuantumDevicePtr() -> QuantumDevice *
+    [[nodiscard]] auto getQuantumDevicePtr() -> const std::unique_ptr<QuantumDevice> &
     {
         if (rtd_qdevice) {
             return rtd_qdevice;
@@ -272,9 +272,9 @@ class RTDevice {
         rtd_dylib = std::make_unique<SharedLibraryManager>(rtd_lib);
         std::string factory_name{rtd_name + "Factory"};
         void *f_ptr = rtd_dylib->getSymbol(factory_name);
-        rtd_qdevice =
+        rtd_qdevice = std::unique_ptr<QuantumDevice>(
             f_ptr ? reinterpret_cast<decltype(GenericDeviceFactory) *>(f_ptr)(rtd_kwargs.c_str())
-                  : nullptr;
+                  : nullptr);
 
         return rtd_qdevice;
     }

--- a/runtime/lib/capi/ExecutionContext.hpp
+++ b/runtime/lib/capi/ExecutionContext.hpp
@@ -255,7 +255,7 @@ class RTDevice {
         _pl2runtime_device_info(rtd_lib, rtd_name);
     }
 
-    ~RTDevice() { rtd_dylib.reset(nullptr); }
+    ~RTDevice() = default;
 
     auto operator==(const RTDevice &other) const -> bool
     {
@@ -316,11 +316,7 @@ class ExecutionContext final {
         memory_man_ptr = std::make_unique<MemoryManager>();
     }
 
-    ~ExecutionContext()
-    {
-        memory_man_ptr.reset(nullptr);
-        py_guard.reset(nullptr);
-    }
+    ~ExecutionContext() = default;
 
     void setDeviceRecorderStatus(bool status) noexcept { initial_tape_recorder_status = status; }
 

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -64,7 +64,10 @@ thread_local static RTDevice *RTD_PTR = nullptr;
 /**
  * @brief get the active device.
  */
-auto getQuantumDevicePtr() -> QuantumDevice * { return RTD_PTR->getQuantumDevicePtr(); }
+auto getQuantumDevicePtr() -> const std::unique_ptr<QuantumDevice> &
+{
+    return RTD_PTR->getQuantumDevicePtr();
+}
 
 /**
  * @brief Inactivate the active device instance.


### PR DESCRIPTION
Currently, the destructor of `QuantumDevice` instances are not properly called after `__quantum__rt__finalize` as the "extern C" device factory generators return raw pointers of heap-allocated instances. This provides a solution to safely transfer ownership of these pointers to C++ smart pointers. Consequently, the management of destructor calls will be handled by `std::unique_ptr` at the end of the program.

Fix #435.
