### PR TITLE
Added a new GradientOpInterface for common attributes in GradOp, JVPOp and VJPOp in the mlir cpp API

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -290,10 +290,10 @@
   ```
   to identify which op it actually is and protect against segfaults (calling `nullptr.getMethod()`), in the new interface we just do 
   ```C++
-        auto gradOpInterface = dyn_cast<GradientOpInterface>(op);
+        auto gradOpInterface = cast<GradientOpInterface>(op);
         llvm::StringRef MethodName = gradOpInterface.getMethod();
   ```
-  
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -269,6 +269,31 @@
   interface and allows for multiple `MemrefCallable` to be defined for a single
   callback, which is necessary for custom gradient of `pure_callbacks`.
 
+* A new `catalyst::gradient::GradientOpInterface` is available when querying the gradient method in the mlir c++ api.
+  [(#800)](https://github.com/PennyLaneAI/catalyst/pull/800)
+
+  `catalyst::gradient::GradOp`, `JVPOp`, and `VJPOp` now inherits traits in this new `GradientOpInterface` (right now there is only a `getMethod()` method, returning "auto"/"fd")
+
+  There are operations that could potentially be used as `GradOp`, `JVPOp` or `VJPOp`. When trying to get the gradient method, instead of doing 
+  ```C++
+        auto gradOp = dyn_cast<GradOp>(op);
+        auto jvpOp = dyn_cast<JVPOp>(op);
+        auto vjpOp = dyn_cast<VJPOp>(op);
+
+        llvm::StringRef MethodName;
+        if (gradOp)
+            MethodName = gradOp.getMethod();
+        else if (jvpOp)
+            MethodName = jvpOp.getMethod();
+        else if (vjpOp)
+            MethodName = vjpOp.getMethod();
+  ```
+  to identify which op it actually is and protect against segfaults (calling `nullptr.getMethod()`), in the new interface we just do 
+  ```C++
+        auto gradOpInterface = dyn_cast<GradientOpInterface>(op);
+        llvm::StringRef MethodName = gradOpInterface.getMethod();
+  ```
+  
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/mlir/include/Gradient/IR/CMakeLists.txt
+++ b/mlir/include/Gradient/IR/CMakeLists.txt
@@ -1,3 +1,5 @@
 add_mlir_dialect(GradientOps gradient)
+add_mlir_interface(GradientInterfaces)
 add_mlir_doc(GradientDialect GradientDialect Gradient/ -gen-dialect-doc)
 add_mlir_doc(GradientOps GradientOps Gradient/ -gen-op-doc)
+add_mlir_doc(GradientInterfaces GradientInterfaces Gradient/ -gen-op-interface-docs)

--- a/mlir/include/Gradient/IR/CMakeLists.txt
+++ b/mlir/include/Gradient/IR/CMakeLists.txt
@@ -3,3 +3,4 @@ add_mlir_interface(GradientInterfaces)
 add_mlir_doc(GradientDialect GradientDialect Gradient/ -gen-dialect-doc)
 add_mlir_doc(GradientOps GradientOps Gradient/ -gen-op-doc)
 add_mlir_doc(GradientInterfaces GradientInterfaces Gradient/ -gen-op-interface-docs)
+

--- a/mlir/include/Gradient/IR/GradientInterfaces.h
+++ b/mlir/include/Gradient/IR/GradientInterfaces.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Xanadu Quantum Technologies Inc.
+// Copyright 2024 Xanadu Quantum Technologies Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,16 +14,10 @@
 
 #pragma once
 
-#include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
-#include "mlir/IR/OpImplementation.h"
-#include "mlir/IR/SymbolTable.h"
-#include "mlir/Interfaces/CallInterfaces.h"
-#include "mlir/Bytecode/BytecodeOpInterface.h"
 
-#include "Gradient/IR/GradientInterfaces.h"
+//===----------------------------------------------------------------------===//
+// Gradient interface declarations.
+//===----------------------------------------------------------------------===//
 
-#define GET_OP_CLASSES
-#include "Gradient/IR/GradientOps.h.inc"
-
+#include "Gradient/IR/GradientInterfaces.h.inc"

--- a/mlir/include/Gradient/IR/GradientInterfaces.td
+++ b/mlir/include/Gradient/IR/GradientInterfaces.td
@@ -28,7 +28,7 @@ def GradientOpInterface : OpInterface<"GradientOpInterface">{
 
     let methods = [
         InterfaceMethod<
-        "Return the gradient method, which can be one of [\"auto\", \"fd\", \"ps\", \"adj\"].",
+        "Return the gradient method, which can be one of [\"auto\", \"fd\"].",
         "llvm::StringRef", "getMethod"
         >
     ];

--- a/mlir/include/Gradient/IR/GradientInterfaces.td
+++ b/mlir/include/Gradient/IR/GradientInterfaces.td
@@ -35,3 +35,4 @@ def GradientOpInterface : OpInterface<"GradientOpInterface">{
 }
 
 #endif // GRADIENT_INTERFACES
+

--- a/mlir/include/Gradient/IR/GradientInterfaces.td
+++ b/mlir/include/Gradient/IR/GradientInterfaces.td
@@ -28,7 +28,7 @@ def GradientOpInterface : OpInterface<"GradientOpInterface">{
 
     let methods = [
         InterfaceMethod<
-        "Return the gradient method, which can be one of [\"auto\", \"fd\"].",
+        "Return the gradient method, which can be one of [\"auto\", \"fd\", \"ps\", \"adj\"].",
         "llvm::StringRef", "getMethod"
         >
     ];

--- a/mlir/include/Gradient/IR/GradientInterfaces.td
+++ b/mlir/include/Gradient/IR/GradientInterfaces.td
@@ -1,0 +1,37 @@
+// Copyright 2024 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GRADIENT_INTERFACES
+#define GRADIENT_INTERFACES
+
+include "mlir/IR/OpBase.td"
+
+def GradientOpInterface : OpInterface<"GradientOpInterface">{
+    let description = [{
+        This interface provides a generic way to interact with instructions that 
+        are considered gradient operations. Currently these include GradOP, JVPOp, 
+        and VJPOp.
+    }];
+    
+    let cppNamespace = "::catalyst::gradient";
+
+    let methods = [
+        InterfaceMethod<
+        "Return the gradient method, which can be one of [\"auto\", \"fd\"].",
+        "llvm::StringRef", "getMethod"
+        >
+    ];
+}
+
+#endif // GRADIENT_INTERFACES

--- a/mlir/include/Gradient/IR/GradientOps.h
+++ b/mlir/include/Gradient/IR/GradientOps.h
@@ -14,16 +14,15 @@
 
 #pragma once
 
+#include "mlir/Bytecode/BytecodeOpInterface.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/CallInterfaces.h"
-#include "mlir/Bytecode/BytecodeOpInterface.h"
 
 #include "Gradient/IR/GradientInterfaces.h"
 
 #define GET_OP_CLASSES
 #include "Gradient/IR/GradientOps.h.inc"
-

--- a/mlir/include/Gradient/IR/GradientOps.td
+++ b/mlir/include/Gradient/IR/GradientOps.td
@@ -23,8 +23,11 @@ include "mlir/IR/OpBase.td"
 include "Gradient/IR/GradientDialect.td"
 include "Gradient/IR/GradientInterfaces.td"
 
-def GradOp : Gradient_Op<"grad", [DeclareOpInterfaceMethods<CallOpInterface>,
-        DeclareOpInterfaceMethods<SymbolUserOpInterface>, DeclareOpInterfaceMethods<GradientOpInterface>]> {
+def GradOp : Gradient_Op<"grad", [
+        DeclareOpInterfaceMethods<CallOpInterface>,
+        DeclareOpInterfaceMethods<SymbolUserOpInterface>, 
+        GradientOpInterface
+        ]> {
     let summary = "Compute the gradient of a function.";
     let description = [{
         The `gradient.grad` operation computes the gradient of a function
@@ -129,7 +132,7 @@ def JVPOp : Gradient_Op<"jvp", [
         SameVariadicResultSize,
         DeclareOpInterfaceMethods<CallOpInterface>,
         DeclareOpInterfaceMethods<SymbolUserOpInterface>,
-        DeclareOpInterfaceMethods<GradientOpInterface>
+        GradientOpInterface
         ]> {
     let summary = "Compute the jvp of a function.";
 
@@ -162,7 +165,8 @@ def VJPOp : Gradient_Op<"vjp", [
         AttrSizedResultSegments,
         DeclareOpInterfaceMethods<CallOpInterface>,
         DeclareOpInterfaceMethods<SymbolUserOpInterface>,
-        DeclareOpInterfaceMethods<GradientOpInterface>]> {
+        GradientOpInterface
+        ]> {
     let summary = "Compute the vjp of a function.";
 
     let arguments = (ins
@@ -188,3 +192,4 @@ def VJPOp : Gradient_Op<"vjp", [
 }
 
 #endif // GRADIENT_OPS
+

--- a/mlir/include/Gradient/IR/GradientOps.td
+++ b/mlir/include/Gradient/IR/GradientOps.td
@@ -21,9 +21,10 @@ include "mlir/IR/BuiltinAttributes.td"
 include "mlir/IR/OpBase.td"
 
 include "Gradient/IR/GradientDialect.td"
+include "Gradient/IR/GradientInterfaces.td"
 
 def GradOp : Gradient_Op<"grad", [DeclareOpInterfaceMethods<CallOpInterface>,
-        DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+        DeclareOpInterfaceMethods<SymbolUserOpInterface>, DeclareOpInterfaceMethods<GradientOpInterface>]> {
     let summary = "Compute the gradient of a function.";
     let description = [{
         The `gradient.grad` operation computes the gradient of a function
@@ -127,7 +128,8 @@ def JVPOp : Gradient_Op<"jvp", [
         AttrSizedOperandSegments,
         SameVariadicResultSize,
         DeclareOpInterfaceMethods<CallOpInterface>,
-        DeclareOpInterfaceMethods<SymbolUserOpInterface>
+        DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+        DeclareOpInterfaceMethods<GradientOpInterface>
         ]> {
     let summary = "Compute the jvp of a function.";
 
@@ -159,7 +161,8 @@ def VJPOp : Gradient_Op<"vjp", [
         AttrSizedOperandSegments,
         AttrSizedResultSegments,
         DeclareOpInterfaceMethods<CallOpInterface>,
-        DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+        DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+        DeclareOpInterfaceMethods<GradientOpInterface>]> {
     let summary = "Compute the vjp of a function.";
 
     let arguments = (ins

--- a/mlir/lib/Gradient/IR/CMakeLists.txt
+++ b/mlir/lib/Gradient/IR/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_library(MLIRGradient
     GradientDialect.cpp
+    GradientInterfaces.cpp
     GradientOps.cpp
 
     ADDITIONAL_HEADER_DIRS
@@ -7,6 +8,7 @@ add_mlir_library(MLIRGradient
 
     DEPENDS
     MLIRGradientOpsIncGen
+    MLIRGradientInterfacesIncGen
 
     LINK_LIBS PRIVATE
     GradientUtils

--- a/mlir/lib/Gradient/IR/GradientInterfaces.cpp
+++ b/mlir/lib/Gradient/IR/GradientInterfaces.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Xanadu Quantum Technologies Inc.
+// Copyright 2024 Xanadu Quantum Technologies Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
-
-#include "mlir/IR/BuiltinTypes.h"
-#include "mlir/IR/Dialect.h"
-#include "mlir/IR/OpDefinition.h"
-#include "mlir/IR/OpImplementation.h"
-#include "mlir/IR/SymbolTable.h"
-#include "mlir/Interfaces/CallInterfaces.h"
-#include "mlir/Bytecode/BytecodeOpInterface.h"
-
 #include "Gradient/IR/GradientInterfaces.h"
 
-#define GET_OP_CLASSES
-#include "Gradient/IR/GradientOps.h.inc"
+using namespace mlir;
+using namespace catalyst::gradient;
 
+//===----------------------------------------------------------------------===//
+// Gradient interface definitions.
+//===----------------------------------------------------------------------===//
+
+#include "Gradient/IR/GradientInterfaces.cpp.inc"

--- a/mlir/lib/Gradient/IR/GradientOps.cpp
+++ b/mlir/lib/Gradient/IR/GradientOps.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <assert.h>
+#include <cassert>
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OpImplementation.h"

--- a/mlir/lib/Gradient/IR/GradientOps.cpp
+++ b/mlir/lib/Gradient/IR/GradientOps.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <assert.h>
+
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OpImplementation.h"
 
@@ -60,6 +62,7 @@ LogicalResult verifyGradInputs(OpState *op_state, func::FuncOp callee, ValueRang
         // Check that the method is not finite difference, as finite difference should always be
         // available
         auto gradOpInterface = dyn_cast<GradientOpInterface>(op_state->getOperation());
+        assert(gradOpInterface);
         llvm::StringRef MethodName = gradOpInterface.getMethod();
 
         if (MethodName != "fd") {

--- a/mlir/lib/Gradient/IR/GradientOps.cpp
+++ b/mlir/lib/Gradient/IR/GradientOps.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cassert>
-
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OpImplementation.h"
 
@@ -61,8 +59,7 @@ LogicalResult verifyGradInputs(OpState *op_state, func::FuncOp callee, ValueRang
     if (callee->getAttrOfType<UnitAttr>(catalyst::quantum::hasInvalidGradientOp)) {
         // Check that the method is not finite difference, as finite difference should always be
         // available
-        auto gradOpInterface = dyn_cast<GradientOpInterface>(op_state->getOperation());
-        assert(gradOpInterface);
+        auto gradOpInterface = cast<GradientOpInterface>(op_state->getOperation());
         llvm::StringRef MethodName = gradOpInterface.getMethod();
 
         if (MethodName != "fd") {

--- a/mlir/lib/Gradient/IR/GradientOps.cpp
+++ b/mlir/lib/Gradient/IR/GradientOps.cpp
@@ -59,20 +59,8 @@ LogicalResult verifyGradInputs(OpState *op_state, func::FuncOp callee, ValueRang
     if (callee->getAttrOfType<UnitAttr>(catalyst::quantum::hasInvalidGradientOp)) {
         // Check that the method is not finite difference, as finite difference should always be
         // available
-        auto gradOp = dyn_cast<GradOp>(op_state->getOperation());
-        auto jvpOp = dyn_cast<JVPOp>(op_state->getOperation());
-        auto vjpOp = dyn_cast<VJPOp>(op_state->getOperation());
-
-        if (!(gradOp || jvpOp || vjpOp))
-            return op_state->emitOpError("The gradient operation should be a grad, jvp or vjp.\n");
-
-        llvm::StringRef MethodName;
-        if (gradOp)
-            MethodName = gradOp.getMethod();
-        else if (jvpOp)
-            MethodName = jvpOp.getMethod();
-        else if (vjpOp)
-            MethodName = vjpOp.getMethod();
+        auto gradOpInterface = dyn_cast<GradientOpInterface>(op_state->getOperation());
+        llvm::StringRef MethodName = gradOpInterface.getMethod();
 
         if (MethodName != "fd") {
             return op_state->emitOpError(

--- a/mlir/test/Gradient/VerifierTest.mlir
+++ b/mlir/test/Gradient/VerifierTest.mlir
@@ -300,3 +300,4 @@ func.func @measure(%arg0: tensor<2xf64>) -> tensor<2xf64> {
 %cst0 = arith.constant dense<[1.0, 0.0]> : tensor<2xf64>
 %cst1 = arith.constant dense<[1.0, 0.0]> : tensor<2xf64>
 gradient.vjp "fd" @measure(%cst0) cotangents(%cst1) {resultSegmentSizes = array<i32: 1, 1>} : (tensor<2xf64>, tensor<2xf64>) -> (tensor<2xf64>, tensor<2xf64>)
+

--- a/mlir/test/Gradient/VerifierTest.mlir
+++ b/mlir/test/Gradient/VerifierTest.mlir
@@ -230,3 +230,73 @@ func.func @foo(%arg0 : f64) -> f64 {
 
 %f0 = arith.constant 0.0 : f64
 gradient.grad "fd" @foo(%f0) : (f64) -> (f64)
+
+// -----
+
+func.func @measure(%arg0: tensor<2xf64>) -> tensor<2xf64> {
+
+    %c0 = arith.constant 0 : i64
+    %0 = quantum.alloc(2) : !quantum.reg
+    %1 = quantum.extract %0[%c0] : !quantum.reg -> !quantum.bit
+    %res, %new_q = quantum.measure %1 : i1, !quantum.bit
+    %c1 = arith.constant dense<[1.0, 0.0]> : tensor<2xf64>
+
+    return %c1 : tensor<2xf64>
+}
+
+%cst0 = arith.constant dense<[1.0, 0.0]> : tensor<2xf64>
+%cst1 = arith.constant dense<[1.0, 0.0]> : tensor<2xf64>
+// expected-error@+1 {{An operation without a valid gradient was found}}
+gradient.jvp "auto" @measure(%cst0) tangents(%cst1) : (tensor<2xf64>, tensor<2xf64>) -> (tensor<2xf64>, tensor<2xf64>)
+
+// -----
+
+func.func @measure(%arg0: tensor<2xf64>) -> tensor<2xf64> {
+
+    %c0 = arith.constant 0 : i64
+    %0 = quantum.alloc(2) : !quantum.reg
+    %1 = quantum.extract %0[%c0] : !quantum.reg -> !quantum.bit
+    %res, %new_q = quantum.measure %1 : i1, !quantum.bit
+    %c1 = arith.constant dense<[1.0, 0.0]> : tensor<2xf64>
+
+    return %c1 : tensor<2xf64>
+}
+
+%cst0 = arith.constant dense<[1.0, 0.0]> : tensor<2xf64>
+%cst1 = arith.constant dense<[1.0, 0.0]> : tensor<2xf64>
+gradient.jvp "fd" @measure(%cst0) tangents(%cst1) : (tensor<2xf64>, tensor<2xf64>) -> (tensor<2xf64>, tensor<2xf64>)
+
+// -----
+
+func.func @measure(%arg0: tensor<2xf64>) -> tensor<2xf64> {
+
+    %c0 = arith.constant 0 : i64
+    %0 = quantum.alloc(2) : !quantum.reg
+    %1 = quantum.extract %0[%c0] : !quantum.reg -> !quantum.bit
+    %res, %new_q = quantum.measure %1 : i1, !quantum.bit
+    %c1 = arith.constant dense<[1.0, 0.0]> : tensor<2xf64>
+
+    return %c1 : tensor<2xf64>
+}
+
+%cst0 = arith.constant dense<[1.0, 0.0]> : tensor<2xf64>
+%cst1 = arith.constant dense<[1.0, 0.0]> : tensor<2xf64>
+// expected-error@+1 {{An operation without a valid gradient was found}}
+gradient.vjp "auto" @measure(%cst0) cotangents(%cst1) {resultSegmentSizes = array<i32: 1, 1>} : (tensor<2xf64>, tensor<2xf64>) -> (tensor<2xf64>, tensor<2xf64>)
+
+// -----
+
+func.func @measure(%arg0: tensor<2xf64>) -> tensor<2xf64> {
+
+    %c0 = arith.constant 0 : i64
+    %0 = quantum.alloc(2) : !quantum.reg
+    %1 = quantum.extract %0[%c0] : !quantum.reg -> !quantum.bit
+    %res, %new_q = quantum.measure %1 : i1, !quantum.bit
+    %c1 = arith.constant dense<[1.0, 0.0]> : tensor<2xf64>
+
+    return %c1 : tensor<2xf64>
+}
+
+%cst0 = arith.constant dense<[1.0, 0.0]> : tensor<2xf64>
+%cst1 = arith.constant dense<[1.0, 0.0]> : tensor<2xf64>
+gradient.vjp "fd" @measure(%cst0) cotangents(%cst1) {resultSegmentSizes = array<i32: 1, 1>} : (tensor<2xf64>, tensor<2xf64>) -> (tensor<2xf64>, tensor<2xf64>)


### PR DESCRIPTION
**Context:** VJP, JVP and Grad should all have a method attribute. An interface for it would be nice. Otherwise we would need a complicated "visitor"-style check for all three types like that in #789. 

**Description of the Change:**
- Added a new interface `catalyst::gradient::GradientOpInterface` in the gradient dialect, along with necessary registry/cmake boilerplates
- `catalyst::gradient::GradOp`, `JVPOp`, and `VJPOp` now inherits traits in this new `GradientOpInterface` (right now there is only a `getMethod()` method, returning "auto"/"fd")
- The complicated visitor check for grad/jvp/vjp in #789 is replaced with utilization of this new interface

**Benefits:** There are operations that could potentially be used as `GradOp`, `JVPOp` or `VJPOp`. When trying to get the gradient method, instead of doing 
```C++
        auto gradOp = dyn_cast<GradOp>(op);
        auto jvpOp = dyn_cast<JVPOp>(op);
        auto vjpOp = dyn_cast<VJPOp>(op);

        llvm::StringRef MethodName;
        if (gradOp)
            MethodName = gradOp.getMethod();
        else if (jvpOp)
            MethodName = jvpOp.getMethod();
        else if (vjpOp)
            MethodName = vjpOp.getMethod();
```
to identify which op it actually is and protect against segfaults (calling `nullptr.getMethod()`), in the new interface we just do 
```C++
        auto gradOpInterface = cast<GradientOpInterface>(op);
        llvm::StringRef MethodName = gradOpInterface.getMethod();
```

**Possible Drawbacks:**

**Related GitHub Issues:** closes #794 

[sc-65342]