### PR TITLE
Support for value_and_grad at the MLIR side (inside a jitting context)

### DIFF
--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -34,7 +34,7 @@ from jaxlib.mlir.dialects.mhlo import ConstantOp, ConvertOp
 from jaxlib.mlir.dialects.scf import ConditionOp, ForOp, IfOp, WhileOp, YieldOp
 from jaxlib.mlir.dialects.stablehlo import ConstantOp as StableHLOConstantOp
 from mlir_quantum.dialects.catalyst import PrintOp, PythonCallOp
-from mlir_quantum.dialects.gradient import GradOp, JVPOp, VJPOp
+from mlir_quantum.dialects.gradient import GradOp, JVPOp, ValueAndGradOp, VJPOp
 from mlir_quantum.dialects.mitigation import ZneOp
 from mlir_quantum.dialects.quantum import (
     AdjointOp,
@@ -217,6 +217,8 @@ print_p = jax.core.Primitive("debug_print")
 print_p.multiple_results = True
 python_callback_p = core.Primitive("python_callback")
 python_callback_p.multiple_results = True
+value_and_grad_p = core.Primitive("value_and_grad")
+value_and_grad_p.multiple_results = True
 
 
 @python_callback_p.def_abstract_eval
@@ -410,6 +412,63 @@ def _grad_lowering(ctx, *args, jaxpr, fn, grad_params):
         mlir.flatten_lowering_ir_args(args_and_consts),
         diffArgIndices=diffArgIndices,
         finiteDiffParam=finiteDiffParam,
+    ).results
+
+
+# value_and_grad
+#
+@value_and_grad_p.def_impl
+def _value_and_grad_def_impl(ctx, *args, jaxpr, fn, grad_params):  # pragma: no cover
+    raise NotImplementedError()
+
+
+@value_and_grad_p.def_abstract_eval
+def _value_and_grad_abstract(*args, jaxpr, fn, grad_params):  # pylint: disable=unused-argument
+    """This function is called with abstract arguments for tracing.
+    Note: argument names must match these of `_value_and_grad_lowering`."""
+    return jaxpr.out_avals + jaxpr.out_avals
+
+
+def _value_and_grad_lowering(ctx, *args, jaxpr, fn, grad_params):
+    """
+    Returns:
+        MLIR results
+    """
+    args = list(args)
+    method, h, argnum = grad_params.method, grad_params.h, grad_params.expanded_argnum
+    mlir_ctx = ctx.module_context.context
+    new_argnum = np.array([len(jaxpr.consts) + num for num in argnum])
+
+    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
+    flat_output_types = util.flatten(output_types)
+    constants = [
+        ConstantOp(ir.DenseElementsAttr.get(np.asarray(const))).results for const in jaxpr.consts
+    ]
+    consts_and_args = constants + args
+    func_call_jaxpr = jaxpr.eqns[0].params["call_jaxpr"]
+    func_args = consts_and_args[: len(func_call_jaxpr.invars)]
+    val_result_types = flat_output_types[: len(flat_output_types) - len(argnum)]
+    gradient_result_types = flat_output_types[len(flat_output_types) - len(argnum) :]
+
+    _func_lowering(
+        ctx,
+        *func_args,
+        call_jaxpr=func_call_jaxpr,
+        fn=fn,
+        call=False,
+    )
+
+    assert (
+        len(flat_output_types) % 2 == 0
+    ), f"The total number of result tensors is expected to be even, not {len(flat_output_types)}"
+    return ValueAndGradOp(
+        val_result_types,
+        gradient_result_types,
+        ir.StringAttr.get(method),
+        ir.FlatSymbolRefAttr.get(mlir_fn_cache[fn]),
+        mlir.flatten_lowering_ir_args(func_args),
+        diffArgIndices=ir.DenseIntElementsAttr.get(new_argnum),
+        finiteDiffParam=ir.FloatAttr.get(ir.F64Type.get(mlir_ctx), h) if h else None,
     ).results
 
 
@@ -1709,6 +1768,7 @@ mlir.register_lowering(vjp_p, _vjp_lowering)
 mlir.register_lowering(adjoint_p, _adjoint_lowering)
 mlir.register_lowering(print_p, _print_lowering)
 mlir.register_lowering(python_callback_p, _python_callback_lowering)
