### PR TITLE
[MLIR] Add specialization for all callbacks

### DIFF
--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -185,11 +185,6 @@ class FlatCallable:
         return map(type, self.getOperands())
 
 
-def clear_callback_cache():
-    """Clear the memref callable cache"""
-    MemrefCallable.CACHE.clear()
-
-
 class MemrefCallable(FlatCallable):
     """Callable that receives void ptrs."""
 
@@ -205,6 +200,11 @@ class MemrefCallable(FlatCallable):
         instance = super().__new__(cls)
         cls.CACHE[cache_key] = instance
         return instance
+
+    @classmethod
+    def clearcache(cls):
+        """Clear the memref callable cache"""
+        cls.CACHE.clear()
 
     def __init__(self, func, results_aval, *args, **kwargs):
         super().__init__(func, *args, **kwargs)

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -21,7 +21,7 @@ but require a Python interpreter instance.
 import ctypes
 import inspect
 from collections.abc import Sequence
-from functools import cache, wraps
+from functools import wraps
 from typing import Any, Callable
 
 import jax.numpy as jnp
@@ -186,15 +186,16 @@ class FlatCallable:
 
 
 def clear_callback_cache():
+    """Clear the memref callable cache"""
     MemrefCallable.CACHE.clear()
 
 
 class MemrefCallable(FlatCallable):
     """Callable that receives void ptrs."""
 
-    CACHE = dict()
+    CACHE = {}
 
-    def __new__(cls, func, results_aval, *args, **kwargs):
+    def __new__(cls, func, results_aval):
         # Hash-cons: https://en.wikipedia.org/wiki/Hash_consing
         flat_results_aval, _ = tree_flatten(results_aval)
         cache_key = (func, *flat_results_aval)

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -195,7 +195,7 @@ class MemrefCallable(FlatCallable):
 
     CACHE = {}
 
