### PR TITLE
Oqc fix

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -288,7 +288,7 @@ jobs:
         cmake -S runtime -B runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$GITHUB_WORKSPACE/runtime-build/lib \
-              -DPYTHON_EXECUTABLE=$(which python${{ matrix.python_version }}) \
+              -DPython_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -Dpybind11_DIR=$(python${{ matrix.python_version }} -c "import pybind11; print(pybind11.get_cmake_dir())") \
               -DENABLE_LIGHTNING_KOKKOS=ON \
               -DLIGHTNING_GIT_TAG="v0.35.0" \
@@ -300,7 +300,7 @@ jobs:
               -DLQ_ENABLE_KERNEL_OMP=OFF
 
         cmake --build runtime-build --target rt_capi rtd_lightning rtd_openqasm
-    
+
     # Build OQC-Runtime
     - name: Build OQC-Runtime
       run: |
@@ -391,7 +391,7 @@ jobs:
         python${{ matrix.python_version }} -m pip install amazon-braket-pennylane-plugin "boto3==1.26"
 
     - name: Install OQC client
-      if: ${{ matrix.python_version == '3.9' || matrix.python_version == '3.10'}} 
+      if: ${{ matrix.python_version == '3.9' || matrix.python_version == '3.10'}}
       run: |
         python${{ matrix.python_version }} -m pip install oqc-qcaas-client
 

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -285,7 +285,7 @@ jobs:
         cmake -S runtime -B runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$GITHUB_WORKSPACE/runtime-build/lib \
-              -DPYTHON_EXECUTABLE=$(which python${{ matrix.python_version }}) \
+              -DPython_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -Dpybind11_DIR=$(python${{ matrix.python_version }} -c "import pybind11; print(pybind11.get_cmake_dir())") \
               -DENABLE_LIGHTNING_KOKKOS=ON \
               -DLIGHTNING_GIT_TAG="v0.35.0" \
@@ -308,7 +308,7 @@ jobs:
         cmake --build runtime-build --target runner_tests_lightning runner_tests_openqasm
         ./runtime-build/tests/runner_tests_lightning
         ./runtime-build/tests/runner_tests_openqasm
-  
+
     # Build OQC-Runtime
     - name: Build OQC-Runtime
       run: |
@@ -396,9 +396,9 @@ jobs:
       run: |
         python${{ matrix.python_version }} -m pip install PennyLane-Lightning-Kokkos
         python${{ matrix.python_version }} -m pip install amazon-braket-pennylane-plugin
-    
+
     - name: Install OQC client
-      if: ${{ matrix.python_version == '3.9' || matrix.python_version == '3.10'}} 
+      if: ${{ matrix.python_version == '3.9' || matrix.python_version == '3.10'}}
       run: |
         python${{ matrix.python_version }} -m pip install oqc-qcaas-client
 

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -258,7 +258,7 @@ jobs:
         cmake -S runtime -B runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$GITHUB_WORKSPACE/runtime-build/lib \
-              -DPYTHON_EXECUTABLE=$(which python${{ matrix.python_version }}) \
+              -DPython_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -Dpybind11_DIR=$(python${{ matrix.python_version }} -c "import pybind11; print(pybind11.get_cmake_dir())") \
               -DLIGHTNING_GIT_TAG="v0.35.0" \
               -DENABLE_LIGHTNING_KOKKOS=ON \
@@ -272,7 +272,7 @@ jobs:
               -DLQ_ENABLE_KERNEL_OMP=OFF
 
         cmake --build runtime-build --target rt_capi rtd_lightning rtd_openqasm
-    
+
     # Build OQC-Runtime
     - name: Build OQC-Runtime
       run: |
@@ -366,9 +366,9 @@ jobs:
       run: |
         python${{ matrix.python_version }} -m pip install PennyLane-Lightning-Kokkos
         python${{ matrix.python_version }} -m pip install amazon-braket-pennylane-plugin
-    
+
     - name: Install OQC client
-      if: ${{ matrix.python_version == '3.9' || matrix.python_version == '3.10'}} 
+      if: ${{ matrix.python_version == '3.9' || matrix.python_version == '3.10'}}
       run: |
         python${{ matrix.python_version }} -m pip install oqc-qcaas-client
 

--- a/frontend/catalyst/oqc/src/CMakeLists.txt
+++ b/frontend/catalyst/oqc/src/CMakeLists.txt
@@ -13,24 +13,28 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(FetchContent)
 
