### PR TITLE
Quick fix for expm gather batching rule bug fix: wheels on macos... 

### DIFF
--- a/frontend/test/pytest/test_jax_dynamic_api.py
+++ b/frontend/test/pytest/test_jax_dynamic_api.py
@@ -23,6 +23,7 @@ from numpy import array_equal
 from numpy.testing import assert_allclose
 
 from catalyst import qjit, while_loop
+from catalyst.utils.exceptions import CompileError
 
 DTYPES = [float, int, jnp.float32, jnp.float64, jnp.int8, jnp.int16, "float32", np.float64]
 SHAPES = [3, (2, 3, 1), (), jnp.array([2, 1, 3], dtype=int)]
@@ -400,7 +401,7 @@ def test_array_assignment():
 
 
 @pytest.mark.xfail(
-    raises=OSError,
+    raises=(OSError, CompileError),
     reason="""JAX requires BLAS to be linked with,
     but we don't have it linked.""",
 )


### PR DESCRIPTION
**Context:** A quick fix for #733 

**Description of the Change:** wheels on macos raise CompileError instead of OSError, so we need to mark CompileError as xfail as well.
