### PR TITLE
[CI/CD] Run async tests when building wheels.

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -390,4 +390,5 @@ jobs:
       run: |
         python${{ matrix.python_version }} -m pytest $GITHUB_WORKSPACE/frontend/test/pytest -n auto
         python${{ matrix.python_version }} -m pytest $GITHUB_WORKSPACE/frontend/test/pytest --backend="lightning.kokkos" -n auto
+        python${{ matrix.python_version }} -m pytest $GITHUB_WORKSPACE/frontend/test/async_tests
         python${{ matrix.python_version }} -m pytest $GITHUB_WORKSPACE/frontend/test/pytest --runbraket=LOCAL -n auto

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -401,4 +401,5 @@ jobs:
       run: |
         python${{ matrix.python_version }} -m pytest -v $GITHUB_WORKSPACE/frontend/test/pytest -n auto
         python${{ matrix.python_version }} -m pytest -v $GITHUB_WORKSPACE/frontend/test/pytest --backend="lightning.kokkos" -n auto
+        python${{ matrix.python_version }} -m pytest $GITHUB_WORKSPACE/frontend/test/async_tests
         python${{ matrix.python_version }} -m pytest -v $GITHUB_WORKSPACE/frontend/test/pytest --runbraket=LOCAL -n auto

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -370,4 +370,5 @@ jobs:
         python${{ matrix.python_version }} -m pytest $GITHUB_WORKSPACE/frontend/test/pytest -n auto
         # TODO: Uncomment after fixing https://github.com/PennyLaneAI/pennylane-lightning/issues/552
         # python${{ matrix.python_version }} -m pytest $GITHUB_WORKSPACE/frontend/test/pytest --backend="lightning.kokkos" -n auto
+        python${{ matrix.python_version }} -m pytest $GITHUB_WORKSPACE/frontend/test/async_tests
         python${{ matrix.python_version }} -m pytest $GITHUB_WORKSPACE/frontend/test/pytest --runbraket=LOCAL -n auto

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -211,6 +211,7 @@
 
 * Handle run time exception in async qnodes.
   [(#447)](https://github.com/PennyLaneAI/catalyst/pull/447)
+  [(#510)](https://github.com/PennyLaneAI/catalyst/pull/510)
 
   This is done by:
   * changeing `llvm.call` to `llvm.invoke`

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -315,7 +315,7 @@ class LinkerDriver:
         # The exception handling mechanism requires linking against
         # __gxx_personality_v0 which is either on -lstdc++ in
         # or -lc++. We choose based on the operating system.
-        if options.async_qnodes and platform.system() == "Linux":
+        if options.async_qnodes and platform.system() == "Linux":  # pragma: nocover
             system_flags += ["-lstdc++"]
         elif options.async_qnodes and platform.system() == "Darwin":  # pragma: nocover
             system_flags += ["-lc++"]

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -251,7 +251,7 @@ class LinkerDriver:
     _default_fallback_compilers = ["clang", "gcc", "c99", "c89", "cc"]
 
     @staticmethod
-    def get_default_flags():
+    def get_default_flags(options):
         """Re-compute the path where the libraries exist.
 
         The use case for this is if someone is in a python jupyter notebook and
@@ -308,12 +308,17 @@ class LinkerDriver:
 
         system_flags = []
         if platform.system() == "Linux":
-            # The exception handling mechanism requires linking against
-            # __gxx_personality_v0 which is either on -lstdc++ in
-            # or -lc++. We choose based on the operating system.
-            system_flags += ["-Wl,-no-as-needed", "-lstdc++"]
+            system_flags += ["-Wl,-no-as-needed"]
         elif platform.system() == "Darwin":  # pragma: nocover
-            system_flags += ["-Wl,-arch_errors_fatal", "-lc++"]
+            system_flags += ["-Wl,-arch_errors_fatal"]
+
+        # The exception handling mechanism requires linking against
+        # __gxx_personality_v0 which is either on -lstdc++ in
+        # or -lc++. We choose based on the operating system.
+        if options.async_qnodes and platform.system() == "Linux":
+            system_flags += ["-lstdc++"]
+        elif options.async_qnodes and platform.system() == "Darwin":  # pragma: nocover
+            system_flags += ["-lc++"]
 
         default_flags = [
             "-shared",
@@ -398,12 +403,12 @@ class LinkerDriver:
         """
         if outfile is None:
             outfile = LinkerDriver.get_output_filename(infile)
-        if flags is None:
-            flags = LinkerDriver.get_default_flags()
-        if fallback_compilers is None:
-            fallback_compilers = LinkerDriver._default_fallback_compilers
         if options is None:
             options = CompileOptions()
+        if flags is None:
+            flags = LinkerDriver.get_default_flags(options)
+        if fallback_compilers is None:
+            fallback_compilers = LinkerDriver._default_fallback_compilers
         for compiler in LinkerDriver._available_compilers(fallback_compilers):
             success = LinkerDriver._attempt_link(compiler, flags, infile, outfile, options)
             if success:

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -308,9 +308,12 @@ class LinkerDriver:
 
         system_flags = []
         if platform.system() == "Linux":
-            system_flags += ["-Wl,-no-as-needed"]
+            # The exception handling mechanism requires linking against
+            # __gxx_personality_v0 which is either on -lstdc++ in
+            # or -lc++. We choose based on the operating system.
+            system_flags += ["-Wl,-no-as-needed", "-lstdc++"]
         elif platform.system() == "Darwin":  # pragma: nocover
-            system_flags += ["-Wl,-arch_errors_fatal"]
+            system_flags += ["-Wl,-arch_errors_fatal", "-lc++"]
 
         default_flags = [
             "-shared",


### PR DESCRIPTION
Run async tests when building wheels. Also link against `-libstdc++` and `-lc++` as we now depend on the personality function `__gxx_personality_v0`.

Fixes #509 