### PR TITLE
Fixing ```Batching rule for 'gather' not implemented``` for jax.scipy.linalg.expm under qml.qjit.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -95,7 +95,8 @@ This release contains contributions from (in alphabetical order):
 
 David Ittah,
 Erick Ochoa,
-Raul Torres.
+Raul Torres,
+Haochen Paul Wang.
 
 # Release 0.6.0
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -73,6 +73,8 @@
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>
+* Correctly querying batching rules for ```jax.scipy.linalg.expm```
+  [(#733)](https://github.com/PennyLaneAI/catalyst/pull/733)
 
 <h3>Internal changes</h3>
 

--- a/frontend/test/pytest/test_jax_dynamic_api.py
+++ b/frontend/test/pytest/test_jax_dynamic_api.py
@@ -18,6 +18,7 @@ import numpy as np
 import pennylane as qml
 import pytest
 from jax import numpy as jnp
+from jax import scipy as jsp
 from numpy import array_equal
 from numpy.testing import assert_allclose
 
@@ -404,7 +405,7 @@ def test_expm():
 
     @qjit
     def f1(x):
-        return jax.scipy.linalg.expm(-2.0 * x)
+        return jsp.linalg.expm(-2.0 * x)
 
     y1 = jnp.array([[0.1, 0.2], [5.3, 1.2]])
     res1 = f1(y1)
@@ -412,7 +413,7 @@ def test_expm():
 
     @qjit
     def f2(x):
-        return jax.scipy.linalg.expm(x)
+        return jsp.linalg.expm(x)
 
     y2 = jnp.array([[1.0, 0.0], [0.0, 1.0]])
     res2 = f2(y2)

--- a/frontend/test/pytest/test_jax_dynamic_api.py
+++ b/frontend/test/pytest/test_jax_dynamic_api.py
@@ -398,5 +398,29 @@ def test_array_assignment():
     assert_array_and_dtype_equal(result, expected)
 
 
+@pytest.mark.xfail(reason="JAX requires BLAS to be linked with, but we don't have it linked.")
+def test_expm():
+    """Test jax.scipy.linalg.expm"""
+
+    @qjit
+    def f1(x):
+        return jax.scipy.linalg.expm(-2.0 * x)
+
+    y1 = jnp.array([[0.1, 0.2], [5.3, 1.2]])
+    res1 = f1(y1)
+    expected1 = jnp.array([[2.0767685, -0.23879551], [-6.32808103, 0.76339319]])
+
+    @qjit
+    def f2(x):
+        return jax.scipy.linalg.expm(x)
+
+    y2 = jnp.array([[1.0, 0.0], [0.0, 1.0]])
+    res2 = f2(y2)
+    expected2 = jnp.array([[2.71828183, 0.0], [0.0, 2.71828183]])
+
+    assert_allclose(res1, expected1)
+    assert_allclose(res2, expected2)
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_jax_dynamic_api.py
+++ b/frontend/test/pytest/test_jax_dynamic_api.py
@@ -401,7 +401,7 @@ def test_array_assignment():
 
 @pytest.mark.xfail(
     raises=OSError,
-    reason="""JAX requires BLAS to be linked with, 
+    reason="""JAX requires BLAS to be linked with,
     but we don't have it linked.""",
 )
 def test_expm():

--- a/frontend/test/pytest/test_jax_dynamic_api.py
+++ b/frontend/test/pytest/test_jax_dynamic_api.py
@@ -399,7 +399,11 @@ def test_array_assignment():
     assert_array_and_dtype_equal(result, expected)
 
 
-@pytest.mark.xfail(raises=OSError, reason="JAX requires BLAS to be linked with, but we don't have it linked.")
+@pytest.mark.xfail(
+    raises=OSError,
+    reason="""JAX requires BLAS to be linked with, 
+    but we don't have it linked.""",
+)
 def test_expm():
     """Test jax.scipy.linalg.expm"""
 

--- a/frontend/test/pytest/test_jax_dynamic_api.py
+++ b/frontend/test/pytest/test_jax_dynamic_api.py
@@ -399,7 +399,7 @@ def test_array_assignment():
     assert_array_and_dtype_equal(result, expected)
 
 
-@pytest.mark.xfail(reason="JAX requires BLAS to be linked with, but we don't have it linked.")
+@pytest.mark.xfail(raises=OSError, reason="JAX requires BLAS to be linked with, but we don't have it linked.")
 def test_expm():
     """Test jax.scipy.linalg.expm"""
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new functions and code must be clearly commented and documented.

- [x] Ensure that code is properly formatted by running `make format`.
      The latest version of black and `clang-format-14` are used in CI/CD to check formatting.

- [x] All new features must include a unit test.
      Integration and frontend tests should be added to [`frontend/test`](../frontend/test/),
      Quantum dialect and MLIR tests should be added to [`mlir/test`](../mlir/test/), and
      Runtime tests should be added to [`runtime/tests`](../runtime/tests/).

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** Bug fix:
```python
@qml.qjit
def f(x):
    return jax.scipy.linalg.expm(-2.0 * x)

>>> f(jnp.array([[0.1, 0.2], [5.3, 1.2]]))
[/usr/local/lib/python3.10/dist-packages/jax/_src/interpreters/batching.py](https://localhost:8080/#) in get_primitive_batcher(self, primitive, frame)
    395       return self.get_axis_primitive_batcher(primitive, frame)
    396     msg = "Batching rule for '{}' not implemented"
--> 397     raise NotImplementedError(msg.format(primitive))
    398 
    399   def get_axis_primitive_batcher(self, primitive, frame):

NotImplementedError: Batching rule for 'gather' not implemented
```


Note:     the expm bug actually consists of two independent bugs. The first one, "batching rule for gather not implemented", is addressed by this PR and unique to expm. The second one seems to be common to some algebraic jax.scipy.linalg functions, including expm and sqrtm, which says 

```
OSError: /tmp/funcb63p6a7m/func.so: undefined symbol: blas_dtrsm
```

The undefined symbol is different for different functions. e.g. for ```sqrtm``` this undefined symbol is ```lapack_zgees```. Since this really is a separate bug, I will open another issue and PR once I investigate further what's going on. For this reason also, the batching rule PR's test will need to marked as xfail for now, and back to success once this second bug is fixed

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:** closes #628 

[sc-62434]