-    def __new__(cls, func, results_aval):
+    def __new__(cls, func, results_aval, *_args, **_kwargs):
         # Hash-cons: https://en.wikipedia.org/wiki/Hash_consing
         flat_results_aval, _ = tree_flatten(results_aval)
         cache_key = (func, *flat_results_aval)

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -252,7 +252,6 @@ def _python_callback_lowering(jax_ctx: mlir.LoweringRuleContext, *args, callback
     callback_id = registry.register(callback)
 
     ctx = jax_ctx.module_context.context
-    i64_type = ir.IntegerType.get_signless(64, ctx)
 
     params_ty = [arg.type for arg in args]
     results_ty = list(convert_shaped_arrays_to_tensors(results_aval))

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -41,7 +41,7 @@ from jaxlib.mlir.dialects.func import CallOp, FunctionType
 from jaxlib.mlir.dialects.scf import ConditionOp, ForOp, IfOp, WhileOp, YieldOp
 from jaxlib.mlir.dialects.stablehlo import ConstantOp as StableHLOConstantOp
 from jaxlib.mlir.dialects.stablehlo import ConvertOp as StableHLOConvertOp
-from mlir_quantum.dialects.catalyst import CallbackOp, PrintOp, PythonCallOp
+from mlir_quantum.dialects.catalyst import CallbackOp, CallbackCallOp, PrintOp
 from mlir_quantum.dialects.gradient import GradOp, JVPOp, VJPOp
 from mlir_quantum.dialects.mitigation import ZneOp
 from mlir_quantum.dialects.quantum import (
@@ -272,7 +272,7 @@ def _python_callback_lowering(jax_ctx: mlir.LoweringRuleContext, *args, callback
     symbol = callbackOp.sym_name.value
     symbol_attr = ir.FlatSymbolRefAttr.get(symbol)
 
-    return PythonCallOp(results_ty, args, identifier, number_original_arg=len(args)).results
+    return CallbackCallOp(results_ty, symbol_attr, args).results
 
 
 #

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -251,8 +251,6 @@ def _python_callback_lowering(jax_ctx: mlir.LoweringRuleContext, *args, callback
 
     callback_id = registry.register(callback)
 
-    ctx = jax_ctx.module_context.context
-
     params_ty = [arg.type for arg in args]
     results_ty = list(convert_shaped_arrays_to_tensors(results_aval))
     fn_ty = FunctionType.get(inputs=params_ty, results=results_ty)

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -240,7 +240,7 @@ def _python_callback_def_impl(*avals, callback, results_aval):  # pragma: no cov
     raise NotImplementedError()
 
 
-CALLBACK_OP_CACHE = dict()
+CALLBACK_OP_CACHE = {}
 
 
 def _python_callback_lowering(jax_ctx: mlir.LoweringRuleContext, *args, callback, results_aval):
@@ -253,7 +253,6 @@ def _python_callback_lowering(jax_ctx: mlir.LoweringRuleContext, *args, callback
 
     ctx = jax_ctx.module_context.context
     i64_type = ir.IntegerType.get_signless(64, ctx)
-    identifier = ir.IntegerAttr.get(i64_type, callback_id)
 
     params_ty = [arg.type for arg in args]
     results_ty = list(convert_shaped_arrays_to_tensors(results_aval))

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -41,7 +41,7 @@ from jaxlib.mlir.dialects.func import CallOp, FunctionType
 from jaxlib.mlir.dialects.scf import ConditionOp, ForOp, IfOp, WhileOp, YieldOp
 from jaxlib.mlir.dialects.stablehlo import ConstantOp as StableHLOConstantOp
 from jaxlib.mlir.dialects.stablehlo import ConvertOp as StableHLOConvertOp
-from mlir_quantum.dialects.catalyst import CallbackOp, CallbackCallOp, PrintOp
+from mlir_quantum.dialects.catalyst import CallbackCallOp, CallbackOp, PrintOp
 from mlir_quantum.dialects.gradient import GradOp, JVPOp, VJPOp
 from mlir_quantum.dialects.mitigation import ZneOp
 from mlir_quantum.dialects.quantum import (

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -29,6 +29,7 @@ from pennylane.tape import QuantumTape
 from pennylane.transforms.core import TransformProgram
 
 import catalyst
+from catalyst.api_extensions.callbacks import clear_callback_cache
 from catalyst.jax_extras import (
     ClosedJaxpr,
     DynamicJaxprTrace,
@@ -372,6 +373,7 @@ def lower_jaxpr_to_mlir(jaxpr, func_name):
     # python function is seen in the cache. This happens during testing or if we wanted to compile a
     # single python function multiple times with different options.
     mlir_fn_cache.clear()
+    clear_callback_cache()
 
     with transient_jax_config():
         # We remove implicit Jaxpr result values since we are compiling a top-level jaxpr program.

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -29,7 +29,7 @@ from pennylane.tape import QuantumTape
 from pennylane.transforms.core import TransformProgram
 
 import catalyst
-from catalyst.api_extensions.callbacks import clear_callback_cache
+from catalyst.api_extensions.callbacks import MemrefCallable
 from catalyst.jax_extras import (
     ClosedJaxpr,
     DynamicJaxprTrace,
@@ -373,7 +373,7 @@ def lower_jaxpr_to_mlir(jaxpr, func_name):
     # python function is seen in the cache. This happens during testing or if we wanted to compile a
     # single python function multiple times with different options.
     mlir_fn_cache.clear()
-    clear_callback_cache()
+    MemrefCallable.clearcache()
 
     with transient_jax_config():
         # We remove implicit Jaxpr result values since we are compiling a top-level jaxpr program.

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -395,5 +395,18 @@ def test_numpy_ufuncs():
     assert np.allclose(np.sin(1.0 / 2.0), f(1.0 / 2.0))
 
 
+def test_callback_cache():
+    """Test callback cache. This test is for coverage."""
+
+    @debug.callback
+    def hello_world():
+        print("hello world")
+
+    @qml.qjit
+    def wrapper():
+        hello_world()
+        hello_world()
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/mlir/include/Catalyst/IR/CatalystDialect.h
+++ b/mlir/include/Catalyst/IR/CatalystDialect.h
@@ -16,6 +16,7 @@
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/IR/Dialect.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
 
 //===----------------------------------------------------------------------===//
 // Catalyst dialect declarations.

--- a/mlir/include/Catalyst/IR/CatalystOps.td
+++ b/mlir/include/Catalyst/IR/CatalystOps.td
@@ -151,41 +151,4 @@ def CallbackOp : Catalyst_Op<"callback",
 
 }
 
-def PythonCallOp: Catalyst_Op<"pycallback",
-    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
-  let summary = "CustomCall specialized for python callbacks.";
-
-  let description = [{
-    A custom call invokes code external to Catalyst. The `inputs` are passed to the
-    external code, and the external code is expected to produce a result of the
-    given type.
-  }];
-
-  let arguments = (ins
-        Variadic<AnyTypeOf<[AnyRankedTensor, MemRefOf<[AnyType]>]>>:$inputs,
-        I64Attr: $identifier,
-        OptionalAttr<I64Attr>: $number_original_arg
-  );
-
-  let results = (outs Variadic<AnyType>);
-
-  let builders = [
-        OpBuilder<(ins "mlir::TypeRange":$resultTypes, "llvm::SmallVector<mlir::Value>":$inputs, "int64_t":$identifier), [{
-            auto id = $_builder.getI64IntegerAttr(identifier);
-            auto argc = $_builder.getI64IntegerAttr(inputs.size());
-            return build($_builder, $_state, resultTypes, inputs, id, argc);
-        }]>,
-
-        OpBuilder<(ins "mlir::TypeRange":$resultTypes, "llvm::SmallVector<mlir::Value>":$inputs, "int64_t":$identifier, "int64_t": $size), [{
-            auto id = $_builder.getI64IntegerAttr(identifier);
-            auto argc = $_builder.getI64IntegerAttr(size);
-            return build($_builder, $_state, resultTypes, inputs, id, argc);
-        }]>
-    ];
-
-  let assemblyFormat = [{
-    `(` $inputs `)` attr-dict `:` functional-type(operands, results)
-  }];
-}
-
 #endif // GRADIENT_OPS

--- a/mlir/include/Catalyst/IR/CatalystOps.td
+++ b/mlir/include/Catalyst/IR/CatalystOps.td
@@ -16,6 +16,7 @@
 #ifndef CATALYST_OPS
 #define CATALYST_OPS
 
+include "mlir/Interfaces/FunctionInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/BuiltinAttributes.td"
@@ -101,6 +102,53 @@ def CustomCallOp: Catalyst_Op<"custom_call",
     `fn` `(`$call_target_name`)` `(` $inputs `)`
       attr-dict `:` functional-type(operands, results)
   }];
+}
+
+def CallbackOp : Catalyst_Op<"callback",
+    [FunctionOpInterface, IsolatedFromAbove]> {
+
+  let summary = "Operation denoting a symbol to refer to user callbacks.";
+
+  let description = [{
+     This is an operation that is intended to be placed at the module level.
+     It corresponds to function bodies that are not yet constructed.
+  }];
+
+  let arguments = (ins
+     SymbolNameAttr: $sym_name,
+     TypeAttrOf<FunctionType>: $function_type,
+     I64Attr: $id,
+     I64Attr: $argc,
+     I64Attr: $resc,
+     OptionalAttr<DictArrayAttr>: $arg_attrs,
+     OptionalAttr<DictArrayAttr>: $res_attrs
+  );
+
+  let regions = (region AnyRegion: $body);
+
+  let builders = [OpBuilder<(ins
+    "mlir::StringRef":$name, "mlir::FunctionType":$type,
+    CArg<"mlir::ArrayRef<mlir::NamedAttribute>", "{}">:$attrs)
+  >];
+
+  let extraClassDeclaration = [{
+    //===------------------------------------------------------------------===//
+    // FunctionOpInterface Methods
+    //===------------------------------------------------------------------===//
+
+    /// Returns the argument types of this function.
+    mlir::ArrayRef<mlir::Type> getArgumentTypes() { return getFunctionType().getInputs(); }
+
+    /// Returns the result types of this function.
+    mlir::ArrayRef<mlir::Type> getResultTypes() { return getFunctionType().getResults(); }
+
+    mlir::Region *getCallableRegion() { return &getBody(); }
+  }];
+
+
+  let hasCustomAssemblyFormat = 1;
+  let skipDefaultBuilders = 1;
+
 }
 
 def PythonCallOp: Catalyst_Op<"pycallback",

--- a/mlir/include/Catalyst/IR/CatalystOps.td
+++ b/mlir/include/Catalyst/IR/CatalystOps.td
@@ -16,6 +16,7 @@
 #ifndef CATALYST_OPS
 #define CATALYST_OPS
 
+include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/FunctionInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
@@ -148,6 +149,22 @@ def CallbackOp : Catalyst_Op<"callback",
 
   let hasCustomAssemblyFormat = 1;
   let skipDefaultBuilders = 1;
+
+}
+
+def CallbackCallOp : Catalyst_Op<"callback_call",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, DeclareOpInterfaceMethods<CallOpInterface>]> {
+
+  let arguments = (ins
+        FlatSymbolRefAttr:$callee,
+        Variadic<AnyTypeOf<[AnyRankedTensor, MemRefOf<[AnyType]>]>>:$inputs
+  );
+
+  let results = (outs Variadic<AnyType>);
+
+  let assemblyFormat = [{
+    $callee `(` $inputs `)` attr-dict `:` functional-type($inputs, results)
+  }];
 
 }
 

--- a/mlir/include/Catalyst/Transforms/Passes.td
+++ b/mlir/include/Catalyst/Transforms/Passes.td
@@ -50,6 +50,7 @@ def CatalystConversionPass : Pass<"convert-catalyst-to-llvm"> {
     let summary = "Lower catalyst utility operations to the LLVM dialect.";
 
     let dependentDialects = [
+        "mlir::func::FuncDialect",
         "mlir::LLVM::LLVMDialect",
     ];
 

--- a/mlir/include/Gradient/Transforms/Utils.h
+++ b/mlir/include/Gradient/Transforms/Utils.h
@@ -22,5 +22,9 @@ using namespace mlir;
 namespace catalyst {
 namespace gradient {
 void wrapMemRefArgs(func::FuncOp, const TypeConverter *, RewriterBase &, Location, bool = false);
+void wrapMemRefArgsFunc(func::FuncOp, const TypeConverter *, RewriterBase &, Location,
+                        bool = false);
+void wrapMemRefArgsCallsites(func::FuncOp, const TypeConverter *, RewriterBase &, Location,
+                             bool = false);
 } // namespace gradient
 } // namespace catalyst

--- a/mlir/include/Gradient/Transforms/Utils.h
+++ b/mlir/include/Gradient/Transforms/Utils.h
@@ -21,7 +21,7 @@ using namespace mlir;
 
 namespace catalyst {
 namespace gradient {
-void wrapMemRefArgs(func::FuncOp, const LLVMTypeConverter *, PatternRewriter &, Location,
+void wrapMemRefArgs(func::FuncOp, const LLVMTypeConverter *, RewriterBase &, Location,
                     bool = false);
 } // namespace gradient
 } // namespace catalyst

--- a/mlir/include/Gradient/Transforms/Utils.h
+++ b/mlir/include/Gradient/Transforms/Utils.h
@@ -1,0 +1,27 @@
+// Copyright 2024 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "Gradient/Transforms/Patterns.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+
+using namespace mlir;
+
+namespace catalyst {
+namespace gradient {
+void wrapMemRefArgs(func::FuncOp, const LLVMTypeConverter *, PatternRewriter &, Location,
+                    bool = false);
+} // namespace gradient
+} // namespace catalyst

--- a/mlir/include/Gradient/Transforms/Utils.h
+++ b/mlir/include/Gradient/Transforms/Utils.h
@@ -21,7 +21,6 @@ using namespace mlir;
 
 namespace catalyst {
 namespace gradient {
-void wrapMemRefArgs(func::FuncOp, const LLVMTypeConverter *, RewriterBase &, Location,
-                    bool = false);
+void wrapMemRefArgs(func::FuncOp, const TypeConverter *, RewriterBase &, Location, bool = false);
 } // namespace gradient
 } // namespace catalyst

--- a/mlir/lib/Catalyst/IR/CatalystDialect.cpp
+++ b/mlir/lib/Catalyst/IR/CatalystDialect.cpp
@@ -65,6 +65,24 @@ void CallbackOp::print(OpAsmPrinter &p)
 }
 
 //===----------------------------------------------------------------------===//
+// CallbackCallOp
+//===----------------------------------------------------------------------===//
+
+CallInterfaceCallable CallbackCallOp::getCallableForCallee()
+{
+    return (*this)->getAttrOfType<SymbolRefAttr>("callee");
+}
+
+void CallbackCallOp::setCalleeFromCallable(CallInterfaceCallable callee)
+{
+    (*this)->setAttr("callee", callee.get<SymbolRefAttr>());
+}
+
+Operation::operand_range CallbackCallOp::getArgOperands() { return getInputs(); }
+
+MutableOperandRange CallbackCallOp::getArgOperandsMutable() { return getInputsMutable(); }
+
+//===----------------------------------------------------------------------===//
 // Catalyst type definitions.
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Catalyst/IR/CatalystOps.cpp
+++ b/mlir/lib/Catalyst/IR/CatalystOps.cpp
@@ -35,13 +35,3 @@ void CustomCallOp::getEffects(
     effects.emplace_back(mlir::MemoryEffects::Write::get());
     effects.emplace_back(mlir::MemoryEffects::Read::get());
 }
-
-void PythonCallOp::getEffects(
-    llvm::SmallVectorImpl<mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>> &effects)
-{
-    // Assume all effects
-    effects.emplace_back(mlir::MemoryEffects::Allocate::get());
-    effects.emplace_back(mlir::MemoryEffects::Free::get());
-    effects.emplace_back(mlir::MemoryEffects::Write::get());
-    effects.emplace_back(mlir::MemoryEffects::Read::get());
-}

--- a/mlir/lib/Catalyst/IR/CatalystOps.cpp
+++ b/mlir/lib/Catalyst/IR/CatalystOps.cpp
@@ -35,3 +35,13 @@ void CustomCallOp::getEffects(
     effects.emplace_back(mlir::MemoryEffects::Write::get());
     effects.emplace_back(mlir::MemoryEffects::Read::get());
 }
+
+void CallbackCallOp::getEffects(
+    llvm::SmallVectorImpl<mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>> &effects)
+{
+    // Assume all effects
+    effects.emplace_back(mlir::MemoryEffects::Allocate::get());
+    effects.emplace_back(mlir::MemoryEffects::Free::get());
+    effects.emplace_back(mlir::MemoryEffects::Write::get());
+    effects.emplace_back(mlir::MemoryEffects::Read::get());
+}

--- a/mlir/lib/Catalyst/Transforms/BufferizationPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/BufferizationPatterns.cpp
@@ -114,6 +114,49 @@ struct BufferizeCallbackOp : public OpConversionPattern<CallbackOp> {
     }
 };
 
+struct BufferizeCallbackCallOp : public OpConversionPattern<CallbackCallOp> {
+  using OpConversionPattern<CallbackCallOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(CallbackCallOp callOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Type> convertedResults;
+    if (failed(typeConverter->convertTypes(callOp.getResultTypes(),
+                                           convertedResults)))
+      return failure();
+
+    if (callOp->getNumResults() != convertedResults.size())
+      return failure();
+
+    auto operands = adaptor.getOperands();
+    SmallVector<Value> newInputs(operands.begin(), operands.end());
+    auto results = callOp.getResults();
+
+    auto loc = callOp->getLoc();
+    auto options = bufferization::BufferizationOptions();
+    SmallVector<Value> outmemrefs;
+    for (auto result : results) {
+       FailureOr<Value> tensorAlloc = bufferization::allocateTensorForShapedValue(rewriter, loc, result, options, false);
+       if (failed(tensorAlloc)) return failure();
+
+       auto tensor = *tensorAlloc;
+       RankedTensorType tensorTy = cast<RankedTensorType>(tensor.getType());
+       auto shape = tensorTy.getShape();
+       auto elementTy = tensorTy.getElementType();
+       auto memrefType = MemRefType::get(shape, elementTy);
+       auto toMemrefOp = rewriter.create<bufferization::ToMemrefOp>(loc, memrefType, tensor);
+       auto memref = toMemrefOp.getResult();
+       outmemrefs.push_back(memref);
+       newInputs.push_back(memref);
+    }
+
+    SmallVector<Type> emptyRets;
+    auto newCallOp = rewriter.create<CallbackCallOp>(loc, emptyRets, callOp.getCallee(), newInputs);
+    rewriter.replaceOp(callOp, outmemrefs);
+    return success();
+  }
+};
+
 } // namespace
 
 namespace catalyst {
@@ -123,6 +166,7 @@ void populateBufferizationPatterns(TypeConverter &typeConverter, RewritePatternS
     patterns.add<BufferizeCustomCallOp>(typeConverter, patterns.getContext());
     patterns.add<BufferizePrintOp>(typeConverter, patterns.getContext());
     patterns.add<BufferizeCallbackOp>(typeConverter, patterns.getContext());
+    patterns.add<BufferizeCallbackCallOp>(typeConverter, patterns.getContext());
 }
 
 } // namespace catalyst

