### PR TITLE
Ensure constants action uses correct Catalyst tag

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -21,6 +21,8 @@ jobs:
   constants:
     name: "Set build matrix"
     uses: ./.github/workflows/constants.yaml
+      with:
+        use_release_tag: ${{ inputs.catalyst == 'stable' }}
 
   check-config:
     name: Build Configuration

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -21,8 +21,8 @@ jobs:
   constants:
     name: "Set build matrix"
     uses: ./.github/workflows/constants.yaml
-      with:
-        use_release_tag: ${{ inputs.catalyst == 'stable' }}
+    with:
+      use_release_tag: ${{ inputs.catalyst == 'stable' }}
 
   check-config:
     name: Build Configuration

--- a/.github/workflows/constants.yaml
+++ b/.github/workflows/constants.yaml
@@ -7,6 +7,10 @@ on:
         required: false
         default: false
         type: boolean
+      use_release_tag:
+        required: false
+        default: false
+        type: boolean
     outputs:
       llvm_version:
         description: "LLVM version"
@@ -45,6 +49,9 @@ jobs:
     steps:
       - name: Checkout Catalyst repo
         uses: actions/checkout@v3
+      - if: ${{ inputs.use_release_tag }}
+        run: |
+          git checkout $(git tag | sort -V | tail -1)
 
       - name: LLVM version
         id: llvm_version

--- a/.github/workflows/constants.yaml
+++ b/.github/workflows/constants.yaml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout Catalyst repo
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - if: ${{ inputs.use_release_tag }}
         run: |
           git checkout $(git tag | sort -V | tail -1)


### PR DESCRIPTION
The failure stems from our pre-processing action (`constants.yml`) not using the correct Catalyst repo tag when looking for dependency versions. So whenever we update the LLVM version for example the `stable` column would look for the new LLVM version instead of the old one.