### PR TITLE
Fix bug where Sphinx builds are failing

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 docutils==0.16
 sphinxcontrib-bibtex
-sphinx==4.5.0
+sphinx==5.3
 ipykernel
 nbsphinx==0.7
 Jinja2==3.1.2

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,11 @@
 docutils==0.16
 sphinxcontrib-bibtex
-sphinx==5.3
+sphinx==4.5.0
+sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-serializinghtml==1.1.5
 ipykernel
 nbsphinx==0.7
 Jinja2==3.1.2


### PR DESCRIPTION
A new version of `sphinxcontrib-applehelp` was released, which requires Sphinx > 5.0 and causes our builds to fail.

This PR attempts to upgrade Sphinx; if this fails, I will instead pin `sphinxcontrib-applehelp` as per https://github.com/PennyLaneAI/pennylane/pull/5062.

edit: upgrading to Sphinx 5 didn't work :(