### PR TITLE
Move runner_mu out of a runtime header into the .cpp file

### DIFF
--- a/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
+++ b/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
@@ -14,6 +14,14 @@
 
 #include "OpenQasmDevice.hpp"
 
+namespace Catalyst::Runtime::Device::OpenQasm {
+
+std::mutex runner_mu;
+
+std::mutex &getOpenQasmRunnerMutex() { return runner_mu; }
+
+} // namespace Catalyst::Runtime::Device::OpenQasm
+
 namespace Catalyst::Runtime::Device {
 
 auto OpenQasmDevice::AllocateQubit() -> QubitIdType

--- a/runtime/lib/backend/openqasm/OpenQasmRunner.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmRunner.hpp
@@ -29,7 +29,7 @@
 namespace Catalyst::Runtime::Device::OpenQasm {
 
 // To protect the py::exec calls concurrently
-std::mutex runner_mu;
+std::mutex &getOpenQasmRunnerMutex();
 
 /**
  * The OpenQasm circuit runner interface.
@@ -108,7 +108,7 @@ struct BraketRunner : public OpenQasmRunner {
                                   size_t shots, const std::string &kwargs = "") const
         -> std::string override
     {
-        std::lock_guard<std::mutex> lock(runner_mu);
+        std::lock_guard<std::mutex> lock(getOpenQasmRunnerMutex());
 
         namespace py = pybind11;
         using namespace py::literals;
@@ -164,7 +164,7 @@ struct BraketRunner : public OpenQasmRunner {
                              size_t num_qubits, const std::string &kwargs = "") const
         -> std::vector<double> override
     {
-        std::lock_guard<std::mutex> lock(runner_mu);
+        std::lock_guard<std::mutex> lock(getOpenQasmRunnerMutex());
         namespace py = pybind11;
         using namespace py::literals;
 
@@ -231,7 +231,7 @@ struct BraketRunner : public OpenQasmRunner {
                               size_t num_qubits, const std::string &kwargs = "") const
         -> std::vector<size_t> override
     {
-        std::lock_guard<std::mutex> lock(runner_mu);
+        std::lock_guard<std::mutex> lock(getOpenQasmRunnerMutex());
         namespace py = pybind11;
         using namespace py::literals;
 
@@ -294,7 +294,7 @@ struct BraketRunner : public OpenQasmRunner {
     [[nodiscard]] auto Expval(const std::string &circuit, const std::string &device, size_t shots,
                               const std::string &kwargs = "") const -> double override
     {
-        std::lock_guard<std::mutex> lock(runner_mu);
+        std::lock_guard<std::mutex> lock(getOpenQasmRunnerMutex());
         namespace py = pybind11;
         using namespace py::literals;
 
@@ -350,7 +350,7 @@ struct BraketRunner : public OpenQasmRunner {
     [[nodiscard]] auto Var(const std::string &circuit, const std::string &device, size_t shots,
                            const std::string &kwargs = "") const -> double override
     {
-        std::lock_guard<std::mutex> lock(runner_mu);
+        std::lock_guard<std::mutex> lock(getOpenQasmRunnerMutex());
         namespace py = pybind11;
         using namespace py::literals;
 


### PR DESCRIPTION
**Context:** AddressSanitizer-related issues

**Description of the Change:** By this we move a global variable out of a header file

**Benefits:** Eliminates the risk of having several similar objects, if someone includes the header from different .cpp files.

**Possible Drawbacks:** N/A

**Related GitHub Issues:** N/A
