### PR TITLE
Bump from manylinux2014_x86_64 to manylinux_2_28_x86_64

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -34,7 +34,7 @@ jobs:
         os: [ubuntu-latest]
         arch: [x86_64]
         python_version: ${{ fromJson(needs.constants.outputs.python_versions) }}
-        container_img: ["quay.io/pypa/manylinux2014_x86_64"]
+        container_img: ["quay.io/pypa/manylinux_2_28_x86_64"]
 
     name: Build Dependencies (Python ${{ matrix.python_version }})
     runs-on: ubuntu-latest
@@ -59,7 +59,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path:  mlir/llvm-project
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-generic-source
+        key: ${{ runner.os }}-${{ matrix.container_img }}-llvm-${{ needs.constants.outputs.llvm_version }}-generic-source
         enableCrossOsArchive: True
 
     - name: Cache MHLO Source
@@ -67,7 +67,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: mlir/mlir-hlo
-        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-source
+        key: ${{ runner.os }}-${{ matrix.container_img }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-source
         enableCrossOsArchive: True
 
     - name: Cache Enzyme Source
@@ -75,7 +75,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path:  mlir/Enzyme
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.enzyme_version }}-generic-source
+        key: ${{ runner.os }}-${{ matrix.container_img }}-enzyme-${{ needs.constants.outputs.enzyme_version }}-generic-source
         enableCrossOsArchive: True
 
     - name: Clone LLVM Submodule
@@ -108,35 +108,40 @@ jobs:
       uses: actions/cache@v3
       with:
         path:  llvm-build
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-${{matrix.python_version}}-generic-build
+        key: ${{ runner.os }}-${{ matrix.container_img }}-llvm-${{ needs.constants.outputs.llvm_version }}-${{matrix.python_version}}-generic-build
 
     - name: Cache MHLO Build
       id: cache-mhlo-build
       uses: actions/cache@v3
       with:
         path:  mhlo-build
