### PR TITLE
Fix CPL stable/stable/stable

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -115,10 +115,13 @@ jobs:
     - name: Build Catalyst Runtime (stable)
       if: ${{ inputs.lightning == 'stable' }}
       run: |
+        # TODO: remove ENABLE_{BACKEND}=ON after the next release
         COMPILER_LAUNCHER="" \
         C_COMPILER=$(which gcc }}) \
         CXX_COMPILER=$(which g++ }}) \
         RT_BUILD_DIR="$(pwd)/runtime-build" \
+        ENABLE_LIGHTNING_KOKKOS=ON \
+        ENABLE_OPENQASM=ON \
         make runtime
 
     - name: Install PennyLane-Lightning (latest)


### PR DESCRIPTION
With merging PR #485, `make runtime` builds all backend devices by default. We still need to use `ENABLE_LIGHTNING_KOKKOS=ON` and `ENABLE_OPENQASM=ON` when building runtime from source against the v0.4.1 version in CPL CI actions. 