### PR TITLE
Bump rc version to 0.35 in tests

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -160,7 +160,7 @@ jobs:
     - name: Install PennyLane (release-candidate)
       if: ${{ inputs.pennylane == 'release-candidate' }}
       run: |
-        pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.34.0-rc0
+        pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.35.0-rc0
 
 
     - name: Add Frontend Dependencies to PATH


### PR DESCRIPTION
Bump the PennyLane release-candidate branch from `v0.34.0` to `v0.35.0` in the test workflow