### PR TITLE
Transiently set JAX dynamic shapes option

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -232,6 +232,9 @@
 
 <h3>Bug fixes</h3>
 
+* Only set `JAX_DYNAMIC_SHAPES` configuration option during `trace_to_mlir()`.
+  [(#526)](https://github.com/PennyLaneAI/catalyst/pull/526)
+
 * Handle run time exception in async qnodes.
   [(#447)](https://github.com/PennyLaneAI/catalyst/pull/447)
 

--- a/frontend/catalyst/compilation_pipelines.py
+++ b/frontend/catalyst/compilation_pipelines.py
@@ -59,9 +59,9 @@ from catalyst.utils.patching import Patcher
 # pylint: disable=unnecessary-lambda
 setattr(jax.interpreters.partial_eval.DynamicJaxprTracer, "__hash__", lambda x: id(x))
 
+# This flag cannot be set in ``QJIT.get_mlir()`` because values created before
+# that function is called must be consistent with the JAX configuration value.
 jax.config.update("jax_enable_x64", True)
-jax.config.update("jax_platform_name", "cpu")
-jax.config.update("jax_dynamic_shapes", True)
 
 
 def are_params_annotated(f: typing.Callable):

--- a/frontend/catalyst/utils/jax_extras.py
+++ b/frontend/catalyst/utils/jax_extras.py
@@ -113,6 +113,7 @@ __all__ = (
     "new_dynamic_main2",
     "new_inner_tracer",
     "sort_eqns",
+    "transient_jax_config",
     "treedef_is_leaf",
     "tree_flatten",
     "tree_structure",
@@ -122,6 +123,26 @@ __all__ = (
 )
 
 map, unsafe_map = safe_map, map  # pylint: disable=redefined-builtin
+
+
+@contextmanager
+def transient_jax_config() -> Generator[None, None, None]:
+    """Context manager which updates transient JAX configuration options,
+    yields, and then restores the original configuration values.
+    """
+    want_vals = {"jax_dynamic_shapes": True}
+    prev_vals = {}
+
+    for name, val in want_vals.items():
+        # Using ``read()`` to retrieve the value of an option is not permitted
+        # for JAX context manager flags.
+        prev_vals[name] = jax.config.values[name]
+        jax.config.update(name, val)
+
+    yield
+
+    for name, val in prev_vals.items():
+        jax.config.update(name, val)
 
 
 @contextmanager

--- a/frontend/test/pytest/test_jax_config.py
+++ b/frontend/test/pytest/test_jax_config.py
@@ -7,7 +7,7 @@ def test_transient_jax_config():
     """Test that the ``transient_jax_config()`` context manager updates and
     restores the value of the JAX dynamic shapes option.
     """
-    assert jax.config.jax_dynamic_shapes is False  # type: ignore
+    jax.config.update("jax_dynamic_shapes", False)
 
     with transient_jax_config():
         assert jax.config.jax_dynamic_shapes is True  # type: ignore

--- a/frontend/test/pytest/test_jax_config.py
+++ b/frontend/test/pytest/test_jax_config.py
@@ -1,3 +1,19 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests JAX configuration utilities."""
+
 import jax
 
 from catalyst.utils.jax_extras import transient_jax_config

--- a/frontend/test/pytest/test_jax_config.py
+++ b/frontend/test/pytest/test_jax_config.py
@@ -1,0 +1,15 @@
+import jax
+
+from catalyst.utils.jax_extras import transient_jax_config
+
+
+def test_transient_jax_config():
+    """Test that the ``transient_jax_config()`` context manager updates and
+    restores the value of the JAX dynamic shapes option.
+    """
+    assert jax.config.jax_dynamic_shapes is False  # type: ignore
+
+    with transient_jax_config():
+        assert jax.config.jax_dynamic_shapes is True  # type: ignore
+
+    assert jax.config.jax_dynamic_shapes is False  # type: ignore


### PR DESCRIPTION
**Context:**

The QSVT example at the top of [this demo](https://pennylane.ai/qml/demos/tutorial_apply_qsvt/#preliminaries) does not work with `@jax.jit`:

```python
import jax
import pennylane as qml
import jax.numpy as jnp

dev = qml.device("default.qubit", wires=[0, 1])

A = jnp.array([[0.1, 0.2], [0.3, 0.4]])
phase_angles = jnp.array([0.0, 1.0, 2.0, 3.0])


@jax.jit
@qml.qnode(dev, interface="jax")
def my_circuit(phase_angles):
    qml.qsvt(A, phase_angles, wires=[0, 1])
    return qml.state()

print(my_circuit(phase_angles))
```

Running the script above gives

```
jax._src.traceback_util.UnfilteredStackTrace: TypeError: cannot unpack non-iterable ShapedArray object
```

since `JAX_DYNAMIC_SHAPES` is toggled to `True` in the middle of JAX's `common_infer_params()` function.

**Description of the Change:**

* Deleted the code which updates the `JAX_PLATFORM_NAME` update since it is no longer needed as of [this JAX release](https://github.com/google/jax/blob/57e59eb6c309acfdfb49a4ce76c996fc5c2a016c/CHANGELOG.md?plain=1#L303-L305).
* Replaced the code which updates the `JAX_DYNAMIC_SHAPES` option with a `transient_jax_config()` context manager which temporarily sets the value of `JAX_DYNAMIC_SHAPES` to `True` and then restores the original configuration value following the `yield`. The context manager is used by `trace_to_mlir()`.

**Benefits:**

* Catalyst can be safely loaded in the middle of constructing a PennyLane circuit (e.g., via `adjoint()` or `qsvt()`).

**Possible Drawbacks:**

* User code which assumes `JAX_DYNAMIC_SHAPES` is set immediately after importing Catalyst might break.

**Related GitHub Issues:**

None.
