### PR TITLE
Legalize ShapeOps to standard

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -39,6 +39,9 @@
 * Fix the issue of triggering the C++ compiler driver twice.
   [(#594)](https://github.com/PennyLaneAI/catalyst/pull/594)
 
+* Adds lowering pass for `shape` dialect. Allowing for a greater set of programs to be compiled.
+  [(#592)](https://github.com/PennyLaneAI/catalyst/pull/592)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -125,6 +125,7 @@ HLO_LOWERING_PASS = (
         "func.func(chlo-legalize-to-hlo)",
         "stablehlo-legalize-to-hlo",
         "func.func(mhlo-legalize-control-flow)",
+        "func.func(hlo-legalize-shapeops-to-standard)",
         "func.func(hlo-legalize-to-linalg)",
         "func.func(mhlo-legalize-to-std)",
         "convert-to-signless",


### PR DESCRIPTION
**Context:** Some StableHLO operations are lowered to [ShapeOps](https://mlir.llvm.org/docs/Dialects/ShapeDialect/). And ShapeOps need to be lowered to standard dialect.

**Description of the Change:** Adds `--legalize-shapeops-to-standard` pass.

**Benefits:** We can compile a larger set of valid programs.
