### PR TITLE
[Runtime] check `amazon-braket-pennylane-plugin`'s version

### DIFF
--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -603,7 +603,7 @@ jobs:
       - name: Install additional dependencies (OpenQasm device)
         if: ${{ matrix.backend == 'openqasm' }}
         run: |
-          pip install numpy amazon-braket-sdk
+          pip install numpy amazon-braket-sdk amazon-braket-pennylane-plugin>=1.27.1
           echo "AWS_DEFAULT_REGION=us-east-1" >> $GITHUB_ENV
 
       - name: Download Catalyst-Runtime Artifact

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -8,11 +8,16 @@
 
 <h3>Bug fixes</h3>
 
+* Bumps minimum required for the amazon-braket-pennylane-plugin to 1.27.1.
+  [(#724)](https://github.com/PennyLaneAI/catalyst/pull/724)
+
 <h3>Internal changes</h3>
 
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
+
+Erick Ochoa Lopez
 
 # Release 0.6.0
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -8,15 +8,11 @@
 
 <h3>Bug fixes</h3>
 
-* Fixes incompatibility with new version of amazon braket local simulator.
-
 <h3>Internal changes</h3>
 
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
-
-Erick Ochoa Lopez
 
 # Release 0.6.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ nbmake
 
 # optional rt/test dependencies
 pennylane-lightning[kokkos]
-amazon-braket-pennylane-plugin>=1.25.0
+amazon-braket-pennylane-plugin>=1.27.1

--- a/runtime/lib/backend/openqasm/OpenQasmRunner.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmRunner.hpp
@@ -122,7 +122,7 @@ struct BraketRunner : public OpenQasmRunner {
             from braket.devices import LocalSimulator
             from braket.ir.openqasm import Program as OpenQasmProgram
             from importlib.metadata import version
-            from packaging.version import Version
+            from semantic_version import Version
 
             obs_version = version("amazon-braket-pennylane-plugin")
             min_version = "1.27.1"
@@ -186,7 +186,7 @@ struct BraketRunner : public OpenQasmRunner {
             from braket.devices import LocalSimulator
             from braket.ir.openqasm import Program as OpenQasmProgram
             from importlib.metadata import version
-            from packaging.version import Version
+            from semantic_version import Version
 
             obs_version = version("amazon-braket-pennylane-plugin")
             min_version = "1.27.1"
@@ -261,7 +261,7 @@ struct BraketRunner : public OpenQasmRunner {
             from braket.devices import LocalSimulator
             from braket.ir.openqasm import Program as OpenQasmProgram
             from importlib.metadata import version
-            from packaging.version import Version
+            from semantic_version import Version
 
             obs_version = version("amazon-braket-pennylane-plugin")
             min_version = "1.27.1"
@@ -331,7 +331,7 @@ struct BraketRunner : public OpenQasmRunner {
             from braket.devices import LocalSimulator
             from braket.ir.openqasm import Program as OpenQasmProgram
             from importlib.metadata import version
-            from packaging.version import Version
+            from semantic_version import Version
 
             obs_version = version("amazon-braket-pennylane-plugin")
             min_version = "1.27.1"
@@ -395,7 +395,7 @@ struct BraketRunner : public OpenQasmRunner {
             from braket.devices import LocalSimulator
             from braket.ir.openqasm import Program as OpenQasmProgram
             from importlib.metadata import version
-            from packaging.version import Version
+            from semantic_version import Version
 
             obs_version = version("amazon-braket-pennylane-plugin")
             min_version = "1.27.1"

--- a/runtime/lib/backend/openqasm/OpenQasmRunner.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmRunner.hpp
@@ -121,6 +121,14 @@ struct BraketRunner : public OpenQasmRunner {
             from braket.aws import AwsDevice
             from braket.devices import LocalSimulator
             from braket.ir.openqasm import Program as OpenQasmProgram
+            from importlib.metadata import version
+            from packaging.version.Version import Version
+
+            obs_version = version("amazon-braket-pennylane-plugin")
+            min_version = "1.27.1"
+            if not Version(min_version) <= Version(obs_version):
+                msg = f"amazon-braket-pennylane-plugin expected to be at least version {min_version}"
+                raise ModuleImportError(msg)
 
             try:
                 if braket_device in ["default", "braket_sv", "braket_dm"]:
@@ -177,6 +185,14 @@ struct BraketRunner : public OpenQasmRunner {
             from braket.aws import AwsDevice
             from braket.devices import LocalSimulator
             from braket.ir.openqasm import Program as OpenQasmProgram
+            from importlib.metadata import version
+            from packaging.version.Version import Version
+
+            obs_version = version("amazon-braket-pennylane-plugin")
+            min_version = "1.27.1"
+            if not Version(min_version) <= Version(obs_version):
+                msg = f"amazon-braket-pennylane-plugin expected to be at least version {min_version}"
+                raise ModuleImportError(msg)
 
             try:
                 if braket_device in ["default", "braket_sv", "braket_dm"]:
@@ -244,6 +260,14 @@ struct BraketRunner : public OpenQasmRunner {
             from braket.aws import AwsDevice
             from braket.devices import LocalSimulator
             from braket.ir.openqasm import Program as OpenQasmProgram
+            from importlib.metadata import version
+            from packaging.version.Version import Version
+
+            obs_version = version("amazon-braket-pennylane-plugin")
+            min_version = "1.27.1"
+            if not Version(min_version) <= Version(obs_version):
+                msg = f"amazon-braket-pennylane-plugin expected to be at least version {min_version}"
+                raise ModuleImportError(msg)
 
             try:
                 if braket_device in ["default", "braket_sv", "braket_dm"]:
@@ -306,6 +330,14 @@ struct BraketRunner : public OpenQasmRunner {
             from braket.aws import AwsDevice
             from braket.devices import LocalSimulator
             from braket.ir.openqasm import Program as OpenQasmProgram
+            from importlib.metadata import version
+            from packaging.version.Version import Version
+
+            obs_version = version("amazon-braket-pennylane-plugin")
+            min_version = "1.27.1"
+            if not Version(min_version) <= Version(obs_version):
+                msg = f"amazon-braket-pennylane-plugin expected to be at least version {min_version}"
+                raise ModuleImportError(msg)
 
             try:
                 if braket_device in ["default", "braket_sv", "braket_dm"]:
@@ -362,6 +394,14 @@ struct BraketRunner : public OpenQasmRunner {
             from braket.aws import AwsDevice
             from braket.devices import LocalSimulator
             from braket.ir.openqasm import Program as OpenQasmProgram
+            from importlib.metadata import version
+            from packaging.version.Version import Version
+
+            obs_version = version("amazon-braket-pennylane-plugin")
+            min_version = "1.27.1"
+            if not Version(min_version) <= Version(obs_version):
+                msg = f"amazon-braket-pennylane-plugin expected to be at least version {min_version}"
+                raise ModuleImportError(msg)
 
             try:
                 if braket_device in ["default", "braket_sv", "braket_dm"]:

--- a/runtime/lib/backend/openqasm/OpenQasmRunner.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmRunner.hpp
@@ -122,13 +122,13 @@ struct BraketRunner : public OpenQasmRunner {
             from braket.devices import LocalSimulator
             from braket.ir.openqasm import Program as OpenQasmProgram
             from importlib.metadata import version
-            from packaging.version.Version import Version
+            from packaging.version import Version
 
             obs_version = version("amazon-braket-pennylane-plugin")
             min_version = "1.27.1"
             if not Version(min_version) <= Version(obs_version):
                 msg = f"amazon-braket-pennylane-plugin expected to be at least version {min_version}"
-                raise ModuleImportError(msg)
+                raise ModuleNotFoundError(msg)
 
             try:
                 if braket_device in ["default", "braket_sv", "braket_dm"]:
@@ -186,13 +186,13 @@ struct BraketRunner : public OpenQasmRunner {
             from braket.devices import LocalSimulator
             from braket.ir.openqasm import Program as OpenQasmProgram
             from importlib.metadata import version
-            from packaging.version.Version import Version
+            from packaging.version import Version
 
             obs_version = version("amazon-braket-pennylane-plugin")
             min_version = "1.27.1"
             if not Version(min_version) <= Version(obs_version):
                 msg = f"amazon-braket-pennylane-plugin expected to be at least version {min_version}"
-                raise ModuleImportError(msg)
+                raise ModuleNotFoundError(msg)
 
             try:
                 if braket_device in ["default", "braket_sv", "braket_dm"]:
@@ -261,13 +261,13 @@ struct BraketRunner : public OpenQasmRunner {
             from braket.devices import LocalSimulator
             from braket.ir.openqasm import Program as OpenQasmProgram
             from importlib.metadata import version
-            from packaging.version.Version import Version
+            from packaging.version import Version
 
             obs_version = version("amazon-braket-pennylane-plugin")
             min_version = "1.27.1"
             if not Version(min_version) <= Version(obs_version):
                 msg = f"amazon-braket-pennylane-plugin expected to be at least version {min_version}"
-                raise ModuleImportError(msg)
+                raise ModuleNotFoundError(msg)
 
             try:
                 if braket_device in ["default", "braket_sv", "braket_dm"]:
@@ -331,13 +331,13 @@ struct BraketRunner : public OpenQasmRunner {
             from braket.devices import LocalSimulator
             from braket.ir.openqasm import Program as OpenQasmProgram
             from importlib.metadata import version
-            from packaging.version.Version import Version
+            from packaging.version import Version
 
             obs_version = version("amazon-braket-pennylane-plugin")
             min_version = "1.27.1"
             if not Version(min_version) <= Version(obs_version):
                 msg = f"amazon-braket-pennylane-plugin expected to be at least version {min_version}"
-                raise ModuleImportError(msg)
+                raise ModuleNotFoundError(msg)
 
             try:
                 if braket_device in ["default", "braket_sv", "braket_dm"]:
@@ -395,13 +395,13 @@ struct BraketRunner : public OpenQasmRunner {
             from braket.devices import LocalSimulator
             from braket.ir.openqasm import Program as OpenQasmProgram
             from importlib.metadata import version
-            from packaging.version.Version import Version
+            from packaging.version import Version
 
             obs_version = version("amazon-braket-pennylane-plugin")
             min_version = "1.27.1"
             if not Version(min_version) <= Version(obs_version):
                 msg = f"amazon-braket-pennylane-plugin expected to be at least version {min_version}"
-                raise ModuleImportError(msg)
+                raise ModuleNotFoundError(msg)
 
             try:
                 if braket_device in ["default", "braket_sv", "braket_dm"]:

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ requirements = [
     "scipy<1.13",
     "numpy<2",
     "diastatic-malt>=2.15.1",
-    "packaging",
+    "semantic_version",
 ]
 
 entry_points = {

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ requirements = [
     "scipy<1.13",
     "numpy<2",
     "diastatic-malt>=2.15.1",
+    "packaging",
 ]
 
 entry_points = {


### PR DESCRIPTION
**Context:** To help users understand which version of `amazon-braket-pennylane-plugin` is compatible with catalyst

**Description of the Change:** 

* raise an error if an incompatible version of `amazon-braket-pennylane-plugin` is found. 
* Also adds dependency to `semantic_version` module in order check non-trivial version compatibilities.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
