### PR TITLE
Fix the issue of triggering the C++ compiler driver twice

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -36,10 +36,14 @@
 
 <h3>Bug fixes</h3>
 
+* Fix the issue of triggering the C++ compiler driver twice.
+  [(#594)](https://github.com/PennyLaneAI/catalyst/pull/594)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
+Ali Asadi,
 David Ittah,
 Romain Moyard.
 

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -269,8 +269,6 @@ class QJIT:
         # `replace` method, so we need to get a regular Python string out of it.
         func_name = str(self.mlir_module.body.operations[0].name).replace('"', "")
         shared_object, llvm_ir, _ = self.compiler.run(self.mlir_module, self.workspace)
-
-        shared_object, llvm_ir, _ = self.compiler.run(self.mlir_module, self.workspace)
         compiled_fn = CompiledFunction(shared_object, func_name, restype, self.compile_options)
 
         return compiled_fn, llvm_ir

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -824,7 +824,6 @@ def vjp(f: DifferentiableLike, params, cotangents, *, method=None, h=None, argnu
         results = (func_res, vjps)
 
     else:
-
         if isinstance(params, jax.numpy.ndarray) and params.ndim == 0:
             primal_outputs, vjp_fn = jax.vjp(f, params)
         else:

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -681,7 +681,6 @@ class TestConditionals:
 
         @qml.qnode(qml.device("lightning.qubit", wires=1))
         def f(switch: bool):
-
             if switch:
                 return qml.expval(qml.PauliY(0))
 

--- a/mlir/include/Quantum/IR/QuantumOps.h
+++ b/mlir/include/Quantum/IR/QuantumOps.h
@@ -34,12 +34,11 @@
 namespace mlir {
 namespace OpTrait {
 
-template <typename ConcreteType> class UnitaryTrait : public TraitBase<ConcreteType, UnitaryTrait> {
-};
+template <typename ConcreteType>
+class UnitaryTrait : public TraitBase<ConcreteType, UnitaryTrait> {};
 
 template <typename ConcreteType>
-class HermitianTrait : public TraitBase<ConcreteType, HermitianTrait> {
-};
+class HermitianTrait : public TraitBase<ConcreteType, HermitianTrait> {};
 
 } // namespace OpTrait
 } // namespace mlir

--- a/mlir/include/Quantum/IR/QuantumOps.h
+++ b/mlir/include/Quantum/IR/QuantumOps.h
@@ -34,11 +34,12 @@
 namespace mlir {
 namespace OpTrait {
 
-template <typename ConcreteType>
-class UnitaryTrait : public TraitBase<ConcreteType, UnitaryTrait> {};
+template <typename ConcreteType> class UnitaryTrait : public TraitBase<ConcreteType, UnitaryTrait> {
+};
 
 template <typename ConcreteType>
-class HermitianTrait : public TraitBase<ConcreteType, HermitianTrait> {};
+class HermitianTrait : public TraitBase<ConcreteType, HermitianTrait> {
+};
 
 } // namespace OpTrait
 } // namespace mlir


### PR DESCRIPTION
The compiler driver currently invokes all lowering methods and passes through the compilation process up to generating the object file twice for each QJIT-decorated program. It turns out that the new compiler refactoring introduced this issue of calling `compiler.run` twice from the frontend. 