### PR TITLE
Fix wheel failures

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -6,4 +6,4 @@ enzyme=1beb98b51442d50652eaa3ffb9574f4720d611f1
 
 # Always remove custom PL/LQ versions before release.
 pennylane=f638bc53a09724a83d9d58964bf37bfd438e6aa3
-lightning=0.35.0-dev17
+lightning=0.35.0-dev21

--- a/.dep-versions
+++ b/.dep-versions
@@ -3,4 +3,7 @@ jax=0.4.23
 mhlo=4611968a5f6818e6bdfb82217b9e836e0400bba9
 llvm=cd9a641613eddf25d4b25eaa96b2c393d401d42c
 enzyme=1beb98b51442d50652eaa3ffb9574f4720d611f1
+
+# Always remove custom PL/LQ versions before release.
 pennylane=f638bc53a09724a83d9d58964bf37bfd438e6aa3
+lightning=0.35.0-dev17

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -292,7 +292,7 @@ jobs:
               -DPYTHON_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -Dpybind11_DIR=$(python${{ matrix.python_version }} -c "import pybind11; print(pybind11.get_cmake_dir())") \
               -DENABLE_LIGHTNING_KOKKOS=ON \
-              -DLIGHTNING_GIT_TAG="2716864521c539429bd382b92151a918d1a076ce" \
+              -DLIGHTNING_GIT_TAG="86f22a768238c3f7c45a6f515b6cb61fc285a636" \
               -DKokkos_ENABLE_SERIAL=ON \
               -DKokkos_ENABLE_OPENMP=ON \
               -DENABLE_WARNINGS=OFF \

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -378,7 +378,7 @@ jobs:
 
     - name: Install Catalyst
       run: |
