### PR TITLE
Remove 'puts' error message from async lowering

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -196,6 +196,9 @@
 * Importing Catalyst will now pollute less of JAX's global variables by using `LoweringParameters`.
   [(#1152)](https://github.com/PennyLaneAI/catalyst/pull/1152)
 
+* Compiling `qnode`s to asynchronous functions will no longer print to stderr in case of an error.
+  [(#645)](https://github.com/PennyLaneAI/catalyst/pull/645)
+
 <h3>Breaking changes</h3>
 
 * Remove `static_size` field from `AbstractQreg` class.

--- a/mlir/include/Catalyst/Transforms/AsyncUtils.h
+++ b/mlir/include/Catalyst/Transforms/AsyncUtils.h
@@ -44,7 +44,9 @@ std::optional<LLVM::LLVMFuncOp> getCalleeSafe(LLVM::CallOp callOp);
 // Helper functions for matching function names
 bool isFunctionNamed(LLVM::LLVMFuncOp funcOp, llvm::StringRef expectedName);
 bool isAbort(LLVM::LLVMFuncOp funcOp);
+bool isPuts(LLVM::LLVMFuncOp funcOp);
 bool callsAbort(LLVM::CallOp callOp);
+bool callsPuts(LLVM::CallOp callOp);
 bool callsAbort(Operation *possibleCall);
 bool isMlirAsyncRuntimeCreateValue(LLVM::LLVMFuncOp funcOp);
 bool isMlirAsyncRuntimeCreateToken(LLVM::LLVMFuncOp funcOp);
@@ -58,6 +60,7 @@ bool callsMlirAsyncRuntimeIsValueError(LLVM::CallOp callOp);
 bool callsMlirAsyncRuntimeIsTokenError(Operation *possibleCall);
 bool callsMlirAsyncRuntimeIsValueError(Operation *possibleCall);
 bool hasAbortInBlock(Block *block);
+bool hasPutsInBlock(Block *block);
 
 // Helper function for creating function declarations
 LLVM::LLVMFuncOp lookupOrCreatePersonality(ModuleOp moduleOp);

--- a/mlir/lib/Catalyst/Transforms/AsyncUtils.cpp
+++ b/mlir/lib/Catalyst/Transforms/AsyncUtils.cpp
@@ -24,6 +24,7 @@ namespace AsyncUtilsConstants {
 
 static constexpr llvm::StringRef qnodeAttr = "qnode";
 static constexpr llvm::StringRef abortName = "abort";
+static constexpr llvm::StringRef putsName = "puts";
 static constexpr llvm::StringRef unrecoverableErrorName =
     "__catalyst__host__rt__unrecoverable_error";
 static constexpr llvm::StringRef scheduleInvokeAttr = "catalyst.preInvoke";
@@ -76,6 +77,13 @@ bool AsyncUtils::hasAbortInBlock(Block *block)
 {
     bool returnVal = false;
     block->walk([&](LLVM::CallOp op) { returnVal |= AsyncUtils::callsAbort(op); });
+    return returnVal;
+}
+
+bool AsyncUtils::hasPutsInBlock(Block *block)
+{
+    bool returnVal = false;
+    block->walk([&](LLVM::CallOp op) { returnVal |= AsyncUtils::callsPuts(op); });
     return returnVal;
 }
 
@@ -311,6 +319,11 @@ bool AsyncUtils::isAbort(LLVM::LLVMFuncOp funcOp)
     return AsyncUtils::isFunctionNamed(funcOp, AsyncUtilsConstants::abortName);
 }
 
+bool AsyncUtils::isPuts(LLVM::LLVMFuncOp funcOp)
+{
+    return AsyncUtils::isFunctionNamed(funcOp, AsyncUtilsConstants::putsName);
+}
+
 bool AsyncUtils::callsAbort(LLVM::CallOp callOp)
 {
     auto maybeCallee = AsyncUtils::getCalleeSafe(callOp);
@@ -319,6 +332,16 @@ bool AsyncUtils::callsAbort(LLVM::CallOp callOp)
 
     auto callee = maybeCallee.value();
     return AsyncUtils::isAbort(callee);
+}
+
+bool AsyncUtils::callsPuts(LLVM::CallOp callOp)
+{
+    auto maybeCallee = AsyncUtils::getCalleeSafe(callOp);
+    if (!maybeCallee)
+        return false;
+
+    auto callee = maybeCallee.value();
+    return AsyncUtils::isPuts(callee);
 }
 
 bool AsyncUtils::callsAbort(Operation *possibleCall)

--- a/mlir/lib/Catalyst/Transforms/DetectQNodes.cpp
+++ b/mlir/lib/Catalyst/Transforms/DetectQNodes.cpp
@@ -946,7 +946,7 @@ struct AddExceptionHandlingPass : impl::AddExceptionHandlingPassBase<AddExceptio
         }
 
         RewritePatternSet patterns3(context);
-        patterns3.add<RemoveAbortInsertCallTransform>(context);
+        patterns3.add<RemoveAbortAndPutsInsertCallTransform>(context);
         if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns3), config))) {
             signalPassFailure();
         }

