### PR TITLE
Use @disable_autograph as alias of Autograph's @do_not_convert

### DIFF
--- a/frontend/catalyst/autograph.py
+++ b/frontend/catalyst/autograph.py
@@ -23,7 +23,7 @@ import inspect
 
 import pennylane as qml
 from malt.core import converter
-from malt.impl.api import PyToPy
+from malt.impl.api import PyToPy, do_not_convert
 
 import catalyst
 from catalyst import ag_primitives
@@ -195,6 +195,41 @@ def autograph_source(fn):
         "The given function was not converted by AutoGraph. If you expect the"
         "given function to be converted, please submit a bug report."
     )
+
+
+def disable_autograph(fn):
+    """Decorator that disables AutoGraph for the given function.
+
+    Args:
+        fn (Callable): the original function object that must not be converted
+
+    Returns:
+        fn: the function not being converted
+
+    **Example**
+
+    .. code-block:: python
+
+        @disable_autograph
+        def f():
+            x = 6
+            if x > 5:
+                y = x ** 2
+            else:
+                y = x ** 3
+            return y
+
+        @qjit(autograph=True)
+        def g(x: float, n: int):
+            for _ in range(n):
+                x = x + f()
+            return x
+
+    >>> print(g(0.4, 6))
+    216.4
+    """
+
+    return do_not_convert(fn)
 
 
 TOPLEVEL_OPTIONS = converter.ConversionOptions(

--- a/frontend/test/lit/test_autograph.py
+++ b/frontend/test/lit/test_autograph.py
@@ -17,7 +17,12 @@
 # RUN: %PYTHON %s | FileCheck %s
 
 from catalyst import qjit
-from catalyst.autograph import AutoGraphError, autograph_source, run_autograph
+from catalyst.autograph import (
+    AutoGraphError,
+    autograph_source,
+    disable_autograph,
+    run_autograph,
+)
 
 
 def print_code(fn):
@@ -552,3 +557,57 @@ def chain_logical_call(x: float):
 
 
 print_code(chain_logical_call)
+
+
+# -----
+
+
+@disable_autograph
+def f():
+    """Simple function with if statements"""
+    x = 6
+    if x > 5:
+        y = x**2
+    else:
+        y = x**3
+    return y
+
+
+# CHECK-LABEL: def disable_autograph_jax
+@qjit(autograph=True)
+def disable_autograph_jax(x: float, n: int):
+    """Checks that Autograph is disabled for a given function."""
+    # CHECK: body_jaxpr={ lambda ; d:i64[] e:f64[]. let f:f64[] = add e 36.0 in (f,) }
+    for _ in range(n):
+        x = x + f()
+    return x
+
+
+print("def disable_autograph_jax")
+print(disable_autograph_jax.jaxpr)
+
+# -----
+
+
+def g():
+    """Simple function with if statements"""
+    x = 6
+    if x > 5:
+        y = x**2
+    else:
+        y = x**3
+    return y
+
+
+# CHECK-LABEL: def enable_autograph_jax
+@qjit(autograph=True)
+def enable_autograph_jax(x: float, n: int):
+    """Checks that Autograph is enabled for a given function."""
+    # CHECK: branch_jaxprs=[{ lambda ; . let  in (36,) }, { lambda ; . let  in (216,) }]
+    for _ in range(n):
+        x = x + g()
+    return x
+
+
+print("def enable_autograph_jax")
+print(enable_autograph_jax.jaxpr)

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -38,7 +38,12 @@ from catalyst import (
     qjit,
     vjp,
 )
-from catalyst.autograph import TRANSFORMER, AutoGraphError, autograph_source
+from catalyst.autograph import (
+    TRANSFORMER,
+    AutoGraphError,
+    autograph_source,
+    disable_autograph,
+)
 
 check_cache = TRANSFORMER.has_cache
 
@@ -1716,6 +1721,31 @@ class TestMixed:
 
         assert f(0.4) == 1
         assert f(0.1) == 3
+
+
+@pytest.mark.tf
+class TestDisableAutograph:
+    """Test ways of disabling autograph conversion"""
+
+    def test_disable_autograph(self):
+        """Test disabling autograph with decorator."""
+
+        @disable_autograph
+        def f():
+            x = 6
+            if x > 5:
+                y = x**2
+            else:
+                y = x**3
+            return y
+
+        @qjit(autograph=True)
+        def g(x: float, n: int):
+            for _ in range(n):
+                x = x + f()
+            return x
+
+        assert g(0.4, 6) == 216.4
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Context:** We want to disable the Autograph capabilities for certain functions using a new decorator

**Description of the Change:** We created an alias for Autograph's @do_not_convert decorator, called @disable_autograph

[sc-60518]