### PR TITLE
Experimental dictionary support for counts

### DIFF
--- a/frontend/test/pytest/test_measurements_results.py
+++ b/frontend/test/pytest/test_measurements_results.py
@@ -70,13 +70,13 @@ class TestCounts:
             qml.RX(x, wires=0)
             return qml.counts()
 
-        expected = [np.array([0, 1]), np.array([1000, 0])]
+        expected = {"0": 1000, "1": 0}
         observed = counts_1qbit(0.0)
-        assert np.array_equal(observed, expected)
+        assert observed == expected
 
-        expected = [np.array([0, 1]), np.array([0, 1000])]
+        expected = {"0": 0, "1": 1000}
         observed = counts_1qbit(np.pi)
-        assert np.array_equal(observed, expected)
+        assert observed == expected
 
     def test_count_on_2qbits(self, backend):
         """Test counts on 2 qubits."""
@@ -88,13 +88,13 @@ class TestCounts:
             qml.RY(x, wires=1)
             return qml.counts()
 
-        expected = [np.array([0, 1, 2, 3]), np.array([1000, 0, 0, 0])]
+        expected = {"00": 1000, "01": 0, "10": 0, "11": 0}
         observed = counts_2qbit(0.0)
-        assert np.array_equal(observed, expected)
+        assert observed == expected
 
-        expected = [np.array([0, 1, 2, 3]), np.array([0, 0, 0, 1000])]
+        expected = {"00": 0, "01": 0, "10": 0, "11": 1000}
         observed = counts_2qbit(np.pi)
-        assert np.array_equal(observed, expected)
+        assert observed == expected
 
     def test_count_on_2qbits_endianness(self, backend):
         """Test counts on 2 qubits with check for endianness."""
@@ -106,13 +106,13 @@ class TestCounts:
             qml.RX(y, wires=1)
             return qml.counts()
 
-        expected = [np.array([0, 1, 2, 3]), np.array([0, 0, 1000, 0])]
+        expected = {"00": 0, "01": 0, "10": 1000, "11": 0}
         observed = counts_2qbit(np.pi, 0)
-        assert np.array_equal(observed, expected)
+        assert observed == expected
 
-        expected = [np.array([0, 1, 2, 3]), np.array([0, 1000, 0, 0])]
+        expected = {"00": 0, "01": 1000, "10": 0, "11": 0}
         observed = counts_2qbit(0, np.pi)
-        assert np.array_equal(observed, expected)
+        assert observed == expected
 
 
 class TestExpval:

--- a/frontend/test/pytest/test_measurements_shots_results.py
+++ b/frontend/test/pytest/test_measurements_shots_results.py
@@ -504,11 +504,10 @@ class TestOtherMeasurements:
         assert result[0].shape == expected(x, qml.sample(wires=[0, 1]), shots=10000).shape
 
         # qml.counts
-        for r, e in zip(
-            result[1][0], expected(x, qml.counts(all_outcomes=True), shots=10000).keys()
-        ):
-            assert format(int(r), "02b") == e
-        assert sum(result[1][1]) == 10000
+        counts_expected = expected(x, qml.counts(all_outcomes=True), shots=10000)
+        assert result[1].keys() == counts_expected.keys()
+        assert all(abs(x - y) < 100 for x, y in zip(result[1].values(), counts_expected.values()))
+        assert sum(result[1].values()) == 10000
 
         # qml.expval
         assert np.allclose(

--- a/frontend/test/pytest/test_pytree_args.py
+++ b/frontend/test/pytest/test_pytree_args.py
@@ -132,7 +132,7 @@ class TestPyTreesReturnValues:
         jitted_fn = qjit(circuit3)
         result = jitted_fn(params)
         assert isinstance(result, tuple)
-        assert isinstance(result[0], tuple)
+        assert isinstance(result[0], dict)
         assert len(result[1]) == 4
         assert jnp.allclose(result[2], expected_expval, atol=tol_stochastic, rtol=tol_stochastic)
 
@@ -256,7 +256,7 @@ class TestPyTreesReturnValues:
         jitted_fn = qjit(circuit2)
         result = jitted_fn(params)
         assert isinstance(result, dict)
-        assert isinstance(result["counts"], tuple)
+        assert isinstance(result["counts"], dict)
         assert len(result["state"]) == 4
         assert jnp.allclose(
             result["expval"]["z0"], expected_expval, atol=tol_stochastic, rtol=tol_stochastic


### PR DESCRIPTION
The idea is to use a custom PyTree class that is injected into the JAXPR when we are tracing the tape. The PyTree node will remain an array tuple for as long as we tracing, and once concrete values are available it unflattens into a Python dictionary.

Benefits:
- works well and does not require a modification of the qml.counts function or a Catalyst clone thereof

Downsides:
- the problem is that qml.counts now presents two different "types" depending on whether you operate on it while tracing (pair of arrays) inside of a qjit function, or outside of a qjit function (dict)

The downside is especially problementic from a UI perspective. A full resolution might be to always present the return type of qml.counts as a dictionary, but this presents a few challenges:
- the key values are no longer "data" but "metadata", that is they are constant and cannot be produced by the program at runtime
- consequently the dictionary can also not be indexed with dynamic values (wether this is a problem or not I'm not sure)
- performance might suffer for large qubit numbers because there are 2^n dictionary elements, each its own array, vs a single array of 2^n

Another solution might involve modifying the proposed class into a user-facing data type. A type that consists of two numeric arrays but which offers a dictionary like interface:
- it prints like a dictionary (and can format the keys into bitstrings if desired)
- elements can be accessed via __getitem__
- keys and values can be extracted as arrays
- it's immutable