-        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-build
+        key: ${{ runner.os }}-${{ matrix.container_img }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-build
 
     - name: Cache Enzyme Build
       id: cache-enzyme-build
       uses: actions/cache@v3
       with:
         path:  enzyme-build
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-generic-build
+        key: ${{ runner.os }}-${{ matrix.container_img }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-generic-build
 
-    - name: Install dependencies (CentOS)
+    - name: Install dependencies (AlmaLinux)
       if: |
         steps.cache-llvm-build.outputs.cache-hit != 'true' ||
         steps.cache-mhlo-build.outputs.cache-hit != 'true' ||
         steps.cache-enzyme-build.outputs.cache-hit != 'true'
       run: |
         # Reduce wait time for repos not responding
-        cat /etc/yum.conf | sed "s/\[main\]/\[main\]\ntimeout=5/g" > /etc/yum.conf
-        yum update -y && yum install -y cmake ninja-build libzstd-devel
+        cat /etc/dnf.conf | sed "s/\[main\]/\[main\]\ntimeout=5/g" > /etc/dnf.conf
+        dnf update -y && dnf install -y libzstd-devel gcc-toolset-13
+        # Update env vars valid for all tasks of this job
+        echo '/opt/rh/gcc-toolset-13/root/usr/bin' >> $GITHUB_PATH
 
     - name: Install Dependencies (Python)
       run: |
-        python${{ matrix.python_version }} -m pip install numpy pybind11 PyYAML
+        python${{ matrix.python_version }} -m pip install numpy pybind11 PyYAML cmake ninja
+        # Add cmake and ninja to the PATH env var
+        PYTHON_BINS=$(find /opt/_internal/cpython-${{ matrix.python_version }}.*/bin -maxdepth 1 -type d | tr '\n' ':' | sed 's/:$//')
+        echo $PYTHON_BINS >> $GITHUB_PATH
 
     # Required for MHLO and building MLIR with protected symbols.
     # (Don't forget to add the build directory to PATH in subsequent steps, so
@@ -212,7 +217,7 @@ jobs:
         os: [ubuntu-latest]
         arch: [x86_64]
         python_version: ${{ fromJson(needs.constants.outputs.python_versions) }}
-        container_img: ["quay.io/pypa/manylinux2014_x86_64"]
+        container_img: ["quay.io/pypa/manylinux_2_28_x86_64"]
 
     name: Build Wheels (Python ${{ matrix.python_version }})
     runs-on: ${{ matrix.os }}
@@ -222,22 +227,27 @@ jobs:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v3
 
-    - name: Install dependencies (CentOS)
+    - name: Install dependencies (AlmaLinux)
       run: |
         # Reduce wait time for repos not responding
-        cat /etc/yum.conf | sed "s/\[main\]/\[main\]\ntimeout=5/g" > /etc/yum.conf
-        yum update -y && yum install -y cmake ninja-build openmpi-devel libzstd-devel
+        cat /etc/dnf.conf | sed "s/\[main\]/\[main\]\ntimeout=5/g" > /etc/dnf.conf
+        dnf update -y && dnf install -y openmpi-devel libzstd-devel gcc-toolset-13
+        # Update env vars valid for all tasks of this job
+        echo '/opt/rh/gcc-toolset-13/root/usr/bin' >> $GITHUB_PATH
 
     - name: Install Dependencies (Python)
       run: |
-        python${{ matrix.python_version }} -m pip install numpy pybind11 PyYAML
+        python${{ matrix.python_version }} -m pip install numpy pybind11 PyYAML cmake ninja
+        # Add cmake and ninja to the PATH env var
+        PYTHON_BINS=$(find /opt/_internal/cpython-${{ matrix.python_version }}.*/bin -maxdepth 1 -type d | tr '\n' ':' | sed 's/:$//')
+        echo $PYTHON_BINS >> $GITHUB_PATH
 
     - name: Get Cached LLVM Source
       id: cache-llvm-source
       uses: actions/cache@v3
       with:
         path: mlir/llvm-project
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-generic-source
+        key: ${{ runner.os }}-${{ matrix.container_img }}-llvm-${{ needs.constants.outputs.llvm_version }}-generic-source
         enableCrossOsArchive: True
         fail-on-cache-miss: True
 
@@ -246,7 +256,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path:  llvm-build
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-${{matrix.python_version}}-generic-build
+        key: ${{ runner.os }}-${{ matrix.container_img }}-llvm-${{ needs.constants.outputs.llvm_version }}-${{matrix.python_version}}-generic-build
         fail-on-cache-miss: True
 
     - name: Get Cached MHLO Source
@@ -254,7 +264,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: mlir/mlir-hlo
-        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-source
+        key: ${{ runner.os }}-${{ matrix.container_img }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-source
         enableCrossOsArchive: True
         fail-on-cache-miss: True
 
@@ -263,7 +273,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path:  mhlo-build
-        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-build
+        key: ${{ runner.os }}-${{ matrix.container_img }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-build
         fail-on-cache-miss: True
 
     - name: Get Cached Enzyme Source
@@ -271,7 +281,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path:  mlir/Enzyme
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.enzyme_version }}-generic-source
+        key: ${{ runner.os }}-${{ matrix.container_img }}-enzyme-${{ needs.constants.outputs.enzyme_version }}-generic-source
         fail-on-cache-miss: True
 
     - name: Get Cached Enzyme Build
@@ -279,7 +289,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path:  enzyme-build
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-generic-build
+        key: ${{ runner.os }}-${{ matrix.container_img }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-generic-build
         fail-on-cache-miss: True
 
     # Build Catalyst-Runtime
@@ -350,7 +360,7 @@ jobs:
     - name: Upload Wheel Artifact
       uses: actions/upload-artifact@v3
       with:
-        name: catalyst-manylinux2014_x86_64-wheel-py-${{ matrix.python_version }}.zip
+        name: catalyst-manylinux_2_28_x86_64-wheel-py-${{ matrix.python_version }}.zip
         path: wheel/
         retention-days: 14
 
@@ -373,7 +383,7 @@ jobs:
     - name: Download Wheel Artifact
       uses: actions/download-artifact@v3
       with:
-        name: catalyst-manylinux2014_x86_64-wheel-py-${{ matrix.python_version }}.zip
+        name: catalyst-manylinux_2_28_x86_64-wheel-py-${{ matrix.python_version }}.zip
         path: dist
 
     - name: Set up Python ${{ matrix.python_version }}

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -139,6 +139,9 @@
 * Add optimization that removes redundant chains of self inverse operations. This is done within a new MLIR pass called `remove-chained-self-inverse`. Currently we only match redundant Hadamard operations but the list of supported operations can be expanded.
   [(#630)](https://github.com/PennyLaneAI/catalyst/pull/630)
 
+* Binary distributions for Linux are now based on `manylinux_2_28` instead of `manylinux_2014`. As a result, Catalyst will only be compatible on systems with `glibc` versions `2.28` and above (e.g. Ubuntu 20.04 and above).
+  [(#663)](https://github.com/PennyLaneAI/catalyst/pull/663)
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>
@@ -176,7 +179,8 @@ Romain Moyard,
 Sergei Mironov,
 Erick Ochoa Lopez,
 Lee James O'Riordan,
-Muzammiluddin Syed.
+Muzammiluddin Syed,
+Raul Torres.
 
 # Release 0.5.0
 


### PR DESCRIPTION
**Context:** We want to use the latest manylinux version to distribute our wheels.

**Description of the Change:** 

- Use the latest manylinux_2_28_x86_64 image.
- Produce a Catalyst wheel based on that name.
- Use GCC 13 for compiling Catalyst and its dependencies too.
- Install CMake from pip.
- Install Ninja from pip (because the one provided by dnf is broken).
- Use new caches that include the manylinux_2_28_x86_64 string.
- Use dnf instead of yum as package manager.

[sc-60086]