### PR TITLE
Plugin matrix fixes

### DIFF
--- a/.github/workflows/CPL_latest-rc-latest.yaml
+++ b/.github/workflows/CPL_latest-rc-latest.yaml
@@ -10,6 +10,6 @@ jobs:
     name: CPL latest/rc/latest
     uses: ./.github/workflows/check-pl-compat.yaml
     with:
-      catalyst: latest
+      catalyst: release-candidate
       pennylane: release-candidate
-      lightning: latest
+      lightning: release-candidate

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -37,6 +37,9 @@ jobs:
     - if: ${{ inputs.catalyst == 'stable' }}
       run: |
         git checkout $(git tag | sort -V | tail -1)
+    - if: ${{ inputs.catalyst == 'release-candidate' }}
+      run: |
+        git checkout v0.6.0-rc
 
     - name: Install deps
       run: |
@@ -90,7 +93,7 @@ jobs:
         ref: ${{ needs.constants.outputs.enzyme_version }}
         path: mlir/Enzyme
 
-    - name: Install Catalyst (latest/stable)
+    - name: Install Catalyst (latest/stable/release-candidate)
       run: |
         CCACHE_DIR="$(pwd)/.ccache" \
         C_COMPILER=$(which gcc }}) \
@@ -126,6 +129,18 @@ jobs:
         ENABLE_OPENQASM=ON \
         make runtime
 
+    - name: Build Catalyst Runtime (release-candidate)
+      if: ${{ inputs.lightning == 'release-candidate' }}
+      run: |
+        COMPILER_LAUNCHER="" \
+        C_COMPILER=$(which gcc }}) \
+        CXX_COMPILER=$(which g++ }}) \
+        RT_BUILD_DIR="$(pwd)/runtime-build" \
+        LIGHTNING_GIT_TAG_VALUE=v0.36.0_rc \
+        ENABLE_LIGHTNING_KOKKOS=ON \
+        ENABLE_OPENQASM=ON \
+        make runtime
+
     - name: Install PennyLane-Lightning (latest)
       if: ${{ inputs.lightning == 'latest' }}
       run: |
@@ -137,6 +152,12 @@ jobs:
       run: |
         pip install --upgrade pennylane-lightning
         pip install --upgrade pennyLane-lightning-kokkos
+
+    - name: Install PennyLane-Lightning (release-candidate)
+      if: ${{ inputs.lightning == 'release-candidate' }}
+      run: |
+        pip install --upgrade git+https://github.com/PennyLaneAI/pennylane-lightning@v0.36.0_rc
+        PL_BACKEND="lightning_kokkos" pip install --upgrade git+https://github.com/PennyLaneAI/pennylane-lightning@v0.36.0_rc
 
     - name: Install PennyLane (latest)
       if: ${{ inputs.pennylane == 'latest' }}
@@ -152,7 +173,6 @@ jobs:
       if: ${{ inputs.pennylane == 'release-candidate' }}
       run: |
         pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.36.0-rc0
-
 
     - name: Add Frontend Dependencies to PATH
       run: |

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -159,10 +159,14 @@ jobs:
         pip install --upgrade git+https://github.com/PennyLaneAI/pennylane-lightning@v0.36.0_rc
         PL_BACKEND="lightning_kokkos" pip install --upgrade git+https://github.com/PennyLaneAI/pennylane-lightning@v0.36.0_rc
 
+    # PennyLane doesn't update its dev version number on every commit like Lightning, so we need to
+    # force the package to be re-installed. First, handle potential dependency changes, then force
+    # install the package itself.
     - name: Install PennyLane (latest)
       if: ${{ inputs.pennylane == 'latest' }}
       run: |
         pip install --upgrade git+https://github.com/PennyLaneAI/pennylane@master
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@master
 
     - name: Install PennyLane (stable)
       if: ${{ inputs.pennylane == 'stable' }}
@@ -172,7 +176,8 @@ jobs:
     - name: Install PennyLane (release-candidate)
       if: ${{ inputs.pennylane == 'release-candidate' }}
       run: |
-        pip install git+https://github.com/PennyLaneAI/pennylane.git@v0.36.0-rc0
+        pip install --upgrade git+https://github.com/PennyLaneAI/pennylane@v0.36.0-rc0
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.36.0-rc0
 
     - name: Add Frontend Dependencies to PATH
       run: |


### PR DESCRIPTION
- Fix pennylane version not updating in latest/latest/latest

Pip will only install a package if the provided requirement does not
already match an installed package. PennyLane maintains the same version
string throughout one development cycle, which led the package to not be
upgraded from the version specified in the Catalyst requirements.

The same fix is not required for lightning, since lightning changes
its version number on every commit to main.

- Update the rc action to include release candidate versions of Catalyst and Lightning
