### PR TITLE
Cherry pick

### DIFF
--- a/demos/qml_optimization.ipynb
+++ b/demos/qml_optimization.ipynb
@@ -1,6 +1,15 @@
 {
   "cells": [
     {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "%pip install optax"
+      ]
+    },
+    {
       "cell_type": "markdown",
       "metadata": {
         "id": "jfGlh7oY6lpx"

--- a/frontend/test/pytest/test_braket_remote_devices.py
+++ b/frontend/test/pytest/test_braket_remote_devices.py
@@ -20,9 +20,7 @@ import pytest
 
 from catalyst import grad, qjit
 
-pytest.importorskip("braket")
-
-from braket.devices import Devices  # pylint: disable=wrong-import-position
+braket = pytest.importorskip("braket")
 
 try:
     qml.device(
@@ -53,7 +51,7 @@ class TestBraketS3Bucket:
             ),
             qml.device(
                 "braket.aws.qubit",
-                device_arn=Devices.Amazon.SV1,
+                device_arn=braket.devices.Devices.Amazon.SV1,
                 s3_destination_folder=("my-bucket", "my-prefix"),
                 wires=2,
             ),
@@ -88,7 +86,7 @@ class TestBraketGates:
             ),
             qml.device(
                 "braket.aws.qubit",
-                device_arn=Devices.Amazon.SV1,
+                device_arn=braket.devices.Devices.Amazon.SV1,
                 wires=3,
             ),
         ],
@@ -139,7 +137,7 @@ class TestBraketGates:
             ),
             qml.device(
                 "braket.aws.qubit",
-                device_arn=Devices.Amazon.SV1,
+                device_arn=braket.devices.Devices.Amazon.SV1,
                 wires=3,
             ),
         ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ extend_skip_glob = [
 skips = ["B607"]
 
 [build-system]
-requires = ["setuptools>=62", "wheel", "pybind11>=2.7.0", "numpy>=1.22"]
+requires = ["setuptools>=62", "wheel", "pybind11>=2.7.0", "numpy>=1.22,<2"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
-# build dependencies
-pip>=22.3 # Due to a bug in `pip install -e .` vs read-only system-wide site-packages
+# Due to a bug in `pip install -e .` vs read-only system-wide site-packages.
+# Cannot be handled in pyproject.toml since it's too late at that point.
+pip>=22.3
 
-numpy
+# Build dependencies for non-Python components
+numpy<2
 pybind11>=2.8.0
 PyYAML
 
@@ -22,5 +24,3 @@ nbmake
 # optional rt/test dependencies
 pennylane-lightning[kokkos]
 amazon-braket-pennylane-plugin>=1.25.0
-lark
-optax

--- a/setup.py
+++ b/setup.py
@@ -73,8 +73,9 @@ requirements = [
     lightning_dep,
     f"jax=={jax_version}",
     f"jaxlib=={jax_version}",
-    "tomlkit;python_version<'3.11'",
-    "scipy<=1.12.0",
+    "tomlkit; python_version < '3.11'",
+    "scipy<1.13",
+    "numpy<2",
     "diastatic-malt>=2.15.1",
 ]
 


### PR DESCRIPTION
- Pin `numpy` to less than `v2`, since the upcoming release will have many breaking changes.
- Fix the braket test import skips. Skipping a test module does not prevent further module-level code from executing, so a top-level `braket` import would still raise an exception when not installed. The way `importskip` is supposed to be used is that the module object is returned from the call (if successful), which can then be used in tests. If the import is not successful the tests won't run, so the module is not accessed.
- Remove some optional dependencies from `requirements.txt`:
- demo-specific imports, like `optax`, should be installed directly in the notebook
- `lark` was removed since it has a very niche use case (toml grammar checker), and using the script will warn about the required dependency when run

Cherry-pick if #671
