### PR TITLE
Remove original device preprocessing (new API)

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -76,7 +76,7 @@
 
 * Catalyst now supports devices built from the
   [new PennyLane device API](https://docs.pennylane.ai/en/stable/code/api/pennylane.devices.Device.html).
-  It currently discard user preprocessing from the original device and is replace by Catalyst specific
+  It currently discards the preprocessing from the original device and it is replaced by Catalyst specific
   preprocessing.
   [(#565)](https://github.com/PennyLaneAI/catalyst/pull/565)
   [(#598)](https://github.com/PennyLaneAI/catalyst/pull/598)

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -76,9 +76,12 @@
 
 * Catalyst now supports devices built from the
   [new PennyLane device API](https://docs.pennylane.ai/en/stable/code/api/pennylane.devices.Device.html).
+  It currently discard user preprocessing from the original device and is replace by Catalyst specific
+  preprocessing.
   [(#565)](https://github.com/PennyLaneAI/catalyst/pull/565)
   [(#598)](https://github.com/PennyLaneAI/catalyst/pull/598)
   [(#599)](https://github.com/PennyLaneAI/catalyst/pull/599)
+  [(#636)](https://github.com/PennyLaneAI/catalyst/pull/636)
 
 * Catalyst now supports return statements inside conditionals in `@qjit(autograph=True)` compiled
   functions.

--- a/frontend/catalyst/qjit_device.py
+++ b/frontend/catalyst/qjit_device.py
@@ -19,6 +19,7 @@ from typing import Optional, Set
 import pennylane as qml
 from pennylane.devices.preprocess import decompose
 from pennylane.measurements import MidMeasureMP
+from pennylane.transforms.core import TransformProgram
 
 from catalyst.preprocess import catalyst_acceptance, decompose_ops_to_unitary
 from catalyst.utils.exceptions import CompileError
@@ -294,7 +295,10 @@ class QJITDeviceNewAPI(qml.devices.Device):
         execution_config: qml.devices.ExecutionConfig = qml.devices.DefaultExecutionConfig,
     ):
         """Device preprocessing function."""
-        program, config = self.original_device.preprocess(execution_config)
+        # TODO: readd the user preprocessing once transforms are compatible with TOML files
+        _, config = self.original_device.preprocess(execution_config)
+
+        program = TransformProgram()
 
         convert_to_matrix_ops = {"MultiControlledX", "BlockEncode"}
         program.add_transform(decompose_ops_to_unitary, convert_to_matrix_ops)

--- a/frontend/catalyst/qjit_device.py
+++ b/frontend/catalyst/qjit_device.py
@@ -295,7 +295,8 @@ class QJITDeviceNewAPI(qml.devices.Device):
         execution_config: qml.devices.ExecutionConfig = qml.devices.DefaultExecutionConfig,
     ):
         """Device preprocessing function."""
-        # TODO: readd the device preprocessing program once transforms are compatible with TOML files
+        # TODO: readd the device preprocessing program once transforms are compatible with
+        # TOML files
         _, config = self.original_device.preprocess(execution_config)
         program = TransformProgram()
 

--- a/frontend/catalyst/qjit_device.py
+++ b/frontend/catalyst/qjit_device.py
@@ -295,7 +295,7 @@ class QJITDeviceNewAPI(qml.devices.Device):
         execution_config: qml.devices.ExecutionConfig = qml.devices.DefaultExecutionConfig,
     ):
         """Device preprocessing function."""
-        # TODO: readd the user preprocessing program once transforms are compatible with TOML files
+        # TODO: readd the device preprocessing program once transforms are compatible with TOML files
         _, config = self.original_device.preprocess(execution_config)
         program = TransformProgram()
 

--- a/frontend/catalyst/qjit_device.py
+++ b/frontend/catalyst/qjit_device.py
@@ -295,9 +295,8 @@ class QJITDeviceNewAPI(qml.devices.Device):
         execution_config: qml.devices.ExecutionConfig = qml.devices.DefaultExecutionConfig,
     ):
         """Device preprocessing function."""
-        # TODO: readd the user preprocessing once transforms are compatible with TOML files
+        # TODO: readd the user preprocessing program once transforms are compatible with TOML files
         _, config = self.original_device.preprocess(execution_config)
-
         program = TransformProgram()
 
         convert_to_matrix_ops = {"MultiControlledX", "BlockEncode"}

--- a/frontend/test/lit/test_device_api.py
+++ b/frontend/test/lit/test_device_api.py
@@ -86,7 +86,8 @@ test_circuit()
 
 def test_preprocess():
     """Test a circuit (with preprocessing transforms) compilation to MLIR when
-    using the new device API."""
+    using the new device API.
+    TODO: we need to readd the two check-not once we accept the device preprocessing."""
 
     # CHECK:    quantum.device["[[PATH:.*]]librtd_lightning.{{so|dylib}}", "dummy.remote", "{'shots': 2048}"]
     dev = DummyDevice(wires=2, shots=2048)
@@ -99,8 +100,8 @@ def test_preprocess():
         # CHECK:   quantum.custom "Hadamard"
         # CHECK:   quantum.custom "CNOT"
         # CHECK:   quantum.namedobs [[QBIT:.*]][ PauliZ]
-        # CHECK:   quantum.custom "Hadamard"
-        # CHECK:   quantum.custom "CNOT"
+        # CHECK-NOT:   quantum.custom "Hadamard"
+        # CHECK-NOT:   quantum.custom "CNOT"
         # CHECK:   quantum.namedobs [[QBIT:.*]][ PauliY]
         # CHECK:    return [[RETURN:.*]]: tensor<f64>, tensor<f64>
         return qml.expval(qml.PauliZ(wires=0)), qml.expval(qml.PauliY(wires=0))

--- a/frontend/test/pytest/test_device_api.py
+++ b/frontend/test/pytest/test_device_api.py
@@ -79,15 +79,16 @@ def test_qjit_device():
     # Check the preprocess of the new device
     transform_program, _ = device_qjit.preprocess()
     assert transform_program
-    assert len(transform_program) == 3
+    assert len(transform_program) == 2
+
+    # TODO: readd when we do not discard user preprocessing
+    # t = transform_program[0].transform.__name__
+    # assert t == "split_non_commuting"
 
     t = transform_program[0].transform.__name__
-    assert t == "split_non_commuting"
-
-    t = transform_program[1].transform.__name__
     assert t == "decompose_ops_to_unitary"
 
-    t = transform_program[2].transform.__name__
+    t = transform_program[1].transform.__name__
     assert t == "decompose"
 
     # Check that the device cannot execute tapes

--- a/frontend/test/pytest/test_device_api.py
+++ b/frontend/test/pytest/test_device_api.py
@@ -81,7 +81,7 @@ def test_qjit_device():
     assert transform_program
     assert len(transform_program) == 2
 
-    # TODO: readd when we do not discard user preprocessing
+    # TODO: readd when we do not discard device preprocessing
     # t = transform_program[0].transform.__name__
     # assert t == "split_non_commuting"
 


### PR DESCRIPTION
**Context:**
The device preprocessing from lightning is currently not compatible with Catalyst.

**Description of the Change:**
This PR adds the discard of the original preprocessing.

**Benefits:**
Easier support for Lightning.

**Possible Drawbacks:**
Device specific preprocessing is ignored.
