### PR TITLE
Fix tests for OpenQasm device

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -48,6 +48,11 @@
 
   This change allows any part of the runtime to start executing Python code through pybind.
 
+* Fix runtime tests to be compatible with amazon-braket-sdk==1.73.3
+  [(#620)](https://github.com/PennyLaneAI/catalyst/pull/620)
+
+  After an update in the amazon-braket-sdk all declared qubits are measured as opposed to drop if there were no uses.
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>

--- a/runtime/tests/Test_OpenQasmDevice.cpp
+++ b/runtime/tests/Test_OpenQasmDevice.cpp
@@ -457,7 +457,7 @@ TEST_CASE("Test MatrixOperation with BuilderType::Braket", "[openqasm]")
     std::unique_ptr<OpenQasmDevice> device = std::make_unique<OpenQasmDevice>(
         "{device_type : braket.local.qubit, backend : default, shots : 1000}");
 
-    constexpr size_t n{5};
+    constexpr size_t n{2};
     constexpr size_t size{1UL << n};
     auto wires = device->AllocateQubits(n);
 
@@ -472,8 +472,8 @@ TEST_CASE("Test MatrixOperation with BuilderType::Braket", "[openqasm]")
     device->MatrixOperation(matrix, {wires[0]}, false);
 
     std::string toqasm = "OPENQASM 3.0;\n"
-                         "qubit[5] qubits;\n"
-                         "bit[5] bits;\n"
+                         "qubit[2] qubits;\n"
+                         "bit[2] bits;\n"
                          "x qubits[0];\n"
                          "y qubits[1];\n"
                          "#pragma braket unitary([[0, 0-1im], [0+1im, 0]]) qubits[0]\n"


### PR DESCRIPTION
**Context:** Recent changes in Amazon's Braket SDK made measurements behave differently. Now it returns all qubits in a qubit array where previously it appeared to return only alived qubits. (In other words, dead code elimination removed extra qubits but now it doesn't apppear to be the case).

**Description of the Change:** Change the test to only create a qubit array of 2 values instead of 5.

**Benefits:** The OpenQASM device tests are now passing. 

**Possible Drawbacks:** None.

**Related GitHub Issues:** None.
