### PR TITLE
Print using callbacks

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -9,29 +9,49 @@
   [(#650)](https://github.com/PennyLaneAI/catalyst/pull/650)
   [(#649)](https://github.com/PennyLaneAI/catalyst/pull/649)
   [(#661)](https://github.com/PennyLaneAI/catalyst/pull/661)
+  [(#621)](https://github.com/PennyLaneAI/catalyst/pull/621)
 
   Catalyst now supports callbacks with parameters and return values.
   The following is now possible:
 
   ```py
-  @pure_callback
+  @debug.callback
   def foo(val):
     return val
 
+  @pure_callback
+  def bar(val) -> int:
+    return val + 1
+
   @qjit
   def circuit(param):
-    return foo(param)
+    x = bar(param)
+    foo(x)
 
   ```
 
   ```pycon
   >>> print(circuit(123))
-  123
+  124
   ```
 
   This includes support for the specialized `pure_callback` and `debug.callback` where
   `pure_callback` is expected to return a value and be side effect free,
   while `debug.callback` is expected to produce a side effect and have no return values.
+
+  Syntactic sugar on top of `debug.callback` includes `debug.print` which allows the user
+  to use f-stringlike to format the string before printing.
+
+  ```py
+  @qjit
+  def cir(a, b, c):
+      debug.print("{c} {b} {a}", a=a, b=b, c=c)
+  ```
+
+  ```pycon
+  >>> cir(1, 2, 3)
+  3 2 1
+  ```
 
   At the moment, callbacks should not be used inside methods which are differentiated.
 
@@ -148,7 +168,11 @@
 * Add optimization that removes redundant chains of self inverse operations. This is done within a new MLIR pass called `remove-chained-self-inverse`. Currently we only match redundant Hadamard operations but the list of supported operations can be expanded.
   [(#630)](https://github.com/PennyLaneAI/catalyst/pull/630)
 
+
 <h3>Breaking changes</h3>
+
+* `catalyst.debug.print` has changed, resulting in the `memref` keyword argument being removed. Please use `catalyst.debug.print_memref` instead.
+  [(#621)](https://github.com/PennyLaneAI/catalyst/pull/621)
 
 <h3>Bug fixes</h3>
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -40,7 +40,7 @@
   while `debug.callback` is expected to produce a side effect and have no return values.
 
   Syntactic sugar on top of `debug.callback` includes `debug.print` which allows the user
-  to use formatstrings to format the string before printing. See https://docs.python.org/3/library/string.html#formatstrings
+  to use string formatting (akin to `str.format()`) before printing. See https://docs.python.org/3/library/string.html#formatstrings
 
   ```py
   @qjit

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -32,7 +32,7 @@
 
   ```pycon
   >>> print(circuit(123))
-myval: 124
+  myval: 124
   ```
 
   This includes support for the specialized `pure_callback` and `debug.callback` where

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -17,7 +17,7 @@
   ```py
   @debug.callback
   def foo(val):
-    return val
+    print(f"myval: {val}")
 
   @pure_callback
   def bar(val) -> int:
@@ -32,7 +32,7 @@
 
   ```pycon
   >>> print(circuit(123))
-  124
+myval: 124
   ```
 
   This includes support for the specialized `pure_callback` and `debug.callback` where
@@ -40,7 +40,7 @@
   while `debug.callback` is expected to produce a side effect and have no return values.
 
   Syntactic sugar on top of `debug.callback` includes `debug.print` which allows the user
-  to use f-stringlike to format the string before printing.
+  to use formatstrings to format the string before printing. See https://docs.python.org/3/library/string.html#formatstrings
 
   ```py
   @qjit

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -47,6 +47,7 @@ def pure_callback(callback_fn, result_type=None):
       1. Given the same arguments *args, the results will be the same each time the function is
          called.
       2. The function has no side effect.
+      3. Examples of side effects include modifying a non-local variable, printing, etc.
 
     A pure callback is a pure python function that can be executed by the python virtual machine.
     This is in direct contrast to functions which get JIT compiled by Catalyst.
@@ -105,7 +106,7 @@ def pure_callback(callback_fn, result_type=None):
 
 
 def debug_callback(callback_fn):
-    """Debug callback
+    """debug.callback : useful for printing and logging
 
     An debug callback is a python function that can write to stdout or to a file.
     It is expected to return no values.

--- a/frontend/catalyst/cuda/primitives/__init__.py
+++ b/frontend/catalyst/cuda/primitives/__init__.py
@@ -22,7 +22,7 @@ from jax import numpy as jnp
 
 # We disable protected access in particular to avoid warnings with cudaq._pycuda.
 # And we disable unused-argument to avoid unused arguments in abstract_eval, particularly kwargs.
-# pylint: disable=protected-access,unused-argument,line-too-long
+# pylint: disable=protected-access,unused-argument,abstract-method,line-too-long
 
 
 class AbsCudaQState(jax.core.AbstractValue):

--- a/frontend/catalyst/cuda/primitives/__init__.py
+++ b/frontend/catalyst/cuda/primitives/__init__.py
@@ -22,7 +22,7 @@ from jax import numpy as jnp
 
 # We disable protected access in particular to avoid warnings with cudaq._pycuda.
 # And we disable unused-argument to avoid unused arguments in abstract_eval, particularly kwargs.
-# pylint: disable=protected-access,unused-argument,abstract-method,line-too-long
+# pylint: disable=protected-access,unused-argument,line-too-long
 
 
 class AbsCudaQState(jax.core.AbstractValue):

--- a/frontend/catalyst/debug/__init__.py
+++ b/frontend/catalyst/debug/__init__.py
@@ -20,7 +20,10 @@ from catalyst.debug.compiler_functions import (
     get_cmain,
     print_compilation_stage,
 )
-from catalyst.debug.printing import print, print_memref  # pylint: disable=redefined-builtin
+from catalyst.debug.printing import (  # pylint: disable=redefined-builtin
+    print,
+    print_memref,
+)
 
 __all__ = (
     "callback",

--- a/frontend/catalyst/debug/__init__.py
+++ b/frontend/catalyst/debug/__init__.py
@@ -20,11 +20,12 @@ from catalyst.debug.compiler_functions import (
     get_cmain,
     print_compilation_stage,
 )
-from catalyst.debug.printing import print  # pylint: disable=redefined-builtin
+from catalyst.debug.printing import print, print_memref  # pylint: disable=redefined-builtin
 
 __all__ = (
     "callback",
     "print",
+    "print_memref",
     "print_compilation_stage",
     "get_cmain",
     "compile_from_mlir",

--- a/frontend/catalyst/debug/printing.py
+++ b/frontend/catalyst/debug/printing.py
@@ -28,20 +28,23 @@ from catalyst.tracing.contexts import EvaluationContext
 def print(fmt, *args, **kwargs):
     """A :func:`~.qjit` compatible print function for printing values at runtime.
 
-    This print function allows printing of values at runtime, unlike usage of standard Python ``print`` which will print values at program capture/compile time.
-    
-    ``debug.print`` is a minimal wrapper around :func:`~.debug.callback` which calls Python's ``builtins.print`` function, and thus will use the same formatting styles as Python's built-in print function.
-    
+    This print function allows printing of values at runtime, unlike usage of standard Python
+    ``print`` which will print values at program capture/compile time.
+
+    ``debug.print`` is a minimal wrapper around :func:`~.debug.callback` which calls Python's
+    ``builtins.print`` function, and thus will use the same formatting styles as Python's built-in
+    print function.
+
     Args:
         fmt (str): The string to be printed. Note that this may also be a
-            format string used to format input arguments (for example 
-            ``cost={x}``), similar to those permitted by ``str.format``. See 
+            format string used to format input arguments (for example
+            ``cost={x}``), similar to those permitted by ``str.format``. See
             the Python docs on
-            `string formatting <https://docs.python.org/3/library/stdtypes.html#str.format>`__
-            and `format string syntax <https://docs.python.org/3/library/string.html#formatstrings>`__.
+            `string formatting <https://docs.python.org/3/library/stdtypes.html#str.format>`__ and
+            `format string syntax <https://docs.python.org/3/library/string.html#formatstrings>`__.
         **args: Arguments to be passed to the format string.
         **kwargs: Keyword arguments to be passed to the format string.
-        
+
     .. seealso:: :func:`~.print_memref`
 
     **Example**
@@ -54,9 +57,9 @@ def print(fmt, *args, **kwargs):
 
     >>> f(1, 2, 3)
     c=3 b=2 a=1
-    
+
     .. note::
-    
+
         Using Python f-strings as the `fmt` string will not work as expected since they will be treated as Python objects.
         This means that array values embedded in them will have their compile-time representation
         printed, instead of actual data.
@@ -88,18 +91,18 @@ def _print_callback(*args, **kwargs):
 def print_memref(x):
     """A :func:`qjit` compatible print function for printing numeric values at runtime with memref information.
 
-    Enables printing of numeric values at runtime.
+    Enables printing of numeric values at runtime and the value's metadata.
+
+    Tensors, in the Catalyst runtime are represented as memref descriptor structs.
+    For more information about memref descirptors visit:
+    https://mlir.llvm.org/docs/Dialects/MemRef/
+    This function will print the base memory address of the data buffer, as well as the rank of
+    the array, the size of each dimension, and the strides between elements.
 
     Args:
         x (jax.Array, Any): A single jax array whose numeric values are printed at runtime.
-            Additional information about how the array is stored in memory is printed.
-            Tensors, in the Catalyst runtime are represented as memref descriptor structs.
-            For more information about memref descirptors visit:
-            https://mlir.llvm.org/docs/Dialects/MemRef/
-            This includes the base memory address of the data buffer, as well as the rank of
-            the array, the size of each dimension, and the strides between elements.
-            
-.. seealso:: :func:`~.debug.print`
+
+    .. seealso:: :func:`~.debug.print`
 
     **Example**
 

--- a/frontend/catalyst/debug/printing.py
+++ b/frontend/catalyst/debug/printing.py
@@ -94,8 +94,8 @@ def print_memref(x):
 
     Enables printing of numeric values at runtime and the value's metadata.
 
-    Tensors, in the Catalyst runtime are represented as memref descriptor structs.
-    For more information about memref descirptors visit:
+    Tensors in the Catalyst runtime are represented as memref descriptor structs.
+    For more information about memref descriptors visit:
     https://mlir.llvm.org/docs/Dialects/MemRef/
     This function will print the base memory address of the data buffer, as well as the rank of
     the array, the size of each dimension, and the strides between elements.

--- a/frontend/catalyst/debug/printing.py
+++ b/frontend/catalyst/debug/printing.py
@@ -15,6 +15,8 @@
 """This module enables runtime printing of program values."""
 
 import builtins
+import sys
+from functools import partial
 
 import jax
 

--- a/frontend/catalyst/debug/printing.py
+++ b/frontend/catalyst/debug/printing.py
@@ -90,7 +90,8 @@ def _print_callback(*args, **kwargs):
 
 # pylint: disable=redefined-builtin
 def print_memref(x):
-    """A :func:`qjit` compatible print function for printing numeric values at runtime with memref information.
+    """A :func:`qjit` compatible print function for printing numeric values at runtime with memref
+    information.
 
     Enables printing of numeric values at runtime and the value's metadata.
 

--- a/frontend/catalyst/debug/printing.py
+++ b/frontend/catalyst/debug/printing.py
@@ -76,9 +76,10 @@ def print_memref(x):
         x (jax.Array, Any): A single jax array whose numeric values are printed at runtime.
             Additional information about how the array is stored in memory is printed.
             Tensors, in the Catalyst runtime are represented as memref descriptor structs.
-            For more information about memref descirptors visit: https://mlir.llvm.org/docs/Dialects/MemRef/
-            This includes the base memory address of the data buffer, as well as the rank of the array,
-            the size of each dimension, and the strides between elements.
+            For more information about memref descirptors visit:
+            https://mlir.llvm.org/docs/Dialects/MemRef/
+            This includes the base memory address of the data buffer, as well as the rank of
+            the array, the size of each dimension, and the strides between elements.
 
     **Example**
 

--- a/frontend/catalyst/debug/printing.py
+++ b/frontend/catalyst/debug/printing.py
@@ -60,7 +60,8 @@ def print(fmt, *args, **kwargs):
 
     .. note::
 
-        Using Python f-strings as the `fmt` string will not work as expected since they will be treated as Python objects.
+        Using Python f-strings as the `fmt` string will not work as expected since they will be
+        treated as Python objects.
         This means that array values embedded in them will have their compile-time representation
         printed, instead of actual data.
     """

--- a/frontend/catalyst/debug/printing.py
+++ b/frontend/catalyst/debug/printing.py
@@ -24,6 +24,7 @@ from catalyst.jax_primitives import print_p
 from catalyst.tracing.contexts import EvaluationContext
 
 
+# pylint: disable=redefined-builtin
 def print(fmt, *args, **kwargs):
     """A print function.
 

--- a/frontend/catalyst/debug/printing.py
+++ b/frontend/catalyst/debug/printing.py
@@ -60,7 +60,7 @@ def print(fmt, *args, **kwargs):
 
     .. note::
 
-        Using Python f-strings as the `fmt` string will not work as expected since they will be
+        Using Python f-strings as the ``fmt`` string will not work as expected since they will be
         treated as Python objects.
         This means that array values embedded in them will have their compile-time representation
         printed, instead of actual data.
@@ -96,8 +96,7 @@ def print_memref(x):
     Enables printing of numeric values at runtime and the value's metadata.
 
     Tensors in the Catalyst runtime are represented as memref descriptor structs.
-    For more information about memref descriptors visit:
-    https://mlir.llvm.org/docs/Dialects/MemRef/
+    For more information about memref descriptors see the `MLIR documentation <https://mlir.llvm.org/docs/Dialects/MemRef/>`__.
     This function will print the base memory address of the data buffer, as well as the rank of
     the array, the size of each dimension, and the strides between elements.
 

--- a/frontend/catalyst/debug/printing.py
+++ b/frontend/catalyst/debug/printing.py
@@ -15,7 +15,6 @@
 """This module enables runtime printing of program values."""
 
 import builtins
-import sys
 from functools import partial
 
 import jax
@@ -25,7 +24,6 @@ from catalyst.jax_primitives import print_p
 from catalyst.tracing.contexts import EvaluationContext
 
 
-# pylint: disable=redefined-builtin
 def print(fmt, *args, **kwargs):
     """A print function.
 

--- a/frontend/catalyst/debug/printing.py
+++ b/frontend/catalyst/debug/printing.py
@@ -96,7 +96,8 @@ def print_memref(x):
     Enables printing of numeric values at runtime and the value's metadata.
 
     Tensors in the Catalyst runtime are represented as memref descriptor structs.
-    For more information about memref descriptors see the `MLIR documentation <https://mlir.llvm.org/docs/Dialects/MemRef/>`__.
+    For more information about memref descriptors see the
+    `MLIR documentation <https://mlir.llvm.org/docs/Dialects/MemRef/>`__.
     This function will print the base memory address of the data buffer, as well as the rank of
     the array, the size of each dimension, and the strides between elements.
 

--- a/frontend/catalyst/debug/printing.py
+++ b/frontend/catalyst/debug/printing.py
@@ -26,22 +26,40 @@ from catalyst.tracing.contexts import EvaluationContext
 
 # pylint: disable=redefined-builtin
 def print(fmt, *args, **kwargs):
-    """A print function.
+    """A :func:`~.qjit` compatible print function for printing values at runtime.
 
-    This print function works with python callbacks, so all arguments will be printed in the same
-    way as the :func:`builtins.print` function prints them.
+    This print function allows printing of values at runtime, unlike usage of standard Python ``print`` which will print values at program capture/compile time.
+    
+    ``debug.print`` is a minimal wrapper around :func:`~.debug.callback` which calls Python's ``builtins.print`` function, and thus will use the same formatting styles as Python's built-in print function.
+    
+    Args:
+        fmt (str): The string to be printed. Note that this may also be a
+            format string used to format input arguments (for example 
+            ``cost={x}``), similar to those permitted by ``str.format``. See 
+            the Python docs on
+            `string formatting <https://docs.python.org/3/library/stdtypes.html#str.format>`__
+            and `format string syntax <https://docs.python.org/3/library/string.html#formatstrings>`__.
+        **args: Arguments to be passed to the format string.
+        **kwargs: Keyword arguments to be passed to the format string.
+        
+    .. seealso:: :func:`~.print_memref`
 
-    One difference is that if the first argument is a string, it may be used similarly to an
-    fstring. Like so:
+    **Example**
 
     .. code-block:: python
 
         @qjit
-        def cir(a, b, c):
+        def f(a, b, c):
             debug.print("c={c} b={b} a={a}", a=a, b=b, c=c)
 
-        cir(1, 2, 3)
-    >>> c=3 b=2 a=1
+    >>> f(1, 2, 3)
+    c=3 b=2 a=1
+    
+    .. note::
+    
+        Using Python f-strings as the `fmt` string will not work as expected since they will be treated as Python objects.
+        This means that array values embedded in them will have their compile-time representation
+        printed, instead of actual data.
     """
 
     if isinstance(fmt, str):
@@ -68,7 +86,7 @@ def _print_callback(*args, **kwargs):
 
 # pylint: disable=redefined-builtin
 def print_memref(x):
-    """A :func:`qjit` compatible print function for printing values at runtime.
+    """A :func:`qjit` compatible print function for printing numeric values at runtime with memref information.
 
     Enables printing of numeric values at runtime.
 
@@ -80,6 +98,8 @@ def print_memref(x):
             https://mlir.llvm.org/docs/Dialects/MemRef/
             This includes the base memory address of the data buffer, as well as the rank of
             the array, the size of each dimension, and the strides between elements.
+            
+.. seealso:: :func:`~.debug.print`
 
     **Example**
 

--- a/frontend/catalyst/debug/printing.py
+++ b/frontend/catalyst/debug/printing.py
@@ -27,6 +27,24 @@ from catalyst.tracing.contexts import EvaluationContext
 
 # pylint: disable=redefined-builtin
 def print(fmt, *args, **kwargs):
+    """A print function.
+
+    This print function works with python callbacks, so all arguments will be printed in the same
+    way as the :func:`builtins.print` function prints them.
+
+    One difference is that if the first argument is a string, it may be used similarly to an
+    fstring. Like so:
+
+    .. code-block:: python
+
+        @qjit
+        def cir(a, b, c):
+            debug.print("c={c} b={b} a={a}", a=a, b=b, c=c)
+
+        cir(1, 2, 3)
+    >>> c=3 b=2 a=1
+    """
+
     if isinstance(fmt, str):
         debug_callback(partial(_format_print_callback, fmt))(*args, **kwargs)
         return
@@ -41,11 +59,11 @@ def _format_print_callback(fmt: str, *args, **kwargs):
     version released under the Apache License, Version 2.0, with the following copyright notice:
     Copyright 2022 The Jax Authors.
     """
-    sys.stdout.write(fmt.format(*args, **kwargs))
-    sys.stdout.write("\n")
+    builtins.print(fmt.format(*args, **kwargs))
 
 
 def _print_callback(*args, **kwargs):
+    """Print without formatting"""
     builtins.print(*args, **kwargs)
 
 

--- a/frontend/catalyst/debug/printing.py
+++ b/frontend/catalyst/debug/printing.py
@@ -73,7 +73,12 @@ def print_memref(x):
     Enables printing of numeric values at runtime.
 
     Args:
-        x (jax.Array, Any): A single jax array whose numeric values are printed at runtime
+        x (jax.Array, Any): A single jax array whose numeric values are printed at runtime.
+            Additional information about how the array is stored in memory is printed.
+            Tensors, in the Catalyst runtime are represented as memref descriptor structs.
+            For more information about memref descirptors visit: https://mlir.llvm.org/docs/Dialects/MemRef/
+            This includes the base memory address of the data buffer, as well as the rank of the array,
+            the size of each dimension, and the strides between elements.
 
     **Example**
 
@@ -88,12 +93,6 @@ def print_memref(x):
     [0.43]
 
     Outside a :func:`qjit` compiled function the operation falls back to the Python print statement.
-
-    .. note::
-
-        Python f-strings will not work as expected since they will be treated as Python objects.
-        This means that array values embeded in them will have their compile-time representation
-        printed, instead of actual data.
     """
     if EvaluationContext.is_tracing():
         if not isinstance(x, jax.core.Tracer):

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -76,7 +76,7 @@ from catalyst.utils.calculate_grad_shape import Signature, calculate_grad_shape
 from catalyst.utils.extra_bindings import FromElementsOp, TensorExtractOp
 from catalyst.utils.types import convert_shaped_arrays_to_tensors
 
-# pylint: disable=unused-argument,abstract-method,too-many-lines
+# pylint: disable=unused-argument,too-many-lines
 
 #########
 # Types #

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -76,7 +76,7 @@ from catalyst.utils.calculate_grad_shape import Signature, calculate_grad_shape
 from catalyst.utils.extra_bindings import FromElementsOp, TensorExtractOp
 from catalyst.utils.types import convert_shaped_arrays_to_tensors
 
-# pylint: disable=unused-argument,too-many-lines
+# pylint: disable=unused-argument,abstract-method,too-many-lines
 
 #########
 # Types #

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -271,8 +271,7 @@ def _print_def_impl(*args, string=None, memref=False):  # pragma: no cover
 
 def _print_lowering(jax_ctx: mlir.LoweringRuleContext, *args, string=None, memref=False):
     val = args[0] if args else None
-    const_val = ir.StringAttr.get(string + "\0") if string else None
-    return PrintOp(val=val, const_val=const_val, print_descriptor=memref).results
+    return PrintOp(val=val, const_val=None, print_descriptor=memref).results
 
 
 #

--- a/frontend/test/pytest/test_debug.py
+++ b/frontend/test/pytest/test_debug.py
@@ -28,25 +28,22 @@ class TestDebugPrint:
     """Test suite for the runtime print functionality."""
 
     @pytest.mark.parametrize(
-        ("arg", "expected"),
+        ("arg"),
         [
-            (True, "1\n"),  # TODO: True/False would be nice
-            (3, "3\n"),
-            (3.5, "3.5\n"),
-            (3 + 4j, "(3,4)\n"),
-            (np.array(3), "3\n"),
-            (jnp.array(3), "3\n"),
-            (jnp.array(3.000001), "3\n"),  # TODO: show more precision
-            (jnp.array(3.1 + 4j), "(3.1,4)\n"),
-            (jnp.array([3]), "[3]\n"),
-            (jnp.array([3, 4, 5]), "[3,  4,  5]\n"),
-            (
-                jnp.array([[3, 4], [5, 6], [7, 8]]),
-                "[[3,   4], \n [5,   6], \n [7,   8]]\n",
-            ),
+            True,
+            3,
+            3.5,
+            3 + 4j,
+            np.array(3),
+            jnp.array(3),
+            jnp.array(3.000001),
+            jnp.array(3.1 + 4j),
+            jnp.array([3]),
+            jnp.array([3, 4, 5]),
+            jnp.array([[3, 4], [5, 6], [7, 8]]),
         ],
     )
-    def test_function_arguments(self, capfd, arg, expected):
+    def test_function_arguments(self, capfd, arg):
         """Test printing of arbitrary JAX tracer values."""
 
         @qjit
@@ -61,7 +58,8 @@ class TestDebugPrint:
 
         out, err = capfd.readouterr()
         assert err == ""
-        assert expected == out
+        expected = str(arg)
+        assert expected == out.strip()
 
     def test_optional_descriptor(self, capfd):
         """Test the optional memref descriptor functionality."""

--- a/frontend/test/pytest/test_debug.py
+++ b/frontend/test/pytest/test_debug.py
@@ -87,6 +87,17 @@ class TestDebugPrint:
         assert err == ""
         assert regex.match(out)
 
+    def test_bad_argument(self):
+        """Test bad argument."""
+
+        @qjit
+        def test(x):
+            debug.print_memref("foo")
+
+        msg = "Arguments to print_memref must be of type jax.core.Tracer"
+        with pytest.raises(TypeError, match=msg):
+            test(3.14)
+
     @pytest.mark.parametrize(
         ("arg", "expected"),
         [

--- a/frontend/test/pytest/test_debug.py
+++ b/frontend/test/pytest/test_debug.py
@@ -91,7 +91,7 @@ class TestDebugPrint:
         """Test bad argument."""
 
         @qjit
-        def test(x):
+        def test(_x):
             debug.print_memref("foo")
 
         msg = "Arguments to print_memref must be of type jax.core.Tracer"
@@ -233,7 +233,7 @@ class TestPrintStage:
 
         print_compilation_stage(func, "HLOLoweringPass")
 
-        out, err = capsys.readouterr()
+        out, _ = capsys.readouterr()
         assert "@jit_func() -> tensor<i64>" in out
         assert "stablehlo.constant" not in out
 

--- a/frontend/test/pytest/test_debug.py
+++ b/frontend/test/pytest/test_debug.py
@@ -66,7 +66,7 @@ class TestDebugPrint:
 
         @qjit
         def test(x):
-            debug.print(x, memref=True)
+            debug.print_memref(x)
 
         out, err = capfd.readouterr()
         assert err == ""


### PR DESCRIPTION
**Context:** Use `debug.callback` to print.

**Description of the Change:** Creates callback to improve printing interface by providing the same semantics as JAX's debug print. Specializes the previous print implementation to memref.

**Benefits:** Better interface.

**Possible Drawbacks:** None.

**Related GitHub Issues:** None.

[sc-59388]
