### PR TITLE
Fix the issue with dispatching to jax.vmap with qjit(vmap)

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -57,6 +57,7 @@
 * Catalyst now supports QJIT compatible `catalyst.vmap` of hybrid programs.
   `catalyst.vmap` offers the vectorization mapping backed by `catalyst.for_loop`.
   [(#497)](https://github.com/PennyLaneAI/catalyst/pull/497)
+  [(#569)](https://github.com/PennyLaneAI/catalyst/pull/569)
 
   For example,
 


### PR DESCRIPTION
This PR fixes the issue with compiling `catalyst.qjit(catalyst.vmap(fn))(*args, **kwargs)`


For example, this example should pass now
``` py
dev = qml.device("lightning.qubit", wires=1)

@qml.qnode(dev)
def circuit(x, y):
    qml.RX(jnp.pi * x[0] + y, wires=0)
    qml.RY(x[1] ** 2, wires=0)
    qml.RX(x[1] * x[2], wires=0)
    return qml.expval(qml.PauliZ(0))

def cost(x, y, z):
    return circuit(x, y) * z

vmapped_cost = qjit(vmap(cost, in_axes=(0, 0, None)))

x = jnp.array([[0.1, 0.2, 0.3],
               [0.4, 0.5, 0.6],
               [0.7, 0.8, 0.9]])
y = jnp.array([jnp.pi, jnp.pi / 2, jnp.pi / 4])

vmapped_cost(x, y, 1)
```