### PR TITLE
Refactor vmap following the decorator callable class pattern

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -92,6 +92,11 @@
   annotations.
   [(#751)](https://github.com/PennyLaneAI/catalyst/pull/751)
 
+* Refactored `vmap` decorator in order to follow a unified pattern that uses a callable 
+  class that implements the decorator's logic. This prevents having to excessively define 
+  functions in a nested fashion.
+  [(#758)](https://github.com/PennyLaneAI/catalyst/pull/758)
+
 <h3>Breaking changes</h3>
 
 * Binary distributions for Linux are now based on `manylinux_2_28` instead of `manylinux_2014`.


### PR DESCRIPTION
**Context:** We intend that all Catalyst's functional decorators are presented uniformly to the user. In this case, the `vmap` decorator was refactored.

**Description of the Change:** Create a `VmapCallable` class and instantiate an object of that class from the `vmap` API. Previous code was moved from the API to the callable class.

**Benefits:** The use of def decorator(): and class DecoratorCallable: is a common pattern used by Catalyst to implement decorators without having to excessively define functions in a nested fashion. A consistent implementation pattern is preferred across all decorators. 

**TODO:**

- [x] Add test cases
- [x] Update changelog

[sc-60279]