### PR TITLE
Improving the catalyst installation guide: prerequsite order and OS specific subsections

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -92,6 +92,9 @@
   annotations.
   [(#751)](https://github.com/PennyLaneAI/catalyst/pull/751)
 
+* The installation guide page for Catalyst now includes a new summary section, allowing users to easily see together all the commands to run depending on their OS.
+  [(#756)](https://github.com/PennyLaneAI/catalyst/pull/756)
+
 <h3>Breaking changes</h3>
 
 * Binary distributions for Linux are now based on `manylinux_2_28` instead of `manylinux_2014`.

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -92,9 +92,6 @@
   annotations.
   [(#751)](https://github.com/PennyLaneAI/catalyst/pull/751)
 
-* The installation guide page for Catalyst now includes a new summary section, allowing users to easily see together all the commands to run depending on their OS.
-  [(#756)](https://github.com/PennyLaneAI/catalyst/pull/756)
-
 <h3>Breaking changes</h3>
 
 * Binary distributions for Linux are now based on `manylinux_2_28` instead of `manylinux_2014`.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -127,6 +127,7 @@ extensions = [
     "sphinxext.opengraph",
     "sphinx_automodapi.automodapi",
     "sphinx_automodapi.smart_resolver",
+    "sphinx_tabs.tabs",
     "m2r2",
 ]
 

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -69,7 +69,9 @@ Minimal Building From Source Guide
 ----------------------------------
 
 
-Most developers might want to build Catalyst from source instead of using a pre-shipped package. In this section we present a minimal building-from-source installation guide. The next section provides a more detailed guide, which we **strongly** recommend the user to read through. Importantly, each component of Catalyst, namely the Python frontend, the MLIR compiler, and the runtime library, can be built and tested indenpendently, which this minimal installation guide does not go over. 
+Most developers might want to build Catalyst from source instead of using a pre-shipped package. In this section we present a minimal building-from-source installation guide. 
+
+The next section provides a more detailed guide, which we **strongly** recommend the user to read through. Importantly, each component of Catalyst, namely the Python frontend, the MLIR compiler, and the runtime library, can be built and tested indenpendently, which this minimal installation guide does not go over. 
 
 
 The essential steps are:
@@ -122,7 +124,7 @@ The essential steps are:
 
 
 
-The essential steps should give you the full functionality of Catalyst. 
+These steps should give you the full functionality of Catalyst. 
 
 
 Detailed Building From Source Guide

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -108,10 +108,10 @@ On **Linux**:
 On **macOS**:
 .. code-block:: console
 
-  # Install XCode Command Line Tools and common requirements
-  xcode-select --install
-  pip install cmake ninja
-  brew install libomp
+  # Install XCode Command Line Tools and common requirements \
+  xcode-select --install \
+  pip install cmake ninja \
+  brew install libomp \
 
   # Clone the Catalyst repository  
   git clone --recurse-submodules --shallow-submodules https://github.com/PennyLaneAI/catalyst.git

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -65,17 +65,19 @@ from within the root of the running container.
 
 
 
-Just Tell Me How To Build Catalyst From Source
+Minimal Building From Source Guide
 ----------------------------------------------
-(This section title is a tribute to the llvm new pass manager guide's section `Just Tell Me How To Run The Default Optimization Pipeline With The New Pass Manager <https://llvm.org/docs/NewPassManager.html#just-tell-me-how-to-run-the-default-optimization-pipeline-with-the-new-pass-manager>`_)
 
 
 Most developers might want to build Catalyst from source instead of using a pre-shipped package. In this section we present a minimal building-from-source installation guide. The next section provides a more detailed guide, which we **strongly** recommend the user to read through. Importantly, each component of Catalyst, namely the Python frontend, the MLIR compiler, and the runtime library, can be built and tested indenpendently, which this minimal installation guide does not go over. 
 
 
+The essential steps are:
+
+
 .. tabs::
 
-   .. tab:: Linux Debian/Ubuntu
+   .. group-tab:: Linux Debian/Ubuntu
 
       .. code-block:: console
 
@@ -92,22 +94,8 @@ Most developers might want to build Catalyst from source instead of using a pre-
         # Build Catalyst
         make all
 
-        # If you are building Catalyst components in custom locations, set environment variables. 
-        # This step should not be required if you are simply following the instructions above. 
-        export PYTHONPATH="$PWD/mlir/build/python_packages/quantum:$PYTHONPATH"
-        export RUNTIME_LIB_DIR="$PWD/runtime/build/lib"
-        export MLIR_LIB_DIR="$PWD/mlir/llvm-project/build/lib"
-        export ENZYME_LIB_DIR="$PWD/mlir/Enzyme/build/Enzyme"
-        export PATH="$PWD/mlir/llvm-project/build/bin:$PWD/mlir/mlir-hlo/mhlo-build/bin:$PWD/mlir/build/bin:$PATH"
 
-        # Optional: test that everything is built properly
-        make test
-
-        # Optional: build and test documentation for Catalyst
-        pip install -r doc/requirements.txt
-        sudo apt install doxygen pandoc
-
-   .. tab:: macOS
+   .. group-tab:: macOS
 
       .. code-block:: console
 
@@ -126,8 +114,40 @@ Most developers might want to build Catalyst from source instead of using a pre-
         # Build Catalyst
         make all
 
+
+
+The essential steps should give you the full functionality of Catalyst. There are also some optional steps:
+
+
+.. tabs::
+
+   .. group-tab:: Linux Debian/Ubuntu
+
+      .. code-block:: console
+
         # If you are building Catalyst components in custom locations, set environment variables. 
         # This step should not be required if you are simply following the instructions above. 
+        # However, performing this step anyway should not cause any failures. 
+        export PYTHONPATH="$PWD/mlir/build/python_packages/quantum:$PYTHONPATH"
+        export RUNTIME_LIB_DIR="$PWD/runtime/build/lib"
+        export MLIR_LIB_DIR="$PWD/mlir/llvm-project/build/lib"
+        export ENZYME_LIB_DIR="$PWD/mlir/Enzyme/build/Enzyme"
+        export PATH="$PWD/mlir/llvm-project/build/bin:$PWD/mlir/mlir-hlo/mhlo-build/bin:$PWD/mlir/build/bin:$PATH"
+
+        # Optional: test that everything is built properly
+        make test
+
+        # Optional: build and test documentation for Catalyst
+        pip install -r doc/requirements.txt
+        sudo apt install doxygen pandoc
+
+   .. group-tab:: macOS
+
+      .. code-block:: console
+
+        # If you are building Catalyst components in custom locations, set environment variables. 
+        # This step should not be required if you are simply following the instructions above. 
+        # However, performing this step anyway should not cause any failures. 
         export PYTHONPATH="$PWD/mlir/build/python_packages/quantum:$PYTHONPATH"
         export RUNTIME_LIB_DIR="$PWD/runtime/build/lib"
         export MLIR_LIB_DIR="$PWD/mlir/llvm-project/build/lib"
@@ -142,9 +162,12 @@ Most developers might want to build Catalyst from source instead of using a pre-
         brew install doxygen pandoc
 
 
-
 Detailed Building From Source Guide
 -----------------------------------
+
+
+.. note::
+  This section is a detailed building-from-source guide. Some commands in this section has already been included in the minimal guide. These command will be marked with a comment after them. 
 
 
 To build Catalyst from source, developers should follow the instructions provided below for building
@@ -169,31 +192,41 @@ installed and available on the path (depending on the platform):
 
 - The Python package manager ``pip`` must be version 22.3 or higher.
 
-They can be installed on **Debian/Ubuntu** via:
+They can be installed via:
 
-.. code-block:: console
 
-  sudo apt install clang lld ccache libomp-dev ninja-build make cmake
+.. tabs::
 
-.. note::
+   .. group-tab:: Linux Debian/Ubuntu
 
-  If the CMake version available in your system is too old, you can also install up-to-date
-  versions of it via ``pip install cmake``.
+      .. code-block:: console
 
-On **macOS**, it is strongly recommended to install the official XCode Command Line Tools
-(for ``clang`` & ``make``). The remaining packages can then be installed via ``pip`` and ``brew``:
+        sudo apt install clang lld ccache libomp-dev ninja-build make cmake  # already in minimal guide
 
-.. code-block:: console
+      .. note::
 
-  pip install cmake ninja
-  brew install libomp
+        If the CMake version available in your system is too old, you can also install up-to-date
+        versions of it via ``pip install cmake``.
+
+
+   .. group-tab:: macOS
+
+      On **macOS**, it is strongly recommended to install the official XCode Command Line Tools (for ``clang`` & ``make``). The remaining packages can then be installed via ``pip`` and ``brew``:
+
+      .. code-block:: console
+
+        xcode-select --install      # already in minimal guide
+        pip install cmake ninja     # already in minimal guide
+        brew install libomp         # already in minimal guide
+
+
 
 Once the pre-requisites are installed, start by cloning the project repository including all its
 submodules:
 
 .. code-block:: console
 
-  git clone --recurse-submodules --shallow-submodules https://github.com/PennyLaneAI/catalyst.git
+  git clone --recurse-submodules --shallow-submodules https://github.com/PennyLaneAI/catalyst.git   # already in minimal guide
 
 For an existing copy of the repository without its submodules, they can also be fetched via:
 
@@ -206,7 +239,7 @@ All additional build and developer dependencies are managed via the repository's
 
 .. code-block:: console
 
-  pip install -r requirements.txt
+  pip install -r requirements.txt   # already in minimal guide
 
 .. note::
 
@@ -222,7 +255,7 @@ directory:
 
 .. code-block:: console
 
-  make all
+  make all   # already in minimal guide
 
 To build each component one by one starting from the runtime, or to build additional backend devices
 beyond ``lightning.qubit``, please follow the instructions below.
@@ -284,32 +317,32 @@ To make the MLIR bindings from the Catalyst dialects discoverable to the compile
 
 .. code-block:: console
 
-  export PYTHONPATH="$PWD/mlir/build/python_packages/quantum:$PYTHONPATH"
+  export PYTHONPATH="$PWD/mlir/build/python_packages/quantum:$PYTHONPATH"   # already in minimal guide
 
 To make runtime libraries discoverable to the compiler:
 
 .. code-block:: console
 
-  export RUNTIME_LIB_DIR="$PWD/runtime/build/lib"
+  export RUNTIME_LIB_DIR="$PWD/runtime/build/lib"   # already in minimal guide
 
 To make MLIR libraries discoverable to the compiler:
 
 .. code-block:: console
 
-  export MLIR_LIB_DIR="$PWD/mlir/llvm-project/build/lib"
+  export MLIR_LIB_DIR="$PWD/mlir/llvm-project/build/lib"   # already in minimal guide
 
 To make Enzyme libraries discoverable to the compiler:
 
 .. code-block:: console
 
-  export ENZYME_LIB_DIR="$PWD/mlir/Enzyme/build/Enzyme"
+  export ENZYME_LIB_DIR="$PWD/mlir/Enzyme/build/Enzyme"   # already in minimal guide
 
 To make required tools in ``llvm-project/build``, ``mlir-hlo/mhlo-build``, and
 ``mlir/build`` discoverable to the compiler:
 
 .. code-block:: console
 
-  export PATH="$PWD/mlir/llvm-project/build/bin:$PWD/mlir/mlir-hlo/mhlo-build/bin:$PWD/mlir/build/bin:$PATH"
+  export PATH="$PWD/mlir/llvm-project/build/bin:$PWD/mlir/mlir-hlo/mhlo-build/bin:$PWD/mlir/build/bin:$PATH"   # already in minimal guide
 
 Tests
 ^^^^^
@@ -318,7 +351,7 @@ The following target runs all available test suites with the default execution d
 
 .. code-block:: console
 
-  make test
+  make test   # already in minimal guide
 
 You can also test each module separately by using running the ``test-frontend``,
 ``test-dialects``, and ``test-runtime`` targets instead. Jupyter Notebook demos are also testable
@@ -364,19 +397,28 @@ To build and test documentation for Catalyst, you will need to install
 
 .. code-block:: console
 
-  pip install -r doc/requirements.txt
+  pip install -r doc/requirements.txt   # already in minimal guide
 
 Additionally, `doxygen <https://www.doxygen.nl>`_ is required to build C++ documentation, and
 `pandoc <https://pandoc.org>`_ to render Jupyter Notebooks.
 
-On **Debian/Ubuntu**, they can be installed via:
+They can be installed via 
 
-.. code-block:: console
 
-  sudo apt install doxygen pandoc
+.. tabs::
 
-On **macOS**, `homebrew <https://brew.sh>`_ is the easiest way to install these packages:
+   .. group-tab:: Linux Debian/Ubuntu
 
-.. code-block:: console
+      .. code-block:: console
 
-  brew install doxygen pandoc
+        sudo apt install doxygen pandoc   # already in minimal guide
+
+
+   .. group-tab:: macOS
+
+      On **macOS**, `homebrew <https://brew.sh>`_ is the easiest way to install these packages:
+
+      .. code-block:: console
+
+        brew install doxygen pandoc   # already in minimal guide
+

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -63,84 +63,92 @@ from within the root of the running container.
   first, open it as a VS Code Workspace, and then reopen the Workspace in a Dev Container via the
   ``Reopen in Container`` command.
 
-Building from source
---------------------
+
+
+Just Tell Me How To Build Catalyst From Source
+----------------------------------------------
+(This section title is a tribute to the llvm new pass manager guide's section `Just Tell Me How To Run The Default Optimization Pipeline With The New Pass Manager <https://llvm.org/docs/NewPassManager.html#just-tell-me-how-to-run-the-default-optimization-pipeline-with-the-new-pass-manager>`_)
+
+
+In this section we present a minimal installation guide. The next section provides a more detailed guide, which we **strongly** recommend the user to read through. Importantly, each component of Catalyst, namely the Python frontend, the MLIR compiler, and the runtime library, can be built and tested indenpendently, which this minimal installation guide does not go over. 
+
+
+.. tabs::
+
+   .. tab:: Linux Debian/Ubuntu
+
+      .. code-block:: console
+
+        # Install common requirements
+        sudo apt install clang lld ccache libomp-dev ninja-build make cmake 
+
+        # Clone the Catalyst repository  
+        git clone --recurse-submodules --shallow-submodules https://github.com/PennyLaneAI/catalyst.git
+
+        # Install specific requirements for Catalyst
+        cd catalyst
+        pip install -r requirements.txt
+
+        # Build Catalyst
+        make all
+
+        # If you are building Catalyst components in custom locations, set environment variables. 
+        # This step should not be required if you are simply following the instructions above. 
+        export PYTHONPATH="$PWD/mlir/build/python_packages/quantum:$PYTHONPATH"
+        export RUNTIME_LIB_DIR="$PWD/runtime/build/lib"
+        export MLIR_LIB_DIR="$PWD/mlir/llvm-project/build/lib"
+        export ENZYME_LIB_DIR="$PWD/mlir/Enzyme/build/Enzyme"
+        export PATH="$PWD/mlir/llvm-project/build/bin:$PWD/mlir/mlir-hlo/mhlo-build/bin:$PWD/mlir/build/bin:$PATH"
+
+        # Optional: test that everything is built properly
+        make test
+
+        # Optional: build and test documentation for Catalyst
+        pip install -r doc/requirements.txt
+        sudo apt install doxygen pandoc
+
+   .. tab:: macOS
+
+      .. code-block:: console
+
+        # Install XCode Command Line Tools and common requirements
+        xcode-select --install
+        pip install cmake ninja
+        brew install libomp
+
+        # Clone the Catalyst repository  
+        git clone --recurse-submodules --shallow-submodules https://github.com/PennyLaneAI/catalyst.git
+
+        # Install specific requirements for Catalyst
+        cd catalyst
+        pip install -r requirements.txt 
+
+        # Build Catalyst
+        make all
+
+        # If you are building Catalyst components in custom locations, set environment variables. 
+        # This step should not be required if you are simply following the instructions above. 
+        export PYTHONPATH="$PWD/mlir/build/python_packages/quantum:$PYTHONPATH"
+        export RUNTIME_LIB_DIR="$PWD/runtime/build/lib"
+        export MLIR_LIB_DIR="$PWD/mlir/llvm-project/build/lib"
+        export ENZYME_LIB_DIR="$PWD/mlir/Enzyme/build/Enzyme"
+        export PATH="$PWD/mlir/llvm-project/build/bin:$PWD/mlir/mlir-hlo/mhlo-build/bin:$PWD/mlir/build/bin:$PATH"
+
+        # Optional: test that everything is built properly
+        make test
+
+        # Optional: build and test documentation for Catalyst
+        pip install -r doc/requirements.txt
+        brew install doxygen pandoc
+
+
+
+Detailed Building From Source Guide
+-----------------------------------
 
 
 To build Catalyst from source, developers should follow the instructions provided below for building
 all three modules: the Python frontend, the MLIR compiler, and the runtime library.
-
-
-Just Tell Me How To Build Catalyst From Source
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-(This section title is a tribute to the llvm new pass manager guide's section `Just Tell Me How To Run The Default Optimization Pipeline With The New Pass Manager <https://llvm.org/docs/NewPassManager.html#just-tell-me-how-to-run-the-default-optimization-pipeline-with-the-new-pass-manager>`_)
-
-On **Linux Debian/Ubuntu**:
-
-.. code-block:: console
-
-  # Install common requirements
-  sudo apt install clang lld ccache libomp-dev ninja-build make cmake 
-
-  # Clone the Catalyst repository  
-  git clone --recurse-submodules --shallow-submodules https://github.com/PennyLaneAI/catalyst.git
-
-  # Install specific requirements for Catalyst
-  pip install -r requirements.txt
-
-  # Build Catalyst
-  make all
-
-  # If you are building Catalyst components in custom locations, set environment variables. 
-  # This step should not be required if you are simply following the instructions above. 
-  export PYTHONPATH="$PWD/mlir/build/python_packages/quantum:$PYTHONPATH"
-  export RUNTIME_LIB_DIR="$PWD/runtime/build/lib"
-  export MLIR_LIB_DIR="$PWD/mlir/llvm-project/build/lib"
-  export ENZYME_LIB_DIR="$PWD/mlir/Enzyme/build/Enzyme"
-  export PATH="$PWD/mlir/llvm-project/build/bin:$PWD/mlir/mlir-hlo/mhlo-build/bin:$PWD/mlir/build/bin:$PATH"
-
-  # Optional: test that everything is built properly
-  make test
-
-  # Optional: build and test documentation for Catalyst
-  pip install -r doc/requirements.txt
-  sudo apt install doxygen pandoc
-
-
-On **macOS**:
-
-.. code-block:: console
-
-  # Install XCode Command Line Tools and common requirements
-  xcode-select --install
-  pip install cmake ninja
-  brew install libomp
-
-  # Clone the Catalyst repository  
-  git clone --recurse-submodules --shallow-submodules https://github.com/PennyLaneAI/catalyst.git
-
-  # Install specific requirements for Catalyst
-  pip install -r requirements.txt 
-
-  # Build Catalyst
-  make all
-
-  # If you are building Catalyst components in custom locations, set environment variables. 
-  # This step should not be required if you are simply following the instructions above. 
-  export PYTHONPATH="$PWD/mlir/build/python_packages/quantum:$PYTHONPATH"
-  export RUNTIME_LIB_DIR="$PWD/runtime/build/lib"
-  export MLIR_LIB_DIR="$PWD/mlir/llvm-project/build/lib"
-  export ENZYME_LIB_DIR="$PWD/mlir/Enzyme/build/Enzyme"
-  export PATH="$PWD/mlir/llvm-project/build/bin:$PWD/mlir/mlir-hlo/mhlo-build/bin:$PWD/mlir/build/bin:$PATH"
-
-  # Optional: test that everything is built properly
-  make test
-
-  # Optional: build and test documentation for Catalyst
-  pip install -r doc/requirements.txt
-  brew install doxygen pandoc
-
-Below is a more detailed guide, which we **strongly** recommend the user to read through. Importantly, each component of Catalyst can be built and tested indenpendently. 
 
 
 Requirements
@@ -167,7 +175,7 @@ They can be installed on **Debian/Ubuntu** via:
 
   sudo apt install clang lld ccache libomp-dev ninja-build make cmake
 
-.. Note::
+.. note::
 
   If the CMake version available in your system is too old, you can also install up-to-date
   versions of it via ``pip install cmake``.
@@ -200,7 +208,7 @@ All additional build and developer dependencies are managed via the repository's
 
   pip install -r requirements.txt
 
-.. Note::
+.. note::
 
   Please ensure that your local site-packages for Python are available on the ``PATH`` - watch out
   for the corresponding warning that ``pip`` may give you during installation.
@@ -326,7 +334,7 @@ them, but using the ``test-runtime`` target instead:
 
   make test-runtime ENABLE_LIGHTNING_KOKKOS=ON ENABLE_OPENQASM=ON
 
-.. Note::
+.. note::
 
   The ``test-runtime`` targets rebuilds the runtime with the specified flags. Therefore,
   running ``make runtime OPENQASM=ON`` and ``make test-runtime`` in succession will leave you

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -130,7 +130,7 @@ Detailed Building From Source Guide
 
 
 .. note::
-  This section is a detailed building-from-source guide. Some commands in this section has already been included in the minimal guide. These command will be marked with a comment after them. 
+  This section is a detailed building-from-source guide. Some commands in this section has already been included in the minimal guide. 
 
 
 To build Catalyst from source, developers should follow the instructions provided below for building

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -76,6 +76,7 @@ Just Tell Me How To Build Catalyst From Source
 (This section title is a tribute to the llvm new pass manager guide's section `Just Tell Me How To Run The Default Optimization Pipeline With The New Pass Manager <https://llvm.org/docs/NewPassManager.html#just-tell-me-how-to-run-the-default-optimization-pipeline-with-the-new-pass-manager>`_)
 
 On **Linux**:
+
 .. code-block:: console
 
   # Install common requirements
@@ -106,6 +107,7 @@ On **Linux**:
 
 
 On **macOS**:
+
 .. code-block:: console
 
   # Install XCode Command Line Tools and common requirements \

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -70,7 +70,7 @@ Just Tell Me How To Build Catalyst From Source
 (This section title is a tribute to the llvm new pass manager guide's section `Just Tell Me How To Run The Default Optimization Pipeline With The New Pass Manager <https://llvm.org/docs/NewPassManager.html#just-tell-me-how-to-run-the-default-optimization-pipeline-with-the-new-pass-manager>`_)
 
 
-In this section we present a minimal installation guide. The next section provides a more detailed guide, which we **strongly** recommend the user to read through. Importantly, each component of Catalyst, namely the Python frontend, the MLIR compiler, and the runtime library, can be built and tested indenpendently, which this minimal installation guide does not go over. 
+Most developers might want to build Catalyst from source instead of using a pre-shipped package. In this section we present a minimal building-from-source installation guide. The next section provides a more detailed guide, which we **strongly** recommend the user to read through. Importantly, each component of Catalyst, namely the Python frontend, the MLIR compiler, and the runtime library, can be built and tested indenpendently, which this minimal installation guide does not go over. 
 
 
 .. tabs::

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -91,7 +91,8 @@ On **Linux Debian/Ubuntu**:
   # Build Catalyst
   make all
 
-  # If you are building Catalyst components in custom locations, set environment variables. This step should not be required if you are simply following the instructions above. 
+  # If you are building Catalyst components in custom locations, set environment variables. 
+  # This step should not be required if you are simply following the instructions above. 
   export PYTHONPATH="$PWD/mlir/build/python_packages/quantum:$PYTHONPATH"
   export RUNTIME_LIB_DIR="$PWD/runtime/build/lib"
   export MLIR_LIB_DIR="$PWD/mlir/llvm-project/build/lib"
@@ -124,7 +125,8 @@ On **macOS**:
   # Build Catalyst
   make all
 
-  # If you are building Catalyst components in custom locations, set environment variables. This step should not be required if you are simply following the instructions above. 
+  # If you are building Catalyst components in custom locations, set environment variables. 
+  # This step should not be required if you are simply following the instructions above. 
   export PYTHONPATH="$PWD/mlir/build/python_packages/quantum:$PYTHONPATH"
   export RUNTIME_LIB_DIR="$PWD/runtime/build/lib"
   export MLIR_LIB_DIR="$PWD/mlir/llvm-project/build/lib"

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -24,7 +24,7 @@ untested and cannot be guaranteed. If you are using one of these platforms, plea
 try out our Docker and Dev Container images described in the `next section <#dev-containers>`_.
 
 If you wish to contribute to Catalyst or develop against our runtime or compiler, instructions for
-building from source are also included `further down <#building-from-source>`_.
+building from source are also included `further down <#minimal-building-from-source-guide>`_.
 
 Dev Containers
 --------------
@@ -66,7 +66,7 @@ from within the root of the running container.
 
 
 Minimal Building From Source Guide
-----------------------------------------------
+----------------------------------
 
 
 Most developers might want to build Catalyst from source instead of using a pre-shipped package. In this section we present a minimal building-from-source installation guide. The next section provides a more detailed guide, which we **strongly** recommend the user to read through. Importantly, each component of Catalyst, namely the Python frontend, the MLIR compiler, and the runtime library, can be built and tested indenpendently, which this minimal installation guide does not go over. 

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -122,40 +122,7 @@ The essential steps are:
 
 
 
-The essential steps should give you the full functionality of Catalyst. There are also some optional steps:
-
-
-.. tabs::
-
-   .. group-tab:: Linux Debian/Ubuntu
-
-      .. code-block:: console
-
-        # If you are building Catalyst components in custom locations, set environment variables. 
-        # This step should not be required if you are simply following the instructions above. 
-        # However, performing this step anyway should not cause any failures. 
-        export PYTHONPATH="$PWD/mlir/build/python_packages/quantum:$PYTHONPATH"
-        export RUNTIME_LIB_DIR="$PWD/runtime/build/lib"
-        export MLIR_LIB_DIR="$PWD/mlir/llvm-project/build/lib"
-        export ENZYME_LIB_DIR="$PWD/mlir/Enzyme/build/Enzyme"
-        export PATH="$PWD/mlir/llvm-project/build/bin:$PWD/mlir/mlir-hlo/mhlo-build/bin:$PWD/mlir/build/bin:$PATH"
-
-
-
-   .. group-tab:: macOS
-
-      .. code-block:: console
-
-        # If you are building Catalyst components in custom locations, set environment variables. 
-        # This step should not be required if you are simply following the instructions above. 
-        # However, performing this step anyway should not cause any failures. 
-        export PYTHONPATH="$PWD/mlir/build/python_packages/quantum:$PYTHONPATH"
-        export RUNTIME_LIB_DIR="$PWD/runtime/build/lib"
-        export MLIR_LIB_DIR="$PWD/mlir/llvm-project/build/lib"
-        export ENZYME_LIB_DIR="$PWD/mlir/Enzyme/build/Enzyme"
-        export PATH="$PWD/mlir/llvm-project/build/bin:$PWD/mlir/mlir-hlo/mhlo-build/bin:$PWD/mlir/build/bin:$PATH"
-
-
+The essential steps should give you the full functionality of Catalyst. 
 
 
 Detailed Building From Source Guide
@@ -197,7 +164,7 @@ They can be installed via:
 
       .. code-block:: console
 
-        sudo apt install clang lld ccache libomp-dev ninja-build make cmake  # already in minimal guide
+        sudo apt install clang lld ccache libomp-dev ninja-build make cmake
 
       .. note::
 
@@ -211,9 +178,9 @@ They can be installed via:
 
       .. code-block:: console
 
-        xcode-select --install      # already in minimal guide
-        pip install cmake ninja     # already in minimal guide
-        brew install libomp         # already in minimal guide
+        xcode-select --install
+        pip install cmake ninja
+        brew install libomp
 
 
 
@@ -222,7 +189,7 @@ submodules:
 
 .. code-block:: console
 
-  git clone --recurse-submodules --shallow-submodules https://github.com/PennyLaneAI/catalyst.git   # already in minimal guide
+  git clone --recurse-submodules --shallow-submodules https://github.com/PennyLaneAI/catalyst.git
 
 For an existing copy of the repository without its submodules, they can also be fetched via:
 
@@ -235,7 +202,7 @@ All additional build and developer dependencies are managed via the repository's
 
 .. code-block:: console
 
-  pip install -r requirements.txt   # already in minimal guide
+  pip install -r requirements.txt
 
 .. note::
 
@@ -251,7 +218,7 @@ directory:
 
 .. code-block:: console
 
-  make all   # already in minimal guide
+  make all
 
 To build each component one by one starting from the runtime, or to build additional backend devices
 beyond ``lightning.qubit``, please follow the instructions below.
@@ -313,32 +280,31 @@ To make the MLIR bindings from the Catalyst dialects discoverable to the compile
 
 .. code-block:: console
 
-  export PYTHONPATH="$PWD/mlir/build/python_packages/quantum:$PYTHONPATH"   # already in minimal guide
-
+  export PYTHONPATH="$PWD/mlir/build/python_packages/quantum:$PYTHONPATH"
 To make runtime libraries discoverable to the compiler:
 
 .. code-block:: console
 
-  export RUNTIME_LIB_DIR="$PWD/runtime/build/lib"   # already in minimal guide
+  export RUNTIME_LIB_DIR="$PWD/runtime/build/lib"
 
 To make MLIR libraries discoverable to the compiler:
 
 .. code-block:: console
 
-  export MLIR_LIB_DIR="$PWD/mlir/llvm-project/build/lib"   # already in minimal guide
+  export MLIR_LIB_DIR="$PWD/mlir/llvm-project/build/lib"
 
 To make Enzyme libraries discoverable to the compiler:
 
 .. code-block:: console
 
-  export ENZYME_LIB_DIR="$PWD/mlir/Enzyme/build/Enzyme"   # already in minimal guide
+  export ENZYME_LIB_DIR="$PWD/mlir/Enzyme/build/Enzyme"
 
 To make required tools in ``llvm-project/build``, ``mlir-hlo/mhlo-build``, and
 ``mlir/build`` discoverable to the compiler:
 
 .. code-block:: console
 
-  export PATH="$PWD/mlir/llvm-project/build/bin:$PWD/mlir/mlir-hlo/mhlo-build/bin:$PWD/mlir/build/bin:$PATH"   # already in minimal guide
+  export PATH="$PWD/mlir/llvm-project/build/bin:$PWD/mlir/mlir-hlo/mhlo-build/bin:$PWD/mlir/build/bin:$PATH"
 
 Tests
 ^^^^^
@@ -347,7 +313,7 @@ The following target runs all available test suites with the default execution d
 
 .. code-block:: console
 
-  make test   # already in minimal guide
+  make test
 
 You can also test each module separately by using running the ``test-frontend``,
 ``test-dialects``, and ``test-runtime`` targets instead. Jupyter Notebook demos are also testable

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -70,6 +70,75 @@ Building from source
 To build Catalyst from source, developers should follow the instructions provided below for building
 all three modules: the Python frontend, the MLIR compiler, and the runtime library.
 
+
+Just Tell Me How To Build Catalyst From Source
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+(This section title is a tribute to the llvm new pass manager guide's section `Just Tell Me How To Run The Default Optimization Pipeline With The New Pass Manager <https://llvm.org/docs/NewPassManager.html#just-tell-me-how-to-run-the-default-optimization-pipeline-with-the-new-pass-manager>`_)
+
+On **Linux**:
+.. code-block:: console
+
+  # Install common requirements
+  sudo apt install clang lld ccache libomp-dev ninja-build make cmake 
+
+  # Clone the Catalyst repository  
+  git clone --recurse-submodules --shallow-submodules https://github.com/PennyLaneAI/catalyst.git
+
+  # Install specific requirements for Catalyst
+  pip install -r requirements.txt
+
+  # Build Catalyst
+  make all
+
+  # If you are building Catalyst components in custom locations, set environment variables. This step should not be required if you are simply following the instructions above. 
+  export PYTHONPATH="$PWD/mlir/build/python_packages/quantum:$PYTHONPATH"
+  export RUNTIME_LIB_DIR="$PWD/runtime/build/lib"
+  export MLIR_LIB_DIR="$PWD/mlir/llvm-project/build/lib"
+  export ENZYME_LIB_DIR="$PWD/mlir/Enzyme/build/Enzyme"
+  export PATH="$PWD/mlir/llvm-project/build/bin:$PWD/mlir/mlir-hlo/mhlo-build/bin:$PWD/mlir/build/bin:$PATH"
+
+  # Optional: test that everything is built properly
+  make test
+
+  # Optional: build and test documentation for Catalyst
+  pip install -r doc/requirements.txt
+  sudo apt install doxygen pandoc
+
+
+On **macOS**:
+.. code-block:: console
+
+  # Install XCode Command Line Tools and common requirements
+  xcode-select --install
+  pip install cmake ninja
+  brew install libomp
+
+  # Clone the Catalyst repository  
+  git clone --recurse-submodules --shallow-submodules https://github.com/PennyLaneAI/catalyst.git
+
+  # install specific requirements for Catalyst
+  pip install -r requirements.txt 
+
+  # Build Catalyst
+  make all
+
+  # If you are building Catalyst components in custom locations, set environment variables. This step should not be required if you are simply following the instructions above. 
+  export PYTHONPATH="$PWD/mlir/build/python_packages/quantum:$PYTHONPATH"
+  export RUNTIME_LIB_DIR="$PWD/runtime/build/lib"
+  export MLIR_LIB_DIR="$PWD/mlir/llvm-project/build/lib"
+  export ENZYME_LIB_DIR="$PWD/mlir/Enzyme/build/Enzyme"
+  export PATH="$PWD/mlir/llvm-project/build/bin:$PWD/mlir/mlir-hlo/mhlo-build/bin:$PWD/mlir/build/bin:$PATH"
+
+  # Optional: test that everything is built properly
+  make test
+
+  # Optional: build and test documentation for Catalyst
+  pip install -r doc/requirements.txt
+  brew install doxygen pandoc
+
+Below is a more detailed guide, which we **strongly** recommend the user to read through. Importantly, each component of Catalyst can be built and tested indenpendently. 
+
+
 Requirements
 ^^^^^^^^^^^^
 
@@ -121,7 +190,7 @@ For an existing copy of the repository without its submodules, they can also be 
   git submodule update --init --depth=1
 
 All additional build and developer dependencies are managed via the repository's
-``requirements.txt`` and can be installed as follows:
+``requirements.txt`` and can be installed as follows once the repository is cloned:
 
 .. code-block:: console
 

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -110,10 +110,10 @@ On **macOS**:
 
 .. code-block:: console
 
-  # Install XCode Command Line Tools and common requirements \
-  xcode-select --install \
-  pip install cmake ninja \
-  brew install libomp \
+  # Install XCode Command Line Tools and common requirements
+  xcode-select --install
+  pip install cmake ninja
+  brew install libomp
 
   # Clone the Catalyst repository  
   git clone --recurse-submodules --shallow-submodules https://github.com/PennyLaneAI/catalyst.git

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -107,18 +107,6 @@ On **macOS**, it is strongly recommended to install the official XCode Command L
   pip install cmake ninja
   brew install libomp
 
-All additional build and developer dependencies are managed via the repository's
-``requirements.txt`` and can be installed as follows:
-
-.. code-block:: console
-
-  pip install -r requirements.txt
-
-.. Note::
-
-  Please ensure that your local site-packages for Python are available on the ``PATH`` - watch out
-  for the corresponding warning that ``pip`` may give you during installation.
-
 Once the pre-requisites are installed, start by cloning the project repository including all its
 submodules:
 
@@ -131,6 +119,18 @@ For an existing copy of the repository without its submodules, they can also be 
 .. code-block:: console
 
   git submodule update --init --depth=1
+
+All additional build and developer dependencies are managed via the repository's
+``requirements.txt`` and can be installed as follows:
+
+.. code-block:: console
+
+  pip install -r requirements.txt
+
+.. Note::
+
+  Please ensure that your local site-packages for Python are available on the ``PATH`` - watch out
+  for the corresponding warning that ``pip`` may give you during installation.
 
 Catalyst
 ^^^^^^^^

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -94,6 +94,9 @@ The essential steps are:
         # Build Catalyst
         make all
 
+        # Test that everything is built properly
+        make test
+
 
    .. group-tab:: macOS
 
@@ -113,6 +116,9 @@ The essential steps are:
 
         # Build Catalyst
         make all
+
+        # Test that everything is built properly
+        make test
 
 
 
@@ -134,12 +140,7 @@ The essential steps should give you the full functionality of Catalyst. There ar
         export ENZYME_LIB_DIR="$PWD/mlir/Enzyme/build/Enzyme"
         export PATH="$PWD/mlir/llvm-project/build/bin:$PWD/mlir/mlir-hlo/mhlo-build/bin:$PWD/mlir/build/bin:$PATH"
 
-        # Optional: test that everything is built properly
-        make test
 
-        # Optional: build and test documentation for Catalyst
-        pip install -r doc/requirements.txt
-        sudo apt install doxygen pandoc
 
    .. group-tab:: macOS
 
@@ -154,12 +155,7 @@ The essential steps should give you the full functionality of Catalyst. There ar
         export ENZYME_LIB_DIR="$PWD/mlir/Enzyme/build/Enzyme"
         export PATH="$PWD/mlir/llvm-project/build/bin:$PWD/mlir/mlir-hlo/mhlo-build/bin:$PWD/mlir/build/bin:$PATH"
 
-        # Optional: test that everything is built properly
-        make test
 
-        # Optional: build and test documentation for Catalyst
-        pip install -r doc/requirements.txt
-        brew install doxygen pandoc
 
 
 Detailed Building From Source Guide
@@ -397,7 +393,7 @@ To build and test documentation for Catalyst, you will need to install
 
 .. code-block:: console
 
-  pip install -r doc/requirements.txt   # already in minimal guide
+  pip install -r doc/requirements.txt
 
 Additionally, `doxygen <https://www.doxygen.nl>`_ is required to build C++ documentation, and
 `pandoc <https://pandoc.org>`_ to render Jupyter Notebooks.
@@ -411,7 +407,7 @@ They can be installed via
 
       .. code-block:: console
 
-        sudo apt install doxygen pandoc   # already in minimal guide
+        sudo apt install doxygen pandoc
 
 
    .. group-tab:: macOS
@@ -420,5 +416,5 @@ They can be installed via
 
       .. code-block:: console
 
-        brew install doxygen pandoc   # already in minimal guide
+        brew install doxygen pandoc
 

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -118,7 +118,7 @@ On **macOS**:
   # Clone the Catalyst repository  
   git clone --recurse-submodules --shallow-submodules https://github.com/PennyLaneAI/catalyst.git
 
-  # install specific requirements for Catalyst
+  # Install specific requirements for Catalyst
   pip install -r requirements.txt 
 
   # Build Catalyst

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -75,7 +75,7 @@ Just Tell Me How To Build Catalyst From Source
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 (This section title is a tribute to the llvm new pass manager guide's section `Just Tell Me How To Run The Default Optimization Pipeline With The New Pass Manager <https://llvm.org/docs/NewPassManager.html#just-tell-me-how-to-run-the-default-optimization-pipeline-with-the-new-pass-manager>`_)
 
-On **Linux**:
+On **Linux Debian/Ubuntu**:
 
 .. code-block:: console
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -11,6 +11,7 @@ nbsphinx==0.7
 Jinja2==3.1.4
 version_information
 sphinx-copybutton
+sphinx-tabs
 markupsafe==2.1.1
 pennylane-sphinx-theme
 nbconvert


### PR DESCRIPTION
**Context:** Improvements to the installation documentation 

**Description of the Change:**
1. It is a bit confusing for the 
`pip install -r requirements.txt`
to come before the
`git clone --recurse-submodules --shallow-submodules https://github.com/PennyLaneAI/catalyst.git`
in the installation guide, since a lot of people don’t carefully read anything before the “git clone”.

2. Added a summary section at the top of the 'compile from source' section for each OS, allowing users to easily see together all the commands to run.

**Benefits:** See above

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-54448]
