### PR TITLE
[Frontend] Omit QCtrl

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -134,6 +134,12 @@
 
 <h3>Breaking changes</h3>
 
+* `QCtrl` is overriden and never used.
+  [(#522)](https://github.com/PennyLaneAI/catalyst/pull/522)
+
+  This is not so much a breaking change, it was just never used in the past.
+  This will be set back to its original behaviour once it is implemented in the frontend.
+
 * We match better the Jax convention for returning gradient, jacobian, vjp and jvp. Therefore some breaking
   changes about the return shapes of those functions were introduced.
   [(#500)](https://github.com/PennyLaneAI/catalyst/pull/500)

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -269,7 +269,8 @@ class QJITDevice(qml.QubitDevice):
             QJITDevice.operations += ["Adjoint"]
 
         if QJITDevice._check_quantum_control(config):  # pragma: nocover
-            QJITDevice.operations += ["QCtrl"]
+            # TODO: Once control is added on the frontend.
+            ...
 
     @staticmethod
     def _set_supported_observables(config):


### PR DESCRIPTION
Do not add `QCtrl` even if the toml file specifies the device is compatible. This behaviour will be changed back once support for quantum control is added in the frontend.