### PR TITLE
Standardize the call sigantures for measurement primitives

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -124,6 +124,9 @@
 * Raise a better error message when no shots are specified and `qml.sample` or `qml.counts` is used.
   [(#786)](https://github.com/PennyLaneAI/catalyst/pull/786)
 
+* The measurement primitives now have a standardized call signature so that `shots` and `shape` can
+  both be provided as keyword arguments.
+
 <h3>Breaking changes</h3>
 
 * Binary distributions for Linux are now based on `manylinux_2_28` instead of `manylinux_2014`.
@@ -228,6 +231,7 @@
 This release contains contributions from (in alphabetical order):
 
 David Ittah,
+Christina Lee,
 Erick Ochoa,
 Haochen Paul Wang,
 Lee James O'Riordan,

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1224,17 +1224,17 @@ def _counts_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shots: in
 # expval measurement
 #
 @expval_p.def_abstract_eval
-def _expval_abstract_eval(obs, shots):
+def _expval_abstract_eval(obs, shots, shape=None):
     assert isinstance(obs, AbstractObs)
     return core.ShapedArray((), jax.numpy.float64)
 
 
 @expval_p.def_impl
-def _expval_def_impl(ctx, obs, shots):  # pragma: no cover
+def _expval_def_impl(ctx, obs, shots, shape=None):  # pragma: no cover
     raise NotImplementedError()
 
 
-def _expval_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shots: int):
+def _expval_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shots: int, shape=None):
     ctx = jax_ctx.module_context.context
     ctx.allow_unregistered_dialects = True
 
@@ -1256,17 +1256,17 @@ def _expval_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shots: in
 # var measurement
 #
 @var_p.def_abstract_eval
-def _var_abstract_eval(obs, shots):
+def _var_abstract_eval(obs, shots, shape=None):
     assert isinstance(obs, AbstractObs)
     return core.ShapedArray((), jax.numpy.float64)
 
 
 @var_p.def_impl
-def _var_def_impl(ctx, obs, shots):  # pragma: no cover
+def _var_def_impl(ctx, obs, shots, shape=None):  # pragma: no cover
     raise NotImplementedError()
 
 
-def _var_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shots: int):
+def _var_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shots: int, shape=None):
     ctx = jax_ctx.module_context.context
     ctx.allow_unregistered_dialects = True
 
@@ -1288,7 +1288,7 @@ def _var_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shots: int):
 # probs measurement
 #
 @probs_p.def_abstract_eval
-def _probs_abstract_eval(obs, shape):
+def _probs_abstract_eval(obs, shape, shots=None):
     assert isinstance(obs, AbstractObs)
 
     if obs.primitive is compbasis_p:
@@ -1300,11 +1300,11 @@ def _probs_abstract_eval(obs, shape):
 
 
 @var_p.def_impl
-def _probs_def_impl(ctx, obs, shape):  # pragma: no cover
+def _probs_def_impl(ctx, obs, shape, shots=None):  # pragma: no cover
     raise NotImplementedError()
 
 
-def _probs_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shape: tuple):
+def _probs_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shape: tuple, shots=None):
     ctx = jax_ctx.module_context.context
     ctx.allow_unregistered_dialects = True
 
@@ -1317,7 +1317,7 @@ def _probs_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shape: tup
 # state measurement
 #
 @state_p.def_abstract_eval
-def _state_abstract_eval(obs, shape):
+def _state_abstract_eval(obs, shape, shots=None):
     assert isinstance(obs, AbstractObs)
 
     if obs.primitive is compbasis_p:
@@ -1329,11 +1329,11 @@ def _state_abstract_eval(obs, shape):
 
 
 @state_p.def_impl
-def _state_def_impl(ctx, obs, shape):  # pragma: no cover
+def _state_def_impl(ctx, obs, shape, shots=None):  # pragma: no cover
     raise NotImplementedError()
 
 
-def _state_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shape: tuple):
+def _state_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shape: tuple, shots=None):
     ctx = jax_ctx.module_context.context
     ctx.allow_unregistered_dialects = True
 


### PR DESCRIPTION
**Context:**

Each type of measurement primitive has a slightly different call signature.  This lack of standardization means that each type of primitive needs custom handling. That custom handling makes conversion and binding of measurements fragile, error-prone, and difficult to extend.  

**Description of the Change:**

Standardizes the call signatures of each measurement primitive to contain `obs` as the first positional keyword arguments, and `shots` and `shape` as keyword arguments.

While the call signatures differ the order of `shots` and `shape`, both of these values should always be passed as keyword arguments due to the fact they are not traceable data.  Differing orders should not effect any use cases.  

**Benefits:**

Able to substitute and dispatch between all the different types of measurement primitives.

**Possible Drawbacks:**

The order of keyword arguments are still not standardized.

**Related GitHub Issues:**

[sc-65000]