-find_package(pybind11 CONFIG)
+function(fetch_pybind11)
+    set(PYBIND11_FINDPYTHON ON) # Avoid warning raised by pybind11 on newer cmake versions.
+    find_package(pybind11 CONFIG)
+    if (pybind11_FOUND)
+        message(STATUS, "FOUND pybind11")
+    else()
+        message(STATUS "Could not find existing pybind11-dev package. Building from source.")
+        set(CMAKE_POLICY_DEFAULT_CMP0127 NEW) # To suppress pybind11 CMP0127 warning
 
-if(pybind11_FOUND)
-    message(STATUS "Found pybind11")
-else()
-    message(STATUS "Cound not find existing pybind11-dev package. Building from source.")
-    set(CMAKE_POLICY_DEFAULT_CMP0127 NEW) # To suppress pybind11 CMP0127 warning
+        # https://cmake.org/cmake/help/latest/module/FindPython.html
+        find_package(Python COMPONENTS Interpreter Development)
 
-    # https://cmake.org/cmake/help/latest/module/FindPython.html
-    find_package(Python COMPONENTS Interpreter Development)
+        FetchContent_Declare(pybind11
+        GIT_REPOSITORY https://github.com/pybind/pybind11.git
+        GIT_TAG        v2.10.1
+        )
 
-    FetchContent_Declare(pybind11
-    GIT_REPOSITORY https://github.com/pybind/pybind11.git
-    GIT_TAG        v2.10.1
-    )
+        FetchContent_MakeAvailable(pybind11)
+    endif()
+endfunction()
 
-    FetchContent_MakeAvailable(pybind11)
-endif()
+fetch_pybind11()
 
 message(STATUS "Building the OQC device.")
 

--- a/frontend/catalyst/oqc/src/Makefile
+++ b/frontend/catalyst/oqc/src/Makefile
@@ -17,7 +17,8 @@ configure:
 		-DCMAKE_C_COMPILER=$(C_COMPILER) \
 		-DCMAKE_CXX_COMPILER=$(CXX_COMPILER) \
 		-DRUNTIME_BUILD_DIR=$(RT_BUILD_DIR) \
-		-DPython_EXECUTABLE=$(PYTHON)
+		-DPython_EXECUTABLE=$(PYTHON) \
+		-Dpybind11_DIR=$(shell $(PYTHON) -c "import pybind11; print(pybind11.get_cmake_dir())")
 
 $(OQC_BUILD_DIR)/librtd_oqc.so: configure
 	cmake --build $(OQC_BUILD_DIR) --target rtd_oqc -j$(NPROC)

--- a/frontend/catalyst/oqc/src/Makefile
+++ b/frontend/catalyst/oqc/src/Makefile
@@ -1,10 +1,12 @@
+PYTHON := $(shell which python3)
+C_COMPILER?=$(shell which clang)
+CXX_COMPILER?=$(shell which clang++)
+NPROC?=$(shell python3 -c "import os; print(os.cpu_count())")
+
 MK_ABSPATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MK_DIR := $(dir $(MK_ABSPATH))
 OQC_BUILD_DIR?=$(MK_DIR)/build
 RT_BUILD_DIR?=$(MK_DIR)/../../../../runtime/build
-C_COMPILER?=$(shell which clang)
-CXX_COMPILER?=$(shell which clang++)
-NPROC?=$(shell python3 -c "import os; print(os.cpu_count())")
 
 
 .PHONY: configure
@@ -15,6 +17,7 @@ configure:
 		-DCMAKE_C_COMPILER=$(C_COMPILER) \
 		-DCMAKE_CXX_COMPILER=$(CXX_COMPILER) \
 		-DRUNTIME_BUILD_DIR=$(RT_BUILD_DIR) \
+		-DPython_EXECUTABLE=$(PYTHON)
 
 $(OQC_BUILD_DIR)/librtd_oqc.so: configure
 	cmake --build $(OQC_BUILD_DIR) --target rtd_oqc -j$(NPROC)
@@ -29,7 +32,6 @@ $(OQC_BUILD_DIR)/tests/runner_tests_oqc: configure
 test: $(OQC_BUILD_DIR)/tests/runner_tests_oqc
 	@echo "test the Catalyst runtime test suite"
 	$(OQC_BUILD_DIR)/tests/runner_tests_oqc
-
 
 .PHONY: clean
 clean:

