### PR TITLE
Support a limited forms of slice assignment in autograph translations

### DIFF
--- a/doc/dev/autograph.rst
+++ b/doc/dev/autograph.rst
@@ -112,6 +112,7 @@ Currently, AutoGraph supports converting the following Python statements:
 - ``for`` loops
 - ``while`` loops
 - ``and``, ``or`, and ``not`` in certain cases
+- Slice assignment in certain cases, such as ``x[i] = 1``
 
 ``break`` and ``continue`` statements are currently not supported.
 
@@ -677,6 +678,37 @@ array(0.87758256)
 
 Note that there are a couple of important constraints and restrictions that must be
 considered when working with logical statements.
+
+Slicing
+~~~~~~~
+
+Indexing an array by slice is supported (it does not need to be translated).
+
+Slice updates are also allowed, although---somewhat confusingly---autograph
+does not support the `Slice` or `Tuple` types.
+
+This means that you can write
+
+>>> @qjit(autograph=True)
+... def f(x):
+...     first_dim = x.shape[0]
+...     x[first_dim - 1] = 0
+...     return x
+>>> f(jnp.array([1, 2, 3]))
+array([1, 2, 0])
+
+and the translation will work fine. But if you want to use a `Slice` or `Tuple`,
+you will have to use
+` ``s_`` <https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.s_.html#jax.numpy.s_> `
+or a similar wrapper.
+
+>>> @qjit(autograph=True)
+... def f(x):
+...     x[jnp.s_[:-1]] = 0
+...     return x
+>>> f(jnp.array([1, 2, 3]))
+array([0, 0, 3])
+
 
 All arguments must be dynamic
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
**Context:** We would like to support slice assignments in autograph (see #516 for more details on why this isn't presently possible).

**Description of the Change:** Adds support for slice assignments.

**Benefits:** A common and (I assume) useful feature is supported by these changes, which means users can write more code in a straightforward, pythonic way.

**Possible Drawbacks:**

I budgeted two hours for this work, but ended up spending closer to six; considering that (1) there were unexpected complications in my implementation (see my comments in #516) and (2) I am not being paid for this work, I am submitting my PR in a state that does not meet my personal standards. If I were more defensive of my time I wouldn't have written docs, but adding them didn't take all too long and I figure they'll be useful if you actually use this code.

I hope this doesn't come across as sounding indignant considering that this is a small (yet incomplete) PR, I just have a lot of other stuff going on. Most of the time I spent was reading code and debugging (measure twice...).

Here are the known limitations of the code I am submitting. All but point 1. are easily addressed with more time.

1. Autograph's default slice converter---confusingly---does not convert `Slice` or `Tuple` types (see [my comment](https://github.com/PennyLaneAI/catalyst/issues/516#issuecomment-1977317517)). This PR does not update the converter. I suggest a temporary workaround in the docs.
2. This change is not thoroughly tested for every possible edge case. Control flow aside from for loops, for example, is untested but presumed working. The examples in the docs are untested.
3. The code is ported from changes I made to the version of catalyst I installed in pip so that I could avoid compiling from source. I did not port these changes automatically (e.g. using a diff patch) and as such there may be human errors in the port.
4. The code is not rebased onto main. I took some time off between starting and finishing this work. Commit 3e81baf858d5d67a41ba4c1dd07eda4e8e7f47de appears to have happened in the in-between. I could not trivially resolve the merge conflicts and so did not rebase it.
5. I did not build the docs to check for any errors in the source text.

**Related GitHub Issues:** #516
