### PR TITLE
Adds map_wires to QCtrl

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -309,6 +309,9 @@
 
 <h3>Bug fixes</h3>
 
+* `QCtrl` now implements `map_wires`.
+  [(#555)](https://github.com/PennyLaneAI/catalyst/pull/555)
+
 * Catalyst will no longer print a warning that recompilation is triggered when a `@qjit` decorated
   function with no arguments is invoke without having been compiled first, for example via the use
   of `target="mlir"`.

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -312,6 +312,9 @@
 * `QCtrl` now implements `map_wires`.
   [(#555)](https://github.com/PennyLaneAI/catalyst/pull/555)
 
+  Applying `map_wires` to `QCtrl` lead to an incorrect circuit.
+  The wires in the nested regions remained unchanged.
+
 * Catalyst will no longer print a warning that recompilation is triggered when a `@qjit` decorated
   function with no arguments is invoke without having been compiled first, for example via the use
   of `target="mlir"`.

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -1091,16 +1091,6 @@ class Adjoint(HybridOp):
 class QCtrl(HybridOp):
     """Catalyst quantum ctrl operation"""
 
-    def map_wires(self, wire_map):
-        """Map wires to new wires according to wire_map"""
-        new_ops = []
-        for op in self.regions[0].quantum_tape.operations:
-            new_ops.append(op.map_wires(wire_map))
-        self.regions[0].quantum_tape = QuantumTape(new_ops, [])
-        self._control_wires = [wire_map.get(wire, wire) for wire in self._control_wires]
-        self._work_wires = [wire_map.get(wire, wire) for wire in self._work_wires]
-        return self
-
     def __init__(self, *args, control_wires, control_values=None, work_wires=None, **kwargs):
         self._control_wires = qml.wires.Wires(control_wires)
         self._work_wires = qml.wires.Wires([] if work_wires is None else work_wires)
@@ -1156,6 +1146,16 @@ class QCtrl(HybridOp):
     def work_wires(self):
         """Optional wires that can be used in the expansion of this op."""
         return self._work_wires
+
+    def map_wires(self, wire_map):
+        """Map wires to new wires according to wire_map"""
+        new_ops = []
+        for op in self.regions[0].quantum_tape.operations:
+            new_ops.append(op.map_wires(wire_map))
+        self.regions[0].quantum_tape = QuantumTape(new_ops, [])
+        self._control_wires = [wire_map.get(wire, wire) for wire in self._control_wires]
+        self._work_wires = [wire_map.get(wire, wire) for wire in self._work_wires]
+        return self
 
 
 def qctrl_distribute(

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -1097,8 +1097,8 @@ class QCtrl(HybridOp):
         for op in self.regions[0].quantum_tape.operations:
             new_ops.append(op.map_wires(wire_map))
         self.regions[0].quantum_tape = QuantumTape(new_ops, [])
-        self._control_wires = [wire_map[wire] for wire in self._control_wires]
-        self._work_wires = [wire_map[wire] for wire in self._work_wires]
+        self._control_wires = [wire_map.get(wire, wire) for wire in self._control_wires]
+        self._work_wires = [wire_map.get(wire, wire) for wire in self._work_wires]
         return self
 
     def __init__(self, *args, control_wires, control_values=None, work_wires=None, **kwargs):

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -1091,6 +1091,16 @@ class Adjoint(HybridOp):
 class QCtrl(HybridOp):
     """Catalyst quantum ctrl operation"""
 
+    def map_wires(self, wire_map):
+        """Map wires to new wires according to wire_map"""
+        new_ops = []
+        for op in self.regions[0].quantum_tape.operations:
+            new_ops.append(op.map_wires(wire_map))
+        self.regions[0].quantum_tape = QuantumTape(new_ops, [])
+        self._control_wires = [wire_map[wire] for wire in self._control_wires]
+        self._work_wires = [wire_map[wire] for wire in self._work_wires]
+        return self
+
     def __init__(self, *args, control_wires, control_values=None, work_wires=None, **kwargs):
         self._control_wires = qml.wires.Wires(control_wires)
         self._work_wires = qml.wires.Wires([] if work_wires is None else work_wires)

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -426,7 +426,7 @@ def test_qctrl_wires_controlflow(backend):
     assert circuit(0.1, 0, 2, 2) == qml.wires.Wires([2, 0, 1])
 
 
-def test_map_wires(backend):
+def test_map_wires():
     """Test map wires."""
 
     X = HybridOpRegion(
@@ -439,7 +439,7 @@ def test_map_wires(backend):
         control_wires=[0], regions=[X], in_classical_tracers=[], out_classical_tracers=[0]
     )
     new_qctrl = qctrl.map_wires({1: 0, 0: 1})
-    assert new_qctrl._control_wires == [1]
+    assert new_qctrl._control_wires == [1]  # pylint: disable=protected-access
     assert new_qctrl.regions[0].quantum_tape.operations[0].wires == Wires([0])
 
 


### PR DESCRIPTION
**Context:** `QCtrl` lacked an implementation of `map_wires`.

**Description of the Change:** Implements `map_wires` for `QCtrl`.

**Benefits:** `QCtrl` can be used with `map_wires`.

[sc-57731]