--- a/mlir/lib/Catalyst/Transforms/BufferizationPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/BufferizationPatterns.cpp
@@ -115,46 +115,48 @@ struct BufferizeCallbackOp : public OpConversionPattern<CallbackOp> {
 };
 
 struct BufferizeCallbackCallOp : public OpConversionPattern<CallbackCallOp> {
-  using OpConversionPattern<CallbackCallOp>::OpConversionPattern;
+    using OpConversionPattern<CallbackCallOp>::OpConversionPattern;
 
-  LogicalResult
-  matchAndRewrite(CallbackCallOp callOp, OpAdaptor adaptor,
-                  ConversionPatternRewriter &rewriter) const override {
-    SmallVector<Type> convertedResults;
-    if (failed(typeConverter->convertTypes(callOp.getResultTypes(),
-                                           convertedResults)))
-      return failure();
+    LogicalResult matchAndRewrite(CallbackCallOp callOp, OpAdaptor adaptor,
+                                  ConversionPatternRewriter &rewriter) const override
+    {
+        SmallVector<Type> convertedResults;
+        if (failed(typeConverter->convertTypes(callOp.getResultTypes(), convertedResults)))
+            return failure();
 
-    if (callOp->getNumResults() != convertedResults.size())
-      return failure();
+        if (callOp->getNumResults() != convertedResults.size())
+            return failure();
 
-    auto operands = adaptor.getOperands();
-    SmallVector<Value> newInputs(operands.begin(), operands.end());
-    auto results = callOp.getResults();
+        auto operands = adaptor.getOperands();
+        SmallVector<Value> newInputs(operands.begin(), operands.end());
+        auto results = callOp.getResults();
 
-    auto loc = callOp->getLoc();
-    auto options = bufferization::BufferizationOptions();
-    SmallVector<Value> outmemrefs;
-    for (auto result : results) {
-       FailureOr<Value> tensorAlloc = bufferization::allocateTensorForShapedValue(rewriter, loc, result, options, false);
-       if (failed(tensorAlloc)) return failure();
+        auto loc = callOp->getLoc();
+        auto options = bufferization::BufferizationOptions();
+        SmallVector<Value> outmemrefs;
+        for (auto result : results) {
+            FailureOr<Value> tensorAlloc =
+                bufferization::allocateTensorForShapedValue(rewriter, loc, result, options, false);
+            if (failed(tensorAlloc))
+                return failure();
 
-       auto tensor = *tensorAlloc;
-       RankedTensorType tensorTy = cast<RankedTensorType>(tensor.getType());
-       auto shape = tensorTy.getShape();
-       auto elementTy = tensorTy.getElementType();
-       auto memrefType = MemRefType::get(shape, elementTy);
-       auto toMemrefOp = rewriter.create<bufferization::ToMemrefOp>(loc, memrefType, tensor);
-       auto memref = toMemrefOp.getResult();
-       outmemrefs.push_back(memref);
-       newInputs.push_back(memref);
+            auto tensor = *tensorAlloc;
+            RankedTensorType tensorTy = cast<RankedTensorType>(tensor.getType());
+            auto shape = tensorTy.getShape();
+            auto elementTy = tensorTy.getElementType();
+            auto memrefType = MemRefType::get(shape, elementTy);
+            auto toMemrefOp = rewriter.create<bufferization::ToMemrefOp>(loc, memrefType, tensor);
+            auto memref = toMemrefOp.getResult();
+            outmemrefs.push_back(memref);
+            newInputs.push_back(memref);
+        }
+
+        SmallVector<Type> emptyRets;
+        auto newCallOp =
+            rewriter.create<CallbackCallOp>(loc, emptyRets, callOp.getCallee(), newInputs);
+        rewriter.replaceOp(callOp, outmemrefs);
+        return success();
     }
-
-    SmallVector<Type> emptyRets;
-    auto newCallOp = rewriter.create<CallbackCallOp>(loc, emptyRets, callOp.getCallee(), newInputs);
-    rewriter.replaceOp(callOp, outmemrefs);
-    return success();
-  }
 };
 
 } // namespace

--- a/mlir/lib/Catalyst/Transforms/catalyst_bufferize.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_bufferize.cpp
@@ -42,6 +42,7 @@ struct CatalystBufferizationPass : impl::CatalystBufferizationPassBase<CatalystB
 
         RewritePatternSet patterns(context);
         populateBufferizationPatterns(typeConverter, patterns);
+        populateFunctionOpInterfaceTypeConversionPattern<CallbackOp>(patterns, typeConverter);
 
         ConversionTarget target(*context);
         bufferization::populateBufferizeMaterializationLegality(target);

--- a/mlir/lib/Catalyst/Transforms/catalyst_bufferize.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_bufferize.cpp
@@ -51,8 +51,6 @@ struct CatalystBufferizationPass : impl::CatalystBufferizationPassBase<CatalystB
             [&](PrintOp op) { return typeConverter.isLegal(op); });
         target.addDynamicallyLegalOp<CustomCallOp>(
             [&](CustomCallOp op) { return typeConverter.isLegal(op); });
