### PR TITLE
Support autograph_include option in qjit

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -67,6 +67,19 @@
 
   ```
 
+* Support for including a list of previously excluded modules
+  for Autograph conversion.
+  [(#725)](https://github.com/PennyLaneAI/catalyst/pull/725)
+  
+  Including previously excluded modules is now possible:
+
+  ```py
+  @qjit(autograph=True, autograph_include=["excluded_module"])
+  def f(x):
+    return excluded_module.func(x)
+
+  ```
+
 <h3>Improvements</h3>
 
 * Added support for IsingZZ gate in Catalyst frontend. Previously, the IsingZZ gate would be

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -67,16 +67,17 @@
 
   ```
 
-* Support for including a list of previously excluded modules
-  for Autograph conversion.
+* Support for including a list of (sub)modules to be allow-listed for autograph conversion.
   [(#725)](https://github.com/PennyLaneAI/catalyst/pull/725)
-  
-  Including previously excluded modules is now possible:
+
+  Although library code is not meant to be targeted by Autograph conversion,
+  it sometimes make sense to enable it for specific submodules that might 
+  benefit from such conversion:
 
   ```py
-  @qjit(autograph=True, autograph_include=["excluded_module"])
+  @qjit(autograph=True, autograph_include=["excluded_module.submodule"])
   def f(x):
-    return excluded_module.func(x)
+    return excluded_module.submodule.func(x)
 
   ```
 

--- a/doc/dev/autograph.rst
+++ b/doc/dev/autograph.rst
@@ -898,6 +898,29 @@ the context will be converted anyways:
 ...     return x
 
 
+Adding modules for Autograph conversion
+---------------------------------------
+
+Library code is not meant to be targeted by Autograph conversion, hence 
+``pennylane``, ``catalyst`` and ``jax`` modules have been excluded from it.
+But sometimes it might make sense enabling specific submodules from the 
+excluded modules for which conversion may be appropriate. For these cases 
+one can use the ``autograph_include`` parameter, which provides a list 
+of modules/submodules that will always be enabled for conversion no matter
+if the default conversion rules were excluding them before.
+
+This example shows how you can enable a previously excluded submodule:
+
+>>> import excluded_module
+...
+... @qjit(autograph=True, autograph_include=["excluded_module.submodule"])
+... def g(x: int):
+...     return excluded_module.submodule.f(x)
+
+Notice that ``autograph=True`` must be set in order to process the 
+``autograph_include`` list. Otherwise an error will be reported.
+
+
 In-place JAX array assignments
 ------------------------------
 

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -57,8 +57,8 @@ class CompileOptions:
             to a list of MLIR passes.
         autograph (Optional[bool]): flag indicating whether experimental autograph support is to
             be enabled.
-        autograph_include (Optional[List[Any]]): A list of previously excluded modules to be
-            actually included for autograph conversion.
+        autograph_include (Optional[Iterable[str]]): A list of (sub)modules to be allow-listed
+        for autograph conversion.
         async_qnodes (Optional[bool]): flag indicating whether experimental asynchronous execution
             of QNodes support is to be enabled.
         lower_to_llvm (Optional[bool]): flag indicating whether to attempt the LLVM lowering after
@@ -74,7 +74,7 @@ class CompileOptions:
     keep_intermediate: Optional[bool] = False
     pipelines: Optional[List[Any]] = None
     autograph: Optional[bool] = False
-    autograph_include: Optional[List[Any]] = ()
+    autograph_include: Optional[Iterable[str]] = ()
     async_qnodes: Optional[bool] = False
     static_argnums: Optional[Union[int, Iterable[int]]] = None
     abstracted_axes: Optional[Union[Iterable[Iterable[str]], Dict[int, str]]] = None

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -57,6 +57,8 @@ class CompileOptions:
             to a list of MLIR passes.
         autograph (Optional[bool]): flag indicating whether experimental autograph support is to
             be enabled.
+        autograph_include (Optional[List[Any]]): A list of previously excluded modules to be
+            actually included for autograph conversion.
         async_qnodes (Optional[bool]): flag indicating whether experimental asynchronous execution
             of QNodes support is to be enabled.
         lower_to_llvm (Optional[bool]): flag indicating whether to attempt the LLVM lowering after
@@ -72,6 +74,7 @@ class CompileOptions:
     keep_intermediate: Optional[bool] = False
     pipelines: Optional[List[Any]] = None
     autograph: Optional[bool] = False
+    autograph_include: Optional[List[Any]] = ()
     async_qnodes: Optional[bool] = False
     static_argnums: Optional[Union[int, Iterable[int]]] = None
     abstracted_axes: Optional[Union[Iterable[Iterable[str]], Dict[int, str]]] = None

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -648,6 +648,28 @@ def qjit(
 
 
     .. details::
+        :title: Adding modules for Autograph conversion
+
+        Due to the experimental state of Autograph support, the following modules have been excluded
+        from Autograph conversion: ``pennylane, catalyst, jax``. However, it is possible to
+        enable these or other previously excluded modules via the ``autograph_include`` parameter,
+        which provides a list of modules that will always be evaluated before the default conversion
+        rules, which means that any module of this list will be enabled for conversion regardless of
+        the default conversion rules that were excluding it before.
+
+        .. code-block:: python
+
+            import excluded_module_1
+            import excluded_module_2
+
+            @qjit(autograph=True, autograph_include=["excluded_module_1", "excluded_module_2"])
+            def g(x: int):
+                return excluded_module_1.f(x) + excluded_module_2.f(x)
+
+        Notice that ``autograph=True`` must be set in order to process the ``autograph_include``
+        list. Otherwise an error will be reported.
+
+    .. details::
         :title: Static arguments
 
         ``static_argnums`` defines which elements should be treated as static. If it takes an

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -481,8 +481,7 @@ def qjit(
             ``elif``, ``else``, and ``for`` statements. Note that this feature requires an
             available TensorFlow installation. For more details, see the
             :doc:`AutoGraph guide </dev/autograph>`.
-        autograph_include: A list of previously excluded modules to be
-            actually included for autograph conversion.
+        autograph_include: A list of (sub)modules to be allow-listed for autograph conversion.
         async_qnodes (bool): Experimental support for automatically executing
             QNodes asynchronously, if supported by the device runtime.
         target (str): the compilation target
@@ -611,6 +610,29 @@ def qjit(
 
 
     .. details::
+        :title: Adding modules for Autograph conversion
+
+        Library code is not meant to be targeted by Autograph conversion, hence
+        ``pennylane``, ``catalyst`` and ``jax`` modules have been excluded from it.
+        But sometimes it might make sense enabling specific submodules from the
+        excluded modules for which conversion may be appropriate. For these cases
+        one can use the ``autograph_include`` parameter, which provides a list
+        of modules/submodules that will always be enabled for conversion no matter
+        if the default conversion rules were excluding them before.
+
+        .. code-block:: python
+
+            import excluded_module
+
+            @qjit(autograph=True, autograph_include=["excluded_module.submodule"])
+            def g(x: int):
+                return excluded_module.submodule.f(x)
+
+        Notice that ``autograph=True`` must be set in order to process the
+        ``autograph_include`` list. Otherwise an error will be reported.
+
+
+    .. details::
         :title: In-place JAX array assignments with Autograph
 
         To update array values when using JAX, the JAX syntax for array assignment
@@ -646,28 +668,6 @@ def qjit(
         Under the hood, Catalyst converts anything coming in the latter notation into the
         former one.
 
-
-    .. details::
-        :title: Adding modules for Autograph conversion
-
-        Due to the experimental state of Autograph support, the following modules have been excluded
-        from Autograph conversion: ``pennylane, catalyst, jax``. However, it is possible to
-        enable these or other previously excluded modules via the ``autograph_include`` parameter,
-        which provides a list of modules that will always be evaluated before the default conversion
-        rules, which means that any module of this list will be enabled for conversion regardless of
-        the default conversion rules that were excluding it before.
-
-        .. code-block:: python
-
-            import excluded_module_1
-            import excluded_module_2
-
-            @qjit(autograph=True, autograph_include=["excluded_module_1", "excluded_module_2"])
-            def g(x: int):
-                return excluded_module_1.f(x) + excluded_module_2.f(x)
-
-        Notice that ``autograph=True`` must be set in order to process the ``autograph_include``
-        list. Otherwise an error will be reported.
 
     .. details::
         :title: Static arguments

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -323,10 +323,10 @@ class QJIT:
         if not hasattr(self.original_function, "__name__"):
             self.__name__ = "unknown"  # allow these cases anyways?
 
-        if not self.compile_options.autograph:
-            assert (
-                len(self.compile_options.autograph_include) == 0
-            ), "In order for 'autograph_include' to work, 'autograph' must be set to True"
+        if not self.compile_options.autograph and len(self.compile_options.autograph_include) > 0:
+            raise CompileError(
+                "In order for 'autograph_include' to work, 'autograph' must be set to True"
+            )
 
     def _verify_static_argnums(self, args):
         for argnum in self.compile_options.static_argnums:

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -27,9 +27,10 @@ import jax.numpy as jnp
 import pennylane as qml
 from jax.interpreters import mlir
 from jax.tree_util import tree_flatten, tree_unflatten
+from malt.core import config as ag_config
 
 import catalyst
-from catalyst.autograph import run_autograph
+from catalyst.autograph import ag_primitives, run_autograph
 from catalyst.compiled_functions import CompilationCache, CompiledFunction
 from catalyst.compiler import CompileOptions, Compiler
 from catalyst.debug.instruments import instrument
@@ -96,7 +97,17 @@ class QJIT:
         self.user_sig = get_type_annotations(fn)
         self._validate_configuration()
 
-        self.user_function = self.pre_compilation()
+        # Patch the conversion rules by adding the included modules before the block list
+        include_convertlist = tuple(
+            ag_config.Convert(rule) for rule in self.compile_options.autograph_include
+        )
+        self.patched_module_allowlist = include_convertlist + ag_primitives.module_allowlist
+
+        # Pre-compile with the patched conversion rules
+        with Patcher(
+            (ag_primitives, "module_allowlist", self.patched_module_allowlist),
+        ):
+            self.user_function = self.pre_compilation()
 
         # Static arguments require values, so we cannot AOT compile.
         if self.user_sig is not None and not self.compile_options.static_argnums:
@@ -128,7 +139,11 @@ class QJIT:
 
         # TODO: awkward, refactor or redesign the target feature
         if self.compile_options.target in ("jaxpr", "mlir", "binary"):
-            self.jaxpr, self.out_treedef, self.c_sig = self.capture(self.user_sig or ())
+            # Capture with the patched conversion rules
+            with Patcher(
+                (ag_primitives, "module_allowlist", self.patched_module_allowlist),
+            ):
+                self.jaxpr, self.out_treedef, self.c_sig = self.capture(self.user_sig or ())
 
         if self.compile_options.target in ("mlir", "binary"):
             self.mlir_module, self.mlir = self.generate_ir()
@@ -166,7 +181,12 @@ class QJIT:
             if self.compiled_function and self.compiled_function.shared_object:
                 self.compiled_function.shared_object.close()
 
-            self.jaxpr, self.out_treedef, self.c_sig = self.capture(args)
+            # Capture with the patched conversion rules
+            with Patcher(
+                (ag_primitives, "module_allowlist", self.patched_module_allowlist),
+            ):
+                self.jaxpr, self.out_treedef, self.c_sig = self.capture(args)
+
             self.mlir_module, self.mlir = self.generate_ir()
             self.compiled_function, self.qir = self.compile()
 
@@ -303,6 +323,11 @@ class QJIT:
         if not hasattr(self.original_function, "__name__"):
             self.__name__ = "unknown"  # allow these cases anyways?
 
+        if not self.compile_options.autograph:
+            assert (
+                len(self.compile_options.autograph_include) == 0
+            ), "In order for 'autograph_include' to work, 'autograph' must be set to True"
+
     def _verify_static_argnums(self, args):
         for argnum in self.compile_options.static_argnums:
             if argnum < 0 or argnum >= len(args):
@@ -428,6 +453,7 @@ def qjit(
     fn=None,
     *,
     autograph=False,
+    autograph_include=(),
     async_qnodes=False,
     target="binary",
     keep_intermediate=False,
@@ -455,6 +481,8 @@ def qjit(
             ``elif``, ``else``, and ``for`` statements. Note that this feature requires an
             available TensorFlow installation. For more details, see the
             :doc:`AutoGraph guide </dev/autograph>`.
+        autograph_include: A list of previously excluded modules to be
+            actually included for autograph conversion.
         async_qnodes (bool): Experimental support for automatically executing
             QNodes asynchronously, if supported by the device runtime.
         target (str): the compilation target

--- a/frontend/catalyst/utils/dummy.py
+++ b/frontend/catalyst/utils/dummy.py
@@ -14,9 +14,11 @@
 """Dummy module for testing"""
 
 
-def dummy_func():
-    """Simple function with if statements for testing"""
-    x = 6
+def dummy_func(x):
+    """Simple function with if statements for testing the 'auto_include' option of @qjit.
+    The parent 'catalayst' module is excluded for autograph conversion by default, hence
+    adding this module explicitely to the inclusion list will override that restriction"""
+
     if x > 5:
         y = x**2
     else:

--- a/frontend/catalyst/utils/dummy.py
+++ b/frontend/catalyst/utils/dummy.py
@@ -1,0 +1,24 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Dummy module for testing"""
+
+
+def dummy_func():
+    """Simple function with if statements for testing"""
+    x = 6
+    if x > 5:
+        y = x**2
+    else:
+        y = x**3
+    return y

--- a/frontend/test/lit/test_autograph.py
+++ b/frontend/test/lit/test_autograph.py
@@ -679,7 +679,7 @@ def include_module_to_autograph(x: float, n: int):
     """Checks that a module is included to Autograph conversion."""
     # CHECK: branch_jaxprs=[{ lambda ; . let  in (36,) }, { lambda ; . let  in (216,) }]
     for _ in range(n):
-        x = x + dummy_func()
+        x = x + dummy_func(6)
     return x
 
 
@@ -696,7 +696,7 @@ def excluded_module_from_autograph(x: float, n: int):
     """Checks that a module is excluded from Autograph conversion."""
     # CHECK: body_jaxpr={ lambda ; d:i64[] e:f64[]. let f:f64[] = add e 36.0 in (f,) }
     for _ in range(n):
-        x = x + dummy_func()
+        x = x + dummy_func(6)
     return x
 
 

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -42,6 +42,7 @@ from catalyst import (
     vjp,
 )
 from catalyst.autograph.transformer import TRANSFORMER
+from catalyst.utils.dummy import dummy_func
 
 check_cache = TRANSFORMER.has_cache
 
@@ -1754,6 +1755,30 @@ class TestDisableAutograph:
             return x
 
         assert g() == 36.4
+
+
+class TestAutographInclude:
+    """Test include modules to autograph conversion"""
+
+    def test_autograph_included_module(self):
+        """Test autograph included module."""
+
+        @qjit(autograph=True)
+        def excluded_by_default(x: float, n: int):
+            for _ in range(n):
+                x = x + dummy_func()
+            return x
+
+        @qjit(autograph=True, autograph_include=["catalyst.utils.dummy"])
+        def included(x: float, n: int):
+            for _ in range(n):
+                x = x + dummy_func()
+            return x
+
+        result_excluded_by_default = excluded_by_default(0.4, 6)
+        assert result_excluded_by_default == 216.4 and result_excluded_by_default == included(
+            0.4, 6
+        )
 
 
 class TestJaxIndexAssignment:

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -43,6 +43,7 @@ from catalyst import (
 )
 from catalyst.autograph.transformer import TRANSFORMER
 from catalyst.utils.dummy import dummy_func
+from catalyst.utils.exceptions import CompileError
 
 check_cache = TRANSFORMER.has_cache
 
@@ -1760,25 +1761,45 @@ class TestDisableAutograph:
 class TestAutographInclude:
     """Test include modules to autograph conversion"""
 
+    def test_dummy_func(self):
+        """Test dummy function branches."""
+
+        assert dummy_func(6) == 36
+        assert dummy_func(4) == 64
+
     def test_autograph_included_module(self):
         """Test autograph included module."""
 
         @qjit(autograph=True)
         def excluded_by_default(x: float, n: int):
             for _ in range(n):
-                x = x + dummy_func()
+                x = x + dummy_func(6)
             return x
 
         @qjit(autograph=True, autograph_include=["catalyst.utils.dummy"])
         def included(x: float, n: int):
             for _ in range(n):
-                x = x + dummy_func()
+                x = x + dummy_func(6)
             return x
 
         result_excluded_by_default = excluded_by_default(0.4, 6)
         assert result_excluded_by_default == 216.4 and result_excluded_by_default == included(
             0.4, 6
         )
+
+    def test_invalid_autograph_include_with_no_autograph(self):
+        """Test including modules when autograph is disabled as invalid input."""
+
+        def fn(x: float, n: int):
+            for _ in range(n):
+                x = x + dummy_func(6)
+            return x
+
+        with pytest.raises(
+            CompileError,
+            match="In order for 'autograph_include' to work, 'autograph' must be set to True",
+        ):
+            qjit(autograph_include=["catalyst.utils.dummy"])(fn)
 
 
 class TestJaxIndexAssignment:


### PR DESCRIPTION
**Context:** It is needed a configuration option to specify which previously excluded modules to include again in Autograph conversion.

**Description of the Change:** Patch the module_allowlist with the included modules at the beginning of it.

**TODO:**

- [x] Update qjit docstring
- [x] Add test cases
- [x] Update changelog.md

[sc-62760]
[sc-60519]