### PR TITLE
Fixes for wire management in Catalyst

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -83,6 +83,13 @@
 
 <h3>Improvements</h3>
 
+* Catalyst now performs a stricter validation of the wire requirements for devices. In particular,
+  only integer, continuous wire labels starting at 0 are allowed.
+  [(#784)](https://github.com/PennyLaneAI/catalyst/pull/784)
+
+* Catalyst no longer disallows quantum circuits with 0 qubits.
+  [(#784)](https://github.com/PennyLaneAI/catalyst/pull/784)
+
 * Catalyst now has support for `qml.sample(m)` where `m` is the result of a mid-circuit
   measurement. For now the feature is equivalent to returning `m` directly from a quantum
   function, but will be improved to return an array with one measurement result for each
@@ -126,6 +133,10 @@
   [(#663)](https://github.com/PennyLaneAI/catalyst/pull/663)
 
 <h3>Bug fixes</h3>
+
+* The Catalyst runtime now raises an error if an qubit is accessed out of bounds from the allocated
+  register.
+  [(#784)](https://github.com/PennyLaneAI/catalyst/pull/784)
 
 * Correctly querying batching rules for `jax.scipy.linalg.expm`
   [(#733)](https://github.com/PennyLaneAI/catalyst/pull/733)

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -526,7 +526,7 @@ def check_device_wires(wires):
     assert isinstance(wires, qml.wires.Wires)
 
     if not all(isinstance(wire, int) for wire in wires.labels):
-        raise AttributeError("Catalyst requires continuous integer wire lables starting at 0.")
+        raise AttributeError("Catalyst requires continuous integer wire labels starting at 0.")
 
     if not wires.labels == tuple(range(len(wires))):
-        raise AttributeError("Catalyst requires continuous integer wire lables starting at 0.")
+        raise AttributeError("Catalyst requires continuous integer wire labels starting at 0.")

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -254,6 +254,8 @@ class QJITDevice(qml.QubitDevice):
     ):
         super().__init__(wires=wires, shots=shots)
 
+        check_device_wires(self.wires)
+
         self.backend_name = backend.c_interface_name if backend else "default"
         self.backend_lib = backend.lpath if backend else ""
         self.backend_kwargs = backend.kwargs if backend else {}
@@ -355,8 +357,7 @@ class QJITDeviceNewAPI(qml.devices.Device):
         for key, value in original_device.__dict__.items():
             self.__setattr__(key, value)
 
-        if original_device.wires is None:
-            raise AttributeError("Catalyst does not support devices without set wires.")
+        check_device_wires(original_device.wires)
 
         super().__init__(wires=original_device.wires, shots=original_device.shots)
 
@@ -515,3 +516,17 @@ def validate_device_capabilities(
                 "Observables in qml.device.observables and specification file do not match.\n"
                 f"Observables that present only in spec: {spec_observables - device_observables}\n"
             )
+
+
+def check_device_wires(wires):
+    """Validate requirements Catalyst imposes on device wires."""
+    if wires is None:
+        raise AttributeError("Catalyst does not support device instances without set wires.")
+
+    assert isinstance(wires, qml.wires.Wires)
+
+    if not all(isinstance(wire, int) for wire in wires.labels):
+        raise AttributeError("Catalyst requires continuous integer wire lables starting at 0.")
+
+    if not wires.labels == tuple(range(len(wires))):
+        raise AttributeError("Catalyst requires continuous integer wire lables starting at 0.")

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -519,7 +519,7 @@ def trace_observables(
         raise NotImplementedError(
             f"Observable {obs} (of type {type(obs)}) is not impemented"
         )  # pragma: no cover
-    return obs_tracers, (len(qubits) if qubits else None)
+    return obs_tracers, (len(qubits) if qubits else 0)
 
 
 def pauli_sentence_to_hamiltonian_obs(paulis, qrp: QRegPromise) -> List[DynamicJaxprTracer]:

--- a/frontend/test/pytest/test_device_api.py
+++ b/frontend/test/pytest/test_device_api.py
@@ -127,7 +127,30 @@ def test_qjit_device_no_wires():
     backend_info = extract_backend_info(device, capabilities)
 
     with pytest.raises(
-        AttributeError, match="Catalyst does not support devices without set wires."
+        AttributeError, match="Catalyst does not support device instances without set wires."
+    ):
+        QJITDeviceNewAPI(device, capabilities, backend_info)
+
+
+@pytest.mark.parametrize(
+    "wires",
+    (
+        qml.wires.Wires(["a", "b"]),
+        qml.wires.Wires([0, 2, 4]),
+        qml.wires.Wires([1, 2, 3]),
+    ),
+)
+def test_qjit_device_invalid_wires(wires):
+    """Test the qjit device from a device using the new api without wires set."""
+    device = DummyDeviceNoWires(shots=2032)
+    device._wires = wires
+
+    # Create qjit device
+    capabilities = get_device_capabilities(device, ProgramFeatures(device.shots is not None))
+    backend_info = extract_backend_info(device, capabilities)
+
+    with pytest.raises(
+        AttributeError, match="Catalyst requires continuous integer wire lables starting at 0"
     ):
         QJITDeviceNewAPI(device, capabilities, backend_info)
 

--- a/frontend/test/pytest/test_device_api.py
+++ b/frontend/test/pytest/test_device_api.py
@@ -150,7 +150,7 @@ def test_qjit_device_invalid_wires(wires):
     backend_info = extract_backend_info(device, capabilities)
 
     with pytest.raises(
-        AttributeError, match="Catalyst requires continuous integer wire lables starting at 0"
+        AttributeError, match="Catalyst requires continuous integer wire labels starting at 0"
     ):
         QJITDeviceNewAPI(device, capabilities, backend_info)
 

--- a/frontend/test/pytest/test_measurements_results.py
+++ b/frontend/test/pytest/test_measurements_results.py
@@ -23,6 +23,18 @@ from catalyst import qjit
 class TestSample:
     """Test sample."""
 
+    def test_sample_on_0qbits(self, backend):
+        """Test sample on 0 qubits."""
+
+        @qjit
+        @qml.qnode(qml.device(backend, wires=0, shots=10))
+        def sample_0qbit():
+            return qml.sample()
+
+        expected = np.empty(shape=(10, 0), dtype=int)
+        observed = sample_0qbit()
+        assert np.array_equal(observed, expected)
+
     def test_sample_on_1qbit(self, backend):
         """Test sample on 1 qubit."""
 
@@ -60,6 +72,18 @@ class TestSample:
 
 class TestCounts:
     """Test counts."""
+
+    def test_counts_on_0qbits(self, backend):
+        """Test counts on 0 qubits."""
+
+        @qjit
+        @qml.qnode(qml.device(backend, wires=0, shots=10))
+        def counts_0qbit():
+            return qml.counts()
+
+        expected = [np.array([0]), np.array([10])]
+        observed = counts_0qbit()
+        assert np.array_equal(observed, expected)
 
     def test_count_on_1qbit(self, backend):
         """Test counts on 1 qubits."""
@@ -625,11 +649,23 @@ class TestVar:
         )
 
 
-class TestOtherMeasurements:
-    """Test other measurement processes."""
+class TestState:
+    """Test state measurement processes."""
 
-    def test_state(self, backend):
-        """Test state."""
+    def test_state_on_0qbits(self, backend):
+        """Test state on 0 qubits."""
+
+        @qjit
+        @qml.qnode(qml.device(backend, wires=0))
+        def state_0qbit():
+            return qml.state()
+
+        expected = np.array([complex(1.0, 0.0)])
+        observed = state_0qbit()
+        assert np.array_equal(observed, expected)
+
+    def test_state_on_1qubit(self, backend):
+        """Test state on 1 qubit."""
 
         @qjit
         @qml.qnode(qml.device(backend, wires=1))
@@ -637,9 +673,38 @@ class TestOtherMeasurements:
             qml.RX(x, wires=0)
             return qml.state()
 
-        expected = np.array([complex(1.0, 0.0), complex(0.0, 0.0)])
-        observed = state(0.0)
+        expected = np.array([complex(1.0, 0.0), complex(0.0, -1.0)]) / np.sqrt(2)
+        observed = state(np.pi / 2)
+        assert np.allclose(observed, expected)
+
+
+class TestProbs:
+    """Test probabilities measurement processes."""
+
+    def test_probs_on_0qbits(self, backend):
+        """Test probs on 0 qubits."""
+
+        @qjit
+        @qml.qnode(qml.device(backend, wires=0))
+        def probs_0qbit():
+            return qml.probs()
+
+        expected = np.array([1.0])
+        observed = probs_0qbit()
         assert np.array_equal(observed, expected)
+
+    def test_probs_on_1qubit(self, backend):
+        """Test probs on 1 qubit."""
+
+        @qjit
+        @qml.qnode(qml.device(backend, wires=1))
+        def probs(x: float):
+            qml.RX(x, wires=0)
+            return qml.probs()
+
+        expected = np.array([0.5, 0.5])
+        observed = probs(np.pi / 2)
+        assert np.allclose(observed, expected)
 
 
 class TestNewArithmeticOps:

--- a/frontend/test/pytest/test_measurements_results.py
+++ b/frontend/test/pytest/test_measurements_results.py
@@ -23,11 +23,11 @@ from catalyst import qjit
 class TestSample:
     """Test sample."""
 
-    def test_sample_on_0qbits(self, backend):
+    def test_sample_on_0qbits(self):
         """Test sample on 0 qubits."""
 
         @qjit
-        @qml.qnode(qml.device(backend, wires=0, shots=10))
+        @qml.qnode(qml.device("lightning.qubit", wires=0, shots=10))
         def sample_0qbit():
             return qml.sample()
 
@@ -73,11 +73,11 @@ class TestSample:
 class TestCounts:
     """Test counts."""
 
-    def test_counts_on_0qbits(self, backend):
+    def test_counts_on_0qbits(self):
         """Test counts on 0 qubits."""
 
         @qjit
-        @qml.qnode(qml.device(backend, wires=0, shots=10))
+        @qml.qnode(qml.device("lightning.qubit", wires=0, shots=10))
         def counts_0qbit():
             return qml.counts()
 
@@ -652,11 +652,11 @@ class TestVar:
 class TestState:
     """Test state measurement processes."""
 
-    def test_state_on_0qbits(self, backend):
+    def test_state_on_0qbits(self):
         """Test state on 0 qubits."""
 
         @qjit
-        @qml.qnode(qml.device(backend, wires=0))
+        @qml.qnode(qml.device("lightning.qubit", wires=0))
         def state_0qbit():
             return qml.state()
 
@@ -681,11 +681,11 @@ class TestState:
 class TestProbs:
     """Test probabilities measurement processes."""
 
-    def test_probs_on_0qbits(self, backend):
+    def test_probs_on_0qbits(self):
         """Test probs on 0 qubits."""
 
         @qjit
-        @qml.qnode(qml.device(backend, wires=0))
+        @qml.qnode(qml.device("lightning.qubit", wires=0))
         def probs_0qbit():
             return qml.probs()
 

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -114,7 +114,7 @@ def AllocOp : Memory_Op<"alloc", [NoMemoryEffect]> {
 
     let arguments = (ins
         Optional<I64>:$nqubits,
-        OptionalAttr<ConfinedAttr<I64Attr, [IntMinValue<1>]>>:$nqubits_attr
+        OptionalAttr<ConfinedAttr<I64Attr, [IntNonNegative]>>:$nqubits_attr
     );
 
     let results = (outs
@@ -150,7 +150,7 @@ def ExtractOp : Memory_Op<"extract", [NoMemoryEffect]> {
     let arguments = (ins
         QuregType:$qreg,
         Optional<I64>:$idx,
-        OptionalAttr<ConfinedAttr<I64Attr, [IntMinValue<0>]>>:$idx_attr
+        OptionalAttr<ConfinedAttr<I64Attr, [IntNonNegative]>>:$idx_attr
     );
 
     let results = (outs
@@ -173,7 +173,7 @@ def InsertOp : Memory_Op<"insert", [NoMemoryEffect]> {
     let arguments = (ins
         QuregType:$in_qreg,
         Optional<I64>:$idx,
-        OptionalAttr<ConfinedAttr<I64Attr, [IntMinValue<0>]>>:$idx_attr,
+        OptionalAttr<ConfinedAttr<I64Attr, [IntNonNegative]>>:$idx_attr,
         QubitType:$qubit
     );
 

--- a/mlir/test/Quantum/VerifierTest.mlir
+++ b/mlir/test/Quantum/VerifierTest.mlir
@@ -39,12 +39,12 @@ quantum.dealloc %r1 : !quantum.reg
 
 // -----
 
-// expected-error @below {{failed to satisfy constraint: 64-bit signless integer attribute whose minimum value is 1}}
-%r = quantum.alloc(0) : !quantum.reg
+// expected-error @below {{failed to satisfy constraint: 64-bit signless integer attribute whose value is non-negative}}
+%r = quantum.alloc(-1) : !quantum.reg
 
 // -----
 
-// expected-error @+2 {{failed to satisfy constraint: 64-bit signless integer attribute whose minimum value is 0}}
+// expected-error @+2 {{failed to satisfy constraint: 64-bit signless integer attribute whose value is non-negative}}
 %r = quantum.alloc(5) : !quantum.reg
 %q = quantum.extract %r[-1] : !quantum.reg -> !quantum.bit
 

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -960,6 +960,11 @@ int64_t __catalyst__rt__array_get_size_1d(QirArray *ptr)
 int8_t *__catalyst__rt__array_get_element_ptr_1d(QirArray *ptr, int64_t idx)
 {
     std::vector<QubitIdType> *qubit_vector_ptr = reinterpret_cast<std::vector<QubitIdType> *>(ptr);
+
+    std::string error_msg = "The qubit register does not contain the requested wire: ";
+    error_msg += std::to_string(idx);
+    RT_FAIL_IF(idx >= qubit_vector_ptr->size(), error_msg.c_str());
+
     QubitIdType *data = qubit_vector_ptr->data();
     return (int8_t *)&data[idx];
 }

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -961,9 +961,10 @@ int8_t *__catalyst__rt__array_get_element_ptr_1d(QirArray *ptr, int64_t idx)
 {
     std::vector<QubitIdType> *qubit_vector_ptr = reinterpret_cast<std::vector<QubitIdType> *>(ptr);
 
+    RT_ASSERT(idx >= 0);
     std::string error_msg = "The qubit register does not contain the requested wire: ";
     error_msg += std::to_string(idx);
-    RT_FAIL_IF(idx >= qubit_vector_ptr->size(), error_msg.c_str());
+    RT_FAIL_IF(static_cast<size_t>(idx) >= qubit_vector_ptr->size(), error_msg.c_str());
 
     QubitIdType *data = qubit_vector_ptr->data();
     return (int8_t *)&data[idx];

--- a/runtime/tests/Test_LightningCoreQIS.cpp
+++ b/runtime/tests/Test_LightningCoreQIS.cpp
@@ -215,6 +215,10 @@ TEST_CASE("Qubits: allocate, release, dump", "[CoreQIS]")
         __catalyst__rt__array_get_element_ptr_1d(qs, 0);
         __catalyst__rt__array_get_element_ptr_1d(qs, 2);
 
+        REQUIRE_THROWS_WITH(
+            __catalyst__rt__array_get_element_ptr_1d(qs, 3),
+            Catch::Contains("The qubit register does not contain the requested wire: 3"));
+
         __catalyst__rt__qubit_release_array(qs); // The `qs` is a dangling pointer from now on.
         __catalyst__rt__device_release();
     }


### PR DESCRIPTION
This PR contains several improvements regarding the wire handling in Catalyst:
- the runtime will now raise an exception when a qubit is accessed out of bounds, which improves memory safety, and doesn't require the backend to raise an invalid qubit error
- the arbitrary restriction of requiring at least one qubit to run a quantum circuit is lifted (now follows PL behaviour)
- the QJITDevice classes in the frontend now perform stricter validation _of existing assumptions_ on the `wires` property of devices

**Related GitHub Issues:** #780 

[sc-65105]
