### PR TITLE
When generating mlir GradOp, correctly querying const array types from parent numpy arrays

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -137,6 +137,9 @@
   In this bug fix, four openblas routines were newly linked and are now discoverable by `stablehlo.custom_call@<blas_routine>`. They are `blas_dtrsm`, `blas_ztrsm`, `lapack_dgetrf`, `lapack_zgetrf`.
   [(#752)](https://github.com/PennyLaneAI/catalyst/pull/752)
 
+* Correctly recording types of constant array when lowering `catalyst.grad` to mlir
+  [(#778)](https://github.com/PennyLaneAI/catalyst/pull/778)
+
 <h3>Internal changes</h3>
 
 * Add support to use a locally cloned PennyLane Lightning repository with the runtime.

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -413,11 +413,10 @@ def _grad_lowering(ctx, *args, jaxpr, fn, grad_params):
     constants = []
     for const in jaxpr.consts:
         const_type = shape_dtype_to_ir_type(const.shape, const.dtype)
-        constants.append(
-            StableHLOConstantOp(
-                ir.DenseElementsAttr.get(np.asarray(const), type=const_type)
-            ).results
-        )
+        nparray = np.asarray(const)
+        attr = ir.DenseElementsAttr.get(nparray, type=const_type)
+        constantVals = StableHLOConstantOp(attr).results
+        constants.append(constantVals)
     args_and_consts = constants + list(args)
 
     return GradOp(

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -457,14 +457,10 @@ def _jvp_lowering(ctx, *args, jaxpr, fn, grad_params):
 
     output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
     flat_output_types = util.flatten(output_types)
-    constants = []
-    for const in jaxpr.consts:
-        const_type = shape_dtype_to_ir_type(const.shape, const.dtype)
-        constants.append(
-            StableHLOConstantOp(
-                ir.DenseElementsAttr.get(np.asarray(const), type=const_type)
-            ).results
-        )
+    constants = [
+        StableHLOConstantOp(ir.DenseElementsAttr.get(np.asarray(const))).results
+        for const in jaxpr.consts
+    ]
     consts_and_args = constants + args
     func_call_jaxpr = jaxpr.eqns[0].params["call_jaxpr"]
     func_args = consts_and_args[: len(func_call_jaxpr.invars)]
@@ -517,14 +513,10 @@ def _vjp_lowering(ctx, *args, jaxpr, fn, grad_params):
 
     output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
     flat_output_types = util.flatten(output_types)
-    constants = []
-    for const in jaxpr.consts:
-        const_type = shape_dtype_to_ir_type(const.shape, const.dtype)
-        constants.append(
-            StableHLOConstantOp(
-                ir.DenseElementsAttr.get(np.asarray(const), type=const_type)
-            ).results
-        )
+    constants = [
+        StableHLOConstantOp(ir.DenseElementsAttr.get(np.asarray(const))).results
+        for const in jaxpr.consts
+    ]
     consts_and_args = constants + args
     func_call_jaxpr = jaxpr.eqns[0].params["call_jaxpr"]
     func_args = consts_and_args[: len(func_call_jaxpr.invars)]

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1157,7 +1157,7 @@ def test_adj_qubitunitary(inp, backend):
 
     def f(x):
         qml.RX(x, wires=0)
-        U1 = (np.array([[0.5+0.5j, -0.5-0.5j], [0.5-0.5j, 0.5-0.5j]], dtype=complex))
+        U1 = np.array([[0.5 + 0.5j, -0.5 - 0.5j], [0.5 - 0.5j, 0.5 - 0.5j]], dtype=complex)
         qml.QubitUnitary(U1, wires=0)
         return qml.expval(qml.PauliY(0))
 

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1157,7 +1157,11 @@ def test_adj_qubitunitary(inp, backend):
 
     def f(x):
         qml.RX(x, wires=0)
-        U1 = 1 / np.sqrt(2) * np.array([[1.0+2.0j, 3.0-4.5j], [9.8-7.6j, -1.0+3j]], dtype=complex)
+        U1 = (
+            1
+            / np.sqrt(2)
+            * np.array([[1.0 + 2.0j, 3.0 - 4.5j], [9.8 - 7.6j, -1.0 + 3j]], dtype=complex)
+        )
         qml.QubitUnitary(U1, wires=0)
         return qml.expval(qml.PauliY(0))
 

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1157,11 +1157,7 @@ def test_adj_qubitunitary(inp, backend):
 
     def f(x):
         qml.RX(x, wires=0)
-        U1 = (
-            1
-            / np.sqrt(2)
-            * np.array([[1.0 + 2.0j, 3.0 - 4.5j], [9.8 - 7.6j, -1.0 + 3j]], dtype=complex)
-        )
+        U1 = (np.array([[0.5+0.5j, -0.5-0.5j], [0.5-0.5j, 0.5-0.5j]], dtype=complex))
         qml.QubitUnitary(U1, wires=0)
         return qml.expval(qml.PauliY(0))
 
@@ -1173,7 +1169,7 @@ def test_adj_qubitunitary(inp, backend):
 
     def interpreted(x):
         device = qml.device("default.qubit", wires=1)
-        g = qml.QNode(f, device, diff_method="adjoint")
+        g = qml.QNode(f, device, diff_method="backprop")
         h = qml.grad(g, argnum=0)
         return h(x)
 

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1163,13 +1163,13 @@ def test_adj_qubitunitary(inp, backend):
 
     @qjit()
     def compiled(x: float):
-        g = qml.qnode(qml.device(backend, wires=1))(f)
+        g = qml.qnode(qml.device(backend, wires=1), diff_method="adjoint")(f)
         h = grad(g, method="auto")
         return h(x)
 
     def interpreted(x):
         device = qml.device("default.qubit", wires=1)
-        g = qml.QNode(f, device)
+        g = qml.QNode(f, device, diff_method="adjoint")
         h = qml.grad(g, argnum=0)
         return h(x)
 

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1151,26 +1151,25 @@ def test_pytrees_args_return_classical():
     assert np.allclose(flatten_res_jax, flatten_res_catalyst)
 
 
-@pytest.mark.xfail(reason="QubitUnitrary is not support with catalyst.grad")
 @pytest.mark.parametrize("inp", [(1.0), (2.0), (3.0), (4.0)])
 def test_adj_qubitunitary(inp, backend):
     """Test the adjoint method."""
 
     def f(x):
         qml.RX(x, wires=0)
-        U1 = 1 / np.sqrt(2) * np.array([[1.0, 1.0], [1.0, -1.0]], dtype=complex)
+        U1 = 1 / np.sqrt(2) * np.array([[1.0+2.0j, 3.0-4.5j], [9.8-7.6j, -1.0+3j]], dtype=complex)
         qml.QubitUnitary(U1, wires=0)
         return qml.expval(qml.PauliY(0))
 
     @qjit()
     def compiled(x: float):
-        g = qml.qnode(qml.device(backend, wires=1), diff_method="adjoint")(f)
+        g = qml.qnode(qml.device(backend, wires=1))(f)
         h = grad(g, method="auto")
         return h(x)
 
     def interpreted(x):
         device = qml.device("default.qubit", wires=1)
-        g = qml.QNode(f, device, diff_method="backprop")
+        g = qml.QNode(f, device)
         h = qml.grad(g, argnum=0)
         return h(x)
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new functions and code must be clearly commented and documented.

- [x] Ensure that code is properly formatted by running `make format`.
      The latest version of black and `clang-format-14` are used in CI/CD to check formatting.

- [x] All new features must include a unit test.
      Integration and frontend tests should be added to [`frontend/test`](../frontend/test/),
      Quantum dialect and MLIR tests should be added to [`mlir/test`](../mlir/test/), and
      Runtime tests should be added to [`runtime/tests`](../runtime/tests/).

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** #774 
`jax.grad` fails on a qnode when the qnode has a `QubitUnitary` that takes in a complex matrix. This is because currently in `frontend/catalyst/jax_primitives.py`, in `_grad_lowering`, when producing the `ConstantOp`s from frontend's numpy arrays, the dtype of the numpy array is not passed in, and the type of the produced `ConstantOp` and the actual data type is not guaranteed to be the same. 

**Description of the Change:**
We now pass in the type of the parent numpy array. Jax provides a utility function that converts numpy types to mlir types (including the shape): https://github.com/google/jax/blob/d6a84cc5f327c789da073a11b1c0d3fbc2a56bdd/jaxlib/hlo_helpers.py#L48

~~A similar usage pattern exists when generating vjp/jvp and is updated as well.~~ More work is needed for `jvp`/`vjp` to fully support complex values. We thus do not implement it in this PR. 

**Benefits:** Bugfix

**Possible Drawbacks:**

**Related GitHub Issues:** closes #774 

[sc-64529]