### PR TITLE
[Frontend] Support for IsingZZ in Catalyst

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -69,6 +69,12 @@
 
 <h3>Improvements</h3>
 
+* Added support for IsingZZ gate in Catalyst frontend. 
+  Previously, the IsingZZ gate would be decomposed into 
+  a CNOT and RZ gates. However, this is not needed as 
+  the PennyLane-Lightning simulator supports this gate.
+  [(#730)](https://github.com/PennyLaneAI/catalyst/pull/730)
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>
@@ -88,6 +94,7 @@
 This release contains contributions from (in alphabetical order):
 
 David Ittah,
+Mehrdad Malekmohammadi,
 Raul Torres.
 
 # Release 0.6.0

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -58,6 +58,7 @@ RUNTIME_OPERATIONS = [
     "IsingXX",
     "IsingXY",
     "IsingYY",
+    "IsingZZ",
     "ISWAP",
     "MultiRZ",
     "PauliX",

--- a/frontend/test/lit/test_multi_qubit_gates.py
+++ b/frontend/test/lit/test_multi_qubit_gates.py
@@ -76,3 +76,16 @@ def circuit(x: float):
 
 
 print(circuit.mlir)
+
+
+# CHECK-LABEL: public @jit_isingZZ_circuit
+@qjit(target="mlir")
+@qml.qnode(qml.device("lightning.qubit", wires=2, shots=100))
+def isingZZ_circuit(x: float):
+    """Circuit that applies an IsingZZ gate to a pair of qubits."""
+    # CHECK: {{%.+}} = quantum.custom "IsingZZ"({{%.+}}) {{.+}} : !quantum.bit, !quantum.bit
+    qml.IsingZZ(x, wires=[0, 1])
+    return qml.state()
+
+
+print(isingZZ_circuit.mlir)

--- a/runtime/tests/Test_LightningGateSet.cpp
+++ b/runtime/tests/Test_LightningGateSet.cpp
@@ -909,3 +909,34 @@ TEMPLATE_LIST_TEST_CASE("Controlled gates", "[GateSet]", SimTypes)
     }
     __catalyst__rt__finalize();
 }
+
+TEMPLATE_LIST_TEST_CASE("IsingZZ Gate Test", "[GateSet]", SimTypes)
+{
+    std::unique_ptr<TestType> sim = std::make_unique<TestType>();
+
+    // state-vector with #qubits = n
+    constexpr size_t n = 2;
+    std::vector<QubitIdType> qubits;
+    qubits.reserve(n);
+
+    for (size_t i = 0; i < n; i++) {
+        qubits.push_back(sim->AllocateQubit());
+    }
+
+    sim->NamedOperation("Hadamard", {}, {qubits[0]}, false);
+    sim->NamedOperation("Hadamard", {}, {qubits[1]}, false);
+    sim->NamedOperation("IsingZZ", {M_PI_4}, {qubits[0], qubits[1]}, false);
+
+    std::vector<std::complex<double>> state(1U << sim->GetNumQubits());
+    DataView<std::complex<double>, 1> view(state);
+    sim->State(view);
+
+    CHECK(state.at(0).real() == Approx(0.4619397663).epsilon(1e-5));
+    CHECK(state.at(0).imag() == Approx(-0.1913417162).epsilon(1e-5));
+    CHECK(state.at(1).real() == Approx(0.4619397663).epsilon(1e-5));
+    CHECK(state.at(1).imag() == Approx(0.1913417162).epsilon(1e-5));
+    CHECK(state.at(2).real() == Approx(0.4619397663).epsilon(1e-5));
+    CHECK(state.at(2).imag() == Approx(0.1913417162).epsilon(1e-5));
+    CHECK(state.at(3).real() == Approx(0.4619397663).epsilon(1e-5));
+    CHECK(state.at(3).imag() == Approx(-0.1913417162).epsilon(1e-5));
+}


### PR DESCRIPTION
**Context:** We would like to add support for the PennyLane IsingZZ operation to our compilation architecture. The PennyLane-Lightning simulator supports this gate, and we would like to be able to support it without relying on the operation decomposition.

**Description of the Change:** Added IsingZZ to the list of supported gates. Added tests to confirm the functionality of IsingZZ gate and that the decomposition is not happening anymore.

**Benefits:** No need to decompose IsingZZ gate into a CNOT and RZ gate

**Possible Drawbacks:** May need more complicated tests to capture the full functionality of IsingZZ gate

**Related GitHub Issues:** #662
