### PR TITLE
Implementation of post-selection for mid-circuit measurements

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -75,6 +75,25 @@
   the current state-vector before qubit re-allocations.
   [(#479)](https://github.com/PennyLaneAI/catalyst/pull/479)
 
+* Add support for post-selection in mid-circuit measurements. This is currently supported only on Lightning simulators.
+  [(#491)](https://github.com/PennyLaneAI/catalyst/pull/491)
+
+  This is an example of post-selection usage:
+
+  ```py
+  import pennylane as qml
+  from catalyst import qjit
+
+  dev = qml.device("lightning.qubit", wires=1)
+
+  @qjit
+  @qml.qnode(dev)
+  def f():
+      qml.Hadamard(0)
+      m = measure(0, postselect=1)
+      return qml.expval(qml.PauliZ(0))
+  ```
+
 <h3>Breaking changes</h3>
 
 * The entry point name convention has changed.
@@ -219,6 +238,7 @@ David Ittah,
 Tzung-Han Juang,
 Erick Ochoa Lopez,
 Romain Moyard,
+Raul Torres,
 Haochen Paul Wang.
 
 # Release 0.4.1

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -810,12 +810,15 @@ def _qmeasure_lowering(jax_ctx: mlir.LoweringRuleContext, qubit: ir.Value, posts
     assert ir.OpaqueType(qubit.type).dialect_namespace == "quantum"
     assert ir.OpaqueType(qubit.type).data == "bit"
 
+    # Prepare postselect attribute
     i8_type = ir.IntegerType.get_signless(8, ctx)
     postselect_attr = ir.IntegerAttr.get(i8_type, postselect)
 
     result_type = ir.IntegerType.get_signless(1)
 
-    result, new_qubit = MeasureOp(result_type, qubit.type, qubit, postselect=postselect_attr).results
+    result, new_qubit = MeasureOp(
+        result_type, qubit.type, qubit, postselect=postselect_attr
+    ).results
 
     result_from_elements_op = ir.RankedTensorType.get((), result.type)
     from_elements_op = FromElementsOp(result_from_elements_op, result)

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -792,13 +792,13 @@ def _qunitary_lowering(jax_ctx: mlir.LoweringRuleContext, matrix: ir.Value, *qub
 # qmeasure
 #
 @qmeasure_p.def_abstract_eval
-def _qmeasure_abstract_eval(qubit):
+def _qmeasure_abstract_eval(qubit, postselect):
     assert isinstance(qubit, AbstractQbit)
     return core.ShapedArray((), bool), qubit
 
 
 @qmeasure_p.def_impl
-def _qmeasure_def_impl(ctx, qubit):  # pragma: no cover
+def _qmeasure_def_impl(ctx, qubit, postselect):  # pragma: no cover
     raise NotImplementedError()
 
 
@@ -811,10 +811,11 @@ def _qmeasure_lowering(jax_ctx: mlir.LoweringRuleContext, qubit: ir.Value, posts
     assert ir.OpaqueType(qubit.type).data == "bit"
 
     i8_type = ir.IntegerType.get_signless(8, ctx)
-    postselect_attr = ir.IntegerAttr.get(i8_type, postselect) if postselect is not None else None
+    postselect_attr = ir.IntegerAttr.get(i8_type, postselect)
 
     result_type = ir.IntegerType.get_signless(1)
-    result, new_qubit = MeasureOp(result_type, qubit.type, qubit, postselect_attr).results
+
+    result, new_qubit = MeasureOp(result_type, qubit.type, qubit, postselect=postselect_attr).results
 
     result_from_elements_op = ir.RankedTensorType.get((), result.type)
     from_elements_op = FromElementsOp(result_from_elements_op, result)

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -802,7 +802,7 @@ def _qmeasure_def_impl(ctx, qubit):  # pragma: no cover
     raise NotImplementedError()
 
 
-def _qmeasure_lowering(jax_ctx: mlir.LoweringRuleContext, qubit: ir.Value):
+def _qmeasure_lowering(jax_ctx: mlir.LoweringRuleContext, qubit: ir.Value, postselect: int):
     ctx = jax_ctx.module_context.context
     ctx.allow_unregistered_dialects = True
 
@@ -810,8 +810,11 @@ def _qmeasure_lowering(jax_ctx: mlir.LoweringRuleContext, qubit: ir.Value):
     assert ir.OpaqueType(qubit.type).dialect_namespace == "quantum"
     assert ir.OpaqueType(qubit.type).data == "bit"
 
+    i8_type = ir.IntegerType.get_signless(8, ctx)
+    postselect_attr = ir.IntegerAttr.get(i8_type, postselect) if postselect is not None else None
+
     result_type = ir.IntegerType.get_signless(1)
-    result, new_qubit = MeasureOp(result_type, qubit.type, qubit).results
+    result, new_qubit = MeasureOp(result_type, qubit.type, qubit, postselect_attr).results
 
     result_from_elements_op = ir.RankedTensorType.get((), result.type)
     from_elements_op = FromElementsOp(result_from_elements_op, result)

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -792,17 +792,17 @@ def _qunitary_lowering(jax_ctx: mlir.LoweringRuleContext, matrix: ir.Value, *qub
 # qmeasure
 #
 @qmeasure_p.def_abstract_eval
-def _qmeasure_abstract_eval(qubit, postselect):
+def _qmeasure_abstract_eval(qubit, postselect: int = None):
     assert isinstance(qubit, AbstractQbit)
     return core.ShapedArray((), bool), qubit
 
 
 @qmeasure_p.def_impl
-def _qmeasure_def_impl(ctx, qubit, postselect):  # pragma: no cover
+def _qmeasure_def_impl(ctx, qubit, postselect: int = None):  # pragma: no cover
     raise NotImplementedError()
 
 
-def _qmeasure_lowering(jax_ctx: mlir.LoweringRuleContext, qubit: ir.Value, postselect: int):
+def _qmeasure_lowering(jax_ctx: mlir.LoweringRuleContext, qubit: ir.Value, postselect: int = None):
     ctx = jax_ctx.module_context.context
     ctx.allow_unregistered_dialects = True
 
@@ -811,14 +811,13 @@ def _qmeasure_lowering(jax_ctx: mlir.LoweringRuleContext, qubit: ir.Value, posts
     assert ir.OpaqueType(qubit.type).data == "bit"
 
     # Prepare postselect attribute
-    i8_type = ir.IntegerType.get_signless(8, ctx)
-    postselect_attr = ir.IntegerAttr.get(i8_type, postselect)
+    if postselect is not None:
+        i8_type = ir.IntegerType.get_signless(8, ctx)
+        postselect = ir.IntegerAttr.get(i8_type, postselect)
 
     result_type = ir.IntegerType.get_signless(1)
 
-    result, new_qubit = MeasureOp(
-        result_type, qubit.type, qubit, postselect=postselect_attr
-    ).results
+    result, new_qubit = MeasureOp(result_type, qubit.type, qubit, postselect=postselect).results
 
     result_from_elements_op = ir.RankedTensorType.get((), result.type)
     from_elements_op = FromElementsOp(result_from_elements_op, result)

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -1101,9 +1101,10 @@ class MidCircuitMeasure(HybridOp):
         wire = op.in_classical_tracers[0]
         qubit = qrp.extract([wire])[0]
 
-        # Check if the postselect value was given
-        postselect = op.in_classical_tracers[1] if len(op.in_classical_tracers) == 2 else -1
-        qubit2 = op.bind_overwrite_classical_tracers(ctx, trace, qubit, postselect=postselect)
+        # Check if the postselect value was given, otherwise default to -1
+        postselect_attr = op.in_classical_tracers[1] if len(op.in_classical_tracers) == 2 else -1
+
+        qubit2 = op.bind_overwrite_classical_tracers(ctx, trace, qubit, postselect=postselect_attr)
         qrp.insert([wire], [qubit2])
         return qrp
 
@@ -1946,6 +1947,22 @@ def measure(wires, postselect: Optional[int] = None) -> DynamicJaxprTracer:
     [array(1.), array(False)]
     >>> circuit(0.43)
     [array(-1.), array(True)]
+
+    **Example with post-selection**
+
+    .. code-block:: python
+
+        dev = qml.device("lightning.qubit", wires=1)
+
+        @qjit
+        @qml.qnode(dev)
+        def circuit():
+            qml.Hadamard(0)
+            m = measure(0, postselect=1)
+            return qml.expval(qml.PauliZ(0))
+
+    >>> circuit()
+    -1.0
     """
     EvaluationContext.check_is_tracing("catalyst.measure can only be used from within @qjit.")
     EvaluationContext.check_is_quantum_tracing(

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -1101,10 +1101,10 @@ class MidCircuitMeasure(HybridOp):
         wire = op.in_classical_tracers[0]
         qubit = qrp.extract([wire])[0]
 
-        # Check if the postselect value was given, otherwise default to -1
-        postselect_attr = op.in_classical_tracers[1] if len(op.in_classical_tracers) == 2 else -1
+        # Check if the postselect value was given, otherwise default to None
+        postselect = op.in_classical_tracers[1] if len(op.in_classical_tracers) > 1 else None
 
-        qubit2 = op.bind_overwrite_classical_tracers(ctx, trace, qubit, postselect=postselect_attr)
+        qubit2 = op.bind_overwrite_classical_tracers(ctx, trace, qubit, postselect=postselect)
         qrp.insert([wire], [qubit2])
         return qrp
 

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -1102,9 +1102,8 @@ class MidCircuitMeasure(HybridOp):
         qubit = qrp.extract([wire])[0]
 
         # Check if the postselect value was given
-        postselect = op.in_classical_tracers[1] if op.in_classical_tracers.size() == 2 else None
-
-        qubit2 = op.bind_overwrite_classical_tracers(ctx, trace, qubit, postselect)
+        postselect = op.in_classical_tracers[1] if len(op.in_classical_tracers) == 2 else -1
+        qubit2 = op.bind_overwrite_classical_tracers(ctx, trace, qubit, postselect=postselect)
         qrp.insert([wire], [qubit2])
         return qrp
 
@@ -1957,7 +1956,7 @@ def measure(wires, postselect: Optional[int] = None) -> DynamicJaxprTracer:
     if len(wires) != 1:
         raise TypeError(f"One classical argument (a wire) is expected, got {wires}")
 
-    in_classical_tracers = [wires]
+    in_classical_tracers = wires
 
     # Check the postselect value. If given, add it to the classical tracers list
     if postselect is not None:

--- a/frontend/test/pytest/test_mid_circuit_measurement.py
+++ b/frontend/test/pytest/test_mid_circuit_measurement.py
@@ -18,6 +18,8 @@ import pytest
 
 from catalyst import CompileError, measure, qjit
 
+# TODO: add tests with other measurement processes (e.g. qml.sample, qml.probs, ...)
+
 
 class TestMidCircuitMeasurement:
     def test_pl_measure(self, backend):
@@ -62,7 +64,7 @@ class TestMidCircuitMeasurement:
     def test_basic(self, backend):
         """Test measure (basic)."""
 
-        @qjit()
+        @qjit
         @qml.qnode(qml.device(backend, wires=1))
         def circuit(x: float):
             qml.RX(x, wires=0)
@@ -74,7 +76,7 @@ class TestMidCircuitMeasurement:
     def test_more_complex(self, backend):
         """Test measure (more complex)."""
 
-        @qjit()
+        @qjit
         @qml.qnode(qml.device(backend, wires=2))
         def circuit(x: float):
             qml.RX(x, wires=0)
@@ -86,6 +88,30 @@ class TestMidCircuitMeasurement:
 
         assert circuit(jnp.pi)  # m will be equal to True if wire 0 is measured in 1 state
         assert not circuit(0.0)
+
+    def test_with_postselect_zero(self, backend):
+        """Test measure (postselect = 0)."""
+
+        @qjit
+        @qml.qnode(qml.device(backend, wires=1))
+        def circuit(x: float):
+            qml.RX(x, wires=0)
+            m = measure(wires=0, postselect=0)
+            return m
+
+        assert not circuit(jnp.pi)  # m will be equal to False
+
+    def test_with_postselect_one(self, backend):
+        """Test measure (postselect = 1)."""
+
+        @qjit
+        @qml.qnode(qml.device(backend, wires=1))
+        def circuit(x: float):
+            qml.RX(x, wires=0)
+            m = measure(wires=0, postselect=1)
+            return m
+
+        assert circuit(jnp.pi)  # m will be equal to True
 
 
 if __name__ == "__main__":

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -522,7 +522,8 @@ def MeasureOp : Quantum_Op<"measure"> {
     }];
 
     let arguments = (ins
-        QubitType:$in_qubit
+        QubitType:$in_qubit,
+        OptionalAttr<ConfinedAttr<I8Attr, [IntMinValue<0>, IntMaxValue<1>]>>:$postselect
     );
 
     let results = (outs

--- a/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
@@ -523,14 +523,25 @@ struct MeasureOpPattern : public OpConversionPattern<MeasureOp> {
         MLIRContext *ctx = getContext();
         TypeConverter *conv = getTypeConverter();
 
+        // Add postselect and qubit types to the function signature
+        Type qubitTy = conv->convertType(QubitType::get(ctx));
+        Type postselectTy = IntegerType::get(ctx, 8);
+        SmallVector<Type> argSignatures = {qubitTy, postselectTy};
+
         StringRef qirName = "__catalyst__qis__Measure";
-        Type qirSignature = LLVM::LLVMFunctionType::get(conv->convertType(ResultType::get(ctx)),
-                                                        conv->convertType(QubitType::get(ctx)));
+        Type qirSignature =
+            LLVM::LLVMFunctionType::get(conv->convertType(ResultType::get(ctx)), argSignatures);
 
         LLVM::LLVMFuncOp fnDecl = ensureFunctionDeclaration(rewriter, op, qirName, qirSignature);
 
-        Value resultPtr =
-            rewriter.create<LLVM::CallOp>(loc, fnDecl, adaptor.getInQubit()).getResult();
+        // Create the postselect value. If not given, it defaults to -1
+        LLVM::ConstantOp postselect = rewriter.create<LLVM::ConstantOp>(
+            loc, op.getPostselect() ? op.getPostselectAttr() : rewriter.getI8IntegerAttr(-1));
+
+        // Add qubit and postselect values as arguments of the CallOp
+        SmallVector<Value> args = {adaptor.getInQubit(), postselect};
+
+        Value resultPtr = rewriter.create<LLVM::CallOp>(loc, fnDecl, args).getResult();
         Value boolPtr = rewriter.create<LLVM::BitcastOp>(
             loc, LLVM::LLVMPointerType::get(IntegerType::get(ctx, 1)), resultPtr);
         Value mres = rewriter.create<LLVM::LoadOp>(loc, boolPtr);

--- a/mlir/test/Quantum/ConversionTest.mlir
+++ b/mlir/test/Quantum/ConversionTest.mlir
@@ -367,12 +367,12 @@ func.func @hamiltonian(%obs : !quantum.obs, %p1 : memref<1xf64>, %p2 : memref<3x
 // Measurements //
 //////////////////
 
-// CHECK: llvm.func @__catalyst__qis__Measure(!llvm.ptr<struct<"Qubit", opaque>>) -> !llvm.ptr<struct<"Result", opaque>>
+// CHECK: llvm.func @__catalyst__qis__Measure(!llvm.ptr<struct<"Qubit", opaque>>, i8) -> !llvm.ptr<struct<"Result", opaque>>
 
 // CHECK-LABEL: @measure
 func.func @measure(%q : !quantum.bit) -> !quantum.bit {
 
-    // CHECK: llvm.call @__catalyst__qis__Measure(%arg0)
+    // CHECK: llvm.call @__catalyst__qis__Measure(%arg0, %0)
     %res, %new_q = quantum.measure %q : i1, !quantum.bit
 
     // CHECK: return %arg0

--- a/mlir/test/Quantum/ConversionTest.mlir
+++ b/mlir/test/Quantum/ConversionTest.mlir
@@ -372,8 +372,26 @@ func.func @hamiltonian(%obs : !quantum.obs, %p1 : memref<1xf64>, %p2 : memref<3x
 // CHECK-LABEL: @measure
 func.func @measure(%q : !quantum.bit) -> !quantum.bit {
 
-    // CHECK: llvm.call @__catalyst__qis__Measure(%arg0, %0)
+    // CHECK: [[postselect:%.+]] = llvm.mlir.constant(-1 : i8) : i8
+
+    // CHECK: llvm.call @__catalyst__qis__Measure(%arg0, [[postselect]])
     %res, %new_q = quantum.measure %q : i1, !quantum.bit
+
+    // CHECK: return %arg0
+    return %new_q : !quantum.bit
+}
+
+// -----
+
+// CHECK: llvm.func @__catalyst__qis__Measure(!llvm.ptr<struct<"Qubit", opaque>>, i8) -> !llvm.ptr<struct<"Result", opaque>>
+
+// CHECK-LABEL: @measure
+func.func @measure(%q : !quantum.bit) -> !quantum.bit {
+
+    // CHECK: [[postselect:%.+]] = llvm.mlir.constant(0 : i8) : i8
+
+    // CHECK: llvm.call @__catalyst__qis__Measure(%arg0, [[postselect]])
+    %res, %new_q = quantum.measure %q {postselect = 0 : i8} : i1, !quantum.bit
 
     // CHECK: return %arg0
     return %new_q : !quantum.bit

--- a/runtime/include/QuantumDevice.hpp
+++ b/runtime/include/QuantumDevice.hpp
@@ -284,10 +284,12 @@ struct QuantumDevice {
      * @brief A general measurement method that acts on a single wire.
      *
      * @param wire The wire to compute Measure on
+     * @param postselect Which basis state to postselect after a mid-circuit measurement (-1 denotes
+     no post-selection)
 
      * @return `Result` The measurement result
      */
-    virtual auto Measure(QubitIdType wire) -> Result = 0;
+    virtual auto Measure(QubitIdType wire, int8_t postselect) -> Result = 0;
 
     /**
      * @brief Compute the gradient of a quantum tape, that is cached using

--- a/runtime/include/RuntimeCAPI.h
+++ b/runtime/include/RuntimeCAPI.h
@@ -89,7 +89,7 @@ ObsIdType __catalyst__qis__TensorObs(int64_t, /*obsKeys*/...);
 ObsIdType __catalyst__qis__HamiltonianObs(MemRefT_double_1d *, int64_t, /*obsKeys*/...);
 
 // Struct pointers arguments here represent return values.
-RESULT *__catalyst__qis__Measure(QUBIT *);
+RESULT *__catalyst__qis__Measure(QUBIT *, int8_t);
 double __catalyst__qis__Expval(ObsIdType);
 double __catalyst__qis__Variance(ObsIdType);
 void __catalyst__qis__Probs(MemRefT_double_1d *, int64_t, /*qubits*/...);

--- a/runtime/lib/backend/common/Utils.hpp
+++ b/runtime/lib/backend/common/Utils.hpp
@@ -70,7 +70,7 @@
         override;                                                                                  \
     void PartialCounts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts,                 \
                        const std::vector<QubitIdType> &wires, size_t shots) override;              \
-    auto Measure(QubitIdType wire)->Result override;                                               \
+    auto Measure(QubitIdType wire, int8_t postselect)->Result override;                            \
     void Gradient(std::vector<DataView<double, 1>> &gradients,                                     \
                   const std::vector<size_t> &trainParams) override;
 

--- a/runtime/lib/backend/common/Utils.hpp
+++ b/runtime/lib/backend/common/Utils.hpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <array>
+#include <random>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -259,6 +260,27 @@ constexpr auto has_gate(const SimulatorGateInfoDataT<size> &arr, const std::stri
         }
     }
     return false;
+}
+
+static inline auto simulateDraw(const std::vector<double> &probs, int8_t postselect) -> bool
+{
+    // Check validity of postselect value
+    RT_FAIL_IF(std::abs(postselect) > 1, "Invalid postselect value");
+
+    // Return the postselect value, do not draw
+    if (postselect != -1) {
+        RT_FAIL_IF(probs[postselect] == 0, "Probability of postselect value is 0");
+
+        return postselect == 1 ? true : false;
+    }
+
+    // Normal flow, no post-selection
+    // Draw a number according to the given distribution
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_real_distribution<> dis(0., 1.);
+    float draw = dis(gen);
+    return draw > probs[0];
 }
 
 } // namespace Catalyst::Runtime::Simulator::Lightning

--- a/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.cpp
+++ b/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.cpp
@@ -394,12 +394,21 @@ void LightningSimulator::PartialCounts(DataView<double, 1> &eigvals, DataView<in
 
 auto LightningSimulator::Measure(QubitIdType wire, int8_t postselect) -> Result
 {
+    // Check validity of postselect value
+    RT_FAIL_IF(postselect < -1 || postselect > 1, "Invalid postselect value");
+    bool enabledPostselect = postselect == -1 ? false : true;
+
     // get a measurement
     std::vector<QubitIdType> wires = {reinterpret_cast<QubitIdType>(wire)};
 
     std::vector<double> probs(1U << wires.size());
     DataView<double, 1> buffer_view(probs);
     this->PartialProbs(buffer_view, wires);
+
+    // Check validity of probability for postselect value
+    if (enabledPostselect) {
+        RT_FAIL_IF(probs[postselect] == 0, "Probability of postselect value is 0");
+    }
 
     std::random_device rd;
     std::mt19937 gen(rd());

--- a/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.cpp
+++ b/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.cpp
@@ -392,7 +392,7 @@ void LightningSimulator::PartialCounts(DataView<double, 1> &eigvals, DataView<in
     }
 }
 
-auto LightningSimulator::Measure(QubitIdType wire) -> Result
+auto LightningSimulator::Measure(QubitIdType wire, int8_t postselect) -> Result
 {
     // get a measurement
     std::vector<QubitIdType> wires = {reinterpret_cast<QubitIdType>(wire)};

--- a/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.cpp
+++ b/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.cpp
@@ -394,10 +394,6 @@ void LightningSimulator::PartialCounts(DataView<double, 1> &eigvals, DataView<in
 
 auto LightningSimulator::Measure(QubitIdType wire, int8_t postselect) -> Result
 {
-    // Check validity of postselect value
-    RT_FAIL_IF(postselect < -1 || postselect > 1, "Invalid postselect value");
-    bool enabledPostselect = postselect == -1 ? false : true;
-
     // get a measurement
     std::vector<QubitIdType> wires = {reinterpret_cast<QubitIdType>(wire)};
 
@@ -405,16 +401,8 @@ auto LightningSimulator::Measure(QubitIdType wire, int8_t postselect) -> Result
     DataView<double, 1> buffer_view(probs);
     this->PartialProbs(buffer_view, wires);
 
-    // Check validity of probability for postselect value
-    if (enabledPostselect) {
-        RT_FAIL_IF(probs[postselect] == 0, "Probability of postselect value is 0");
-    }
-
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_real_distribution<> dis(0., 1.);
-    float draw = dis(gen);
-    bool mres = draw > probs[0];
+    // It represents the measured result, true for 1, false for 0
+    bool mres = Lightning::simulateDraw(probs, postselect);
 
     const size_t numQubits = this->GetNumQubits();
 

--- a/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.hpp
+++ b/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.hpp
@@ -22,7 +22,6 @@
 #include <iostream>
 #include <limits>
 #include <numeric>
-#include <random>
 #include <span>
 
 #include "StateVectorLQubitDynamic.hpp"

--- a/runtime/lib/backend/lightning/lightning_kokkos/LightningKokkosSimulator.cpp
+++ b/runtime/lib/backend/lightning/lightning_kokkos/LightningKokkosSimulator.cpp
@@ -435,8 +435,6 @@ void LightningKokkosSimulator::PartialCounts(DataView<double, 1> &eigvals,
 
 auto LightningKokkosSimulator::Measure(QubitIdType wire, int8_t postselect) -> Result
 {
-    RT_FAIL_IF(postselect != -1, "Post-selection is not supported yet");
-
     using UnmanagedComplexHostView = Kokkos::View<Kokkos::complex<double> *, Kokkos::HostSpace,
                                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 
@@ -447,11 +445,8 @@ auto LightningKokkosSimulator::Measure(QubitIdType wire, int8_t postselect) -> R
     DataView<double, 1> buffer_view(probs);
     this->PartialProbs(buffer_view, wires);
 
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_real_distribution<> dis(0., 1.);
-    float draw = dis(gen);
-    bool mres = draw > probs[0];
+    // It represents the measured result, true for 1, false for 0
+    bool mres = Lightning::simulateDraw(probs, postselect);
 
     const size_t num_qubits = this->GetNumQubits();
 

--- a/runtime/lib/backend/lightning/lightning_kokkos/LightningKokkosSimulator.cpp
+++ b/runtime/lib/backend/lightning/lightning_kokkos/LightningKokkosSimulator.cpp
@@ -433,8 +433,10 @@ void LightningKokkosSimulator::PartialCounts(DataView<double, 1> &eigvals,
     }
 }
 
-auto LightningKokkosSimulator::Measure(QubitIdType wire) -> Result
+auto LightningKokkosSimulator::Measure(QubitIdType wire, int8_t postselect) -> Result
 {
+    RT_FAIL_IF(postselect != -1, "Post-selection is not supported yet");
+
     using UnmanagedComplexHostView = Kokkos::View<Kokkos::complex<double> *, Kokkos::HostSpace,
                                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;
 

--- a/runtime/lib/backend/lightning/lightning_kokkos/LightningKokkosSimulator.hpp
+++ b/runtime/lib/backend/lightning/lightning_kokkos/LightningKokkosSimulator.hpp
@@ -20,7 +20,6 @@
 #include <cstdint>
 #include <iostream>
 #include <limits>
-#include <random>
 #include <span>
 #include <stdexcept>
 

--- a/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
+++ b/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
@@ -473,8 +473,10 @@ void OpenQasmDevice::PartialCounts(DataView<double, 1> &eigvals, DataView<int64_
     }
 }
 
-auto OpenQasmDevice::Measure([[maybe_unused]] QubitIdType wire) -> Result
+auto OpenQasmDevice::Measure([[maybe_unused]] QubitIdType wire, int8_t postselect) -> Result
 {
+    RT_FAIL_IF(postselect != -1, "Post-selection is not supported yet");
+
     if (builder_type != OpenQasm::BuilderType::Common) {
         RT_FAIL("Unsupported functionality");
         return Result{};

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -739,9 +739,10 @@ ObsIdType __catalyst__qis__HamiltonianObs(MemRefT_double_1d *coeffs, int64_t num
     return Catalyst::Runtime::getQuantumDevicePtr()->HamiltonianObservable(coeffs_vec, obsKeys);
 }
 
-RESULT *__catalyst__qis__Measure(QUBIT *wire)
+RESULT *__catalyst__qis__Measure(QUBIT *wire, int8_t postselect)
 {
-    return Catalyst::Runtime::getQuantumDevicePtr()->Measure(reinterpret_cast<QubitIdType>(wire));
+    return Catalyst::Runtime::getQuantumDevicePtr()->Measure(reinterpret_cast<QubitIdType>(wire),
+                                                             postselect);
 }
 
 double __catalyst__qis__Expval(ObsIdType obsKey)

--- a/runtime/tests/Test_LightningCoreQIS.cpp
+++ b/runtime/tests/Test_LightningCoreQIS.cpp
@@ -522,7 +522,7 @@ TEST_CASE("Test __catalyst__qis__Measure", "[CoreQIS]")
 
         __catalyst__qis__PauliX(wire0, false);
 
-        Result m = __catalyst__qis__Measure(wire0);
+        Result m = __catalyst__qis__Measure(wire0, -1);
 
         Result one = __catalyst__rt__result_get_one();
         CHECK(*m == *one);
@@ -1347,7 +1347,7 @@ TEST_CASE("Test __catalyst__qis__Measure with false", "[CoreQIS]")
         // qml.Hadamard(wires=0)
         __catalyst__qis__RY(0.0, target, false);
 
-        Result mres = __catalyst__qis__Measure(target);
+        Result mres = __catalyst__qis__Measure(target, -1);
 
         Result zero = __catalyst__rt__result_get_zero();
         CHECK(__catalyst__rt__result_equal(mres, zero));
@@ -1370,7 +1370,7 @@ TEST_CASE("Test __catalyst__qis__Measure with true", "[CoreQIS]")
         // qml.Hadamard(wires=0)
         __catalyst__qis__RY(3.14, target, false);
 
-        Result mres = __catalyst__qis__Measure(target);
+        Result mres = __catalyst__qis__Measure(target, -1);
 
         Result one = __catalyst__rt__result_get_one();
         CHECK(__catalyst__rt__result_equal(mres, one));
@@ -1400,8 +1400,8 @@ TEST_CASE("Test __catalyst__qis__MultiRZ", "[CoreQIS]")
         __catalyst__qis__Hadamard(*q0, false);
         __catalyst__qis__Hadamard(*q1, false);
 
-        Result q0_m = __catalyst__qis__Measure(*q0);
-        Result q1_m = __catalyst__qis__Measure(*q1);
+        Result q0_m = __catalyst__qis__Measure(*q0, -1);
+        Result q1_m = __catalyst__qis__Measure(*q1, -1);
 
         Result zero = __catalyst__rt__result_get_zero();
         Result one = __catalyst__rt__result_get_one();
@@ -1431,8 +1431,8 @@ TEST_CASE("Test __catalyst__qis__CSWAP ", "[CoreQIS]")
         __catalyst__qis__RX(M_PI, *q1, false);
         __catalyst__qis__CSWAP(*q0, *q1, *q2, false);
 
-        Result q1_m = __catalyst__qis__Measure(*q1);
-        Result q2_m = __catalyst__qis__Measure(*q2);
+        Result q1_m = __catalyst__qis__Measure(*q1, -1);
+        Result q2_m = __catalyst__qis__Measure(*q2, -1);
 
         Result zero = __catalyst__rt__result_get_zero();
         Result one = __catalyst__rt__result_get_one();

--- a/runtime/tests/Test_LightningMeasures.cpp
+++ b/runtime/tests/Test_LightningMeasures.cpp
@@ -79,7 +79,7 @@ TEMPLATE_LIST_TEST_CASE("Measurement collapse test with 2 wires", "[Measures]", 
     std::vector<QubitIdType> Qs = sim->AllocateQubits(n);
 
     sim->NamedOperation("Hadamard", {}, {Qs[0]}, false);
-    auto m = sim->Measure(Qs[0]);
+    auto m = sim->Measure(Qs[0], -1);
     std::vector<std::complex<double>> state(1U << sim->GetNumQubits());
     DataView<std::complex<double>, 1> view(state);
     sim->State(view);
@@ -112,7 +112,7 @@ TEMPLATE_LIST_TEST_CASE("Measurement collapse concrete logical qubit difference"
     Qs = sim->AllocateQubits(n);
 
     sim->NamedOperation("Hadamard", {}, {Qs[0]}, false);
-    sim->Measure(Qs[0]);
+    sim->Measure(Qs[0], -1);
     std::vector<std::complex<double>> state(1U << sim->GetNumQubits());
     DataView<std::complex<double>, 1> view(state);
     sim->State(view);
@@ -137,7 +137,7 @@ TEMPLATE_LIST_TEST_CASE("Mid-circuit measurement naive test", "[Measures]", SimT
 
     sim->NamedOperation("PauliX", {}, {q}, false);
 
-    auto m = sim->Measure(q);
+    auto m = sim->Measure(q, -1);
 
     CHECK(*m);
 }

--- a/runtime/tests/Test_LightningMeasures.cpp
+++ b/runtime/tests/Test_LightningMeasures.cpp
@@ -142,6 +142,65 @@ TEMPLATE_LIST_TEST_CASE("Mid-circuit measurement naive test", "[Measures]", SimT
     CHECK(*m);
 }
 
+TEMPLATE_LIST_TEST_CASE("Mid-circuit measurement test with postselect = 0", "[Measures]", SimTypes)
+{
+    std::unique_ptr<TestType> sim = std::make_unique<TestType>();
+
+    QubitIdType q;
+
+    q = sim->AllocateQubit();
+
+    sim->NamedOperation("Hadamard", {}, {q}, false);
+
+    auto m = sim->Measure(q, 0);
+
+    CHECK(*m == 0);
+}
+
+TEMPLATE_LIST_TEST_CASE("Mid-circuit measurement test with postselect = 1", "[Measures]", SimTypes)
+{
+    std::unique_ptr<TestType> sim = std::make_unique<TestType>();
+
+    QubitIdType q;
+
+    q = sim->AllocateQubit();
+
+    sim->NamedOperation("Hadamard", {}, {q}, false);
+
+    auto m = sim->Measure(q, 1);
+
+    CHECK(*m == 1);
+}
+
+TEMPLATE_LIST_TEST_CASE("Mid-circuit measurement test with invalid postselect value", "[Measures]",
+                        SimTypes)
+{
+    std::unique_ptr<TestType> sim = std::make_unique<TestType>();
+
+    QubitIdType q;
+
+    q = sim->AllocateQubit();
+
+    sim->NamedOperation("Hadamard", {}, {q}, false);
+
+    REQUIRE_THROWS_WITH(sim->Measure(q, 2), Catch::Contains("Invalid postselect value"));
+}
+
+TEMPLATE_LIST_TEST_CASE("Mid-circuit measurement test with postselect value at zero probability",
+                        "[Measures]", SimTypes)
+{
+    std::unique_ptr<TestType> sim = std::make_unique<TestType>();
+
+    QubitIdType q;
+
+    q = sim->AllocateQubit();
+
+    sim->NamedOperation("PauliX", {}, {q}, false);
+
+    REQUIRE_THROWS_WITH(sim->Measure(q, 0),
+                        Catch::Contains("Probability of postselect value is 0"));
+}
+
 TEMPLATE_LIST_TEST_CASE("Expval(ObsT) test with invalid key for cached observables", "[Measures]",
                         SimTypes)
 {

--- a/runtime/tests/Test_OpenQasmDevice.cpp
+++ b/runtime/tests/Test_OpenQasmDevice.cpp
@@ -124,7 +124,7 @@ TEST_CASE("Test the bell pair circuit with BuilderType::Common", "[openqasm]")
     device->NamedOperation("Hadamard", {}, {wires[0]}, false);
     device->NamedOperation("CNOT", {}, {wires[0], wires[1]}, false);
 
-    device->Measure(wires[1]);
+    device->Measure(wires[1], -1);
 
     std::string toqasm = "OPENQASM 3.0;\n"
                          "qubit[2] qubits;\n"

--- a/runtime/tests/third_party/dummy_device.cpp
+++ b/runtime/tests/third_party/dummy_device.cpp
@@ -27,7 +27,7 @@ struct DummyDevice final : public Catalyst::Runtime::QuantumDevice {
     {
         return 0;
     }
-    auto Measure(QubitIdType) -> Result override
+    auto Measure(QubitIdType, int8_t) -> Result override
     {
         bool *ret = (bool *)malloc(sizeof(bool));
         *ret = true;


### PR DESCRIPTION
**Context:** At the python level the **postselect** argument is optional and defaults to `None`. When given, it can only be `1` or `0`. At the Quantum dialect level **postselect** is also optional, but when lowered to the LLVM dialect, the call to the **measure** function expect a mandatory **postselect** argument that can contain one of the following values:

- -1, meaning **postselect** was not used
-  0, for `postselect = 0`
-  1, for `postselect = 1`

**Related GitHub Issues:** #448 

**TODO:** 

- [x] Complete the frontend implementation and connect it with the MLIR part.
- [x] Improve test at `ConversionTests.mlir`
- [x] Implement the post-selection logic at the runtime side.
- [x] ... also in Lightning.Kokkos
- [x] Add test cases.

[sc-46409]