### PR TITLE
[Build-system] Fix build process to allow catalyst attributes

### DIFF
--- a/mlir/include/Catalyst/IR/CMakeLists.txt
+++ b/mlir/include/Catalyst/IR/CMakeLists.txt
@@ -1,3 +1,11 @@
 add_mlir_dialect(CatalystOps catalyst)
 add_mlir_doc(CatalystDialect CatalystDialect Catalyst/ -gen-dialect-doc)
 add_mlir_doc(CatalystOps CatalystOps Catalyst/ -gen-op-doc)
+
+set(LLVM_TARGET_DEFINITIONS CatalystOps.td)
+mlir_tablegen(CatalystEnums.h.inc -gen-enum-decls)
+mlir_tablegen(CatalystEnums.cpp.inc -gen-enum-defs)
+mlir_tablegen(CatalystAttributes.h.inc -gen-attrdef-decls -attrdefs-dialect=catalyst)
+mlir_tablegen(CatalystAttributes.cpp.inc -gen-attrdef-defs -attrdefs-dialect=catalyst)
+add_public_tablegen_target(MLIRCatalystEnumsIncGen)
+

--- a/mlir/include/Catalyst/IR/CatalystDialect.td
+++ b/mlir/include/Catalyst/IR/CatalystDialect.td
@@ -39,6 +39,7 @@ def Catalyst_Dialect : Dialect {
 
     /// Use the default type printing/parsing hooks, otherwise we would explicitly define them.
     let useDefaultTypePrinterParser = 1;
+
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/Catalyst/IR/CatalystOps.h
+++ b/mlir/include/Catalyst/IR/CatalystOps.h
@@ -25,5 +25,9 @@
 
 #include "Catalyst/IR/CatalystDialect.h"
 
+#include "Catalyst/IR/CatalystEnums.h.inc"
+#define GET_ATTRDEF_CLASSES
+#include "Catalyst/IR/CatalystAttributes.h.inc"
+
 #define GET_OP_CLASSES
 #include "Catalyst/IR/CatalystOps.h.inc"

--- a/mlir/include/Catalyst/IR/CatalystOps.td
+++ b/mlir/include/Catalyst/IR/CatalystOps.td
@@ -23,6 +23,18 @@ include "mlir/IR/OpBase.td"
 
 include "Catalyst/IR/CatalystDialect.td"
 
+//===----------------------------------------------------------------------===//
+// Catalyst dialect enums.
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Catalyst dialect attributes.
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Catalyst dialect operations.
+//===----------------------------------------------------------------------===//
+
 def ListInitOp : Catalyst_Op<"list_init"> {
     let summary = "Initialize a dynamically resizable arraylist.";
     let results = (outs ArrayListType:$list);
@@ -140,4 +152,4 @@ def PythonCallOp: Catalyst_Op<"pycallback",
   }];
 }
 
-#endif // GRADIENT_OPS
+#endif // CATALYST_OPS

--- a/mlir/lib/Catalyst/IR/CMakeLists.txt
+++ b/mlir/lib/Catalyst/IR/CMakeLists.txt
@@ -7,6 +7,7 @@ add_mlir_library(MLIRCatalyst
 
     DEPENDS
     MLIRCatalystOpsIncGen
+    MLIRCatalystEnumsIncGen
 
     LINK_LIBS PRIVATE
 )

--- a/mlir/lib/Catalyst/IR/CatalystDialect.cpp
+++ b/mlir/lib/Catalyst/IR/CatalystDialect.cpp
@@ -35,6 +35,11 @@ void CatalystDialect::initialize()
 #include "Catalyst/IR/CatalystOpsTypes.cpp.inc"
         >();
 
+    addAttributes<
+#define GET_ATTRDEF_LIST
+#include "Catalyst/IR/CatalystAttributes.cpp.inc"
+        >();
+
     addOperations<
 #define GET_OP_LIST
 #include "Catalyst/IR/CatalystOps.cpp.inc"
@@ -47,3 +52,5 @@ void CatalystDialect::initialize()
 
 #define GET_TYPEDEF_CLASSES
 #include "Catalyst/IR/CatalystOpsTypes.cpp.inc"
+#define GET_ATTRDEF_CLASSES
+#include "Catalyst/IR/CatalystAttributes.cpp.inc"

--- a/mlir/lib/Catalyst/IR/CatalystOps.cpp
+++ b/mlir/lib/Catalyst/IR/CatalystOps.cpp
@@ -23,6 +23,7 @@
 using namespace mlir;
 using namespace catalyst;
 
+#include "Catalyst/IR/CatalystEnums.cpp.inc"
 #define GET_OP_CLASSES
 #include "Catalyst/IR/CatalystOps.cpp.inc"
 


### PR DESCRIPTION
**Context:** I will be adding an EnumAttribute with possible values being forward and reverse. This is just the build process. Feels like it should be a different commit to help review process.

**Description of the Change:** Updates build process to allow the generation of catalyst attributes and enums.

Note: Future changes could include changing some unit attributes (which work a little bit like a state machine's state) into enum attributes.