### PR TITLE
[frontend] Remove pytest.mark.tf marker

### DIFF
--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -38,12 +38,7 @@ from catalyst import (
     qjit,
     vjp,
 )
-from catalyst.autograph import (
-    TRANSFORMER,
-    AutoGraphError,
-    autograph_source,
-    disable_autograph,
-)
+from catalyst.autograph import TRANSFORMER, AutoGraphError, autograph_source
 
 check_cache = TRANSFORMER.has_cache
 
@@ -72,7 +67,6 @@ class Failing:
         return self.ref
 
 
-@pytest.mark.tf
 class TestSourceCodeInfo:
     """Unit tests for exception utilities that retrieves traceback information for the original
     source code."""
@@ -154,7 +148,6 @@ class TestSourceCodeInfo:
                 assert e.args == ("Test failure",)
 
 
-@pytest.mark.tf
 class TestIntegration:
     """Test that the autograph transformations trigger correctly in different settings."""
 
@@ -399,7 +392,6 @@ class TestIntegration:
         assert np.allclose(fn(3)[1], tuple([jnp.array(2.0), jnp.array(6.0)]))
 
 
-@pytest.mark.tf
 class TestCodePrinting:
     """Test that the transformed source code can be printed in different settings."""
 
@@ -529,7 +521,6 @@ class TestCodePrinting:
         assert autograph_source(inner)
 
 
-@pytest.mark.tf
 class TestConditionals:
     """Test that the autograph transformations produce correct results on conditionals.
     These tests are adapted from the test_conditionals.TestCond class of tests."""
@@ -695,7 +686,6 @@ class TestConditionals:
             qjit(autograph=True)(f)
 
 
-@pytest.mark.tf
 class TestForLoops:
     """Test that the autograph transformations produce correct results on for loops."""
 
@@ -1249,7 +1239,6 @@ class TestForLoops:
         assert f() == 9
 
 
-@pytest.mark.tf
 class TestWhileLoops:
     """Test that the autograph transformations produce correct results on while loops."""
 
@@ -1432,7 +1421,6 @@ class TestWhileLoops:
             qjit(autograph=True)(f)
 
 
-@pytest.mark.tf
 @pytest.mark.parametrize(
     "execution_context", (lambda fn: fn, qml.qnode(qml.device("lightning.qubit", wires=1)))
 )
@@ -1542,7 +1530,6 @@ class TestFallback:
         assert results[1] == (2) * 1 * 2 * 3  # i = range(1, 4)
 
 
-@pytest.mark.tf
 class TestLogicalOps:
     """Test logical operations: and, or, not"""
 
@@ -1617,7 +1604,6 @@ class TestLogicalOps:
             assert qjit(autograph=True)(lambda d: d or s)(d) == (d or s)
 
 
-@pytest.mark.tf
 class TestMixed:
     """Test a mix of supported autograph conversions and Catalyst control flow."""
 
@@ -1721,31 +1707,6 @@ class TestMixed:
 
         assert f(0.4) == 1
         assert f(0.1) == 3
-
-
-@pytest.mark.tf
-class TestDisableAutograph:
-    """Test ways of disabling autograph conversion"""
-
-    def test_disable_autograph(self):
-        """Test disabling autograph with decorator."""
-
-        @disable_autograph
-        def f():
-            x = 6
-            if x > 5:
-                y = x**2
-            else:
-                y = x**3
-            return y
-
-        @qjit(autograph=True)
-        def g(x: float, n: int):
-            for _ in range(n):
-                x = x + f()
-            return x
-
-        assert g(0.4, 6) == 216.4
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Context:** This marker is removed because we don't use Tensorflow for Autograph anymore

**Benefits:** Housecleaning
