### PR TITLE
Global Phase Gate

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -376,14 +376,14 @@ jobs:
       run: |
         python${{ matrix.python_version }} -m pip install pytest pytest-xdist
 
-    - name: Install Catalyst
-      run: |
-        python${{ matrix.python_version }} -m pip install $GITHUB_WORKSPACE/dist/*.whl --extra-index-url https://test.pypi.org/simple
-
     - name: Install PennyLane Plugins
       run: |
         python${{ matrix.python_version }} -m pip install PennyLane-Lightning-Kokkos
         python${{ matrix.python_version }} -m pip install amazon-braket-pennylane-plugin "boto3==1.26"
+
+    - name: Install Catalyst
+      run: |
+        python${{ matrix.python_version }} -m pip install $GITHUB_WORKSPACE/dist/*.whl --extra-index-url https://test.pypi.org/simple
 
     - name: Run Python Pytest Tests
       run: |

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,4 +1,4 @@
-# Release 0.5.0-dev
+# Release 0.5.0
 
 <h3>New features</h3>
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -89,6 +89,8 @@
   >>> catalyst.qjit(catalyst.grad(f))(x)
   [1. 0. 1. 0.]
   ```
+* Add support for `GlobalPhase` gate in the runtime.
+  [(#563)](https://github.com/PennyLaneAI/catalyst/pull/563)
 
 * Catalyst no longer relies on a TensorFlow installation for its AutoGraph functionality. Instead,
   the standalone `diastatic-malt` package is used and automatically installed as a dependency.

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.5.0-dev"
+__version__ = "0.5.0"

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -679,30 +679,48 @@ def _qinsert_lowering(
     qreg_type = ir.OpaqueType.get("quantum", "reg", ctx)
     return InsertOp(qreg_type, qreg_old, qubit, idx=qubit_idx).results
 
+
 #
 # gphase
 #
 @gphase_p.def_abstract_eval
-def _gphase_abstract_eval(*qubits_or_params, qubits_len=None):
-    """This operation returns qubits in JAX"""
+def _gphase_abstract_eval(
+    *qubits_or_params, op=None, qubits_len: int = 0, params_len: int = 0, ctrl_len: int = 0
+):
+    # The signature here is: (using * to denote zero or more)
+    # qubits*, params*, ctrl_qubits*, ctrl_values*
     qubits = qubits_or_params[:qubits_len]
-    for qubit in qubits:
+    ctrl_qubits = qubits_or_params[-2 * ctrl_len : -ctrl_len]
+    all_qubits = qubits + ctrl_qubits
+    for idx in range(qubits_len + ctrl_len):
+        qubit = all_qubits[idx]
         assert isinstance(qubit, AbstractQbit)
-    return (AbstractQbit(),) * len(qubits)
+    return (AbstractQbit(),) * (qubits_len + ctrl_len)
+
 
 @qinst_p.def_impl
-def _gphase_abstract_eval(*qubits_or_params):
+def _gphase_abstract_eval(
+    *qubits_or_params, op=None, qubits_len: int = 0, params_len: int = 0, ctrl_len: int = 0
+):
     """Not implemented"""
     raise NotImplementedError()
 
+
 def _gphase_lowering(
-    jax_ctx: mlir.LoweringRuleContext, *qubits_or_params: tuple, qubits_len=None
+    jax_ctx: mlir.LoweringRuleContext,
+    *qubits_or_params,
+    op=None,
+    qubits_len: int = 0,
+    params_len: int = 0,
+    ctrl_len: int = 0,
 ):
     ctx = jax_ctx.module_context.context
     ctx.allow_unregistered_dialects = True
 
-    # We don't care about qubits
-    params = qubits_or_params[qubits_len:]
+    qubits = qubits_or_params[:qubits_len]
+    params = qubits_or_params[qubits_len : qubits_len + params_len]
+    ctrl_qubits = qubits_or_params[qubits_len + params_len : qubits_len + params_len + ctrl_len]
+    ctrl_values = qubits_or_params[qubits_len + params_len + ctrl_len :]
 
     float_params = []
     assert 1 == len(params), "Only one param in GlobalPhase"
@@ -723,9 +741,19 @@ def _gphase_lowering(
 
         float_params.append(p)
 
-    GlobalPhaseOp(float_params[0])
-    qubits = qubits_or_params[:qubits_len]
-    return qubits
+    ctrl_values_i1 = []
+    for v in ctrl_values:
+        p = TensorExtractOp(ir.IntegerType.get_signless(1), v, []).result
+        ctrl_values_i1.append(p)
+
+    GlobalPhaseOp(
+        params=float_params[0],
+        out_ctrl_qubits=[qubit.type for qubit in ctrl_qubits],
+        in_ctrl_qubits=ctrl_qubits,
+        in_ctrl_values=ctrl_values_i1,
+    )
+    return qubits + ctrl_qubits
+
 
 #
 # qinst

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -684,8 +684,11 @@ def _qinsert_lowering(
 #
 @gphase_p.def_abstract_eval
 def _gphase_abstract_eval(*qubits_or_params, qubits_len=None):
-    """This operation returns nothing"""
-    return tuple()
+    """This operation returns qubits in JAX"""
+    qubits = qubits_or_params[:qubits_len]
+    for qubit in qubits:
+        assert isinstance(qubit, AbstractQbit)
+    return (AbstractQbit(),) * len(qubits)
 
 @qinst_p.def_impl
 def _gphase_abstract_eval(*qubits_or_params):
@@ -721,7 +724,8 @@ def _gphase_lowering(
         float_params.append(p)
 
     GlobalPhaseOp(float_params[0])
-    return tuple()
+    qubits = qubits_or_params[:qubits_len]
+    return qubits
 
 #
 # qinst

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -117,7 +117,7 @@ KNOWN_NAMED_OBS = (qml.Identity, qml.PauliX, qml.PauliY, qml.PauliZ, qml.Hadamar
 # Take care when adding primitives to this set in order to avoid introducing a quadratic number of
 # edges to the jaxpr equation graph in ``sort_eqns()``. Each equation with a primitive in this set
 # is constrained to occur before all subsequent equations in the quantum operations trace.
-FORCED_ORDER_PRIMITIVES = {qdevice_p}
+FORCED_ORDER_PRIMITIVES = {qdevice_p, gphase_p}
 
 PAULI_NAMED_MAP = {
     "I": "Identity",

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -211,6 +211,9 @@ class QRegPromise:
         for w in wires:
             if w in qrp.cache:
                 qubit = qrp.cache[w]
+                assert (
+                    qubit is not None
+                ), f"Attempting to extract wire {w} from register {qrp.base} for the second time"
                 qubits.append(qubit)
                 if not allow_reuse:
                     qrp.cache[w] = None

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -445,8 +445,8 @@ def trace_quantum_tape(
                 params_len=len(op.parameters),
                 ctrl_len=len(controlled_qubits),
             )
-            qrp.insert(op.wires, qubits2[:len(qubits))
-            qrp.insert(controlled_wires, qubits2[len(qubits) :)
+            qrp.insert(op.wires, qubits2[: len(qubits)])
+            qrp.insert(controlled_wires, qubits2[len(qubits) :])
         else:
             qubits = qrp.extract(op.wires)
             controlled_qubits = qrp.extract(controlled_wires)

--- a/frontend/catalyst/qjit_device.py
+++ b/frontend/catalyst/qjit_device.py
@@ -77,6 +77,7 @@ class QJITDevice(qml.QubitDevice):
         "QubitUnitary",
         "ISWAP",
         "PSWAP",
+        "GlobalPhase",
     }
 
     @staticmethod

--- a/frontend/test/pytest/test_global_phase.py
+++ b/frontend/test/pytest/test_global_phase.py
@@ -59,6 +59,10 @@ def test_global_phase_in_region(backend, inp):
 
 def test_global_phase_control(backend):
     """Test global phase controlled"""
+
+    if backend == "lightning.kokkos":
+        pytest.skip("control phase is unsupported in kokkos or at least its toml file.")
+
     dev = qml.device(backend, wires=2)
 
     @qml.qnode(dev)

--- a/frontend/test/pytest/test_global_phase.py
+++ b/frontend/test/pytest/test_global_phase.py
@@ -46,12 +46,27 @@ def test_global_phase_in_region(backend, inp):
         qml.RX(np.pi / 4, wires=[0])
 
         @cond(c)
-        def foo():
+        def cir():
             qml.GlobalPhase(np.pi / 4)
 
-        foo()
+        cir()
         return qml.state()
 
     expected = qnn(inp)
     observed = qjit(qnn)(inp)
+    assert np.allclose(expected, observed)
+
+
+def test_global_phase_control(backend):
+    """Test global phase controlled"""
+    dev = qml.device(backend, wires=2)
+
+    @qml.qnode(dev)
+    def qnn():
+        qml.RX(np.pi / 4, wires=[0])
+        qml.ctrl(qml.GlobalPhase(np.pi / 4), control=[0])
+        return qml.state()
+
+    expected = qnn()
+    observed = qjit(qnn)()
     assert np.allclose(expected, observed)

--- a/frontend/test/pytest/test_global_phase.py
+++ b/frontend/test/pytest/test_global_phase.py
@@ -1,0 +1,57 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Global Phase"""
+
+import numpy as np
+import pennylane as qml
+import pytest
+
+from catalyst import qjit, cond
+
+
+def test_global_phase(backend):
+    """Test vanilla global phase"""
+    dev = qml.device(backend, wires=1)
+
+    @qml.qnode(dev)
+    def qnn():
+        qml.RX(np.pi / 4, wires=[0])
+        qml.GlobalPhase(np.pi / 4)
+        return qml.state()
+
+    expected = qnn()
+    observed = qjit(qnn())
+    assert np.allclose(expected, observed)
+
+
+@pytest.mark.parametrize("inp", [True, False])
+def test_global_phase_in_region(backend, inp):
+    """Test global phase in region"""
+    dev = qml.device(backend, wires=1)
+
+    @qml.qnode(dev)
+    def qnn(c):
+        qml.RX(np.pi / 4, wires=[0])
+
+        @cond(c)
+        def foo():
+            qml.GlobalPhase(np.pi / 4)
+
+        foo()
+        return qml.state()
+
+    expected = qnn(inp)
+    observed = qjit(qnn(inp))
+    assert np.allclose(expected, observed)

--- a/frontend/test/pytest/test_global_phase.py
+++ b/frontend/test/pytest/test_global_phase.py
@@ -18,7 +18,7 @@ import numpy as np
 import pennylane as qml
 import pytest
 
-from catalyst import qjit, cond
+from catalyst import cond, qjit
 
 
 def test_global_phase(backend):
@@ -32,7 +32,7 @@ def test_global_phase(backend):
         return qml.state()
 
     expected = qnn()
-    observed = qjit(qnn())
+    observed = qjit(qnn)()
     assert np.allclose(expected, observed)
 
 
@@ -53,5 +53,5 @@ def test_global_phase_in_region(backend, inp):
         return qml.state()
 
     expected = qnn(inp)
-    observed = qjit(qnn(inp))
+    observed = qjit(qnn)(inp)
     assert np.allclose(expected, observed)

--- a/mlir/include/Quantum/IR/QuantumInterfaces.td
+++ b/mlir/include/Quantum/IR/QuantumInterfaces.td
@@ -104,9 +104,6 @@ def QuantumGate : OpInterface<"QuantumGate"> {
     let verify = [{
         auto gate = mlir::cast<ConcreteOp>($_op);
 
-        if (gate.getQubitOperands().size() < 1)
-            return $_op->emitOpError("must have at least 1 qubit");
-
         if (gate.getCtrlValueOperands().size() != gate.getCtrlQubitOperands().size())
             return $_op->emitError() <<
                 "number of controlling qubits in input (" <<
@@ -132,7 +129,7 @@ def QuantumGate : OpInterface<"QuantumGate"> {
     }];
 }
 
-def ParametrizedGate : OpInterface<"ParametrizedGate", []> {
+def ParametrizedGate : OpInterface<"ParametrizedGate", [QuantumGate]> {
     let description = [{
         This interface provides a generic way to interact with parametrized
         quantum instructions. These are quantum operations with differentiable

--- a/mlir/include/Quantum/IR/QuantumInterfaces.td
+++ b/mlir/include/Quantum/IR/QuantumInterfaces.td
@@ -132,7 +132,7 @@ def QuantumGate : OpInterface<"QuantumGate"> {
     }];
 }
 
-def ParametrizedGate : OpInterface<"ParametrizedGate", [QuantumGate]> {
+def ParametrizedGate : OpInterface<"ParametrizedGate", []> {
     let description = [{
         This interface provides a generic way to interact with parametrized
         quantum instructions. These are quantum operations with differentiable

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -272,6 +272,33 @@ def CustomOp : Gate_Op<"custom", [DifferentiableGate,
     }];
 }
 
+def GlobalPhaseOp : Quantum_Op<"gphase", [DifferentiableGate]> {
+    let summary = "A generic quantum gate on n qubits with m floating point parameters.";
+    let description = [{
+    }];
+
+    let arguments = (ins
+        Variadic<F64>:$params,
+        OptionalAttr<UnitAttr>:$adjoint
+    );
+
+    let assemblyFormat = [{
+        `(` $params `)` attr-dict
+    }];
+
+    code extraClassDeclaration = [{
+        mlir::ValueRange getAllParams() {
+            return getParams();
+        }
+        bool getAdjointFlag() {
+            return getAdjoint().has_value() ? getAdjoint().value() : false;
+        }
+        void setAdjointFlag(bool adjoint) {
+            setAdjoint(adjoint);
+        };
+    }];
+}
+
 def MultiRZOp : Gate_Op<"multirz", [DifferentiableGate, AttrSizedOperandSegments, AttrSizedResultSegments ]> {
     let summary = "Apply an arbitrary multi Z rotation";
     let description = [{

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -279,6 +279,7 @@ def GlobalPhaseOp : Quantum_Op<"gphase", [DifferentiableGate, AttrSizedOperandSe
 
     let arguments = (ins
         F64:$params,
+        OptionalAttr<UnitAttr>:$adjoint,
         Variadic<QubitType>:$in_ctrl_qubits,
         Variadic<I1>:$in_ctrl_values
     );
@@ -305,8 +306,6 @@ def GlobalPhaseOp : Quantum_Op<"gphase", [DifferentiableGate, AttrSizedOperandSe
 
         std::vector<mlir::Value> getQubitResults() {
             std::vector<mlir::Value> values;
-            values.insert(values.end(), getOutQubits().begin(),
-                          getOutQubits().end());
             values.insert(values.end(), getOutCtrlQubits().begin(),
                           getOutCtrlQubits().end());
             return values;
@@ -323,13 +322,13 @@ def GlobalPhaseOp : Quantum_Op<"gphase", [DifferentiableGate, AttrSizedOperandSe
             return getInCtrlValues();
         }
         mlir::ValueRange getNonCtrlQubitOperands() {
-            return getInQubits();
+            return mlir::ValueRange();
         }
         mlir::ValueRange getCtrlQubitOperands() {
             return getInCtrlQubits();
         }
         mlir::ValueRange getNonCtrlQubitResults() {
-            return getOutQubits();
+            return mlir::ValueRange();
         }
         mlir::ValueRange getCtrlQubitResults() {
             return getOutCtrlQubits();

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -272,40 +272,72 @@ def CustomOp : Gate_Op<"custom", [DifferentiableGate,
     }];
 }
 
-def GlobalPhaseOp : Quantum_Op<"gphase", [DifferentiableGate]> {
-    let summary = "A generic quantum gate on n qubits with m floating point parameters.";
+def GlobalPhaseOp : Quantum_Op<"gphase", [DifferentiableGate, AttrSizedOperandSegments]> {
+    let summary = "Global Phase.";
     let description = [{
     }];
 
     let arguments = (ins
         F64:$params,
-        OptionalAttr<UnitAttr>:$adjoint
+        Variadic<QubitType>:$in_ctrl_qubits,
+        Variadic<I1>:$in_ctrl_values
+    );
+
+    let results = (outs
+        Variadic<QubitType>:$out_ctrl_qubits
     );
 
     let assemblyFormat = [{
-        `(` $params `)` attr-dict
+        `(` $params `)` attr-dict ( `ctrls` `(` $in_ctrl_qubits^ `)` )?  ( `ctrlvals` `(` $in_ctrl_values^ `)` )? `:` (`ctrls` type($out_ctrl_qubits)^ )?
     }];
 
-    code extraClassDeclaration = [{
-
-        mlir::ValueRange getQubitOperands() {
-            return mlir::ValueRange();
-        }
-
-        mlir::ValueRange getQubitResults() {
-            return mlir::ValueRange();
-        }
-
+    code extraBaseClassDeclaration = [{
         mlir::ValueRange getAllParams() {
-            return getParams();
+            return getODSOperands(getParamOperandIdx());
         }
+
+        std::vector<mlir::Value> getQubitOperands() {
+            std::vector<mlir::Value> values;
+            values.insert(values.end(), getInCtrlQubits().begin(),
+                          getInCtrlQubits().end());
+            return values;
+        }
+
+        std::vector<mlir::Value> getQubitResults() {
+            std::vector<mlir::Value> values;
+            values.insert(values.end(), getOutQubits().begin(),
+                          getOutQubits().end());
+            values.insert(values.end(), getOutCtrlQubits().begin(),
+                          getOutCtrlQubits().end());
+            return values;
+        }
+
         bool getAdjointFlag() {
             return getAdjoint().has_value() ? getAdjoint().value() : false;
         }
         void setAdjointFlag(bool adjoint) {
             setAdjoint(adjoint);
         };
+
+        mlir::ValueRange getCtrlValueOperands() {
+            return getInCtrlValues();
+        }
+        mlir::ValueRange getNonCtrlQubitOperands() {
+            return getInQubits();
+        }
+        mlir::ValueRange getCtrlQubitOperands() {
+            return getInCtrlQubits();
+        }
+        mlir::ValueRange getNonCtrlQubitResults() {
+            return getOutQubits();
+        }
+        mlir::ValueRange getCtrlQubitResults() {
+            return getOutCtrlQubits();
+        }
     }];
+
+    let extraClassDeclaration = extraBaseClassDeclaration;
+
 }
 
 def MultiRZOp : Gate_Op<"multirz", [DifferentiableGate, AttrSizedOperandSegments, AttrSizedResultSegments ]> {

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -287,6 +287,15 @@ def GlobalPhaseOp : Quantum_Op<"gphase", [DifferentiableGate]> {
     }];
 
     code extraClassDeclaration = [{
+
+        mlir::ValueRange getQubitOperands() {
+            return mlir::ValueRange();
+        }
+
+        mlir::ValueRange getQubitResults() {
+            return mlir::ValueRange();
+        }
+
         mlir::ValueRange getAllParams() {
             return getParams();
         }

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -278,7 +278,7 @@ def GlobalPhaseOp : Quantum_Op<"gphase", [DifferentiableGate]> {
     }];
 
     let arguments = (ins
-        Variadic<F64>:$params,
+        F64:$params,
         OptionalAttr<UnitAttr>:$adjoint
     );
 

--- a/mlir/lib/Gradient/Transforms/GradMethods/ClassicalJacobian.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/ClassicalJacobian.cpp
@@ -172,9 +172,7 @@ func::FuncOp genSplitPreprocessed(PatternRewriter &rewriter, Location loc, func:
                     rewriter.create<memref::StoreOp>(loc, paramIdx, paramsProcessed);
                 }
 
-                if (auto g = dyn_cast<quantum::QuantumGate>(op)) {
-                    rewriter.replaceOp(op, g.getQubitOperands());
-                }
+                rewriter.replaceOp(op, gate.getQubitOperands());
             }
             // Any other gates or quantum instructions also need to be stripped.
             // Measurements are handled separately.
@@ -268,9 +266,7 @@ func::FuncOp genArgMapFunction(PatternRewriter &rewriter, Location loc, func::Fu
                     rewriter.create<memref::StoreOp>(loc, paramIdx, paramsProcessed);
                 }
 
-                if (auto g = dyn_cast<quantum::QuantumGate>(op)) {
-                    rewriter.replaceOp(op, g.getQubitOperands());
-                }
+                rewriter.replaceOp(op, gate.getQubitOperands());
             }
             // Any other gates or quantum instructions also need to be stripped.
             // Measurements are handled separately.

--- a/mlir/lib/Gradient/Transforms/GradMethods/ClassicalJacobian.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/ClassicalJacobian.cpp
@@ -172,7 +172,9 @@ func::FuncOp genSplitPreprocessed(PatternRewriter &rewriter, Location loc, func:
                     rewriter.create<memref::StoreOp>(loc, paramIdx, paramsProcessed);
                 }
 
-                rewriter.replaceOp(op, gate.getQubitOperands());
+                if (auto g = dyn_cast<quantum::QuantumGate>(op)) {
+                    rewriter.replaceOp(op, g.getQubitOperands());
+                }
             }
             // Any other gates or quantum instructions also need to be stripped.
             // Measurements are handled separately.
@@ -266,7 +268,9 @@ func::FuncOp genArgMapFunction(PatternRewriter &rewriter, Location loc, func::Fu
                     rewriter.create<memref::StoreOp>(loc, paramIdx, paramsProcessed);
                 }
 
-                rewriter.replaceOp(op, gate.getQubitOperands());
+                if (auto g = dyn_cast<quantum::QuantumGate>(op)) {
+                    rewriter.replaceOp(op, g.getQubitOperands());
+                }
             }
             // Any other gates or quantum instructions also need to be stripped.
             // Measurements are handled separately.

--- a/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
@@ -406,6 +406,7 @@ struct GlobalPhaseOpPattern : public OpConversionPattern<GlobalPhaseOp> {
         args.insert(args.begin() + 1, modifiersPtr);
 
         rewriter.create<LLVM::CallOp>(loc, fnDecl, args);
+        rewriter.eraseOp(op);
 
         return success();
     }

--- a/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
@@ -378,7 +378,8 @@ struct GlobalPhaseOpPattern : public OpConversionPattern<GlobalPhaseOp> {
         Location loc = op.getLoc();
         MLIRContext *ctx = getContext();
         const TypeConverter *conv = getTypeConverter();
-        auto modifiersPtr = getModifiersPtr(loc, rewriter, conv, op.getAdjointFlag(), adaptor.getInCtrlQubits(), adaptor.getInCtrlValues());
+        auto modifiersPtr = getModifiersPtr(loc, rewriter, conv, op.getAdjointFlag(),
+                                            adaptor.getInCtrlQubits(), adaptor.getInCtrlValues());
 
         std::string qirName = "__catalyst__qis__GlobalPhase";
         Type qirSignature = LLVM::LLVMFunctionType::get(
@@ -386,8 +387,9 @@ struct GlobalPhaseOpPattern : public OpConversionPattern<GlobalPhaseOp> {
 
         LLVM::LLVMFuncOp fnDecl = ensureFunctionDeclaration(rewriter, op, qirName, qirSignature);
 
-        SmallVector<Value> args = adaptor.getOperands();
-        args.insert(args.begin() + 1, modifiersPtr);
+        SmallVector<Value> args;
+        args.insert(args.end(), adaptor.getParams());
+        args.insert(args.end(), modifiersPtr);
 
         rewriter.create<LLVM::CallOp>(loc, fnDecl, args);
         rewriter.eraseOp(op);

--- a/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
@@ -343,22 +343,6 @@ struct CustomOpPattern : public OpConversionPattern<CustomOp> {
         auto modifiersPtr = getModifiersPtr(loc, rewriter, conv, op.getAdjointFlag(),
                                             adaptor.getInCtrlQubits(), adaptor.getInCtrlValues());
 
-        if (0 == op.getGateName().str().compare("GlobalPhase")) {
-            std::string qirName = "__catalyst__qis__" + op.getGateName().str();
-            SmallVector<Type> argTypes;
-            argTypes.insert(argTypes.end(), adaptor.getParams().getTypes().begin(),
-                            adaptor.getParams().getTypes().end());
-            Type qirSignature = LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(ctx), argTypes);
-            LLVM::LLVMFuncOp fnDecl =
-                ensureFunctionDeclaration(rewriter, op, qirName, qirSignature);
-            SmallVector<Value> args;
-            args.insert(args.end(), adaptor.getParams().begin(), adaptor.getParams().end());
-            rewriter.create<LLVM::CallOp>(loc, fnDecl, args);
-            SmallVector<Value> values;
-            values.insert(values.end(), adaptor.getInQubits().begin(), adaptor.getInQubits().end());
-            rewriter.replaceOp(op, values);
-            return success();
-        }
         std::string qirName = "__catalyst__qis__" + op.getGateName().str();
         SmallVector<Type> argTypes;
         argTypes.insert(argTypes.end(), adaptor.getParams().getTypes().begin(),

--- a/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
@@ -385,6 +385,32 @@ struct CustomOpPattern : public OpConversionPattern<CustomOp> {
     }
 };
 
+struct GlobalPhaseOpPattern : public OpConversionPattern<GlobalPhaseOp> {
+    using OpConversionPattern::OpConversionPattern;
+
+    LogicalResult matchAndRewrite(GlobalPhaseOp op, GlobalPhaseOpAdaptor adaptor,
+                                  ConversionPatternRewriter &rewriter) const override
+    {
+        Location loc = op.getLoc();
+        MLIRContext *ctx = getContext();
+        const TypeConverter *conv = getTypeConverter();
+        auto modifiersPtr = getModifiersPtr(loc, rewriter, conv, op.getAdjointFlag(), {}, {});
+
+        std::string qirName = "__catalyst__qis__GlobalPhase";
+        Type qirSignature = LLVM::LLVMFunctionType::get(
+            LLVM::LLVMVoidType::get(ctx), {Float64Type::get(ctx), modifiersPtr.getType()});
+
+        LLVM::LLVMFuncOp fnDecl = ensureFunctionDeclaration(rewriter, op, qirName, qirSignature);
+
+        SmallVector<Value> args = adaptor.getOperands();
+        args.insert(args.begin() + 1, modifiersPtr);
+
+        rewriter.create<LLVM::CallOp>(loc, fnDecl, args);
+
+        return success();
+    }
+};
+
 struct MultiRZOpPattern : public OpConversionPattern<MultiRZOp> {
     using OpConversionPattern::OpConversionPattern;
 
@@ -882,6 +908,7 @@ void populateQIRConversionPatterns(TypeConverter &typeConverter, RewritePatternS
     patterns.add<InsertOpPattern>(typeConverter, patterns.getContext());
     patterns.add<CustomOpPattern>(typeConverter, patterns.getContext());
     patterns.add<MultiRZOpPattern>(typeConverter, patterns.getContext());
+    patterns.add<GlobalPhaseOpPattern>(typeConverter, patterns.getContext());
     patterns.add<QubitUnitaryOpPattern>(typeConverter, patterns.getContext());
     patterns.add<MeasureOpPattern>(typeConverter, patterns.getContext());
     patterns.add<ComputationalBasisOpPattern>(typeConverter, patterns.getContext());

--- a/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
@@ -378,7 +378,7 @@ struct GlobalPhaseOpPattern : public OpConversionPattern<GlobalPhaseOp> {
         Location loc = op.getLoc();
         MLIRContext *ctx = getContext();
         const TypeConverter *conv = getTypeConverter();
-        auto modifiersPtr = getModifiersPtr(loc, rewriter, conv, op.getAdjointFlag(), {}, {});
+        auto modifiersPtr = getModifiersPtr(loc, rewriter, conv, op.getAdjointFlag(), adaptor.getInCtrlQubits(), adaptor.getInCtrlValues());
 
         std::string qirName = "__catalyst__qis__GlobalPhase";
         Type qirSignature = LLVM::LLVMFunctionType::get(

--- a/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
@@ -343,6 +343,22 @@ struct CustomOpPattern : public OpConversionPattern<CustomOp> {
         auto modifiersPtr = getModifiersPtr(loc, rewriter, conv, op.getAdjointFlag(),
                                             adaptor.getInCtrlQubits(), adaptor.getInCtrlValues());
 
+        if (0 == op.getGateName().str().compare("GlobalPhase")) {
+            std::string qirName = "__catalyst__qis__" + op.getGateName().str();
+            SmallVector<Type> argTypes;
+            argTypes.insert(argTypes.end(), adaptor.getParams().getTypes().begin(),
+                            adaptor.getParams().getTypes().end());
+            Type qirSignature = LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(ctx), argTypes);
+            LLVM::LLVMFuncOp fnDecl =
+                ensureFunctionDeclaration(rewriter, op, qirName, qirSignature);
+            SmallVector<Value> args;
+            args.insert(args.end(), adaptor.getParams().begin(), adaptor.getParams().end());
+            rewriter.create<LLVM::CallOp>(loc, fnDecl, args);
+            SmallVector<Value> values;
+            values.insert(values.end(), adaptor.getInQubits().begin(), adaptor.getInQubits().end());
+            rewriter.replaceOp(op, values);
+            return success();
+        }
         std::string qirName = "__catalyst__qis__" + op.getGateName().str();
         SmallVector<Type> argTypes;
         argTypes.insert(argTypes.end(), adaptor.getParams().getTypes().begin(),

--- a/mlir/test/Quantum/VerifierTest.mlir
+++ b/mlir/test/Quantum/VerifierTest.mlir
@@ -67,15 +67,6 @@ func.func @custom(%f : f64, %q1 : !quantum.bit, %q2 : !quantum.bit) {
 
 // -----
 
-func.func @multirz1(%theta : f64) {
-    // expected-error@+1 {{must have at least 1 qubit}}
-    %err = quantum.multirz(%theta) : !quantum.bit
-
-    return
-}
-
-// -----
-
 func.func @multirz2(%q0 : !quantum.bit, %q1 : !quantum.bit, %theta : f64) {
     // expected-error@+1 {{number of qubits in input (2) and output (1) must be the same}}
     %err = quantum.multirz(%theta) %q0, %q1 : !quantum.bit
@@ -88,15 +79,6 @@ func.func @multirz2(%q0 : !quantum.bit, %q1 : !quantum.bit, %theta : f64) {
 func.func @multirz3(%q0 : !quantum.bit, %theta : f64) {
     // expected-error@+1 {{number of qubits in input (1) and output (2) must be the same}}
     %err:2 = quantum.multirz(%theta) %q0 : !quantum.bit, !quantum.bit
-
-    return
-}
-
-// -----
-
-func.func @unitary1(%m : tensor<4x4xcomplex<f64>>) {
-    // expected-error@+1 {{must have at least 1 qubit}}
-    %err = quantum.unitary(%m: tensor<4x4xcomplex<f64>>) : !quantum.bit
 
     return
 }

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -15,7 +15,7 @@ ENABLE_LIGHTNING_KOKKOS?=ON
 ENABLE_OPENQASM?=ON
 ENABLE_ASAN?=OFF
 # TODO: Update to v0.35.0 after the next lightning release.
-LIGHTNING_GIT_TAG_VALUE?="86f22a768238c3f7c45a6f515b6cb61fc285a636"
+LIGHTNING_GIT_TAG_VALUE?="efb946a736f824835ebf4fd692568d49e6cf1ca5"
 NPROC?=$(shell python3 -c "import os; print(os.cpu_count())")
 
 BUILD_TARGETS := rt_capi

--- a/runtime/include/RuntimeCAPI.h
+++ b/runtime/include/RuntimeCAPI.h
@@ -75,7 +75,7 @@ void __catalyst__qis__CRot(double, double, double, QUBIT *, QUBIT *, const Modif
 void __catalyst__qis__CSWAP(QUBIT *, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__Toffoli(QUBIT *, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__MultiRZ(double, const Modifiers *, int64_t, /*qubits*/...);
