### PR TITLE
[Cherry pick to RC] Fix Python version used by OQC build recipe

### DIFF
--- a/frontend/catalyst/oqc/src/CMakeLists.txt
+++ b/frontend/catalyst/oqc/src/CMakeLists.txt
@@ -11,26 +11,31 @@ set(oqc_backend_dir "${OQC_BUILD_DIR}/backend")
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Avoid warning raised by pybind11 on newer cmake versions. PYBIND11_FINDPYTHON=ON caused issues.
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.27")
+ cmake_policy(SET CMP0148 OLD)
+endif()
+
 include(FetchContent)
 
-find_package(pybind11 CONFIG)
+function(fetch_pybind11)
+    find_package(pybind11 CONFIG)
+    if (pybind11_FOUND)
+        message(STATUS, "FOUND pybind11")
+    else()
+        message(STATUS "Could not find existing pybind11-dev package. Building from source.")
+        set(CMAKE_POLICY_DEFAULT_CMP0127 NEW) # To suppress pybind11 CMP0127 warning
 
-if(pybind11_FOUND)
-    message(STATUS "Found pybind11")
-else()
-    message(STATUS "Cound not find existing pybind11-dev package. Building from source.")
-    set(CMAKE_POLICY_DEFAULT_CMP0127 NEW) # To suppress pybind11 CMP0127 warning
+        FetchContent_Declare(pybind11
+        GIT_REPOSITORY https://github.com/pybind/pybind11.git
+        GIT_TAG        v2.10.1
+        )
 
-    # https://cmake.org/cmake/help/latest/module/FindPython.html
-    find_package(Python COMPONENTS Interpreter Development)
+        FetchContent_MakeAvailable(pybind11)
+    endif()
+endfunction()
 
-    FetchContent_Declare(pybind11
-    GIT_REPOSITORY https://github.com/pybind/pybind11.git
-    GIT_TAG        v2.10.1
-    )
-
-    FetchContent_MakeAvailable(pybind11)
-endif()
+fetch_pybind11()
 
 message(STATUS "Building the OQC device.")
 

--- a/frontend/catalyst/oqc/src/Makefile
+++ b/frontend/catalyst/oqc/src/Makefile
@@ -1,10 +1,12 @@
+PYTHON := $(shell which python3)
+C_COMPILER?=$(shell which clang)
+CXX_COMPILER?=$(shell which clang++)
+NPROC?=$(shell python3 -c "import os; print(os.cpu_count())")
+
 MK_ABSPATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MK_DIR := $(dir $(MK_ABSPATH))
 OQC_BUILD_DIR?=$(MK_DIR)/build
 RT_BUILD_DIR?=$(MK_DIR)/../../../../runtime/build
-C_COMPILER?=$(shell which clang)
-CXX_COMPILER?=$(shell which clang++)
-NPROC?=$(shell python3 -c "import os; print(os.cpu_count())")
 
 
 .PHONY: configure
@@ -15,6 +17,8 @@ configure:
 		-DCMAKE_C_COMPILER=$(C_COMPILER) \
 		-DCMAKE_CXX_COMPILER=$(CXX_COMPILER) \
 		-DRUNTIME_BUILD_DIR=$(RT_BUILD_DIR) \
+		-DPYTHON_EXECUTABLE=$(PYTHON) \
+		-Dpybind11_DIR=$(shell $(PYTHON) -c "import pybind11; print(pybind11.get_cmake_dir())")
 
 $(OQC_BUILD_DIR)/librtd_oqc.so: configure
 	cmake --build $(OQC_BUILD_DIR) --target rtd_oqc -j$(NPROC)
@@ -29,7 +33,6 @@ $(OQC_BUILD_DIR)/tests/runner_tests_oqc: configure
 test: $(OQC_BUILD_DIR)/tests/runner_tests_oqc
 	@echo "test the Catalyst runtime test suite"
 	$(OQC_BUILD_DIR)/tests/runner_tests_oqc
-
 
 .PHONY: clean
 clean:

--- a/frontend/catalyst/oqc/src/tests/CMakeLists.txt
+++ b/frontend/catalyst/oqc/src/tests/CMakeLists.txt
@@ -14,24 +14,7 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(Catch2)
 
