### PR TITLE
Pin pytest version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ isort
 
 # testing
 lit
-pytest
+pytest==8.0.2
 pytest-xdist
 pytest-cov
 nbmake


### PR DESCRIPTION
It looks like an incompatibility between flaky and the changes to pytest leads to failures in the test matrix.