### PR TITLE
Add Github action workflow to notify on main jobs failures

### DIFF
--- a/.github/workflows/alert-failed-jobs.yaml
+++ b/.github/workflows/alert-failed-jobs.yaml
@@ -1,0 +1,25 @@
+name: Notify on main failures
+on:
+  workflow_run:
+    branches:
+      - main
+    types:
+      - completed
+    workflows:
+      - Build Catalyst Wheel on Linux (x86_64)
+      - Build Catalyst Wheel on macOS (arm64)
+      - Build Catalyst Wheel on macOS (x86_64)
+
+jobs:
+  on-failure:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out'
+    steps:
+      - uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ github.event.workflow_run.conclusion }}
+          notification_title: " ${{github.event.workflow_run.name}} - ${{github.event.workflow_run.conclusion}} on ${{github.event.workflow_run.head_branch}} - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure>"
+          message_format: ":fire: *${{github.event.workflow_run.name}}* ${{github.event.workflow_run.conclusion}} in <${{github.server_url}}/${{github.repository}}/${{github.event.workflow_run.head_branch}}|${{github.repository}}>"
+          footer: "Linked Repo <${{github.server_url}}/${{github.repository}}|${{github.repository}}> | <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure>"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_FAILED_JOBS_WEBHOOK }}

--- a/.github/workflows/notify-failed-jobs.yaml
+++ b/.github/workflows/notify-failed-jobs.yaml
@@ -22,4 +22,4 @@ jobs:
           message_format: ":fire: *${{github.event.workflow_run.name}}* ${{github.event.workflow_run.conclusion}} in <${{github.server_url}}/${{github.repository}}/${{github.event.workflow_run.head_branch}}|${{github.repository}}>"
           footer: "Linked Repo <${{github.server_url}}/${{github.repository}}|${{github.repository}}> | <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure>"
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_FAILED_JOBS_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATIONS_WEBHOOK_URL }}


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new functions and code must be clearly commented and documented.

- [ ] Ensure that code is properly formatted by running `make format`.
      The latest version of black and `clang-format-14` are used in CI/CD to check formatting.

- [ ] All new features must include a unit test.
      Integration and frontend tests should be added to [`frontend/test`](../frontend/test/),
      Quantum dialect and MLIR tests should be added to [`mlir/test`](../mlir/test/), and
      Runtime tests should be added to [`runtime/tests`](../runtime/tests/).

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
It is useful to receive notifications whenever a github action workflow running on mail fails. Github has a slack integration that can be configured, but that sends notification for every job in any state(started, cancelled, failed, succeeded). There is an [open issue](https://github.com/integrations/slack/issues/1563) that hasn't been solved for 2 years.
Because of this, a manual job that triggers based on failures of selected job on main is a better approach, and it won't need to add the notification on each single job.

**Description of the Change:**
A new workflow is added that will send notification to a slack channel(specified in the webhook configuration in the slack settings).

**Benefits:**
Get notification when specified jobs fails on main

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None