### PR TITLE
Fix extension when looking for mlir_c_runner library

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -7,6 +7,7 @@
   [(#596)](https://github.com/PennyLaneAI/catalyst/pull/596)
   [(#610)](https://github.com/PennyLaneAI/catalyst/pull/610)
   [(#650)](https://github.com/PennyLaneAI/catalyst/pull/650)
+  [(#649)](https://github.com/PennyLaneAI/catalyst/pull/649)
 
   Catalyst now supports callbacks with parameters and return values.
   The following is now possible:

--- a/runtime/lib/registry/Registry.cpp
+++ b/runtime/lib/registry/Registry.cpp
@@ -72,6 +72,32 @@ class LibraryManager {
     }
 };
 
+inline const uintptr_t ext_macos()
+{
+#ifdef __APPLE__
+    return reinterpret_cast<uintptr_t>(".dylib");
+#else
+    return reinterpret_cast<uintptr_t>(nullptr);
+#endif
+}
+
+inline const uintptr_t ext_unix()
+{
+#ifdef __linux__
+    return reinterpret_cast<uintptr_t>(".so");
+#else
+    return reinterpret_cast<uintptr_t>(nullptr);
+#endif
+}
+
+inline const char *ext()
+{
+    const uintptr_t ext_target = ext_macos() | ext_unix();
+    return reinterpret_cast<char *>(ext_target);
+}
+
+std::string library_name(std::string name) { return name + ext(); }
+
 void convertResult(py::handle tuple)
 {
     py::object unrankedMemrefPtrSizeTuple = tuple.attr("__getitem__")(0);
@@ -91,7 +117,7 @@ void convertResult(py::handle tuple)
     UnrankedMemrefType *src = (UnrankedMemrefType *)unranked_memref_ptr;
     UnrankedMemrefType destMemref = {src->rank, destAsPtr};
 
-    std::string libpath = libmlirpath + "/libmlir_c_runner_utils.so";
+    std::string libpath = libmlirpath + library_name("/libmlir_c_runner_utils");
     LibraryManager memrefCopy(libpath);
     memrefCopy(e_size, src, &destMemref);
 }

--- a/runtime/lib/registry/Registry.cpp
+++ b/runtime/lib/registry/Registry.cpp
@@ -72,28 +72,15 @@ class LibraryManager {
     }
 };
 
-inline const uintptr_t ext_macos()
-{
-#ifdef __APPLE__
-    return reinterpret_cast<uintptr_t>(".dylib");
-#else
-    return reinterpret_cast<uintptr_t>(nullptr);
-#endif
-}
-
-inline const uintptr_t ext_unix()
-{
-#ifdef __linux__
-    return reinterpret_cast<uintptr_t>(".so");
-#else
-    return reinterpret_cast<uintptr_t>(nullptr);
-#endif
-}
-
 inline const char *ext()
 {
-    const uintptr_t ext_target = ext_macos() | ext_unix();
-    return reinterpret_cast<char *>(ext_target);
+#ifdef __APPLE__
+    return ".dylib";
+#elif __linux__
+    return ".so";
+#else
+#error "Only apple and linux are currently supported";
+#endif
 }
 
 std::string library_name(std::string name) { return name + ext(); }


### PR DESCRIPTION
**Context:** When merging callbacks, something that was an oversight was the extension of shared libraries in different operating systems. In Darwin, the extension is `.dylib`. In unix, it is `.so`. 

**Description of the Change:** This commit selects the correct extension based on the operating system that the code is being run.

**Benefits:** No errors on tests.
