### PR TITLE
Fixing `jax.scipy.linalg.expm` complaints regarding undefined symbols.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -82,8 +82,13 @@
   [(#663)](https://github.com/PennyLaneAI/catalyst/pull/663)
 
 <h3>Bug fixes</h3>
+
 * Correctly querying batching rules for `jax.scipy.linalg.expm`
   [(#733)](https://github.com/PennyLaneAI/catalyst/pull/733)
+
+* Correctly linking openblas routines necessary for `jax.scipy.linalg.expm`.
+  In this bug fix, four openblas routines were newly linked and are now discoverable by `stablehlo.custom_call@<blas_routine>`. They are `blas_dtrsm`, `blas_ztrsm`, `lapack_dgetrf`, `lapack_zgetrf`.
+  [(#752)](https://github.com/PennyLaneAI/catalyst/pull/752)    
 
 <h3>Internal changes</h3>
 

--- a/frontend/test/pytest/test_jax_dynamic_api.py
+++ b/frontend/test/pytest/test_jax_dynamic_api.py
@@ -18,12 +18,10 @@ import numpy as np
 import pennylane as qml
 import pytest
 from jax import numpy as jnp
-from jax import scipy as jsp
 from numpy import array_equal
 from numpy.testing import assert_allclose
 
 from catalyst import qjit, while_loop
-from catalyst.utils.exceptions import CompileError
 
 DTYPES = [float, int, jnp.float32, jnp.float64, jnp.int8, jnp.int16, "float32", np.float64]
 SHAPES = [3, (2, 3, 1), (), jnp.array([2, 1, 3], dtype=int)]
@@ -398,34 +396,6 @@ def test_array_assignment():
     result = fun(5, 2, 33)
     expected = jnp.ones((5, 3, 5), dtype=int).at[2, 0, 2].set(33)
     assert_array_and_dtype_equal(result, expected)
-
-
-@pytest.mark.xfail(
-    raises=(OSError, CompileError),
-    reason="""JAX requires BLAS to be linked with,
-    but we don't have it linked.""",
-)
-def test_expm():
-    """Test jax.scipy.linalg.expm"""
-
-    @qjit
-    def f1(x):
-        return jsp.linalg.expm(-2.0 * x)
-
-    y1 = jnp.array([[0.1, 0.2], [5.3, 1.2]])
-    res1 = f1(y1)
-    expected1 = jnp.array([[2.0767685, -0.23879551], [-6.32808103, 0.76339319]])
-
-    @qjit
-    def f2(x):
-        return jsp.linalg.expm(x)
-
-    y2 = jnp.array([[1.0, 0.0], [0.0, 1.0]])
-    res2 = f2(y2)
-    expected2 = jnp.array([[2.71828183, 0.0], [0.0, 2.71828183]])
-
-    assert_allclose(res1, expected1)
-    assert_allclose(res2, expected2)
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_jax_numerical.py
+++ b/frontend/test/pytest/test_jax_numerical.py
@@ -1,0 +1,97 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test that numerical jax functions produce correct results when compiled with qml.qjit"""
+
+import numpy as np
+import pennylane as qml
+import pytest
+import scipy as sp
+from jax import numpy as jnp
+from jax import scipy as jsp
+
+from catalyst import qjit
+
+
+def test_expm_numerical():
+    """Test jax.scipy.linalg.expm is numerically correct"""
+
+    """Test floating point numerics with jax.scipy.linalg.expm"""
+
+    @qjit
+    def f1(x):
+        return jsp.linalg.expm(-2.0 * x)
+
+    y1 = jnp.array([[0.1, 0.2], [5.3, 1.2]])
+    res1 = f1(y1)
+    # expected1 = jnp.array([[2.0767685, -0.23879551], [-6.32808103, 0.76339319]])
+    expected1 = sp.linalg.expm(-2.0 * y1)
+
+    """Test integer numerics with jax.scipy.linalg.expm"""
+
+    @qjit
+    def f2(x):
+        return jsp.linalg.expm(x)
+
+    y2 = jnp.array([[1, 0], [0, 1]])
+    res2 = f2(y2)
+    # expected2 = jnp.array([[2.71828183, 0.0], [0.0, 2.71828183]])
+    expected2 = sp.linalg.expm(y2)
+
+    """Test complex numerics with jax.scipy.linalg.expm"""
+    """
+	Note: a common usage pattern in Hamiltonian simulation is 
+	   exp(-iHt)
+	where H is a (Hermitian) matrix.
+	"""
+
+    @qjit
+    def f3(x):
+        return jsp.linalg.expm(-2j * x)
+
+    y3 = jnp.array([[1, -1j], [1j, -1]])  # This is PauliY + PauliZ
+    res3 = f3(y3)
+    # expected3 = jnp.array([[-0.95136313-0.21783962j, -0.21783962+0.j],
+    #                       [ 0.21783962+0.j, -0.95136313+0.21783962j]])
+    expected3 = sp.linalg.expm(-2j * y3)
+
+    """Test an entire quantum workflow with jax.scipy.linag.expm"""
+    """Rotate |0> about Bloch x axis for 180 degrees to get |1>"""
+
+    @qjit
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    def circuit_expm():
+        generator = -1j * jnp.pi * jnp.array([[0, 1], [1, 0]]) / 2
+        unitary = jsp.linalg.expm(generator)
+        qml.QubitUnitary(unitary, wires=[0])
+        return qml.probs()
+
+    res4 = circuit_expm()
+
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    def circuit_rot():
+        qml.RX(np.pi, wires=[0])
+        return qml.probs()
+
+    # expected4 = [0,1]
+    expected4 = circuit_rot()
+
+    assert np.allclose(res1, expected1)
+    assert np.allclose(res2, expected2)
+    assert np.allclose(res3, expected3)
+    assert np.allclose(res4, expected4)
+
+
+if __name__ == "__main__":
+    pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_jax_numerical.py
+++ b/frontend/test/pytest/test_jax_numerical.py
@@ -25,25 +25,25 @@ from catalyst import qjit
 
 
 class TestExpmNumerical:
-    """Test jax.scipy.linalg.expm is numerically correct for float, int, and complex"""
+    """Test jax.scipy.linalg.expm is numerically correct when being qjit compiled"""
 
     @pytest.mark.parametrize(
         "inp",
         [
-            (jnp.array([[0.1, 0.2], [5.3, 1.2]]), np.array([[0.1, 0.2], [5.3, 1.2]])),
-            (jnp.array([[1, 2], [3, 4]]), np.array([[1, 2], [3, 4]])),
-            (jnp.array([[1.0, -1.0j], [1.0j, -1.0]]), np.array([[1.0, -1.0j], [1.0j, -1.0]])),
+            jnp.array([[0.1, 0.2], [5.3, 1.2]]),
+            jnp.array([[1, 2], [3, 4]]),
+            jnp.array([[1.0, -1.0j], [1.0j, -1.0]]),
         ],
     )
     def test_expm_numerical(self, inp):
-        """Test basic numerical correctness for jax.scipy.linalg.expm"""
+        """Test basic numerical correctness for jax.scipy.linalg.expm for float, int, complex"""
 
         @qjit
         def f(x):
             return jsp.linalg.expm(x)
 
-        observed = f(inp[0])
-        expected = sp.linalg.expm(inp[1])
+        observed = f(inp)
+        expected = jsp.linalg.expm(inp)
 
         assert np.allclose(observed, expected)
 

--- a/frontend/test/pytest/test_jax_numerical.py
+++ b/frontend/test/pytest/test_jax_numerical.py
@@ -27,24 +27,25 @@ from catalyst import qjit
 class TestExpmNumerical:
     """Test jax.scipy.linalg.expm is numerically correct for float, int, and complex"""
 
-    _float = jnp.array([[0.1, 0.2], [5.3, 1.2]])
-    _int = jnp.array([[1, 2], [3, 4]])
-    _complex = jnp.array([[1.0, -1.0j], [1.0j, -1.0]])
-    _expected = [
-        (_float, -2.0, sp.linalg.expm(-2.0 * _float)),
-        (_int, 1, sp.linalg.expm(1 * _int)),
-        (_complex, 3.5j, sp.linalg.expm(3.5j * _complex)),
-    ]
-
-    @pytest.mark.parametrize("test_input,exp_factor,expected", _expected)
-    def test_expm_numerical(self, test_input, exp_factor, expected):
+    @pytest.mark.parametrize(
+        "inp",
+        [
+            (jnp.array([[0.1, 0.2], [5.3, 1.2]]), np.array([[0.1, 0.2], [5.3, 1.2]])),
+            (jnp.array([[1, 2], [3, 4]]), np.array([[1, 2], [3, 4]])),
+            (jnp.array([[1.0, -1.0j], [1.0j, -1.0]]), np.array([[1.0, -1.0j], [1.0j, -1.0]])),
+        ],
+    )
+    def test_expm_numerical(self, inp):
         """Test basic numerical correctness for jax.scipy.linalg.expm"""
 
         @qjit
         def f(x):
-            return jsp.linalg.expm(exp_factor * x)
+            return jsp.linalg.expm(x)
 
-        assert np.allclose(f(test_input), expected)
+        observed = f(inp[0])
+        expected = sp.linalg.expm(inp[1])
+
+        assert np.allclose(observed, expected)
 
 
 class TestExpmInCircuit:

--- a/frontend/test/pytest/test_jax_numerical.py
+++ b/frontend/test/pytest/test_jax_numerical.py
@@ -17,7 +17,6 @@
 import numpy as np
 import pennylane as qml
 import pytest
-import scipy as sp
 from jax import numpy as jnp
 from jax import scipy as jsp
 

--- a/frontend/test/pytest/test_jax_numerical.py
+++ b/frontend/test/pytest/test_jax_numerical.py
@@ -38,6 +38,8 @@ class TestExpmNumerical:
 
     @pytest.mark.parametrize("test_input,exp_factor,expected", _expected)
     def test_expm_numerical(self, test_input, exp_factor, expected):
+        """Test basic numerical correctness for jax.scipy.linalg.expm"""
+
         @qjit
         def f(x):
             return jsp.linalg.expm(exp_factor * x)


### PR DESCRIPTION
**Context:** The original issue #628 raises a bug about `jax.scipy.linalg.expm` not working with `qml.qjit`. Upon investigation, two bugs were the cause of this: a batching rule query bug which was fixed in #733 (and #740), and a undefined symbol bug, raised in a new issue #747 which this PR addresses.

Bug: `jax.scipy.linalg.expm` does not work 
```python
@qml.qjit
def func(x):
	res = jax.scipy.linalg.expm(x)
	return res

y = jnp.array( [[1.0, 0.0], [0.0, 1.0]] )
x = func(y)


Traceback (most recent call last):
  File "/home/paul.wang/expmfix.py", line 43, in <module>
    x = func(y)
  File "/home/paul.wang/catalyst/frontend/catalyst/jit.py", line 110, in __call__
    requires_promotion = self.jit_compile(args)
  File "/home/paul.wang/catalyst/frontend/catalyst/jit.py", line 171, in jit_compile
    self.compiled_function, self.qir = self.compile()
  File "/home/paul.wang/catalyst/frontend/catalyst/debug/instruments.py", line 143, in wrapper
    return fn(*args, **kwargs)
  File "/home/paul.wang/catalyst/frontend/catalyst/jit.py", line 278, in compile
    compiled_fn = CompiledFunction(shared_object, func_name, restype, self.compile_options)
  File "/home/paul.wang/catalyst/frontend/catalyst/compiled_functions.py", line 132, in __init__
    self.shared_object = SharedObjectManager(shared_object_file, func_name)
  File "/home/paul.wang/catalyst/frontend/catalyst/compiled_functions.py", line 61, in __init__
    self.open()
  File "/home/paul.wang/catalyst/frontend/catalyst/compiled_functions.py", line 65, in open
    self.shared_object = ctypes.CDLL(self.shared_object_file)
  File "/usr/lib/python3.10/ctypes/__init__.py", line 374, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: /tmp/func4eeltbvg/func.so: undefined symbol: blas_dtrsm
```

**Description of the Change:**
1. Added new wrapper definitions for blas core routines required by `jax.scipy.linalg.expm` in `frontend/catalyst/utils/libcustom_calls.cpp`. See the detailed bug fix report below. 
2. Added a new file `frontend/test/pytest/test_jax_numerical.py` to hold tests regarding correctness of qjit handling calls to jaxlib. In the first expm fix PR #733 (and #740 ) the new test for expm was added to `test_jax_dynamic_api.py`. This is the inappropriate place, and the test is moved to the new `test_jax_numerial.py`. Originally the test was marked as xfail since batching rule query was fixed but undefined symbol was not. Now that expm is fully supported, the test is no longer marked as xfail. 

**Benefits:** `jax.scipy.linalg.expm` now works

**Possible Drawbacks:** other calls to jaxlib, such as `sqrtm`, still does not work, and the openblas routines need to be added by hand one at a time. This might not be the best way to link jaxlib. This is not a drawback in the sense that this PR makes anything worse, but a note that something could be improved. 

**Related GitHub Issues:** closes #628, closes #747 

[sc-63402]