--- a/frontend/catalyst/oqc/src/tests/CMakeLists.txt
+++ b/frontend/catalyst/oqc/src/tests/CMakeLists.txt
@@ -14,24 +14,7 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(Catch2)
 
-find_package(pybind11 CONFIG)
-
-if(pybind11_FOUND)
-    message(STATUS "Found pybind11")
-else()
-    message(STATUS "Cound not find existing pybind11-dev package. Building from source.")
-    set(CMAKE_POLICY_DEFAULT_CMP0127 NEW) # To suppress pybind11 CMP0127 warning
-
-    # https://cmake.org/cmake/help/latest/module/FindPython.html
-    find_package(Python COMPONENTS Interpreter Development)
-
-    FetchContent_Declare(pybind11
-    GIT_REPOSITORY https://github.com/pybind/pybind11.git
-    GIT_TAG        v2.10.1
-    )
-
-    FetchContent_MakeAvailable(pybind11)
-endif()
+fetch_pybind11()
 
 # Required for catch_discover_tests().
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -45,6 +45,7 @@ FetchContent_Declare(
 )
 
 function(fetch_pybind11)
+    set(PYBIND11_FINDPYTHON ON) # Avoid warning raised by pybind11 on newer cmake versions.
     find_package(pybind11 CONFIG)
     if (pybind11_FOUND)
         message(STATUS, "FOUND pybind11")

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -83,6 +83,7 @@ configure:
 		-DRUNTIME_ENABLE_WARNINGS=$(ENABLE_WARNINGS) \
 		-DENABLE_WARNINGS=OFF \
 		-DPython_EXECUTABLE=$(PYTHON) \
+		-Dpybind11_DIR=$(shell $(PYTHON) -c "import pybind11; print(pybind11.get_cmake_dir())") \
 		-DENABLE_ADDRESS_SANITIZER=$(ENABLE_ASAN) \
 		-DLIGHTNING_GIT_TAG=$(LIGHTNING_GIT_TAG_VALUE) \
 		$(CMAKE_ARGS)
@@ -107,6 +108,7 @@ lq_configure:
 		-DRUNTIME_ENABLE_WARNINGS=$(ENABLE_WARNINGS) \
 		-DENABLE_WARNINGS=OFF \
 		-DPython_EXECUTABLE=$(PYTHON) \
+		-Dpybind11_DIR=$(shell $(PYTHON) -c "import pybind11; print(pybind11.get_cmake_dir())") \
 		-DENABLE_ADDRESS_SANITIZER=$(ENABLE_ASAN) \
 		-DLIGHTNING_GIT_TAG=$(LIGHTNING_GIT_TAG_VALUE) \
 		$(CMAKE_ARGS)

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -2,6 +2,7 @@ PYTHON := $(shell which python3)
 C_COMPILER?=$(shell which clang)
 CXX_COMPILER?=$(shell which clang++)
 COMPILER_LAUNCHER?=$(shell which ccache)
+NPROC?=$(shell python3 -c "import os; print(os.cpu_count())")
 
 MK_ABSPATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MK_DIR := $(dir $(MK_ABSPATH))
@@ -15,7 +16,6 @@ ENABLE_LIGHTNING_KOKKOS?=ON
 ENABLE_OPENQASM?=ON
 ENABLE_ASAN?=OFF
 LIGHTNING_GIT_TAG_VALUE?=v0.35.0
-NPROC?=$(shell python3 -c "import os; print(os.cpu_count())")
 
 BUILD_TARGETS := rt_capi
 TEST_TARGETS := ""


### PR DESCRIPTION
- Ensure OQC build recipe uses correct Python version. The issue was noted on the macOS wheel runner using an [arbitrary Python version (OQC Runtime step)](https://github.com/PennyLaneAI/catalyst/actions/runs/8785072013/job/24104858693).
- Unify handling of Python CMake dependency:
  - Ensure runtime always has `Python_Executable` and `pybind11_DIR` set.
  - Ensure mlir always has `Python3_Executable` and `Python3_NumPy_INCLUDE_DIRS` set.
  - See [FindPython](https://cmake.org/cmake/help/latest/module/FindPython.html) and [FindPython3](https://cmake.org/cmake/help/latest/module/FindPython3.html) docs.
- Avoid warning raised by CMake since version 3.27 due to policy [0148](https://cmake.org/cmake/help/latest/policy/CMP0148.html). The solution ensures Pybind uses the correct CMake functions by setting a Pybind-project variable. Alternatively, the policy could be set but this needs to be done depending on the CMake version used.