### PR TITLE
Refactor gradient APIs for using partials 

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -102,11 +102,12 @@
   annotations.
   [(#751)](https://github.com/PennyLaneAI/catalyst/pull/751)
 
-* Refactored `vmap` and `qjit` decorators in order to follow a unified pattern 
+* Refactored `vmap`,`qjit` and gradient decorators in order to follow a unified pattern 
   that uses a callable class that implements the decorator's logic. This prevents having to 
   excessively define functions in a nested fashion.
   [(#758)](https://github.com/PennyLaneAI/catalyst/pull/758)
   [(#761)](https://github.com/PennyLaneAI/catalyst/pull/761)
+  [(#762)](https://github.com/PennyLaneAI/catalyst/pull/762)
 
 * Catalyst tests now manipulate device capabilities rather than text configurations files.
   [(#712)](https://github.com/PennyLaneAI/catalyst/pull/712)

--- a/frontend/catalyst/api_extensions/differentiation.py
+++ b/frontend/catalyst/api_extensions/differentiation.py
@@ -18,6 +18,8 @@ capabilities for hybrid quantum programs. This includes the computation
 of gradients, jacobians, jacobian-vector products, and more.
 """
 
+import copy
+import functools
 import numbers
 from typing import Callable, Iterable, List, Optional, Union
 
@@ -45,7 +47,7 @@ DifferentiableLike = Union[Differentiable, Callable, "catalyst.QJIT"]
 
 
 ## API ##
-def grad(f: DifferentiableLike, *, method=None, h=None, argnum=None):
+def grad(fn=None, *, method=None, h=None, argnum=None):
     """A :func:`~.qjit` compatible gradient transformation for PennyLane/Catalyst.
 
     This function allows the gradient of a hybrid quantum-classical function to be computed within
@@ -58,7 +60,7 @@ def grad(f: DifferentiableLike, *, method=None, h=None, argnum=None):
         method.
 
     Args:
-        f (Callable): a function or a function object to differentiate
+        fn (Callable): a function or a function object to differentiate
         method (str): The method used for differentiation, which can be any of ``["auto", "fd"]``,
                       where:
 
@@ -171,8 +173,15 @@ def grad(f: DifferentiableLike, *, method=None, h=None, argnum=None):
     >>> dsquare(2.3)
     array(4.6)
     """
+    kwargs = copy.copy(locals())
+    kwargs.pop("fn")
+
+    if fn is None:
+        return functools.partial(grad, **kwargs)
+
     scalar_out = True
-    return Grad(f, GradParams(method, scalar_out, h, argnum))
+
+    return Grad(fn, GradParams(method, scalar_out, h, argnum))
 
 
 def value_and_grad(f: DifferentiableLike, *, method=None, h=None, argnum=None):

--- a/frontend/catalyst/api_extensions/differentiation.py
+++ b/frontend/catalyst/api_extensions/differentiation.py
@@ -296,7 +296,7 @@ def value_and_grad(fn=None, *, method=None, h=None, argnum=None):
     return Grad(fn, GradParams(method, scalar_out, h, argnum, with_value=True))
 
 
-def jacobian(f: DifferentiableLike, *, method=None, h=None, argnum=None):
+def jacobian(fn=None, *, method=None, h=None, argnum=None):
     """A :func:`~.qjit` compatible Jacobian transformation for PennyLane/Catalyst.
 
     This function allows the Jacobian of a hybrid quantum-classical function to be computed within
@@ -304,7 +304,7 @@ def jacobian(f: DifferentiableLike, *, method=None, h=None, argnum=None):
     JAX counterpart ``jax.jacobian``. The function ``f`` can return any pytree-like shape.
 
     Args:
-        f (Callable): a function or a function object to differentiate
+        fn (Callable): a function or a function object to differentiate
         method (str): The method used for differentiation, which can be any of ``["auto", "fd"]``,
                       where:
 
@@ -357,8 +357,15 @@ def jacobian(f: DifferentiableLike, *, method=None, h=None, argnum=None):
     array([[ 3.48786850e-16 -4.20735492e-01]
            [-8.71967125e-17  4.20735492e-01]])
     """
+    kwargs = copy.copy(locals())
+    kwargs.pop("fn")
+
+    if fn is None:
+        return functools.partial(grad, **kwargs)
+
     scalar_out = False
-    return Grad(f, GradParams(method, scalar_out, h, argnum))
+
+    return Grad(fn, GradParams(method, scalar_out, h, argnum))
 
 
 # pylint: disable=too-many-arguments

--- a/frontend/catalyst/api_extensions/differentiation.py
+++ b/frontend/catalyst/api_extensions/differentiation.py
@@ -184,7 +184,7 @@ def grad(fn=None, *, method=None, h=None, argnum=None):
     return Grad(fn, GradParams(method, scalar_out, h, argnum))
 
 
-def value_and_grad(f: DifferentiableLike, *, method=None, h=None, argnum=None):
+def value_and_grad(fn=None, *, method=None, h=None, argnum=None):
     """A :func:`~.qjit` compatible gradient transformation for PennyLane/Catalyst.
 
     This function allows the value and the gradient of a hybrid quantum-classical function to be
@@ -198,7 +198,7 @@ def value_and_grad(f: DifferentiableLike, *, method=None, h=None, argnum=None):
         method.
 
     Args:
-        f (Callable): a function or a function object to differentiate
+        fn (Callable): a function or a function object to differentiate
         method (str): The method used for differentiation, which can be any of ``["auto", "fd"]``,
                       where:
 
@@ -285,8 +285,15 @@ def value_and_grad(f: DifferentiableLike, *, method=None, h=None, argnum=None):
     >>> dsquare(2.3)
     (array(5.29), array(4.6))
     """
+    kwargs = copy.copy(locals())
+    kwargs.pop("fn")
+
+    if fn is None:
+        return functools.partial(value_and_grad, **kwargs)
+
     scalar_out = True
-    return Grad(f, GradParams(method, scalar_out, h, argnum, with_value=True))
+
+    return Grad(fn, GradParams(method, scalar_out, h, argnum, with_value=True))
 
 
 def jacobian(f: DifferentiableLike, *, method=None, h=None, argnum=None):

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1244,7 +1244,7 @@ class TestGradientUsagePatterns:
         res_pattern_fn_as_argument = grad(fn)(x)
         res_pattern_partial = grad()(fn)(x)
         expected = jax.grad(fn)(x)
-        
+
         assert np.allclose(res_pattern_fn_as_argument, expected)
         assert np.allclose(res_pattern_partial, expected)
 
@@ -1264,6 +1264,21 @@ class TestGradientUsagePatterns:
         assert np.allclose(partial_val, expected_val)
         assert np.allclose(fn_as_argument_grad, expected_grad)
         assert np.allclose(partial_grad, expected_grad)
+
+    def test_jacobian_usage_patterns(self):
+        """Test usage patterns of catalyst.jacobian."""
+
+        def fn(x):
+            return x**2
+
+        x = 4.0
+
+        res_pattern_fn_as_argument = jacobian(fn)(x)
+        res_pattern_partial = jacobian()(fn)(x)
+        expected = jax.jacobian(fn)(x)
+
+        assert np.allclose(res_pattern_fn_as_argument, expected)
+        assert np.allclose(res_pattern_partial, expected)
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1230,5 +1230,24 @@ class TestGradientErrors:
                 return grad(g)(x)
 
 
+class TestGradientUsagePatterns:
+    """Test usage patterns of Gradient functions"""
+
+    def test_grad_usage_patterns(self):
+        """Test usage patterns of catalyst.grad."""
+
+        def fn(x):
+            return x**2
+
+        x = 4.0
+
+        res_pattern_fn_as_argument = grad(fn)(x)
+        res_pattern_partial = grad()(fn)(x)
+        expected = jax.grad(fn)(x)
+        
+        assert np.allclose(res_pattern_fn_as_argument, expected)
+        assert np.allclose(res_pattern_partial, expected)
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1248,6 +1248,23 @@ class TestGradientUsagePatterns:
         assert np.allclose(res_pattern_fn_as_argument, expected)
         assert np.allclose(res_pattern_partial, expected)
 
+    def test_value_and_grad_usage_patterns(self):
+        """Test usage patterns of catalyst.value_and_grad."""
+
+        def fn(x):
+            return x**2
+
+        x = 4.0
+
+        fn_as_argument_val, fn_as_argument_grad = value_and_grad(fn)(x)
+        partial_val, partial_grad = value_and_grad()(fn)(x)
+        expected_val, expected_grad = jax.value_and_grad(fn)(x)
+
+        assert np.allclose(fn_as_argument_val, expected_val)
+        assert np.allclose(partial_val, expected_val)
+        assert np.allclose(fn_as_argument_grad, expected_grad)
+        assert np.allclose(partial_grad, expected_grad)
+
 
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1241,8 +1241,8 @@ class TestGradientUsagePatterns:
 
         x = 4.0
 
-        res_pattern_fn_as_argument = grad(fn)(x)
-        res_pattern_partial = grad()(fn)(x)
+        res_pattern_fn_as_argument = grad(fn, method="fd")(x)
+        res_pattern_partial = grad(method="fd")(fn)(x)
         expected = jax.grad(fn)(x)
 
         assert np.allclose(res_pattern_fn_as_argument, expected)
@@ -1256,8 +1256,8 @@ class TestGradientUsagePatterns:
 
         x = 4.0
 
-        fn_as_argument_val, fn_as_argument_grad = value_and_grad(fn)(x)
-        partial_val, partial_grad = value_and_grad()(fn)(x)
+        fn_as_argument_val, fn_as_argument_grad = value_and_grad(fn, method="fd")(x)
+        partial_val, partial_grad = value_and_grad(method="fd")(fn)(x)
         expected_val, expected_grad = jax.value_and_grad(fn)(x)
 
         assert np.allclose(fn_as_argument_val, expected_val)
@@ -1273,8 +1273,8 @@ class TestGradientUsagePatterns:
 
         x = 4.0
 
-        res_pattern_fn_as_argument = jacobian(fn)(x)
-        res_pattern_partial = jacobian()(fn)(x)
+        res_pattern_fn_as_argument = jacobian(fn, method="fd")(x)
+        res_pattern_partial = jacobian(method="fd")(fn)(x)
         expected = jax.jacobian(fn)(x)
 
         assert np.allclose(res_pattern_fn_as_argument, expected)


### PR DESCRIPTION
**Context:** The function can be used with and without specifying the function.

**Description of the Change:** Use `functools.partial` for when the function is `None`

**Benefits:** Favors decorator syntax.

[sc-60279]