### PR TITLE
Manual cleanup of workspace during garbage collection 

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -68,6 +68,9 @@
 
 <h3>Improvements</h3>
 
+* Manually cleanup the workspace, which prevents a warning from showing up during testing.
+  [(#656)](https://github.com/PennyLaneAI/catalyst/pull/656)
+
 * An exception is now raised when OpenBLAS cannot be found by Catalyst.
   [(#643)](https://github.com/PennyLaneAI/catalyst/pull/643)
 

--- a/frontend/catalyst/utils/filesystem.py
+++ b/frontend/catalyst/utils/filesystem.py
@@ -53,6 +53,11 @@ class Directory:
             return
         shutil.rmtree(str(self))
 
+    def __del__(self):
+        """Avoid warning by doing manual cleanup during deletion."""
+        if isinstance(self._impl, tempfile.TemporaryDirectory):
+            self._impl.cleanup()
+
 
 class WorkspaceManager:
     """Singleton object that manages the output files for the IR.


### PR DESCRIPTION
**Context:** There is a `ResourceWarning` message with contents similar to the following:

```
Implicitly cleaning up <TemporaryDirectory '/private/var/folders/91/0sd1rhg56rs8y299zcsyg1hh0000zc/T/f1h7aj47n_'>
```

This is expected from the [TemporaryDirectory](https://docs.python.org/3/library/tempfile.html#module-tempfile), which implicitly cleans up after itself. 

>  It will be destroyed as soon as it is closed (including an implicit close when the object is garbage collected)

When this warning is paired with tests that will treat all warnings as errors, such as when using the decorator:

```
    @pytest.mark.filterwarnings("error")
```

[All warnings will instead raise an exception: ](https://docs.python.org/3/library/warnings.html#testing-warnings)

> One can also cause all warnings to be exceptions by using error instead of always. 

Which will then make pytest raise another warning

```
frontend/test/pytest/test_autograph.py::TestForLoops::test_ignore_warnings - pytest.PytestUnraisableExceptionWarning:
```

which since it is treated as an error, may make a test fail.

**Description of the Change:** In order to avoid this warning, explicitly clean up. This will remove the initial warning that triggers these events.

**Benefits:** Avoid a warning / tests to fail.

**Drawbacks**: It is a bit redundant to cleanup explicitly during garbage collection of the parent object.
