### PR TITLE
Have a nice interface for creating qml.Cond, qml.ForLoop, qml.WhileLoop without using the queue. (#486)

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -94,12 +94,11 @@
 * Small changes to make pylint==3.2.0 succeed.
   [(#739)](https://github.com/PennyLaneAI/catalyst/pull/739)
 
-* The underlying objects for `cond`, `for_loop`, and `while_loop` can now be accessed
-  directly via `body_function.operation`. 
+* The underlying PennyLane `Operation` objects for `cond`, `for_loop`, and `while_loop` can now be accessed directly via `body_function.operation`. 
   [(#711)](https://github.com/PennyLaneAI/catalyst/pull/711)
 
   This can be beneficial when, among other things, 
-  writing transforms without explicitly referring to a new tape:
+  writing transforms without using the queuing mechanism:
   ```py
         @qml.transform
         def my_quantum_transform(tape):

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -78,7 +78,7 @@
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>
-* Correctly querying batching rules for ```jax.scipy.linalg.expm```
+* Correctly querying batching rules for `jax.scipy.linalg.expm`
   [(#733)](https://github.com/PennyLaneAI/catalyst/pull/733)
 
 <h3>Internal changes</h3>
@@ -94,6 +94,45 @@
 * Small changes to make pylint==3.2.0 succeed.
   [(#739)](https://github.com/PennyLaneAI/catalyst/pull/739)
 
+* The underlying objects for `cond`, `for_loop`, and `while_loop` can now be accessed
+  directly via `body_function.operation`. 
+  [(#711)](https://github.com/PennyLaneAI/catalyst/pull/711)
+
+  This can be beneficial when, among other things, 
+  writing transforms without explicitly referring to a new tape:
+  ```py
+        @qml.transform
+        def my_quantum_transform(tape):
+            ops = tape.operations.copy()
+
+            @for_loop(0, 4, 1)
+            def f(i, sum):
+                qml.Hadamard(0)
+                return sum+1
+
+            res = f(0)
+            ops.append(f.operation)   # This is now supported!
+
+            def post_processing_fn(results):
+                return results
+            modified_tape = qml.tape.QuantumTape(ops, tape.measurements)
+            print(res)
+            print(modified_tape.operations)
+            return [modified_tape], post_processing_fn
+
+        @qml.qjit
+        @my_quantum_transform
+        @qml.qnode(qml.device("lightning.qubit", wires=2))
+        def main():
+            qml.Hadamard(0)
+            return qml.probs()
+
+        >>> main()
+        Traced<ShapedArray(int64[], weak_type=True)>with<DynamicJaxprTrace(level=2/1)>
+        [Hadamard(wires=[0]), ForLoop(tapes=[[Hadamard(wires=[0])]])]
+        (array([0.5, 0. , 0.5, 0. ]),)  
+  ```
+  
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -660,9 +660,9 @@ class ForLoopCallable:
 
 class WhileLoopCallable:
     """
-    Wrapping while_loop decorator into a class so that the actual "WhileLoop" operation object, which
-    is created locally in _call_with_quantum_ctx(ctx), can be retrived without changing its
-    return type. The retrived WhileLoop is in LoopBodyFunction.operation.
+    Wrapping while_loop decorator into a class so that the actual "WhileLoop" operation object,
+    which is created locally in _call_with_quantum_ctx(ctx), can be retrived without changing
+    its return type. The retrived WhileLoop is in LoopBodyFunction.operation.
 
     **Example**
 

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -444,10 +444,14 @@ class CondCallable:
 
     @property
     def operation(self):
-        if self._operation == None:
+        """
+        @property for CondCallable.operation
+        """
+        if self._operation is None:
             raise ValueError(
                 """
-                The cond() was not called (or has not been called) in a quantum context and thus has no associated quantum operation.
+                The cond() was not called (or has not been called) in a quantum context,
+                and thus has no associated quantum operation.
                 """
             )
         return self._operation
@@ -599,10 +603,14 @@ class ForLoopCallable:
 
     @property
     def operation(self):
-        if self._operation == None:
+        """
+        @property for ForLoopCallable.operation
+        """
+        if self._operation is None:
             raise ValueError(
                 """
-                The for_loop() was not called (or has not been called) in a quantum context and thus has no associated quantum operation.
+                The for_loop() was not called (or has not been called) in a quantum context,
+                and thus has no associated quantum operation.
                 """
             )
         return self._operation
@@ -735,10 +743,14 @@ class WhileLoopCallable:
 
     @property
     def operation(self):
-        if self._operation == None:
+        """
+        @property for WhileLoopCallable.operation
+        """
+        if self._operation is None:
             raise ValueError(
                 """
-                The while_loop() was not called (or has not been called) in a quantum context and thus has no associated quantum operation.
+                The while_loop() was not called (or has not been called) in a quantum context,
+                and thus has no associated quantum operation.
                 """
             )
         return self._operation

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -440,7 +440,7 @@ class CondCallable:
         self.preds = [pred]
         self.branch_fns = [true_fn]
         self.otherwise_fn = lambda: None
-        self.operation = None
+        self._operation = None
 
     @property
     def operation(self):
@@ -448,17 +448,13 @@ class CondCallable:
         @property for CondCallable.operation
         """
         if self._operation is None:
-            raise ValueError(
+            raise AttributeError(
                 """
                 The cond() was not called (or has not been called) in a quantum context,
                 and thus has no associated quantum operation.
                 """
             )
         return self._operation
-
-    @operation.setter
-    def operation(self, op):
-        self._operation = op
 
     def else_if(self, pred):
         """
@@ -518,7 +514,7 @@ class CondCallable:
         _assert_cond_result_structure(out_treedefs)
         _assert_cond_result_types(out_signatures)
         out_classical_tracers = [new_inner_tracer(outer_trace, aval) for aval in out_signatures[0]]
-        self.operation = Cond(in_classical_tracers, out_classical_tracers, regions)
+        self._operation = Cond(in_classical_tracers, out_classical_tracers, regions)
         return tree_unflatten(out_tree(), out_classical_tracers)
 
     def _call_with_classical_ctx(self):
@@ -599,7 +595,7 @@ class ForLoopCallable:
         self.upper_bound = upper_bound
         self.step = step
         self.body_fn = body_fn
-        self.operation = None
+        self._operation = None
 
     @property
     def operation(self):
@@ -607,17 +603,13 @@ class ForLoopCallable:
         @property for ForLoopCallable.operation
         """
         if self._operation is None:
-            raise ValueError(
+            raise AttributeError(
                 """
                 The for_loop() was not called (or has not been called) in a quantum context,
                 and thus has no associated quantum operation.
                 """
             )
         return self._operation
-
-    @operation.setter
-    def operation(self, op):
-        self._operation = op
 
     def _call_with_quantum_ctx(self, ctx: JaxTracingContext, *init_state):
         quantum_tape = QuantumTape()
@@ -640,7 +632,7 @@ class ForLoopCallable:
 
         res_avals = list(map(shaped_abstractify, res_classical_tracers))
         out_classical_tracers = [new_inner_tracer(outer_trace, aval) for aval in res_avals]
-        self.operation = ForLoop(
+        self._operation = ForLoop(
             in_classical_tracers,
             out_classical_tracers,
             [
@@ -739,7 +731,7 @@ class WhileLoopCallable:
     def __init__(self, cond_fn, body_fn):
         self.cond_fn = cond_fn
         self.body_fn = body_fn
-        self.operation = None
+        self._operation = None
 
     @property
     def operation(self):
@@ -747,17 +739,13 @@ class WhileLoopCallable:
         @property for WhileLoopCallable.operation
         """
         if self._operation is None:
-            raise ValueError(
+            raise AttributeError(
                 """
                 The while_loop() was not called (or has not been called) in a quantum context,
                 and thus has no associated quantum operation.
                 """
             )
         return self._operation
-
-    @operation.setter
-    def operation(self, op):
-        self._operation = op
 
     def _call_with_quantum_ctx(self, ctx: JaxTracingContext, *init_state):
         outer_trace = ctx.trace
@@ -790,7 +778,7 @@ class WhileLoopCallable:
         res_avals = list(map(shaped_abstractify, res_classical_tracers))
         out_classical_tracers = [new_inner_tracer(outer_trace, aval) for aval in res_avals]
 
-        self.operation = WhileLoop(
+        self._operation = WhileLoop(
             in_classical_tracers, out_classical_tracers, [cond_region, body_region]
         )
         return tree_unflatten(body_tree(), out_classical_tracers)

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -451,9 +451,12 @@ def for_loop(lower_bound, upper_bound, step):
     >>> circuit(7, 1.6)
     [array(0.97926626), array(0.55395718)]
     """
+
     def _body_query(body_fn):
         return ForLoopCallable(lower_bound, upper_bound, step, body_fn)
+
     return _body_query
+
 
 ## IMPL ##
 class CondCallable:
@@ -560,10 +563,11 @@ class CondCallable:
             assert mode == EvaluationMode.INTERPRETATION, f"Unsupported evaluation mode {mode}"
             return self._call_during_interpretation()
 
+
 class ForLoopCallable:
     """
     Wrapping for_loop decorator into a class so that the actual ForLoop operation object, which
-    is created locally in _call_with_quantum_ctx(ctx), can be retrived without changing its 
+    is created locally in _call_with_quantum_ctx(ctx), can be retrived without changing its
     return type. THe retrived ForLoop is in LoopBodyFunction.operation.
 
     **Example**
@@ -604,6 +608,7 @@ class ForLoopCallable:
     (array([0.5, 0. , 0.5, 0. ]),)
 
     """
+
     def __init__(self, lower_bound, upper_bound, step, body_fn):
         self.lower_bound = lower_bound
         self.upper_bound = upper_bound
@@ -628,8 +633,7 @@ class ForLoopCallable:
                 arg_classical_tracers = _input_type_to_tracers(inner_trace.new_arg, in_avals)
                 with QueuingManager.stop_recording(), quantum_tape:
                     res_classical_tracers = [
-                        inner_trace.full_raise(t)
-                        for t in wffa.call_wrapped(*arg_classical_tracers)
+                        inner_trace.full_raise(t) for t in wffa.call_wrapped(*arg_classical_tracers)
                     ]
 
             res_avals = list(map(shaped_abstractify, res_classical_tracers))

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -575,7 +575,7 @@ class TestCondOperatorAccess:
                 and thus has no associated quantum operation.
                 """,
             ):
-                op = cond_fn.operation
+                isinstance(cond_fn.operation, api_extensions.control_flow.Cond)
 
             return cond_fn()
 
@@ -604,7 +604,7 @@ class TestCondOperatorAccess:
                 and thus has no associated quantum operation.
                 """,
             ):
-                op = branch_t.operation
+                isinstance(branch_t.operation, api_extensions.control_flow.Cond)
 
             return branch_t()
 

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -569,7 +569,7 @@ class TestCondOperatorAccess:
 
             cond_fn()
             with pytest.raises(
-                ValueError,
+                AttributeError,
                 match=r"""
                 The cond\(\) was not called \(or has not been called\) in a quantum context,
                 and thus has no associated quantum operation.
@@ -598,7 +598,7 @@ class TestCondOperatorAccess:
 
             branch_t()
             with pytest.raises(
-                ValueError,
+                AttributeError,
                 match=r"""
                 The cond\(\) was not called \(or has not been called\) in a quantum context,
                 and thus has no associated quantum operation.

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -17,7 +17,7 @@ import numpy as np
 import pennylane as qml
 import pytest
 
-from catalyst import cond, measure, qjit
+from catalyst import api_extensions, cond, measure, qjit
 
 # pylint: disable=missing-function-docstring
 
@@ -515,6 +515,101 @@ class TestClassicalCompilation:
 
         with pytest.raises(TypeError, match="Conditional 'False'"):
             qjit(arithc1)
+
+
+class TestCondOperatorAccess:
+    """Test suite for accessing the Cond operation in quantum contexts in Catalyst."""
+
+    def test_cond_access_quantum(self, backend):
+        """Test Cond operation access in quantum context."""
+
+        @qjit
+        @qml.qnode(qml.device(backend, wires=1))
+        def circuit(n):
+            @cond(n > 4)
+            def cond_fn():
+                qml.PauliZ(0)
+                return 1
+
+            @cond_fn.otherwise
+            def else_fn():
+                qml.PauliX(0)
+                return 0
+
+            cond_fn()
+            assert isinstance(cond_fn.operation, api_extensions.control_flow.Cond)
+
+            return qml.probs()
+
+        assert circuit(2)[0] == 0
+        assert circuit(2)[1] == 1
+        assert circuit(5)[0] == 1
+        assert circuit(5)[1] == 0
+
+    def test_cond_access_classical(self):
+        """Test Cond operation access in classical context."""
+
+        @qjit
+        def circuit(x):
+            @cond(x > 4.8)
+            def cond_fn():
+                return x * 16
+
+            @cond_fn.else_if(x > 2.7)
+            def cond_elif():
+                return x * 8
+
+            @cond_fn.else_if(x > 1.4)
+            def cond_elif2():
+                return x * 4
+
+            @cond_fn.otherwise
+            def cond_else():
+                return x
+
+            cond_fn()
+            with pytest.raises(
+                ValueError,
+                match=r"""
+                The cond\(\) was not called \(or has not been called\) in a quantum context,
+                and thus has no associated quantum operation.
+                """,
+            ):
+                cond_fn.operation
+
+            return cond_fn()
+
+        assert circuit(5) == 80
+        assert circuit(3) == 24
+        assert circuit(2) == 8
+        assert circuit(-3) == -3
+
+    def test_cond_access_interpreted(self):
+        """Test Cond operation access in interpreted context."""
+
+        def func(flag: bool):
+            @cond(flag)
+            def branch_t():
+                return 1
+
+            @branch_t.otherwise
+            def branch_f():
+                return 0
+
+            branch_t()
+            with pytest.raises(
+                ValueError,
+                match=r"""
+                The cond\(\) was not called \(or has not been called\) in a quantum context,
+                and thus has no associated quantum operation.
+                """,
+            ):
+                branch_t.operation
+
+            return branch_t()
+
+        assert func(True) == 1
+        assert func(False) == 0
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -575,7 +575,7 @@ class TestCondOperatorAccess:
                 and thus has no associated quantum operation.
                 """,
             ):
-                cond_fn.operation
+                op = cond_fn.operation
 
             return cond_fn()
 
@@ -604,7 +604,7 @@ class TestCondOperatorAccess:
                 and thus has no associated quantum operation.
                 """,
             ):
-                branch_t.operation
+                op = branch_t.operation
 
             return branch_t()
 

--- a/frontend/test/pytest/test_loops.py
+++ b/frontend/test/pytest/test_loops.py
@@ -19,8 +19,7 @@ import pytest
 
 from catalyst import api_extensions, for_loop, measure, qjit, while_loop
 
-# pylint: disable=no-value-for-parameter
-
+# pylint: disable=no-value-for-parameter,unused-argument
 
 class TestLoopToJaxpr:
     """Collection of tests that examine the generated JAXPR of loops."""
@@ -227,12 +226,12 @@ class TestWhileLoops:
         @qml.qnode(qml.device(backend, wires=1))
         def circuit(n, m):
             @while_loop(lambda i, _: i < n)
-            def outer(i, sum):
+            def outer(i, accum):
                 @while_loop(lambda j: j < m)
                 def inner(j):
                     return j + 1
 
-                return i + 1, sum + inner(0)
+                return i + 1, accum + inner(0)
 
             return outer(0, 0)[1]
 
@@ -404,12 +403,12 @@ class TestClassicalCompilation:
         @qjit
         def mulc(x: int, n: int):
             @while_loop(lambda i, _: i < x)
-            def loop(i, sum):
+            def loop(i, accum):
                 @while_loop(lambda j: j < n)
                 def loop2(j):
                     return j + 1
 
-                return i + 1, sum + loop2(0)
+                return i + 1, accum + loop2(0)
 
             _, x_times_n = loop(0, 0)
             return x_times_n
@@ -699,9 +698,9 @@ class TestForLoopOperatorAccess:
         @qml.qnode(qml.device(backend, wires=1))
         def circuit():
             @for_loop(0, 4, 1)
-            def body(i, sum):
+            def body(i, accum):
                 qml.PauliZ(0)
-                return sum + 1
+                return accum + 1
 
             body(0)
             assert isinstance(body.operation, api_extensions.control_flow.ForLoop)
@@ -717,8 +716,8 @@ class TestForLoopOperatorAccess:
         @qjit
         def circuit(x):
             @for_loop(0, 10, 1)
-            def body(i, sum):
-                return sum + x
+            def body(i, accum):
+                return accum + x
 
             x_times_10 = body(0)
             with pytest.raises(
@@ -788,8 +787,8 @@ class TestWhileLoopOperatorAccess:
         @qjit
         def circuit(x):
             @while_loop(lambda i, _: i < 10)
-            def body(i, sum):
-                return i + 1, sum + x
+            def body(i, accum):
+                return i + 1, accum + x
 
             _, x_times_10 = body(0, 0)
             with pytest.raises(

--- a/frontend/test/pytest/test_loops.py
+++ b/frontend/test/pytest/test_loops.py
@@ -722,7 +722,7 @@ class TestForLoopOperatorAccess:
 
             x_times_10 = body(0)
             with pytest.raises(
-                ValueError,
+                AttributeError,
                 match=r"""
                 The for_loop\(\) was not called \(or has not been called\) in a quantum context,
                 and thus has no associated quantum operation.
@@ -745,7 +745,7 @@ class TestForLoopOperatorAccess:
 
             two_to_the_n = body(1)
             with pytest.raises(
-                ValueError,
+                AttributeError,
                 match=r"""
                 The for_loop\(\) was not called \(or has not been called\) in a quantum context,
                 and thus has no associated quantum operation.
@@ -793,7 +793,7 @@ class TestWhileLoopOperatorAccess:
 
             _, x_times_10 = body(0, 0)
             with pytest.raises(
-                ValueError,
+                AttributeError,
                 match=r"""
                 The while_loop\(\) was not called \(or has not been called\) in a quantum context,
                 and thus has no associated quantum operation.
@@ -816,7 +816,7 @@ class TestWhileLoopOperatorAccess:
 
             _, two_to_the_n = body(0, 1)
             with pytest.raises(
-                ValueError,
+                AttributeError,
                 match=r"""
                 The while_loop\(\) was not called \(or has not been called\) in a quantum context,
                 and thus has no associated quantum operation.

--- a/frontend/test/pytest/test_loops.py
+++ b/frontend/test/pytest/test_loops.py
@@ -21,6 +21,7 @@ from catalyst import api_extensions, for_loop, measure, qjit, while_loop
 
 # pylint: disable=no-value-for-parameter,unused-argument
 
+
 class TestLoopToJaxpr:
     """Collection of tests that examine the generated JAXPR of loops."""
 

--- a/frontend/test/pytest/test_loops.py
+++ b/frontend/test/pytest/test_loops.py
@@ -17,7 +17,7 @@ import numpy as np
 import pennylane as qml
 import pytest
 
-from catalyst import for_loop, measure, qjit, while_loop
+from catalyst import api_extensions, for_loop, measure, qjit, while_loop
 
 # pylint: disable=no-value-for-parameter
 
@@ -687,6 +687,148 @@ class TestResultStructureInterpreted:
         assert while_loop(lambda _, y: y[0] < 1)(loop)(x, y) == (x, (y[0] + 0,) + y[1:])
         assert while_loop(lambda _, y: y[0] < 2)(loop)(x, y) == (x, (y[0] + 1,) + y[1:])
         assert while_loop(lambda _, y: y[0] < 3)(loop)(x, y) == (x, (y[0] + 2,) + y[1:])
+
+
+class TestForLoopOperatorAccess:
+    """Test suite for accessing the ForLoop operation in quantum contexts in Catalyst."""
+
+    def test_for_loop_access_quantum(self, backend):
+        """Test ForLoop operation access in quantum context."""
+
+        @qjit
+        @qml.qnode(qml.device(backend, wires=1))
+        def circuit():
+            @for_loop(0, 4, 1)
+            def body(i, sum):
+                qml.PauliZ(0)
+                return sum + 1
+
+            body(0)
+            assert isinstance(body.operation, api_extensions.control_flow.ForLoop)
+
+            return qml.probs()
+
+        assert circuit()[0] == 1
+        assert circuit()[1] == 0
+
+    def test_for_loop_access_classical(self):
+        """Test ForLoop operation access in classical context."""
+
+        @qjit
+        def circuit(x):
+            @for_loop(0, 10, 1)
+            def body(i, sum):
+                return sum + x
+
+            x_times_10 = body(0)
+            with pytest.raises(
+                ValueError,
+                match=r"""
+                The for_loop\(\) was not called \(or has not been called\) in a quantum context,
+                and thus has no associated quantum operation.
+                """,
+            ):
+                isinstance(body.operation, api_extensions.control_flow.ForLoop)
+
+            return x_times_10
+
+        assert circuit(5) == 50
+        assert circuit(3) == 30
+
+    def test_for_loop_access_interpreted(self):
+        """Test ForLoop operation access in interpreted context."""
+
+        def func(n):
+            @for_loop(0, n, 1)
+            def body(i, prod):
+                return prod * 2
+
+            two_to_the_n = body(1)
+            with pytest.raises(
+                ValueError,
+                match=r"""
+                The for_loop\(\) was not called \(or has not been called\) in a quantum context,
+                and thus has no associated quantum operation.
+                """,
+            ):
+                isinstance(body.operation, api_extensions.control_flow.ForLoop)
+
+            return two_to_the_n
+
+        assert func(10) == 1024
+        assert func(5) == 32
+        assert func(0) == 1
+
+
+class TestWhileLoopOperatorAccess:
+    """Test suite for accessing the WhileLoop operation in quantum contexts in Catalyst."""
+
+    def test_while_loop_access_quantum(self, backend):
+        """Test WhileLoop operation access in quantum context."""
+
+        @qjit
+        @qml.qnode(qml.device(backend, wires=1))
+        def circuit():
+            @while_loop(lambda i: i < 5)
+            def body(i):
+                qml.PauliX(0)
+                return i + 1
+
+            body(0)
+            assert isinstance(body.operation, api_extensions.control_flow.WhileLoop)
+
+            return qml.probs()
+
+        assert circuit()[0] == 0
+        assert circuit()[1] == 1
+
+    def test_while_loop_access_classical(self):
+        """Test WhileLoop operation access in classical context."""
+
+        @qjit
+        def circuit(x):
+            @while_loop(lambda i, _: i < 10)
+            def body(i, sum):
+                return i + 1, sum + x
+
+            _, x_times_10 = body(0, 0)
+            with pytest.raises(
+                ValueError,
+                match=r"""
+                The while_loop\(\) was not called \(or has not been called\) in a quantum context,
+                and thus has no associated quantum operation.
+                """,
+            ):
+                isinstance(body.operation, api_extensions.control_flow.WhileLoop)
+
+            return x_times_10
+
+        assert circuit(5) == 50
+        assert circuit(3) == 30
+
+    def test_while_loop_access_interpreted(self):
+        """Test WhileLoop operation access in interpreted context."""
+
+        def func(n):
+            @while_loop(lambda i, _: i < n)
+            def body(i, prod):
+                return i + 1, prod * 2
+
+            _, two_to_the_n = body(0, 1)
+            with pytest.raises(
+                ValueError,
+                match=r"""
+                The while_loop\(\) was not called \(or has not been called\) in a quantum context,
+                and thus has no associated quantum operation.
+                """,
+            ):
+                isinstance(body.operation, api_extensions.control_flow.WhileLoop)
+
+            return two_to_the_n
+
+        assert func(10) == 1024
+        assert func(5) == 32
+        assert func(0) == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Have a nice interface for creating qml.Cond, qml.ForLoop, qml.WhileLoop without using the queue. (#486)

PL is moving away from using the queue when implementing decompositions. So, to help PL developers, we should be able to construct these operations and use these operations during decomposition.

------------------------------------------------------------------------------------------------------------

**Context:** Have a nice interface for creating qml.Cond, qml.ForLoop, qml.WhileLoop without using the queue. PL is moving away from using the queue when implementing decompositions. So, to help PL developers, we should be able to construct these operations and use these operations during decomposition.

**Description of the Change:** Providing access to the underlaying PennyLane operator via cond_fn.operation. The main concern is to allow PL developers to define decompositions without queuing (as the overhead can add up), allowing users to write decompositions/transforms like they write normal programs.

qml.Cond, qml.ForLoop, ... style interfaces which return the operator instance would conflict with the classical return values, which may be ok in situations where there are none, but then we would also have to support yet another user interface for control flow.

**Benefits:** Can write circuit transforms without an extra tape. Provides access to the underlying control flow operators via ```bodyfunction.operation```. Example:
```python
        @qml.transform
        def my_quantum_transform(tape):
            ops = tape.operations.copy()

            @for_loop(0, 4, 1)
            def f(i, sum):
                qml.Hadamard(0)
                return sum+1

            res = f(0)
            ops.append(f.operation)

            def post_processing_fn(results):
                return results
            modified_tape = qml.tape.QuantumTape(ops, tape.measurements)
            print(res)
            print(modified_tape.operations)
            return [modified_tape], post_processing_fn

        @qml.qjit
        @my_quantum_transform
        @qml.qnode(qml.device("lightning.qubit", wires=2))
        def main():
            qml.Hadamard(0)
            return qml.probs()

        >>> main()
        Traced<ShapedArray(int64[], weak_type=True)>with<DynamicJaxprTrace(level=2/1)>
        [Hadamard(wires=[0]), ForLoop(tapes=[[Hadamard(wires=[0])]])]
        (array([0.5, 0. , 0.5, 0. ]),)
```
The returned object of the body function remains as a trace, and access to the ```ForLoop``` operator is provided via ```f.operation```. The functionality result remains correct: the loop adds 4 Hadamards to the same wire and thus does nothing, so the circuit is just the one in main, which is Hadamard(0) on |00> and gives |00>+|10>/sqrt2

**Possible Drawbacks:**

**Related GitHub Issues:** closes #486

[sc-62967]