### PR TITLE
Do not report cumulative time for MLIR passes in instrumentation

### DIFF
--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -567,8 +567,7 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
     catalyst::utils::LinesCount::ModuleOp(*op);
 
     if (op) {
-        if (failed(timer::timer(runLowering, "runMLIRPasses", /* add_endl */ true, options, &ctx,
-                                *op, output))) {
+        if (failed(runLowering(options, &ctx, *op, output))) {
             CO_MSG(options, Verbosity::Urgent, "Failed to lower MLIR module\n");
             return failure();
         }


### PR DESCRIPTION
This is confusing when looking at the report since both a cumulative time and each individual pass time is reported without clear indication that the timings do not sum up to the total.