--- a/mlir/lib/Catalyst/Transforms/DetectQNodes.cpp
+++ b/mlir/lib/Catalyst/Transforms/DetectQNodes.cpp
@@ -35,7 +35,9 @@ void collectResultsForMlirAsyncRuntimeErrorFunctions(SmallVector<Value> &values,
 void collectPotentialConditions(SmallVector<Value> &values, SmallVector<Value> &conditions);
 void collectSuccessorBlocks(SmallVector<Value> &conditions, SmallVector<Block *> &aborts,
                             SmallVector<Block *> &success);
+void collectPutsBlocks(SmallVector<Value> &conditions, SmallVector<Block *> &puts);
 void collectCallsToAbortInBlocks(SmallVector<Block *> &blocks, SmallVector<LLVM::CallOp> &calls);
+void RemoveCallsToPutsInBlocks(SmallVector<Block *> &blocks, PatternRewriter &rewriter);
 void replaceCallsWithCallToTarget(SmallVector<LLVM::CallOp> &oldCallOps, LLVM::LLVMFuncOp target,
                                   SmallVector<LLVM::CallOp> &newCalls, PatternRewriter &rewriter);
 void replaceTerminatorWithUnconditionalJumpToSuccessBlock(SmallVector<Block *> abortBlocks,
@@ -259,7 +261,7 @@ void AddExceptionHandlingTransform::rewrite(LLVM::CallOp callOp, PatternRewriter
  * So, in other words, we will be inspecting the callers of functions annotated with {
  * catalyst.preHandleError }
  */
-struct RemoveAbortInsertCallTransform : public OpRewritePattern<LLVM::CallOp> {
+struct RemoveAbortAndPutsInsertCallTransform : public OpRewritePattern<LLVM::CallOp> {
     using OpRewritePattern<LLVM::CallOp>::OpRewritePattern;
 
     LogicalResult match(LLVM::CallOp op) const override;
@@ -274,7 +276,7 @@ struct RemoveAbortInsertCallTransform : public OpRewritePattern<LLVM::CallOp> {
 //    %results = call @async_execute_fn()
 //
 // These functions return async values or tokens.
-LogicalResult RemoveAbortInsertCallTransform::match(LLVM::CallOp callOp) const
+LogicalResult RemoveAbortAndPutsInsertCallTransform::match(LLVM::CallOp callOp) const
 {
     auto maybeCallee = AsyncUtils::getCalleeSafe(callOp);
     if (!maybeCallee)
@@ -289,7 +291,8 @@ LogicalResult RemoveAbortInsertCallTransform::match(LLVM::CallOp callOp) const
     return success();
 }
 
-void RemoveAbortInsertCallTransform::rewrite(LLVM::CallOp callOp, PatternRewriter &rewriter) const
+void RemoveAbortAndPutsInsertCallTransform::rewrite(LLVM::CallOp callOp,
+                                                    PatternRewriter &rewriter) const
 {
     auto maybeCallee = AsyncUtils::getCalleeSafe(callOp);
     if (!maybeCallee)
@@ -381,6 +384,13 @@ void RemoveAbortInsertCallTransform::rewrite(LLVM::CallOp callOp, PatternRewrite
     //
     // newCalls = { llvm.call @__catalyst__host_ ..., ..., ... }
     replaceCallsWithCallToTarget(aborts, unrecoverableError, newCalls, rewriter);
+
+    // Collect blocks with puts calls
+    SmallVector<Block *> putsBlocks;
+    collectPutsBlocks(potentialConditions, putsBlocks);
+
+    // Remove puts calls
+    RemoveCallsToPutsInBlocks(putsBlocks, rewriter);
 
     // This is a subtlety, but it is a very important one!
     // In order for the (liveness) dataflow analysis, the values need to flow from failure block
@@ -620,6 +630,18 @@ void collectCallsToAbortInBlocks(SmallVector<Block *> &blocks, SmallVector<LLVM:
     }
 }
 
+void RemoveCallsToPutsInBlocks(SmallVector<Block *> &blocks, PatternRewriter &rewriter)
+{
+    for (Block *block : blocks) {
+        block->walk([&](LLVM::CallOp op) {
+            if (AsyncUtils::callsPuts(op)) {
+                LLVM::CallOp putsCall = cast<LLVM::CallOp>(op);
+                rewriter.eraseOp(putsCall);
+            }
+        });
+    }
+}
+
 void replaceCallsWithCallToTarget(SmallVector<LLVM::CallOp> &oldCallOps, LLVM::LLVMFuncOp target,
                                   SmallVector<LLVM::CallOp> &newCalls, PatternRewriter &rewriter)
 {
@@ -650,6 +672,20 @@ void collectSuccessorBlocks(SmallVector<Value> &conditions, SmallVector<Block *>
                     aborts.push_back(falseDest);
                     success.push_back(trueDest);
                 }
+            }
+        }
+    }
+}
+
+void collectPutsBlocks(SmallVector<Value> &conditions, SmallVector<Block *> &puts)
+{
+    for (auto condition : conditions) {
+        for (Operation *user : condition.getUsers()) {
+            if (isa<LLVM::CondBrOp>(user)) {
+                LLVM::CondBrOp brOp = cast<LLVM::CondBrOp>(user);
+                Block *trueDest = brOp.getTrueDest();
+                Block *falseDest = brOp.getFalseDest();
+                puts.push_back(AsyncUtils::hasPutsInBlock(trueDest) ? trueDest : falseDest);
             }
         }
     }

--- a/mlir/lib/Catalyst/Transforms/DetectQNodes.cpp
+++ b/mlir/lib/Catalyst/Transforms/DetectQNodes.cpp
@@ -630,7 +630,7 @@ void collectCallsToAbortInBlocks(SmallVector<Block *> &blocks, SmallVector<LLVM:
     }
 }
 
-void RemoveCallsToPutsInBlocks(SmallVector<Block *> &blocks, PatternRewriter &rewriter)
+void removeCallsToPutsInBlocks(SmallVector<Block *> &blocks, PatternRewriter &rewriter)
 {
     for (Block *block : blocks) {
         block->walk([&](LLVM::CallOp op) {

--- a/mlir/lib/Catalyst/Transforms/DetectQNodes.cpp
+++ b/mlir/lib/Catalyst/Transforms/DetectQNodes.cpp
@@ -37,7 +37,7 @@ void collectSuccessorBlocks(SmallVector<Value> &conditions, SmallVector<Block *>
                             SmallVector<Block *> &success);
 void collectPutsBlocks(SmallVector<Value> &conditions, SmallVector<Block *> &puts);
 void collectCallsToAbortInBlocks(SmallVector<Block *> &blocks, SmallVector<LLVM::CallOp> &calls);
-void RemoveCallsToPutsInBlocks(SmallVector<Block *> &blocks, PatternRewriter &rewriter);
+void removeCallsToPutsInBlocks(SmallVector<Block *> &blocks, PatternRewriter &rewriter);
 void replaceCallsWithCallToTarget(SmallVector<LLVM::CallOp> &oldCallOps, LLVM::LLVMFuncOp target,
                                   SmallVector<LLVM::CallOp> &newCalls, PatternRewriter &rewriter);
 void replaceTerminatorWithUnconditionalJumpToSuccessBlock(SmallVector<Block *> abortBlocks,

--- a/mlir/lib/Catalyst/Transforms/DetectQNodes.cpp
+++ b/mlir/lib/Catalyst/Transforms/DetectQNodes.cpp
@@ -390,7 +390,7 @@ void RemoveAbortAndPutsInsertCallTransform::rewrite(LLVM::CallOp callOp,
     collectPutsBlocks(potentialConditions, putsBlocks);
 
     // Remove puts calls
-    RemoveCallsToPutsInBlocks(putsBlocks, rewriter);
+    removeCallsToPutsInBlocks(putsBlocks, rewriter);
 
     // This is a subtlety, but it is a very important one!
     // In order for the (liveness) dataflow analysis, the values need to flow from failure block


### PR DESCRIPTION
**Context:** The async lowering will add a puts and a message about values in an error state. We should remove them as we now return an exception. Not really a bug, but a user experience issue.

**Description of the Change:** We renamed the RemoveAbortInsertCallTransform to RemoveAbortAndPutsInsertCallTransform to avoid creating a new transform with boiler-plate code. We just have added the methods and functions that allowed us to, first, collect the blocks including calls to puts, and second, to erase those call operations.

**Benefits:** avoid having to create a new transform.

**Possible Drawbacks:** 

- Maybe we want to separate aborts logic from and puts logic?
- Maybe we can delete the puts call ops at the very moment we check for the blocks containing them?

**Related GitHub Issues:** Fixes https://github.com/PennyLaneAI/catalyst/issues/514

[sc-59514]
