### PR TITLE
Add Python-native logging to Catalyst frontend

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -5,4 +5,4 @@ llvm=cd9a641613eddf25d4b25eaa96b2c393d401d42c
 enzyme=1beb98b51442d50652eaa3ffb9574f4720d611f1
 
 # Always remove custom PL/LQ versions before release.
-pennylane=fbc2a393e90f04e337c3c3609efeebffe4235ff2
+pennylane=f318ec44fd717434854a87b8d67197c9b0672089

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -526,6 +526,11 @@ jobs:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v4
 
+    - name: Install device dependencies (OpenQasm device)
+      run: |
+        pip install amazon-braket-pennylane-plugin
+        echo "AWS_DEFAULT_REGION=us-east-1" >> $GITHUB_ENV
+
     - name: Install Deps
       run: |
         sudo apt-get update
@@ -553,11 +558,6 @@ jobs:
       with:
         name: runtime-build-${{ matrix.compiler }}
         path: runtime-build/lib
-
-    - name: Install additional dependencies (OpenQasm device)
-      run: |
-        pip install amazon-braket-pennylane-plugin
-        echo "AWS_DEFAULT_REGION=us-east-1" >> $GITHUB_ENV
 
     - name: Add Frontend Dependencies to PATH
       run: |

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,6 +2,9 @@
 
 <h3>New features</h3>
 
