### PR TITLE
Add the `wires` property to `catalyst.adjoint` and `catalyst.ctrl`

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -13,6 +13,9 @@
 * Remove `qextract_p` and `qinst_p` from forced-order primitives.
   [(#469)](https://github.com/PennyLaneAI/catalyst/pull/469)
 
+* Add the `wires` property to `catalyst.adjoint` and `catalyst.ctrl`.
+  [(#480)](https://github.com/PennyLaneAI/catalyst/pull/480)
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -13,9 +13,6 @@
 * Remove `qextract_p` and `qinst_p` from forced-order primitives.
   [(#469)](https://github.com/PennyLaneAI/catalyst/pull/469)
 
-* Add the `wires` property to `catalyst.adjoint` and `catalyst.ctrl`.
-  [(#480)](https://github.com/PennyLaneAI/catalyst/pull/480)
-
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>
@@ -63,6 +60,17 @@
 * Fix the issue in `LightningKokkos::AllocateQubits` with allocating too many qubit IDs on
   qubit re-allocation.
   [(#473)](https://github.com/PennyLaneAI/catalyst/pull/473)
+
+* Add the `wires` property to `catalyst.adjoint` and `catalyst.ctrl`.
+  [(#480)](https://github.com/PennyLaneAI/catalyst/pull/480)
+
+  Without implementing the `wires` property, users would get `<Wires = [<WiresEnum.AnyWires: -1>]>`
+  for the list of wires in these operations.
+  Currently, `catalyst.adjoint.wires` supports static wires and workflows with nested branches,
+  and `catalyst.ctrl.wires` provides support for workflows with static and variable wires as well as
+  nested branches. The `wires` property in `adjoint` and `ctrl` cannot be used in workflows with
+  control flow operations.
+
 
 <h3>Contributors</h3>
 

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -1204,6 +1204,12 @@ class Adjoint(HybridOp):
         qrp2 = QRegPromise(op_results[-1])
         return qrp2
 
+    @property
+    def wires(self):
+        assert len(self.regions) == 1, "Adjoint is expected to have one region"
+        total_wires = sum((op.wires for op in self.regions[0].quantum_tape.operations), [])
+        return total_wires
+
 
 # TODO: This class needs to be made interoperable with qml.Controlled since qml.ctrl dispatches
 #       to this class whenever a qjit context is active.
@@ -1238,6 +1244,15 @@ class QCtrl(HybridOp):
             self._work_wires,
         )
         return new_tape.operations
+
+    @property
+    def wires(self):
+        assert len(self.regions) == 1, "Qctrl is expected to have one region"
+        total_wires = sum(
+            (op.wires for op in self.regions[0].quantum_tape.operations),
+            self._control_wires + self._work_wires,
+        )
+        return total_wires
 
     @property
     def control_wires(self):

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -1250,12 +1250,13 @@ class QCtrl(HybridOp):
     @property
     def wires(self):
         """The list of all control-wires, work-wires, and active-wires."""
-
         assert len(self.regions) == 1, "Qctrl is expected to have one region"
+
         total_wires = sum(
             (op.wires for op in self.regions[0].quantum_tape.operations),
-            self._control_wires + self._work_wires,
+            self._control_wires,
         )
+        total_wires += self._work_wires
         return total_wires
 
     @property

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -1206,6 +1206,8 @@ class Adjoint(HybridOp):
 
     @property
     def wires(self):
+        """The list of all static wires."""
+
         assert len(self.regions) == 1, "Adjoint is expected to have one region"
         total_wires = sum((op.wires for op in self.regions[0].quantum_tape.operations), [])
         return total_wires
@@ -1247,6 +1249,8 @@ class QCtrl(HybridOp):
 
     @property
     def wires(self):
+        """The list of all control-wires, work-wires, and active-wires."""
+
         assert len(self.regions) == 1, "Qctrl is expected to have one region"
         total_wires = sum(
             (op.wires for op in self.regions[0].quantum_tape.operations),

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -521,9 +521,10 @@ def test_adjoint_wires_qubitunitary(backend):
 #         qml.PauliX(wires=0)
 #         cadj = C_adjoint(func)(w0, w1, theta)
 #         catalyst.debug.print(cadj.wires)
-#         # <Wires = [Traced<ShapedArray(int64[], weak_type=True)>with<DynamicJaxprTrace(level=3/1)>,
-#         #           Traced<ShapedArray(int64[], weak_type=True)>with<DynamicJaxprTrace(level=3/1)>,
-#         #           2]>
+#         # <Wires =
+#         #    [Traced<ShapedArray(int64[], weak_type=True)>with<DynamicJaxprTrace(level=3/1)>,
+#         #     Traced<ShapedArray(int64[], weak_type=True)>with<DynamicJaxprTrace(level=3/1)>,
+#         #     2]>
 #         return qml.state()
 #     C_workflow(0, 1, 0.23)
 

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -463,5 +463,87 @@ def test_adjoint_outside_qjit():
     assert C_adjoint(qml.T(wires=0)) == PL_adjoint(qml.T(wires=0))
 
 
+def test_adjoint_wires(backend):
+    """Test the wires property of Adjoint"""
+
+    @qml.qjit
+    @qml.qnode(qml.device(backend, wires=3))
+    def circuit(theta):
+        def func(theta):
+            qml.RX(theta, wires=[0])
+            qml.Hadamard(2)
+            qml.CNOT([0, 2])
+
+        qctrl = C_adjoint(func)(theta)
+        return qctrl.wires
+
+    # Without the `wires` property, returns `[-1]`
+    assert circuit(0.3) == qml.wires.Wires([0, 2])
+
+
+def test_adjoint_wires_qubitunitary(backend):
+    """Test the wires property of nested Adjoint with QubitUnitary"""
+
+    @qml.qjit
+    @qml.qnode(qml.device(backend, wires=3))
+    def circuit():
+        def func():
+            qml.QubitUnitary(
+                jnp.array(
+                    [
+                        [0.99500417 - 0.09983342j, 0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
+                        [0.0 + 0.0j, 0.99500417 + 0.09983342j, 0.0 + 0.0j, 0.0 + 0.0j],
+                        [0.0 + 0.0j, 0.0 + 0.0j, 0.99500417 + 0.09983342j, 0.0 + 0.0j],
+                        [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j, 0.99500417 - 0.09983342j],
+                    ]
+                ),
+                wires=[0, 1],
+            )
+
+        qadj = C_adjoint(C_adjoint(C_adjoint(func)))()
+        return qadj.wires
+
+    # Without the `wires` property, returns `[-1]`
+    assert circuit() == qml.wires.Wires([0, 1])
+
+
+# # Variable wires is not supported!
+# def test_adjoint_var_wires(backend):
+#     """Test catalyst.adjoint.wires with variable wires."""
+#     device = qml.device(backend, wires=3)
+#     def func(w0, w1, theta):
+#         qml.RX(theta * pnp.pi / 2, wires=w0)
+#         qml.RY(theta / 2, wires=w1)
+#         qml.RZ(theta, wires=2)
+#     @qml.qjit
+#     @qml.qnode(device)
+#     def C_workflow(w0, w1, theta):
+#         qml.PauliX(wires=0)
+#         cadj = C_adjoint(func)(w0, w1, theta)
+#         catalyst.debug.print(cadj.wires)
+#         # <Wires = [Traced<ShapedArray(int64[], weak_type=True)>with<DynamicJaxprTrace(level=3/1)>,
+#         #           Traced<ShapedArray(int64[], weak_type=True)>with<DynamicJaxprTrace(level=3/1)>,
+#         #           2]>
+#         return qml.state()
+#     C_workflow(0, 1, 0.23)
+
+
+# # `adjoint.wires` in control-flow branches is not supported!
+# def test_adjoint_wires_controlflow(backend):
+#     """Test the wires property of Adjoint  in a conditional branch"""
+#     @qml.qjit
+#     @qml.qnode(qml.device(backend, wires=3))
+#     def circuit():
+#         def func(pred, theta):
+#             @cond(pred)
+#             def cond_fn():
+#                 qml.RX(theta, wires=0)
+#             cond_fn()
+#         qadj = C_adjoint(func)(True, 3.14)
+#         return qadj.wires
+#     # It returns `-1` instead of `0`
+#     assert circuit() == qml.wires.Wires([0])
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -19,6 +19,7 @@
 from typing import Callable
 
 import pennylane as qml
+import pennylane.numpy as pnp
 import pytest
 from numpy.testing import assert_allclose
 from pennylane import adjoint as PL_adjoint
@@ -295,6 +296,103 @@ def test_control_outside_qjit():
     assert C_ctrl(
         qml.T(wires=0), control=[1, 2], control_values=[False, True], work_wires=3
     ) == PL_ctrl(qml.T(wires=0), control=[1, 2], control_values=[False, True], work_wires=3)
+
+
+def test_qctrl_wires(backend):
+    """Test the wires property of QCtrl"""
+
+    @qml.qjit
+    @qml.qnode(qml.device(backend, wires=3))
+    def circuit(theta):
+        def func(theta):
+            qml.RX(theta, wires=[0])
+            qml.Hadamard(2)
+            qml.CNOT([0, 2])
+
+        qctrl = C_ctrl(func, control=[1])(theta)
+        return qctrl.wires
+
+    # Without the `wires` property, returns `[-1]`
+    assert circuit(0.3) == qml.wires.Wires([1, 0, 2])
+
+
+def test_qctrl_wires_arg_fun(backend):
+    """Test the wires property of QCtrl with argument wires"""
+
+    @qml.qjit
+    @qml.qnode(qml.device(backend, wires=4))
+    def circuit():
+        def func(anc, wires):
+            qml.Hadamard(anc)
+            h = pnp.array([[1, 1], [1, -1]]) / pnp.sqrt(2)
+            qml.ctrl(qml.BlockEncode, control=(anc))(h, wires=wires)
+            qml.Hadamard(anc)
+
+        qctrl = C_ctrl(func, control=[1])(0, [2, 3])
+        return qctrl.wires
+
+    assert circuit() == qml.wires.Wires([1, 0, 2, 3])
+
+
+def test_qctrl_var_wires(backend):
+    """Test the wires property of QCtrl with variable wires"""
+
+    @qml.qjit
+    @qml.qnode(qml.device(backend, wires=4))
+    def circuit(anc, wires):
+        def func(anc, wires):
+            qml.Hadamard(anc)
+            h = pnp.array([[1, 1], [1, -1]]) / pnp.sqrt(2)
+            qml.ctrl(qml.BlockEncode, control=(anc))(h, wires=wires)
+            qml.Hadamard(anc)
+
+        qctrl = C_ctrl(func, control=[1])(anc, wires)
+        return qctrl.wires
+
+    assert circuit(0, [2, 3]) == qml.wires.Wires([1, 0, 2, 3])
+
+
+def test_qctrl_wires_nested(backend):
+    """Test the wires property of QCtrl with nested branches"""
+
+    @qml.qjit
+    @qml.qnode(qml.device(backend, wires=4))
+    def circuit(theta, w1, w2, cw1, cw2):
+        def _func1():
+            qml.RX(theta, wires=[w1])
+
+            def _func2():
+                qml.RY(theta, wires=[w2])
+
+            C_ctrl(_func2, control=[cw2], control_values=[True])()
+
+            qml.RZ(theta, wires=w1)
+
+        qctrl = C_ctrl(_func1, control=[cw1], control_values=[True])()
+        return qctrl.wires
+
+    assert circuit(0.1, 0, 1, 2, 3) == qml.wires.Wires([2, 0, 3, 1])
+
+
+# # `ctrl.wires` in control-flow branches is not supported!
+# def test_qctrl_wires_controlflow(backend):
+#     """Test the wires property of QCtrl with control flow branches"""
+#     @qml.qjit
+#     @qml.qnode(qml.device(backend, wires=3))
+#     def circuit(theta, w1, w2, cw):
+#         def _func():
+#             qml.RX(theta, wires=[w1])
+#             s = 0
+#             @for_loop(0, w2, 1)
+#             def _for_loop(i, s):
+#                 qml.RY(theta, wires=i)
+#                 return s + 1
+#             s = _for_loop(s)
+#             qml.RZ(s * theta, wires=w1)
+#         qctrl = C_ctrl(_func, control=[cw], control_values=[True])()
+#         return qctrl.wires
+#     # It returns `[2, 0, -1]`
+#     assert circuit(0.1, 0, 2, 2) == qml.wires.Wires([2, 0, 1])
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -325,7 +325,7 @@ def test_qctrl_wires_arg_fun(backend):
         def func(anc, wires):
             qml.Hadamard(anc)
             h = pnp.array([[1, 1], [1, -1]]) / pnp.sqrt(2)
-            qml.ctrl(qml.BlockEncode, control=(anc))(h, wires=wires)
+            qml.ctrl(qml.BlockEncode, control=anc)(h, wires=wires)
             qml.Hadamard(anc)
 
         qctrl = C_ctrl(func, control=[1])(0, [2, 3])
@@ -343,7 +343,7 @@ def test_qctrl_var_wires(backend):
         def func(anc, wires):
             qml.Hadamard(anc)
             h = pnp.array([[1, 1], [1, -1]]) / pnp.sqrt(2)
-            qml.ctrl(qml.BlockEncode, control=(anc))(h, wires=wires)
+            qml.ctrl(qml.BlockEncode, control=anc)(h, wires=wires)
             qml.Hadamard(anc)
 
         qctrl = C_ctrl(func, control=[1])(anc, wires)


### PR DESCRIPTION
Without implementing the `wires` property, the result of `catalyst.adjoint.wires` and `catalyst.ctrl.wires` would be `<Wires = [<WiresEnum.AnyWires: -1>]>`. This property is used in some of PennyLane's hybrid algorithms/demos. This PR adds this property to both of these Catalyst operations to unblock us with QJIT compiling those algorithms. 

[sc-55351]