### PR TITLE
Fix github CI rule: do apt-get update, part 2

### DIFF
--- a/.github/workflows/check-formatting.yaml
+++ b/.github/workflows/check-formatting.yaml
@@ -42,7 +42,9 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run: sudo apt-get -y install clang-format-14 python3
+        run:
+          sudo apt-get update
+          sudo apt-get -y install clang-format-14 python3
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/check-formatting.yaml
+++ b/.github/workflows/check-formatting.yaml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run:
+        run: |
           sudo apt-get update
           sudo apt-get -y install clang-format-14 python3
 

--- a/.github/workflows/check-jax-release.yaml
+++ b/.github/workflows/check-jax-release.yaml
@@ -24,6 +24,7 @@ jobs:
 
     - name: Install deps
       run: |
+        sudo apt-get update
         sudo apt-get install -y cmake ninja-build clang lld libomp-dev
         python3 -m pip install -r requirements.txt
         echo "COMPILER_LAUNCHER=" >> $GITHUB_ENV

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -40,6 +40,7 @@ jobs:
 
     - name: Install deps
       run: |
+        sudo apt-get update
         sudo apt-get install -y cmake ninja-build ccache libomp-dev libasan6 lld
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt


### PR DESCRIPTION
By this commit we `apt-get update` before installing system dependencies. Running this command is considered a good practice. It will make the upstream link breaks less probable.

This is a second PR continuing the [previous one](https://github.com/PennyLaneAI/catalyst/pull/545)