+* The Catalyst frontend now supports Python logging through PennyLane's `qml.logging` module.
+  [(#660)](https://github.com/PennyLaneAI/catalyst/pull/660)
+
 * Support for disabling Autograph for a specific function or
   only for the function calls inside a specific context,
   without affecting the bare code inside such context.

--- a/frontend/catalyst/__init__.py
+++ b/frontend/catalyst/__init__.py
@@ -82,7 +82,7 @@ sys.modules["mlir_quantum._mlir_libs._quantumDialects.mitigation"] = types.Modul
     "mlir_quantum._mlir_libs._quantumDialects.mitigation"
 )
 
-from catalyst import debug
+from catalyst import debug, logging
 from catalyst.api_extensions import *
 from catalyst.api_extensions import __all__ as _api_extension_list
 from catalyst.autograph import *
@@ -185,6 +185,7 @@ __all__ = (
     "DifferentiableCompileError",
     "CompileOptions",
     "debug",
+    "logging",
     *_api_extension_list,
     *_autograph_functions,
 )

--- a/frontend/catalyst/__init__.py
+++ b/frontend/catalyst/__init__.py
@@ -185,7 +185,6 @@ __all__ = (
     "DifferentiableCompileError",
     "CompileOptions",
     "debug",
-    "logging",
     *_api_extension_list,
     *_autograph_functions,
 )

--- a/frontend/catalyst/compiled_functions.py
+++ b/frontend/catalyst/compiled_functions.py
@@ -29,7 +29,7 @@ from mlir_quantum.runtime import (
 )
 
 from catalyst.jax_extras import get_implicit_and_explicit_flat_args
-from catalyst.logging import debug_logger, debug_logger_init
+from catalyst.logging import debug_logger_init
 from catalyst.tracing.type_signatures import (
     TypeCompatibility,
     filter_static_args,

--- a/frontend/catalyst/compiled_functions.py
+++ b/frontend/catalyst/compiled_functions.py
@@ -15,6 +15,7 @@
 """This module contains classes to manage compiled functions and their underlying resources."""
 
 import ctypes
+import logging
 from dataclasses import dataclass
 from typing import Tuple
 
@@ -28,6 +29,7 @@ from mlir_quantum.runtime import (
 )
 
 from catalyst.jax_extras import get_implicit_and_explicit_flat_args
+from catalyst.logging import debug_logger, debug_logger_init
 from catalyst.tracing.type_signatures import (
     TypeCompatibility,
     filter_static_args,
@@ -38,6 +40,9 @@ from catalyst.utils import wrapper  # pylint: disable=no-name-in-module
 from catalyst.utils.c_template import get_template, mlir_type_to_numpy_type
 from catalyst.utils.filesystem import Directory
 from catalyst.utils.jnp_to_memref import get_ranked_memref_descriptor
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 class SharedObjectManager:
@@ -50,6 +55,7 @@ class SharedObjectManager:
         func_name (str): name of compiled function
     """
 
+    @debug_logger_init
     def __init__(self, shared_object_file, func_name):
         self.shared_object_file = shared_object_file
         self.shared_object = None
@@ -128,6 +134,7 @@ class CompiledFunction:
         compile_options (CompileOptions): compilation options used
     """
 
+    @debug_logger_init
     def __init__(self, shared_object_file, func_name, restype, compile_options):
         self.shared_object = SharedObjectManager(shared_object_file, func_name)
         self.compile_options = compile_options
@@ -386,6 +393,7 @@ class CompilationCache:
     combination of PyTreeDefs and static arguments.
     """
 
+    @debug_logger_init
     def __init__(self, static_argnums, abstracted_axes):
         self.static_argnums = static_argnums
         self.abstracted_axes = abstracted_axes

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -16,6 +16,7 @@ MLIR/LLVM representations.
 """
 import glob
 import importlib
+import logging
 import os
 import pathlib
 import platform
@@ -31,9 +32,13 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from mlir_quantum.compiler_driver import run_compiler_driver
 
+from catalyst.logging import debug_logger, debug_logger_init
 from catalyst.utils.exceptions import CompileError
 from catalyst.utils.filesystem import Directory
 from catalyst.utils.runtime_environment import get_lib_path
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 package_root = os.path.dirname(__file__)
 
@@ -108,6 +113,7 @@ class CompileOptions:
         return DEFAULT_PIPELINES
 
 
+@debug_logger
 def run_writing_command(command: List[str], compile_options: Optional[CompileOptions]) -> None:
     """Run the command after optionally announcing this fact to the user.
 
@@ -258,6 +264,7 @@ class LinkerDriver:
     _default_fallback_compilers = ["clang", "gcc", "c99", "c89", "cc"]
 
     @staticmethod
+    @debug_logger
     def get_default_flags(options):
         """Re-compute the path where the libraries exist.
 
@@ -400,6 +407,7 @@ class LinkerDriver:
             return False
 
     @staticmethod
+    @debug_logger
     def get_output_filename(infile):
         """Rename object file to shared object
 
@@ -413,6 +421,7 @@ class LinkerDriver:
         return str(infile_path.with_suffix(".so"))
 
     @staticmethod
+    @debug_logger
     def run(infile, outfile=None, flags=None, fallback_compilers=None, options=None):
         """
         Link the infile against the necessary libraries and produce the outfile.
@@ -446,10 +455,12 @@ class LinkerDriver:
 class Compiler:
     """Compiles MLIR modules to shared objects by executing the Catalyst compiler driver library."""
 
+    @debug_logger_init
     def __init__(self, options: Optional[CompileOptions] = None):
         self.options = options if options is not None else CompileOptions()
         self.last_compiler_output = None
 
+    @debug_logger
     def run_from_ir(self, ir: str, module_name: str, workspace: Directory):
         """Compile a shared object from a textual IR (MLIR or LLVM).
 
@@ -510,6 +521,7 @@ class Compiler:
         self.last_compiler_output = compiler_output
         return output_filename, out_IR, [func_name, ret_type_name]
 
+    @debug_logger
     def run(self, mlir_module, *args, **kwargs):
         """Compile an MLIR module to a shared object.
 
@@ -534,6 +546,7 @@ class Compiler:
             **kwargs,
         )
 
+    @debug_logger
     def get_output_of(self, pipeline) -> Optional[str]:
         """Get the output IR of a pipeline.
         Args:

--- a/frontend/catalyst/debug/compiler_functions.py
+++ b/frontend/catalyst/debug/compiler_functions.py
@@ -15,7 +15,7 @@
 """
 This module contains debug functions to interact with the compiler and compiled functions.
 """
-
+import logging
 import os
 
 from jax.interpreters import mlir
@@ -23,11 +23,16 @@ from jax.interpreters import mlir
 import catalyst
 from catalyst.compiled_functions import CompiledFunction
 from catalyst.compiler import Compiler
+from catalyst.logging import debug_logger
 from catalyst.tracing.contexts import EvaluationContext
 from catalyst.tracing.type_signatures import filter_static_args, promote_arguments
 from catalyst.utils.filesystem import WorkspaceManager
 
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
+
+@debug_logger
 def print_compilation_stage(fn, stage):
     """Print one of the recorded compilation stages for a JIT-compiled function.
 
@@ -58,6 +63,7 @@ def print_compilation_stage(fn, stage):
     print(fn.compiler.get_output_of(stage))
 
 
+@debug_logger
 def get_cmain(fn, *args):
     """Return a C program that calls a jitted function with the provided arguments.
 
@@ -83,6 +89,7 @@ def get_cmain(fn, *args):
 
 
 # pylint: disable=line-too-long
+@debug_logger
 def compile_from_mlir(ir, compiler=None, compile_options=None):
     """Compile a Catalyst function to binary code from the provided MLIR.
 

--- a/frontend/catalyst/device/decomposition.py
+++ b/frontend/catalyst/device/decomposition.py
@@ -37,7 +37,7 @@ from pennylane.tape.tape import (
 
 from catalyst.api_extensions.quantum_operators import QCtrl
 from catalyst.jax_tracer import HybridOpRegion, has_nested_tapes
-from catalyst.logging import debug_logger, debug_logger_init
+from catalyst.logging import debug_logger
 from catalyst.tracing.contexts import EvaluationContext
 from catalyst.utils.exceptions import CompileError
 from catalyst.utils.toml import DeviceCapabilities

--- a/frontend/catalyst/device/decomposition.py
+++ b/frontend/catalyst/device/decomposition.py
@@ -16,7 +16,7 @@
 This module contains the decomposition functions to pre-process tapes for
 compilation & execution on devices.
 """
-
+import logging
 from functools import partial
 
 import jax
@@ -37,9 +37,13 @@ from pennylane.tape.tape import (
 
 from catalyst.api_extensions.quantum_operators import QCtrl
 from catalyst.jax_tracer import HybridOpRegion, has_nested_tapes
+from catalyst.logging import debug_logger, debug_logger_init
 from catalyst.tracing.contexts import EvaluationContext
 from catalyst.utils.exceptions import CompileError
 from catalyst.utils.toml import DeviceCapabilities
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 def catalyst_decomposer(op, capabilities: DeviceCapabilities):
@@ -54,6 +58,7 @@ def catalyst_decomposer(op, capabilities: DeviceCapabilities):
 
 
 @transform
+@debug_logger
 def catalyst_decompose(
     tape: qml.tape.QuantumTape,
     ctx,
@@ -132,6 +137,7 @@ def _decompose_nested_tapes(op, ctx, stopping_condition, capabilities, max_expan
 
 
 @transform
+@debug_logger
 def decompose_ops_to_unitary(tape, convert_to_matrix_ops):
     r"""Quantum transform that decomposes operations to unitary given a list of operations name.
 
@@ -173,6 +179,7 @@ def catalyst_acceptance(op: qml.operation.Operator, operations) -> bool:
 
 
 @transform
+@debug_logger
 def measurements_from_counts(tape):
     r"""Replace all measurements from a tape with a single count measurement, it adds postprocessing
     functions for each original measurement.

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -16,6 +16,7 @@
 This module contains device stubs for the old and new PennyLane device API, which facilitate
 the application of decomposition and other device pre-processing routines.
 """
+import logging
 import os
 import pathlib
 import platform
@@ -34,6 +35,7 @@ from catalyst.device.decomposition import (
     catalyst_decompose,
     measurements_from_counts,
 )
+from catalyst.logging import debug_logger, debug_logger_init
 from catalyst.utils.exceptions import CompileError
 from catalyst.utils.patching import Patcher
 from catalyst.utils.runtime_environment import get_lib_path
@@ -43,6 +45,9 @@ from catalyst.utils.toml import (
     intersect_operations,
     pennylane_operation_set,
 )
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 RUNTIME_OPERATIONS = [
     "CNOT",
@@ -105,6 +110,7 @@ class BackendInfo:
     kwargs: Dict[str, Any]
 
 
+@debug_logger
 def extract_backend_info(device: qml.QubitDevice, capabilities: DeviceCapabilities) -> BackendInfo:
     """Extract the backend info from a quantum device. The device is expected to carry a reference
     to a valid TOML config file."""
@@ -167,6 +173,7 @@ def extract_backend_info(device: qml.QubitDevice, capabilities: DeviceCapabiliti
     return BackendInfo(dname, device_name, device_lpath, device_kwargs)
 
 
+@debug_logger
 def get_qjit_device_capabilities(target_capabilities: DeviceCapabilities) -> Set[str]:
     """Calculate the set of supported quantum gates for the QJIT device from the gates
     allowed on the target quantum device."""
@@ -245,6 +252,7 @@ class QJITDevice(qml.QubitDevice):
         # TODO: https://github.com/PennyLaneAI/catalyst/issues/398
         return {"MultiControlledX", "BlockEncode"}
 
+    @debug_logger_init
     def __init__(
         self,
         original_device_capabilities: DeviceCapabilities,
@@ -276,6 +284,7 @@ class QJITDevice(qml.QubitDevice):
         """
         raise RuntimeError("QJIT devices cannot apply operations.")  # pragma: no cover
 
+    @debug_logger
     def default_expand_fn(self, circuit, max_expansion=10):
         """
         Most decomposition logic will be equivalent to PennyLane's decomposition.
@@ -344,6 +353,7 @@ class QJITDeviceNewAPI(qml.devices.Device):
         backend_kwargs (Dict(str, AnyType)): An optional dictionary of the device specifications
     """
 
+    @debug_logger_init
     def __init__(
         self,
         original_device,
@@ -381,6 +391,7 @@ class QJITDeviceNewAPI(qml.devices.Device):
         """Get the device measurement processes"""
         return self.qjit_capabilities.measurement_processes
 
+    @debug_logger
     def preprocess(
         self,
         ctx,
@@ -457,6 +468,7 @@ def check_no_overlap(*args, device_name):
     raise CompileError(msg)
 
 
+@debug_logger
 def validate_device_capabilities(
     device: qml.QubitDevice, device_capabilities: DeviceCapabilities
 ) -> None:

--- a/frontend/catalyst/jax_extras/lowering.py
+++ b/frontend/catalyst/jax_extras/lowering.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 """ Jax extras module containing functions related to the StableHLO lowering """
 
-import logging
 from __future__ import annotations
+
+import logging
 
 import jax
 from jax._src.dispatch import jaxpr_replicas
@@ -34,7 +35,7 @@ from jax.interpreters.mlir import (
     lowerable_effects,
 )
 
-from catalyst.logging import debug_logger, debug_logger_init
+from catalyst.logging import debug_logger
 from catalyst.utils.patching import Patcher
 
 # pylint: disable=protected-access

--- a/frontend/catalyst/jax_extras/lowering.py
+++ b/frontend/catalyst/jax_extras/lowering.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """ Jax extras module containing functions related to the StableHLO lowering """
 
+import logging
 from __future__ import annotations
 
 import jax
@@ -33,6 +34,7 @@ from jax.interpreters.mlir import (
     lowerable_effects,
 )
 
+from catalyst.logging import debug_logger, debug_logger_init
 from catalyst.utils.patching import Patcher
 
 # pylint: disable=protected-access
@@ -41,7 +43,11 @@ __all__ = ("jaxpr_to_mlir", "custom_lower_jaxpr_to_module")
 
 from catalyst.jax_extras.patches import _no_clean_up_dead_vars, get_aval2
 
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
+
+@debug_logger
 def jaxpr_to_mlir(func_name, jaxpr):
     """Lower a Jaxpr into an MLIR module.
 
@@ -76,6 +82,7 @@ def jaxpr_to_mlir(func_name, jaxpr):
 
 
 # pylint: disable=too-many-arguments
+@debug_logger
 def custom_lower_jaxpr_to_module(
     func_name: str,
     module_name: str,

--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """ Jax extras module containing functions related to the Python program tracing  """
 
-import logging
 from __future__ import annotations
 
+import logging
 from contextlib import ExitStack, contextmanager
 from typing import Any, Callable, Dict, Generator, List, Optional, Sequence, Set, Type
 

--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """ Jax extras module containing functions related to the Python program tracing  """
 
+import logging
 from __future__ import annotations
 
 from contextlib import ExitStack, contextmanager
@@ -62,6 +63,7 @@ from jax.tree_util import (
 from jaxlib.xla_extension import PyTreeRegistry
 
 from catalyst.jax_extras.patches import _gather_shape_rule_dynamic, get_aval2
+from catalyst.logging import debug_logger, debug_logger_init
 from catalyst.utils.patching import Patcher
 
 # pylint: disable=protected-access
@@ -99,6 +101,9 @@ __all__ = (
     "wrap_init",
 )
 
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
 map, unsafe_map = safe_map, map  # pylint: disable=redefined-builtin
 
 
@@ -106,6 +111,7 @@ class DynshapedClosedJaxpr(ClosedJaxpr):
     """A wrapper class to handle implicit/explicit result information used by JAX for dynamically
     shaped arrays. Can be used inplace of any other ClosedJaxpr instance."""
 
+    @debug_logger_init
     def __init__(self, jaxpr: Jaxpr, consts: Sequence, output_type: OutputType):
         super().__init__(jaxpr, consts)
         self.output_type = output_type
@@ -152,6 +158,7 @@ def transient_jax_config() -> Generator[None, None, None]:
 
 
 @contextmanager
+@debug_logger
 def new_dynamic_main2(
     trace_type: Type[Trace],
     main: Optional[MainTrace] = None,
@@ -354,6 +361,7 @@ def get_implicit_and_explicit_flat_args(abstracted_axes, *args, **kwargs):
     return args_flat
 
 
+@debug_logger
 def make_jaxpr2(
     fun: Callable,
     static_argnums: Any | None = None,

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -14,6 +14,7 @@
 """This module contains functions tracing and lowering JAX code to MLIR.
 """
 
+import logging
 from dataclasses import dataclass
 from functools import partial, reduce
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
@@ -77,12 +78,16 @@ from catalyst.jax_primitives import (
     tensorobs_p,
     var_p,
 )
+from catalyst.logging import debug_logger, debug_logger_init
 from catalyst.tracing.contexts import (
     EvaluationContext,
     EvaluationMode,
     JaxTracingContext,
 )
 from catalyst.utils.exceptions import CompileError
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 class Function:
@@ -98,10 +103,12 @@ class Function:
         AssertionError: Invalid function type.
     """
 
+    @debug_logger_init
     def __init__(self, fn):
         self.fn = fn
         self.__name__ = fn.__name__
 
+    @debug_logger
     def __call__(self, *args, **kwargs):
         jaxpr, out_tree = make_jaxpr2(self.fn)(*args)
 
@@ -128,6 +135,7 @@ PAULI_NAMED_MAP = {
 }
 
 
+@debug_logger
 def retrace_with_result_types(jaxpr: ClosedJaxpr, target_types: List[ShapedArray]) -> ClosedJaxpr:
     """Return a JAXPR that is identical to the given one but with added type conversion operations
     to produce the provided type signature in its output."""
@@ -152,6 +160,7 @@ def retrace_with_result_types(jaxpr: ClosedJaxpr, target_types: List[ShapedArray
     return ClosedJaxpr(jaxpr2, consts)
 
 
+@debug_logger
 def unify_jaxpr_result_types(jaxprs: List[ClosedJaxpr]) -> List[ClosedJaxpr]:
     """Unify result signatures across a set of JAXPRs by promoting to common types.
 
@@ -187,10 +196,12 @@ class QRegPromise:
     """QReg adaptor tracing the qubit extractions and insertions. The adaptor works by postponing
     the insertions in order to re-use qubits later thus skipping the extractions."""
 
+    @debug_logger_init
     def __init__(self, qreg: DynamicJaxprTracer):
         self.base: DynamicJaxprTracer = qreg
         self.cache: Dict[Any, DynamicJaxprTracer] = {}
 
+    @debug_logger
     def extract(self, wires: List[Any], allow_reuse=False) -> List[DynamicJaxprTracer]:
         """Extract qubits from the wrapped quantum register or get the already extracted qubits
         from cache"""
@@ -214,6 +225,7 @@ class QRegPromise:
                 qubits.append(qextract_p.bind(qrp.base, w))
         return qubits
 
+    @debug_logger
     def insert(self, wires, qubits) -> None:
         """Insert qubits to the cache."""
         qrp = self
@@ -224,6 +236,7 @@ class QRegPromise:
             ), f"Attempting to insert an already-inserted wire {w} into {qrp.base}"
             qrp.cache[w] = qubit
 
+    @debug_logger
     def actualize(self) -> DynamicJaxprTracer:
         """Prune the qubit cache by performing the postponed insertions."""
         qrp = self
@@ -279,6 +292,7 @@ class HybridOp(Operation):
     num_wires = AnyWires
     binder: Callable = _no_binder
 
+    @debug_logger_init
     def __init__(self, in_classical_tracers, out_classical_tracers, regions: List[HybridOpRegion]):
         self.in_classical_tracers = in_classical_tracers
         self.out_classical_tracers = out_classical_tracers
@@ -290,6 +304,7 @@ class HybridOp(Operation):
         nested_ops = [r.quantum_tape.operations for r in self.regions if r.quantum_tape]
         return f"{self.name}(tapes={nested_ops})"
 
+    @debug_logger
     def bind_overwrite_classical_tracers(
         self, ctx: JaxTracingContext, trace: DynamicJaxprTrace, *args, **kwargs
     ) -> DynamicJaxprTracer:
@@ -308,6 +323,7 @@ class HybridOp(Operation):
             eqn.outvars[i] = trace.getvar(t)
         return out_quantum_tracer
 
+    @debug_logger
     def trace_quantum(
         self,
         ctx: JaxTracingContext,
@@ -328,6 +344,7 @@ def has_nested_tapes(op: Operation) -> bool:
     )
 
 
+@debug_logger
 def trace_to_jaxpr(func, static_argnums, abstracted_axes, args, kwargs):
     """Trace a Python function to JAXPR.
 
@@ -355,6 +372,7 @@ def trace_to_jaxpr(func, static_argnums, abstracted_axes, args, kwargs):
     return jaxpr, out_treedef
 
 
+@debug_logger
 def lower_jaxpr_to_mlir(jaxpr, func_name):
     """Lower a JAXPR to MLIR.
 
@@ -383,6 +401,7 @@ def lower_jaxpr_to_mlir(jaxpr, func_name):
     return mlir_module, ctx
 
 
+@debug_logger
 def trace_quantum_tape(
     quantum_tape: QuantumTape,
     device: QubitDevice,
@@ -472,6 +491,7 @@ def trace_quantum_tape(
     return qrp
 
 
+@debug_logger
 def trace_observables(
     obs: Operation, qrp: QRegPromise, m_wires: int
 ) -> Tuple[List[DynamicJaxprTracer], Optional[int]]:
@@ -522,6 +542,7 @@ def trace_observables(
     return obs_tracers, (len(qubits) if qubits else None)
 
 
+@debug_logger
 def pauli_sentence_to_hamiltonian_obs(paulis, qrp: QRegPromise) -> List[DynamicJaxprTracer]:
     """Convert a :class:`pennylane.pauli.PauliSentence` into a Hamiltonian.
 
@@ -543,6 +564,7 @@ def pauli_sentence_to_hamiltonian_obs(paulis, qrp: QRegPromise) -> List[DynamicJ
     return hamiltonian_p.bind(coeffs, *nested_obs)
 
 
+@debug_logger
 def pauli_word_to_tensor_obs(obs, qrp: QRegPromise) -> List[DynamicJaxprTracer]:
     """Convert a :class:`pennylane.pauli.PauliWord` into a Named or Tensor observable.
 
@@ -572,6 +594,7 @@ def identity_qnode_transform(tape: QuantumTape) -> (Sequence[QuantumTape], Calla
 
 
 # pylint: disable=too-many-statements,too-many-branches
+@debug_logger
 def trace_quantum_measurements(
     device: QubitDevice,
     qrp: QRegPromise,
@@ -661,6 +684,7 @@ def trace_quantum_measurements(
     return out_classical_tracers, out_tree
 
 
+@debug_logger
 def is_transform_valid_for_batch_transforms(tape, flat_results):
     """Not all transforms are valid for batch transforms.
     Batch transforms will increase the number of tapes from 1 to N.
@@ -704,6 +728,7 @@ def is_transform_valid_for_batch_transforms(tape, flat_results):
     return are_batch_transforms_valid
 
 
+@debug_logger
 def apply_transform(qnode_program, device_program, device_modify_measurements, tape, flat_results):
     """Apply transform."""
     # Some transforms use trainability as a basis for transforming.
@@ -730,6 +755,7 @@ def apply_transform(qnode_program, device_program, device_modify_measurements, t
     return tapes, post_processing
 
 
+@debug_logger
 def split_tracers_and_measurements(flat_values):
     """Return classical tracers and measurements"""
     classical = []
@@ -747,6 +773,7 @@ def split_tracers_and_measurements(flat_values):
     return classical, measurements
 
 
+@debug_logger
 def trace_post_processing(ctx, trace, post_processing: Callable, pp_args):
     """Trace post processing function.
 
@@ -780,6 +807,7 @@ def trace_post_processing(ctx, trace, post_processing: Callable, pp_args):
         return closed_jaxpr, out_type, out_tree_promise()
 
 
+@debug_logger
 def reset_qubit(qreg_in, w):
     """Perform a qubit reset on a single wire. Suitable for use during late-stage tracing,
     as JAX primitives are used directly. These operations will not appear on tape."""
@@ -805,6 +833,7 @@ def reset_qubit(qreg_in, w):
     return qreg_out
 
 
+@debug_logger
 def trace_quantum_function(
     f: Callable, device: QubitDevice, args, kwargs, qnode=None
 ) -> Tuple[ClosedJaxpr, Any]:

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -599,6 +599,7 @@ class QJIT:
         return requires_promotion
 
     # Processing Stages #
+
     @instrument
     @debug_logger
     def pre_compilation(self):

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -36,8 +36,8 @@ from catalyst.compiled_functions import CompilationCache, CompiledFunction
 from catalyst.compiler import CompileOptions, Compiler
 from catalyst.debug.instruments import instrument
 from catalyst.jax_tracer import lower_jaxpr_to_mlir, trace_to_jaxpr
-from catalyst.qfunc import QFunc
 from catalyst.logging import debug_logger, debug_logger_init
+from catalyst.qfunc import QFunc
 from catalyst.tracing.contexts import EvaluationContext
 from catalyst.tracing.type_signatures import (
     filter_static_args,

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -19,6 +19,7 @@ compilation of hybrid quantum-classical functions using Catalyst.
 import copy
 import functools
 import inspect
+import logging
 import os
 import warnings
 
@@ -36,6 +37,7 @@ from catalyst.compiler import CompileOptions, Compiler
 from catalyst.debug.instruments import instrument
 from catalyst.jax_tracer import lower_jaxpr_to_mlir, trace_to_jaxpr
 from catalyst.qfunc import QFunc
+from catalyst.logging import debug_logger, debug_logger_init
 from catalyst.tracing.contexts import EvaluationContext
 from catalyst.tracing.type_signatures import (
     filter_static_args,
@@ -50,6 +52,9 @@ from catalyst.utils.filesystem import WorkspaceManager
 from catalyst.utils.gen_mlir import inject_functions
 from catalyst.utils.patching import Patcher
 
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
 # Required for JAX tracer objects as PennyLane wires.
 # pylint: disable=unnecessary-lambda
 setattr(jax.interpreters.partial_eval.DynamicJaxprTracer, "__hash__", lambda x: id(x))
@@ -60,6 +65,7 @@ jax.config.update("jax_enable_x64", True)
 
 
 ## API ##
+@debug_logger
 def qjit(
     fn=None,
     *,
@@ -450,6 +456,7 @@ class QJIT:
         compile_options (CompileOptions): compilation options to use
     """
 
+    @debug_logger_init
     def __init__(self, fn, compile_options):
         self.original_function = fn
         self.compile_options = compile_options
@@ -490,6 +497,7 @@ class QJIT:
         if self.user_sig is not None and not self.compile_options.static_argnums:
             self.aot_compile()
 
+    @debug_logger
     def __call__(self, *args, **kwargs):
         # Transparantly call Python function in case of nested QJIT calls.
         if EvaluationContext.is_tracing():
@@ -509,6 +517,7 @@ class QJIT:
 
         return self.run(args, kwargs)
 
+    @debug_logger
     def aot_compile(self):
         """Compile Python function on initialization using the type hint signature."""
 
@@ -531,6 +540,7 @@ class QJIT:
                 self.compiled_function, self.user_sig, self.out_treedef, self.workspace
             )
 
+    @debug_logger
     def jit_compile(self, args):
         """Compile Python function on invocation using the provided arguments.
 
@@ -582,8 +592,8 @@ class QJIT:
         return requires_promotion
 
     # Processing Stages #
-
     @instrument
+    @debug_logger
     def pre_compilation(self):
         """Perform pre-processing tasks on the Python function, such as AST transformations."""
         processed_fn = self.original_function
@@ -594,6 +604,7 @@ class QJIT:
         return processed_fn
 
     @instrument(size_from=0)
+    @debug_logger
     def capture(self, args):
         """Capture the JAX program representation (JAXPR) of the wrapped function.
 
@@ -625,6 +636,7 @@ class QJIT:
         return jaxpr, treedef, dynamic_sig
 
     @instrument(size_from=0, has_finegrained=True)
+    @debug_logger
     def generate_ir(self):
         """Generate Catalyst's intermediate representation (IR) as an MLIR module.
 
@@ -649,6 +661,7 @@ class QJIT:
         return mlir_module, mlir_string
 
     @instrument(size_from=1, has_finegrained=True)
+    @debug_logger
     def compile(self):
         """Compile an MLIR module to LLVMIR and shared library code.
 
@@ -677,6 +690,7 @@ class QJIT:
         return compiled_fn, llvm_ir
 
     @instrument(has_finegrained=True)
+    @debug_logger
     def run(self, args, kwargs):
         """Invoke a previously compiled function with the supplied arguments.
 
@@ -733,6 +747,7 @@ class JAX_QJIT:
         qjit_function (QJIT): the compiled quantum function object to wrap
     """
 
+    @debug_logger_init
     def __init__(self, qjit_function):
         @jax.custom_jvp
         def jaxed_function(*args, **kwargs):
@@ -744,6 +759,7 @@ class JAX_QJIT:
         jaxed_function.defjvp(self.compute_jvp, symbolic_zeros=True)
 
     @staticmethod
+    @debug_logger
     def wrap_callback(qjit_function, *args, **kwargs):
         """Wrap a QJIT function inside a jax host callback."""
         data = jax.pure_callback(
@@ -754,6 +770,7 @@ class JAX_QJIT:
         assert qjit_function.out_treedef is not None, "PyTree shape must not be none."
         return tree_unflatten(qjit_function.out_treedef, data)
 
+    @debug_logger
     def get_derivative_qjit(self, argnums):
         """Compile a function computing the derivative of the wrapped QJIT for the given argnums."""
 
@@ -784,6 +801,7 @@ class JAX_QJIT:
         )
         return self.derivative_functions[argnum_key]
 
+    @debug_logger
     def compute_jvp(self, primals, tangents):
         """Compute the set of results and JVPs for a QJIT function."""
         # Assume we have primals of shape `[a,b]` and results of shape `[c,d]`. Derivatives [2]
@@ -822,5 +840,6 @@ class JAX_QJIT:
 
         return results, jvps
 
+    @debug_logger
     def __call__(self, *args, **kwargs):
         return self.jaxed_function(*args, **kwargs)

--- a/frontend/catalyst/logging/__init__.py
+++ b/frontend/catalyst/logging/__init__.py
@@ -1,0 +1,21 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Wrapper for PennyLane logging module. 
+"""
+from pennylane.logging import debug_logger, debug_logger_init
+
+
+__all__ = ("debug_logger", "debug_logger_init")

--- a/frontend/catalyst/logging/__init__.py
+++ b/frontend/catalyst/logging/__init__.py
@@ -17,5 +17,4 @@ Wrapper for PennyLane logging module.
 """
 from pennylane.logging import debug_logger, debug_logger_init
 
-
 __all__ = ("debug_logger", "debug_logger_init")

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -18,6 +18,7 @@ what happens when a QNode object is called during tracing. Mostly this involves 
 the default behaviour and replacing it with a function-like "QNode" primitive.
 """
 
+import logging
 import pennylane as qml
 from jax.core import eval_jaxpr
 from jax.tree_util import tree_flatten, tree_unflatten
@@ -36,11 +37,15 @@ from catalyst.jax_extras import (
 )
 from catalyst.jax_primitives import func_p
 from catalyst.jax_tracer import trace_quantum_function
+from catalyst.logging import debug_logger, debug_logger_init
 from catalyst.utils.toml import (
     DeviceCapabilities,
     ProgramFeatures,
     get_device_capabilities,
 )
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 class QFunc:
@@ -58,6 +63,7 @@ class QFunc:
         raise NotImplementedError()  # pragma: no-cover
 
     @staticmethod
+    @debug_logger
     def extract_backend_info(
         device: qml.QubitDevice, capabilities: DeviceCapabilities
     ) -> BackendInfo:
@@ -65,6 +71,7 @@ class QFunc:
         return extract_backend_info(device, capabilities)
 
     # pylint: disable=no-member, attribute-defined-outside-init
+    @debug_logger
     def __call__(self, *args, **kwargs):
         assert isinstance(self, qml.QNode)
 

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -19,6 +19,7 @@ the default behaviour and replacing it with a function-like "QNode" primitive.
 """
 
 import logging
+
 import pennylane as qml
 from jax.core import eval_jaxpr
 from jax.tree_util import tree_flatten, tree_unflatten
@@ -37,7 +38,7 @@ from catalyst.jax_extras import (
 )
 from catalyst.jax_primitives import func_p
 from catalyst.jax_tracer import trace_quantum_function
-from catalyst.logging import debug_logger, debug_logger_init
+from catalyst.logging import debug_logger
 from catalyst.utils.toml import (
     DeviceCapabilities,
     ProgramFeatures,

--- a/frontend/catalyst/tracing/contexts.py
+++ b/frontend/catalyst/tracing/contexts.py
@@ -16,6 +16,7 @@
 This module provides context classes to manage and query Catalyst's and JAX's tracing state.
 """
 
+import logging
 from contextlib import contextmanager
 from dataclasses import dataclass
 from enum import Enum
@@ -33,7 +34,11 @@ from jax.core import find_top_trace
 from pennylane.queuing import QueuingManager
 
 from catalyst.jax_extras import new_dynamic_main2
+from catalyst.logging import debug_logger, debug_logger_init
 from catalyst.utils.exceptions import CompileError
+
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 
 class EvaluationMode(Enum):
@@ -69,6 +74,7 @@ class JaxTracingContext:
     mains: Dict[DynamicJaxprTrace, JaxMainTrace]
     trace: Optional[DynamicJaxprTrace]
 
+    @debug_logger_init
     def __init__(self, main: JaxMainTrace):
         self.main, self.frames, self.mains, self.trace = main, {}, {}, None
 
@@ -82,6 +88,7 @@ class EvaluationContext:
 
     _tracing_stack: List[Tuple[EvaluationMode, Optional[JaxTracingContext]]] = []
 
+    @debug_logger_init
     def __init__(self, mode: EvaluationMode):
         """Initialise a new instance of the Evaluation context.
         Args:

--- a/frontend/catalyst/tracing/contexts.py
+++ b/frontend/catalyst/tracing/contexts.py
@@ -34,7 +34,7 @@ from jax.core import find_top_trace
 from pennylane.queuing import QueuingManager
 
 from catalyst.jax_extras import new_dynamic_main2
-from catalyst.logging import debug_logger, debug_logger_init
+from catalyst.logging import debug_logger_init
 from catalyst.utils.exceptions import CompileError
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new functions and code must be clearly commented and documented.

- [x] Ensure that code is properly formatted by running `make format`.
      The latest version of black and `clang-format-14` are used in CI/CD to check formatting.

- [ ] All new features must include a unit test.
      Integration and frontend tests should be added to [`frontend/test`](../frontend/test/),
      Quantum dialect and MLIR tests should be added to [`mlir/test`](../mlir/test/), and
      Runtime tests should be added to [`runtime/tests`](../runtime/tests/).

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** PennyLane's [logging support](https://docs.pennylane.ai/en/stable/introduction/logging.html) allows developers to explore the execution pipeline end-to-end, while tying into the Python-native logging framework. This has the advantage of being enterprise ready, consumable by a variety of log sinks, and unifies/removes the need for adding `print` statements throughout a code-base, with all control to be handled by the Python [language standard libraries](https://docs.python.org/3/library/logging.html). This PR aims to unify Catalyst to follow the same design as PennyLane to support logging with the same unified configuration, allowing ease of examining of function entry points at the `DEBUG` level, and a custom `TRACE` method for expanding functions passed as arguments.

**Description of the Change:** Adds preliminary support to a variety of Catalyst frontend public API entry-points. Any workload using `qml.logging.enable_logging()`  allows the function entry data to be streamed to the pre-configured log-handlers from PennyLane. 

**Benefits:** More easily allows time-order and standardised data formatting for consumption with complex application execution, debugging, and end-to-end validation of call-points.

**Possible Drawbacks:** 

**Related GitHub Issues:** https://github.com/PennyLaneAI/pennylane/pull/5528
