### PR TITLE
Limit warning as errors in autograph test to only `UserWarning`

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -77,6 +77,9 @@
 * Manually cleanup the workspace, which prevents a warning from showing up during testing.
   [(#656)](https://github.com/PennyLaneAI/catalyst/pull/656)
 
+* Ignore unraisable warning in autograph test.
+  [(#652)](https://github.com/PennyLaneAI/catalyst/pull/652)
+
 * An exception is now raised when OpenBLAS cannot be found by Catalyst.
   [(#643)](https://github.com/PennyLaneAI/catalyst/pull/643)
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -77,7 +77,7 @@
 * Manually cleanup the workspace, which prevents a warning from showing up during testing.
   [(#656)](https://github.com/PennyLaneAI/catalyst/pull/656)
 
-* Ignore unraisable warning in autograph test.
+* Fix a stochastic autograph test failure due to broadly turning warnings into errors.
   [(#652)](https://github.com/PennyLaneAI/catalyst/pull/652)
 
 * An exception is now raised when OpenBLAS cannot be found by Catalyst.

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -1227,8 +1227,7 @@ class TestForLoops:
         with pytest.raises(AutoGraphError, match="'x' was initialized with the wrong type"):
             qjit(autograph=True)(f)
 
-    @pytest.mark.filterwarnings("error")
-    @pytest.mark.filterwarnings("ignore::UserWarning")
+    @pytest.mark.filterwarnings("error::UserWarning")
     def test_ignore_warnings(self, monkeypatch):
         """Test the AutoGraph config flag properly silences warnings."""
         monkeypatch.setattr("catalyst.autograph_ignore_fallbacks", True)

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -1228,7 +1228,7 @@ class TestForLoops:
             qjit(autograph=True)(f)
 
     @pytest.mark.filterwarnings("error")
-    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+    @pytest.mark.filterwarnings("ignore::UserWarning")
     def test_ignore_warnings(self, monkeypatch):
         """Test the AutoGraph config flag properly silences warnings."""
         monkeypatch.setattr("catalyst.autograph_ignore_fallbacks", True)

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -1228,6 +1228,7 @@ class TestForLoops:
             qjit(autograph=True)(f)
 
     @pytest.mark.filterwarnings("error")
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     def test_ignore_warnings(self, monkeypatch):
         """Test the AutoGraph config flag properly silences warnings."""
         monkeypatch.setattr("catalyst.autograph_ignore_fallbacks", True)


### PR DESCRIPTION
**Context:** The autograph test sets all warnings as errors. However, there is a warning that gets triggered that makes the test fail, even though it has nothing to do with the test.

**Description of the Change:** Limit the warning as error in this test to only `UserWarning`.

**Benefits:** Test pass.
