### PR TITLE
Fix github CI rule: do apt-get update

### DIFF
--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -553,6 +553,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get -y -q install cmake ninja-build libomp-dev lcov libasan5
 
       - name: Install additional dependencies (OpenQasm device)
@@ -612,6 +613,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get -y -q install cmake ninja-build libomp-dev lcov
 
       - name: Build Runtime test suite for Lightning simulator

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -31,6 +31,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get -y -q install ninja-build make cmake clang libomp-dev
 
       - name: Build Catalyst-Runtime

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -103,6 +103,7 @@ jobs:
     - name: Install Deps
       if: steps.cache-llvm-build.outputs.cache-hit != 'true'
       run: |
+        sudo apt-get update
         sudo apt-get install -y python3 python3-pip cmake ninja-build clang lld
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install numpy pybind11
@@ -177,6 +178,7 @@ jobs:
     - name: Install Deps
       if: steps.cache-mhlo.outputs.cache-hit != 'true'
       run: |
+        sudo apt-get update
         sudo apt-get install -y cmake ninja-build clang lld
 
     - name: Build MHLO Dialect
@@ -246,6 +248,7 @@ jobs:
     - name: Install Deps
       if: steps.cache-enzyme-build.outputs.cache-hit != 'true'
       run: |
+        sudo apt-get update
         sudo apt-get install -y cmake ninja-build clang lld
 
     - name: Build Enzyme
@@ -272,6 +275,7 @@ jobs:
 
     - name: Install Deps
       run: |
+        sudo apt-get update
         sudo apt-get install -y python3 python3-pip cmake ninja-build ccache clang lld
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install numpy pybind11
@@ -373,6 +377,7 @@ jobs:
 
     - name: Install Deps
       run: |
+        sudo apt-get update
         sudo apt-get install -y python3 python3-pip libomp-dev libasan6
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
@@ -444,6 +449,7 @@ jobs:
 
     - name: Install Deps
       run: |
+        sudo apt-get update
         sudo apt-get install -y python3 python3-pip libomp-dev libasan6
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
@@ -497,6 +503,7 @@ jobs:
 
     - name: Install Deps
       run: |
+        sudo apt-get update
         sudo apt-get install -y python3 python3-pip libomp-dev libasan6
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt


### PR DESCRIPTION
By this commit we `apt-get update` before installing system dependencies. Running this command is considered a good practice. It will make the upstream link breaks less probable.

An error example 
![image](https://github.com/PennyLaneAI/catalyst/assets/4477729/e523c4ef-eeca-4f57-9198-2fbbaa1a6305)
