### PR TITLE
[Frontend] Eliminate python3.11 warnings

### DIFF
--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -536,6 +536,9 @@ class Compiler:
             (Optional[str]): output IR
         """
         if len(dict(self.options.get_pipelines()).get(pipeline, [])) == 0:
-            raise CompileError("Requesting the output of an empty pipeline")
+            msg = f"Attempting to get output for pipeline: {pipeline},"
+            msg += " but no file was found.\n"
+            msg += "Are you sure the file exists?"
+            raise CompileError(msg)
 
         return self.last_compiler_output.get_pipeline_output(pipeline)

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -538,7 +538,4 @@ class Compiler:
         if len(dict(self.options.get_pipelines()).get(pipeline, [])) == 0:
             raise CompileError("Requesting the output of an empty pipeline")
 
-        if not self.last_compiler_output:
-            return None
-
         return self.last_compiler_output.get_pipeline_output(pipeline)

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -536,7 +536,7 @@ class Compiler:
             (Optional[str]): output IR
         """
         if len(dict(self.options.get_pipelines()).get(pipeline, [])) == 0:
-            warnings.warn("Requesting an output of an empty pipeline")  # pragma: no cover
+            raise CompileError("Requesting the output of an empty pipeline")
 
         if not self.last_compiler_output:
             return None

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -119,10 +119,10 @@ class TestCompilerErrors:
             )
 
     def test_attempts_to_get_inexistent_intermediate_file(self):
-        """Test return value if user request intermediate file that doesn't exist."""
+        """Test the return value if a user requests an intermediate file that doesn't exist."""
         compiler = Compiler()
-        result = compiler.get_output_of("inexistent-file")
-        assert result is None
+        with pytest.raises(CompileError, match="Requesting the output of an empty pipeline"):
+            compiler.get_output_of("inexistent-file")
 
     def test_runtime_error(self, backend):
         """Test with non-default flags."""
@@ -218,15 +218,16 @@ class TestCompilerState:
             return qml.state()
 
         compiler = workflow.compiler
-        assert compiler.get_output_of("EmptyPipeline1") is None
+        with pytest.raises(CompileError, match="Requesting the output of an empty pipeline"):
+            compiler.get_output_of("EmptyPipeline1")
         assert compiler.get_output_of("HLOLoweringPass")
         assert compiler.get_output_of("QuantumCompilationPass")
+        with pytest.raises(CompileError, match="Requesting the output of an empty pipeline"):
+            compiler.get_output_of("EmptyPipeline2")
         assert compiler.get_output_of("BufferizationPass")
         assert compiler.get_output_of("MLIRToLLVMDialect")
-        assert compiler.get_output_of("EmptyPipeline2") is None
-        assert compiler.get_output_of("PreEnzymeOpt")
-        assert compiler.get_output_of("Enzyme")
-        assert compiler.get_output_of("None-existing-pipeline") is None
+        with pytest.raises(CompileError, match="Requesting the output of an empty pipeline"):
+            compiler.get_output_of("None-existing-pipeline")
         workflow.workspace.cleanup()
 
     def test_print_nonexistent_stages(self, backend):
@@ -238,7 +239,8 @@ class TestCompilerState:
             qml.PauliX(wires=0)
             return qml.state()
 
-        assert workflow.compiler.get_output_of("None-existing-pipeline") is None
+        with pytest.raises(CompileError, match="Requesting the output of an empty pipeline"):
+            workflow.compiler.get_output_of("None-existing-pipeline")
         workflow.workspace.cleanup()
 
     def test_workspace(self):

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -121,7 +121,7 @@ class TestCompilerErrors:
     def test_attempts_to_get_inexistent_intermediate_file(self):
         """Test the return value if a user requests an intermediate file that doesn't exist."""
         compiler = Compiler()
-        with pytest.raises(CompileError, match="Requesting the output of an empty pipeline"):
+        with pytest.raises(CompileError, match="Attempting to get output for pipeline"):
             compiler.get_output_of("inexistent-file")
 
     def test_runtime_error(self, backend):
@@ -218,15 +218,15 @@ class TestCompilerState:
             return qml.state()
 
         compiler = workflow.compiler
-        with pytest.raises(CompileError, match="Requesting the output of an empty pipeline"):
+        with pytest.raises(CompileError, match="Attempting to get output for pipeline"):
             compiler.get_output_of("EmptyPipeline1")
         assert compiler.get_output_of("HLOLoweringPass")
         assert compiler.get_output_of("QuantumCompilationPass")
-        with pytest.raises(CompileError, match="Requesting the output of an empty pipeline"):
+        with pytest.raises(CompileError, match="Attempting to get output for pipeline"):
             compiler.get_output_of("EmptyPipeline2")
         assert compiler.get_output_of("BufferizationPass")
         assert compiler.get_output_of("MLIRToLLVMDialect")