-        target.addDynamicallyLegalOp<PythonCallOp>(
-            [&](PythonCallOp op) { return typeConverter.isLegal(op); });
         target.addDynamicallyLegalOp<CallbackOp>([&](CallbackOp op) {
             return typeConverter.isSignatureLegal(op.getFunctionType()) &&
                    typeConverter.isLegal(&op.getBody()) && op.getResultTypes().empty();

--- a/mlir/lib/Catalyst/Transforms/catalyst_bufferize.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_bufferize.cpp
@@ -52,6 +52,10 @@ struct CatalystBufferizationPass : impl::CatalystBufferizationPassBase<CatalystB
             [&](CustomCallOp op) { return typeConverter.isLegal(op); });
         target.addDynamicallyLegalOp<PythonCallOp>(
             [&](PythonCallOp op) { return typeConverter.isLegal(op); });
+        target.addDynamicallyLegalOp<CallbackOp>([&](CallbackOp op) {
+            return typeConverter.isSignatureLegal(op.getFunctionType()) &&
+                   typeConverter.isLegal(&op.getBody()) && op.getResultTypes().empty();
+        });
 
         if (failed(applyPartialConversion(getOperation(), target, std::move(patterns)))) {
             signalPassFailure();

--- a/mlir/lib/Catalyst/Transforms/catalyst_bufferize.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_bufferize.cpp
@@ -55,6 +55,8 @@ struct CatalystBufferizationPass : impl::CatalystBufferizationPassBase<CatalystB
             return typeConverter.isSignatureLegal(op.getFunctionType()) &&
                    typeConverter.isLegal(&op.getBody()) && op.getResultTypes().empty();
         });
