### PR TITLE
Enable multi-threading compilation

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -32,6 +32,9 @@
   Note that returning different *kinds* of results, like different observables or differently
   shaped arrays, is not possible.
 
+* Multi-threaded compilation is re-enabled.
+  [(#595)](https://github.com/PennyLaneAI/catalyst/pull/595)
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -404,9 +404,7 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
     MLIRContext ctx(registry);
     ctx.printOpOnDiagnostic(true);
     ctx.printStackTraceOnDiagnostic(options.verbosity >= Verbosity::Debug);
-    // TODO: FIXME:
-    // Let's try to enable multithreading. Do not forget to protect the printing.
-    ctx.disableMultithreading();
+    ctx.enableMultithreading();
     ScopedDiagnosticHandler scopedHandler(
         &ctx, [&](Diagnostic &diag) { diag.print(options.diagnosticStream); });
 

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -62,23 +62,6 @@ std::string joinPasses(const Pipeline::PassList &passes)
     return joined;
 }
 
-struct CatalystIRPrinterConfig : public PassManager::IRPrinterConfig {
-    typedef std::function<LogicalResult(Pass *, PrintCallbackFn print)> PrintHandler;
-    PrintHandler printHandler;
-
-    CatalystIRPrinterConfig(PrintHandler printHandler)
-        : IRPrinterConfig(/*printModuleScope=*/true), printHandler(printHandler)
-    {
-    }
-
-    void printAfterIfEnabled(Pass *pass, Operation *operation, PrintCallbackFn printCallback) final
-    {
-        if (failed(printHandler(pass, printCallback))) {
-            operation->emitError("IR printing failed");
-        }
-    }
-};
-
 struct CatalystPassInstrumentation : public PassInstrumentation {
     typedef std::function<void(Pass *pass, Operation *operation)> Callback;
     Callback afterPassCallback;


### PR DESCRIPTION
**Context:** Multi-threading compilation was disabled in the past due to issues with how the IR was being printed.

**Description of the Change:** Re-enable multi threaded compilation. Remove dead code.

**Benefits:** Possibly better compile times.

**Related GitHub Issues:** Fixes #466 
