### PR TITLE
[Frontend] Fix decomposition tests

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -5,3 +5,5 @@ llvm=cd9a641613eddf25d4b25eaa96b2c393d401d42c
 enzyme=1beb98b51442d50652eaa3ffb9574f4720d611f1
 
 # Always remove custom PL/LQ versions before release.
+
+lightning=0.37.0-dev4

--- a/.dep-versions
+++ b/.dep-versions
@@ -6,4 +6,4 @@ enzyme=1beb98b51442d50652eaa3ffb9574f4720d611f1
 
 # Always remove custom PL/LQ versions before release.
 
-lightning=0.37.0-dev7
+lightning=0.37.0-dev9

--- a/.dep-versions
+++ b/.dep-versions
@@ -6,4 +6,4 @@ enzyme=1beb98b51442d50652eaa3ffb9574f4720d611f1
 
 # Always remove custom PL/LQ versions before release.
 
-lightning=0.37.0-dev4
+lightning=0.37.0-dev7

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -132,9 +132,6 @@
         (array([0.5, 0. , 0.5, 0. ]),)  
   ```
   
-* Fix decomposition tests.
-  [(#745)](https://github.com/PennyLaneAI/catalyst/pull/745)
-
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -132,6 +132,9 @@
         (array([0.5, 0. , 0.5, 0. ]),)  
   ```
   
+* Fix decomposition tests.
+  [(#745)](https://github.com/PennyLaneAI/catalyst/pull/745)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -29,5 +29,5 @@ lxml_html_clean
 
 # Pre-install development lightning wheels
 --extra-index-url https://test.pypi.org/simple/
-pennylane-lightning==0.36.0
+pennylane-lightning==0.37.0-dev4
 pennylane==0.36.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -29,5 +29,5 @@ lxml_html_clean
 
 # Pre-install development lightning wheels
 --extra-index-url https://test.pypi.org/simple/
-pennylane-lightning==0.37.0-dev4
+pennylane-lightning==0.37.0-dev7
 pennylane==0.36.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -29,5 +29,5 @@ lxml_html_clean
 
 # Pre-install development lightning wheels
 --extra-index-url https://test.pypi.org/simple/
-pennylane-lightning==0.37.0-dev7
+pennylane-lightning==0.37.0-dev9
 pennylane==0.36.0

--- a/frontend/test/lit/test_decomposition.py
+++ b/frontend/test/lit/test_decomposition.py
@@ -64,7 +64,7 @@ def get_custom_device_without(num_wires, discards):
             for line in toml_contents:
                 skip = False
                 for gate in discards:
-                    regex = fr"^{gate}\s"
+                    regex = rf"^{gate}\s"
                     skip |= bool(re.match(regex, line))
                     if skip:
                         break

--- a/frontend/test/lit/test_decomposition.py
+++ b/frontend/test/lit/test_decomposition.py
@@ -59,7 +59,6 @@ def get_custom_device_without(num_wires, discards):
             with open(lightning_toml, mode="r", encoding="UTF-8") as f:
                 toml_contents = f.readlines()
 
-            # TODO: update once schema 2 is merged
             updated_toml_contents = []
             for line in toml_contents:
                 skip = False

--- a/frontend/test/lit/test_decomposition.py
+++ b/frontend/test/lit/test_decomposition.py
@@ -16,6 +16,7 @@
 # pylint: disable=line-too-long
 
 import os
+import re
 import tempfile
 
 import jax
@@ -61,7 +62,13 @@ def get_custom_device_without(num_wires, discards):
             # TODO: update once schema 2 is merged
             updated_toml_contents = []
             for line in toml_contents:
-                if any(f'"{gate}",' in line for gate in discards):
+                skip = False
+                for gate in discards:
+                    regex = fr"^{gate}\s"
+                    skip |= bool(re.match(regex, line))
+                    if skip:
+                        break
+                if skip:
                     continue
                 updated_toml_contents.append(line)
 
@@ -181,7 +188,7 @@ test_decompose_multicontrolledx_in_for_loop()
 
 def test_decompose_rot():
     """Test decomposition of Rot gate."""
-    with get_custom_device_without(1, {"Rot", "C(Rot)"}) as dev:
+    with get_custom_device_without(1, {"Rot", "CRot", "C(Rot)"}) as dev:
 
         @qjit(target="mlir")
         @qml.qnode(dev)

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import re
 import tempfile
 
 import pennylane as qml
@@ -62,11 +63,11 @@ class CustomDevice(qml.QubitDevice):
         # TODO: update once schema 2 is merged
         updated_toml_contents = []
         for line in toml_contents:
-            if '"MultiControlledX",' in line:
+            if re.match("^MultiControlledX\s", line):
                 continue
-            if '"Rot",' in line:
+            if re.match("^Rot\s", line):
                 continue
-            if '"S",' in line:
+            if re.match("^S\s", line):
                 continue
 
             updated_toml_contents.append(line)

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -63,11 +63,11 @@ class CustomDevice(qml.QubitDevice):
         # TODO: update once schema 2 is merged
         updated_toml_contents = []
         for line in toml_contents:
-            if re.match("^MultiControlledX\s", line):
+            if re.match(r"^MultiControlledX\s", line):
                 continue
-            if re.match("^Rot\s", line):
+            if re.match(r"^Rot\s", line):
                 continue
-            if re.match("^S\s", line):
+            if re.match(r"^S\s", line):
                 continue
 
             updated_toml_contents.append(line)


### PR DESCRIPTION
**Context:**  Recent changes in the TOML files broke some tests.

**Description of the Change:** Fix those tests.

**Benefits:** Latest/latest/latest passes again (at least for lightning.qubit).

Comment:

The minimum version of pennylane-lightning required is 0.37.0-dev7 but those wheels failed to be uploaded. I have used 0.37.0-dev9. If the minimum version required is required for this PR, let me know and I will ask the team to push wheels for -dev7

[sc-63376]