### PR TITLE
Add support to AG for Jax array single assignment

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -48,6 +48,25 @@
 
   ```
 
+* Support for usage of single index JAX array assignments 
+  inside Autograph annotated functions.
+  [(#717)](https://github.com/PennyLaneAI/catalyst/pull/717)
+  
+  Using `x[i] = y` in favor of `x = x.at(i).set(y)` is now possible:
+
+  ```py
+  @qjit(autograph=True)
+  def f(x):
+    first_dim = x.shape[0]
+    result = jnp.empty((first_dim,), dtype=x.dtype)
+
+    for i in range(first_dim):
+      result[i] = x[i] * 2
+
+    return result
+
+  ```
+
 <h3>Improvements</h3>
 
 <h3>Breaking changes</h3>

--- a/frontend/catalyst/autograph/transformer.py
+++ b/frontend/catalyst/autograph/transformer.py
@@ -267,18 +267,21 @@ class DisableAutograph(ag_ctx.ControlStatusCtx, ContextDecorator):
 # Singleton instance of DisableAutograph
 disable_autograph = DisableAutograph()
 
+# converter.Feature.LISTS permits overloading the 'set_item' function in 'ag_primitives.py'
+OPTIONAL_FEATURES = [converter.Feature.BUILTIN_FUNCTIONS, converter.Feature.LISTS]
+
 TOPLEVEL_OPTIONS = converter.ConversionOptions(
     recursive=True,
     user_requested=True,
     internal_convert_user_code=True,
-    optional_features=[converter.Feature.BUILTIN_FUNCTIONS],
+    optional_features=OPTIONAL_FEATURES,
 )
 
 NESTED_OPTIONS = converter.ConversionOptions(
     recursive=True,
     user_requested=False,
     internal_convert_user_code=True,
-    optional_features=[converter.Feature.BUILTIN_FUNCTIONS],
+    optional_features=OPTIONAL_FEATURES,
 )
 
 STANDARD_OPTIONS = converter.STANDARD_OPTIONS

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -1756,5 +1756,86 @@ class TestDisableAutograph:
         assert g() == 36.4
 
 
+class TestJaxIndexAssignment:
+    """Test Jax index assignment"""
+
+    def test_single_index_assignment_one_item(self):
+        """Test single index assignment for Jax arrays for one array item."""
+
+        @qjit(autograph=True)
+        def zero_last_element_single_assignment_syntax(x):
+            """Set the last element of x to 0 using single index assignment"""
+
+            last_element = x.shape[0] - 1
+            x[last_element] = 0
+            return x
+
+        @qjit(autograph=True)
+        def zero_last_element_at_set_syntax(x):
+            """Set the last element of x to 0 using at and set"""
+
+            last_element = x.shape[0] - 1
+            x = x.at[last_element].set(0)
+            return x
+
+        result_assignment_syntax = zero_last_element_single_assignment_syntax(jnp.array([5, 3, 4]))
+
+        assert jnp.allclose(result_assignment_syntax, jnp.array([5, 3, 0]))
+        assert jnp.allclose(
+            result_assignment_syntax,
+            zero_last_element_at_set_syntax(jnp.array([5, 3, 4])),
+        )
+
+    def test_single_index_assignment_all_items(self):
+        """Test single index assignment for Jax arrays for all array items."""
+
+        @qjit(autograph=True)
+        def double_all_single_assignment_syntax(x):
+            """Create a new array that is equal to 2 * x using single index assignment"""
+
+            first_dim = x.shape[0]
+            result = jnp.empty((first_dim,), dtype=x.dtype)
+
+            for i in range(first_dim):
+                result[i] = x[i] * 2
+
+            return result
+
+        @qjit(autograph=True)
+        def double_all_at_set_syntax(x):
+            """Create a new array that is equal to 2 * x using at and set"""
+
+            first_dim = x.shape[0]
+            result = jnp.empty((first_dim,), dtype=x.dtype)
+
+            for i in range(first_dim):
+                result = result.at[i].set(x[i] * 2)
+
+            return result
+
+        result_assignment_syntax = double_all_single_assignment_syntax(jnp.array([5, 3, 4]))
+
+        assert jnp.allclose(result_assignment_syntax, jnp.array([10, 6, 8]))
+        assert jnp.allclose(
+            result_assignment_syntax,
+            double_all_at_set_syntax(jnp.array([5, 3, 4])),
+        )
+
+    def test_single_index_assignment_python_array(self):
+        """Test single index assignment for Non-Jax arrays for one array item."""
+
+        @qjit(autograph=True)
+        def zero_last_element_python_array(x):
+            """Set the last element of a python array to 0"""
+
+            last_element = len(x) - 1
+            x[last_element] = 0
+            return x
+
+        assert jnp.allclose(
+            jnp.array(zero_last_element_python_array([5, 3, 4])), jnp.array([5, 3, 0])
+        )
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])


### PR DESCRIPTION
**Context:** We want to support NumPy-style in-place array updates, such as arr[i] = x

**Description of the Change:** Overload set_item function from Autograph and enable converter.Feature.LISTS option.

**Benefits:** We can use directly arr[i] = x instead of arr = arr.at[i].set(x)

**Related GitHub Issues:** #516 

**Based on the solution presented in this PR:** #582 

[sc-60313]