### PR TITLE
Fix config for wheels.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -65,9 +65,9 @@ This release contains contributions from (in alphabetical order):
 
 Ali Asadi,
 David Ittah,
-Erick Ochoa Lopez,
 Romain Moyard,
-Sergei Mironov.
+Sergei Mironov,
+Erick Ochoa Lopez.
 
 # Release 0.5.0
 

--- a/frontend/test/pytest/test_config_functions.py
+++ b/frontend/test/pytest/test_config_functions.py
@@ -71,7 +71,7 @@ def test_validate_config_with_device(schema):
                     """
                 )
             )
-        with open(toml_file, encoding="utf-8") as f:
+        with open(toml_file, "rb") as f:
             config = toml_load(f)
 
         device = DummyDevice()
@@ -98,7 +98,7 @@ def test_get_observables_schema1():
                     """
                 )
             )
-        with open(toml_file, encoding="utf-8") as f:
+        with open(toml_file, "rb") as f:
             config = toml_load(f)
     assert test_deduced_gates == get_pennylane_observables(config, False, "device_name")
 
@@ -119,7 +119,7 @@ def test_get_observables_schema2():
                     """
                 )
             )
-        with open(toml_file, encoding="utf-8") as f:
+        with open(toml_file, "rb") as f:
             config = toml_load(f)
     assert test_deduced_gates == get_pennylane_observables(config, False, "device_name")
 
@@ -142,7 +142,7 @@ def test_get_native_gates_schema1_no_qcontrol():
                     """
                 )
             )
-        with open(toml_file, encoding="utf-8") as f:
+        with open(toml_file, "rb") as f:
             config = toml_load(f)
     assert test_deduced_gates == get_pennylane_operations(config, False, "device_name")
 
@@ -165,7 +165,7 @@ def test_get_native_gates_schema1_qcontrol():
                     """
                 )
             )
-        with open(toml_file, encoding="utf-8") as f:
+        with open(toml_file, "rb") as f:
             config = toml_load(f)
     assert test_deduced_gates == get_pennylane_operations(config, False, "device_name")
 
@@ -186,7 +186,7 @@ def test_get_adjoint_schema2():
                     """
                 )
             )
-        with open(toml_file, encoding="utf-8") as f:
+        with open(toml_file, "rb") as f:
             config = toml_load(f)
     assert check_adjoint_flag(config, False)
 
@@ -208,7 +208,7 @@ def test_get_native_gates_schema2():
                     """
                 )
             )
-        with open(toml_file, encoding="utf-8") as f:
+        with open(toml_file, "rb") as f:
             config = toml_load(f)
     assert test_deduced_gates == get_pennylane_operations(config, False, "device_name")
 
@@ -230,7 +230,7 @@ def test_get_native_gates_schema2_optional_shots():
                     """
                 )
             )
-        with open(toml_file, encoding="utf-8") as f:
+        with open(toml_file, "rb") as f:
             config = toml_load(f)
     assert test_deduced_gates == get_pennylane_operations(config, True, "device_name")
 
@@ -251,7 +251,7 @@ def test_get_native_gates_schema2_optional_noshots():
                     """
                 )
             )
-        with open(toml_file, encoding="utf-8") as f:
+        with open(toml_file, "rb") as f:
             config = toml_load(f)
     assert test_deduced_gates == get_pennylane_operations(config, False, "device")
 
@@ -272,7 +272,7 @@ def test_get_decomp_gates_schema1():
                 )
             )
 
-        with open(toml_file, encoding="utf-8") as f:
+        with open(toml_file, "rb") as f:
             config = toml_load(f)
 
     assert test_gates == get_decomposable_gates(config, False)
@@ -294,7 +294,7 @@ def test_get_decomp_gates_schema2():
                 )
             )
 
-        with open(toml_file, encoding="utf-8") as f:
+        with open(toml_file, "rb") as f:
             config = toml_load(f)
 
     assert test_gates == get_decomposable_gates(config, False)
@@ -316,7 +316,7 @@ def test_get_matrix_decomposable_gates_schema1():
                 )
             )
 
-        with open(toml_file, encoding="utf-8") as f:
+        with open(toml_file, "rb") as f:
             config = toml_load(f)
 
     assert test_gates == get_matrix_decomposable_gates(config, False)
@@ -337,7 +337,7 @@ def test_get_matrix_decomposable_gates_schema2():
                 )
             )
 
-        with open(toml_file, encoding="utf-8") as f:
+        with open(toml_file, "rb") as f:
             config = toml_load(f)
 
     assert {"TestMatrixGate": {}} == get_matrix_decomposable_gates(config, False)
@@ -373,7 +373,7 @@ def test_config_invalid_attr():
                 )
             )
 
-        with open(toml_file, encoding="utf-8") as f:
+        with open(toml_file, "rb") as f:
             config = toml_load(f)
 
         with pytest.raises(
@@ -397,7 +397,7 @@ def test_config_invalid_condition_unknown():
                 )
             )
 
-        with open(toml_file, encoding="utf-8") as f:
+        with open(toml_file, "rb") as f:
             config = toml_load(f)
 
         with pytest.raises(
@@ -421,7 +421,7 @@ def test_config_invalid_property_unknown():
                 )
             )
 
-        with open(toml_file, encoding="utf-8") as f:
+        with open(toml_file, "rb") as f:
             config = toml_load(f)
 
         with pytest.raises(
@@ -445,7 +445,7 @@ def test_config_invalid_condition_duplicate():
                 )
             )
 
-        with open(toml_file, encoding="utf-8") as f:
+        with open(toml_file, "rb") as f:
             config = toml_load(f)
 
         with pytest.raises(CompileError, match="Configuration for gate 'TestGate'"):
@@ -468,7 +468,7 @@ def test_config_unsupported_schema():
                 )
             )
 
-        with open(toml_file, encoding="utf-8") as f:
+        with open(toml_file, "rb") as f:
             config = toml_load(f)
 
         with pytest.raises(CompileError):


### PR DESCRIPTION
**Context:** We use different versions of toml depending on which version of python is running. The tomllib library which we use for Python 3.11 and Python 3.12 specifies that in order to load a toml file it must be read in binary mode.

**Description of the Change:** Change the flags to open to binary mode.

**Benefits:** Toml works for wheels of all versions.

**Possible Drawbacks:** None.

**Related GitHub Issues:**

See wheel testing errors

```
FAILED frontend/test/pytest/test_config_functions.py::test_validate_config_with_device[1] - TypeError: File must be opened in binary mode, e.g. use `open('foo.toml', 'rb')`
```

since [here](https://github.com/PennyLaneAI/catalyst/actions/runs/8270528619/job/22628713441)
