### PR TITLE
Refactor mitigate_with_zne API for using partials

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -102,12 +102,13 @@
   annotations.
   [(#751)](https://github.com/PennyLaneAI/catalyst/pull/751)
 
-* Refactored `vmap`,`qjit` and gradient decorators in order to follow a unified pattern 
-  that uses a callable class that implements the decorator's logic. This prevents having to 
-  excessively define functions in a nested fashion.
+* Refactored `vmap`,`qjit`, `mitigate_with_zne` and gradient decorators in order to follow
+  a unified pattern that uses a callable class implementing the decorator's logic. This 
+  prevents having to excessively define functions in a nested fashion.
   [(#758)](https://github.com/PennyLaneAI/catalyst/pull/758)
   [(#761)](https://github.com/PennyLaneAI/catalyst/pull/761)
   [(#762)](https://github.com/PennyLaneAI/catalyst/pull/762)
+  [(#763)](https://github.com/PennyLaneAI/catalyst/pull/763)
 
 * Catalyst tests now manipulate device capabilities rather than text configurations files.
   [(#712)](https://github.com/PennyLaneAI/catalyst/pull/712)


### PR DESCRIPTION
Context: The function can be used with and without specifying the function.

Description of the Change: Use functools.partial for when the function is None

Benefits: Favors decorator syntax.

[sc-60279]