### PR TITLE
Re-apply bump from manylinux2014_x86_64 to manylinux_2_28_x86_64

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -42,7 +42,7 @@ jobs:
         os: [ubuntu-latest]
         arch: [x86_64]
         python_version: [3.9]
-        container_img: ["quay.io/pypa/manylinux2014_x86_64"]
+        container_img: ["quay.io/pypa/manylinux_2_28_x86_64"]
 
     name: Build Dependencies (Python ${{ matrix.python_version }})
     runs-on: ${{ needs.determine_runner.outputs.runner_group }}
@@ -68,7 +68,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path:  mlir/llvm-project
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-generic-source
+        key: ${{ runner.os }}-${{ matrix.container_img }}-llvm-${{ needs.constants.outputs.llvm_version }}-generic-source
         enableCrossOsArchive: True
 
     - name: Cache MHLO Source
@@ -76,7 +76,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: mlir/mlir-hlo
-        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-source
+        key: ${{ runner.os }}-${{ matrix.container_img }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-source
         enableCrossOsArchive: True
 
     - name: Cache Enzyme Source
@@ -84,7 +84,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path:  mlir/Enzyme
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.enzyme_version }}-generic-source
+        key: ${{ runner.os }}-${{ matrix.container_img }}-enzyme-${{ needs.constants.outputs.enzyme_version }}-generic-source
         enableCrossOsArchive: True
 
     # TODO: Cannot use actions/checkout@v4 as node20 is not supported in manylinux2014 container
@@ -120,35 +120,38 @@ jobs:
       uses: actions/cache@v3
       with:
         path:  llvm-build
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-${{matrix.python_version}}-generic-build
+        key: ${{ runner.os }}-${{ matrix.container_img }}-llvm-${{ needs.constants.outputs.llvm_version }}-${{matrix.python_version}}-generic-build
 
     - name: Cache MHLO Build
       id: cache-mhlo-build
       uses: actions/cache@v3
       with:
         path:  mhlo-build