-void __catalyst__qis__GlobalPhase(double, /* ignored */...);
+void __catalyst__qis__GlobalPhase(double);
 void __catalyst__qis__ISWAP(QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__PSWAP(double, QUBIT *, QUBIT *, const Modifiers *);
 

--- a/runtime/include/RuntimeCAPI.h
+++ b/runtime/include/RuntimeCAPI.h
@@ -75,6 +75,7 @@ void __catalyst__qis__CRot(double, double, double, QUBIT *, QUBIT *, const Modif
 void __catalyst__qis__CSWAP(QUBIT *, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__Toffoli(QUBIT *, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__MultiRZ(double, const Modifiers *, int64_t, /*qubits*/...);
+void __catalyst__qis__GlobalPhase(double, /* ignored */...);
 void __catalyst__qis__ISWAP(QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__PSWAP(double, QUBIT *, QUBIT *, const Modifiers *);
 

--- a/runtime/include/RuntimeCAPI.h
+++ b/runtime/include/RuntimeCAPI.h
@@ -75,7 +75,7 @@ void __catalyst__qis__CRot(double, double, double, QUBIT *, QUBIT *, const Modif
 void __catalyst__qis__CSWAP(QUBIT *, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__Toffoli(QUBIT *, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__MultiRZ(double, const Modifiers *, int64_t, /*qubits*/...);
-void __catalyst__qis__GlobalPhase(double);
+void __catalyst__qis__GlobalPhase(double, const Modifiers *);
 void __catalyst__qis__ISWAP(QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__PSWAP(double, QUBIT *, QUBIT *, const Modifiers *);
 

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -377,7 +377,7 @@ void __catalyst__qis__Gradient_params(MemRefT_int64_1d *params, int64_t numResul
     Catalyst::Runtime::getQuantumDevicePtr()->Gradient(mem_views, train_params);
 }
 
-void __catalyst__qis__GlobalPhase(double phi, /* ignored = */...)
+void __catalyst__qis__GlobalPhase(double phi)
 {
     Catalyst::Runtime::getQuantumDevicePtr()->NamedOperation("GlobalPhase", {phi}, {},
                                                              MODIFIERS_ARGS(nullptr));

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -377,10 +377,10 @@ void __catalyst__qis__Gradient_params(MemRefT_int64_1d *params, int64_t numResul
     Catalyst::Runtime::getQuantumDevicePtr()->Gradient(mem_views, train_params);
 }
 
-void __catalyst__qis__GlobalPhase(double phi)
+void __catalyst__qis__GlobalPhase(double phi, const Modifiers *modifiers)
 {
     Catalyst::Runtime::getQuantumDevicePtr()->NamedOperation("GlobalPhase", {phi}, {},
-                                                             MODIFIERS_ARGS(nullptr));
+                                                             MODIFIERS_ARGS(modifiers));
 }
 
 void __catalyst__qis__Identity(QUBIT *qubit, const Modifiers *modifiers)

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -377,6 +377,12 @@ void __catalyst__qis__Gradient_params(MemRefT_int64_1d *params, int64_t numResul
     Catalyst::Runtime::getQuantumDevicePtr()->Gradient(mem_views, train_params);
 }
 
+void __catalyst__qis__GlobalPhase(double phi, /* ignored = */...)
+{
+    Catalyst::Runtime::getQuantumDevicePtr()->NamedOperation("GlobalPhase", {phi}, {},
+                                                             MODIFIERS_ARGS(nullptr));
+}
+
 void __catalyst__qis__Identity(QUBIT *qubit, const Modifiers *modifiers)
 {
     Catalyst::Runtime::getQuantumDevicePtr()->NamedOperation(

--- a/runtime/tests/Test_LightningCoreQIS.cpp
+++ b/runtime/tests/Test_LightningCoreQIS.cpp
@@ -603,6 +603,31 @@ TEST_CASE("Test __catalyst__qis__ CRot, IsingXY and Toffoli", "[CoreQIS]")
     __catalyst__rt__finalize();
 }
 
+TEST_CASE("Test __catalyst__qis__ GlobalPhase", "[CoreQIS]")
+{
+    for (const auto &[rtd_lib, rtd_name, rtd_kwargs] : getDevices()) {
+        __catalyst__rt__initialize();
+        __catalyst__rt__device_init((int8_t *)rtd_lib.c_str(), (int8_t *)rtd_name.c_str(),
+                                    (int8_t *)rtd_kwargs.c_str());
+
+        QirArray *qs = __catalyst__rt__qubit_allocate_array(1);
+
+        __catalyst__qis__GlobalPhase(M_PI / 4);
+
+        MemRefT_CplxT_double_1d result = getState(2);
+        __catalyst__qis__State(&result, 0);
+        CplxT_double *state = result.data_allocated;
+
+        CHECK((state[0].real == Approx(0.70710678).margin(1e-5) &&
+               state[0].imag == Approx(-0.70710678).margin(1e-5)));
+
+        freeState(result);
+        __catalyst__rt__qubit_release_array(qs);
+        __catalyst__rt__device_release();
+        __catalyst__rt__finalize();
+    }
+}
+
 TEST_CASE("Test __catalyst__qis__ Hadamard, PauliX, IsingYY, CRX, and Expval", "[CoreQIS]")
 {
     for (const auto &[rtd_lib, rtd_name, rtd_kwargs] : getDevices()) {

--- a/runtime/tests/Test_LightningCoreQIS.cpp
+++ b/runtime/tests/Test_LightningCoreQIS.cpp
@@ -612,7 +612,7 @@ TEST_CASE("Test __catalyst__qis__ GlobalPhase", "[CoreQIS]")
 
         QirArray *qs = __catalyst__rt__qubit_allocate_array(1);
 
-        __catalyst__qis__GlobalPhase(M_PI / 4);
+        __catalyst__qis__GlobalPhase(M_PI / 4, NO_MODIFIERS);
 
         MemRefT_CplxT_double_1d result = getState(2);
         __catalyst__qis__State(&result, 0);


### PR DESCRIPTION
Add `GlobalPhase` to:

* Frontend
* MLIR
* Runtime

The `GlobalPhase` frontend primitive accepts input wires as inputs and wires outputs but are not required. To maintain its position in the program we place the primitive in `FORCED_ORDER_PRIMITIVES`.

In MLIR and the runtime, the `GlobalPhaseOp` takes no wires as inputs.