### PR TITLE
[MLIR] Specialize active callbacks to their own function

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -104,6 +104,14 @@
 * Catalyst tests now manipulate device capabilities rather than text configurations files.
   [(#712)](https://github.com/PennyLaneAI/catalyst/pull/712)
 
+* `callback.pure_callback` are now lowered to `ActiveCallbackOp`s.
+  Which will be treated as active callbacks by Enzyme. During the lowering of
+  `ActiveCallbackOp`s, the callback will create a specialized function for the
+  `ActiveCallback`. This is necessary for registering custom gradients with
+  Enzyme.
+  [(#735)](https://github.com/PennyLaneAI/catalyst/pull/735)
+
+
 <h3>Breaking changes</h3>
 
 * Binary distributions for Linux are now based on `manylinux_2_28` instead of `manylinux_2014`.

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -122,17 +122,18 @@
 
    ```mlir
    // This function has been declared in the module
-   llvm.func @active_callback_0xdeadbeef(%arg0 : !llvm.ptr, ... %argN : !llvm.ptr, ...
+   func.func @active_callback_0xdeadbeef(%arg0 : !llvm.ptr, ... %argN : !llvm.ptr, ...
                                          %res0 : !llvm.ptr, ... %resM : !llvm.ptr)
    {
        %id = llvm.mlir.constant(0xdeadbeef : i64)
        %argc = llvm.mlir.constant(N: i64)
        %retc = llvm.mlir.constant(M: i64)
        llvm.call @inactive_callback(%id, %argc, %retc, %arg0, ..., %argN, %res0, ..., %resM)
+       return
    }
 
    // there will be a call to the function above where catalyst.activeCallbackCall was.
-   llvm.call @active_callback_0xdeadbeef(%arg0, ..., %argN, %res0, ... %resM)
+   func.call @active_callback_0xdeadbeef(%arg0, ..., %argN, %res0, ... %resM)
    ```
 
    This will allow for custom functions to be defined as forward and reverse passes for

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -142,6 +142,7 @@ HLO_LOWERING_PASS = (
 QUANTUM_COMPILATION_PASS = (
     "QuantumCompilationPass",
     [
+        # TODO: Pass here that will transform
         "annotate-function",
         "lower-mitigation",
         "lower-gradients",

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -142,7 +142,7 @@ HLO_LOWERING_PASS = (
 QUANTUM_COMPILATION_PASS = (
     "QuantumCompilationPass",
     [
-        # TODO: Pass here that will transform
+        "specialize-active-callback-pass",
         "annotate-function",
         "lower-mitigation",
         "lower-gradients",

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -41,7 +41,7 @@ from jaxlib.mlir.dialects.func import CallOp
 from jaxlib.mlir.dialects.scf import ConditionOp, ForOp, IfOp, WhileOp, YieldOp
 from jaxlib.mlir.dialects.stablehlo import ConstantOp as StableHLOConstantOp
 from jaxlib.mlir.dialects.stablehlo import ConvertOp as StableHLOConvertOp
-from mlir_quantum.dialects.catalyst import InactiveCallbackOp, PrintOp
+from mlir_quantum.dialects.catalyst import ActiveCallbackOp, InactiveCallbackOp, PrintOp
 from mlir_quantum.dialects.gradient import GradOp, JVPOp, VJPOp
 from mlir_quantum.dialects.mitigation import ZneOp
 from mlir_quantum.dialects.quantum import (
@@ -253,7 +253,9 @@ def _python_callback_lowering(jax_ctx: mlir.LoweringRuleContext, *args, callback
     identifier = ir.IntegerAttr.get(i64_type, callback_id)
 
     mlir_ty = list(convert_shaped_arrays_to_tensors(results_aval))
-    return InactiveCallbackOp(mlir_ty, args, identifier, number_original_arg=len(args)).results
+    if not mlir_ty:
+        return InactiveCallbackOp(mlir_ty, args, identifier, number_original_arg=len(args)).results
+    return ActiveCallbackOp(mlir_ty, args, identifier, number_original_arg=len(args)).results
 
 
 #

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -254,7 +254,7 @@ def _python_callback_lowering(jax_ctx: mlir.LoweringRuleContext, *args, callback
 
     mlir_ty = list(convert_shaped_arrays_to_tensors(results_aval))
     if not mlir_ty:
-        return InactiveCallbackOp(mlir_ty, args, identifier, number_original_arg=len(args)).results
+        return InactiveCallbackOp([], args, identifier, number_original_arg=len(args)).results
     return ActiveCallbackOp(mlir_ty, args, identifier, number_original_arg=len(args)).results
 
 

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -41,7 +41,7 @@ from jaxlib.mlir.dialects.func import CallOp
 from jaxlib.mlir.dialects.scf import ConditionOp, ForOp, IfOp, WhileOp, YieldOp
 from jaxlib.mlir.dialects.stablehlo import ConstantOp as StableHLOConstantOp
 from jaxlib.mlir.dialects.stablehlo import ConvertOp as StableHLOConvertOp
-from mlir_quantum.dialects.catalyst import PrintOp, PythonCallOp
+from mlir_quantum.dialects.catalyst import PrintOp, InactiveCallbackOp
 from mlir_quantum.dialects.gradient import GradOp, JVPOp, VJPOp
 from mlir_quantum.dialects.mitigation import ZneOp
 from mlir_quantum.dialects.quantum import (
@@ -253,7 +253,7 @@ def _python_callback_lowering(jax_ctx: mlir.LoweringRuleContext, *args, callback
     identifier = ir.IntegerAttr.get(i64_type, callback_id)
 
     mlir_ty = list(convert_shaped_arrays_to_tensors(results_aval))
-    return PythonCallOp(mlir_ty, args, identifier, number_original_arg=len(args)).results
+    return InactiveCallbackOp(mlir_ty, args, identifier, number_original_arg=len(args)).results
 
 
 #

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -41,7 +41,7 @@ from jaxlib.mlir.dialects.func import CallOp
 from jaxlib.mlir.dialects.scf import ConditionOp, ForOp, IfOp, WhileOp, YieldOp
 from jaxlib.mlir.dialects.stablehlo import ConstantOp as StableHLOConstantOp
 from jaxlib.mlir.dialects.stablehlo import ConvertOp as StableHLOConvertOp
-from mlir_quantum.dialects.catalyst import PrintOp, InactiveCallbackOp
+from mlir_quantum.dialects.catalyst import InactiveCallbackOp, PrintOp
 from mlir_quantum.dialects.gradient import GradOp, JVPOp, VJPOp
 from mlir_quantum.dialects.mitigation import ZneOp
 from mlir_quantum.dialects.quantum import (

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -252,9 +252,9 @@ def _python_callback_lowering(jax_ctx: mlir.LoweringRuleContext, *args, callback
     i64_type = ir.IntegerType.get_signless(64, ctx)
     identifier = ir.IntegerAttr.get(i64_type, callback_id)
 
+    if not results_aval:
+        return InactiveCallbackOp(args, identifier, number_original_arg=len(args)).results
     mlir_ty = list(convert_shaped_arrays_to_tensors(results_aval))
-    if not mlir_ty:
-        return InactiveCallbackOp([], args, identifier, number_original_arg=len(args)).results
     return ActiveCallbackOp(mlir_ty, args, identifier, number_original_arg=len(args)).results
 
 

--- a/mlir/include/Catalyst/IR/CatalystOps.td
+++ b/mlir/include/Catalyst/IR/CatalystOps.td
@@ -153,27 +153,14 @@ def ActiveCallbackOp: Catalyst_Op<"activeCallbackCall",
   let arguments = (ins
         Variadic<AnyTypeOf<[AnyRankedTensor, MemRefOf<[AnyType]>]>>:$inputs,
         I64Attr: $identifier,
-        OptionalAttr<I64Attr>: $number_original_arg
+        OptionalAttr<I64Attr>: $number_original_arg,
+        OptionalAttr<FlatSymbolRefAttr>: $specialized
   );
 
   let results = (outs Variadic<AnyType>);
 
-  let builders = [
-        OpBuilder<(ins "mlir::TypeRange":$resultTypes, "llvm::SmallVector<mlir::Value>":$inputs, "int64_t":$identifier), [{
-            auto id = $_builder.getI64IntegerAttr(identifier);
-            auto argc = $_builder.getI64IntegerAttr(inputs.size());
-            return build($_builder, $_state, resultTypes, inputs, id, argc);
-        }]>,
-
-        OpBuilder<(ins "mlir::TypeRange":$resultTypes, "llvm::SmallVector<mlir::Value>":$inputs, "int64_t":$identifier, "int64_t": $size), [{
-            auto id = $_builder.getI64IntegerAttr(identifier);
-            auto argc = $_builder.getI64IntegerAttr(size);
-            return build($_builder, $_state, resultTypes, inputs, id, argc);
-        }]>
-    ];
-
   let assemblyFormat = [{
-    `(` $inputs `)` attr-dict `:` functional-type(operands, results)
+    `(` $inputs `)` (`as` $specialized^ )? attr-dict `:` functional-type(operands, results)
   }];
 }
 

--- a/mlir/include/Catalyst/IR/CatalystOps.td
+++ b/mlir/include/Catalyst/IR/CatalystOps.td
@@ -105,12 +105,10 @@ def CustomCallOp: Catalyst_Op<"custom_call",
 
 def InactiveCallbackOp: Catalyst_Op<"inactiveCallbackCall",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
-  let summary = "CustomCall specialized for python callbacks.";
+  let summary = "Operation denoting a `debug.callback` call in the user program.";
 
   let description = [{
-    A custom call invokes code external to Catalyst. The `inputs` are passed to the
-    external code, and the external code is expected to produce a result of the
-    given type.
+        This operation is lowered to `inactive_callback` defined in the Catalyst runtime.
   }];
 
   let arguments = (ins
@@ -140,12 +138,22 @@ def InactiveCallbackOp: Catalyst_Op<"inactiveCallbackCall",
 
 def ActiveCallbackOp: Catalyst_Op<"activeCallbackCall",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
-  let summary = "CustomCall specialized for python callbacks.";
+  let summary = "Operation denoting a `pure_callback` call in the user program.";
 
   let description = [{
-    A custom call invokes code external to Catalyst. The `inputs` are passed to the
-    external code, and the external code is expected to produce a result of the
-    given type.
+        This operation is lowered to a compile time generated function that looks like the following:
+
+        ```mlir
+        func.func @active_callback_0xdeadbeef(%arg0: !llvm.ptr, ..., %argN: !llvm.ptr,
+                                                 %res0: !llvm.ptr, ..., %resM: !llvm.ptr)
+        {
+            %id = llvm.mlir.constant(0xdeadbeef : i64)
+            %argc = llvm.mlir.constant(N: i64)
+            %retc = llvm.mlir.constant(M: i64)
+            llvm.call @inactive_callback(%id, %argc, %retc, %arg0, ..., %argN, %res0, ..., %resM)
+            return
+        }
+        ```
   }];
 
   let arguments = (ins

--- a/mlir/include/Catalyst/IR/CatalystOps.td
+++ b/mlir/include/Catalyst/IR/CatalystOps.td
@@ -140,4 +140,41 @@ def InactiveCallbackOp: Catalyst_Op<"inactiveCallbackCall",
   }];
 }
 
+def ActiveCallbackOp: Catalyst_Op<"activeCallbackCall",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
+  let summary = "CustomCall specialized for python callbacks.";
+
+  let description = [{
+    A custom call invokes code external to Catalyst. The `inputs` are passed to the
+    external code, and the external code is expected to produce a result of the
+    given type.
+  }];
+
+  let arguments = (ins
+        Variadic<AnyTypeOf<[AnyRankedTensor, MemRefOf<[AnyType]>]>>:$inputs,
+        I64Attr: $identifier,
+        OptionalAttr<I64Attr>: $number_original_arg
+  );
+
+  let results = (outs Variadic<AnyType>);
+
+  let builders = [
+        OpBuilder<(ins "mlir::TypeRange":$resultTypes, "llvm::SmallVector<mlir::Value>":$inputs, "int64_t":$identifier), [{
+            auto id = $_builder.getI64IntegerAttr(identifier);
+            auto argc = $_builder.getI64IntegerAttr(inputs.size());
+            return build($_builder, $_state, resultTypes, inputs, id, argc);
+        }]>,
+
+        OpBuilder<(ins "mlir::TypeRange":$resultTypes, "llvm::SmallVector<mlir::Value>":$inputs, "int64_t":$identifier, "int64_t": $size), [{
+            auto id = $_builder.getI64IntegerAttr(identifier);
+            auto argc = $_builder.getI64IntegerAttr(size);
+            return build($_builder, $_state, resultTypes, inputs, id, argc);
+        }]>
+    ];
+
+  let assemblyFormat = [{
+    `(` $inputs `)` attr-dict `:` functional-type(operands, results)
+  }];
+}
+
 #endif // GRADIENT_OPS

--- a/mlir/include/Catalyst/IR/CatalystOps.td
+++ b/mlir/include/Catalyst/IR/CatalystOps.td
@@ -103,7 +103,7 @@ def CustomCallOp: Catalyst_Op<"custom_call",
   }];
 }
 
-def PythonCallOp: Catalyst_Op<"pycallback",
+def InactiveCallbackOp: Catalyst_Op<"inactiveCallbackCall",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let summary = "CustomCall specialized for python callbacks.";
 

--- a/mlir/include/Catalyst/IR/CatalystOps.td
+++ b/mlir/include/Catalyst/IR/CatalystOps.td
@@ -119,19 +119,17 @@ def InactiveCallbackOp: Catalyst_Op<"inactiveCallbackCall",
         OptionalAttr<I64Attr>: $number_original_arg
   );
 
-  let results = (outs Variadic<AnyType>);
-
   let builders = [
-        OpBuilder<(ins "mlir::TypeRange":$resultTypes, "llvm::SmallVector<mlir::Value>":$inputs, "int64_t":$identifier), [{
+        OpBuilder<(ins "llvm::SmallVector<mlir::Value>":$inputs, "int64_t":$identifier), [{
             auto id = $_builder.getI64IntegerAttr(identifier);
             auto argc = $_builder.getI64IntegerAttr(inputs.size());
-            return build($_builder, $_state, resultTypes, inputs, id, argc);
+            return build($_builder, $_state, inputs, id, argc);
         }]>,
 
-        OpBuilder<(ins "mlir::TypeRange":$resultTypes, "llvm::SmallVector<mlir::Value>":$inputs, "int64_t":$identifier, "int64_t": $size), [{
+        OpBuilder<(ins "llvm::SmallVector<mlir::Value>":$inputs, "int64_t":$identifier, "int64_t": $size), [{
             auto id = $_builder.getI64IntegerAttr(identifier);
             auto argc = $_builder.getI64IntegerAttr(size);
-            return build($_builder, $_state, resultTypes, inputs, id, argc);
+            return build($_builder, $_state, inputs, id, argc);
         }]>
     ];
 

--- a/mlir/include/Catalyst/Transforms/Passes.h
+++ b/mlir/include/Catalyst/Transforms/Passes.h
@@ -29,6 +29,7 @@ std::unique_ptr<mlir::Pass> createQnodeToAsyncLoweringPass();
 std::unique_ptr<mlir::Pass> createAddExceptionHandlingPass();
 std::unique_ptr<mlir::Pass> createGEPInboundsPass();
 std::unique_ptr<mlir::Pass> createRegisterInactiveCallbackPass();
+std::unique_ptr<mlir::Pass> createSpecializeActiveCallbackPass();
 
 void registerAllCatalystPasses();
 

--- a/mlir/include/Catalyst/Transforms/Passes.td
+++ b/mlir/include/Catalyst/Transforms/Passes.td
@@ -150,7 +150,7 @@ def SpecializeActiveCallbackPass : Pass<"specialize-active-callback-pass", "Modu
            2.1 If the activeCallbackOp has been specialized: then continue.
            2.2 If the activeCallbackOp has not been specialized:
                2.2.1 Create a function activeCallbackOp${ID} where the first three parameters are literals.
-               2.2.2 Annotate the activeCallbackOp with a FlatSymbolRefAttr to the activeCallbackOp${ID}
+           2.3 Annotate the activeCallbackOp with a FlatSymbolRefAttr to the activeCallbackOp${ID}
     }];
 
     let dependentDialects = [

--- a/mlir/include/Catalyst/Transforms/Passes.td
+++ b/mlir/include/Catalyst/Transforms/Passes.td
@@ -50,6 +50,7 @@ def CatalystConversionPass : Pass<"convert-catalyst-to-llvm"> {
     let summary = "Lower catalyst utility operations to the LLVM dialect.";
 
     let dependentDialects = [
+        "mlir::func::FuncDialect",
         "mlir::LLVM::LLVMDialect",
     ];
 

--- a/mlir/include/Catalyst/Transforms/Passes.td
+++ b/mlir/include/Catalyst/Transforms/Passes.td
@@ -154,7 +154,8 @@ def SpecializeActiveCallbackPass : Pass<"specialize-active-callback-pass", "Modu
 
     let dependentDialects = [
         "catalyst::CatalystDialect",
-        "mlir::LLVM::LLVMDialect"
+        "mlir::func::FuncDialect",
+        "LLVM::LLVMDialect"
     ];
 
     let constructor = "catalyst::createSpecializeActiveCallbackPass()";

--- a/mlir/include/Catalyst/Transforms/Passes.td
+++ b/mlir/include/Catalyst/Transforms/Passes.td
@@ -138,7 +138,26 @@ def RegisterInactiveCallbackPass : Pass<"register-inactive-callback", "ModuleOp"
     ];
 
     let constructor = "catalyst::createRegisterInactiveCallbackPass()";
+}
 
+def SpecializeActiveCallbackPass : Pass<"specialize-active-callback-pass", "ModuleOp"> {
+    let summary = "Specializes active callbacks to their own function.";
+
+    let description = [{
+        1. The outermost module is walked.
+        2. For each activeCallbackOp
+           2.1 If the activeCallbackOp has been specialized: then continue.
+           2.2 If the activeCallbackOp has not been specialized:
+               2.2.1 Create a function activeCallbackOp${ID} where the first three parameters are literals.
+               2.2.2 Annotate the activeCallbackOp with a FlatSymbolRefAttr to the activeCallbackOp${ID}
+    }];
+
+    let dependentDialects = [
+        "catalyst::CatalystDialect",
+        "mlir::LLVM::LLVMDialect"
+    ];
+
+    let constructor = "catalyst::createSpecializeActiveCallbackPass()";
 }
 
 #endif // CATALYST_PASSES

--- a/mlir/lib/Catalyst/IR/CatalystOps.cpp
+++ b/mlir/lib/Catalyst/IR/CatalystOps.cpp
@@ -36,7 +36,7 @@ void CustomCallOp::getEffects(
     effects.emplace_back(mlir::MemoryEffects::Read::get());
 }
 
-void PythonCallOp::getEffects(
+void InactiveCallbackOp::getEffects(
     llvm::SmallVectorImpl<mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>> &effects)
 {
     // Assume all effects

--- a/mlir/lib/Catalyst/IR/CatalystOps.cpp
+++ b/mlir/lib/Catalyst/IR/CatalystOps.cpp
@@ -45,3 +45,13 @@ void InactiveCallbackOp::getEffects(
     effects.emplace_back(mlir::MemoryEffects::Write::get());
     effects.emplace_back(mlir::MemoryEffects::Read::get());
 }
+
+void ActiveCallbackOp::getEffects(
+    llvm::SmallVectorImpl<mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>> &effects)
+{
+    // Assume all effects
+    effects.emplace_back(mlir::MemoryEffects::Allocate::get());
+    effects.emplace_back(mlir::MemoryEffects::Free::get());
+    effects.emplace_back(mlir::MemoryEffects::Write::get());
+    effects.emplace_back(mlir::MemoryEffects::Read::get());
+}

--- a/mlir/lib/Catalyst/Transforms/BufferizationPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/BufferizationPatterns.cpp
@@ -82,10 +82,10 @@ struct BufferizeCustomCallOp : public OpConversionPattern<CustomCallOp> {
     }
 };
 
-struct BufferizePythonCallOp : public OpConversionPattern<PythonCallOp> {
+struct BufferizeInactiveCallbackOp : public OpConversionPattern<InactiveCallbackOp> {
     using OpConversionPattern::OpConversionPattern;
 
-    LogicalResult matchAndRewrite(PythonCallOp op, OpAdaptor adaptor,
+    LogicalResult matchAndRewrite(InactiveCallbackOp op, OpAdaptor adaptor,
                                   ConversionPatternRewriter &rewriter) const override
     {
         // Add bufferized arguments
@@ -110,7 +110,7 @@ struct BufferizePythonCallOp : public OpConversionPattern<PythonCallOp> {
             bufferArgs.push_back(newBuffer);
         }
 
-        rewriter.create<PythonCallOp>(op.getLoc(), TypeRange{}, bufferArgs, adaptor.getIdentifier(),
+        rewriter.create<InactiveCallbackOp>(op.getLoc(), TypeRange{}, bufferArgs, adaptor.getIdentifier(),
                                       op.getOperands().size());
         size_t startIndex = bufferArgs.size() - op.getNumResults();
         SmallVector<Value> bufferResults(bufferArgs.begin() + startIndex, bufferArgs.end());
@@ -126,7 +126,7 @@ namespace catalyst {
 void populateBufferizationPatterns(TypeConverter &typeConverter, RewritePatternSet &patterns)
 {
     patterns.add<BufferizeCustomCallOp>(typeConverter, patterns.getContext());
-    patterns.add<BufferizePythonCallOp>(typeConverter, patterns.getContext());
+    patterns.add<BufferizeInactiveCallbackOp>(typeConverter, patterns.getContext());
     patterns.add<BufferizePrintOp>(typeConverter, patterns.getContext());
 }
 

--- a/mlir/lib/Catalyst/Transforms/BufferizationPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/BufferizationPatterns.cpp
@@ -147,8 +147,10 @@ struct BufferizeActiveCallbackOp : public OpConversionPattern<ActiveCallbackOp> 
             bufferArgs.push_back(newBuffer);
         }
 
+        auto originalArgsSize = rewriter.getI64IntegerAttr(op.getOperands().size());
         rewriter.create<ActiveCallbackOp>(op.getLoc(), TypeRange{}, bufferArgs,
-                                          adaptor.getIdentifier(), op.getOperands().size());
+                                          adaptor.getIdentifier(), originalArgsSize,
+                                          adaptor.getSpecializedAttr());
         size_t startIndex = bufferArgs.size() - op.getNumResults();
         SmallVector<Value> bufferResults(bufferArgs.begin() + startIndex, bufferArgs.end());
         rewriter.replaceOp(op, bufferResults);

--- a/mlir/lib/Catalyst/Transforms/CMakeLists.txt
+++ b/mlir/lib/Catalyst/Transforms/CMakeLists.txt
@@ -17,6 +17,7 @@ file(GLOB SRC
     GEPInboundsPatterns.cpp
     GEPInboundsPass.cpp
     RegisterInactiveCallbackPass.cpp
+    SpecializeActiveCallbackPass.cpp
 )
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)

--- a/mlir/lib/Catalyst/Transforms/RegisterAllPasses.cpp
+++ b/mlir/lib/Catalyst/Transforms/RegisterAllPasses.cpp
@@ -41,4 +41,5 @@ void catalyst::registerAllCatalystPasses()
     mlir::registerPass(catalyst::createRemoveChainedSelfInversePass);
     mlir::registerPass(catalyst::createAnnotateFunctionPass);
     mlir::registerPass(catalyst::createRegisterInactiveCallbackPass);
+    mlir::registerPass(catalyst::createSpecializeActiveCallbackPass);
 }

--- a/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
+++ b/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
@@ -141,9 +141,13 @@ struct SpecializeActiveCallbackPass
         auto ctx = &getContext();
         RewritePatternSet patterns(ctx);
         patterns.add<AddDeclarationToModulePattern>(ctx);
-        if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+        GreedyRewriteConfig config;
+        config.strictMode = GreedyRewriteStrictness::ExistingOps;
+        auto moduleOp = getOperation();
+        if (failed(applyPatternsAndFoldGreedily(moduleOp, std::move(patterns), config))) {
             signalPassFailure();
         }
+
     }
 };
 

--- a/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
+++ b/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
@@ -30,14 +30,19 @@ struct AddDeclarationToModulePattern : public OpRewritePattern<catalyst::ActiveC
     void rewrite(catalyst::ActiveCallbackOp op, PatternRewriter &rewriter) const override;
 };
 
-LogicalResult AddDeclarationToModulePattern::match(catalyst::ActiveCallbackOp) const
+LogicalResult AddDeclarationToModulePattern::match(catalyst::ActiveCallbackOp op) const
 {
-    return failure();
+    return op.getSpecialized() ? failure() : success();
 }
 
-void AddDeclarationToModulePattern::rewrite(catalyst::ActiveCallbackOp,
+void AddDeclarationToModulePattern::rewrite(catalyst::ActiveCallbackOp op,
                                             PatternRewriter &rewriter) const
 {
+    rewriter.updateRootInPlace(op, [&] {
+        auto specializedFakeName = rewriter.getStringAttr("hello");
+        auto specializedFake = FlatSymbolRefAttr::get(specializedFakeName);
+        op.setSpecializedAttr(specializedFake);
+    });
     return;
 }
 

--- a/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
+++ b/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
@@ -21,6 +21,28 @@
 
 using namespace mlir;
 
+namespace {
+
+struct AddDeclarationToModulePattern : public OpRewritePattern<catalyst::ActiveCallbackOp> {
+    using OpRewritePattern<catalyst::ActiveCallbackOp>::OpRewritePattern;
+
+    LogicalResult match(catalyst::ActiveCallbackOp op) const override;
+    void rewrite(catalyst::ActiveCallbackOp op, PatternRewriter &rewriter) const override;
+};
+
+LogicalResult AddDeclarationToModulePattern::match(catalyst::ActiveCallbackOp) const
+{
+    return failure();
+}
+
+void AddDeclarationToModulePattern::rewrite(catalyst::ActiveCallbackOp,
+                                            PatternRewriter &rewriter) const
+{
+    return;
+}
+
+} // namespace
+
 namespace catalyst {
 
 #define GEN_PASS_DEF_SPECIALIZEACTIVECALLBACKPASS
@@ -30,7 +52,15 @@ namespace catalyst {
 struct SpecializeActiveCallbackPass
     : impl::SpecializeActiveCallbackPassBase<SpecializeActiveCallbackPass> {
     using SpecializeActiveCallbackPassBase::SpecializeActiveCallbackPassBase;
-    void runOnOperation() final {}
+    void runOnOperation() final
+    {
+        auto ctx = &getContext();
+        RewritePatternSet patterns(ctx);
+        patterns.add<AddDeclarationToModulePattern>(ctx);
+        if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+            signalPassFailure();
+        }
+    }
 };
 
 std::unique_ptr<Pass> createSpecializeActiveCallbackPass()

--- a/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
+++ b/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/FunctionCallUtils.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #include "Catalyst/IR/CatalystOps.h"
@@ -30,6 +32,70 @@ std::string getSpecializedName(ActiveCallbackOp op)
     return "active_callback_" + id;
 }
 
+LLVM::LLVMFuncOp lookupOrDeclareInactiveCallback(ActiveCallbackOp op, PatternRewriter &rewriter)
+{
+    std::string name = "inactive_callback";
+    auto moduleOp = op->getParentOfType<ModuleOp>();
+    auto maybeFuncOp = moduleOp.lookupSymbol<LLVM::LLVMFuncOp>(name);
+    if (maybeFuncOp) {
+        return maybeFuncOp;
+    }
+
+    auto ctx = rewriter.getContext();
+    Type i64 = rewriter.getI64Type();
+
+    auto point = rewriter.saveInsertionPoint();
+    rewriter.setInsertionPointToStart(moduleOp.getBody());
+    bool isVarArg = true;
+    Type voidType = LLVM::LLVMVoidType::get(ctx);
+    LLVM::LLVMFuncOp inactiveCallback = mlir::LLVM::lookupOrCreateFn(
+        moduleOp, name, {/*args=*/i64, i64, i64}, /*ret_type=*/voidType, isVarArg);
+    // inactiveCallback.setPrivate();
+    rewriter.restoreInsertionPoint(point);
+    return inactiveCallback;
+}
+
+func::FuncOp lookupOrCreateSpecialized(ActiveCallbackOp op, PatternRewriter &rewriter)
+{
+    auto name = getSpecializedName(op);
+    auto moduleOp = op->getParentOfType<ModuleOp>();
+    auto maybeFuncOp = moduleOp.lookupSymbol<func::FuncOp>(name);
+    if (maybeFuncOp) {
+        return maybeFuncOp;
+    }
+
+    Type i64 = rewriter.getI64Type();
+    auto ctx = rewriter.getContext();
+    SmallVector<Type> inputs = {i64, i64, i64};
+    for (auto input : op.getInputs()) {
+        inputs.push_back(input.getType());
+    }
+
+    auto funcTy = FunctionType::get(ctx, inputs, {});
+    auto loc = op.getLoc();
+    func::FuncOp funcSpecialized = nullptr;
+
+    {
+        OpBuilder::InsertionGuard guard(rewriter);
+        rewriter.setInsertionPointToStart(moduleOp.getBody());
+        funcSpecialized = rewriter.create<func::FuncOp>(loc, name, funcTy);
+    }
+
+    Block *entryBlock = funcSpecialized.addEntryBlock();
+    rewriter.setInsertionPointToStart(entryBlock);
+
+    SmallVector<Value> args;
+    for (auto arg : entryBlock->getArguments()) {
+        args.push_back(arg);
+    }
+
+    auto inactive = lookupOrDeclareInactiveCallback(op, rewriter);
+    rewriter.create<LLVM::CallOp>(loc, inactive, args);
+    rewriter.create<func::ReturnOp>(loc);
+
+    return funcSpecialized;
+}
+
 struct AddDeclarationToModulePattern : public OpRewritePattern<ActiveCallbackOp> {
     using OpRewritePattern<ActiveCallbackOp>::OpRewritePattern;
 
@@ -44,6 +110,7 @@ LogicalResult AddDeclarationToModulePattern::match(ActiveCallbackOp op) const
 
 void AddDeclarationToModulePattern::rewrite(ActiveCallbackOp op, PatternRewriter &rewriter) const
 {
+    lookupOrCreateSpecialized(op, rewriter);
     auto specializedName = getSpecializedName(op);
     auto specializedNameAttr = rewriter.getStringAttr(specializedName);
     rewriter.updateRootInPlace(op, [&] {

--- a/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
+++ b/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/FunctionCallUtils.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"

--- a/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
+++ b/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
@@ -1,0 +1,40 @@
+// Copyright 2024 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "Catalyst/IR/CatalystOps.h"
+#include "Catalyst/Transforms/Passes.h"
+#include "Catalyst/Transforms/Patterns.h"
+
+using namespace mlir;
+
+namespace catalyst {
+
+#define GEN_PASS_DEF_SPECIALIZEACTIVECALLBACKPASS
+#define GEN_PASS_DECL_SPECIALIZEACTIVECALLBACKPASS
+#include "Catalyst/Transforms/Passes.h.inc"
+
+struct SpecializeActiveCallbackPass
+    : impl::SpecializeActiveCallbackPassBase<SpecializeActiveCallbackPass> {
+    using SpecializeActiveCallbackPassBase::SpecializeActiveCallbackPassBase;
+    void runOnOperation() final {}
+};
+
+std::unique_ptr<Pass> createSpecializeActiveCallbackPass()
+{
+    return std::make_unique<SpecializeActiveCallbackPass>();
+}
+} // namespace catalyst

--- a/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
+++ b/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
@@ -41,9 +41,9 @@ LLVM::LLVMFuncOp lookupOrDeclareInactiveCallback(ActiveCallbackOp &op, PatternRe
 
     bool isVarArg = true;
     Type retTy = LLVM::LLVMVoidType::get(ctx);
-    SmallVector<Type> paramTys = { i64, i64, i64 };
-    LLVM::LLVMFuncOp inactiveCallback = mlir::LLVM::lookupOrCreateFn(
-        moduleOp, name, paramTys, retTy, isVarArg);
+    SmallVector<Type> paramTys = {i64, i64, i64};
+    LLVM::LLVMFuncOp inactiveCallback =
+        mlir::LLVM::lookupOrCreateFn(moduleOp, name, paramTys, retTy, isVarArg);
     return inactiveCallback;
 }
 
@@ -63,9 +63,10 @@ func::FuncOp lookupOrCreateSpecialized(ActiveCallbackOp &op, PatternRewriter &re
         inputs.push_back(ptrTy);
     }
 
-    auto funcOp = SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(op, rewriter.getStringAttr(name));
+    auto funcOp =
+        SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(op, rewriter.getStringAttr(name));
     if (funcOp) {
-       return funcOp;
+        return funcOp;
     }
 
     PatternRewriter::InsertionGuard insertGuard(rewriter);
@@ -147,7 +148,6 @@ struct SpecializeActiveCallbackPass
         if (failed(applyPatternsAndFoldGreedily(moduleOp, std::move(patterns), config))) {
             signalPassFailure();
         }
-
     }
 };
 

--- a/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
+++ b/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #include "Catalyst/IR/CatalystOps.h"

--- a/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
+++ b/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
@@ -32,7 +32,7 @@ std::string getSpecializedName(ActiveCallbackOp op)
     return "active_callback_" + id;
 }
 
-LLVM::LLVMFuncOp lookupOrDeclareInactiveCallback(ActiveCallbackOp op, PatternRewriter &rewriter)
+LLVM::LLVMFuncOp lookupOrDeclareInactiveCallback(ActiveCallbackOp &op, PatternRewriter &rewriter)
 {
     std::string name = "inactive_callback";
     auto moduleOp = op->getParentOfType<ModuleOp>();
@@ -46,7 +46,7 @@ LLVM::LLVMFuncOp lookupOrDeclareInactiveCallback(ActiveCallbackOp op, PatternRew
     return inactiveCallback;
 }
 
-LLVM::LLVMFuncOp lookupOrCreateSpecialized(ActiveCallbackOp op, PatternRewriter &rewriter)
+LLVM::LLVMFuncOp lookupOrCreateSpecialized(ActiveCallbackOp &op, PatternRewriter &rewriter)
 {
     auto name = getSpecializedName(op);
     auto moduleOp = op->getParentOfType<ModuleOp>();

--- a/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
+++ b/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
@@ -40,9 +40,10 @@ LLVM::LLVMFuncOp lookupOrDeclareInactiveCallback(ActiveCallbackOp &op, PatternRe
     Type i64 = rewriter.getI64Type();
 
     bool isVarArg = true;
-    Type voidType = LLVM::LLVMVoidType::get(ctx);
+    Type retTy = LLVM::LLVMVoidType::get(ctx);
+    SmallVector<Type> paramTys = { i64, i64, i64 };
     LLVM::LLVMFuncOp inactiveCallback = mlir::LLVM::lookupOrCreateFn(
-        moduleOp, name, {/*args=*/i64, i64, i64}, /*ret_type=*/voidType, isVarArg);
+        moduleOp, name, paramTys, retTy, isVarArg);
     return inactiveCallback;
 }
 

--- a/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
+++ b/mlir/lib/Catalyst/Transforms/SpecializeActiveCallbackPass.cpp
@@ -37,11 +37,6 @@ LLVM::LLVMFuncOp lookupOrDeclareInactiveCallback(ActiveCallbackOp op, PatternRew
 {
     std::string name = "inactive_callback";
     auto moduleOp = op->getParentOfType<ModuleOp>();
-    auto maybeFuncOp = moduleOp.lookupSymbol<LLVM::LLVMFuncOp>(name);
-    if (maybeFuncOp) {
-        return maybeFuncOp;
-    }
-
     auto ctx = rewriter.getContext();
     Type i64 = rewriter.getI64Type();
 

--- a/mlir/lib/Catalyst/Transforms/catalyst_bufferize.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_bufferize.cpp
@@ -52,6 +52,8 @@ struct CatalystBufferizationPass : impl::CatalystBufferizationPassBase<CatalystB
             [&](CustomCallOp op) { return typeConverter.isLegal(op); });
         target.addDynamicallyLegalOp<InactiveCallbackOp>(
             [&](InactiveCallbackOp op) { return typeConverter.isLegal(op); });
+        target.addDynamicallyLegalOp<ActiveCallbackOp>(
+            [&](ActiveCallbackOp op) { return typeConverter.isLegal(op); });
 
         if (failed(applyPartialConversion(getOperation(), target, std::move(patterns)))) {
             signalPassFailure();

--- a/mlir/lib/Catalyst/Transforms/catalyst_bufferize.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_bufferize.cpp
@@ -50,8 +50,8 @@ struct CatalystBufferizationPass : impl::CatalystBufferizationPassBase<CatalystB
             [&](PrintOp op) { return typeConverter.isLegal(op); });
         target.addDynamicallyLegalOp<CustomCallOp>(
             [&](CustomCallOp op) { return typeConverter.isLegal(op); });
-        target.addDynamicallyLegalOp<PythonCallOp>(
-            [&](PythonCallOp op) { return typeConverter.isLegal(op); });
+        target.addDynamicallyLegalOp<InactiveCallbackOp>(
+            [&](InactiveCallbackOp op) { return typeConverter.isLegal(op); });
 
         if (failed(applyPartialConversion(getOperation(), target, std::move(patterns)))) {
             signalPassFailure();

--- a/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
@@ -493,7 +493,8 @@ struct ActiveCallbackOpPattern : public OpConversionPattern<ActiveCallbackOp> {
         auto specializedAttr = op.getSpecializedAttr();
         auto specialized = mod.lookupSymbol<LLVM::LLVMFuncOp>(specializedAttr);
         if (!specialized) {
-            op.emitError() << "No specialized";
+            op.emitError() << "No specialized attribute was found.";
+            return failure();
         }
 
         // The argument convention is as follows:

--- a/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
@@ -438,9 +438,8 @@ struct InactiveCallbackOpPattern : public OpConversionPattern<InactiveCallbackOp
         // The argument convention is as follows:
         // arg0 =        identifier
         // arg1 =        length of operands
-        // arg2 =        length of results
+        // arg2 =        length of results (always 0)
         // arg3..N+3     varargs pointers to memrefs
-        // argN+4..N+M+4 varargs pointers to result memrefs
 
         bool isVarArg = true;
         LLVM::LLVMFuncOp customCallFnOp = mlir::LLVM::lookupOrCreateFn(

--- a/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
@@ -489,9 +489,8 @@ struct ActiveCallbackOpPattern : public OpConversionPattern<ActiveCallbackOp> {
         Location loc = op.getLoc();
 
         // Create function
-        Type voidType = LLVM::LLVMVoidType::get(ctx);
         ModuleOp mod = op->getParentOfType<ModuleOp>();
-        auto specializedAttr = adaptor.getSpecializedAttr();
+        auto specializedAttr = op.getSpecializedAttr();
         auto specialized = mod.lookupSymbol<LLVM::LLVMFuncOp>(specializedAttr);
         if (!specialized) {
             op.emitError() << "No specialized";
@@ -516,8 +515,6 @@ struct ActiveCallbackOpPattern : public OpConversionPattern<ActiveCallbackOp> {
         // }
         // where the first parameter is N
         // and the second parameter is M.
-
-        bool isVarArg = true;
 
         SmallVector<Value> callArgs;
 

--- a/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
@@ -419,10 +419,10 @@ struct CustomCallOpPattern : public OpConversionPattern<CustomCallOp> {
     }
 };
 
-struct PythonCallOpPattern : public OpConversionPattern<PythonCallOp> {
+struct InactiveCallbackOpPattern : public OpConversionPattern<InactiveCallbackOp> {
     using OpConversionPattern::OpConversionPattern;
 
-    LogicalResult matchAndRewrite(PythonCallOp op, PythonCallOpAdaptor adaptor,
+    LogicalResult matchAndRewrite(InactiveCallbackOp op, InactiveCallbackOpAdaptor adaptor,
                                   ConversionPatternRewriter &rewriter) const override
     {
         MLIRContext *ctx = op.getContext();
@@ -496,7 +496,7 @@ struct CatalystConversionPass : impl::CatalystConversionPassBase<CatalystConvers
 
         RewritePatternSet patterns(context);
         patterns.add<CustomCallOpPattern>(typeConverter, context);
-        patterns.add<PythonCallOpPattern>(typeConverter, context);
+        patterns.add<InactiveCallbackOpPattern>(typeConverter, context);
         patterns.add<PrintOpPattern>(typeConverter, context);
 
         LLVMConversionTarget target(*context);

--- a/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
@@ -491,7 +491,7 @@ struct ActiveCallbackOpPattern : public OpConversionPattern<ActiveCallbackOp> {
         // Create function
         ModuleOp mod = op->getParentOfType<ModuleOp>();
         auto specializedAttr = op.getSpecializedAttr();
-        auto specialized = mod.lookupSymbol<LLVM::LLVMFuncOp>(specializedAttr);
+        auto specialized = mod.lookupSymbol<func::FuncOp>(specializedAttr);
         if (!specialized) {
             op.emitError() << "No specialized attribute was found.";
             return failure();
@@ -529,7 +529,7 @@ struct ActiveCallbackOpPattern : public OpConversionPattern<ActiveCallbackOp> {
             // add the ptr to the arguments
             callArgs.push_back(ptr);
         }
-        rewriter.create<LLVM::CallOp>(loc, specialized, callArgs);
+        rewriter.create<func::CallOp>(loc, specialized, callArgs);
         rewriter.eraseOp(op);
         return success();
     }
@@ -557,6 +557,7 @@ struct CatalystConversionPass : impl::CatalystConversionPassBase<CatalystConvers
         patterns.add<PrintOpPattern>(typeConverter, context);
 
         LLVMConversionTarget target(*context);
+        target.addLegalDialect<func::FuncDialect>();
         target.addIllegalDialect<CatalystDialect>();
 
         if (failed(applyPartialConversion(getOperation(), target, std::move(patterns)))) {

--- a/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
@@ -455,9 +455,7 @@ struct InactiveCallbackOpPattern : public OpConversionPattern<InactiveCallbackOp
         long argcint = argcAttr ? argcAttr.value() : 0;
         auto argc = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI64IntegerAttr(argcint));
 
-        auto resultsSizeAttr = op.getOperands().size() - argcint;
-        auto resultsSizeVal =
-            rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI64IntegerAttr(resultsSizeAttr));
+        auto resultsSizeVal = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI64IntegerAttr(0));
 
         SmallVector<Value> callArgs{ident};
         callArgs.insert(callArgs.end(), argc);

--- a/mlir/lib/Quantum/Transforms/annotate_function.cpp
+++ b/mlir/lib/Quantum/Transforms/annotate_function.cpp
@@ -36,7 +36,7 @@ bool isAnnotated(func::FuncOp op, const char *attr)
 bool invalidGradientOperation(func::FuncOp op)
 {
     auto res = op.walk([](Operation *o) {
-        if (dyn_cast<MeasureOp>(o) || dyn_cast<catalyst::PythonCallOp>(o) ||
+        if (dyn_cast<MeasureOp>(o) || dyn_cast<catalyst::InactiveCallbackOp>(o) ||
             dyn_cast<catalyst::CustomCallOp>(o)) {
             return WalkResult::interrupt();
         }

--- a/mlir/lib/Quantum/Transforms/annotate_function.cpp
+++ b/mlir/lib/Quantum/Transforms/annotate_function.cpp
@@ -37,7 +37,7 @@ bool invalidGradientOperation(func::FuncOp op)
 {
     auto res = op.walk([](Operation *o) {
         if (dyn_cast<MeasureOp>(o) || dyn_cast<catalyst::InactiveCallbackOp>(o) ||
-            dyn_cast<catalyst::CustomCallOp>(o)) {
+            dyn_cast<catalyst::ActiveCallbackOp>(o) || dyn_cast<catalyst::CustomCallOp>(o)) {
             return WalkResult::interrupt();
         }
         else {

--- a/mlir/test/Catalyst/ConversionTest.mlir
+++ b/mlir/test/Catalyst/ConversionTest.mlir
@@ -118,6 +118,6 @@ func.func @python_call () {
     // CHECK: [[argcount:%.+]] = llvm.mlir.constant(0 : i64)
     // CHECK: [[rescount:%.+]] = llvm.mlir.constant(0 : i64)
     // CHECK: llvm.call @inactive_callback([[identifier]], [[argcount]], [[rescount]])
-    catalyst.pycallback() { identifier = 0} : () -> ()
+    catalyst.inactiveCallbackCall() { identifier = 0} : () -> ()
     return
 }

--- a/mlir/test/Catalyst/ConversionTest.mlir
+++ b/mlir/test/Catalyst/ConversionTest.mlir
@@ -129,7 +129,7 @@ func.func @python_call () {
 module @testfoo {
 
   llvm.func @inactive_callback(i64, i64, i64, ...)
-  llvm.func @active_callback_0() {
+  func.func @active_callback_0() {
     %0 = llvm.mlir.constant(0 : i64) : i64
     llvm.call @inactive_callback(%0, %0, %0) vararg(!llvm.func<void (i64, i64, i64, ...)>) : (i64, i64, i64) -> ()
     llvm.return

--- a/mlir/test/Catalyst/ConversionTest.mlir
+++ b/mlir/test/Catalyst/ConversionTest.mlir
@@ -121,3 +121,23 @@ func.func @python_call () {
     catalyst.inactiveCallbackCall() { identifier = 0} : () -> ()
     return
 }
+
+// -----
+
+// A python without parameters and without returns.
+// CHECK-LABEL: @testfoo
+module @testfoo {
+
+  llvm.func @inactive_callback(i64, i64, i64, ...)
+  llvm.func @active_callback_0() {
+    %0 = llvm.mlir.constant(0 : i64) : i64
+    llvm.call @inactive_callback(%0, %0, %0) vararg(!llvm.func<void (i64, i64, i64, ...)>) : (i64, i64, i64) -> ()
+    llvm.return
+  }
+
+  func.func @python_call () {
+    // CHECK: llvm.call @active_callback_0()
+    catalyst.activeCallbackCall() as @active_callback_0 { identifier = 0} : () -> ()
+    return
+  }
+}

--- a/mlir/test/Catalyst/ConversionTest.mlir
+++ b/mlir/test/Catalyst/ConversionTest.mlir
@@ -136,8 +136,8 @@ module @testfoo {
   }
 
   func.func @python_call () {
-    // CHECK: llvm.call @active_callback_0()
-    catalyst.activeCallbackCall() as @active_callback_0 { identifier = 0} : () -> ()
+    // CHECK: call @active_callback_0()
+    catalyst.activeCallbackCall() as @active_callback_0 { identifier = 0 : i64, number_original_arg = 0 : i64} : () -> ()
     return
   }
 }

--- a/mlir/test/Catalyst/SpecializeActiveCallback.mlir
+++ b/mlir/test/Catalyst/SpecializeActiveCallback.mlir
@@ -1,0 +1,26 @@
+// Copyright 2024 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RUN: quantum-opt %s --specialize-active-callback-pass --split-input-file --verify-diagnostics | FileCheck %s
+
+// This test just makes sure that we can
+// run the compiler with the option
+//
+//   --specialize-active-callback-pass
+
+// CHECK-LABEL: @foo
+func.func @foo() {
+  return
+}
+

--- a/mlir/test/Catalyst/SpecializeActiveCallback.mlir
+++ b/mlir/test/Catalyst/SpecializeActiveCallback.mlir
@@ -66,9 +66,8 @@ module @test2 {
 // CHECK-LABEL: @test3
 module @test3 {
 
-  // CHECK-LABEL: @active_callback_0
+  // CHECK-LABEL: private @active_callback_0
   // CHECK-SAME: %arg0: !llvm.ptr
-  // CHECK-SAME: sym_visibility = "private"
   // CHECK-DAG: [[zero:%.+]] = llvm.mlir.constant(0 : i64)
   // CHECK-DAG: [[one:%.+]] = llvm.mlir.constant(1 : i64)
 
@@ -88,10 +87,9 @@ module @test3 {
 // CHECK-LABEL: @test4
 module @test4 {
 
-  // CHECK-LABEL: @active_callback_123
+  // CHECK-LABEL: private @active_callback_123
   // CHECK-SAME: %arg0: !llvm.ptr
   // CHECK-SAME: %arg1: !llvm.ptr
-  // CHECK-SAME: sym_visibility = "private"
 
   // CHECK: [[one:%.+]] = llvm.mlir.constant(1 : i64)
   // CHECK: llvm.call @inactive_callback({{%.+}}, [[one]], [[one]], %arg0, %arg1)

--- a/mlir/test/Catalyst/SpecializeActiveCallback.mlir
+++ b/mlir/test/Catalyst/SpecializeActiveCallback.mlir
@@ -24,3 +24,17 @@ func.func @foo() {
   return
 }
 
+// -----
+
+// This test checks that if an active callback
+// is found, then we create a declaration
+// in the module
+
+// CHECK-LABEL: @test1
+module @test1 {
+
+  llvm.func @cir() {
+     catalyst.activeCallbackCall() { identifier = 0 } : () -> ()
+     llvm.return
+  }
+}

--- a/mlir/test/Catalyst/SpecializeActiveCallback.mlir
+++ b/mlir/test/Catalyst/SpecializeActiveCallback.mlir
@@ -36,7 +36,7 @@ func.func @foo() {
 module @test1 {
 
   llvm.func @cir() {
-     // CHECK: catalyst.activeCallbackCall() as @hello
+     // CHECK: catalyst.activeCallbackCall() as @active_callback_0
      catalyst.activeCallbackCall() { identifier = 0 } : () -> ()
      llvm.return
   }

--- a/mlir/test/Catalyst/SpecializeActiveCallback.mlir
+++ b/mlir/test/Catalyst/SpecializeActiveCallback.mlir
@@ -99,3 +99,26 @@ module @test4 {
     return %arg1 : memref<i64>
   }
 }
+
+// -----
+
+// Test same callback multiple times
+
+// CHECK-LABEL: @test5
+module @test5 {
+
+  // CHECK-LABEL: func.func private @active_callback_123
+  // CHECK-SAME: %arg0: !llvm.ptr
+  // CHECK-SAME: %arg1: !llvm.ptr
+
+  // CHECK: [[one:%.+]] = llvm.mlir.constant(1 : i64)
+  // CHECK: llvm.call @inactive_callback({{%.+}}, [[one]], [[one]], %arg0, %arg1)
+
+  // CHECK-NOT: func.func private @active_callback
+
+  func.func public @jit_cir(%arg0: memref<i64>, %arg1: memref<i64>) -> memref<i64> {
+    catalyst.activeCallbackCall(%arg0, %arg1) {identifier = 123 : i64, number_original_arg = 1 : i64} : (memref<i64>, memref<i64>) -> ()
+    catalyst.activeCallbackCall(%arg0, %arg1) {identifier = 123 : i64, number_original_arg = 1 : i64} : (memref<i64>, memref<i64>) -> ()
+    return %arg1 : memref<i64>
+  }
+}

--- a/mlir/test/Catalyst/SpecializeActiveCallback.mlir
+++ b/mlir/test/Catalyst/SpecializeActiveCallback.mlir
@@ -27,13 +27,16 @@ func.func @foo() {
 // -----
 
 // This test checks that if an active callback
-// is found, then we create a declaration
-// in the module
+// then we also add the specialization.
+// The specialization is denoted with `as` followed by the name
+// of the specialized version.
+// Suggestions for syntax are welcomed.
 
 // CHECK-LABEL: @test1
 module @test1 {
 
   llvm.func @cir() {
+     // CHECK: catalyst.activeCallbackCall() as @hello
      catalyst.activeCallbackCall() { identifier = 0 } : () -> ()
      llvm.return
   }

--- a/mlir/test/Catalyst/SpecializeActiveCallback.mlir
+++ b/mlir/test/Catalyst/SpecializeActiveCallback.mlir
@@ -41,3 +41,22 @@ module @test1 {
      llvm.return
   }
 }
+
+// -----
+
+// This test checks to see that the active callback is correctly defined
+// CHECK-LABEL: @test2
+module @test2 {
+
+
+  // CHECK: llvm.func @inactive_callback(i64, i64, i64, ...)
+  // CHECK-LABEL: @active_callback_0()
+  // CHECK-NEXT: [[zero:%.+]] = llvm.mlir.constant(0 : i64)
+  // CHEKC-NEXT: llvm.call @inactive_callback([[zero]], [[zero]], [[zero]])
+  llvm.func @cir() {
+     catalyst.activeCallbackCall() { identifier = 0 } : () -> ()
+     llvm.return
+  }
+
+}
+


### PR DESCRIPTION
**Context:** Enzyme allows one to specify custom gradients for specific functions. In order to specify custom gradients for callbacks, callbacks need to be specialized to their own specific functions. E.g., instead of having the following code:

```
func.call @callback(%identifier, %argc, %retc, %0, %1, ..., %m, %n)
```

And be unable to register custom gradients for `@callback`. Specialize callbacks to their identifiers like so:

```
func.func @active_callback_123(%arg0, %arg1, ..., %argm, %argn) {
  %identifier = llvm.constant ...
  %argc = llvm.constant ...
  %retc = llvm.constant ...
  llvm.call @callback(%identifier, %argc, %retc, %arg0, %arg1, ... %argm, %argn)
  return
}

  // ...
  func.call @active_callback_123(%0, %1, ... %m, %n)
  // ..
```

And now we can register a custom gradient for `callback_123` and any other `callback_456`.

**Description of the Change:**

* Iterate over all ActiveCallbackOps and create the specialize function. Each ActiveCallbackOp will be annotated with the specialized function.
* During the lowering of ActiveCallbackOps to LLVM-IR replace with a call to the specialized function.

[sc-60494]