### PR TITLE
[Runtime] Add GlobalPhase gate

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -292,7 +292,7 @@ jobs:
               -DPYTHON_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -Dpybind11_DIR=$(python${{ matrix.python_version }} -c "import pybind11; print(pybind11.get_cmake_dir())") \
               -DENABLE_LIGHTNING_KOKKOS=ON \
-              -DLIGHTNING_GIT_TAG="2716864521c539429bd382b92151a918d1a076ce" \
+              -DLIGHTNING_GIT_TAG="efb946a736f824835ebf4fd692568d49e6cf1ca5" \
               -DKokkos_ENABLE_SERIAL=ON \
               -DKokkos_ENABLE_OPENMP=ON \
               -DENABLE_WARNINGS=OFF \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -289,7 +289,7 @@ jobs:
               -DPYTHON_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -Dpybind11_DIR=$(python${{ matrix.python_version }} -c "import pybind11; print(pybind11.get_cmake_dir())") \
               -DENABLE_LIGHTNING_KOKKOS=ON \
-              -DLIGHTNING_GIT_TAG="2716864521c539429bd382b92151a918d1a076ce" \
+              -DLIGHTNING_GIT_TAG="efb946a736f824835ebf4fd692568d49e6cf1ca5" \
               -DKokkos_ENABLE_SERIAL=ON \
               -DKokkos_ENABLE_OPENMP=ON \
               -DKokkos_ENABLE_COMPLEX_ALIGN=OFF \

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -261,7 +261,7 @@ jobs:
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$GITHUB_WORKSPACE/runtime-build/lib \
               -DPYTHON_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -Dpybind11_DIR=$(python${{ matrix.python_version }} -c "import pybind11; print(pybind11.get_cmake_dir())") \
-              -DLIGHTNING_GIT_TAG="2716864521c539429bd382b92151a918d1a076ce" \
+              -DLIGHTNING_GIT_TAG="efb946a736f824835ebf4fd692568d49e6cf1ca5" \
               -DENABLE_LIGHTNING_KOKKOS=ON \
               -DKokkos_ENABLE_SERIAL=ON \
               -DKokkos_ENABLE_OPENMP=OFF \

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -53,6 +53,9 @@
 
 <h3>Improvements</h3>
 
