### PR TITLE
Implement reset feature for mid-circuit measurements

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -116,6 +116,22 @@
       return qml.expval(qml.PauliZ(0))
   ```
 
+* Add support for reset option in mid-circuit measurements.
+  [(#507)](https://github.com/PennyLaneAI/catalyst/pull/507)
+
+  This is an example of reset usage:
+
+  ```py
+  dev = qml.device("lightning.qubit", wires=1)
+
+  @qjit
+  @qml.qnode(dev)
+  def f():
+      qml.Hadamard(0)
+      m = measure(0, reset=True)
+      return qml.expval(qml.PauliZ(0))
+  ```
+
 <h3>Breaking changes</h3>
 
 * We match better the Jax convention for returning gradient, jacobian, vjp and jvp. Therefore some breaking

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -1142,9 +1142,7 @@ class MidCircuitMeasure(HybridOp):
         op = self
         wire = op.in_classical_tracers[0]
         qubit = qrp.extract([wire])[0]
-
-        # Check if the postselect value was given, otherwise default to None
-        postselect = op.in_classical_tracers[1] if len(op.in_classical_tracers) > 1 else None
+        postselect = op.in_classical_tracers[1]
 
         qubit2 = op.bind_overwrite_classical_tracers(ctx, trace, qubit, postselect=postselect)
         qrp.insert([wire], [qubit2])
@@ -1949,7 +1947,9 @@ def while_loop(cond_fn):
     return _body_query
 
 
-def measure(wires, postselect: Optional[int] = None) -> DynamicJaxprTracer:
+def measure(
+    wires, reset: Optional[bool] = False, postselect: Optional[int] = None
+) -> DynamicJaxprTracer:
     """A :func:`qjit` compatible mid-circuit measurement for PennyLane/Catalyst.
 
     .. important::
@@ -1959,6 +1959,7 @@ def measure(wires, postselect: Optional[int] = None) -> DynamicJaxprTracer:
 
     Args:
         wires (Wires): The wire of the qubit the measurement process applies to
+        reset (Optional[bool]): Whether to reset the wire to the |0⟩ state after measurement.
         postselect (Optional[int]): Which basis state to postselect after a mid-circuit measurement.
 
     Returns:
@@ -2005,6 +2006,22 @@ def measure(wires, postselect: Optional[int] = None) -> DynamicJaxprTracer:
 
     >>> circuit()
     -1.0
+
+    **Example with reset**
+
+    .. code-block:: python
+
+        dev = qml.device("lightning.qubit", wires=1)
+
+        @qjit
+        @qml.qnode(dev)
+        def circuit():
+            qml.Hadamard(0)
+            m = measure(0, reset=True)
+            return qml.expval(qml.PauliZ(0))
+
+    >>> circuit()
+    1.0
     """
     EvaluationContext.check_is_tracing("catalyst.measure can only be used from within @qjit.")
     EvaluationContext.check_is_quantum_tracing(
@@ -2015,22 +2032,31 @@ def measure(wires, postselect: Optional[int] = None) -> DynamicJaxprTracer:
     if len(wires) != 1:
         raise TypeError(f"One classical argument (a wire) is expected, got {wires}")
 
-    in_classical_tracers = wires
+    # Copy, so wires remain unmodified
+    in_classical_tracers = wires.copy()
 
-    # Check the postselect value. If given, add it to the classical tracers list
-    if postselect is not None:
-        if postselect not in [0, 1]:
-            raise TypeError(f"postselect must be '0' or '1', got {postselect}")
-        in_classical_tracers.append(postselect)
+    if postselect is not None and postselect not in [0, 1]:
+        raise TypeError(f"postselect must be '0' or '1', got {postselect}")
+    in_classical_tracers.append(postselect)
 
     # assert len(ctx.trace.frame.eqns) == 0, ctx.trace.frame.eqns
-    out_classical_tracer = new_inner_tracer(ctx.trace, get_aval(True))
+    m = new_inner_tracer(ctx.trace, get_aval(True))
     MidCircuitMeasure(
         in_classical_tracers=in_classical_tracers,
-        out_classical_tracers=[out_classical_tracer],
+        out_classical_tracers=[m],
         regions=[],
     )
-    return out_classical_tracer
+
+    # If reset was requested, reset qubit only if the measurement result was 1
+    if reset:
+
+        @cond(m)
+        def reset_fn():
+            qml.PauliX(wires=wires)
+
+        reset_fn()
+
+    return m
 
 
 def adjoint(f: Union[Callable, Operator]) -> Union[Callable, Operator]:

--- a/frontend/test/pytest/test_mid_circuit_measurement.py
+++ b/frontend/test/pytest/test_mid_circuit_measurement.py
@@ -113,6 +113,32 @@ class TestMidCircuitMeasurement:
 
         assert circuit(jnp.pi)  # m will be equal to True
 
+    def test_with_reset_false(self, backend):
+        """Test measure (reset = False)."""
+
+        @qjit
+        @qml.qnode(qml.device(backend, wires=1))
+        def circuit():
+            qml.Hadamard(wires=0)
+            m1 = measure(wires=0, reset=False, postselect=1)
+            m2 = measure(wires=0)
+            return m1 == m2
+
+        assert circuit()  # both measures are the same
+
+    def test_with_reset_true(self, backend):
+        """Test measure (reset = True)."""
+
+        @qjit
+        @qml.qnode(qml.device(backend, wires=1))
+        def circuit():
+            qml.Hadamard(wires=0)
+            m1 = measure(wires=0, reset=True, postselect=1)
+            m2 = measure(wires=0)
+            return m1 != m2
+
+        assert circuit()  # measures are different
+
 
 if __name__ == "__main__":
     pytest.main(["-x", __file__])


### PR DESCRIPTION
**Context:** We want to support in Catalyst the existent **reset** feature of the measure function of PennyLane.

**Description of the Change:** The logic is implemented at the measure function right after the instantiation of the MidCircuitMeasure object. It applies a **PauliX** gate to the qubit, but only if the measurement result was 1.

**Benefits:** No need to involve MLIR and runtime on the process.

**TODO**: 

- [x] Frontend implementation
- [x] Tests
- [x] Changelog updates

[sc-56696]