+        target.addDynamicallyLegalOp<CallbackCallOp>(
+            [&](CallbackCallOp op) { return typeConverter.isLegal(op); });
 
         if (failed(applyPartialConversion(getOperation(), target, std::move(patterns)))) {
             signalPassFailure();

--- a/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
@@ -460,11 +460,10 @@ struct CallbackOpPatternOne : public OpConversionPattern<CallbackOp> {
             mlir::LLVM::lookupOrCreateFn(mod, "inactive_callback", {/*args=*/i64, i64, i64},
                                          /*ret_type=*/voidType, isVarArg);
 
-        for (auto arg : llvm::enumerate(op.getArguments())) {
-            auto val = arg.value();
-            Type structTy = typeConverter->convertType(val.getType());
+        for (auto arg : op.getArguments()) {
+            Type structTy = typeConverter->convertType(arg.getType());
             auto structVal =
-                rewriter.create<UnrealizedConversionCastOp>(loc, structTy, val).getResult(0);
+                rewriter.create<UnrealizedConversionCastOp>(loc, structTy, arg).getResult(0);
             Value ptr = rewriter.create<LLVM::AllocaOp>(loc, ptrTy, structTy, c1);
             rewriter.create<LLVM::StoreOp>(loc, structVal, ptr);
             callArgs.push_back(ptr);

--- a/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
@@ -492,8 +492,7 @@ struct CallbackOpPatternTwo : public OpConversionPattern<CallbackOp> {
             rewriter.create<mlir::func::FuncOp>(op.getLoc(), op.getSymName(), op.getFunctionType());
         rewriter.inlineRegionBefore(op.getRegion(), func.getBody(), func.end());
         auto typeConverter = getTypeConverter();
-        // This one also modifies the callers...
-        gradient::wrapMemRefArgs(func, typeConverter, rewriter, op.getLoc());
+        gradient::wrapMemRefArgsFunc(func, typeConverter, rewriter, op.getLoc());
         rewriter.eraseOp(op);
     }
 };

--- a/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
@@ -420,66 +420,6 @@ struct CustomCallOpPattern : public OpConversionPattern<CustomCallOp> {
     }
 };
 
-struct PythonCallOpPattern : public OpConversionPattern<PythonCallOp> {
-    using OpConversionPattern::OpConversionPattern;
-
-    LogicalResult matchAndRewrite(PythonCallOp op, PythonCallOpAdaptor adaptor,
-                                  ConversionPatternRewriter &rewriter) const override
-    {
-        MLIRContext *ctx = op.getContext();
-        Location loc = op.getLoc();
-
-        // Create function
-        Type voidType = LLVM::LLVMVoidType::get(ctx);
-        auto point = rewriter.saveInsertionPoint();
-        ModuleOp mod = op->getParentOfType<ModuleOp>();
-        rewriter.setInsertionPointToStart(mod.getBody());
-
-        Type i64 = rewriter.getI64Type();
-        // The argument convention is as follows:
-        // arg0 =        identifier
-        // arg1 =        length of operands
-        // arg2 =        length of results
-        // arg3..N+3     varargs pointers to memrefs
-        // argN+4..N+M+4 varargs pointers to result memrefs
-
-        bool isVarArg = true;
-        LLVM::LLVMFuncOp customCallFnOp = mlir::LLVM::lookupOrCreateFn(
-            mod, "inactive_callback", {/*args=*/i64, i64, i64}, /*ret_type=*/voidType, isVarArg);
-        customCallFnOp.setPrivate();
-        rewriter.restoreInsertionPoint(point);
-
-        auto identAttr = op.getIdentifier();
-        auto ident = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI64IntegerAttr(identAttr));
-
-        auto argcAttr = op.getNumberOriginalArg();
-        long argcint = argcAttr ? argcAttr.value() : 0;
-        auto argc = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI64IntegerAttr(argcint));
-
-        auto resultsSizeAttr = op.getOperands().size() - argcint;
-        auto resultsSizeVal =
-            rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI64IntegerAttr(resultsSizeAttr));
-
-        SmallVector<Value> callArgs{ident};
-        callArgs.insert(callArgs.end(), argc);
-        callArgs.insert(callArgs.end(), resultsSizeVal);
-
-        Value c1 = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI64IntegerAttr(1));
-        for (auto memref : adaptor.getInputs()) {
-            Type ptrTy = LLVM::LLVMPointerType::get(ctx);
-            // allocate a memref descriptor on the stack
-            Value ptr = rewriter.create<LLVM::AllocaOp>(loc, ptrTy, memref.getType(), c1);
-            // store the memref descriptor on the pointer
-            rewriter.create<LLVM::StoreOp>(loc, memref, ptr);
-            // add the ptr to the arguments
-            callArgs.push_back(ptr);
-        }
-        rewriter.create<LLVM::CallOp>(loc, customCallFnOp, callArgs);
-        rewriter.eraseOp(op);
-        return success();
-    }
-};
-
 struct CallbackOpPatternOne : public OpConversionPattern<CallbackOp> {
     using OpConversionPattern::OpConversionPattern;
 
@@ -575,7 +515,6 @@ struct CatalystConversionPass : impl::CatalystConversionPassBase<CatalystConvers
 
         RewritePatternSet patterns(context);
         patterns.add<CustomCallOpPattern>(typeConverter, context);
-        patterns.add<PythonCallOpPattern>(typeConverter, context);
         patterns.add<PrintOpPattern>(typeConverter, context);
         patterns.add<CallbackOpPatternOne>(typeConverter, context);
         patterns.add<CallbackOpPatternTwo>(typeConverter, context);

--- a/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
@@ -460,6 +460,7 @@ struct DefineCallbackOpPattern : public OpConversionPattern<CallbackOp> {
             mlir::LLVM::lookupOrCreateFn(mod, "inactive_callback", {/*args=*/i64, i64, i64},
                                          /*ret_type=*/voidType, isVarArg);
 
+        // TODO: remove redundant alloca+store since ultimately we'll receive struct*
         for (auto arg : op.getArguments()) {
             Type structTy = typeConverter->convertType(arg.getType());
             auto structVal =

--- a/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
@@ -503,7 +503,6 @@ struct CallbackCallOpPattern : public OpConversionPattern<CallbackCallOp> {
     LogicalResult matchAndRewrite(CallbackCallOp op, CallbackCallOpAdaptor adaptor,
                                   ConversionPatternRewriter &rewriter) const override
     {
-
         // Just change the calling convention from scalar replacement of aggregates
         // to pointer to struct.
         auto loc = op.getLoc();

--- a/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
@@ -420,7 +420,7 @@ struct CustomCallOpPattern : public OpConversionPattern<CustomCallOp> {
     }
 };
 
-struct CallbackOpPatternOne : public OpConversionPattern<CallbackOp> {
+struct DefineCallbackOpPattern : public OpConversionPattern<CallbackOp> {
     using OpConversionPattern::OpConversionPattern;
 
     LogicalResult match(CallbackOp op) const override
@@ -473,7 +473,7 @@ struct CallbackOpPatternOne : public OpConversionPattern<CallbackOp> {
     }
 };
 
-struct CallbackOpPatternTwo : public OpConversionPattern<CallbackOp> {
+struct ReplaceCallbackOpWithFuncOp : public OpConversionPattern<CallbackOp> {
     using OpConversionPattern::OpConversionPattern;
 
     LogicalResult match(CallbackOp op) const override
@@ -541,8 +541,8 @@ struct CatalystConversionPass : impl::CatalystConversionPassBase<CatalystConvers
         RewritePatternSet patterns(context);
         patterns.add<CustomCallOpPattern>(typeConverter, context);
         patterns.add<PrintOpPattern>(typeConverter, context);
-        patterns.add<CallbackOpPatternOne>(typeConverter, context);
-        patterns.add<CallbackOpPatternTwo>(typeConverter, context);
+        patterns.add<DefineCallbackOpPattern>(typeConverter, context);
+        patterns.add<ReplaceCallbackOpWithFuncOp>(typeConverter, context);
         patterns.add<CallbackCallOpPattern>(typeConverter, context);
 
         LLVMConversionTarget target(*context);

--- a/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
@@ -139,7 +139,6 @@ void wrapMemRefArgsCallsites(func::FuncOp func, const TypeConverter *typeConvert
 void wrapMemRefArgs(func::FuncOp func, const TypeConverter *typeConverter, RewriterBase &rewriter,
                     Location loc, bool volatileArgs = false)
 {
-
     if (llvm::none_of(func.getArgumentTypes(),
                       [](Type argType) { return isa<MemRefType>(argType); })) {
         // The memref arguments are already wrapped

--- a/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
@@ -52,7 +52,7 @@ namespace gradient {
 /// rather than having their fields unpacked. This function automatically transforms MemRef
 /// arguments of a function to wrapped pointers.
 void wrapMemRefArgs(func::FuncOp func, const LLVMTypeConverter *typeConverter,
-                    PatternRewriter &rewriter, Location loc, bool volatileArgs = false)
+                    RewriterBase &rewriter, Location loc, bool volatileArgs = false)
 {
     if (llvm::none_of(func.getArgumentTypes(),
                       [](Type argType) { return isa<MemRefType>(argType); })) {

--- a/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
@@ -45,6 +45,99 @@
 using namespace mlir;
 using namespace catalyst::gradient;
 
+namespace catalyst {
+namespace gradient {
+/// Enzyme custom gradients appear to exhibit better stability when they are registered for
+/// functions where MemRefs are passed via wrapped pointers (!llvm.ptr<struct(ptr, ptr, i64, ...)>)
+/// rather than having their fields unpacked. This function automatically transforms MemRef
+/// arguments of a function to wrapped pointers.
+void wrapMemRefArgs(func::FuncOp func, const LLVMTypeConverter *typeConverter,
+                    PatternRewriter &rewriter, Location loc, bool volatileArgs = false)
+{
+    if (llvm::none_of(func.getArgumentTypes(),
+                      [](Type argType) { return isa<MemRefType>(argType); })) {
+        // The memref arguments are already wrapped
+        return;
+    }
+
+    ModuleOp moduleOp = func->getParentOfType<ModuleOp>();
+    MLIRContext *ctx = rewriter.getContext();
+    auto ptrType = LLVM::LLVMPointerType::get(ctx);
+    PatternRewriter::InsertionGuard insertionGuard(rewriter);
+    rewriter.setInsertionPointToStart(&func.getFunctionBody().front());
+    for (const auto [idx, argType] : llvm::enumerate(func.getArgumentTypes())) {
+        if (auto memrefType = dyn_cast<MemRefType>(argType)) {
+            BlockArgument memrefArg = func.getArgument(idx);
+            func.insertArgument(idx, ptrType, DictionaryAttr::get(ctx), loc);
+            Value wrappedMemref = func.getArgument(idx);
+            Type structType = typeConverter->convertType(memrefType);
+
+            // We potentially need all arguments for the custom quantum gradient, but not all of
+            // them will be used by the primal. Mark the load of the wrapped memref as volatile and
+            // perform a no-op store to ensure that the function argument is considered used.
+            // Otherwise, LLVM may optimize it away with a poison value.
+            //   Note: both the volatile load and store are necessary. MLIR respects the store but
+            //   not the load, while LLVM respects the volatile load but not the store.
+            Value replacedMemref = rewriter.create<LLVM::LoadOp>(
+                loc, structType, wrappedMemref, /*alignment*/ 0, /*isVolatile=*/volatileArgs);
+            if (volatileArgs) {
+                rewriter.create<LLVM::StoreOp>(loc, replacedMemref, wrappedMemref);
+            }
+            replacedMemref =
+                rewriter.create<UnrealizedConversionCastOp>(loc, argType, replacedMemref)
+                    .getResult(0);
+            memrefArg.replaceAllUsesWith(replacedMemref);
+            func.eraseArgument(memrefArg.getArgNumber());
+        }
+    }
+
+    std::optional<SymbolTable::UseRange> uses = func.getSymbolUses(moduleOp);
+    if (uses.has_value()) {
+        for (auto use : *uses) {
+            if (auto callOp = dyn_cast<func::CallOp>(use.getUser())) {
+                PatternRewriter::InsertionGuard insertionGuard(rewriter);
+                rewriter.setInsertionPoint(callOp);
+
+                Value c1 = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI64IntegerAttr(1));
+
+                SmallVector<Value> operands;
+                SmallVector<Value> outputs;
+                auto wrapMemref = [&](Value memref) {
+                    Type convertedType = typeConverter->convertType(memref.getType());
+                    Value space =
+                        rewriter.create<LLVM::AllocaOp>(loc, /*resultType=*/ptrType,
+                                                        /*elementType=*/convertedType, c1);
+                    Value convertedValue =
+                        rewriter.create<UnrealizedConversionCastOp>(loc, convertedType, memref)
+                            .getResult(0);
+                    rewriter.create<LLVM::StoreOp>(loc, convertedValue, space);
+                    return space;
+                };
+                for (Value oldOperand : callOp.getOperands()) {
+                    if (isa<MemRefType>(oldOperand.getType())) {
+                        operands.push_back(wrapMemref(oldOperand));
+                    }
+                }
+                for (Type resultType : callOp.getResultTypes()) {
+                    if (auto memrefType = dyn_cast<MemRefType>(resultType)) {
+                        assert(memrefType.hasStaticShape());
+                        Value memref = rewriter.create<memref::AllocOp>(loc, memrefType);
+                        outputs.push_back(memref);
+
+                        memref = wrapMemref(memref);
+                        operands.push_back(memref);
+                    }
+                }
+
+                rewriter.create<func::CallOp>(callOp.getLoc(), func, operands);
+                rewriter.replaceOp(callOp, outputs);
+            }
+        }
+    }
+}
+} // namespace gradient
+} // namespace catalyst
+
 namespace {
 
 constexpr int64_t UNKNOWN = ShapedType::kDynamic;
@@ -149,95 +242,6 @@ struct EnzymeMemRefInterfaceOptions {
     /// Mark memref as dupnoneed, allowing Enzyme to avoid computing its primal value.
     bool dupNoNeed = false;
 };
-
-/// Enzyme custom gradients appear to exhibit better stability when they are registered for
-/// functions where MemRefs are passed via wrapped pointers (!llvm.ptr<struct(ptr, ptr, i64, ...)>)
-/// rather than having their fields unpacked. This function automatically transforms MemRef
-/// arguments of a function to wrapped pointers.
-void wrapMemRefArgs(func::FuncOp func, const LLVMTypeConverter *typeConverter,
-                    PatternRewriter &rewriter, Location loc, bool volatileArgs = false)
-{
-    if (llvm::none_of(func.getArgumentTypes(),
-                      [](Type argType) { return isa<MemRefType>(argType); })) {
-        // The memref arguments are already wrapped
-        return;
-    }
-
-    ModuleOp moduleOp = func->getParentOfType<ModuleOp>();
-    MLIRContext *ctx = rewriter.getContext();
-    auto ptrType = LLVM::LLVMPointerType::get(ctx);
-    PatternRewriter::InsertionGuard insertionGuard(rewriter);
-    rewriter.setInsertionPointToStart(&func.getFunctionBody().front());
-    for (const auto [idx, argType] : llvm::enumerate(func.getArgumentTypes())) {
-        if (auto memrefType = dyn_cast<MemRefType>(argType)) {
-            BlockArgument memrefArg = func.getArgument(idx);
-            func.insertArgument(idx, ptrType, DictionaryAttr::get(ctx), loc);
-            Value wrappedMemref = func.getArgument(idx);
-            Type structType = typeConverter->convertType(memrefType);
-
-            // We potentially need all arguments for the custom quantum gradient, but not all of
-            // them will be used by the primal. Mark the load of the wrapped memref as volatile and
-            // perform a no-op store to ensure that the function argument is considered used.
-            // Otherwise, LLVM may optimize it away with a poison value.
-            //   Note: both the volatile load and store are necessary. MLIR respects the store but
-            //   not the load, while LLVM respects the volatile load but not the store.
-            Value replacedMemref = rewriter.create<LLVM::LoadOp>(
-                loc, structType, wrappedMemref, /*alignment*/ 0, /*isVolatile=*/volatileArgs);
-            if (volatileArgs) {
-                rewriter.create<LLVM::StoreOp>(loc, replacedMemref, wrappedMemref);
-            }
-            replacedMemref =
-                rewriter.create<UnrealizedConversionCastOp>(loc, argType, replacedMemref)
-                    .getResult(0);
-            memrefArg.replaceAllUsesWith(replacedMemref);
-            func.eraseArgument(memrefArg.getArgNumber());
-        }
-    }
-
-    std::optional<SymbolTable::UseRange> uses = func.getSymbolUses(moduleOp);
-    if (uses.has_value()) {
-        for (auto use : *uses) {
-            if (auto callOp = dyn_cast<func::CallOp>(use.getUser())) {
-                PatternRewriter::InsertionGuard insertionGuard(rewriter);
-                rewriter.setInsertionPoint(callOp);
-
-                Value c1 = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI64IntegerAttr(1));
-
-                SmallVector<Value> operands;
-                SmallVector<Value> outputs;
-                auto wrapMemref = [&](Value memref) {
-                    Type convertedType = typeConverter->convertType(memref.getType());
-                    Value space =
-                        rewriter.create<LLVM::AllocaOp>(loc, /*resultType=*/ptrType,
-                                                        /*elementType=*/convertedType, c1);
-                    Value convertedValue =
-                        rewriter.create<UnrealizedConversionCastOp>(loc, convertedType, memref)
-                            .getResult(0);
-                    rewriter.create<LLVM::StoreOp>(loc, convertedValue, space);
-                    return space;
-                };
-                for (Value oldOperand : callOp.getOperands()) {
-                    if (isa<MemRefType>(oldOperand.getType())) {
-                        operands.push_back(wrapMemref(oldOperand));
-                    }
-                }
-                for (Type resultType : callOp.getResultTypes()) {
-                    if (auto memrefType = dyn_cast<MemRefType>(resultType)) {
-                        assert(memrefType.hasStaticShape());
-                        Value memref = rewriter.create<memref::AllocOp>(loc, memrefType);
-                        outputs.push_back(memref);
-
-                        memref = wrapMemref(memref);
-                        operands.push_back(memref);
-                    }
-                }
-
-                rewriter.create<func::CallOp>(callOp.getLoc(), func, operands);
-                rewriter.replaceOp(callOp, outputs);
-            }
-        }
-    }
-}
 
 struct BackpropOpPattern : public ConvertOpToLLVMPattern<BackpropOp> {
     using ConvertOpToLLVMPattern::ConvertOpToLLVMPattern;

--- a/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
@@ -51,8 +51,8 @@ namespace gradient {
 /// functions where MemRefs are passed via wrapped pointers (!llvm.ptr<struct(ptr, ptr, i64, ...)>)
 /// rather than having their fields unpacked. This function automatically transforms MemRef
 /// arguments of a function to wrapped pointers.
-void wrapMemRefArgs(func::FuncOp func, const LLVMTypeConverter *typeConverter,
-                    RewriterBase &rewriter, Location loc, bool volatileArgs = false)
+void wrapMemRefArgs(func::FuncOp func, const TypeConverter *typeConverter, RewriterBase &rewriter,
+                    Location loc, bool volatileArgs = false)
 {
     if (llvm::none_of(func.getArgumentTypes(),
                       [](Type argType) { return isa<MemRefType>(argType); })) {

--- a/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
@@ -47,6 +47,91 @@ using namespace catalyst::gradient;
 
 namespace catalyst {
 namespace gradient {
+void wrapMemRefArgsFunc(func::FuncOp func, const TypeConverter *typeConverter,
+                        RewriterBase &rewriter, Location loc, bool volatileArgs = false)
+{
+    MLIRContext *ctx = rewriter.getContext();
+    auto ptrType = LLVM::LLVMPointerType::get(ctx);
+    PatternRewriter::InsertionGuard insertionGuard(rewriter);
+    rewriter.setInsertionPointToStart(&func.getFunctionBody().front());
+    for (const auto [idx, argType] : llvm::enumerate(func.getArgumentTypes())) {
+        if (auto memrefType = dyn_cast<MemRefType>(argType)) {
+            BlockArgument memrefArg = func.getArgument(idx);
+            func.insertArgument(idx, ptrType, DictionaryAttr::get(ctx), loc);
+            Value wrappedMemref = func.getArgument(idx);
+            Type structType = typeConverter->convertType(memrefType);
+
+            // We potentially need all arguments for the custom quantum gradient, but not all of
+            // them will be used by the primal. Mark the load of the wrapped memref as volatile
+            // and perform a no-op store to ensure that the function argument is considered
+            // used. Otherwise, LLVM may optimize it away with a poison value.
+            //   Note: both the volatile load and store are necessary. MLIR respects the store
+            //   but not the load, while LLVM respects the volatile load but not the store.
+            Value replacedMemref = rewriter.create<LLVM::LoadOp>(
+                loc, structType, wrappedMemref, /*alignment*/ 0, /*isVolatile=*/volatileArgs);
+            if (volatileArgs) {
+                rewriter.create<LLVM::StoreOp>(loc, replacedMemref, wrappedMemref);
+            }
+            replacedMemref =
+                rewriter.create<UnrealizedConversionCastOp>(loc, argType, replacedMemref)
+                    .getResult(0);
+            memrefArg.replaceAllUsesWith(replacedMemref);
+            func.eraseArgument(memrefArg.getArgNumber());
+        }
+    }
+}
+
+void wrapMemRefArgsCallsites(func::FuncOp func, const TypeConverter *typeConverter,
+                             RewriterBase &rewriter, Location loc, bool volatileArgs = false)
+{
+    ModuleOp moduleOp = func->getParentOfType<ModuleOp>();
+    MLIRContext *ctx = rewriter.getContext();
+    auto ptrType = LLVM::LLVMPointerType::get(ctx);
+    std::optional<SymbolTable::UseRange> uses = func.getSymbolUses(moduleOp);
+    if (uses.has_value()) {
+        for (auto use : *uses) {
+            if (auto callOp = dyn_cast<func::CallOp>(use.getUser())) {
+                PatternRewriter::InsertionGuard insertionGuard(rewriter);
+                rewriter.setInsertionPoint(callOp);
+
+                Value c1 = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI64IntegerAttr(1));
+
+                SmallVector<Value> operands;
+                SmallVector<Value> outputs;
+                auto wrapMemref = [&](Value memref) {
+                    Type convertedType = typeConverter->convertType(memref.getType());
+                    Value space =
+                        rewriter.create<LLVM::AllocaOp>(loc, /*resultType=*/ptrType,
+                                                        /*elementType=*/convertedType, c1);
+                    Value convertedValue =
+                        rewriter.create<UnrealizedConversionCastOp>(loc, convertedType, memref)
+                            .getResult(0);
+                    rewriter.create<LLVM::StoreOp>(loc, convertedValue, space);
+                    return space;
+                };
+                for (Value oldOperand : callOp.getOperands()) {
+                    if (isa<MemRefType>(oldOperand.getType())) {
+                        operands.push_back(wrapMemref(oldOperand));
+                    }
+                }
+                for (Type resultType : callOp.getResultTypes()) {
+                    if (auto memrefType = dyn_cast<MemRefType>(resultType)) {
+                        assert(memrefType.hasStaticShape());
+                        Value memref = rewriter.create<memref::AllocOp>(loc, memrefType);
+                        outputs.push_back(memref);
+
+                        memref = wrapMemref(memref);
+                        operands.push_back(memref);
+                    }
+                }
+
+                rewriter.create<func::CallOp>(callOp.getLoc(), func, operands);
+                rewriter.replaceOp(callOp, outputs);
+            }
+        }
+    }
+}
+
 /// Enzyme custom gradients appear to exhibit better stability when they are registered for
 /// functions where MemRefs are passed via wrapped pointers (!llvm.ptr<struct(ptr, ptr, i64, ...)>)
 /// rather than having their fields unpacked. This function automatically transforms MemRef
@@ -54,93 +139,14 @@ namespace gradient {
 void wrapMemRefArgs(func::FuncOp func, const TypeConverter *typeConverter, RewriterBase &rewriter,
                     Location loc, bool volatileArgs = false)
 {
-        if (llvm::none_of(func.getArgumentTypes(),
-                          [](Type argType) { return isa<MemRefType>(argType); })) {
-            // The memref arguments are already wrapped
-            return;
-        }
-    [&]() {
 
-        MLIRContext *ctx = rewriter.getContext();
-        auto ptrType = LLVM::LLVMPointerType::get(ctx);
-        PatternRewriter::InsertionGuard insertionGuard(rewriter);
-        rewriter.setInsertionPointToStart(&func.getFunctionBody().front());
-        for (const auto [idx, argType] : llvm::enumerate(func.getArgumentTypes())) {
-            if (auto memrefType = dyn_cast<MemRefType>(argType)) {
-                BlockArgument memrefArg = func.getArgument(idx);
-                func.insertArgument(idx, ptrType, DictionaryAttr::get(ctx), loc);
-                Value wrappedMemref = func.getArgument(idx);
-                Type structType = typeConverter->convertType(memrefType);
-
-                // We potentially need all arguments for the custom quantum gradient, but not all of
-                // them will be used by the primal. Mark the load of the wrapped memref as volatile
-                // and perform a no-op store to ensure that the function argument is considered
-                // used. Otherwise, LLVM may optimize it away with a poison value.
-                //   Note: both the volatile load and store are necessary. MLIR respects the store
-                //   but not the load, while LLVM respects the volatile load but not the store.
-                Value replacedMemref = rewriter.create<LLVM::LoadOp>(
-                    loc, structType, wrappedMemref, /*alignment*/ 0, /*isVolatile=*/volatileArgs);
-                if (volatileArgs) {
-                    rewriter.create<LLVM::StoreOp>(loc, replacedMemref, wrappedMemref);
-                }
-                replacedMemref =
-                    rewriter.create<UnrealizedConversionCastOp>(loc, argType, replacedMemref)
-                        .getResult(0);
-                memrefArg.replaceAllUsesWith(replacedMemref);
-                func.eraseArgument(memrefArg.getArgNumber());
-            }
-        }
-    }();
-
-    [&]() {
-        ModuleOp moduleOp = func->getParentOfType<ModuleOp>();
-        MLIRContext *ctx = rewriter.getContext();
-        auto ptrType = LLVM::LLVMPointerType::get(ctx);
-        std::optional<SymbolTable::UseRange> uses = func.getSymbolUses(moduleOp);
-        if (uses.has_value()) {
-            for (auto use : *uses) {
-                if (auto callOp = dyn_cast<func::CallOp>(use.getUser())) {
-                    PatternRewriter::InsertionGuard insertionGuard(rewriter);
-                    rewriter.setInsertionPoint(callOp);
-
-                    Value c1 =
-                        rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI64IntegerAttr(1));
-
-                    SmallVector<Value> operands;
-                    SmallVector<Value> outputs;
-                    auto wrapMemref = [&](Value memref) {
-                        Type convertedType = typeConverter->convertType(memref.getType());
-                        Value space =
-                            rewriter.create<LLVM::AllocaOp>(loc, /*resultType=*/ptrType,
-                                                            /*elementType=*/convertedType, c1);
-                        Value convertedValue =
-                            rewriter.create<UnrealizedConversionCastOp>(loc, convertedType, memref)
-                                .getResult(0);
-                        rewriter.create<LLVM::StoreOp>(loc, convertedValue, space);
-                        return space;
-                    };
-                    for (Value oldOperand : callOp.getOperands()) {
-                        if (isa<MemRefType>(oldOperand.getType())) {
-                            operands.push_back(wrapMemref(oldOperand));
-                        }
-                    }
-                    for (Type resultType : callOp.getResultTypes()) {
-                        if (auto memrefType = dyn_cast<MemRefType>(resultType)) {
-                            assert(memrefType.hasStaticShape());
-                            Value memref = rewriter.create<memref::AllocOp>(loc, memrefType);
-                            outputs.push_back(memref);
-
-                            memref = wrapMemref(memref);
-                            operands.push_back(memref);
-                        }
-                    }
-
-                    rewriter.create<func::CallOp>(callOp.getLoc(), func, operands);
-                    rewriter.replaceOp(callOp, outputs);
-                }
-            }
-        }
-    }();
+    if (llvm::none_of(func.getArgumentTypes(),
+                      [](Type argType) { return isa<MemRefType>(argType); })) {
+        // The memref arguments are already wrapped
+        return;
+    }
+    wrapMemRefArgsFunc(func, typeConverter, rewriter, loc, volatileArgs);
+    wrapMemRefArgsCallsites(func, typeConverter, rewriter, loc, volatileArgs);
 }
 } // namespace gradient
 } // namespace catalyst

--- a/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
@@ -54,86 +54,93 @@ namespace gradient {
 void wrapMemRefArgs(func::FuncOp func, const TypeConverter *typeConverter, RewriterBase &rewriter,
                     Location loc, bool volatileArgs = false)
 {
-    if (llvm::none_of(func.getArgumentTypes(),
-                      [](Type argType) { return isa<MemRefType>(argType); })) {
-        // The memref arguments are already wrapped
-        return;
-    }
-
-    ModuleOp moduleOp = func->getParentOfType<ModuleOp>();
-    MLIRContext *ctx = rewriter.getContext();
-    auto ptrType = LLVM::LLVMPointerType::get(ctx);
-    PatternRewriter::InsertionGuard insertionGuard(rewriter);
-    rewriter.setInsertionPointToStart(&func.getFunctionBody().front());
-    for (const auto [idx, argType] : llvm::enumerate(func.getArgumentTypes())) {
-        if (auto memrefType = dyn_cast<MemRefType>(argType)) {
-            BlockArgument memrefArg = func.getArgument(idx);
-            func.insertArgument(idx, ptrType, DictionaryAttr::get(ctx), loc);
-            Value wrappedMemref = func.getArgument(idx);
-            Type structType = typeConverter->convertType(memrefType);
-
-            // We potentially need all arguments for the custom quantum gradient, but not all of
-            // them will be used by the primal. Mark the load of the wrapped memref as volatile and
-            // perform a no-op store to ensure that the function argument is considered used.
-            // Otherwise, LLVM may optimize it away with a poison value.
-            //   Note: both the volatile load and store are necessary. MLIR respects the store but
-            //   not the load, while LLVM respects the volatile load but not the store.
-            Value replacedMemref = rewriter.create<LLVM::LoadOp>(
-                loc, structType, wrappedMemref, /*alignment*/ 0, /*isVolatile=*/volatileArgs);
-            if (volatileArgs) {
-                rewriter.create<LLVM::StoreOp>(loc, replacedMemref, wrappedMemref);
-            }
-            replacedMemref =
-                rewriter.create<UnrealizedConversionCastOp>(loc, argType, replacedMemref)
-                    .getResult(0);
-            memrefArg.replaceAllUsesWith(replacedMemref);
-            func.eraseArgument(memrefArg.getArgNumber());
+        if (llvm::none_of(func.getArgumentTypes(),
+                          [](Type argType) { return isa<MemRefType>(argType); })) {
+            // The memref arguments are already wrapped
+            return;
         }
-    }
+    [&]() {
 
-    std::optional<SymbolTable::UseRange> uses = func.getSymbolUses(moduleOp);
-    if (uses.has_value()) {
-        for (auto use : *uses) {
-            if (auto callOp = dyn_cast<func::CallOp>(use.getUser())) {
-                PatternRewriter::InsertionGuard insertionGuard(rewriter);
-                rewriter.setInsertionPoint(callOp);
+        MLIRContext *ctx = rewriter.getContext();
+        auto ptrType = LLVM::LLVMPointerType::get(ctx);
+        PatternRewriter::InsertionGuard insertionGuard(rewriter);
+        rewriter.setInsertionPointToStart(&func.getFunctionBody().front());
+        for (const auto [idx, argType] : llvm::enumerate(func.getArgumentTypes())) {
+            if (auto memrefType = dyn_cast<MemRefType>(argType)) {
+                BlockArgument memrefArg = func.getArgument(idx);
+                func.insertArgument(idx, ptrType, DictionaryAttr::get(ctx), loc);
+                Value wrappedMemref = func.getArgument(idx);
+                Type structType = typeConverter->convertType(memrefType);
 
-                Value c1 = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI64IntegerAttr(1));
-
-                SmallVector<Value> operands;
-                SmallVector<Value> outputs;
-                auto wrapMemref = [&](Value memref) {
-                    Type convertedType = typeConverter->convertType(memref.getType());
-                    Value space =
-                        rewriter.create<LLVM::AllocaOp>(loc, /*resultType=*/ptrType,
-                                                        /*elementType=*/convertedType, c1);
-                    Value convertedValue =
-                        rewriter.create<UnrealizedConversionCastOp>(loc, convertedType, memref)
-                            .getResult(0);
-                    rewriter.create<LLVM::StoreOp>(loc, convertedValue, space);
-                    return space;
-                };
-                for (Value oldOperand : callOp.getOperands()) {
-                    if (isa<MemRefType>(oldOperand.getType())) {
-                        operands.push_back(wrapMemref(oldOperand));
-                    }
+                // We potentially need all arguments for the custom quantum gradient, but not all of
+                // them will be used by the primal. Mark the load of the wrapped memref as volatile
+                // and perform a no-op store to ensure that the function argument is considered
+                // used. Otherwise, LLVM may optimize it away with a poison value.
+                //   Note: both the volatile load and store are necessary. MLIR respects the store
+                //   but not the load, while LLVM respects the volatile load but not the store.
+                Value replacedMemref = rewriter.create<LLVM::LoadOp>(
+                    loc, structType, wrappedMemref, /*alignment*/ 0, /*isVolatile=*/volatileArgs);
+                if (volatileArgs) {
+                    rewriter.create<LLVM::StoreOp>(loc, replacedMemref, wrappedMemref);
                 }
-                for (Type resultType : callOp.getResultTypes()) {
-                    if (auto memrefType = dyn_cast<MemRefType>(resultType)) {
-                        assert(memrefType.hasStaticShape());
-                        Value memref = rewriter.create<memref::AllocOp>(loc, memrefType);
-                        outputs.push_back(memref);
-
-                        memref = wrapMemref(memref);
-                        operands.push_back(memref);
-                    }
-                }
-
-                rewriter.create<func::CallOp>(callOp.getLoc(), func, operands);
-                rewriter.replaceOp(callOp, outputs);
+                replacedMemref =
+                    rewriter.create<UnrealizedConversionCastOp>(loc, argType, replacedMemref)
+                        .getResult(0);
+                memrefArg.replaceAllUsesWith(replacedMemref);
+                func.eraseArgument(memrefArg.getArgNumber());
             }
         }
-    }
+    }();
+
+    [&]() {
+        ModuleOp moduleOp = func->getParentOfType<ModuleOp>();
+        MLIRContext *ctx = rewriter.getContext();
+        auto ptrType = LLVM::LLVMPointerType::get(ctx);
+        std::optional<SymbolTable::UseRange> uses = func.getSymbolUses(moduleOp);
+        if (uses.has_value()) {
+            for (auto use : *uses) {
+                if (auto callOp = dyn_cast<func::CallOp>(use.getUser())) {
+                    PatternRewriter::InsertionGuard insertionGuard(rewriter);
+                    rewriter.setInsertionPoint(callOp);
+
+                    Value c1 =
+                        rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI64IntegerAttr(1));
+
+                    SmallVector<Value> operands;
+                    SmallVector<Value> outputs;
+                    auto wrapMemref = [&](Value memref) {
+                        Type convertedType = typeConverter->convertType(memref.getType());
+                        Value space =
+                            rewriter.create<LLVM::AllocaOp>(loc, /*resultType=*/ptrType,
+                                                            /*elementType=*/convertedType, c1);
+                        Value convertedValue =
+                            rewriter.create<UnrealizedConversionCastOp>(loc, convertedType, memref)
+                                .getResult(0);
+                        rewriter.create<LLVM::StoreOp>(loc, convertedValue, space);
+                        return space;
+                    };
+                    for (Value oldOperand : callOp.getOperands()) {
+                        if (isa<MemRefType>(oldOperand.getType())) {
+                            operands.push_back(wrapMemref(oldOperand));
+                        }
+                    }
+                    for (Type resultType : callOp.getResultTypes()) {
+                        if (auto memrefType = dyn_cast<MemRefType>(resultType)) {
+                            assert(memrefType.hasStaticShape());
+                            Value memref = rewriter.create<memref::AllocOp>(loc, memrefType);
+                            outputs.push_back(memref);
+
+                            memref = wrapMemref(memref);
+                            operands.push_back(memref);
+                        }
+                    }
+
+                    rewriter.create<func::CallOp>(callOp.getLoc(), func, operands);
+                    rewriter.replaceOp(callOp, outputs);
+                }
+            }
+        }
+    }();
 }
 } // namespace gradient
 } // namespace catalyst

--- a/mlir/lib/Quantum/Transforms/annotate_function.cpp
+++ b/mlir/lib/Quantum/Transforms/annotate_function.cpp
@@ -36,7 +36,8 @@ bool isAnnotated(func::FuncOp op, const char *attr)
 bool invalidGradientOperation(func::FuncOp op)
 {
     auto res = op.walk([](Operation *o) {
-        if (dyn_cast<MeasureOp>(o) || dyn_cast<catalyst::CustomCallOp>(o)) {
+        if (dyn_cast<MeasureOp>(o) || dyn_cast<catalyst::CustomCallOp>(o) ||
+            dyn_cast<catalyst::CallbackCallOp>(o)) {
             return WalkResult::interrupt();
         }
         else {

--- a/mlir/lib/Quantum/Transforms/annotate_function.cpp
+++ b/mlir/lib/Quantum/Transforms/annotate_function.cpp
@@ -36,8 +36,7 @@ bool isAnnotated(func::FuncOp op, const char *attr)
 bool invalidGradientOperation(func::FuncOp op)
 {
     auto res = op.walk([](Operation *o) {
-        if (dyn_cast<MeasureOp>(o) || dyn_cast<catalyst::PythonCallOp>(o) ||
-            dyn_cast<catalyst::CustomCallOp>(o)) {
+        if (dyn_cast<MeasureOp>(o) || dyn_cast<catalyst::CustomCallOp>(o)) {
             return WalkResult::interrupt();
         }
         else {

--- a/mlir/test/Catalyst/BufferizationTest.mlir
+++ b/mlir/test/Catalyst/BufferizationTest.mlir
@@ -68,3 +68,22 @@ module @test0 {
   catalyst.callback @callback_1(tensor<f64>) -> tensor<f64> attributes { argc = 1:i64, resc = 1 : i64, id = 1:i64}
 }
 
+// -----
+
+// CHECK-LABEL: @test1
+module @test1 {
+  catalyst.callback @callback_1(tensor<f64>) -> tensor<f64> attributes { argc = 1:i64, resc = 1 : i64, id = 1:i64}
+
+  // CHECK-LABEL: @foo(
+  // CHECK-SAME: [[arg0:%.+]]: tensor<f64>)
+  func.func private @foo(%arg0: tensor<f64>) -> tensor<f64> {
+    // CHECK-DAG: [[memref0:%.+]] = bufferization.to_memref [[arg0]]
+    // CHECK-DAG: [[tensor1:%.+]] = bufferization.alloc_tensor
+    // CHECK:     [[memref1:%.+]] = bufferization.to_memref [[tensor1]]
+    // CHECK:     catalyst.callback_call @callback_1([[memref0]], [[memref1]])
+    %1 = catalyst.callback_call @callback_1(%arg0) : (tensor<f64>) -> (tensor<f64>)
+    // CHECK:     [[retval:%.+]] = bufferization.to_tensor [[memref1]]
+    // CHECK:     return [[retval]]
+    return %1 : tensor<f64>
+  }
+}

--- a/mlir/test/Catalyst/BufferizationTest.mlir
+++ b/mlir/test/Catalyst/BufferizationTest.mlir
@@ -59,3 +59,12 @@ func.func @custom_call(%arg0: tensor<3x3xf64>) -> tensor<3x3xf64> {
 
     return %0 : tensor<3x3xf64>
 }
+
+// -----
+
+// CHECK-LABEL: @test0
+module @test0 {
+  // CHECK: catalyst.callback @callback_1(memref<f64>, memref<f64>)
+  catalyst.callback @callback_1(tensor<f64>) -> tensor<f64> attributes { argc = 1:i64, resc = 1 : i64, id = 1:i64}
+}
+

--- a/mlir/test/Catalyst/ConversionTest.mlir
+++ b/mlir/test/Catalyst/ConversionTest.mlir
@@ -121,3 +121,23 @@ func.func @python_call () {
     catalyst.pycallback() { identifier = 0} : () -> ()
     return
 }
+
+// -----
+
+// CHECK-LABEL @test0
+module @test0 {
+
+  // Make sure that arguments are !llvm.ptrs.
+  // CHECK-LABEL: func.func @callback_4(
+  // CHECK-SAME: [[arg0:%.+]]: !llvm.ptr,
+  // CHECK-SAME: [[arg1:%.+]]: !llvm.ptr)
+
+  // Make sure that we pass the constants that we need.
+  // CHECK-DAG: [[id:%.+]] = llvm.mlir.constant(4
+  // CHECK-DAG: [[argc:%.+]] = llvm.mlir.constant(2
+  // CHECK-DAG: [[resc:%.+]] = llvm.mlir.constant(3
+
+  // CHECK: llvm.call @inactive_callback([[id]], [[argc]], [[resc]]
+  catalyst.callback @callback_4(memref<f64>, memref<f64>) attributes {argc = 2 : i64, id = 4 : i64, resc = 3 : i64}
+}
+

--- a/mlir/test/Catalyst/ConversionTest.mlir
+++ b/mlir/test/Catalyst/ConversionTest.mlir
@@ -111,19 +111,6 @@ func.func @custom_call(%arg0: memref<3x3xf64>) -> memref<3x3xf64> {
 
 // -----
 
-// A python without parameters and without returns.
-
-func.func @python_call () {
-    // CHECK: [[identifier:%.+]] = llvm.mlir.constant(0 : i64)
-    // CHECK: [[argcount:%.+]] = llvm.mlir.constant(0 : i64)
-    // CHECK: [[rescount:%.+]] = llvm.mlir.constant(0 : i64)
-    // CHECK: llvm.call @inactive_callback([[identifier]], [[argcount]], [[rescount]])
-    catalyst.pycallback() { identifier = 0} : () -> ()
-    return
-}
-
-// -----
-
 // CHECK-LABEL @test0
 module @test0 {
 


### PR DESCRIPTION
**Context:** This PR replaces #735 

**Description of the Change:**

1. Creates a `CallbackOp` and a `CallbackCallOp` separating the declaration/definition of the call site.
2. Replaces the signature of `CallbackOp` and `CallbackOp` with the correct calling convention.
3. Generates bodies for `CallbackOp`s that include calling the runtime function `inactive_callback`.


**Related GitHub Issues:**

[sc-60494]