+mlir.register_lowering(value_and_grad_p, _value_and_grad_lowering)
 
 
 def _scalar_abstractify(t):

--- a/frontend/catalyst/pennylane_extensions.py
+++ b/frontend/catalyst/pennylane_extensions.py
@@ -74,6 +74,7 @@ from catalyst.jax_primitives import (
     probs_p,
     python_callback_p,
     qmeasure_p,
+    value_and_grad_p,
     vjp_p,
     while_p,
     zne_p,
@@ -405,10 +406,6 @@ class Grad:
         """
 
         if EvaluationContext.is_tracing():
-            assert (
-                not self.grad_params.with_value
-            ), "Tracing of value_and_grad is not implemented yet"
-
             fn = _ensure_differentiable(self.fn)
 
             args_data, in_tree = tree_flatten(args)
@@ -422,15 +419,33 @@ class Grad:
                 self.grad_params.with_value,
             )
             jaxpr, out_tree = _make_jaxpr_check_differentiable(fn, grad_params, *args)
-            args_argnum = tuple(args[i] for i in grad_params.argnum)
-            _, in_tree = tree_flatten(args_argnum)
+            if self.grad_params.with_value:  # use value_and_grad
+                # It always returns list as required by catalyst control-flows
+                results = value_and_grad_p.bind(
+                    *args_data, jaxpr=jaxpr, fn=fn, grad_params=grad_params
+                )
 
-            # It always returns list as required by catalyst control-flows
-            results = grad_p.bind(*args_data, jaxpr=jaxpr, fn=fn, grad_params=grad_params)
+                # value_and_grad returns two results: the values and the gradients,
+                # hence we have to split the obtained results
+                vals = results[: len(jaxpr.out_avals)]
+                gradients = results[len(jaxpr.out_avals) :]
 
-            results = _unflatten_derivatives(
-                results, in_tree, out_tree, grad_params, len(jaxpr.out_avals)
-            )
+                vals = tree_unflatten(out_tree, vals)
+                gradients = tree_unflatten(out_tree, gradients)
+                results = (vals, gradients)
+            else:  # use grad
+                args_argnum = tuple(args[i] for i in grad_params.argnum)
+                _, in_tree = tree_flatten(args_argnum)
+
+                # It always returns list as required by catalyst control-flows
+                results = grad_p.bind(*args_data, jaxpr=jaxpr, fn=fn, grad_params=grad_params)
+
+                # grad returns only the gradients,
+                # so there is no need to split the results.
+
+                results = _unflatten_derivatives(
+                    results, in_tree, out_tree, grad_params, len(jaxpr.out_avals)
+                )
         else:
             if argnums := self.grad_params.argnum is None:
                 argnums = 0

--- a/mlir/include/Gradient/IR/GradientOps.td
+++ b/mlir/include/Gradient/IR/GradientOps.td
@@ -117,8 +117,11 @@ def AdjointOp : Gradient_Op<"adjoint", [AttrSizedOperandSegments]> {
     }];
 }
 
-def BackpropOp : Gradient_Op<"backprop", [AttrSizedOperandSegments,
-        DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+def BackpropOp : Gradient_Op<"backprop", [
+        AttrSizedOperandSegments,
+        AttrSizedResultSegments,
+        DeclareOpInterfaceMethods<SymbolUserOpInterface>
+        ]> {
     let summary = "Perform classic automatic differentiation using Enzyme AD.";
 
     let arguments = (ins
@@ -134,6 +137,10 @@ def BackpropOp : Gradient_Op<"backprop", [AttrSizedOperandSegments,
     );
 
     let results = (outs
+        Variadic<AnyTypeOf<[
+            AnyFloat,
+            RankedTensorOf<[AnyFloat]>
+        ]>>:$vals,
         Variadic<AnyTypeOf<[
             AnyFloat,
             RankedTensorOf<[AnyFloat]>

--- a/mlir/include/Gradient/IR/GradientOps.td
+++ b/mlir/include/Gradient/IR/GradientOps.td
@@ -63,6 +63,35 @@ def GradOp : Gradient_Op<"grad", [DeclareOpInterfaceMethods<CallOpInterface>,
     }];
 }
 
+def ValueAndGradOp : Gradient_Op<"value_and_grad", [
+        SameVariadicResultSize,
+        DeclareOpInterfaceMethods<CallOpInterface>,
+        DeclareOpInterfaceMethods<SymbolUserOpInterface>
+        ]> {
+    let summary = "Compute the value and gradient of a function.";
+
+    let arguments = (ins
+        StrAttr:$method,
+        FlatSymbolRefAttr:$callee,
+        Variadic<AnyType>:$operands,
+        OptionalAttr<AnyIntElementsAttr>:$diffArgIndices,
+        OptionalAttr<Builtin_FloatAttr>:$finiteDiffParam
+    );
+
+    let results = (outs
+        Variadic<AnyTypeOf<[AnyFloat, RankedTensorOf<[AnyFloat]>]>>:$vals,
+        Variadic<AnyTypeOf<[AnyFloat, RankedTensorOf<[AnyFloat]>]>>:$gradients
+    );
+
+    let assemblyFormat = [{
+        $method $callee `(` $operands `)`
+        attr-dict `:` functional-type(operands, results)
+    }];
+
+
+    let hasVerifier = 1;
+}
+
 def AdjointOp : Gradient_Op<"adjoint", [AttrSizedOperandSegments]> {
     let summary = "Perform quantum AD using the adjoint method on a device.";
 

--- a/mlir/lib/Gradient/IR/GradientOps.cpp
+++ b/mlir/lib/Gradient/IR/GradientOps.cpp
@@ -154,6 +154,81 @@ LogicalResult GradOp::verify()
 MutableOperandRange GradOp::getArgOperandsMutable() { return getOperandsMutable(); }
 
 //===----------------------------------------------------------------------===//
+// ValueAndGradOp, CallOpInterface
+//===----------------------------------------------------------------------===//
+
+CallInterfaceCallable ValueAndGradOp::getCallableForCallee() { return getCalleeAttr(); }
+
+void ValueAndGradOp::setCalleeFromCallable(CallInterfaceCallable callee)
+{
+    (*this)->setAttr("callee", callee.get<SymbolRefAttr>());
+};
+
+Operation::operand_range ValueAndGradOp::getArgOperands() { return getOperands(); }
+
+//===----------------------------------------------------------------------===//
+// ValueAndGradOp, SymbolUserOpInterface
+//===----------------------------------------------------------------------===//
+
+LogicalResult ValueAndGradOp::verifySymbolUses(SymbolTableCollection &symbolTable)
+{
+    // Check that the callee attribute refers to a valid function.
+    func::FuncOp callee = ({
+        auto cattr = this->getCalleeAttr();
+        auto fn = symbolTable.lookupNearestSymbolFrom<func::FuncOp>(this->getOperation(), cattr);
+        if (!fn)
+            return this->emitOpError("invalid function name specified: ") << cattr;
+        fn;
+    });
+
+    auto diffArgIndices = computeDiffArgIndices(this->getDiffArgIndices());
+    auto r1 = ::verifyGradInputs(this, callee, this->getOperands(), diffArgIndices);
+    if (r1.failed()) {
+        return r1;
+    }
+
+    if (this->getNumResults() != 2 * callee.getFunctionType().getNumResults()) {
+        return this->emitOpError(
+                   "invalid number of results: must be twice the number of callee results")
+               << " which is " << 2 * callee.getFunctionType().getNumResults() << " but got "
+               << this->getNumResults();
+    }
+
+    std::vector<Type> grad_types;
+    {
+        for (auto s : this->getGradients()) {
+            grad_types.push_back(s.getType());
+        }
+    }
+
+    for (size_t i = 0; i < callee.getFunctionType().getNumResults(); i++) {
+        auto calleeRtype = callee.getFunctionType().getResult(i);
+        auto gradRtype = grad_types[i];
+        if (calleeRtype != gradRtype) {
+            return this->emitOpError("result types do not match")
+                   << " result " << i << " should match "
+                   << " was expected to match the type " << gradRtype << " but got " << calleeRtype;
+        }
+    }
+
+    return success();
+}
+
+//===----------------------------------------------------------------------===//
+// ValueAndGradOp Extra methods
+//===----------------------------------------------------------------------===//
+
+LogicalResult ValueAndGradOp::verify()
+{
+    StringRef method = this->getMethod();
+    if (method != "fd" && method != "ps" && method != "adj" && method != "auto")
+        return emitOpError("got invalid differentiation method: ") << method;
+    return success();
+}
+
+MutableOperandRange ValueAndGradOp::getArgOperandsMutable() { return getOperandsMutable(); }
+
+//===----------------------------------------------------------------------===//
 // JVPOp, CallOpInterface
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Gradient/IR/GradientOps.cpp
+++ b/mlir/lib/Gradient/IR/GradientOps.cpp
@@ -421,18 +421,23 @@ LogicalResult BackpropOp::verifySymbolUses(SymbolTableCollection &symbolTable)
     if (hasTensorSemantics(getOperandTypes(), getResultTypes())) {
         // Verify the types of the outputs
         std::vector<Type> backpropTypes = computeBackpropTypes(fn, diffArgIndices);
-        TypeRange resultTypes = this->getResultTypes();
-        if (backpropTypes.size() != resultTypes.size()) {
-            return emitOpError("incorrect number of results in the backprop of the callee, ")
-                   << "expected " << backpropTypes.size() << " results "
-                   << "but got " << resultTypes.size();
+
+        std::vector<Type> gradientTypes;
+        for (auto &&grad : this->getGradients()) {
+            gradientTypes.push_back(grad.getType());
+        }
+
+        if (backpropTypes.size() != gradientTypes.size()) {
+            return emitOpError("incorrect number of gradients in the backprop of the callee, ")
+                   << "expected " << backpropTypes.size() << " gradients "
+                   << "but got " << gradientTypes.size();
         }
 
         for (unsigned i = 0; i < backpropTypes.size(); ++i) {
-            if (backpropTypes[i] != resultTypes[i]) {
-                return emitOpError("result type mismatch: expected operand type ")
-                       << backpropTypes[i] << ", but provided " << resultTypes[i]
-                       << " for result number " << i;
+            if (backpropTypes[i] != gradientTypes[i]) {
+                return emitOpError("gradient type mismatch: expected operand type ")
+                       << backpropTypes[i] << ", but provided " << gradientTypes[i]
+                       << " for gradient number " << i;
             }
         }
     }
@@ -461,10 +466,10 @@ LogicalResult BackpropOp::verify()
                << ", expected " << this->getCotangents().size() << " but got "
                << this->getCalleeResults().size();
 
-    if (this->getDiffArgShadows().size() + this->getNumResults() != numDiffArgs)
+    if (this->getDiffArgShadows().size() + this->getGradients().size() != numDiffArgs)
         return emitOpError("number of gradient results did not match number of differentiable")
                << " arguments, expected " << numDiffArgs << " but got "
-               << this->getDiffArgShadows().size() + this->getNumResults();
+               << this->getDiffArgShadows().size() + this->getGradients().size();
 
     return success();
 }

--- a/mlir/lib/Gradient/Transforms/BufferizationPatterns.cpp
+++ b/mlir/lib/Gradient/Transforms/BufferizationPatterns.cpp
@@ -138,34 +138,24 @@ class BufferizeBackpropOp : public OpConversionPattern<BackpropOp> {
             rewriter.create<memref::CopyOp>(loc, cotangent, resShadow);
         }
 
-        // Collect the value types
-        SmallVector<Type> valTypes;
-        {
-            for (auto &&val : op.getVals()) {
-                valTypes.push_back(val.getType());
-            }
-        }
-
-        // Infer if we are lowering a value_and_grad operation
-        bool isValueAndGradOp = !valTypes.empty();
-
         DenseIntElementsAttr diffArgIndicesAttr = adaptor.getDiffArgIndices().value_or(nullptr);
         auto bufferizedBackpropOp = rewriter.create<BackpropOp>(
-            loc, valTypes, scalarReturnTypes, op.getCalleeAttr(), adaptor.getArgs(), argShadows,
+            loc, TypeRange{}, scalarReturnTypes, op.getCalleeAttr(), adaptor.getArgs(), argShadows,
             calleeResults, resShadows, diffArgIndicesAttr);
 
         // Fill in the null placeholders.
         for (const auto &[idx, scalarResult] :
-                llvm::enumerate(bufferizedBackpropOp.getGradients())) {
+             llvm::enumerate(bufferizedBackpropOp.getGradients())) {
             gradients[scalarIndices[idx]] = scalarResult;
         }
-        
+
         // BackpropOp can return two results for value_and_grad: values and gradients
         // or only one for grad: gradients
         SmallVector<Value> results;
         {
-            // The values are the calleeResults
-            if (isValueAndGradOp) {
+            // If we are lowering a value_and_grad operation, then take values from the
+            // calleeResults
+            if (!op.getVals().empty()) {
                 results.insert(results.end(), calleeResults.begin(), calleeResults.end());
             }
             results.insert(results.end(), gradients.begin(), gradients.end());

--- a/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
@@ -362,9 +362,15 @@ struct BackpropOpPattern : public ConvertOpToLLVMPattern<BackpropOp> {
             }
         }
 
+        // If we don't have any vals, it means we are coming from a GradOp, then we mark the results
+        // for being ignored by Enzime. But if we have vals, we are coming from a ValueAndGradOp,
+        // then we tell Enzime to keep them.
+        bool dupNoNeed = op.getVals().empty();
+
         for (auto [result, cotangent] :
              llvm::zip_equal(op.getCalleeResults(), op.getCotangents())) {
-            unpackMemRefAndAppend(result, cotangent, callArgs, rewriter, loc, {.dupNoNeed = true});
+            unpackMemRefAndAppend(result, cotangent, callArgs, rewriter, loc,
+                                  {.dupNoNeed = dupNoNeed});
         }
 
         // The results of backprop are in argShadows, except scalar derivatives which are in the

--- a/mlir/lib/Gradient/Transforms/GradMethods/HybridGradient.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/HybridGradient.cpp
@@ -337,8 +337,8 @@ func::FuncOp HybridGradientLowering::genFullGradFunction(PatternRewriter &rewrit
                                              rewriter, loc, cotangents);
 
                         auto backpropOp = rewriter.create<gradient::BackpropOp>(
-                            loc, computeBackpropTypes(callee, diffArgIndices), callee.getName(),
-                            entryBlock->getArguments(),
+                            loc, TypeRange{}, computeBackpropTypes(callee, diffArgIndices),
+                            callee.getName(), entryBlock->getArguments(),
                             /*arg_shadows=*/ValueRange{},
                             /*primal results=*/ValueRange{}, cotangents,
                             gradOp.getDiffArgIndicesAttr());
@@ -399,8 +399,8 @@ func::FuncOp HybridGradientLowering::genFullGradFunction(PatternRewriter &rewrit
                                      loc, cotangents);
 
                 auto backpropOp = rewriter.create<gradient::BackpropOp>(
-                    loc, computeBackpropTypes(callee, diffArgIndices), callee.getName(),
-                    entryBlock->getArguments(),
+                    loc, TypeRange{}, computeBackpropTypes(callee, diffArgIndices),
+                    callee.getName(), entryBlock->getArguments(),
                     /*arg_shadows=*/ValueRange{}, /*primal results=*/ValueRange{}, cotangents,
                     gradOp.getDiffArgIndicesAttr());
                 for (const auto &[backpropIdx, jacobianSlice] :

--- a/mlir/lib/Gradient/Transforms/GradMethods/HybridGradient.hpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/HybridGradient.hpp
@@ -24,10 +24,20 @@ namespace gradient {
 
 /// A pattern responsible for common transformations required when differentiating hybrid circuits
 /// with Enzyme.
+
+// grad lowering
 struct HybridGradientLowering : public mlir::OpRewritePattern<GradOp> {
     using OpRewritePattern<GradOp>::OpRewritePattern;
 
     mlir::LogicalResult matchAndRewrite(GradOp op, mlir::PatternRewriter &rewriter) const override;
+};
+
+// value_and_grad lowering
+struct HybridValueAndGradientLowering : public mlir::OpRewritePattern<ValueAndGradOp> {
+    using OpRewritePattern<ValueAndGradOp>::OpRewritePattern;
+
+    mlir::LogicalResult matchAndRewrite(ValueAndGradOp op,
+                                        mlir::PatternRewriter &rewriter) const override;
 };
 
 } // namespace gradient

--- a/mlir/lib/Gradient/Transforms/GradMethods/HybridGradient.hpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/HybridGradient.hpp
@@ -28,23 +28,6 @@ struct HybridGradientLowering : public mlir::OpRewritePattern<GradOp> {
     using OpRewritePattern<GradOp>::OpRewritePattern;
 
     mlir::LogicalResult matchAndRewrite(GradOp op, mlir::PatternRewriter &rewriter) const override;
-
-  private:
-    /// Recursively process all the QNodes of the `callee` being differentiated. The resulting
-    /// BackpropOps will be called with `backpropArgs`.
-    static mlir::FailureOr<mlir::func::FuncOp>
-    cloneCallee(mlir::PatternRewriter &rewriter, GradOp gradOp, mlir::func::FuncOp callee,
-                mlir::SmallVectorImpl<Value> &backpropArgs);
-
-    /// Generate a version of the QNode that accepts the parameter buffer. This is so Enzyme will
-    /// see that the gate parameters flow into the custom quantum function.
-    static mlir::func::FuncOp genQNodeQuantumOnly(mlir::PatternRewriter &rewriter,
-                                                  mlir::Location loc, mlir::func::FuncOp qnode);
-
-    /// Generate a function that computes a Jacobian row-by-row using one or more BackpropOps.
-    static mlir::func::FuncOp genFullGradFunction(mlir::PatternRewriter &rewriter,
-                                                  mlir::Location loc, GradOp gradOp,
-                                                  mlir::func::FuncOp callee, FunctionType fnType);
 };
 
 } // namespace gradient

--- a/mlir/lib/Gradient/Transforms/LoweringPatterns.cpp
+++ b/mlir/lib/Gradient/Transforms/LoweringPatterns.cpp
@@ -31,6 +31,7 @@ namespace gradient {
 void populateLoweringPatterns(RewritePatternSet &patterns)
 {
     patterns.add<HybridGradientLowering>(patterns.getContext());
+    patterns.add<HybridValueAndGradientLowering>(patterns.getContext());
     patterns.add<FiniteDiffLowering>(patterns.getContext(), 1);
     patterns.add<ParameterShiftLowering>(patterns.getContext(), 1);
     patterns.add<AdjointLowering>(patterns.getContext(), 1);

--- a/mlir/test/Gradient/BufferizationTest.mlir
+++ b/mlir/test/Gradient/BufferizationTest.mlir
@@ -37,8 +37,8 @@ func.func @backprop(%arg0: f64, %arg1: tensor<?xf64>) {
 
     // CHECK:   [[dim:%.+]] = memref.dim
     // CHECK:   [[calleeRes:%.+]] = memref.alloc([[dim]]) : memref<?xf64>
-    // CHECK:   gradient.backprop @circuit2({{%.+}}) callee_out([[calleeRes]] : memref<?xf64>) cotangents({{%.+}} : memref<?xf64>) {diffArgIndices = dense<0> : tensor<1xindex>} : (f64) -> f64
-    %grad = gradient.backprop @circuit2(%arg0) cotangents(%arg1: tensor<?xf64>) {diffArgIndices = dense<0> : tensor<1xindex>}: (f64) -> f64
+    // CHECK:   gradient.backprop @circuit2({{%.+}}) callee_out([[calleeRes]] : memref<?xf64>) cotangents({{%.+}} : memref<?xf64>) {diffArgIndices = dense<0> : tensor<1xindex>, resultSegmentSizes = array<i32: 0, 1>} : (f64) -> f64
+    %grad = gradient.backprop @circuit2(%arg0) cotangents(%arg1: tensor<?xf64>) {diffArgIndices = dense<0> : tensor<1xindex>, resultSegmentSizes = array<i32: 0, 1>}: (f64) -> f64
     return
 }
 
@@ -52,8 +52,8 @@ func.func @backprop2(%arg0: tensor<?x2xf64>, %arg1: tensor<?xf64>) {
     // CHECK:   [[argShadow:%.+]] = memref.alloc(%dim) : memref<?x2xf64>
     // CHECK:   [[dim:%.+]] = memref.dim
     // CHECK:   [[calleeRes:%.+]] = memref.alloc([[dim]]) : memref<?xf64>
-    // CHECK:   gradient.backprop @circuit3({{%.+}}) grad_out([[argShadow]] : memref<?x2xf64>) callee_out([[calleeRes]] : memref<?xf64>) cotangents({{%.+}} : memref<?xf64>) {diffArgIndices = dense<0> : tensor<1xindex>} : (memref<?x2xf64>) -> ()
-    %grad = gradient.backprop @circuit3(%arg0) cotangents(%arg1: tensor<?xf64>) {diffArgIndices = dense<0> : tensor<1xindex>}: (tensor<?x2xf64>) -> tensor<?x2xf64>
+    // CHECK:   gradient.backprop @circuit3({{%.+}}) grad_out([[argShadow]] : memref<?x2xf64>) callee_out([[calleeRes]] : memref<?xf64>) cotangents({{%.+}} : memref<?xf64>) {diffArgIndices = dense<0> : tensor<1xindex>, resultSegmentSizes = array<i32: 0, 0>} : (memref<?x2xf64>) -> ()
+    %grad = gradient.backprop @circuit3(%arg0) cotangents(%arg1: tensor<?xf64>) {diffArgIndices = dense<0> : tensor<1xindex>, resultSegmentSizes = array<i32: 0, 1>}: (tensor<?x2xf64>) -> tensor<?x2xf64>
     return
 }
 
@@ -68,7 +68,7 @@ func.func @backprop3(%arg0: tensor<10xf64>, %arg1: tensor<2xf64>, %arg2: tensor<
     // CHECK:   [[argShadow2:%.+]] = memref.alloc() : memref<2xf64>
     // CHECK:   [[dim:%.+]] = memref.dim
     // CHECK:   [[calleeRes:%.+]] = memref.alloc([[dim]]) : memref<?xf64>
-    // CHECK:   gradient.backprop @circuit4({{%.+}}, {{%.+}}) grad_out([[argShadow1]], [[argShadow2]] : memref<10xf64>, memref<2xf64>) callee_out([[calleeRes]] : memref<?xf64>) cotangents({{%.+}} : memref<?xf64>) {diffArgIndices = dense<[0, 1]> : tensor<2xindex>} : (memref<10xf64>, memref<2xf64>) -> ()
-    %grad:2 = gradient.backprop @circuit4(%arg0, %arg1) cotangents(%arg2: tensor<?xf64>) {diffArgIndices = dense<[0, 1]> : tensor<2xindex>}: (tensor<10xf64>, tensor<2xf64>) -> (tensor<10xf64>, tensor<2xf64>)
+    // CHECK:   gradient.backprop @circuit4({{%.+}}, {{%.+}}) grad_out([[argShadow1]], [[argShadow2]] : memref<10xf64>, memref<2xf64>) callee_out([[calleeRes]] : memref<?xf64>) cotangents({{%.+}} : memref<?xf64>) {diffArgIndices = dense<[0, 1]> : tensor<2xindex>, resultSegmentSizes = array<i32: 0, 0>} : (memref<10xf64>, memref<2xf64>) -> ()
+    %grad:2 = gradient.backprop @circuit4(%arg0, %arg1) cotangents(%arg2: tensor<?xf64>) {diffArgIndices = dense<[0, 1]> : tensor<2xindex>, resultSegmentSizes = array<i32: 0, 2>}: (tensor<10xf64>, tensor<2xf64>) -> (tensor<10xf64>, tensor<2xf64>)
     return
 }

--- a/mlir/test/Gradient/ConversionBackprop.mlir
+++ b/mlir/test/Gradient/ConversionBackprop.mlir
@@ -133,7 +133,7 @@ func.func @backpropArgmap2(%arg0: memref<f64>, %arg1: f64, %arg2: memref<f64>, %
     // CHECK-DAG: [[outputStride1:%.+]] = llvm.extractvalue [[outputCasted1]][4, 0]
 
     // CHECK: [[res:%.+]] = llvm.call @__enzyme_autodiff1([[argmapCasted]], [[enzymeConst]], [[arg0Allocated]], [[arg0Aligned]], [[shadowAligned]], [[arg0Offset]], %arg1, [[enzymeConst]], [[outputAllocated]], [[enzymeDupNoNeed]], [[outputAligned]], [[qJacobianAligned]], [[outputOffset]], [[outputSize]], [[outputStride]], [[enzymeConst]], [[outputAllocated1]], [[enzymeDupNoNeed]], [[outputAligned1]], [[qJacobianAligned1]], [[outputOffset1]], [[outputSize1]], [[outputStride1]])
-    %res = gradient.backprop @argmap2(%arg0, %arg1) grad_out(%arg2: memref<f64>) callee_out(%arg3, %arg4 : memref<?xf64>, memref<?xf64>) cotangents(%arg5, %arg6 : memref<?xf64>, memref<?xf64>) {diffArgIndices = dense<[0, 1]> : tensor<2xindex>} : (memref<f64>, f64) -> f64
+    %res = gradient.backprop @argmap2(%arg0, %arg1) grad_out(%arg2: memref<f64>) callee_out(%arg3, %arg4 : memref<?xf64>, memref<?xf64>) cotangents(%arg5, %arg6 : memref<?xf64>, memref<?xf64>) {diffArgIndices = dense<[0, 1]> : tensor<2xindex>, resultSegmentSizes = array<i32: 0, 1>} : (memref<f64>, f64) -> f64
     // CHECK: return %arg2, [[res]]
     return %arg2, %res: memref<f64>, f64
 }

--- a/mlir/test/Gradient/VerifierTest.mlir
+++ b/mlir/test/Gradient/VerifierTest.mlir
@@ -122,7 +122,7 @@ func.func private @foo(%arg0: tensor<f64>)
 %m0 = memref.alloc() : memref<f64>
 
 // expected-error@+1 {{cannot have both tensor results and memref output arguments}}
-%grad = gradient.backprop @foo(%t0) grad_out(%m0 : memref<f64>) cotangents(%t0: tensor<f64>) : (tensor<f64>) -> tensor<f64>
+%grad = gradient.backprop @foo(%t0) grad_out(%m0 : memref<f64>) cotangents(%t0: tensor<f64>) {resultSegmentSizes = array<i32: 0, 1>} : (tensor<f64>) -> tensor<f64>
 
 // -----
 
@@ -133,7 +133,7 @@ func.func private @foo(%arg0: tensor<f64>)
 %m0 = memref.alloc() : memref<f64>
 
 // expected-error@+1 {{cannot have callee result buffers before bufferization}}
-%grad = gradient.backprop @foo(%t0) callee_out(%m0 : memref<f64>) cotangents(%t0: tensor<f64>) : (tensor<f64>) -> tensor<f64>
+%grad = gradient.backprop @foo(%t0) callee_out(%m0 : memref<f64>) cotangents(%t0: tensor<f64>) {resultSegmentSizes = array<i32: 0, 1>}: (tensor<f64>) -> tensor<f64>
 
 // -----
 
@@ -152,4 +152,4 @@ func.func private @multiple_args(%arg0: tensor<f64>, %arg1: tensor<f64>)
 %t0 = tensor.from_elements %f0 : tensor<f64>
 
 // expected-error@+1 {{number of gradient results did not match number of differentiable arguments, expected 1 but got 2}}
-%grad:2 = gradient.backprop @multiple_args(%t0, %t0) cotangents(%t0: tensor<f64>) {diffArgIndices = dense<0> : tensor<1xindex>}: (tensor<f64>, tensor<f64>) -> (tensor<f64>, tensor<f64>)
+%grad:2 = gradient.backprop @multiple_args(%t0, %t0) cotangents(%t0: tensor<f64>) {diffArgIndices = dense<0> : tensor<1xindex>, resultSegmentSizes = array<i32: 0, 2>}: (tensor<f64>, tensor<f64>) -> (tensor<f64>, tensor<f64>)


### PR DESCRIPTION
**Context:** Lowering of value_and_grad to MLIR is now supported when @qjit is used.

**Description of the Change:** A new ValueAndGradOp was added and the existing BackpropOp was modified to return two results: values and gradients. 

**Benefits:** Code reutilization.

**TODO:**
- [ ] Add unit tests.
- [ ] Test corner cases.
- [ ] Update the changelog.md file

[sc-55116] 