### PR TITLE
Avoid infinite recursion in decomposition of `Controlled`

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -11,6 +11,10 @@
 
 <h3>Bug fixes</h3>
 
+* Resolve an infinite recursion in the decomposition of the `Controlled`
+  operator whenever computing a Unitary matrix for the operator fails.
+  [(#468)](https://github.com/PennyLaneAI/catalyst/pull/468)
+
 * Resolve a failure to generate gradient code for specific input circuits.
   [(#439)](https://github.com/PennyLaneAI/catalyst/issues/439)
 

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -323,7 +323,7 @@ class QJITDevice(qml.QubitDevice):
         decompose_to_qubit_unitary = QJITDevice._get_operations_to_convert_to_matrix(self.config)
 
         def _decomp_to_unitary(self, *_args, **_kwargs):
-            return [qml.QubitUnitary(qml.matrix(self), wires=self.wires)]
+            return [qml.QubitUnitary(self.matrix(), wires=self.wires)]
 
         # Fallback for controlled gates that won't decompose successfully.
         # Doing so before rather than after decomposition is generally a trade-off. For low

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -323,7 +323,13 @@ class QJITDevice(qml.QubitDevice):
         decompose_to_qubit_unitary = QJITDevice._get_operations_to_convert_to_matrix(self.config)
 
         def _decomp_to_unitary(self, *_args, **_kwargs):
-            return [qml.QubitUnitary(self.matrix(), wires=self.wires)]
+            try:
+                mat = self.matrix()
+            except Exception as e:
+                raise CompileError(
+                    f"Operation {self} could not be decomposed, it might be unsupported."
+                ) from e
+            return [qml.QubitUnitary(mat, wires=self.wires)]
 
         # Fallback for controlled gates that won't decompose successfully.
         # Doing so before rather than after decomposition is generally a trade-off. For low


### PR DESCRIPTION
The `qml.matrix` falls back to decomposition of the supplied operator if the matrix cannot be computed. Since we explicitly map the decomposition function of an operator to a `qml.matrix` call, this can lead to infinite decomposition loop.

Avoid the problem by invoking `op.matrix()` directly.

fixes #463 
[sc-54969]