### PR TITLE
[Frontend] Support ``static_argnums``

### DIFF
--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -1036,6 +1036,42 @@ def qjit(
         appearing as is.
 
     .. details::
+        :title: Static arguments
+
+        ``static_argnums`` defines which elements should be treated as static. If it takes an
+        integer, it means the argument whose index is equal to the integer is static. If it takes
+        an iterable of integers, arguments whose index is contained in the iterable are static.
+        Changing static arguments will introduce re-compilation.
+
+        .. code-block:: python
+
+            @qjit(static_argnums=1)
+            def f(
+                x: int,
+                y: MyClass,
+            ):
+                return x + y.val
+
+            f(1, MyClass(5))
+            f(1, MyClass(6)) # re-compilation
+
+        In the example above, ``y`` is static. Note that the second function calls triggers
+        re-compilation since the input object is different from the previous one.
+
+        .. code-block:: python
+
+            @qjit(static_argnums=(1, 2))
+            def f(
+                x: int,
+                y: MyClass,
+                z: MyClass,
+            ):
+                return x + y.val + z.val
+
+        In the example above, ``y`` and ``z`` are static.
+
+
+    .. details::
         :title: Dynamically-shaped arrays
 
         There are three ways to use ``abstracted_axes``; by passing a sequence of tuples, a

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -61,6 +61,8 @@ class CompileOptions:
             of QNodes support is to be enabled.
         lower_to_llvm (Optional[bool]): flag indicating whether to attempt the LLVM lowering after
             the main compilation pipeline is complete. Default is ``True``.
+        static_argnums (Optional[Union[int, Iterable[int]]]): indices of static arguments.
+            Default is ``None``.
         abstracted_axes (Optional[Any]): store the abstracted_axes value. Defaults to ``None``.
     """
 
@@ -72,6 +74,7 @@ class CompileOptions:
     autograph: Optional[bool] = False
     async_qnodes: Optional[bool] = False
     lower_to_llvm: Optional[bool] = True
+    static_argnums: Optional[Union[int, Iterable[int]]] = None
     abstracted_axes: Optional[Union[Iterable[Iterable[str]], Dict[int, str]]] = None
 
     def __deepcopy__(self, memo):

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -327,11 +327,12 @@ def has_nested_tapes(op: Operation) -> bool:
     )
 
 
-def trace_to_mlir(func, abstracted_axes, *args, **kwargs):
+def trace_to_mlir(func, static_argnums, abstracted_axes, *args, **kwargs):
     """Lower a Python function into an MLIR module.
 
     Args:
         func: python function to be lowered
+        static_argnums: indices of static arguments.
         abstracted_axes: abstracted axes specification. Necessary for JAX to use dynamic tensor
             sizes.
         args: arguments to ``func``
@@ -353,7 +354,7 @@ def trace_to_mlir(func, abstracted_axes, *args, **kwargs):
     mlir_fn_cache.clear()
 
     with EvaluationContext(EvaluationMode.CLASSICAL_COMPILATION):
-        make_jaxpr_kwargs = {"abstracted_axes": abstracted_axes}
+        make_jaxpr_kwargs = {"static_argnums": static_argnums, "abstracted_axes": abstracted_axes}
         jaxpr, out_type, out_tree = make_jaxpr2(func, **make_jaxpr_kwargs)(*args, **kwargs)
 
     # We remove implicit Jaxpr result values since we are compiling a top-level jaxpr program.

--- a/frontend/catalyst/utils/jax_extras.py
+++ b/frontend/catalyst/utils/jax_extras.py
@@ -494,8 +494,8 @@ def make_jaxpr2(
         ), ExitStack():
             f = wrap_init(fun)
             if static_argnums:
-                static_argnums_pack = [static_argnums] if isinstance(static_argnums, int) else static_argnums
-                dynamic_argnums = [i for i in range(len(args)) if i not in static_argnums_pack]
+                argnums = [static_argnums] if isinstance(static_argnums, int) else static_argnums
+                dynamic_argnums = [i for i in range(len(args)) if i not in argnums]
                 f, args = jax._src.api_util.argnums_partial(f, dynamic_argnums, args)
             in_type, in_tree = abstractify(args, kwargs)
             f, out_tree_promise = flatten_fun(f, in_tree)

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -22,6 +22,7 @@ import pennylane as qml
 import pytest
 from jax import numpy as jnp
 from numpy import pi
+from dataclasses import dataclass
 
 from catalyst import for_loop, grad, measure, qjit
 from catalyst.compilation_pipelines import CompiledFunction, TypeCompatibility
@@ -945,6 +946,28 @@ class TestTwoQJITsOneName:
         assert foo_2() == 2
         foo_1.workspace.cleanup()
         foo_2.workspace.cleanup()
+
+class TestStaticArguments:
+    """Test QJIT with static arguments."""
+
+    def test_one_static_argument(self):
+        """Test QJIT with one static argument."""
+
+        @dataclass
+        class MyClass:
+            val: int
+
+            def __hash__(self):
+                return hash(str(self))
+
+        @qjit(static_argnums=1)
+        def f(
+            x: int,
+            y: MyClass,
+        ):
+            return x + y.val
+
+        assert f(1, MyClass(5)) == 6
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -950,6 +950,42 @@ class TestTwoQJITsOneName:
 class TestStaticArguments:
     """Test QJIT with static arguments."""
 
+    def test_zero_static_argument(self):
+        """Test QJIT with zero static argument."""
+
+        @qjit
+        def f0(
+            x: int,
+        ):
+            return x
+
+        @qjit(static_argnums=())
+        def f1(
+            x: int,
+        ):
+            return x
+
+        @qjit(static_argnums=None)
+        def f2(
+            x: int,
+        ):
+            return x
+
+        assert f0(1) == 1
+        assert f1(2) == 2
+        assert f2(3) == 3
+
+    def test_out_of_bounds_static_argument(self):
+        """Test QJIT with invalid static argument index."""
+
+        @qjit(static_argnums=100)
+        def f(
+            x: int,
+        ):
+            return x
+
+        assert f(1) == 1
+
     def test_one_static_argument(self):
         """Test QJIT with one static argument."""
 
@@ -968,6 +1004,63 @@ class TestStaticArguments:
             return x + y.val
 
         assert f(1, MyClass(5)) == 6
+        function = f.compiled_function
+        assert f(1, MyClass(7)) == 8
+        assert(function != f.compiled_function)
+        # Same static argument should not trigger re-compilation.
+        assert f(2, MyClass(5)) == 7
+        assert(function == f.compiled_function)
+
+    def test_multiple_static_arguments(self):
+        """Test QJIT with more than one static arguments."""
+
+        @dataclass
+        class MyClass:
+            val: int
+
+            def __hash__(self):
+                return hash(str(self))
+
+        @qjit(static_argnums=(2, 0))
+        def f(
+            x: MyClass,
+            y: int,
+            z: MyClass
+        ):
+            return x.val + y + z.val
+
+        assert f(MyClass(5), 1, MyClass(5)) == 11
+        function = f.compiled_function
+        assert f(MyClass(7), 1, MyClass(7)) == 15
+        assert(function != f.compiled_function)
+        assert f(MyClass(5), 2, MyClass(5)) == 12
+        assert(function == f.compiled_function)
+
+    def test_mutable_static_arguments(self):
+        """Test QJIT with mutable static arguments."""
+
+        @dataclass
+        class MyClass:
+            val0: int
+            val1: int
+
+            def __hash__(self):
+                return hash(str(self))
+
+        @qjit(static_argnums=1)
+        def f(
+            x: int,
+            y: MyClass,
+        ):
+            return x + y.val0 + y.val1
+
+        myObj = MyClass(5, 5)
+        assert f(1, myObj) == 11
+        function = f.compiled_function
+        # Changing mutable object should introduce re-compilation.
+        myObj.val1 = 3
+        assert f(1, myObj) == 9
+        assert(function != f.compiled_function)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Context:** Supporting ``static_argnums`` to identify which arguments are static. I

**Description of the Change:** Introduce the ``static_argnums`` parameter to ``@qjit`` and add a mechanism to determine if the function needs to be recompiled when the static arguments are changed.

**Benefits:** Users can pass custom objects to a function with ``@qjit``.  The ``QJIT`` object also stores all previously compiled functions for different arguments. If the arguments are seen before, there is no need for re-compilation.

**Possible Drawbacks:** The ``QJIT`` object will store all the previously compiled functions and require more space.
The mechanism for recompilation is based on checking hash values, so there might be a possibility of collision.  The re-compilation mechanism will keep creating new ``catalyst.utils.filesystem.WorkspaceManager`` for new functions.  If we do not create a new ``WorkspaceManager``, the new function will not be properly compiled. I am not sure if I should modify anything related to it.

**Related GitHub Issues:** #461 
