### PR TITLE
Allow for return type signature in `@qjit` methods

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -75,6 +75,10 @@
   the PennyLane-Lightning simulator supports this gate.
   [(#730)](https://github.com/PennyLaneAI/catalyst/pull/730)
 
+* Can now compile functions that have been annotated with return type
+  annotations.
+  [(#751)](https://github.com/PennyLaneAI/catalyst/pull/751)
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>

--- a/frontend/catalyst/tracing/type_signatures.py
+++ b/frontend/catalyst/tracing/type_signatures.py
@@ -31,19 +31,27 @@ from catalyst.jax_extras import get_aval2
 from catalyst.utils.patching import Patcher
 
 
-def params_are_annotated(fn: Callable):
-    """Return true if all parameters are typed-annotated, or no parameters are present."""
+def get_param_annotations(fn: Callable):
+    """Return true all parameters typed-annotations."""
     assert isinstance(fn, Callable)
     signature = inspect.signature(fn)
     parameters = signature.parameters
-    return all(p.annotation is not inspect.Parameter.empty for p in parameters.values())
+    return (p.annotation for p in parameters.values())
+
+
+def params_are_annotated(fn: Callable):
+    """Return true if all parameters are typed-annotated, or no parameters are present."""
+    assert isinstance(fn, Callable)
+    annotations = get_param_annotations(fn)
+    return all(annotation is not inspect.Parameter.empty for annotation in annotations)
 
 
 def get_type_annotations(fn: Callable):
     """Get type annotations if all parameters are annotated."""
     assert isinstance(fn, Callable)
     if fn is not None and params_are_annotated(fn):
-        return tuple(getattr(fn, "__annotations__", {}).values())
+        annotations = get_param_annotations(fn)
+        return tuple(annotations)
 
     return None
 

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -37,7 +37,7 @@ def f_aot_builder(backend, wires=1, shots=1000):
 
     @qjit
     @qml.qnode(qml.device(backend, wires=wires, shots=shots))
-    def f(x: float):
+    def f(x: float) -> bool:
         qml.RY(x, wires=0)
         return measure(wires=0)
 


### PR DESCRIPTION
**Context:** Methods with return type signatures are not compiled.

**Description of the Change:** At the moment, ignore the return type signature as it is computed by JAX.

**Benefits:** More valid python code is able to be compiled.

**Possible Drawbacks:** It would be nice to incorporate return type signature to the warning message if the detected return type is not the same as the one specified by the user. But we can leave this to the next PR.

**Related GitHub Issues:** Fixes #750 