-        with pytest.raises(CompileError, match="Requesting the output of an empty pipeline"):
+        with pytest.raises(CompileError, match="Attempting to get output for pipeline"):
             compiler.get_output_of("None-existing-pipeline")
         workflow.workspace.cleanup()
 
@@ -239,7 +239,7 @@ class TestCompilerState:
             qml.PauliX(wires=0)
             return qml.state()
 
-        with pytest.raises(CompileError, match="Requesting the output of an empty pipeline"):
+        with pytest.raises(CompileError, match="Attempting to get output for pipeline"):
             workflow.compiler.get_output_of("None-existing-pipeline")
         workflow.workspace.cleanup()
 

--- a/frontend/test/pytest/test_config_functions.py
+++ b/frontend/test/pytest/test_config_functions.py
@@ -35,7 +35,7 @@ from catalyst.utils.runtime import (
 from catalyst.utils.toml import check_adjoint_flag, read_toml_file
 
 
-class DummyDevice(qml.QubitDevice):
+class DeviceTest(qml.QubitDevice):
     """Test device"""
 
     name = "Dummy Device"
@@ -72,13 +72,12 @@ def test_validate_config_with_device(schema):
             )
 
         config = read_toml_file(toml_file)
-
-        device = DummyDevice()
+        name = DeviceTest.name
         with pytest.raises(
             CompileError,
-            match=f"Attempting to compile program for incompatible device '{device.name}'",
+            match=f"Attempting to compile program for incompatible device '{name}'",
         ):
-            validate_config_with_device(device, config)
+            validate_config_with_device(DeviceTest(), config)
 
 
 def test_get_observables_schema1():

--- a/frontend/test/pytest/test_config_functions.py
+++ b/frontend/test/pytest/test_config_functions.py
@@ -35,7 +35,7 @@ from catalyst.utils.runtime import (
 from catalyst.utils.toml import check_adjoint_flag, read_toml_file
 
 
-class DeviceTest(qml.QubitDevice):
+class DeviceToBeTested(qml.QubitDevice):
     """Test device"""
 
     name = "Dummy Device"
@@ -72,12 +72,12 @@ def test_validate_config_with_device(schema):
             )
 
         config = read_toml_file(toml_file)
-        name = DeviceTest.name
+        name = DeviceToBeTested.name
         with pytest.raises(
             CompileError,
             match=f"Attempting to compile program for incompatible device '{name}'",
         ):
-            validate_config_with_device(DeviceTest(), config)
+            validate_config_with_device(DeviceToBeTested(), config)
 
 
 def test_get_observables_schema1():

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -19,6 +19,7 @@ import numpy as np
 import pennylane as qml
 import pytest
 from jax import numpy as jnp
