### PR TITLE
Use autoray<0.6.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ nbmake
 # optional rt/test dependencies
 pennylane-lightning[kokkos]
 amazon-braket-pennylane-plugin>=1.25,<=1.27.0
+autoray<0.6.10


### PR DESCRIPTION
**Context:** Until a new version of autoray that uses PR https://github.com/jcmgray/autoray/pull/23, we will pin to less that 0.6.10 to allow CI/CD to pass.
