### PR TITLE
Fix postselect issues

### DIFF
--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -812,8 +812,8 @@ def _qmeasure_lowering(jax_ctx: mlir.LoweringRuleContext, qubit: ir.Value, posts
 
     # Prepare postselect attribute
     if postselect is not None:
-        i8_type = ir.IntegerType.get_signless(8, ctx)
-        postselect = ir.IntegerAttr.get(i8_type, postselect)
+        i32_type = ir.IntegerType.get_signless(32, ctx)
+        postselect = ir.IntegerAttr.get(i32_type, postselect)
 
     result_type = ir.IntegerType.get_signless(1)
 

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -523,7 +523,7 @@ def MeasureOp : Quantum_Op<"measure"> {
 
     let arguments = (ins
         QubitType:$in_qubit,
-        OptionalAttr<ConfinedAttr<I8Attr, [IntMinValue<0>, IntMaxValue<1>]>>:$postselect
+        OptionalAttr<ConfinedAttr<I32Attr, [IntMinValue<0>, IntMaxValue<1>]>>:$postselect
     );
 
     let results = (outs

--- a/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
@@ -26,6 +26,7 @@ using namespace catalyst::quantum;
 namespace {
 
 constexpr int64_t UNKNOWN = ShapedType::kDynamic;
+constexpr int32_t NO_POSTSELECT = -1;
 
 LLVM::LLVMFuncOp ensureFunctionDeclaration(PatternRewriter &rewriter, Operation *op,
                                            StringRef fnSymbol, Type fnType)
@@ -525,7 +526,7 @@ struct MeasureOpPattern : public OpConversionPattern<MeasureOp> {
 
         // Add postselect and qubit types to the function signature
         Type qubitTy = conv->convertType(QubitType::get(ctx));
-        Type postselectTy = IntegerType::get(ctx, 8);
+        Type postselectTy = IntegerType::get(ctx, 32);
         SmallVector<Type> argSignatures = {qubitTy, postselectTy};
 
         StringRef qirName = "__catalyst__qis__Measure";
@@ -534,9 +535,10 @@ struct MeasureOpPattern : public OpConversionPattern<MeasureOp> {
 
         LLVM::LLVMFuncOp fnDecl = ensureFunctionDeclaration(rewriter, op, qirName, qirSignature);
 
-        // Create the postselect value. If not given, it defaults to -1
+        // Create the postselect value. If not given, it defaults to NO_POSTSELECT
         LLVM::ConstantOp postselect = rewriter.create<LLVM::ConstantOp>(
-            loc, op.getPostselect() ? op.getPostselectAttr() : rewriter.getI8IntegerAttr(-1));
+            loc, op.getPostselect() ? op.getPostselectAttr()
+                                    : rewriter.getI32IntegerAttr(NO_POSTSELECT));
 
         // Add qubit and postselect values as arguments of the CallOp
         SmallVector<Value> args = {adaptor.getInQubit(), postselect};

--- a/mlir/test/Quantum/ConversionTest.mlir
+++ b/mlir/test/Quantum/ConversionTest.mlir
@@ -367,12 +367,12 @@ func.func @hamiltonian(%obs : !quantum.obs, %p1 : memref<1xf64>, %p2 : memref<3x
 // Measurements //
 //////////////////
 
-// CHECK: llvm.func @__catalyst__qis__Measure(!llvm.ptr<struct<"Qubit", opaque>>, i8) -> !llvm.ptr<struct<"Result", opaque>>
+// CHECK: llvm.func @__catalyst__qis__Measure(!llvm.ptr<struct<"Qubit", opaque>>, i32) -> !llvm.ptr<struct<"Result", opaque>>
 
 // CHECK-LABEL: @measure
 func.func @measure(%q : !quantum.bit) -> !quantum.bit {
 
-    // CHECK: [[postselect:%.+]] = llvm.mlir.constant(-1 : i8) : i8
+    // CHECK: [[postselect:%.+]] = llvm.mlir.constant(-1 : i32) : i32
 
     // CHECK: llvm.call @__catalyst__qis__Measure(%arg0, [[postselect]])
     %res, %new_q = quantum.measure %q : i1, !quantum.bit
@@ -383,15 +383,15 @@ func.func @measure(%q : !quantum.bit) -> !quantum.bit {
 
 // -----
 
-// CHECK: llvm.func @__catalyst__qis__Measure(!llvm.ptr<struct<"Qubit", opaque>>, i8) -> !llvm.ptr<struct<"Result", opaque>>
+// CHECK: llvm.func @__catalyst__qis__Measure(!llvm.ptr<struct<"Qubit", opaque>>, i32) -> !llvm.ptr<struct<"Result", opaque>>
 
 // CHECK-LABEL: @measure
 func.func @measure(%q : !quantum.bit) -> !quantum.bit {
 
-    // CHECK: [[postselect:%.+]] = llvm.mlir.constant(0 : i8) : i8
+    // CHECK: [[postselect:%.+]] = llvm.mlir.constant(0 : i32) : i32
 
     // CHECK: llvm.call @__catalyst__qis__Measure(%arg0, [[postselect]])
-    %res, %new_q = quantum.measure %q {postselect = 0 : i8} : i1, !quantum.bit
+    %res, %new_q = quantum.measure %q {postselect = 0 : i32} : i1, !quantum.bit
 
     // CHECK: return %arg0
     return %new_q : !quantum.bit

--- a/runtime/include/QuantumDevice.hpp
+++ b/runtime/include/QuantumDevice.hpp
@@ -290,7 +290,7 @@ struct QuantumDevice {
 
      * @return `Result` The measurement result
      */
-    virtual auto Measure(QubitIdType wire, std::optional<int8_t> postselect) -> Result = 0;
+    virtual auto Measure(QubitIdType wire, std::optional<int32_t> postselect) -> Result = 0;
 
     /**
      * @brief Compute the gradient of a quantum tape, that is cached using

--- a/runtime/include/QuantumDevice.hpp
+++ b/runtime/include/QuantumDevice.hpp
@@ -16,6 +16,7 @@
 
 #include <complex>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "DataView.hpp"
@@ -289,7 +290,7 @@ struct QuantumDevice {
 
      * @return `Result` The measurement result
      */
-    virtual auto Measure(QubitIdType wire, int8_t postselect) -> Result = 0;
+    virtual auto Measure(QubitIdType wire, std::optional<int8_t> postselect) -> Result = 0;
 
     /**
      * @brief Compute the gradient of a quantum tape, that is cached using

--- a/runtime/include/RuntimeCAPI.h
+++ b/runtime/include/RuntimeCAPI.h
@@ -89,7 +89,7 @@ ObsIdType __catalyst__qis__TensorObs(int64_t, /*obsKeys*/...);
 ObsIdType __catalyst__qis__HamiltonianObs(MemRefT_double_1d *, int64_t, /*obsKeys*/...);
 
 // Struct pointers arguments here represent return values.
-RESULT *__catalyst__qis__Measure(QUBIT *, int8_t);
+RESULT *__catalyst__qis__Measure(QUBIT *, int32_t);
 double __catalyst__qis__Expval(ObsIdType);
 double __catalyst__qis__Variance(ObsIdType);
 void __catalyst__qis__Probs(MemRefT_double_1d *, int64_t, /*qubits*/...);

--- a/runtime/lib/backend/common/Utils.hpp
+++ b/runtime/lib/backend/common/Utils.hpp
@@ -72,7 +72,7 @@
         override;                                                                                  \
     void PartialCounts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts,                 \
                        const std::vector<QubitIdType> &wires, size_t shots) override;              \
-    auto Measure(QubitIdType wire, std::optional<int8_t> postselect = std::nullopt)                \
+    auto Measure(QubitIdType wire, std::optional<int32_t> postselect = std::nullopt)               \
         ->Result override;                                                                         \
     void Gradient(std::vector<DataView<double, 1>> &gradients,                                     \
                   const std::vector<size_t> &trainParams) override;
@@ -264,7 +264,7 @@ constexpr auto has_gate(const SimulatorGateInfoDataT<size> &arr, const std::stri
     return false;
 }
 
-static inline auto simulateDraw(const std::vector<double> &probs, std::optional<int8_t> postselect)
+static inline auto simulateDraw(const std::vector<double> &probs, std::optional<int32_t> postselect)
     -> bool
 {
     if (postselect) {

--- a/runtime/lib/backend/common/Utils.hpp
+++ b/runtime/lib/backend/common/Utils.hpp
@@ -268,10 +268,12 @@ static inline auto simulateDraw(const std::vector<double> &probs, std::optional<
     -> bool
 {
     if (postselect) {
-        RT_FAIL_IF(*postselect < 0 || *postselect > 1, "Invalid postselect value");
-        RT_FAIL_IF(probs[*postselect] == 0, "Probability of postselect value is 0");
+        auto postselect_value = postselect.value();
 
-        return *postselect == 1 ? true : false;
+        RT_FAIL_IF(postselect_value < 0 || postselect_value > 1, "Invalid postselect value");
+        RT_FAIL_IF(probs[postselect_value] == 0, "Probability of postselect value is 0");
+
+        return postselect_value == 1 ? true : false;
     }
 
     // Normal flow, no post-selection

--- a/runtime/lib/backend/common/Utils.hpp
+++ b/runtime/lib/backend/common/Utils.hpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <array>
+#include <optional>
 #include <random>
 #include <sstream>
 #include <string>
@@ -71,7 +72,8 @@
         override;                                                                                  \
     void PartialCounts(DataView<double, 1> &eigvals, DataView<int64_t, 1> &counts,                 \
                        const std::vector<QubitIdType> &wires, size_t shots) override;              \
-    auto Measure(QubitIdType wire, int8_t postselect)->Result override;                            \
+    auto Measure(QubitIdType wire, std::optional<int8_t> postselect = std::nullopt)                \
+        ->Result override;                                                                         \
     void Gradient(std::vector<DataView<double, 1>> &gradients,                                     \
                   const std::vector<size_t> &trainParams) override;
 
@@ -262,16 +264,19 @@ constexpr auto has_gate(const SimulatorGateInfoDataT<size> &arr, const std::stri
     return false;
 }
 
-static inline auto simulateDraw(const std::vector<double> &probs, int8_t postselect) -> bool
+static inline auto simulateDraw(const std::vector<double> &probs, std::optional<int8_t> postselect)
+    -> bool
 {
-    // Check validity of postselect value
-    RT_FAIL_IF(std::abs(postselect) > 1, "Invalid postselect value");
+    if (postselect) {
+        // Check validity of postselect value
+        RT_FAIL_IF(std::abs(*postselect) > 1, "Invalid postselect value");
 
-    // Return the postselect value, do not draw
-    if (postselect != -1) {
-        RT_FAIL_IF(probs[postselect] == 0, "Probability of postselect value is 0");
+        // Return the postselect value, do not draw
+        if (*postselect != -1) {
+            RT_FAIL_IF(probs[*postselect] == 0, "Probability of postselect value is 0");
 
-        return postselect == 1 ? true : false;
+            return *postselect == 1 ? true : false;
+        }
     }
 
     // Normal flow, no post-selection

--- a/runtime/lib/backend/common/Utils.hpp
+++ b/runtime/lib/backend/common/Utils.hpp
@@ -268,15 +268,10 @@ static inline auto simulateDraw(const std::vector<double> &probs, std::optional<
     -> bool
 {
     if (postselect) {
-        // Check validity of postselect value
-        RT_FAIL_IF(std::abs(*postselect) > 1, "Invalid postselect value");
+        RT_FAIL_IF(*postselect < 0 || *postselect > 1, "Invalid postselect value");
+        RT_FAIL_IF(probs[*postselect] == 0, "Probability of postselect value is 0");
 
-        // Return the postselect value, do not draw
-        if (*postselect != -1) {
-            RT_FAIL_IF(probs[*postselect] == 0, "Probability of postselect value is 0");
-
-            return *postselect == 1 ? true : false;
-        }
+        return *postselect == 1 ? true : false;
     }
 
     // Normal flow, no post-selection

--- a/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.cpp
+++ b/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.cpp
@@ -392,7 +392,7 @@ void LightningSimulator::PartialCounts(DataView<double, 1> &eigvals, DataView<in
     }
 }
 
-auto LightningSimulator::Measure(QubitIdType wire, int8_t postselect) -> Result
+auto LightningSimulator::Measure(QubitIdType wire, std::optional<int8_t> postselect) -> Result
 {
     // get a measurement
     std::vector<QubitIdType> wires = {reinterpret_cast<QubitIdType>(wire)};

--- a/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.cpp
+++ b/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.cpp
@@ -392,7 +392,7 @@ void LightningSimulator::PartialCounts(DataView<double, 1> &eigvals, DataView<in
     }
 }
 
-auto LightningSimulator::Measure(QubitIdType wire, std::optional<int8_t> postselect) -> Result
+auto LightningSimulator::Measure(QubitIdType wire, std::optional<int32_t> postselect) -> Result
 {
     // get a measurement
     std::vector<QubitIdType> wires = {reinterpret_cast<QubitIdType>(wire)};

--- a/runtime/lib/backend/lightning/lightning_kokkos/LightningKokkosSimulator.cpp
+++ b/runtime/lib/backend/lightning/lightning_kokkos/LightningKokkosSimulator.cpp
@@ -433,7 +433,7 @@ void LightningKokkosSimulator::PartialCounts(DataView<double, 1> &eigvals,
     }
 }
 
-auto LightningKokkosSimulator::Measure(QubitIdType wire, int8_t postselect) -> Result
+auto LightningKokkosSimulator::Measure(QubitIdType wire, std::optional<int8_t> postselect) -> Result
 {
     using UnmanagedComplexHostView = Kokkos::View<Kokkos::complex<double> *, Kokkos::HostSpace,
                                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;

--- a/runtime/lib/backend/lightning/lightning_kokkos/LightningKokkosSimulator.cpp
+++ b/runtime/lib/backend/lightning/lightning_kokkos/LightningKokkosSimulator.cpp
@@ -433,7 +433,8 @@ void LightningKokkosSimulator::PartialCounts(DataView<double, 1> &eigvals,
     }
 }
 
-auto LightningKokkosSimulator::Measure(QubitIdType wire, std::optional<int8_t> postselect) -> Result
+auto LightningKokkosSimulator::Measure(QubitIdType wire, std::optional<int32_t> postselect)
+    -> Result
 {
     using UnmanagedComplexHostView = Kokkos::View<Kokkos::complex<double> *, Kokkos::HostSpace,
                                                   Kokkos::MemoryTraits<Kokkos::Unmanaged>>;

--- a/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
+++ b/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
@@ -473,9 +473,10 @@ void OpenQasmDevice::PartialCounts(DataView<double, 1> &eigvals, DataView<int64_
     }
 }
 
-auto OpenQasmDevice::Measure([[maybe_unused]] QubitIdType wire, int8_t postselect) -> Result
+auto OpenQasmDevice::Measure([[maybe_unused]] QubitIdType wire, std::optional<int8_t> postselect)
+    -> Result
 {
-    RT_FAIL_IF(postselect != -1, "Post-selection is not supported yet");
+    RT_FAIL_IF(postselect && *postselect != -1, "Post-selection is not supported yet");
 
     if (builder_type != OpenQasm::BuilderType::Common) {
         RT_FAIL("Unsupported functionality");

--- a/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
+++ b/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
@@ -473,7 +473,7 @@ void OpenQasmDevice::PartialCounts(DataView<double, 1> &eigvals, DataView<int64_
     }
 }
 
-auto OpenQasmDevice::Measure([[maybe_unused]] QubitIdType wire, std::optional<int8_t> postselect)
+auto OpenQasmDevice::Measure([[maybe_unused]] QubitIdType wire, std::optional<int32_t> postselect)
     -> Result
 {
     RT_FAIL_IF(postselect, "Post-selection is not supported yet");

--- a/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
+++ b/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
@@ -476,7 +476,7 @@ void OpenQasmDevice::PartialCounts(DataView<double, 1> &eigvals, DataView<int64_
 auto OpenQasmDevice::Measure([[maybe_unused]] QubitIdType wire, std::optional<int8_t> postselect)
     -> Result
 {
-    RT_FAIL_IF(postselect && *postselect != -1, "Post-selection is not supported yet");
+    RT_FAIL_IF(postselect, "Post-selection is not supported yet");
 
     if (builder_type != OpenQasm::BuilderType::Common) {
         RT_FAIL("Unsupported functionality");

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -741,8 +741,14 @@ ObsIdType __catalyst__qis__HamiltonianObs(MemRefT_double_1d *coeffs, int64_t num
 
 RESULT *__catalyst__qis__Measure(QUBIT *wire, int8_t postselect)
 {
+    std::optional postselectOpt = postselect;
+
+    // Absence of postselect is denoted now by a nullopt
+    if (postselect == -1) {
+        postselectOpt = std::nullopt;
+    }
     return Catalyst::Runtime::getQuantumDevicePtr()->Measure(reinterpret_cast<QubitIdType>(wire),
-                                                             postselect);
+                                                             postselectOpt);
 }
 
 double __catalyst__qis__Expval(ObsIdType obsKey)

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -744,7 +744,7 @@ RESULT *__catalyst__qis__Measure(QUBIT *wire, int8_t postselect)
     std::optional postselectOpt = postselect;
 
     // Absence of postselect is denoted now by a nullopt
-    if (postselect != 0 || postselect != 1) {
+    if (postselect != 0 && postselect != 1) {
         postselectOpt = std::nullopt;
     }
     return Catalyst::Runtime::getQuantumDevicePtr()->Measure(reinterpret_cast<QubitIdType>(wire),

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -739,14 +739,16 @@ ObsIdType __catalyst__qis__HamiltonianObs(MemRefT_double_1d *coeffs, int64_t num
     return Catalyst::Runtime::getQuantumDevicePtr()->HamiltonianObservable(coeffs_vec, obsKeys);
 }
 
-RESULT *__catalyst__qis__Measure(QUBIT *wire, int8_t postselect)
+RESULT *__catalyst__qis__Measure(QUBIT *wire, int32_t postselect)
 {
-    std::optional postselectOpt = postselect;
+    std::optional<int32_t> postselectOpt{postselect};
 
-    // Absence of postselect is denoted now by a nullopt
+    // Any value different to 0 or 1 denotes absence of postselect, and it is hence turned into
+    // std::nullopt at the C++ interface
     if (postselect != 0 && postselect != 1) {
         postselectOpt = std::nullopt;
     }
+
     return Catalyst::Runtime::getQuantumDevicePtr()->Measure(reinterpret_cast<QubitIdType>(wire),
                                                              postselectOpt);
 }

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -744,7 +744,7 @@ RESULT *__catalyst__qis__Measure(QUBIT *wire, int8_t postselect)
     std::optional postselectOpt = postselect;
 
     // Absence of postselect is denoted now by a nullopt
-    if (postselect == -1) {
+    if (postselect != 0 || postselect != 1) {
         postselectOpt = std::nullopt;
     }
     return Catalyst::Runtime::getQuantumDevicePtr()->Measure(reinterpret_cast<QubitIdType>(wire),

--- a/runtime/tests/Test_LightningMeasures.cpp
+++ b/runtime/tests/Test_LightningMeasures.cpp
@@ -79,7 +79,7 @@ TEMPLATE_LIST_TEST_CASE("Measurement collapse test with 2 wires", "[Measures]", 
     std::vector<QubitIdType> Qs = sim->AllocateQubits(n);
 
     sim->NamedOperation("Hadamard", {}, {Qs[0]}, false);
-    auto m = sim->Measure(Qs[0], -1);
+    auto m = sim->Measure(Qs[0]);
     std::vector<std::complex<double>> state(1U << sim->GetNumQubits());
     DataView<std::complex<double>, 1> view(state);
     sim->State(view);
@@ -112,7 +112,7 @@ TEMPLATE_LIST_TEST_CASE("Measurement collapse concrete logical qubit difference"
     Qs = sim->AllocateQubits(n);
 
     sim->NamedOperation("Hadamard", {}, {Qs[0]}, false);
-    sim->Measure(Qs[0], -1);
+    sim->Measure(Qs[0]);
     std::vector<std::complex<double>> state(1U << sim->GetNumQubits());
     DataView<std::complex<double>, 1> view(state);
     sim->State(view);
@@ -137,7 +137,7 @@ TEMPLATE_LIST_TEST_CASE("Mid-circuit measurement naive test", "[Measures]", SimT
 
     sim->NamedOperation("PauliX", {}, {q}, false);
 
-    auto m = sim->Measure(q, -1);
+    auto m = sim->Measure(q);
 
     CHECK(*m);
 }

--- a/runtime/tests/Test_OpenQasmDevice.cpp
+++ b/runtime/tests/Test_OpenQasmDevice.cpp
@@ -124,7 +124,7 @@ TEST_CASE("Test the bell pair circuit with BuilderType::Common", "[openqasm]")
     device->NamedOperation("Hadamard", {}, {wires[0]}, false);
     device->NamedOperation("CNOT", {}, {wires[0], wires[1]}, false);
 
-    device->Measure(wires[1], -1);
+    device->Measure(wires[1]);
 
     std::string toqasm = "OPENQASM 3.0;\n"
                          "qubit[2] qubits;\n"

--- a/runtime/tests/third_party/dummy_device.cpp
+++ b/runtime/tests/third_party/dummy_device.cpp
@@ -27,7 +27,7 @@ struct DummyDevice final : public Catalyst::Runtime::QuantumDevice {
     {
         return 0;
     }
-    auto Measure(QubitIdType, int8_t) -> Result override
+    auto Measure(QubitIdType, std::optional<int8_t>) -> Result override
     {
         bool *ret = (bool *)malloc(sizeof(bool));
         *ret = true;

--- a/runtime/tests/third_party/dummy_device.cpp
+++ b/runtime/tests/third_party/dummy_device.cpp
@@ -27,7 +27,7 @@ struct DummyDevice final : public Catalyst::Runtime::QuantumDevice {
     {
         return 0;
     }
-    auto Measure(QubitIdType, std::optional<int8_t>) -> Result override
+    auto Measure(QubitIdType, std::optional<int32_t>) -> Result override
     {
         bool *ret = (bool *)malloc(sizeof(bool));
         *ret = true;


### PR DESCRIPTION
I quote @maliasadi: 

Just to remind us!

- Let's avoid writing C-like C++ code 
- Always check the wheels for almost all PRs before merging (using ci:build-wheels flag).
TODO:

- [x] Make postselect an optional argument at the C++ interface
- [x] Fix Wheels check failures