### PR TITLE
Depend on scipy less than or equal to 1.12.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ requirements = [
     f"jax=={jax_version}",
     f"jaxlib=={jax_version}",
     "tomlkit;python_version<'3.11'",
-    "scipy==1.12.0",
+    "scipy<=1.12.0",
     "diastatic-malt>=2.15.1",
 ]
 


### PR DESCRIPTION
**Description of the Change:** Reduce strictness in dependency of scipy

**Benefits:** More flexibility to the user