### PR TITLE
Define qjit API before its implementation to comply with the api_extensions convention

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -96,10 +96,11 @@
   annotations.
   [(#751)](https://github.com/PennyLaneAI/catalyst/pull/751)
 
-* Refactored `vmap` decorator in order to follow a unified pattern that uses a callable
-  class that implements the decorator's logic. This prevents having to excessively define
-  functions in a nested fashion.
+* Refactored `vmap` and `qjit` decorators in order to follow a unified pattern 
+  that uses a callable class that implements the decorator's logic. This prevents having to 
+  excessively define functions in a nested fashion.
   [(#758)](https://github.com/PennyLaneAI/catalyst/pull/758)
+  [(#761)](https://github.com/PennyLaneAI/catalyst/pull/761)
 
 * Catalyst tests now manipulate device capabilities rather than text configurations files.
   [(#712)](https://github.com/PennyLaneAI/catalyst/pull/712)

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -941,5 +941,22 @@ class TestTwoQJITsOneName:
         foo_2.workspace.cleanup()
 
 
+class TestQJITUsagePatterns:
+    """Test usage patterns of catalyst.qjit."""
+
+    def test_usage_patterns(self):
+        """Test two usage patterns of catalyst.qjit."""
+
+        def fn(x, y):
+            return x * y
+
+        res_pattern_fn_as_argument = qjit(fn, autograph=False)(5, 6)
+        res_pattern_partial = qjit(autograph=False)(fn)(5, 6)
+
+        expected = 30
+        assert res_pattern_fn_as_argument == expected
+        assert res_pattern_partial == expected
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])


### PR DESCRIPTION
**Context:** In order to stick to the convention in the api_extensions, the API functions are at the top of the files.

**Description of the Change:** Move the API to the beginning of the file.

**Benefits:** Code readability.

[sc-60279]
