### PR TITLE
Add lowering for the `lapack_dsyevd` custom call

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -170,6 +170,23 @@ would no longer decompose the `PSWAP` and `ISWAP` gates to `SWAP`s, `CNOT`s and 
   nested branches. The `wires` property in `adjoint` and `ctrl` cannot be used in workflows with
   control flow operations.
 
+* Add support for lowering the eigen vectors/values computation lapack method: `lapack_dsyevd`
+  via `stablehlo.custom_call`. For Catalyst, it means that you now can QJIT compile eigen
+  vector/values operations and any other `qml.math` methods that uses these operations.
+  [(#488)](https://github.com/PennyLaneAI/catalyst/pull/488)
+
+  For example, you can compile `qml.math.sqrt_matrix`:
+
+  ```python
+  @qml.qjit
+  def workflow(A):
+      B = qml.math.sqrt_matrix(A)
+      return B @ A
+  ```
+
+* Fix the issue with multiple lapack symbol definitions in the compiled program by updating
+  the `stablehlo.custom_call` conversion pass.
+  [(#488)](https://github.com/PennyLaneAI/catalyst/pull/488)
 
 <h3>Contributors</h3>
 

--- a/frontend/catalyst/utils/libcustom_calls.cpp
+++ b/frontend/catalyst/utils/libcustom_calls.cpp
@@ -54,7 +54,8 @@ void dgesdd_(char *jobz, lapack_int *m, lapack_int *n, double *a, lapack_int *ld
 void dsyevd_(char *jobz, char *uplo, lapack_int *n, double *a, int *lda, double *w, double *work,
              lapack_int *lwork, lapack_int *iwork, lapack_int *liwork, lapack_int *info);
 
-// Wrapper to call the SVD solver dgesdd_ and dsyevd_ from Lapack:
+// Wrapper to call the SVD solver `dgesdd_` and the eigen vectors/values computation `dsyevd_`
+// from Lapack:
 // https://github.com/google/jax/blob/main/jaxlib/cpu/lapack_kernels.cc released under the Apache
 // License, Version 2.0, with the following copyright notice:
 

--- a/frontend/catalyst/utils/libcustom_calls.cpp
+++ b/frontend/catalyst/utils/libcustom_calls.cpp
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <cstring>
 #include <iostream>
+#include <limits>
 #include <optional>
 #include <string>
 #include <vector>
@@ -50,7 +51,10 @@ void dgesdd_(char *jobz, lapack_int *m, lapack_int *n, double *a, lapack_int *ld
              double *u, lapack_int *ldu, double *vt, lapack_int *ldvt, double *work,
              lapack_int *lwork, lapack_int *iwork, lapack_int *info);
 
-// Wrapper to call the SVD solver dgesdd_ from Lapack:
+void dsyevd_(char *jobz, char *uplo, lapack_int *n, double *a, int *lda, double *w, double *work,
+             lapack_int *lwork, lapack_int *iwork, lapack_int *liwork, lapack_int *info);
+
+// Wrapper to call the SVD solver dgesdd_ and dsyevd_ from Lapack:
 // https://github.com/google/jax/blob/main/jaxlib/cpu/lapack_kernels.cc released under the Apache
 // License, Version 2.0, with the following copyright notice:
 
@@ -107,6 +111,51 @@ void lapack_dgesdd(void **dataEncoded, void **resultsEncoded)
         u += static_cast<int64_t>(m) * tdu;
         vt += static_cast<int64_t>(ldvt) * n;
         ++info;
+    }
+}
+
+// Copyright 2021 The JAX Authors.
+void lapack_dsyevd(void **dataEncoded, void **resultsEncoded)
+{
+    std::vector<void *> data;
+    for (size_t i = 0; i < 4; ++i) {
+        auto encodedMemref = *(reinterpret_cast<EncodedMemref *>(dataEncoded[i]));
+        data.push_back(encodedMemref.data_aligned);
+    }
+
+    std::vector<void *> out;
+    for (size_t i = 0; i < 5; ++i) {
+        auto encodedMemref = *(reinterpret_cast<EncodedMemref *>(resultsEncoded[i]));
+        out.push_back(encodedMemref.data_aligned);
+    }
+
+    int32_t lower = *(reinterpret_cast<int32_t *>(data[0]));
+    int b = *(reinterpret_cast<int32_t *>(data[1]));
+    int n = *(reinterpret_cast<int32_t *>(data[2]));
+    const double *a_in = reinterpret_cast<double *>(data[3]);
+
+    double *a_out = reinterpret_cast<double *>(out[0]);
+    double *w_out = reinterpret_cast<double *>(out[1]);
+    int *info_out = reinterpret_cast<int *>(out[2]);
+    double *work = reinterpret_cast<double *>(out[3]);
+    int *iwork = reinterpret_cast<int *>(out[4]);
+    if (a_out != a_in) {
+        std::memcpy(a_out, a_in,
+                    static_cast<int64_t>(b) * static_cast<int64_t>(n) * static_cast<int64_t>(n) *
+                        sizeof(double));
+    }
+
+    char jobz = 'V';
+    char uplo = lower ? 'L' : 'U';
+
+    lapack_int lwork =
+        std::min<int64_t>(std::numeric_limits<lapack_int>::max(), 1 + 6 * n + 2 * n * n);
+    lapack_int liwork = std::min<int64_t>(std::numeric_limits<lapack_int>::max(), 3 + 5 * n);
+    for (int i = 0; i < b; ++i) {
+        dsyevd_(&jobz, &uplo, &n, a_out, &n, w_out, work, &lwork, iwork, &liwork, info_out);
+        a_out += static_cast<int64_t>(n) * n;
+        w_out += n;
+        ++info_out;
     }
 }
 }

--- a/frontend/test/lit/test_aot_compilation.py
+++ b/frontend/test/lit/test_aot_compilation.py
@@ -408,7 +408,7 @@ print(function_tensor_jaxnumpy_int64.mlir)
 # CHECK-LABEL: module @lowering_to_stablehlo_custom_call
 @qjit(target="mlir")
 def lowering_to_stablehlo_custom_call(A: ShapedArray([2, 2], jax.numpy.float64)):
-    """Test lowering to stablehlo.custom_call @lapack_dsyevd"""
+    """Test lowering to `stablehlo.custom_call @lapack_dsyevd`"""
 
     # CHECK: func.func private @eigh
     # CHECK: stablehlo.custom_call @lapack_dsyevd
@@ -417,3 +417,19 @@ def lowering_to_stablehlo_custom_call(A: ShapedArray([2, 2], jax.numpy.float64))
 
 
 print(lowering_to_stablehlo_custom_call.mlir)
+
+
+# CHECK-LABEL: module @multiple_stablehlo_custom_call
+@qjit(target="mlir")
+def multiple_stablehlo_custom_call(A: ShapedArray([2, 2], jax.numpy.float64)):
+    """Test lowering to `stablehlo.custom_call @lapack_dsyevd` of multiple lapack methods"""
+
+    # CHECK: func.func private @eigh
+    # CHECK: stablehlo.custom_call @lapack_dsyevd
+    # CHECK: func.func private @eigh_1
+    # CHECK: stablehlo.custom_call @lapack_dsyevd
+    B = qml.math.sqrt_matrix(A) @ qml.math.sqrt_matrix(A)
+    return B
+
+
+print(multiple_stablehlo_custom_call.mlir)

--- a/frontend/test/lit/test_aot_compilation.py
+++ b/frontend/test/lit/test_aot_compilation.py
@@ -403,3 +403,17 @@ def function_tensor_jaxnumpy_int64(
 
 
 print(function_tensor_jaxnumpy_int64.mlir)
+
+
+# CHECK-LABEL: module @lowering_to_stablehlo_custom_call
+@qjit(target="mlir")
+def lowering_to_stablehlo_custom_call(A: ShapedArray([2, 2], jax.numpy.float64)):
+    """Test lowering to stablehlo.custom_call @lapack_dsyevd"""
+
+    # CHECK: func.func private @eigh
+    # CHECK: stablehlo.custom_call @lapack_dsyevd
+    B = qml.math.sqrt_matrix(A)
+    return B
+
+
+print(lowering_to_stablehlo_custom_call.mlir)

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -25,6 +25,7 @@ import tempfile
 import warnings
 from os.path import isfile
 
+import numpy as np
 import pennylane as qml
 import pytest
 
@@ -356,6 +357,21 @@ module @workflow {
             qjit(circuit, pipelines=test_pipelines, verbose=True)()
 
         assert "Trace" in e.value.args[0]
+
+
+class TestCustomCall:
+    """Test compilation of lapack_dsyevd via lowering to stablehlo.custom_call."""
+
+    def test_dsyevd(self):
+        A = np.array([[4, 9], [9, 4]])
+
+        def circuit(A):
+            B = qml.math.sqrt_matrix(A)
+            return B
+
+        qjit_result = qjit(circuit)(A)
+        pl_result = circuit(A)
+        assert np.allclose(qjit_result, pl_result)
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -360,13 +360,28 @@ module @workflow {
 
 
 class TestCustomCall:
-    """Test compilation of lapack_dsyevd via lowering to stablehlo.custom_call."""
+    """Test compilation of `lapack_dsyevd` via lowering to `stablehlo.custom_call`."""
 
     def test_dsyevd(self):
+        """Test the support of `lapack_dsyevd` in one single `stablehlo.custom_call` call."""
+
         A = np.array([[4, 9], [9, 4]])
 
         def workflow(A):
             B = qml.math.sqrt_matrix(A)
+            return B @ A
+
+        qjit_result = qjit(workflow)(A)
+        pl_result = workflow(A)
+        assert np.allclose(qjit_result, pl_result)
+
+    def test_dsyevd_multiple_calls(self):
+        """Test the support of `lapack_dsyevd` in multiple `stablehlo.custom_call` calls."""
+
+        A = np.array([[4, 9], [9, 4]])
+
+        def workflow(A):
+            B = qml.math.sqrt_matrix(A) @ qml.math.sqrt_matrix(A)
             return B @ A
 
         qjit_result = qjit(workflow)(A)

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -365,12 +365,12 @@ class TestCustomCall:
     def test_dsyevd(self):
         A = np.array([[4, 9], [9, 4]])
 
-        def circuit(A):
+        def workflow(A):
             B = qml.math.sqrt_matrix(A)
-            return B
+            return B @ A
 
-        qjit_result = qjit(circuit)(A)
-        pl_result = circuit(A)
+        qjit_result = qjit(workflow)(A)
+        pl_result = workflow(A)
         assert np.allclose(qjit_result, pl_result)
 
 

--- a/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
@@ -319,12 +319,13 @@ struct CustomCallOpPattern : public OpConversionPattern<CustomCallOp> {
         Type ptr = LLVM::LLVMPointerType::get(ctx);
 
         Type voidType = LLVM::LLVMVoidType::get(ctx);
-        auto type = LLVM::LLVMFunctionType::get(voidType, {/*args=*/ptr, /*rets=*/ptr});
         auto point = rewriter.saveInsertionPoint();
         ModuleOp mod = op->getParentOfType<ModuleOp>();
         rewriter.setInsertionPointToStart(mod.getBody());
-        LLVM::LLVMFuncOp customCallFnOp =
-            rewriter.create<LLVM::LLVMFuncOp>(loc, op.getCallTargetName(), type);
+
+        LLVM::LLVMFuncOp customCallFnOp = mlir::LLVM::lookupOrCreateFn(
+            mod, op.getCallTargetName(), {/*args=*/ptr, /*rets=*/ptr}, /*ret_type=*/voidType);
+
         customCallFnOp.setPrivate();
         rewriter.restoreInsertionPoint(point);
 


### PR DESCRIPTION
This lowering will enable the QJIT compilation of `qml.BlockEncode` and `qml.qsvt` with variable matrices.

For example, the compilation of the following circuits are now possible

``` python
@qml.qjit
@qml.qnode(dev)
def circuit1(A):
    qml.BlockEncode(A, wires=range(2))
    return qml.state()


>>> circuit1(np.array([[0.1, 0.2], [0.3, 0.4]]))
``` 

``` python
A = np.array([[0.1, 0.2], [0.3, 0.4]])
angles = np.array([0.1, 0.2, 0.3])

@qml.qjit
@qml.qnode(dev)
def circuit2(A):
    qml.qsvt(A, angles, wires=[0, 1])
    return qml.expval(qml.PauliZ(wires=0))

circuit2(A)
```

[sc-54971]
[sc-55370]