### PR TITLE
Fixes missing OQC setup in macOS x86_64

### DIFF
--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -277,7 +277,7 @@ jobs:
     - name: Build OQC-Runtime
       run: |
           OQC_BUILD_DIR="$(pwd)/oqc-build" \
-          RUNTIME_BUILD_DIR="$(pwd)/runtime-build" \
+          RT_BUILD_DIR="$(pwd)/runtime-build" \
           make oqc
 
     - name: Test Catalyst-Runtime


### PR DESCRIPTION
Context: Recent changes in the runtime changed a variable name. These change ought to be reflected in all build wheels scripts, but by oversight it was forgotten in x86_64.

Description: This commit adds the missing changes in macOS x86_64 build wheel script.
