### PR TITLE
[frontend] Sink signature

### DIFF
--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -88,8 +88,8 @@ def pure_callback(callback_fn, result_type=None):
     At the moment, `pure_callback`s should not be used inside gradients.
     """
 
-    signature = inspect.signature(callback_fn)
     if result_type is None:
+        signature = inspect.signature(callback_fn)
         result_type = signature.return_annotation
 
     result_type = tree_map(convert_pytype_to_shaped_array, result_type)

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -384,5 +384,16 @@ def test_tuple_out():
     f(0.1)
 
 
+def test_numpy_ufuncs():
+    """Test with numpy ufuncs."""
+
+    @qml.qjit
+    def f(x):
+        y = pure_callback(np.sin, float)(x)
+        return y
+
+    assert np.allclose(np.sin(1.0 / 2.0), f(1.0 / 2.0))
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])


### PR DESCRIPTION
**Context:** QA showed that the following syntax could be desirable:

```python
pure_callback(np.sin, float)(x)
```

however, `np.sin` is a ufunc and does not have a python signature.

**Description of the Change:** Sink the retrieval of python signatures.

**Benefits:** the syntax above can be used.

This change will be cherry-picked for version 0.6.0 release.
