### PR TITLE
Fix return types

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -10,6 +10,7 @@
   [(#649)](https://github.com/PennyLaneAI/catalyst/pull/649)
   [(#661)](https://github.com/PennyLaneAI/catalyst/pull/661)
   [(#621)](https://github.com/PennyLaneAI/catalyst/pull/621)
+  [(#686)](https://github.com/PennyLaneAI/catalyst/pull/686)
 
   Catalyst now supports callbacks with parameters and return values.
   The following is now possible:

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -202,7 +202,9 @@ def callback_implementation(
         args, kwargs = tree_unflatten(in_tree, jnpargs)
         retvals = tree_leaves(cb(*args, **kwargs))
         return_values = []
-        results_aval_sequence = results_aval if isinstance(results_aval, Sequence) else [results_aval]
+        results_aval_sequence = (
+            results_aval if isinstance(results_aval, Sequence) else [results_aval]
+        )
         for retval, exp_aval in zip(retvals, results_aval_sequence):
             obs_aval = shaped_abstractify(retval)
             if obs_aval != exp_aval:

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -189,8 +189,6 @@ def callback_implementation(
     metadata = CallbackClosure(args, kwargs)
 
     results_aval = tree_map(convert_pytype_to_shaped_array, result_shape_dtypes)
-    if not isinstance(results_aval, Sequence):
-        results_aval = [results_aval]
 
     flat_results_aval, out_tree = tree_flatten(results_aval)
 
@@ -204,7 +202,8 @@ def callback_implementation(
         args, kwargs = tree_unflatten(in_tree, jnpargs)
         retvals = tree_leaves(cb(*args, **kwargs))
         return_values = []
-        for retval, exp_aval in zip(retvals, results_aval):
+        results_aval_sequence = results_aval if isinstance(results_aval, Sequence) else [results_aval]
+        for retval, exp_aval in zip(retvals, results_aval_sequence):
             obs_aval = shaped_abstractify(retval)
             if obs_aval != exp_aval:
                 raise TypeError(

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -14,6 +14,8 @@
 """Test callbacks"""
 
 
+from collections.abc import Sequence
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -344,6 +346,24 @@ def test_io_callback_modify_global(capsys):
 
     captured = capsys.readouterr()
     assert captured.out.strip() == "0\n1"
+
+
+@pytest.mark.parametrize(
+    "arg",
+    [0.1, jnp.array(0.1)],
+)
+def test_no_return_list(arg):
+    @pure_callback
+    def callback_fn(x) -> float:
+        return np.sin(x)
+
+    @qml.qjit
+    def f(x):
+        res = callback_fn(x**2)
+        assert not isinstance(res, Sequence)
+        return jnp.cos(res)
+
+    f(arg)
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -353,6 +353,8 @@ def test_io_callback_modify_global(capsys):
     [0.1, jnp.array(0.1)],
 )
 def test_no_return_list(arg):
+    """Test that the callback returns a scalar and not a list."""
+
     @pure_callback
     def callback_fn(x) -> float:
         return np.sin(x)
@@ -364,6 +366,22 @@ def test_no_return_list(arg):
         return jnp.cos(res)
 
     f(arg)
+
+
+def test_tuple_out():
+    """Test with multiple tuples."""
+
+    @pure_callback
+    def callback_fn(x) -> (bool, bool):
+        return x > 1.0, x > 2.0
+
+    @qml.qjit
+    def f(x):
+        res = callback_fn(x**2)
+        assert isinstance(res, tuple) and len(res) == 2
+        return jnp.cos(res[0])
+
+    f(0.1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Context:**  Callbacks was incorrectly returning a list when it should return scalar values.

**Description of the Change:** Does not modify the shape of the return type pytrees.

**Benefits:** Fixes issue seen

**Possible Drawbacks:** None
