### PR TITLE
Verify static argnums during program capture

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -4,6 +4,7 @@
 
 * Catalyst now supports just-in-time compilation of static arguments.
   [(#476)](https://github.com/PennyLaneAI/catalyst/pull/476)
+  [(#550)](https://github.com/PennyLaneAI/catalyst/pull/550)
 
   The ``@qjit`` decorator can now be used to compile functions with static arguments with
   the ``static_argnums`` keyword argument. ``static_argnums`` can be an integer or an iterable

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -205,6 +205,7 @@ class QJIT:
             Tuple[Any]: the dynamic argument signature
         """
 
+        self._verify_static_argnums(args)
         static_argnums = self.compile_options.static_argnums
         abstracted_axes = self.compile_options.abstracted_axes
 
@@ -297,11 +298,10 @@ class QJIT:
         if not hasattr(self.original_function, "__name__"):
             self.__name__ = "unknown"  # allow these cases anyways?
 
-        # TODO: remove bug since this only works with user-provided signatures
-        parameter_types = self.user_sig or ()
+    def _verify_static_argnums(self, args):
         for argnum in self.compile_options.static_argnums:
-            if argnum < 0 or argnum >= len(parameter_types):
-                msg = f"argnum {argnum} is beyond the valid range of [0, {len(parameter_types)})."
+            if argnum < 0 or argnum >= len(args):
+                msg = f"argnum {argnum} is beyond the valid range of [0, {len(args)})."
                 raise CompileError(msg)
 
     def _get_workspace(self):


### PR DESCRIPTION
The previous implementation verified the argnums during QJIT
construction, which only works if the number of arguments is known
ahead of time.

closes #548 