+from jax.tree_util import tree_flatten
 
 import catalyst.utils.calculate_grad_shape as infer
 from catalyst import (
@@ -1101,8 +1102,8 @@ def test_pytrees_return_classical():
     jax_expected_results = jax.jit(jax.jacobian(f, argnums=[0, 1]))(x, y)
     catalyst_results = qjit(jacobian(f, argnum=[0, 1]))(x, y)
 
-    flatten_res_jax, tree_jax = jax.tree_util.tree_flatten(jax_expected_results)
-    flatten_res_catalyst, tree_catalyst = jax.tree_util.tree_flatten(catalyst_results)
+    flatten_res_jax, tree_jax = tree_flatten(jax_expected_results)
+    flatten_res_catalyst, tree_catalyst = tree_flatten(catalyst_results)
 
     assert tree_jax == tree_catalyst
     assert np.allclose(flatten_res_jax, flatten_res_catalyst)
@@ -1120,8 +1121,8 @@ def test_pytrees_args_classical():
     jax_expected_results = jax.jit(jax.jacobian(f, argnums=[0, 1]))(x, y)
     catalyst_results = qjit(jacobian(f, argnum=[0, 1]))(x, y)
 
-    flatten_res_jax, tree_jax = jax.tree_flatten(jax_expected_results)
-    flatten_res_catalyst, tree_catalyst = jax.tree_flatten(catalyst_results)
+    flatten_res_jax, tree_jax = tree_flatten(jax_expected_results)
+    flatten_res_catalyst, tree_catalyst = tree_flatten(catalyst_results)
 
     assert tree_jax == tree_catalyst
     assert np.allclose(flatten_res_jax, flatten_res_catalyst)
@@ -1139,8 +1140,8 @@ def test_pytrees_args_return_classical():
     jax_expected_results = jax.jit(jax.jacobian(f, argnums=[0, 1]))(x, y)
     catalyst_results = qjit(jacobian(f, argnum=[0, 1]))(x, y)
 
-    flatten_res_jax, tree_jax = jax.tree_flatten(jax_expected_results)
-    flatten_res_catalyst, tree_catalyst = jax.tree_flatten(catalyst_results)
+    flatten_res_jax, tree_jax = tree_flatten(jax_expected_results)
+    flatten_res_catalyst, tree_catalyst = tree_flatten(catalyst_results)
 
     assert tree_jax == tree_catalyst
     assert np.allclose(flatten_res_jax, flatten_res_catalyst)

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1101,8 +1101,8 @@ def test_pytrees_return_classical():
     jax_expected_results = jax.jit(jax.jacobian(f, argnums=[0, 1]))(x, y)
     catalyst_results = qjit(jacobian(f, argnum=[0, 1]))(x, y)
 
-    flatten_res_jax, tree_jax = jax.tree_flatten(jax_expected_results)
-    flatten_res_catalyst, tree_catalyst = jax.tree_flatten(catalyst_results)
+    flatten_res_jax, tree_jax = jax.tree_util.tree_flatten(jax_expected_results)
+    flatten_res_catalyst, tree_catalyst = jax.tree_util.tree_flatten(catalyst_results)
 
     assert tree_jax == tree_catalyst
     assert np.allclose(flatten_res_jax, flatten_res_catalyst)

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -616,7 +616,7 @@ class TestArraysInHamiltonian:
     def test_array_repr_from_context1(self, coeffs, backend):
         """Test array representation from context in Hamiltonian."""
 
-        @qjit
+        @qjit(target="mlir")
         @qml.qnode(qml.device(backend, wires=6))
         def f():
             qml.Hadamard(wires=0)

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -204,6 +204,7 @@ class TestJittedWithOneTypeRunWithAnother:
         assert id_from != id_to
         assert jnp.allclose(res_from, res_to)
 
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     @pytest.mark.parametrize(
         "to_type",
         [

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -616,7 +616,7 @@ class TestArraysInHamiltonian:
     def test_array_repr_from_context1(self, coeffs, backend):
         """Test array representation from context in Hamiltonian."""
 
-        @qjit(target="mlir")
+        @qjit
         @qml.qnode(qml.device(backend, wires=6))
         def f():
             qml.Hadamard(wires=0)

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -204,7 +204,6 @@ class TestJittedWithOneTypeRunWithAnother:
         assert id_from != id_to
         assert jnp.allclose(res_from, res_to)
 
-    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     @pytest.mark.parametrize(
         "to_type",
         [

--- a/frontend/test/pytest/test_measurements_shots_results.py
+++ b/frontend/test/pytest/test_measurements_shots_results.py
@@ -535,7 +535,10 @@ class TestOtherMeasurements:
         )
 
         # qml.state
-        with pytest.warns(UserWarning, match="Requested state or density matrix with finite shots; the returned state information is analytic and is unaffected by sampling. To silence this warning, set shots=None on the device."):
+        with pytest.warns(
+            UserWarning,
+            match="Requested state or density matrix with finite shots; the returned state information is analytic and is unaffected by sampling. To silence this warning, set shots=None on the device.",
+        ):
             assert np.allclose(result[5], expected(x, qml.state()))
 
 

--- a/frontend/test/pytest/test_measurements_shots_results.py
+++ b/frontend/test/pytest/test_measurements_shots_results.py
@@ -534,6 +534,10 @@ class TestOtherMeasurements:
             rtol=tol_stochastic,
         )
 
+        # qml.state
+        with pytest.warns(UserWarning, match="Requested state or density matrix with finite shots; the returned state information is analytic and is unaffected by sampling. To silence this warning, set shots=None on the device."):
+            assert np.allclose(result[5], expected(x, qml.state()))
+
 
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_measurements_shots_results.py
+++ b/frontend/test/pytest/test_measurements_shots_results.py
@@ -534,14 +534,7 @@ class TestOtherMeasurements:
             rtol=tol_stochastic,
         )
 
-        # qml.state
-        with pytest.warns(
-            UserWarning,
-            match="Requested state or density matrix with finite shots; the returned "
-            "state information is analytic and is unaffected by sampling. To silence "
-            "this warning, set shots=None on the device.",
-        ):
-            assert np.allclose(result[5], expected(x, qml.state()))
+        assert np.allclose(result[5], expected(x, qml.state()))
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_measurements_shots_results.py
+++ b/frontend/test/pytest/test_measurements_shots_results.py
@@ -537,7 +537,9 @@ class TestOtherMeasurements:
         # qml.state
         with pytest.warns(
             UserWarning,
-            match="Requested state or density matrix with finite shots; the returned state information is analytic and is unaffected by sampling. To silence this warning, set shots=None on the device.",
+            match="Requested state or density matrix with finite shots; the returned "
+            "state information is analytic and is unaffected by sampling. To silence "
+            "this warning, set shots=None on the device.",
         ):
             assert np.allclose(result[5], expected(x, qml.state()))
 

--- a/frontend/test/pytest/test_measurements_shots_results.py
+++ b/frontend/test/pytest/test_measurements_shots_results.py
@@ -534,7 +534,6 @@ class TestOtherMeasurements:
             rtol=tol_stochastic,
         )
 
-        assert np.allclose(result[5], expected(x, qml.state()))
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_meta_ops.py
+++ b/frontend/test/pytest/test_meta_ops.py
@@ -104,7 +104,9 @@ def test_control_variable_wires(g, ctrls):
         qml.ctrl(g, control=ctrls)
         return qml.state()
 
-    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=7), interface="jax")(circuit))(jnp.array(ctrls))
+    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=7), interface="jax")(circuit))(
+        jnp.array(ctrls)
+    )
     expected = qml.qnode(qml.device("default.qubit", 7), interface="jax")(circuit)(ctrls)
 
     assert jnp.allclose(result, expected)