-        python${{ matrix.python_version }} -m pip install $GITHUB_WORKSPACE/dist/*.whl
+        python${{ matrix.python_version }} -m pip install $GITHUB_WORKSPACE/dist/*.whl --extra-index-url https://test.pypi.org/simple
 
     - name: Install PennyLane Plugins
       run: |

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -292,7 +292,7 @@ jobs:
               -DPYTHON_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -Dpybind11_DIR=$(python${{ matrix.python_version }} -c "import pybind11; print(pybind11.get_cmake_dir())") \
               -DENABLE_LIGHTNING_KOKKOS=ON \
-              -DLIGHTNING_GIT_TAG="86f22a768238c3f7c45a6f515b6cb61fc285a636" \
+              -DLIGHTNING_GIT_TAG="03e465d96a665a2d1bcea2f1e6d79321e9d1c3fe" \
               -DKokkos_ENABLE_SERIAL=ON \
               -DKokkos_ENABLE_OPENMP=ON \
               -DENABLE_WARNINGS=OFF \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -385,14 +385,14 @@ jobs:
       run: |
         python${{ matrix.python_version }} -m pip install pytest pytest-xdist
 
-    - name: Install Catalyst
-      run: |
-        python${{ matrix.python_version }} -m pip install $GITHUB_WORKSPACE/dist/*.whl --extra-index-url https://test.pypi.org/simple
-
     - name: Install PennyLane Plugins
       run: |
         python${{ matrix.python_version }} -m pip install PennyLane-Lightning-Kokkos
         python${{ matrix.python_version }} -m pip install amazon-braket-pennylane-plugin
+
+    - name: Install Catalyst
+      run: |
+        python${{ matrix.python_version }} -m pip install $GITHUB_WORKSPACE/dist/*.whl --extra-index-url https://test.pypi.org/simple
 
     - name: Run Python Pytest Tests
       run: |

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -289,7 +289,7 @@ jobs:
               -DPYTHON_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -Dpybind11_DIR=$(python${{ matrix.python_version }} -c "import pybind11; print(pybind11.get_cmake_dir())") \
               -DENABLE_LIGHTNING_KOKKOS=ON \
-              -DLIGHTNING_GIT_TAG="2716864521c539429bd382b92151a918d1a076ce" \
+              -DLIGHTNING_GIT_TAG="86f22a768238c3f7c45a6f515b6cb61fc285a636" \
               -DKokkos_ENABLE_SERIAL=ON \
               -DKokkos_ENABLE_OPENMP=ON \
               -DKokkos_ENABLE_COMPLEX_ALIGN=OFF \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -387,7 +387,7 @@ jobs:
 
     - name: Install Catalyst
       run: |
-        python${{ matrix.python_version }} -m pip install $GITHUB_WORKSPACE/dist/*.whl
+        python${{ matrix.python_version }} -m pip install $GITHUB_WORKSPACE/dist/*.whl --extra-index-url https://test.pypi.org/simple
 
     - name: Install PennyLane Plugins
       run: |

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -289,7 +289,7 @@ jobs:
               -DPYTHON_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -Dpybind11_DIR=$(python${{ matrix.python_version }} -c "import pybind11; print(pybind11.get_cmake_dir())") \
               -DENABLE_LIGHTNING_KOKKOS=ON \
-              -DLIGHTNING_GIT_TAG="86f22a768238c3f7c45a6f515b6cb61fc285a636" \
+              -DLIGHTNING_GIT_TAG="03e465d96a665a2d1bcea2f1e6d79321e9d1c3fe" \
               -DKokkos_ENABLE_SERIAL=ON \
               -DKokkos_ENABLE_OPENMP=ON \
               -DKokkos_ENABLE_COMPLEX_ALIGN=OFF \

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -261,7 +261,7 @@ jobs:
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$GITHUB_WORKSPACE/runtime-build/lib \
               -DPYTHON_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -Dpybind11_DIR=$(python${{ matrix.python_version }} -c "import pybind11; print(pybind11.get_cmake_dir())") \
-              -DLIGHTNING_GIT_TAG="2716864521c539429bd382b92151a918d1a076ce" \
+              -DLIGHTNING_GIT_TAG="86f22a768238c3f7c45a6f515b6cb61fc285a636" \
               -DENABLE_LIGHTNING_KOKKOS=ON \
               -DKokkos_ENABLE_SERIAL=ON \
               -DKokkos_ENABLE_OPENMP=OFF \

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -261,7 +261,7 @@ jobs:
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$GITHUB_WORKSPACE/runtime-build/lib \
               -DPYTHON_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -Dpybind11_DIR=$(python${{ matrix.python_version }} -c "import pybind11; print(pybind11.get_cmake_dir())") \
-              -DLIGHTNING_GIT_TAG="86f22a768238c3f7c45a6f515b6cb61fc285a636" \
+              -DLIGHTNING_GIT_TAG="03e465d96a665a2d1bcea2f1e6d79321e9d1c3fe" \
               -DENABLE_LIGHTNING_KOKKOS=ON \
               -DKokkos_ENABLE_SERIAL=ON \
               -DKokkos_ENABLE_OPENMP=OFF \

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -362,7 +362,7 @@ jobs:
 
     - name: Install Catalyst
       run: |
-        python${{ matrix.python_version }} -m pip install $GITHUB_WORKSPACE/dist/*.whl
+        python${{ matrix.python_version }} -m pip install $GITHUB_WORKSPACE/dist/*.whl --extra-index-url https://test.pypi.org/simple
 
     - name: Run Python Pytest Tests
       run: |

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -357,7 +357,7 @@ jobs:
 
     - name: Install Catalyst
       run: |
-        python${{ matrix.python_version }} -m pip install $GITHUB_WORKSPACE/dist/*.whl
+        python${{ matrix.python_version }} -m pip install $GITHUB_WORKSPACE/dist/*.whl --extra-index-url https://test.pypi.org/simple
 
     - name: Install PennyLane Plugins
       run: |

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -355,14 +355,14 @@ jobs:
       run: |
         python${{ matrix.python_version }} -m pip install pytest pytest-xdist
 
-    - name: Install Catalyst
-      run: |
-        python${{ matrix.python_version }} -m pip install $GITHUB_WORKSPACE/dist/*.whl --extra-index-url https://test.pypi.org/simple
-
     - name: Install PennyLane Plugins
       run: |
         python${{ matrix.python_version }} -m pip install PennyLane-Lightning-Kokkos
         python${{ matrix.python_version }} -m pip install amazon-braket-pennylane-plugin
+
+    - name: Install Catalyst
+      run: |
+        python${{ matrix.python_version }} -m pip install $GITHUB_WORKSPACE/dist/*.whl
 
     - name: Run Python Pytest Tests
       run: |

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -378,14 +378,14 @@ jobs:
     - name: Install Deps
       run: |
         sudo apt-get update
-        sudo apt-get install -y python3 python3-pip libomp-dev libasan6
+        sudo apt-get install -y python3 python3-pip libomp-dev libasan6 make
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
         # cuda-quantum is added manually here.
         # It can't be in requirements.txt as that will break
         # macOS requirements.txt
         python3 -m pip install cuda-quantum
-        python3 -m pip install .
+        make frontend
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build
@@ -450,10 +450,10 @@ jobs:
     - name: Install Deps
       run: |
         sudo apt-get update
-        sudo apt-get install -y python3 python3-pip libomp-dev libasan6
+        sudo apt-get install -y python3 python3-pip libomp-dev libasan6 make
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
-        python3 -m pip install .
+        make frontend
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build
@@ -504,10 +504,10 @@ jobs:
     - name: Install Deps
       run: |
         sudo apt-get update
-        sudo apt-get install -y python3 python3-pip libomp-dev libasan6
+        sudo apt-get install -y python3 python3-pip libomp-dev libasan6 make
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
-        python3 -m pip install .
+        make frontend
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -101,13 +101,7 @@ jobs:
         DIALECTS_BUILD_DIR="$(pwd)/quantum-build" \
         ENABLE_LLD=ON \
         make dialects
-        if [ ${{ inputs.pennylane }} = "stable" ]; then
-            pip install --upgrade .
-        else
-            # TODO(@erick-xanadu): Remove after release. See issue
-            # https://github.com/PennyLaneAI/catalyst/issues/494
-            pl_version="==0.35.0.dev0" pip install --upgrade .
-        fi
+        make frontend
 
     - name: Build Catalyst Runtime (latest)
       if: ${{ inputs.lightning == 'latest' }}
@@ -128,6 +122,7 @@ jobs:
         C_COMPILER=$(which gcc }}) \
         CXX_COMPILER=$(which g++ }}) \
         RT_BUILD_DIR="$(pwd)/runtime-build" \
+        LIGHTNING_GIT_TAG_VALUE=latest_release \
         ENABLE_LIGHTNING_KOKKOS=ON \
         ENABLE_OPENQASM=ON \
         make runtime

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ all: runtime mlir frontend
 .PHONY: frontend
 frontend:
 	@echo "install Catalyst Frontend"
-	$(PYTHON) -m pip install -e .
+	$(PYTHON) -m pip install -e . --extra-index-url https://test.pypi.org/simple
 	rm -r frontend/PennyLane_Catalyst.egg-info
 
 .PHONY: mlir llvm mhlo enzyme dialects runtime
@@ -202,7 +202,7 @@ coverage-frontend:
 	@echo "Generating coverage report for the frontend"
 	$(ASAN_COMMAND) $(PYTHON) -m pytest frontend/test/pytest $(PARALLELIZE) --cov=catalyst --tb=native --cov-report=$(COVERAGE_REPORT)
 ifeq ($(TEST_BRAKET), NONE)
-	$(ASAN_COMMAND) $(PYTHON) -m pytest frontend/test/async_tests --tb=native --backend=$(TEST_BACKEND) --tb=native 
+	$(ASAN_COMMAND) $(PYTHON) -m pytest frontend/test/async_tests --tb=native --backend=$(TEST_BACKEND) --tb=native
 endif
 
 coverage-runtime:

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -28,4 +28,4 @@ matplotlib==3.8.0
 
 # Pre-install development lightning wheels
 --extra-index-url https://test.pypi.org/simple/
-pennylane-lightning==0.35.0-dev17
+pennylane-lightning==0.35.0-dev21

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -25,3 +25,7 @@ m2r2
 mistune==0.8.4
 sphinxext-opengraph==0.9.0
 matplotlib==3.8.0
+
+# Pre-install development lightning wheels
+--extra-index-url https://test.pypi.org/simple/
+pennylane-lightning==0.35.0-dev17

--- a/frontend/test/pytest/test_template.py
+++ b/frontend/test/pytest/test_template.py
@@ -171,6 +171,7 @@ def test_basis_state_preparation(backend):
     assert np.allclose(interpreted_fn(params), jitted_fn(params))
 
 
+@pytest.mark.skip(reason="GlobalPhase not implemented in QIR")
 def test_mottonen_state_preparation(backend):
     """Test mottonen state preparation."""
 

--- a/setup.py
+++ b/setup.py
@@ -34,13 +34,25 @@ with open(path.join("frontend", "catalyst", "_version.py")) as f:
 
 with open(".dep-versions") as f:
     lines = f.readlines()
-    jax_version = [line[4:].strip() for line in lines if "jax=" in line][0]
-    pl_str = "pennylane="
-    pl_str_length = len(pl_str)
-    pl_version = [line[pl_str_length:].strip() for line in lines if pl_str in line][0]
+    jax_version = next(line[4:].strip() for line in lines if "jax=" in line)
+    pl_version = next((line[10:].strip() for line in lines if "pennylane=" in line), None)
+    lq_version = next((line[10:].strip() for line in lines if "lightning=" in line), None)
+
+pl_min_release = 0.35
+lq_min_release = pl_min_release
+
+if pl_version is not None:
+    pennylane_dep = f"pennylane @ git+https://github.com/pennylaneai/pennylane@{pl_version}"
+else:
+    pennylane_dep = f"pennylane>={pl_min_release}"
+if lq_version is not None:
+    lightning_dep = f"pennylane-lightning=={lq_version}"  # use TestPyPI wheels to avoid rebuild
+else:
+    lightning_dep = f"pennylane-lightning>={lq_min_release}"
 
 requirements = [
-    f"pennylane @ git+https://github.com/pennylaneai/pennylane@{pl_version}",
+    pennylane_dep,
+    lightning_dep,
     f"jax=={jax_version}",
     f"jaxlib=={jax_version}",
     "tomlkit;python_version<'3.11'",


### PR DESCRIPTION
One issue that is fixed is that the lightning pip package and the lightning C++ library shipped with the runtime are not always in sync. This commit attempts to remedy that by allowing a prebuilt development wheel for lightning to be installed automatically when installing Catalyst via make. Using pip install directly is not recommended because an extra flag is needed to allow fetching wheels from TestPyPI, and this cannot be supplied from within the package requirements (setup.py) itself.

In order to depend on development versions of PennyLane or Lightning during Catalyst development, the .dep-versions file needs to be updated:
- for PL with the commit hash on master
- for LQ with the version tag (ending in .dev) corresponding to a specific PR
  Additionally for LQ the wheel actions and runtime MakeFile need to be updated with the commit hash corresponding to said PR, but this is a temporary measure. The git tag selected for LQ also needs to be specified in the RTD requirements.txt, although ideally we'd remove the need to specify it here. 

Temporarily skip one test that is failing due to lack of GlobalPhase support.

Update plugin test matrix action for stable to use latest_release tag in lightning, since it is okay for stable entries to fail with development versions.