### PR TITLE
[Integration with PL] Change entry point convention

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -77,6 +77,58 @@
 
 <h3>Breaking changes</h3>
 
+* The entry point name convention has changed.
+  [(#493)](https://github.com/PennyLaneAI/catalyst/pull/493)
+
+  From the [documentation](https://packaging.python.org/en/latest/specifications/entry-points/#data-model):
+
+     Within a distribution, entry points should be unique.
+
+  This meant that within a single distribution there cannot be two different `qjit` entry points like so:
+
+  ```py
+  entry_points={"pennylane.compilers": [
+      "qjit = foo:Foo",
+      "qjit = bar:Bar",
+  ]}
+  ```
+
+  Now, entry point's names are preppended with the name of the compiler.
+
+  ```py
+  entry_points={"pennylane.compilers": [
+      "compilerFoo.qjit = foo:Foo",
+      "compilerBar.qjit = bar:Bar",
+  ]}
+  ```
+
+  The behaviour will be reflected when using the `@qml.qjit` decorator.
+  For example,
+
+  ```py
+  @qml.qjit(compiler="compilerFoo")
+  def circuit(): ...
+  ```
+
+  will point call `foo:Foo` in the entry points' distribution.
+  Please note that `compilerFoo` can also be `foo`. The compiler name
+  does not have to be distinct from the object reference path. To keep
+  the previous user facing behaviour, simply define entry points as follows:
+
+  ```py
+  entry_points={"pennylane.compilers": [
+      "foo.qjit = foo:Foo",
+      "bar.qjit = bar:Bar",
+  ]}
+  ```
+
+  and the following example will still work:
+
+  ```py
+  @qml.qjit(compiler="foo")
+  def circuit(): ...
+  ```
+
 * The Catalyst runtime now has a different API from QIR instructions.
   [(#464)](https://github.com/PennyLaneAI/catalyst/pull/464)
 

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,10 @@ requirements = [
     "scipy",
 ]
 
+# TODO: Once PL version 0.35 is released:
+# * remove this special handling
+# * make pennylane>=0.35 a requirement
+# * Close this ticket https://github.com/PennyLaneAI/catalyst/issues/494
 one_compiler_per_distribution = pl_version == ">=0.32,<=0.34"
 if one_compiler_per_distribution:
     entry_points = {

--- a/setup.py
+++ b/setup.py
@@ -157,9 +157,9 @@ setup(
     python_requires=">=3.9",
     entry_points={
         "pennylane.compilers": [
-            "context = catalyst.utils.contexts:EvaluationContext",
-            "ops = catalyst:pennylane_extensions",
-            "qjit = catalyst:qjit",
+            "catalyst.context = catalyst.utils.contexts:EvaluationContext",
+            "catalyst.ops = catalyst:pennylane_extensions",
+            "catalyst.qjit = catalyst:qjit",
         ]
     },
     install_requires=requirements,

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ with open(path.join("frontend", "catalyst", "_version.py")) as f:
 with open(".dep-versions") as f:
     jax_version = [line[4:].strip() for line in f.readlines() if "jax=" in line][0]
 
-pl_version = environ.get("pl_version", ">=0.32,<=0.34")
+pl_version = environ.get("PL_VERSION", ">=0.32,<=0.34")
 requirements = [
     f"pennylane{pl_version}",
     f"jax=={jax_version}",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import glob
 import platform
 import subprocess
 from distutils import sysconfig
-from os import path
+from os import environ, path
 
 import numpy as np
 from pybind11.setup_helpers import intree_extensions
@@ -35,13 +35,34 @@ with open(path.join("frontend", "catalyst", "_version.py")) as f:
 with open(".dep-versions") as f:
     jax_version = [line[4:].strip() for line in f.readlines() if "jax=" in line][0]
 
+pl_version = environ.get("pl_version", ">=0.32,<=0.34")
 requirements = [
-    "pennylane>=0.32",
+    f"pennylane{pl_version}",
     f"jax=={jax_version}",
     f"jaxlib=={jax_version}",
     "tomlkit;python_version<'3.11'",
     "scipy",
 ]
+
+one_compiler_per_distribution = pl_version == ">=0.32,<=0.34"
+if one_compiler_per_distribution:
+    entry_points = {
+        "pennylane.plugins": "cudaq = catalystcuda:CudaQDevice",
+        "pennylane.compilers": [
+            "context = catalyst.utils.contexts:EvaluationContext",
+            "ops = catalyst:pennylane_extensions",
+            "qjit = catalyst:qjit",
+        ],
+    }
+else:
+    entry_points = {
+        "pennylane.plugins": "cudaq = catalystcuda:CudaQDevice",
+        "pennylane.compilers": [
+            "catalyst.context = catalyst.utils.contexts:EvaluationContext",
+            "catalyst.ops = catalyst:pennylane_extensions",
+            "catalyst.qjit = catalyst:qjit",
+        ],
+    }
 
 classifiers = [
     "Environment :: Console",
@@ -155,13 +176,7 @@ setup(
     provides=["catalyst"],
     version=version,
     python_requires=">=3.9",
-    entry_points={
-        "pennylane.compilers": [
-            "catalyst.context = catalyst.utils.contexts:EvaluationContext",
-            "catalyst.ops = catalyst:pennylane_extensions",
-            "catalyst.qjit = catalyst:qjit",
-        ]
-    },
+    entry_points=entry_points,
     install_requires=requirements,
     packages=find_namespace_packages(
         where="frontend",


### PR DESCRIPTION
**Context:** We would like allow a single python package to define multiple compilers. [Entry points are defined by the following syntax:](https://packaging.python.org/en/latest/specifications/entry-points/#data-model)

```
name = object reference
```

where:

> The name identifies this entry point within its group. The precise meaning of this is up to the consumer. For console scripts, the name of the entry point is the command that will be used to launch it. **Within a distribution, entry point names should be unique. If different distributions provide the same name, the consumer decides how to handle such conflicts.** The name may contain any characters except =, but it cannot start or end with any whitespace character, or start with [. For new entry points, it is recommended to use only letters, numbers, underscores, dots and dashes (regex [\w.-]+).
> 
> The object reference points to a Python object. It is either in the form importable.module, or importable.module:object.attr. Each of the parts delimited by dots and the colon is a valid Python identifier.

Previously, in PL the name of an entrypoint was `qjit` and we handled conflicts between multiple distributions by using the object reference path to disambiguate between multiple `qjit` definitions. The base of the object reference path was used as the compiler name.

E.g.,

```
qjit = catalyst:qjit
```

meant that this is the entry point for the `catalyst` compiler.

Names are meant to be unique within a single distribution. It is not possible to setup a python package with two entry points with the same name.

E.g.,

```
qjit = foo:qjit
qjit = bar:qjit
```


**Description of the Change:**

Let's change the entrypoint to be:

```
$compiler.qjit = object.path:qjit
```

This allows a package to have multiple `qjit`s defined within a single distribution.

This commit also takes into account backward compatibility at the moment of pip configuration. The old naming convention is the default option. The new naming convention, which will need changes in PL main branch, can be achieved via:

```
PL_VERSION="==0.35.0.dev0" pip install  -e .
```

**Benefits:** Multiple definitions of different `qjit`'s.