### PR TITLE
Downgrade scipy in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ requirements = [
     f"jax=={jax_version}",
     f"jaxlib=={jax_version}",
     "tomlkit;python_version<'3.11'",
-    "scipy",
+    "scipy==1.12.0",
     "diastatic-malt>=2.15.1",
 ]
 


### PR DESCRIPTION
**Context:**
Scipy released version 1.13.0 yesterday and is currently not compatible with Jax.

**Description of the Change:**
Downgrade to version 1.12.0 in the setup.py file