### PR TITLE
[Frontend] Runtime check for cuda-quantum version

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -226,6 +226,9 @@
 * Fixes adjoint lowering bug that did not take into account control wires.
   [(#591)](https://github.com/PennyLaneAI/catalyst/pull/591)
 
+* Raises an exception if the user has an incompatible CUDA Quantum version installed.
+  [(#707)](https://github.com/PennyLaneAI/catalyst/pull/707)
+
 <h3>Internal changes</h3>
 
 * The deprecated `@qfunc` decorator, in use mainly by the LIT test suite, has been removed.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -96,7 +96,6 @@ MOCK_MODULES = [
     "mlir_quantum.compiler_driver",
     "pybind11",
     "cudaq",
-    "cuda_quantum",
 ]
 
 mock = Mock()

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -96,6 +96,7 @@ MOCK_MODULES = [
     "mlir_quantum.compiler_driver",
     "pybind11",
     "cudaq",
+    "cuda_quantum",
 ]
 
 mock = Mock()

--- a/frontend/catalyst/cuda/__init__.py
+++ b/frontend/catalyst/cuda/__init__.py
@@ -16,10 +16,18 @@ This module contains a CudaQDevice and the qjit
 entry point.
 """
 
+from importlib.metadata import version
 from pathlib import Path
 
 import cudaq
 import pennylane as qml
+
+installed_version = version("cuda_quantum")
+compatible_version = "0.6.0"
+if installed_version != compatible_version:
+    msg = f"Attempting to compile with incompatible version cuda_quantum=={installed_version}."
+    msg += f"Please install compatible version cuda_quantum=={compatible_version}."
+    raise ValueError(msg)
 
 from catalyst.cuda.catalyst_to_cuda_interpreter import interpret
 

--- a/frontend/catalyst/cuda/__init__.py
+++ b/frontend/catalyst/cuda/__init__.py
@@ -27,9 +27,9 @@ def _check_version_compatibility():
     installed_version = version("cuda_quantum")
     compatible_version = "0.6.0"
     if installed_version != compatible_version:
-        msg = f"Compiling with incompatible version cuda_quantum=={installed_version}."
+        msg = f"Compiling with incompatible version cuda_quantum=={installed_version}. "
         msg += f"Please install compatible version cuda_quantum=={compatible_version}."
-        raise ValueError(msg)
+        raise ModuleNotFoundError(msg)
 
 
 def cudaqjit(fn=None, **kwargs):

--- a/frontend/catalyst/cuda/__init__.py
+++ b/frontend/catalyst/cuda/__init__.py
@@ -22,14 +22,14 @@ from pathlib import Path
 import cudaq
 import pennylane as qml
 
-installed_version = version("cuda_quantum")
-compatible_version = "0.6.0"
-if installed_version != compatible_version:
-    msg = f"Attempting to compile with incompatible version cuda_quantum=={installed_version}."
-    msg += f"Please install compatible version cuda_quantum=={compatible_version}."
-    raise ValueError(msg)
 
-from catalyst.cuda.catalyst_to_cuda_interpreter import interpret
+def _check_version_compatibility():
+    installed_version = version("cuda_quantum")
+    compatible_version = "0.6.0"
+    if installed_version != compatible_version:
+        msg = f"Compiling with incompatible version cuda_quantum=={installed_version}."
+        msg += f"Please install compatible version cuda_quantum=={compatible_version}."
+        raise ValueError(msg)
 
 
 def cudaqjit(fn=None, **kwargs):
@@ -83,6 +83,8 @@ def cudaqjit(fn=None, **kwargs):
     compilation; in particular, AutoGraph, control flow, differentiation, and various measurement
     statistics (such as probabilities and variance) are not yet supported.
     """
+    _check_version_compatibility()
+    from catalyst.cuda.catalyst_to_cuda_interpreter import interpret
 
     if fn is not None:
         return interpret(fn, **kwargs)
@@ -130,6 +132,7 @@ class BaseCudaInstructionSet(qml.QubitDevice):
     config = Path(__file__).parent / "cuda_quantum.toml"
 
     def __init__(self, shots=None, wires=None):
+        _check_version_compatibility()
         super().__init__(wires=wires, shots=shots)
 
     def apply(self, operations, **kwargs):

--- a/frontend/catalyst/cuda/primitives/__init__.py
+++ b/frontend/catalyst/cuda/primitives/__init__.py
@@ -16,9 +16,18 @@
 This module implements JAXPR primitives for CUDA-quantum.
 """
 
+from importlib.metadata import version
+
 import cudaq
 import jax
 from jax import numpy as jnp
+
+installed_version = version("cuda_quantum")
+compatible_version = "0.6.0"
+if installed_version != compatible_version:
+    msg = f"Attempting to compile with incompatible version cuda_quantum=={installed_version}."
+    msg += f"Please install compatible version cuda_quantum=={compatible_version}."
+    raise ValueError(msg)
 
 # We disable protected access in particular to avoid warnings with cudaq._pycuda.
 # And we disable unused-argument to avoid unused arguments in abstract_eval, particularly kwargs.

--- a/frontend/catalyst/cuda/primitives/__init__.py
+++ b/frontend/catalyst/cuda/primitives/__init__.py
@@ -22,13 +22,6 @@ import cudaq
 import jax
 from jax import numpy as jnp
 
-installed_version = version("cuda_quantum")
-compatible_version = "0.6.0"
-if installed_version != compatible_version:
-    msg = f"Attempting to compile with incompatible version cuda_quantum=={installed_version}."
-    msg += f"Please install compatible version cuda_quantum=={compatible_version}."
-    raise ValueError(msg)
-
 # We disable protected access in particular to avoid warnings with cudaq._pycuda.
 # And we disable unused-argument to avoid unused arguments in abstract_eval, particularly kwargs.
 # pylint: disable=protected-access,unused-argument,abstract-method,line-too-long

--- a/frontend/test/pytest/test_cuda_integration.py
+++ b/frontend/test/pytest/test_cuda_integration.py
@@ -60,6 +60,8 @@ class TestCudaQ:
                 qml.RX(jnp.pi / 4, wires=[0])
                 return measure(0)
 
+            circuit()
+
     def test_measurement_side_effect(self):
         """Test the measurement code is added."""
 

--- a/frontend/test/pytest/test_cuda_integration.py
+++ b/frontend/test/pytest/test_cuda_integration.py
@@ -47,59 +47,32 @@ class TestCudaQ:
         with pytest.raises(ValueError, match="Unavailable target"):
             circuit_foo()
 
-    def test_qjit_cuda_remove_host_context(self):
-        """Test removing the host context."""
-
-        from catalyst.cuda.catalyst_to_cuda_interpreter import (
-            QJIT_CUDAQ,
-            remove_host_context,
-        )
-
-        @qml.qnode(qml.device("softwareq.qpp", wires=1))
-        def circuit_foo():
-            return qml.state()
-
-        observed_jaxpr, _ = QJIT_CUDAQ(circuit_foo).get_jaxpr()
-        jaxpr = remove_host_context(observed_jaxpr)
-        assert jaxpr
-
-    def test_qjit_catalyst_to_cuda_jaxpr(self):
-        """Assert that catalyst_to_cuda returns something."""
-        from catalyst.cuda.catalyst_to_cuda_interpreter import interpret
-
-        @qml.qnode(qml.device("softwareq.qpp", wires=1))
-        def circuit_foo():
-            return qml.state()
-
-        cuda_jaxpr = jax.make_jaxpr(interpret(circuit_foo))
-        assert cuda_jaxpr
-
     def test_measurement_return(self):
         """Test the measurement code is added."""
 
-        from catalyst.cuda.catalyst_to_cuda_interpreter import interpret
+        from catalyst.cuda import cudaqjit as cjit
 
         with pytest.raises(NotImplementedError, match="cannot return measurements directly"):
 
+            @cjit
             @qml.qnode(qml.device("softwareq.qpp", wires=1, shots=30))
             def circuit():
                 qml.RX(jnp.pi / 4, wires=[0])
                 return measure(0)
 
-            jax.make_jaxpr(interpret(circuit))()
-
     def test_measurement_side_effect(self):
         """Test the measurement code is added."""
 
-        from catalyst.cuda.catalyst_to_cuda_interpreter import interpret
+        from catalyst.cuda import cudaqjit as cjit
 
+        @cjit
         @qml.qnode(qml.device("softwareq.qpp", wires=1, shots=30))
         def circuit():
             qml.RX(jnp.pi / 4, wires=[0])
             measure(0)
             return qml.state()
 
-        jax.make_jaxpr(interpret(circuit))()
+        circuit()
 
     def test_pytrees(self):
         """Test that we can return a dictionary."""


### PR DESCRIPTION
**Context:** The CUDA Quantum integration (now CUDA-Q) is only compatible with version 0.6.0. 

**Description of the Change:** We raise a `ModuleNotFoundError` if the wrong version is installed. Had to change tests to avoid issues when building documentation.

**Benefits:** Clearer error.

[sc-62438]