--- a/frontend/test/pytest/test_meta_ops.py
+++ b/frontend/test/pytest/test_meta_ops.py
@@ -76,8 +76,8 @@ def test_adjoint(g):
         qml.adjoint(g)
         return qml.state()
 
-    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=4))(circuit))()
-    expected = qml.qnode(qml.device("default.qubit", 4))(circuit)()
+    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=4), interface="jax")(circuit))()
+    expected = qml.qnode(qml.device("default.qubit", 4), interface="jax")(circuit)()
 
     assert jnp.allclose(result, expected)
 
@@ -90,8 +90,8 @@ def test_control(g, ctrls):
         qml.ctrl(g, control=ctrls)
         return qml.state()
 
-    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=7))(circuit))()
-    expected = qml.qnode(qml.device("default.qubit", 7))(circuit)()
+    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=7), interface="jax")(circuit))()
+    expected = qml.qnode(qml.device("default.qubit", 7), interface="jax")(circuit)()
 
     assert jnp.allclose(result, expected)
 
@@ -104,8 +104,8 @@ def test_control_variable_wires(g, ctrls):
         qml.ctrl(g, control=ctrls)
         return qml.state()
 
-    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=7))(circuit))(jnp.array(ctrls))
-    expected = qml.qnode(qml.device("default.qubit", 7))(circuit)(ctrls)
+    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=7), interface="jax")(circuit))(jnp.array(ctrls))
+    expected = qml.qnode(qml.device("default.qubit", 7), interface="jax")(circuit)(ctrls)
 
     assert jnp.allclose(result, expected)
 

--- a/frontend/test/pytest/test_meta_ops.py
+++ b/frontend/test/pytest/test_meta_ops.py
@@ -76,7 +76,7 @@ def test_adjoint(g):
         qml.adjoint(g)
         return qml.state()
 
-    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=4), interface="jax")(circuit))()
+    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=4))(circuit))()
     expected = qml.qnode(qml.device("default.qubit", 4), interface="jax")(circuit)()
 
     assert jnp.allclose(result, expected)
@@ -90,7 +90,7 @@ def test_control(g, ctrls):
         qml.ctrl(g, control=ctrls)
         return qml.state()
 
-    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=7), interface="jax")(circuit))()
+    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=7))(circuit))()
     expected = qml.qnode(qml.device("default.qubit", 7), interface="jax")(circuit)()
 
     assert jnp.allclose(result, expected)
@@ -104,7 +104,7 @@ def test_control_variable_wires(g, ctrls):
         qml.ctrl(g, control=ctrls)
         return qml.state()
 
-    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=7), interface="jax")(circuit))(
+    result = qjit(qml.qnode(qml.device("lightning.qubit", wires=7))(circuit))(
         jnp.array(ctrls)
     )
     expected = qml.qnode(qml.device("default.qubit", 7), interface="jax")(circuit)(ctrls)

--- a/frontend/test/pytest/test_transform.py
+++ b/frontend/test/pytest/test_transform.py
@@ -432,7 +432,7 @@ class TestQFuncTransforms:
         # TODO: Test by inspecting the circuit actually produced, testing the
         #       results does not verify the transform was applied correctly.
 
-        @qml.qfunc_transform
+        @qml.transform
         def unroll_ccrz(tape):
             """Needed for lightning.qubit, as it does not natively support expansion of
             multi-controlled RZ."""


### PR DESCRIPTION

**Context:**
Clean up the warnings generated by the frontend tests.

**Description of the Change:**
All warnings were removed except two:
-  test_template.py::test_gate_fabric,  Contains tensors of types {'autograd', 'jax'} 
- test_template.py::test_quantum_phase_estimation, div by 0
  -  Lightning bug logged in [sc-57055].

**Benefits:**
Reduction in noise when running the test suite.  Discover issues that might exist in the code.

**Possible Drawbacks:**
Possibly trapping a warning instead of fixing the underlying cause.

[sc-48324]