+* Add support for `GlobalPhase` gate in the runtime.
+  [(#558)](https://github.com/PennyLaneAI/catalyst/pull/558)
+
 * Catalyst no longer relies on a TensorFlow installation for its AutoGraph functionality. Instead,
   the standalone `diastatic-malt` package is used and automatically installed as a dependency.
   [(#401)](https://github.com/PennyLaneAI/catalyst/pull/401)

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -730,7 +730,7 @@ def _qinst_lowering(
     name_str = str(name_attr)
     name_str = name_str.replace('"', "")
 
-    if name_str == "MultiRZ" or name_str == "GlobalPhase":
+    if name_str in {"MultiRZ", "GlobalPhase"}:
         assert len(float_params) == 1, f"{name_str} takes one float parameter"
         float_param = float_params[0]
         return MultiQubitOp(

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -50,7 +50,7 @@ from mlir_quantum.dialects.quantum import (
     HermitianOp,
     InsertOp,
     MeasureOp,
-    MultiRZOp,
+    MultiQubitOp,
     NamedObsOp,
     ProbsOp,
     QubitUnitaryOp,
@@ -730,10 +730,12 @@ def _qinst_lowering(
     name_str = str(name_attr)
     name_str = name_str.replace('"', "")
 
-    if name_str == "MultiRZ":
-        assert len(float_params) == 1, "MultiRZ takes one float parameter"
+    if name_str == "MultiRZ" or name_str == "GlobalPhase":
+        assert len(float_params) == 1, f"{name_str} takes one float parameter"
         float_param = float_params[0]
-        return MultiRZOp([qubit.type for qubit in qubits], float_param, qubits).results
+        return MultiQubitOp(
+            [qubit.type for qubit in qubits], float_param, qubits, name_attr
+        ).results
 
     return CustomOp([qubit.type for qubit in qubits], float_params, qubits, name_attr).results
 

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -544,10 +544,12 @@ def pauli_word_to_tensor_obs(obs, qrp: QRegPromise) -> List[DynamicJaxprTracer]:
 
 @transform
 def add_wires_to_global_phase(tape: QuantumTape) -> (Sequence[QuantumTape], Callable):
+    """Transform to add wires to global phase"""
     return _add_wires_to_global_phase(tape)
 
 
 def _add_wires_to_global_phase(tape: QuantumTape) -> (Sequence[QuantumTape], Callable):
+    """Actual implementation. Useful to be able to call without warning."""
     new_ops = []
 
     for op in tape.operations:
@@ -560,7 +562,7 @@ def _add_wires_to_global_phase(tape: QuantumTape) -> (Sequence[QuantumTape], Cal
                 # the GlobalPhase. I think this is good enough.
                 inner_tape = region.quantum_tape
                 # This is needed to avoid an error
-                inner_tapes, inner_res = _add_wires_to_global_phase(inner_tape)
+                inner_tapes, _ = _add_wires_to_global_phase(inner_tape)
                 inner_tape = inner_tapes[0]
                 region.quantum_tape = inner_tape
 

--- a/frontend/catalyst/qjit_device.py
+++ b/frontend/catalyst/qjit_device.py
@@ -77,6 +77,7 @@ class QJITDevice(qml.QubitDevice):
         "QubitUnitary",
         "ISWAP",
         "PSWAP",
+        "GlobalPhase",
     }
 
     @staticmethod

--- a/frontend/test/lit/test_custom_ops.py
+++ b/frontend/test/lit/test_custom_ops.py
@@ -102,11 +102,11 @@ def compile_circuit_with_device(device):
 
 # CHECK-LABEL: public @jit_f
 # CHECK-NOT: RXX
-# CHECK: multirz
+# CHECK: multi "MultiRZ"
 # CHECK-NOT: RXX
 compile_circuit_with_device(devMultiRZ)
 # CHECK-LABEL: public @jit_f
-# CHECK-NOT: multirz
+# CHECK-NOT: multi "MultiRZ"
 # CHECK: RXX
-# CHECK-NOT: multirz
+# CHECK-NOT: multi "MultiRZ"
 compile_circuit_with_device(devRXX)

--- a/frontend/test/lit/test_multi_qubit_gates.py
+++ b/frontend/test/lit/test_multi_qubit_gates.py
@@ -31,7 +31,7 @@ def circuit(x: float):
     # CHECK: {{%.+}} = quantum.custom "CSWAP"() {{.+}} : !quantum.bit, !quantum.bit, !quantum.bit
     qml.CSWAP(wires=[0, 1, 2])
     # pylint: disable=line-too-long
-    # CHECK: {{%.+}} = quantum.multirz({{%.+}}) {{%.+}}, {{%.+}}, {{%.+}}, {{%.+}}, {{%.+}} : !quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit
+    # CHECK: {{%.+}} = quantum.multi "MultiRZ"({{%.+}}) {{%.+}}, {{%.+}}, {{%.+}}, {{%.+}}, {{%.+}} : !quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit
     qml.MultiRZ(x, wires=[0, 1, 2, 3, 4])
     return measure(wires=0)
 

--- a/frontend/test/pytest/test_global_phase.py
+++ b/frontend/test/pytest/test_global_phase.py
@@ -18,7 +18,7 @@ import numpy as np
 import pennylane as qml
 import pytest
 
-from catalyst import qjit, cond
+from catalyst import cond, qjit
 
 
 def test_global_phase(backend):

--- a/frontend/test/pytest/test_global_phase.py
+++ b/frontend/test/pytest/test_global_phase.py
@@ -1,0 +1,57 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Global Phase"""
+
+import numpy as np
+import pennylane as qml
+import pytest
+
+from catalyst import qjit, cond
+
+
+def test_global_phase(backend):
+    """Test vanilla global phase"""
+    dev = qml.device(backend, wires=1)
+
+    @qml.qnode(dev)
+    def qnn():
+        qml.RX(np.pi / 4, wires=[0])
+        qml.GlobalPhase(np.pi / 4)
+        return qml.state()
+
+    expected = qnn()
+    observed = qjit(qnn())
+    assert np.allclose(expected, observed)
+
+
+@pytest.mark.parametrize("inp", [True, False])
+def test_global_phase_in_region(backend, inp):
+    """Test global phase in region"""
+    dev = qml.device(backend, wires=1)
+
+    @qml.qnode(dev)
+    def qnn(c):
+        qml.RX(np.pi / 4, wires=[0])
+
+        @cond(c)
+        def foo():
+            qml.GlobalPhase(np.pi / 4)
+
+        foo()
+        return qml.state()
+
+    expected = qnn(inp)
+    observed = qjit(qnn(inp))
+    assert np.allclose(expected, observed)

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -242,7 +242,7 @@ def CustomOp : Gate_Op<"custom", [AttrSizedOperandSegments, DifferentiableGate]>
     }];
 }
 
-def MultiRZOp : Gate_Op<"multirz", [DifferentiableGate]> {
+def MultiQubitOp : Gate_Op<"multi", [DifferentiableGate]> {
     let summary = "Apply an arbitrary multi Z rotation";
     let description = [{
         The `quantum.multirz` operation applies an arbitrary multi Z rotation to the state-vector.
@@ -252,6 +252,7 @@ def MultiRZOp : Gate_Op<"multirz", [DifferentiableGate]> {
     let arguments = (ins
         F64:$theta,
         Variadic<QubitType>:$in_qubits,
+        StrAttr:$gate_name,
         OptionalAttr<UnitAttr>:$adjoint
     );
 
@@ -260,7 +261,7 @@ def MultiRZOp : Gate_Op<"multirz", [DifferentiableGate]> {
     );
 
     let assemblyFormat = [{
-        `(` $theta `)` $in_qubits attr-dict `:` type($out_qubits)
+        $gate_name `(` $theta `)` $in_qubits attr-dict `:` type($out_qubits)
     }];
 
     let extraClassDeclaration = extraBaseClassDeclaration # [{

--- a/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
@@ -342,6 +342,22 @@ struct CustomOpPattern : public OpConversionPattern<CustomOp> {
         const TypeConverter *conv = getTypeConverter();
         auto modifiersPtr = getModifiersPtr(loc, rewriter, conv, op.getAdjointFlag(), {}, {});
 
+        if (0 == op.getGateName().str().compare("GlobalPhase")) {
+            std::string qirName = "__catalyst__qis__" + op.getGateName().str();
+            SmallVector<Type> argTypes;
+            argTypes.insert(argTypes.end(), adaptor.getParams().getTypes().begin(),
+                            adaptor.getParams().getTypes().end());
+            Type qirSignature = LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(ctx), argTypes);
+            LLVM::LLVMFuncOp fnDecl =
+                ensureFunctionDeclaration(rewriter, op, qirName, qirSignature);
+            SmallVector<Value> args;
+            args.insert(args.end(), adaptor.getParams().begin(), adaptor.getParams().end());
+            rewriter.create<LLVM::CallOp>(loc, fnDecl, args);
+            SmallVector<Value> values;
+            values.insert(values.end(), adaptor.getInQubits().begin(), adaptor.getInQubits().end());
+            rewriter.replaceOp(op, values);
+            return success();
+        }
         std::string qirName = "__catalyst__qis__" + op.getGateName().str();
         SmallVector<Type> argTypes;
         argTypes.insert(argTypes.end(), adaptor.getParams().getTypes().begin(),

--- a/mlir/test/Gradient/ClassicalJacobianTest.mlir
+++ b/mlir/test/Gradient/ClassicalJacobianTest.mlir
@@ -249,7 +249,7 @@ func.func @all_ops_circuit(%arg0: tensor<1xf64>) -> f64 attributes {qnode, diff_
     // CHECK: [[idx:%[a-zA-Z0-9_]+]] = memref.load [[count]]
     // CHECK-NEXT: memref.store [[e0]], [[paramBuffer]][[[idx]]]
     // CHECK-NOT: quantum.
-    %q_2:3 = quantum.multirz(%f0) %q_0, %q_0, %q_0 : !quantum.bit, !quantum.bit, !quantum.bit
+    %q_2:3 = quantum.multi "MultiRZ"(%f0) %q_0, %q_0, %q_0 : !quantum.bit, !quantum.bit, !quantum.bit
 
     func.return %f0 : f64
 }

--- a/mlir/test/Quantum/ConversionTest.mlir
+++ b/mlir/test/Quantum/ConversionTest.mlir
@@ -214,19 +214,19 @@ func.func @multirz(%q0 : !quantum.bit, %p : f64) -> (!quantum.bit, !quantum.bit,
     // CHECK: [[p:%.+]] = llvm.mlir.zero : !llvm.ptr
     // CHECK: [[c1:%.+]] = llvm.mlir.constant(1 : i64)
     // CHECK: llvm.call @__catalyst__qis__MultiRZ(%arg1, [[p]], [[c1]], %arg0)
-    %q1 = quantum.multirz(%p) %q0 : !quantum.bit
+    %q1 = quantum.multi "MultiRZ"(%p) %q0 : !quantum.bit
 
     // CHECK: [[z:%.+]] = llvm.mlir.constant(0 : i64) : i64
     // CHECK: [[p:%.+]] = llvm.mlir.zero : !llvm.ptr
     // CHECK: [[c2:%.+]] = llvm.mlir.constant(2 : i64)
     // CHECK: llvm.call @__catalyst__qis__MultiRZ(%arg1, [[p]], [[c2]], %arg0, %arg0)
-    %q2:2 = quantum.multirz(%p) %q1, %q1 : !quantum.bit, !quantum.bit
+    %q2:2 = quantum.multi "MultiRZ"(%p) %q1, %q1 : !quantum.bit, !quantum.bit
 
     // CHECK: [[z:%.+]] = llvm.mlir.constant(0 : i64) : i64
     // CHECK: [[p:%.+]] = llvm.mlir.zero : !llvm.ptr
     // CHECK: [[c3:%.+]] = llvm.mlir.constant(3 : i64)
     // CHECK: llvm.call @__catalyst__qis__MultiRZ(%arg1, [[p]], [[c3]], %arg0, %arg0, %arg0)
-    %q3:3 = quantum.multirz(%p) %q2#0, %q2#1, %q2#1 : !quantum.bit, !quantum.bit, !quantum.bit
+    %q3:3 = quantum.multi "MultiRZ"(%p) %q2#0, %q2#1, %q2#1 : !quantum.bit, !quantum.bit, !quantum.bit
 
     // CHECK: [[st1:%.+]] = llvm.insertvalue %arg0
     // CHECK: [[st2:%.+]] = llvm.insertvalue %arg0, [[st1]]

--- a/mlir/test/Quantum/VerifierTest.mlir
+++ b/mlir/test/Quantum/VerifierTest.mlir
@@ -69,7 +69,7 @@ func.func @custom(%f : f64, %q1 : !quantum.bit, %q2 : !quantum.bit) {
 
 func.func @multirz1(%theta : f64) {
     // expected-error@+1 {{must have at least 1 qubit}}
-    %err = quantum.multirz(%theta) : !quantum.bit
+    %err = quantum.multi "MultiRZ"(%theta) : !quantum.bit
 
     return
 }
@@ -78,7 +78,7 @@ func.func @multirz1(%theta : f64) {
 
 func.func @multirz2(%q0 : !quantum.bit, %q1 : !quantum.bit, %theta : f64) {
     // expected-error@+1 {{number of qubits in input and output must be the same}}
-    %err = quantum.multirz(%theta) %q0, %q1 : !quantum.bit
+    %err = quantum.multi "MultiRZ"(%theta) %q0, %q1 : !quantum.bit
 
     return
 }
@@ -87,7 +87,7 @@ func.func @multirz2(%q0 : !quantum.bit, %q1 : !quantum.bit, %theta : f64) {
 
 func.func @multirz3(%q0 : !quantum.bit, %theta : f64) {
     // expected-error@+1 {{number of qubits in input and output must be the same}}
-    %err:2 = quantum.multirz(%theta) %q0 : !quantum.bit, !quantum.bit
+    %err:2 = quantum.multi "MultiRZ"(%theta) %q0 : !quantum.bit, !quantum.bit
 
     return
 }

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -15,7 +15,7 @@ ENABLE_LIGHTNING_KOKKOS?=ON
 ENABLE_OPENQASM?=ON
 ENABLE_ASAN?=OFF
 # TODO: Update to v0.35.0 after the next lightning release.
-LIGHTNING_GIT_TAG_VALUE?="2716864521c539429bd382b92151a918d1a076ce"
+LIGHTNING_GIT_TAG_VALUE?="efb946a736f824835ebf4fd692568d49e6cf1ca5"
 NPROC?=$(shell python3 -c "import os; print(os.cpu_count())")
 
 BUILD_TARGETS := rt_capi

--- a/runtime/include/RuntimeCAPI.h
+++ b/runtime/include/RuntimeCAPI.h
@@ -75,7 +75,7 @@ void __catalyst__qis__CRot(double, double, double, QUBIT *, QUBIT *, const Modif
 void __catalyst__qis__CSWAP(QUBIT *, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__Toffoli(QUBIT *, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__MultiRZ(double, const Modifiers *, int64_t, /*qubits*/...);
-void __catalyst__qis__GlobalPhase(double, /* ignored */...);
+void __catalyst__qis__GlobalPhase(double);
 void __catalyst__qis__ISWAP(QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__PSWAP(double, QUBIT *, QUBIT *, const Modifiers *);
 

--- a/runtime/include/RuntimeCAPI.h
+++ b/runtime/include/RuntimeCAPI.h
@@ -75,7 +75,7 @@ void __catalyst__qis__CRot(double, double, double, QUBIT *, QUBIT *, const Modif
 void __catalyst__qis__CSWAP(QUBIT *, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__Toffoli(QUBIT *, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__MultiRZ(double, const Modifiers *, int64_t, /*qubits*/...);
-void __catalyst__qis__GlobalPhase(double);
+void __catalyst__qis__GlobalPhase(double, const Modifiers *, int64_t, /*qubits*/...);
 void __catalyst__qis__ISWAP(QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__PSWAP(double, QUBIT *, QUBIT *, const Modifiers *);
 

--- a/runtime/include/RuntimeCAPI.h
+++ b/runtime/include/RuntimeCAPI.h
@@ -75,6 +75,7 @@ void __catalyst__qis__CRot(double, double, double, QUBIT *, QUBIT *, const Modif
 void __catalyst__qis__CSWAP(QUBIT *, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__Toffoli(QUBIT *, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__MultiRZ(double, const Modifiers *, int64_t, /*qubits*/...);
+void __catalyst__qis__GlobalPhase(double, /* ignored */...);
 void __catalyst__qis__ISWAP(QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__PSWAP(double, QUBIT *, QUBIT *, const Modifiers *);
 

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -377,7 +377,7 @@ void __catalyst__qis__Gradient_params(MemRefT_int64_1d *params, int64_t numResul
     Catalyst::Runtime::getQuantumDevicePtr()->Gradient(mem_views, train_params);
 }
 
-void __catalyst__qis__GlobalPhase(double phi, /* ignored = */...)
+void __catalyst__qis__GlobalPhase(double phi)
 {
     Catalyst::Runtime::getQuantumDevicePtr()->NamedOperation("GlobalPhase", {phi}, {},
                                                              MODIFIERS_ARGS(nullptr));

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -377,12 +377,6 @@ void __catalyst__qis__Gradient_params(MemRefT_int64_1d *params, int64_t numResul
     Catalyst::Runtime::getQuantumDevicePtr()->Gradient(mem_views, train_params);
 }
 
-void __catalyst__qis__GlobalPhase(double phi)
-{
-    Catalyst::Runtime::getQuantumDevicePtr()->NamedOperation("GlobalPhase", {phi}, {},
-                                                             MODIFIERS_ARGS(nullptr));
-}
-
 void __catalyst__qis__Identity(QUBIT *qubit, const Modifiers *modifiers)
 {
     Catalyst::Runtime::getQuantumDevicePtr()->NamedOperation(
@@ -598,6 +592,20 @@ void __catalyst__qis__Toffoli(QUBIT *wire0, QUBIT *wire1, QUBIT *wire2, const Mo
         {reinterpret_cast<QubitIdType>(wire0), reinterpret_cast<QubitIdType>(wire1),
          reinterpret_cast<QubitIdType>(wire2)},
         /* modifiers */ MODIFIERS_ARGS(modifiers));
+}
+
+void __catalyst__qis__GlobalPhase(double phi, const Modifiers *modifiers, int64_t numQubits, ...)
+{
+    va_list args;
+    va_start(args, numQubits);
+    std::vector<QubitIdType> wires(numQubits);
+    for (int64_t i = 0; i < numQubits; i++) {
+        wires[i] = va_arg(args, QubitIdType);
+    }
+    va_end(args);
+
+    Catalyst::Runtime::getQuantumDevicePtr()->NamedOperation("GlobalPhase", {phi}, {wires},
+                                                             MODIFIERS_ARGS(modifiers));
 }
 
 void __catalyst__qis__MultiRZ(double theta, const Modifiers *modifiers, int64_t numQubits, ...)

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -377,6 +377,12 @@ void __catalyst__qis__Gradient_params(MemRefT_int64_1d *params, int64_t numResul
     Catalyst::Runtime::getQuantumDevicePtr()->Gradient(mem_views, train_params);
 }
 
+void __catalyst__qis__GlobalPhase(double phi, /* ignored = */...)
+{
+    Catalyst::Runtime::getQuantumDevicePtr()->NamedOperation("GlobalPhase", {phi}, {},
+                                                             MODIFIERS_ARGS(nullptr));
+}
+
 void __catalyst__qis__Identity(QUBIT *qubit, const Modifiers *modifiers)
 {
     Catalyst::Runtime::getQuantumDevicePtr()->NamedOperation(

--- a/runtime/tests/Test_LightningCoreQIS.cpp
+++ b/runtime/tests/Test_LightningCoreQIS.cpp
@@ -603,6 +603,31 @@ TEST_CASE("Test __catalyst__qis__ CRot, IsingXY and Toffoli", "[CoreQIS]")
     __catalyst__rt__finalize();
 }
 
+TEST_CASE("Test __catalyst__qis__ GlobalPhase", "[CoreQIS]")
+{
+    for (const auto &[rtd_lib, rtd_name, rtd_kwargs] : getDevices()) {
+        __catalyst__rt__initialize();
+        __catalyst__rt__device_init((int8_t *)rtd_lib.c_str(), (int8_t *)rtd_name.c_str(),
+                                    (int8_t *)rtd_kwargs.c_str());
+
+        QirArray *qs = __catalyst__rt__qubit_allocate_array(1);
+
+        __catalyst__qis__GlobalPhase(M_PI / 4);
+
+        MemRefT_CplxT_double_1d result = getState(2);
+        __catalyst__qis__State(&result, 0);
+        CplxT_double *state = result.data_allocated;
+
+        CHECK((state[0].real == Approx(0.70710678).margin(1e-5) &&
+               state[0].imag == Approx(-0.70710678).margin(1e-5)));
+
+        freeState(result);
+        __catalyst__rt__qubit_release_array(qs);
+        __catalyst__rt__device_release();
+        __catalyst__rt__finalize();
+    }
+}
+
 TEST_CASE("Test __catalyst__qis__ Hadamard, PauliX, IsingYY, CRX, and Expval", "[CoreQIS]")
 {
     for (const auto &[rtd_lib, rtd_name, rtd_kwargs] : getDevices()) {

--- a/runtime/tests/Test_LightningCoreQIS.cpp
+++ b/runtime/tests/Test_LightningCoreQIS.cpp
@@ -611,8 +611,9 @@ TEST_CASE("Test __catalyst__qis__ GlobalPhase", "[CoreQIS]")
                                     (int8_t *)rtd_kwargs.c_str());
 
         QirArray *qs = __catalyst__rt__qubit_allocate_array(1);
+        QUBIT **q0 = (QUBIT **)__catalyst__rt__array_get_element_ptr_1d(qs, 0);
 
-        __catalyst__qis__GlobalPhase(M_PI / 4);
+        __catalyst__qis__GlobalPhase(M_PI / 4, NO_MODIFIERS, 1, *q0);
 
         MemRefT_CplxT_double_1d result = getState(2);
         __catalyst__qis__State(&result, 0);


### PR DESCRIPTION
**Context:** Catalyst lacked a GlobalPhase. This means that the GlobalPhase gate was decomposed, but the decomposition does not preserve the GlobalPhase. 

**Description of the Change:** Generalize MultiRZOp gate into MultiQubitOp. Implement GlobalPhase as a special case of MultiQubitOp.

**Benefits:** Matches the execution of gates in PL-lightning.

[sc-57732]
