### PR TITLE
Move OpenQASM mutex and make it a python mutex.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -43,6 +43,11 @@
   Note that returning different *kinds* of results, like different observables or differently
   shaped arrays, is not possible.
 
+* The Python interpreter is now a shared resource across the runtime.
+  [(#615)](https://github.com/PennyLaneAI/catalyst/pull/615)
+
+  This change allows any part of the runtime to start executing Python code through pybind.
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -21,6 +21,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(runtime_includes "${PROJECT_SOURCE_DIR}/include")
 set(capi_utils_includes "${PROJECT_SOURCE_DIR}/lib/capi")
 set(backend_includes "${PROJECT_SOURCE_DIR}/lib/backend/common")
+set(util_includes "${PROJECT_SOURCE_DIR}/lib/utils")
 
 
 # Get LLVM hash to target from source tree.
@@ -105,3 +106,4 @@ endif()
 
 add_subdirectory(lib)
 add_subdirectory(tests)
+add_subdirectory(utils)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(runtime_includes "${PROJECT_SOURCE_DIR}/include")
 set(capi_utils_includes "${PROJECT_SOURCE_DIR}/lib/capi")
 set(backend_includes "${PROJECT_SOURCE_DIR}/lib/backend/common")
-set(util_includes "${PROJECT_SOURCE_DIR}/lib/utils")
+set(util_includes "${PROJECT_SOURCE_DIR}/utils")
 
 
 # Get LLVM hash to target from source tree.

--- a/runtime/lib/backend/openqasm/CMakeLists.txt
+++ b/runtime/lib/backend/openqasm/CMakeLists.txt
@@ -39,8 +39,9 @@ add_library(rtd_openqasm SHARED OpenQasmDevice.cpp)
 target_include_directories(rtd_openqasm PRIVATE .
     ${runtime_includes}
     ${backend_includes}
+    ${util_includes}
     )
 
-target_link_libraries(rtd_openqasm pybind11::module)
+target_link_libraries(rtd_openqasm pybind11::module catalyst_python_interpreter)
 
 set_property(TARGET rtd_openqasm PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
+++ b/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
@@ -16,10 +16,6 @@
 
 namespace Catalyst::Runtime::Device::OpenQasm {
 
-std::mutex runner_mu;
-
-std::mutex &getOpenQasmRunnerMutex() { return runner_mu; }
-
 } // namespace Catalyst::Runtime::Device::OpenQasm
 
 namespace Catalyst::Runtime::Device {

--- a/runtime/lib/backend/openqasm/OpenQasmRunner.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmRunner.hpp
@@ -23,11 +23,9 @@
 #include <vector>
 
 #include "Exception.hpp"
+#include "Python.hpp"
 
 #include <pybind11/embed.h>
-
-// To protect the py::exec calls concurrently
-extern std::mutex &getPythonMutex();
 
 namespace Catalyst::Runtime::Device::OpenQasm {
 

--- a/runtime/lib/backend/openqasm/OpenQasmRunner.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmRunner.hpp
@@ -29,7 +29,7 @@
 namespace Catalyst::Runtime::Device::OpenQasm {
 
 // To protect the py::exec calls concurrently
-std::mutex &getOpenQasmRunnerMutex();
+extern std::mutex &getPythonMutex();
 
 /**
  * The OpenQasm circuit runner interface.
@@ -108,7 +108,7 @@ struct BraketRunner : public OpenQasmRunner {
                                   size_t shots, const std::string &kwargs = "") const
         -> std::string override
     {
-        std::lock_guard<std::mutex> lock(getOpenQasmRunnerMutex());
+        std::lock_guard<std::mutex> lock(getPythonMutex());
 
         namespace py = pybind11;
         using namespace py::literals;
@@ -164,7 +164,7 @@ struct BraketRunner : public OpenQasmRunner {
                              size_t num_qubits, const std::string &kwargs = "") const
         -> std::vector<double> override
     {
-        std::lock_guard<std::mutex> lock(getOpenQasmRunnerMutex());
+        std::lock_guard<std::mutex> lock(getPythonMutex());
         namespace py = pybind11;
         using namespace py::literals;
 
@@ -231,7 +231,7 @@ struct BraketRunner : public OpenQasmRunner {
                               size_t num_qubits, const std::string &kwargs = "") const
         -> std::vector<size_t> override
     {
-        std::lock_guard<std::mutex> lock(getOpenQasmRunnerMutex());
+        std::lock_guard<std::mutex> lock(getPythonMutex());
         namespace py = pybind11;
         using namespace py::literals;
 
@@ -294,7 +294,7 @@ struct BraketRunner : public OpenQasmRunner {
     [[nodiscard]] auto Expval(const std::string &circuit, const std::string &device, size_t shots,
                               const std::string &kwargs = "") const -> double override
     {
-        std::lock_guard<std::mutex> lock(getOpenQasmRunnerMutex());
+        std::lock_guard<std::mutex> lock(getPythonMutex());
         namespace py = pybind11;
         using namespace py::literals;
 
@@ -350,7 +350,7 @@ struct BraketRunner : public OpenQasmRunner {
     [[nodiscard]] auto Var(const std::string &circuit, const std::string &device, size_t shots,
                            const std::string &kwargs = "") const -> double override
     {
-        std::lock_guard<std::mutex> lock(getOpenQasmRunnerMutex());
+        std::lock_guard<std::mutex> lock(getPythonMutex());
         namespace py = pybind11;
         using namespace py::literals;
 

--- a/runtime/lib/backend/openqasm/OpenQasmRunner.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmRunner.hpp
@@ -26,10 +26,10 @@
 
 #include <pybind11/embed.h>
 
-namespace Catalyst::Runtime::Device::OpenQasm {
-
 // To protect the py::exec calls concurrently
 extern std::mutex &getPythonMutex();
+
+namespace Catalyst::Runtime::Device::OpenQasm {
 
 /**
  * The OpenQasm circuit runner interface.

--- a/runtime/lib/capi/CMakeLists.txt
+++ b/runtime/lib/capi/CMakeLists.txt
@@ -9,7 +9,7 @@ FetchContent_MakeAvailable(MLIRRunnerUtils)
 FetchContent_MakeAvailable(MLIRCRunnerUtils)
 
 # link to rt_backend
-target_link_libraries(catalyst_qir_qis_obj ${CMAKE_DL_LIBS})
+target_link_libraries(catalyst_qir_qis_obj ${CMAKE_DL_LIBS} catalyst_python_interpreter)
 
 if(ENABLE_OPENQASM)
     include(FetchContent)
@@ -43,6 +43,7 @@ target_link_libraries(catalyst_qir_qis_obj
 target_include_directories(catalyst_qir_qis_obj PUBLIC .
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${runtime_includes}
+    ${util_includes}
     ${mlirrunnerutils_SOURCE_DIR}/../..  # includes are relative to mlir/ExecutionEngine
     )
 

--- a/runtime/lib/capi/ExecutionContext.hpp
+++ b/runtime/lib/capi/ExecutionContext.hpp
@@ -23,59 +23,11 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#if __has_include("pybind11/embed.h")
-#include <pybind11/embed.h>
-#define __build_with_pybind11
-#endif
-
 #include "Exception.hpp"
+#include "Python.hpp"
 #include "QuantumDevice.hpp"
 
 namespace Catalyst::Runtime {
-
-/**
- * A (RAII) class for `pybind11::initialize_interpreter` and `pybind11::finalize_interpreter`.
- *
- * @note This is not copyable or movable and used in C++ tests and the ExecutionContext manager
- * of the runtime to solve the issue with re-initialization of the Python interpreter in `catch2`
- * tests which also enables the runtime to reuse the same interpreter in the scope of the global
- * quantum device unique pointer.
- *
- * @note This is only required for OpenQasmDevice and when CAPI is built with pybind11.
- */
-#ifdef __build_with_pybind11
-// LCOV_EXCL_START
-struct PythonInterpreterGuard {
-    // This ensures the guard scope to avoid Interpreter
-    // conflicts with runtime calls from the frontend.
-    bool _init_by_guard = false;
-
-    PythonInterpreterGuard()
-    {
-        if (!Py_IsInitialized()) {
-            pybind11::initialize_interpreter();
-            _init_by_guard = true;
-        }
-    }
-    ~PythonInterpreterGuard()
-    {
-        if (_init_by_guard) {
-            pybind11::finalize_interpreter();
-        }
-    }
-
-    PythonInterpreterGuard(const PythonInterpreterGuard &) = delete;
-    PythonInterpreterGuard(PythonInterpreterGuard &&) = delete;
-    PythonInterpreterGuard &operator=(const PythonInterpreterGuard &) = delete;
-    PythonInterpreterGuard &operator=(PythonInterpreterGuard &&) = delete;
-};
-// LCOV_EXCL_STOP
-#else
-struct PythonInterpreterGuard {
-    PythonInterpreterGuard() {}
-    ~PythonInterpreterGuard() {}
-};
-#endif
 
 class MemoryManager final {
   private:

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -104,10 +104,6 @@ void deactivateDevice()
 }
 } // namespace Catalyst::Runtime
 
-std::mutex python_mutex;
-
-std::mutex &getPythonMutex() { return python_mutex; }
-
 extern "C" {
 
 void __catalyst__host__rt__unrecoverable_error()

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -104,6 +104,10 @@ void deactivateDevice()
 }
 } // namespace Catalyst::Runtime
 
+std::mutex python_mutex;
+
+std::mutex &getPythonMutex() { return python_mutex; }
+
 extern "C" {
 
 void __catalyst__host__rt__unrecoverable_error()

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ include(Catch)
 
 if(ENABLE_LIGHTNING OR ENABLE_LIGHTNING_KOKKOS)
     add_executable(runner_tests_lightning runner_main.cpp)
+    target_include_directories(runner_tests_lightning PRIVATE catalyst_python_interpreter)
 
     add_subdirectory(third_party)
 

--- a/runtime/tests/Test_OpenQasmDevice.cpp
+++ b/runtime/tests/Test_OpenQasmDevice.cpp
@@ -18,9 +18,10 @@
 #include "OpenQasmBuilder.hpp"
 #include "OpenQasmDevice.hpp"
 #include "OpenQasmRunner.hpp"
+#include "Python.hpp"
 #include "RuntimeCAPI.h"
 
-Catalyst::Runtime::PythonInterpreterGuard guard{};
+PythonInterpreterGuard guard{};
 
 #include <catch2/catch.hpp>
 

--- a/runtime/utils/CMakeLists.txt
+++ b/runtime/utils/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(catalyst_python_interpreter SHARED Python.cpp)
+target_include_directories(catalyst_python_interpreter PRIVATE ${util_includes})
+

--- a/runtime/utils/Python.cpp
+++ b/runtime/utils/Python.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Xanadu Quantum Technologies Inc.
+// Copyright 2024 Xanadu Quantum Technologies Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/runtime/utils/Python.cpp
+++ b/runtime/utils/Python.cpp
@@ -1,0 +1,4 @@
+#include "Python.hpp"
+
+std::mutex python_mutex;
+std::mutex &getPythonMutex() { return python_mutex; }

--- a/runtime/utils/Python.cpp
+++ b/runtime/utils/Python.cpp
@@ -1,3 +1,17 @@
+// Copyright 2022-2024 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "Python.hpp"
 
 std::mutex python_mutex;

--- a/runtime/utils/Python.hpp
+++ b/runtime/utils/Python.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2024 Xanadu Quantum Technologies Inc.
+// Copyright 2024 Xanadu Quantum Technologies Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/runtime/utils/Python.hpp
+++ b/runtime/utils/Python.hpp
@@ -1,3 +1,67 @@
+// Copyright 2022-2024 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <mutex>
 
+#if __has_include("pybind11/embed.h")
+#include <pybind11/embed.h>
+#define __build_with_pybind11
+#endif
+
+struct PythonInterpreterGuard;
 std::mutex &getPythonMutex();
+
+/**
+ * A (RAII) class for `pybind11::initialize_interpreter` and `pybind11::finalize_interpreter`.
+ *
+ * @note This is not copyable or movable and used in C++ tests and the ExecutionContext manager
+ * of the runtime to solve the issue with re-initialization of the Python interpreter in `catch2`
+ * tests which also enables the runtime to reuse the same interpreter in the scope of the global
+ * quantum device unique pointer.
+ *
+ * @note This is only required for OpenQasmDevice and when CAPI is built with pybind11.
+ */
+#ifdef __build_with_pybind11
+// LCOV_EXCL_START
+struct PythonInterpreterGuard {
+    // This ensures the guard scope to avoid Interpreter
+    // conflicts with runtime calls from the frontend.
+    bool _init_by_guard = false;
+
+    PythonInterpreterGuard()
+    {
+        if (!Py_IsInitialized()) {
+            pybind11::initialize_interpreter();
+            _init_by_guard = true;
+        }
+    }
+    ~PythonInterpreterGuard()
+    {
+        if (_init_by_guard) {
+            pybind11::finalize_interpreter();
+        }
+    }
+
+    PythonInterpreterGuard(const PythonInterpreterGuard &) = delete;
+    PythonInterpreterGuard(PythonInterpreterGuard &&) = delete;
+    PythonInterpreterGuard &operator=(const PythonInterpreterGuard &) = delete;
+    PythonInterpreterGuard &operator=(PythonInterpreterGuard &&) = delete;
+};
+// LCOV_EXCL_STOP
+#else
+struct PythonInterpreterGuard {
+    PythonInterpreterGuard() {}
+    ~PythonInterpreterGuard() {}
+};
+#endif

--- a/runtime/utils/Python.hpp
+++ b/runtime/utils/Python.hpp
@@ -1,0 +1,3 @@
+#include <mutex>
+
+std::mutex &getPythonMutex();

--- a/runtime/utils/Python.hpp
+++ b/runtime/utils/Python.hpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#pragma once
+
 #include <mutex>
 
 #if __has_include("pybind11/embed.h")


### PR DESCRIPTION
**Context:** The OpenQASM3 mutex actually guards the python interpreter. Callbacks will also need to lock the python interpreter. So I am just moving it to be a shared lock for the python interpreter.

**Description of the Change:** Moving the mutex to be visible to all runtime. The lock now locks the python interpreter. There's a Python library that manages the python interpreter as a resource.

**Benefits:** Python interpreter is a shared resource among threads.

**Possible Drawbacks:** None.

**Related GitHub Issues:** None.