-find_package(pybind11 CONFIG)
-
-if(pybind11_FOUND)
-    message(STATUS "Found pybind11")
-else()
-    message(STATUS "Cound not find existing pybind11-dev package. Building from source.")
-    set(CMAKE_POLICY_DEFAULT_CMP0127 NEW) # To suppress pybind11 CMP0127 warning
-
-    # https://cmake.org/cmake/help/latest/module/FindPython.html
-    find_package(Python COMPONENTS Interpreter Development)
-
-    FetchContent_Declare(pybind11
-    GIT_REPOSITORY https://github.com/pybind/pybind11.git
-    GIT_TAG        v2.10.1
-    )
-
-    FetchContent_MakeAvailable(pybind11)
-endif()
+fetch_pybind11()
 
 # Required for catch_discover_tests().
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -6,6 +6,11 @@ include(FetchContent)
 set(CMAKE_CXX_STANDARD  20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Avoid warning raised by pybind11 on newer cmake versions. PYBIND11_FINDPYTHON=ON caused issues.
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.27")
+ cmake_policy(SET CMP0148 OLD)
+endif()
+
 # Compiler options
 option(ENABLE_CODE_COVERAGE "Enable code coverage" OFF)
 option(ENABLE_ADDRESS_SANITIZER "Enable address sanitizer" OFF)
@@ -51,9 +56,6 @@ function(fetch_pybind11)
     else()
         message(STATUS "Could not find existing pybind11-dev package. Building from source.")
         set(CMAKE_POLICY_DEFAULT_CMP0127 NEW) # To suppress pybind11 CMP0127 warning
-
-        # https://cmake.org/cmake/help/latest/module/FindPython.html
-        find_package(Python COMPONENTS Interpreter Development)
 
         FetchContent_Declare(pybind11
         GIT_REPOSITORY https://github.com/pybind/pybind11.git

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -2,6 +2,7 @@ PYTHON := $(shell which python3)
 C_COMPILER?=$(shell which clang)
 CXX_COMPILER?=$(shell which clang++)
 COMPILER_LAUNCHER?=$(shell which ccache)
+NPROC?=$(shell python3 -c "import os; print(os.cpu_count())")
 
 MK_ABSPATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MK_DIR := $(dir $(MK_ABSPATH))
@@ -14,9 +15,8 @@ ENABLE_LIGHTNING?=ON
 ENABLE_LIGHTNING_KOKKOS?=ON
 ENABLE_OPENQASM?=ON
 ENABLE_ASAN?=OFF
-ENABLE_LAPACK?=OFF
 LIGHTNING_GIT_TAG_VALUE?=5feb4a10c9cd15fa590c513fc7c6a10a0b334269
-NPROC?=$(shell python3 -c "import os; print(os.cpu_count())")
+ENABLE_LAPACK?=OFF
 
 BUILD_TARGETS := rt_capi rtd_dummy
 TEST_TARGETS := ""
@@ -83,7 +83,8 @@ configure:
 		-DENABLE_CODE_COVERAGE=$(CODE_COVERAGE) \
 		-DRUNTIME_ENABLE_WARNINGS=$(ENABLE_WARNINGS) \
 		-DENABLE_WARNINGS=OFF \
-		-DPython_EXECUTABLE=$(PYTHON) \
+		-DPYTHON_EXECUTABLE=$(PYTHON) \
+		-Dpybind11_DIR=$(shell $(PYTHON) -c "import pybind11; print(pybind11.get_cmake_dir())") \
 		-DENABLE_ADDRESS_SANITIZER=$(ENABLE_ASAN) \
 		-DLIGHTNING_GIT_TAG=$(LIGHTNING_GIT_TAG_VALUE) \
 		-DENABLE_LAPACK=$(ENABLE_LAPACK) \
@@ -108,7 +109,8 @@ lq_configure:
 		-DENABLE_CODE_COVERAGE=$(CODE_COVERAGE) \
 		-DRUNTIME_ENABLE_WARNINGS=$(ENABLE_WARNINGS) \
 		-DENABLE_WARNINGS=OFF \
-		-DPython_EXECUTABLE=$(PYTHON) \
+		-DPYTHON_EXECUTABLE=$(PYTHON) \
+		-Dpybind11_DIR=$(shell $(PYTHON) -c "import pybind11; print(pybind11.get_cmake_dir())") \
 		-DENABLE_ADDRESS_SANITIZER=$(ENABLE_ASAN) \
 		-DLIGHTNING_GIT_TAG=$(LIGHTNING_GIT_TAG_VALUE) \
 		-DENABLE_LAPACK=$(ENABLE_LAPACK) \


### PR DESCRIPTION
- Ensure OQC build recipe uses correct Python version. The issue was noted on the macOS wheel runner using an [arbitrary Python version (OQC Runtime
step)](https://github.com/PennyLaneAI/catalyst/actions/runs/8785072013/job/24104858693).
- Unify handling of Python CMake dependency:
- Ensure runtime always has `Python_Executable` and `pybind11_DIR` set.
- Ensure mlir always has `Python3_Executable` and `Python3_NumPy_INCLUDE_DIRS` set.
- See [FindPython](https://cmake.org/cmake/help/latest/module/FindPython.html) and
[FindPython3](https://cmake.org/cmake/help/latest/module/FindPython3.html) docs.
- Avoid warning raised by CMake since version 3.27 due to policy [0148](https://cmake.org/cmake/help/latest/policy/CMP0148.html). The solution ensures Pybind uses the correct CMake functions by setting a Pybind-project variable. Alternatively, the policy could be set but this needs to be done depending on the CMake version used.