### PR TITLE
Add lxml to `/doc/requirements.txt` file.

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -25,6 +25,7 @@ m2r2
 mistune==0.8.4
 sphinxext-opengraph==0.9.0
 matplotlib==3.8.0
+lxml_html_clean
 
 # Pre-install development lightning wheels
 --extra-index-url https://test.pypi.org/simple/


### PR DESCRIPTION
**Context:** Docs seem to be failing with the message:

```
Extension error:
Could not import extension nbsphinx (exception: lxml.html.clean module is now a separate project lxml_html_clean.
Install lxml[html_clean] or lxml_html_clean directly.)
```

See for example PR: #632 

**Description of the Change:** Add lxml_html_clean to docs requirements.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