-        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-build
+        key: ${{ runner.os }}-${{ matrix.container_img }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-build
 
     - name: Cache Enzyme Build
       id: cache-enzyme-build
       uses: actions/cache@v3
       with:
         path:  enzyme-build
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-generic-build
+        key: ${{ runner.os }}-${{ matrix.container_img }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-generic-build
 
-    - name: Install dependencies (CentOS)
+    - name: Install dependencies (AlmaLinux)
       if: |
         steps.cache-llvm-build.outputs.cache-hit != 'true' ||
         steps.cache-mhlo-build.outputs.cache-hit != 'true' ||
         steps.cache-enzyme-build.outputs.cache-hit != 'true'
       run: |
         # Reduce wait time for repos not responding
-        cat /etc/yum.conf | sed "s/\[main\]/\[main\]\ntimeout=5/g" > /etc/yum.conf
-        yum update -y && yum install -y libzstd-devel
+        cat /etc/dnf.conf | sed "s/\[main\]/\[main\]\ntimeout=5/g" > /etc/dnf.conf
+        dnf update -y && dnf install -y libzstd-devel gcc-toolset-13
+        # Update env vars valid for all tasks of this job
+        echo '/opt/rh/gcc-toolset-13/root/usr/bin' >> $GITHUB_PATH
 
     - name: Install Dependencies (Python)
       run: |
         python${{ matrix.python_version }} -m pip install numpy pybind11 PyYAML cmake ninja
+        # Add cmake and ninja to the PATH env var
         PYTHON_BINS=$(find /opt/_internal/cpython-${{ matrix.python_version }}.*/bin -maxdepth 1 -type d | tr '\n' ':' | sed 's/:$//')
         echo $PYTHON_BINS >> $GITHUB_PATH
 
@@ -227,7 +230,7 @@ jobs:
         os: ${{ fromJSON(format('["{0}"]', needs.determine_runner.outputs.runner_group)) }}
         arch: [x86_64]
         python_version: ${{ fromJSON(needs.constants.outputs.python_versions) }}
-        container_img: ["quay.io/pypa/manylinux2014_x86_64"]
+        container_img: ["quay.io/pypa/manylinux_2_28_x86_64"]
 
     name: Build Wheels (Python ${{ matrix.python_version }})
     runs-on: ${{ matrix.os }}
@@ -238,15 +241,18 @@ jobs:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v3
 
-    - name: Install dependencies (CentOS)
+    - name: Install dependencies (AlmaLinux)
       run: |
         # Reduce wait time for repos not responding
-        cat /etc/yum.conf | sed "s/\[main\]/\[main\]\ntimeout=5/g" > /etc/yum.conf
-        yum update -y && yum install -y openmpi-devel libzstd-devel
+        cat /etc/dnf.conf | sed "s/\[main\]/\[main\]\ntimeout=5/g" > /etc/dnf.conf
+        dnf update -y && dnf install -y openmpi-devel libzstd-devel gcc-toolset-13
+        # Update env vars valid for all tasks of this job
+        echo '/opt/rh/gcc-toolset-13/root/usr/bin' >> $GITHUB_PATH
 
     - name: Install Dependencies (Python)
       run: |
         python${{ matrix.python_version }} -m pip install numpy pybind11 PyYAML cmake ninja
+        # Add cmake and ninja to the PATH env var
         PYTHON_BINS=$(find /opt/_internal/cpython-${{ matrix.python_version }}.*/bin -maxdepth 1 -type d | tr '\n' ':' | sed 's/:$//')
         echo $PYTHON_BINS >> $GITHUB_PATH
 
@@ -255,7 +261,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: mlir/llvm-project
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-generic-source
+        key: ${{ runner.os }}-${{ matrix.container_img }}-llvm-${{ needs.constants.outputs.llvm_version }}-generic-source
         enableCrossOsArchive: True
         fail-on-cache-miss: True
 
@@ -264,7 +270,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path:  llvm-build
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-3.9-generic-build
+        key: ${{ runner.os }}-${{ matrix.container_img }}-llvm-${{ needs.constants.outputs.llvm_version }}-3.9-generic-build
         fail-on-cache-miss: True
 
     - name: Get Cached MHLO Source
@@ -272,7 +278,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: mlir/mlir-hlo
-        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-source
+        key: ${{ runner.os }}-${{ matrix.container_img }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-source
         enableCrossOsArchive: True
         fail-on-cache-miss: True
 
@@ -281,7 +287,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path:  mhlo-build
-        key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-build
+        key: ${{ runner.os }}-${{ matrix.container_img }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-build
         fail-on-cache-miss: True
 
     - name: Get Cached Enzyme Source
@@ -289,7 +295,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path:  mlir/Enzyme
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.enzyme_version }}-generic-source
+        key: ${{ runner.os }}-${{ matrix.container_img }}-enzyme-${{ needs.constants.outputs.enzyme_version }}-generic-source
         fail-on-cache-miss: True
 
     - name: Get Cached Enzyme Build
@@ -297,7 +303,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path:  enzyme-build
-        key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-generic-build
+        key: ${{ runner.os }}-${{ matrix.container_img }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-generic-build
         fail-on-cache-miss: True
 
     # Build Catalyst-Runtime
@@ -370,7 +376,7 @@ jobs:
     - name: Upload Wheel Artifact
       uses: actions/upload-artifact@v3
       with:
-        name: catalyst-manylinux2014_x86_64-wheel-py-${{ matrix.python_version }}.zip
+        name: catalyst-manylinux_2_28_x86_64-wheel-py-${{ matrix.python_version }}.zip
         path: wheel/
         retention-days: 14
 
@@ -393,7 +399,7 @@ jobs:
     - name: Download Wheel Artifact
       uses: actions/download-artifact@v3
       with:
-        name: catalyst-manylinux2014_x86_64-wheel-py-${{ matrix.python_version }}.zip
+        name: catalyst-manylinux_2_28_x86_64-wheel-py-${{ matrix.python_version }}.zip
         path: dist
 
     - name: Set up Python ${{ matrix.python_version }}

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -48,10 +48,10 @@
 
   ```
 
-* Support for usage of single index JAX array assignments 
+* Support for usage of single index JAX array assignments
   inside Autograph annotated functions.
   [(#717)](https://github.com/PennyLaneAI/catalyst/pull/717)
-  
+
   Using `x[i] = y` in favor of `x = x.at(i).set(y)` is now possible:
 
   ```py
@@ -69,13 +69,17 @@
 
 <h3>Improvements</h3>
 
-* Added support for IsingZZ gate in Catalyst frontend. 
-  Previously, the IsingZZ gate would be decomposed into 
-  a CNOT and RZ gates. However, this is not needed as 
-  the PennyLane-Lightning simulator supports this gate.
+* Added support for IsingZZ gate in Catalyst frontend. Previously, the IsingZZ gate would be
+  decomposed into a CNOT and RZ gates. However, this is not needed as the PennyLane-Lightning
+  simulator supports this gate.
   [(#730)](https://github.com/PennyLaneAI/catalyst/pull/730)
 
 <h3>Breaking changes</h3>
+
+* Binary distributions for Linux are now based on `manylinux_2_28` instead of `manylinux_2014`.
+  As a result, Catalyst will only be compatible on systems with `glibc` versions `2.28` and above
+  (e.g. Ubuntu 20.04 and above).
+  [(#663)](https://github.com/PennyLaneAI/catalyst/pull/663)
 
 <h3>Bug fixes</h3>
 * Correctly querying batching rules for `jax.scipy.linalg.expm`
@@ -94,10 +98,11 @@
 * Small changes to make pylint==3.2.0 succeed.
   [(#739)](https://github.com/PennyLaneAI/catalyst/pull/739)
 
-* The underlying PennyLane `Operation` objects for `cond`, `for_loop`, and `while_loop` can now be accessed directly via `body_function.operation`. 
+* The underlying PennyLane `Operation` objects for `cond`, `for_loop`, and `while_loop` can now be
+  accessed directly via `body_function.operation`.
   [(#711)](https://github.com/PennyLaneAI/catalyst/pull/711)
 
-  This can be beneficial when, among other things, 
+  This can be beneficial when, among other things,
   writing transforms without using the queuing mechanism:
   ```py
         @qml.transform
@@ -129,9 +134,9 @@
         >>> main()
         Traced<ShapedArray(int64[], weak_type=True)>with<DynamicJaxprTrace(level=2/1)>
         [Hadamard(wires=[0]), ForLoop(tapes=[[Hadamard(wires=[0])]])]
-        (array([0.5, 0. , 0.5, 0. ]),)  
+        (array([0.5, 0. , 0.5, 0. ]),)
   ```
-  
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):


### PR DESCRIPTION
This PR reapplies #663 since it was reverted before release.

**Context:** We want to use the latest manylinux version to distribute our wheels.

**Description of the Change:**

- Use the latest manylinux_2_28_x86_64 image.
- Produce a Catalyst wheel based on that name.
- Use GCC 13 for compiling Catalyst and its dependencies too.
- Install CMake from pip.
- Install Ninja from pip (because the one provided by dnf is broken).
- Use new caches that include the manylinux_2_28_x86_64 string.
- Use dnf instead of yum as package manager.

[sc-60086]
