### PR TITLE
[MLIR] Fix adjoint lowering pass

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -39,13 +39,17 @@
 * Fix the issue of triggering the C++ compiler driver twice.
   [(#594)](https://github.com/PennyLaneAI/catalyst/pull/594)
 
+* Fixes adjoint lowering bug that did not take into account control wires.
+  [(#591)](https://github.com/PennyLaneAI/catalyst/pull/591)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
 Ali Asadi,
 David Ittah,
-Romain Moyard.
+Romain Moyard,
+Erick Ochoa Lopez.
 
 # Release 0.5.0
 

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -557,5 +557,28 @@ def test_adjoint_wires_controlflow(backend):
     assert circuit() == qml.wires.Wires([0])
 
 
+def test_adjoint_ctrl_ctrl_subroutine(backend):
+    """https://github.com/PennyLaneAI/catalyst/issues/589"""
+
+    def subsubroutine():
+        qml.ctrl(qml.PhaseShift, control=2)(0.1, wires=3)
+
+    def subroutine():
+        # If either of the two lines below are commented, there is no error. Only when both run.
+        subsubroutine()
+        qml.adjoint(qml.ctrl(subsubroutine, control=0))()
+
+    dev = qml.device("lightning.qubit", wires=4, shots=500)
+
+    @qml.qnode(dev)
+    def circuit():
+        qml.adjoint(subroutine)()
+        return qml.probs(wires=dev.wires)
+
+    expected = circuit()
+    observed = qjit(circuit)()
+    assert_allclose(expected, observed)
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -564,11 +564,10 @@ def test_adjoint_ctrl_ctrl_subroutine(backend):
         qml.ctrl(qml.PhaseShift, control=2)(0.1, wires=3)
 
     def subroutine():
-        # If either of the two lines below are commented, there is no error. Only when both run.
         subsubroutine()
         qml.adjoint(qml.ctrl(subsubroutine, control=0))()
 
-    dev = qml.device("lightning.qubit", wires=4, shots=500)
+    dev = qml.device(backend, wires=4, shots=500)
 
     @qml.qnode(dev)
     def circuit():

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -265,7 +265,7 @@ class AdjointGenerator {
         }
 
         for (const auto &[qubitResult, qubitOperand] :
-             llvm::zip(clone.getNonCtrlQubitResults(), gate.getNonCtrlQubitOperands())) {
+             llvm::zip(clone.getQubitResults(), gate.getQubitOperands())) {
             remappedValues.map(qubitOperand, qubitResult);
         }
     }


### PR DESCRIPTION
**Context:** It looks like adjoint was not correctly taking into account all wires in control operations.

**Description of the Change:** Modifies the adjoint lowering pass to take into account all wires in control operations

**Benefits:** Fixes #589 

**Related GitHub Issues:** #589 
