### PR TITLE
Fix OQC Makefile variable

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -307,7 +307,7 @@ jobs:
           C_COMPILER=$(which gcc) \
           CXX_COMPILER=$(which g++) \
           OQC_BUILD_DIR="$(pwd)/oqc-build" \
-          RUNTIME_BUILD_DIR="$(pwd)/runtime-build" \
+          RT_BUILD_DIR="$(pwd)/runtime-build" \
           make oqc
 
     # Build Quantum and Gradient Dialects

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -313,7 +313,7 @@ jobs:
     - name: Build OQC-Runtime
       run: |
           OQC_BUILD_DIR="$(pwd)/oqc-build" \
-          RUNTIME_BUILD_DIR="$(pwd)/runtime-build" \
+          RT_BUILD_DIR="$(pwd)/runtime-build" \
           make oqc
 
     # Build Quantum and Gradient Dialects

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -601,7 +601,7 @@ jobs:
         run: |
           C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
           CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
-          RUNTIME_BUILD_DIR="$(pwd)/runtime-build" \
+          RT_BUILD_DIR="$(pwd)/runtime-build" \
           make test-oqc
   
       - name: Build Runtime test suite for Lightning simulator

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -55,8 +55,8 @@ jobs:
           COMPILER_LAUNCHER="" \
           C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
           CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
+          RT_BUILD_DIR="$(pwd)/runtime-build" \
           OQC_BUILD_DIR="$(pwd)/oqc-build" \
-          RUNTIME_BUILD_DIR="$(pwd)/runtime-build" \
           make oqc
 
 

--- a/frontend/catalyst/oqc/src/Makefile
+++ b/frontend/catalyst/oqc/src/Makefile
@@ -1,7 +1,7 @@
 MK_ABSPATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MK_DIR := $(dir $(MK_ABSPATH))
 OQC_BUILD_DIR?=$(MK_DIR)/build
-RUNTIME_BUILD_DIR?=$(MK_DIR)/../../../../runtime/build
+RT_BUILD_DIR?=$(MK_DIR)/../../../../runtime/build
 C_COMPILER?=$(shell which clang)
 CXX_COMPILER?=$(shell which clang++)
 NPROC?=$(shell python3 -c "import os; print(os.cpu_count())")
@@ -14,7 +14,7 @@ configure:
 	cmake -G Ninja -B $(OQC_BUILD_DIR) \
 		-DCMAKE_C_COMPILER=$(C_COMPILER) \
 		-DCMAKE_CXX_COMPILER=$(CXX_COMPILER) \
-		-DRUNTIME_BUILD_DIR=$(RUNTIME_BUILD_DIR) \
+		-DRUNTIME_BUILD_DIR=$(RT_BUILD_DIR) \
 
 $(OQC_BUILD_DIR)/librtd_oqc.so: configure
 	cmake --build $(OQC_BUILD_DIR) --target rtd_oqc -j$(NPROC)


### PR DESCRIPTION
**Context:** We allow users to change the locations of build directories by changing environment or Makefile variables.

**Description of the Change:** In order to read user environment settings, we must use the same variables in all parts of our buildsystem. By this PR we make the runtime build dir variable the same with what we have in our main Makefile  (`RT_BUILD_DIR`)

**Benefits:** Fixes builds involving custom runtime build directories 

**Possible Drawbacks:** N/A

**Related GitHub Issues:** N/A