### PR TITLE
Fix undiscoverable OpenMP on macOS

### DIFF
--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -293,7 +293,6 @@ jobs:
               -DKokkos_ENABLE_SERIAL=ON \
               -DKokkos_ENABLE_OPENMP=ON \
               -DKokkos_ENABLE_COMPLEX_ALIGN=OFF \
-              -DOpenMP_ROOT=$(brew --prefix libomp) \
               -DENABLE_WARNINGS=OFF \
               -DENABLE_OPENQASM=ON \
               -DENABLE_OPENMP=OFF \

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -69,6 +69,17 @@ if(ENABLE_OPENQASM)
     list(APPEND devices_list rtd_openqasm)
 endif()
 
+# On macOS libomp is typically installed via brew, which doesn't make the package discoverable by
+# default to avoid conflicting with GCC's OpenMP library.
+if(APPLE)
+    execute_process (
+        COMMAND brew --prefix libomp
+        OUTPUT_VARIABLE BREW_OMP
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    set(OpenMP_ROOT ${BREW_OMP})
+endif()
+
 add_library(catalyst_qir_runtime INTERFACE)
 
 target_link_libraries(catalyst_qir_runtime INTERFACE ${devices_list} rt_capi)


### PR DESCRIPTION
On macOS libomp is typically installed via brew, which doesn't make the package discoverable by default to avoid conflicting with a potential GCC installation of OpenMP (not sure that really applies on mac but oh well).

This issue was introduced in #457 which setup the proper CMake flag for the wheel recipe but not for local builds.