### PR TITLE
Remove test suite warning

### DIFF
--- a/frontend/test/pytest/test_config_functions.py
+++ b/frontend/test/pytest/test_config_functions.py
@@ -33,7 +33,7 @@ from catalyst.utils.runtime import (
 from catalyst.utils.toml import toml_load
 
 
-class TestDevice(qml.QubitDevice):
+class DeviceTest(qml.QubitDevice):
     """Test device"""
 
     name = "Test Device"
@@ -54,31 +54,31 @@ qjit_compatible = false
         config = toml_load(f)
         f.close()
 
-        name = TestDevice.name
+        name = DeviceTest.name
         with pytest.raises(
             CompileError, match=f"Attempting to compile program for incompatible device {name}."
         ):
-            check_qjit_compatibility(TestDevice, config)
+            check_qjit_compatibility(DeviceTest, config)
 
 
 def test_device_has_config_attr():
     """Test error is raised when device has no config attr."""
-    name = TestDevice.name
+    name = DeviceTest.name
     msg = f"Attempting to compile program for incompatible device {name}."
     with pytest.raises(CompileError, match=msg):
-        check_device_config(TestDevice)
+        check_device_config(DeviceTest)
 
 
 def test_device_with_invalid_config_attr():
     """Test error is raised when device has invalid config attr."""
-    name = TestDevice.name
+    name = DeviceTest.name
     with tempfile.NamedTemporaryFile(mode="w+b") as f:
         f.close()
-        setattr(TestDevice, "config", Path(f.name))
+        setattr(DeviceTest, "config", Path(f.name))
         msg = f"Attempting to compile program for incompatible device {name}."
         with pytest.raises(CompileError, match=msg):
-            check_device_config(TestDevice)
-        delattr(TestDevice, "config")
+            check_device_config(DeviceTest)
+        delattr(DeviceTest, "config")
 
 
 def test_get_native_gates():
@@ -145,3 +145,6 @@ def test_check_full_overlap():
     msg = f"Gates in qml.device.operations and specification file do not match"
     with pytest.raises(CompileError, match=msg):
         check_full_overlap(Device(), ["A", "A", "A"], ["B", "B"])
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/frontend/test/pytest/test_config_functions.py
+++ b/frontend/test/pytest/test_config_functions.py
@@ -146,5 +146,6 @@ def test_check_full_overlap():
     with pytest.raises(CompileError, match=msg):
         check_full_overlap(Device(), ["A", "A", "A"], ["B", "B"])
 
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/frontend/test/pytest/test_config_functions.py
+++ b/frontend/test/pytest/test_config_functions.py
@@ -33,7 +33,7 @@ from catalyst.utils.runtime import (
 from catalyst.utils.toml import toml_load
 
 
-class DeviceTest(qml.QubitDevice):
+class DummyDevice(qml.QubitDevice):
     """Test device"""
 
     name = "Test Device"
@@ -54,31 +54,31 @@ qjit_compatible = false
         config = toml_load(f)
         f.close()
 
-        name = DeviceTest.name
+        name = DummyDevice.name
         with pytest.raises(
             CompileError, match=f"Attempting to compile program for incompatible device {name}."
         ):
-            check_qjit_compatibility(DeviceTest, config)
+            check_qjit_compatibility(DummyDevice, config)
 
 
 def test_device_has_config_attr():
     """Test error is raised when device has no config attr."""
-    name = DeviceTest.name
+    name = DummyDevice.name
     msg = f"Attempting to compile program for incompatible device {name}."
     with pytest.raises(CompileError, match=msg):
-        check_device_config(DeviceTest)
+        check_device_config(DummyDevice)
 
 
 def test_device_with_invalid_config_attr():
     """Test error is raised when device has invalid config attr."""
-    name = DeviceTest.name
+    name = DummyDevice.name
     with tempfile.NamedTemporaryFile(mode="w+b") as f:
         f.close()
-        setattr(DeviceTest, "config", Path(f.name))
+        setattr(DummyDevice, "config", Path(f.name))
         msg = f"Attempting to compile program for incompatible device {name}."
         with pytest.raises(CompileError, match=msg):
-            check_device_config(DeviceTest)
-        delattr(DeviceTest, "config")
+            check_device_config(DummyDevice)
+        delattr(DummyDevice, "config")
 
 
 def test_get_native_gates():


### PR DESCRIPTION
**Description of the Change:**

Removes `cannot collect test class 'TestDevice' because it has a __init__ constructor (from: pytest/test_config_functions.py`, pytest thinks TestDevice is a class containing test.