### PR TITLE
Simplify Adjoint/Control structure in Catalyst

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -5,4 +5,4 @@ llvm=cd9a641613eddf25d4b25eaa96b2c393d401d42c
 enzyme=1beb98b51442d50652eaa3ffb9574f4720d611f1
 
 # Always remove custom PL/LQ versions before release.
-pennylane=7f97ea735b3c43b43a0ffe34040bffaa49603268
+pennylane=f0bc6120747749497b8ef08238485526ec376a26

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,9 @@ catalyst: runtime dialects frontend
 .PHONY: frontend
 frontend:
 	@echo "install Catalyst Frontend"
+	# Uninstall pennylane before updating Catalyst, since pip will not replace two development
+	# versions of a package with the same version tag (e.g. 0.37-dev0).
+	$(PYTHON) -m pip uninstall -y pennylane
 	$(PYTHON) -m pip install -e . --extra-index-url https://test.pypi.org/simple
 	rm -r frontend/PennyLane_Catalyst.egg-info
 

--- a/frontend/catalyst/api_extensions/__init__.py
+++ b/frontend/catalyst/api_extensions/__init__.py
@@ -35,7 +35,6 @@ from catalyst.api_extensions.differentiation import (
 from catalyst.api_extensions.error_mitigation import mitigate_with_zne
 from catalyst.api_extensions.function_maps import vmap
 from catalyst.api_extensions.quantum_operators import (
-    Controlled,
     HybridAdjoint,
     HybridCtrl,
     MidCircuitMeasure,

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -28,7 +28,7 @@ import pennylane as qml
 from jax._src.tree_util import tree_flatten
 from jax.core import get_aval
 from pennylane import QueuingManager
-from pennylane.operation import Operation, Operator, Wires
+from pennylane.operation import Operator
 from pennylane.ops.op_math.adjoint import create_adjoint_op
 from pennylane.ops.op_math.controlled import create_controlled_op
 from pennylane.tape import QuantumTape

--- a/frontend/catalyst/device/decomposition.py
+++ b/frontend/catalyst/device/decomposition.py
@@ -36,7 +36,6 @@ from pennylane.tape.tape import (
     rotations_and_diagonal_measurements,
 )
 
-from catalyst.api_extensions import HybridAdjoint
 from catalyst.api_extensions.quantum_operators import QCtrl
 from catalyst.jax_tracer import HybridOpRegion, has_nested_tapes
 from catalyst.logging import debug_logger
@@ -54,6 +53,7 @@ def catalyst_decomposer(op, capabilities: DeviceCapabilities):
     Raises a CompileError for MidMeasureMP"""
     if isinstance(op, MidMeasureMP):
         raise CompileError("Must use 'measure' from Catalyst instead of PennyLane.")
+    # TODO: remove hardcoded controlled to matrix decomp
     if capabilities.to_matrix_ops.get(op.name) or isinstance(op, qml.ops.Controlled):
         return _decompose_to_matrix(op)
     return op.decomposition()
@@ -177,12 +177,6 @@ def decompose_ops_to_unitary(tape, convert_to_matrix_ops):
 
 def catalyst_acceptance(op: qml.operation.Operator, operations) -> bool:
     """Specify whether or not an Operator is supported."""
-    # Adjoint of a single op does not pass the acceptance criteria, since it inherits the PL `.name`
-    # attribute (= "Adjoint(op)"). Hence we should move away from name-based matching of operations
-    # to instance-based matching.
-    if isinstance(op, HybridAdjoint):
-        return "HybridAdjoint" in operations
-
     return op.name in operations
 
 

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -221,6 +221,17 @@ def get_qjit_device_capabilities(target_capabilities: DeviceCapabilities) -> Set
             }
         )
 
+    # TODO: Optionally enable runtime-powered quantum gate controlling once they
+    #       are supported natively in MLIR.
+    # if any(ng.controllable for ng in target_capabilities.native_ops.values()):
+    #     qjit_capabilities.native_ops.update(
+    #         {
+    #             "HybridCtrl": OperationProperties(
+    #                 invertible=True, controllable=True, differentiable=True
+    #             )
+    #
+    #     )
+
     return qjit_capabilities
 
 

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -742,7 +742,7 @@ def _qinsert_lowering(
 # gphase
 #
 @gphase_p.def_abstract_eval
-def _gphase_abstract_eval(*qubits_or_params, op=None, ctrl_len: int = 0):
+def _gphase_abstract_eval(*qubits_or_params, op=None, ctrl_len=0, adjoint=False):
     # The signature here is: (using * to denote zero or more)
     # param, ctrl_qubits*, ctrl_values*
     # since gphase has no target qubits.
@@ -755,17 +755,14 @@ def _gphase_abstract_eval(*qubits_or_params, op=None, ctrl_len: int = 0):
     return (AbstractQbit(),) * (ctrl_len)
 
 
-@qinst_p.def_impl
-def _gphase_abstract_eval(*qubits_or_params, op=None, ctrl_len: int = 0):
+@gphase_p.def_impl
+def _gphase_def_impl(*args, **kwargs):
     """Not implemented"""
     raise NotImplementedError()
 
 
 def _gphase_lowering(
-    jax_ctx: mlir.LoweringRuleContext,
-    *qubits_or_params,
-    op=None,
-    ctrl_len: int = 0,
+    jax_ctx: mlir.LoweringRuleContext, *qubits_or_params, op=None, ctrl_len=0, adjoint=False
 ):
     ctx = jax_ctx.module_context.context
     ctx.allow_unregistered_dialects = True
@@ -798,6 +795,7 @@ def _gphase_lowering(
         out_ctrl_qubits=[qubit.type for qubit in ctrl_qubits],
         in_ctrl_qubits=ctrl_qubits,
         in_ctrl_values=ctrl_values_i1,
+        adjoint=adjoint,
     )
     return ctrl_qubits
 
@@ -807,7 +805,7 @@ def _gphase_lowering(
 #
 @qinst_p.def_abstract_eval
 def _qinst_abstract_eval(
-    *qubits_or_params, op=None, qubits_len: int = 0, params_len: int = 0, ctrl_len: int = 0
+    *qubits_or_params, op=None, qubits_len=0, params_len=0, ctrl_len=0, adjoint=False
 ):
     # The signature here is: (using * to denote zero or more)
     # qubits*, params*, ctrl_qubits*, ctrl_values*
@@ -821,19 +819,18 @@ def _qinst_abstract_eval(
 
 
 @qinst_p.def_impl
-def _qinst_def_impl(
-    ctx, *qubits_or_params, op, qubits_len, params_len, ctrl_len
-):  # pragma: no cover
+def _qinst_def_impl(*args, **kwargs):  # pragma: no cover
     raise NotImplementedError()
 
 
 def _qinst_lowering(
     jax_ctx: mlir.LoweringRuleContext,
-    *qubits_or_params: tuple,
+    *qubits_or_params,
     op=None,
-    qubits_len: int = 0,
-    params_len: int = 0,
-    ctrl_len: int = 0,
+    qubits_len=0,
+    params_len=0,
+    ctrl_len=0,
+    adjoint=False,
 ):
     ctx = jax_ctx.module_context.context
     ctx.allow_unregistered_dialects = True
@@ -885,6 +882,7 @@ def _qinst_lowering(
             in_qubits=qubits,
             in_ctrl_qubits=ctrl_qubits,
             in_ctrl_values=ctrl_values_i1,
+            adjoint=adjoint,
         ).results
 
     return CustomOp(
@@ -895,6 +893,7 @@ def _qinst_lowering(
         gate_name=name_attr,
         in_ctrl_qubits=ctrl_qubits,
         in_ctrl_values=ctrl_values_i1,
+        adjoint=adjoint,
     ).results
 
 
@@ -902,7 +901,7 @@ def _qinst_lowering(
 # qubit unitary operation
 #
 @qunitary_p.def_abstract_eval
-def _qunitary_abstract_eval(matrix, *qubits, qubits_len: int = 0, ctrl_len: int = 0):
+def _qunitary_abstract_eval(matrix, *qubits, qubits_len=0, ctrl_len=0, adjoint=False):
     for idx in range(qubits_len + ctrl_len):
         qubit = qubits[idx]
         assert isinstance(qubit, AbstractQbit)
@@ -910,9 +909,7 @@ def _qunitary_abstract_eval(matrix, *qubits, qubits_len: int = 0, ctrl_len: int 
 
 
 @qunitary_p.def_impl
-def _qunitary_def_impl(
-    ctx, matrix, qubits, qubits_len: int = None, ctrl_len: int = 0
-):  # pragma: no cover
+def _qunitary_def_impl(*args, **kwargs):  # pragma: no cover
     raise NotImplementedError()
 
 
@@ -920,8 +917,9 @@ def _qunitary_lowering(
     jax_ctx: mlir.LoweringRuleContext,
     matrix: ir.Value,
     *qubits_or_controlled: tuple,
-    qubits_len: int = 0,
-    ctrl_len: int = 0,
+    qubits_len=0,
+    ctrl_len=0,
+    adjoint=False,
 ):
     qubits = qubits_or_controlled[:qubits_len]
     ctrl_qubits = qubits_or_controlled[qubits_len : qubits_len + ctrl_len]
@@ -970,6 +968,7 @@ def _qunitary_lowering(
         in_qubits=qubits,
         in_ctrl_qubits=ctrl_qubits,
         in_ctrl_values=ctrl_values_i1,
+        adjoint=adjoint,
     ).results
 
 

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -823,6 +823,7 @@ def _qinst_def_impl(*args, **kwargs):  # pragma: no cover
     raise NotImplementedError()
 
 
+# pylint: disable=too-many-arguments
 def _qinst_lowering(
     jax_ctx: mlir.LoweringRuleContext,
     *qubits_or_params,

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -476,8 +476,7 @@ def trace_quantum_tape(
     def bind_native_operation(qrp, op, controlled_wires, controlled_values, adjoint=False):
         # For named-controlled operations (e.g. CNOT, CY, CZ) - bind directly by name. For
         # Controlled(OP) bind OP with native quantum control syntax, and similarly for Adjoint(OP).
-        is_catalyst_ctrl = isinstance(op, catalyst.api_extensions.Controlled)
-        if type(op) in (Controlled, ControlledOp, ControlledQubitUnitary) or is_catalyst_ctrl:
+        if type(op) in (Controlled, ControlledOp, ControlledQubitUnitary):
             return bind_native_operation(qrp, op.base, op.control_wires, op.control_values, adjoint)
         elif isinstance(op, Adjoint):
             return bind_native_operation(qrp, op.base, controlled_wires, controlled_values, True)
@@ -526,13 +525,7 @@ def trace_quantum_tape(
 
     for op in ops:
         qrp2 = None
-        # We need to exclude HybridCtrl here because single-op control instances are kept
-        # as instances of the Catalyst Controlled class, which also inherits from HybridCtrl,
-        # but should be translated to JAXPR as a regular PennyLane Controlled op.
-        # Native HybridCtrl operations are not yet supported in the compiler.
-        if isinstance(op, HybridOp) and not isinstance(
-            op, catalyst.api_extensions.quantum_operators.HybridCtrl
-        ):
+        if isinstance(op, HybridOp):
             qrp2 = op.trace_quantum(ctx, device, trace, qrp)
         elif isinstance(op, MeasurementProcess):
             qrp2 = qrp

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -98,6 +98,8 @@ from catalyst.utils.exceptions import CompileError
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
+# TODO: refactor the tracer module
+# pylint: disable=too-many-lines
 
 # Global flag tracing wether the function that we trace might be used for gradients
 TRACING_GRADIENTS: List[str] = []

--- a/frontend/catalyst/programs/verification.py
+++ b/frontend/catalyst/programs/verification.py
@@ -17,15 +17,9 @@
 from typing import Any, Callable
 
 from pennylane import transform
-from pennylane.measurements import (
-    MeasurementProcess,
-    MutualInfoMP,
-    StateMP,
-    VarianceMP,
-    VnEntropyMP,
-)
+from pennylane.measurements import MutualInfoMP, StateMP, VarianceMP, VnEntropyMP
 from pennylane.operation import Operation
-from pennylane.ops import Controlled, ControlledOp, ControlledQubitUnitary
+from pennylane.ops import Adjoint, Controlled, ControlledOp, ControlledQubitUnitary
 from pennylane.tape import QuantumTape
 
 from catalyst.tracing.contexts import EvaluationContext
@@ -87,7 +81,7 @@ def verify_operations(tape: QuantumTape, grad_method, qjit_device):
 
     # FIXME: How should we re-organize the code to avoid this kind of circular dependency?
     from catalyst.api_extensions import MidCircuitMeasure
-    from catalyst.api_extensions.quantum_operators import Adjoint, HybridAdjoint, QCtrl
+    from catalyst.api_extensions.quantum_operators import HybridAdjoint, QCtrl
     from catalyst.jax_tracer import HybridOp
 
     def _paramshift_op_checker(op):
@@ -109,50 +103,69 @@ def verify_operations(tape: QuantumTape, grad_method, qjit_device):
                 f"{op.name} is non-differentiable on '{qjit_device.original_device.name}' device"
             )
 
-    def _ctrl_op_checker(op, in_qctrl, in_controllable):
-        if not (in_qctrl or in_controllable):
-            # PennyLane has many flavors of controlled operations. Here we check if the operation is
-            # supported as a self-contained native operation for a device.
-            if op.__class__ in {Controlled, ControlledOp, ControlledQubitUnitary}:
-                if not qjit_device.qjit_capabilities.native_ops.get(op.name):
-                    return _ctrl_op_checker(op.base, in_qctrl, in_controllable=True)
-        else:
-            # Otherwise we check that the operation is supported and is marked as
-            # 'controllable'.
-            if not qjit_device.qjit_capabilities.native_ops.get(
-                op.name, EMPTY_PROPERTIES
-            ).controllable:
+    def _ctrl_op_checker(op, in_control):
+        # For PL controlled instances we don't recurse via nested tapes, so check the base op here.
+        if type(op) in (Controlled, ControlledOp):
+            if isinstance(op.base, HybridOp):
                 raise CompileError(
-                    f"{op.name} is not controllable on '{qjit_device.original_device.name}' device"
+                    f"Cannot compile PennyLane control of the hybrid op {type(op.base)}."
                 )
-        return True if isinstance(op, QCtrl) else in_qctrl
+            _ctrl_op_checker(op.base, True)
+            return in_control
+        # Early exit when not in inverse, only determine the control status for recursing later.
+        elif not in_control:
+            return isinstance(op, QCtrl)
+
+        # For PL adjoint instances look at control support of the base gate, since Adjoint(Op)
+        # is implemented as Op(..., inverse=True).
+        if isinstance(op, Adjoint):
+            op_name = op.base.name
+        else:
+            op_name = op.name
+
+        if not qjit_device.qjit_capabilities.native_ops.get(op_name, EMPTY_PROPERTIES).controllable:
+            raise CompileError(
+                f"{op_name} is not controllable on '{qjit_device.original_device.name}' device"
+            )
+
+        return True
 
     def _inv_op_checker(op, in_inverse):
+        # For PL adjoint instances we don't recurse via nested tapes, so check the base op here.
         if isinstance(op, Adjoint):
-            # if the operator just is Adjoint, check its base is invertible
-            if not qjit_device.qjit_capabilities.native_ops.get(op.name):
-                return _inv_op_checker(op.base, in_inverse=True)
-        elif in_inverse:
-            # if we are inside a tape on a HybridAdjoint, check that the operators is invertible
-            op_name = (
-                op.base.name
-                if op.__class__ in {Controlled, ControlledOp, ControlledQubitUnitary}
-                else op.name
-            )
-            if not qjit_device.qjit_capabilities.native_ops.get(
-                op_name, EMPTY_PROPERTIES
-            ).invertible:
+            if isinstance(op.base, HybridOp):
                 raise CompileError(
-                    f"{op_name} is not invertible on '{qjit_device.original_device.name}' device"
+                    f"Cannot compile PennyLane inverse of the hybrid op {type(op.base)}."
                 )
-        return True if isinstance(op, HybridAdjoint) else in_inverse
+            _inv_op_checker(op.base, in_inverse=True)
+            return in_inverse
+        # Early exit when not in inverse, only determine the inverse status for recursing later.
+        elif not in_inverse:
+            return isinstance(op, HybridAdjoint)
+
+        # For PL controlled instances look at adjoint support of the base gate, since Controlled(Op)
+        # is implemented as Op(..., control_wires=...).
+        # TODO: remove ControlledQubitUnitary to treat it as independant gate everywhere
+        if type(op) in (Controlled, ControlledOp, ControlledQubitUnitary):
+            op_name = op.base.name
+        else:
+            op_name = op.name
+
+        if not qjit_device.qjit_capabilities.native_ops.get(op_name, EMPTY_PROPERTIES).invertible:
+            raise CompileError(
+                f"{op_name} is not invertible on '{qjit_device.original_device.name}' device"
+            )
+
+        return True
 
     def _op_checker(op, state):
 
-        # all non-controlled ops are in the native ops of the device
-        if isinstance(op, (Controlled, QCtrl, Adjoint, HybridAdjoint)):
-            # Controlled and QCtrl are checked in _ctrl_op_checker
-            # Adjoint is checked in _inv_op_checker
+        # Don't check PennyLane Adjoint / Controlled instances directly since the compound name
+        # (e.g. "Adjoint(Hadamard)") will not show up in the device capabilities. Instead the check
+        # is handled in _inv_op_checker and _ctrl_op_checker.
+        # Specialed control op classes (e.g. CRZ) should be checked directly though, which is why we
+        # can't use isinstance(op, Controlled).
+        if type(op) in (Controlled, ControlledOp) or isinstance(op, Adjoint):
             pass
         elif not qjit_device.qjit_capabilities.native_ops.get(op.name):
             raise CompileError(
@@ -162,7 +175,7 @@ def verify_operations(tape: QuantumTape, grad_method, qjit_device):
         # check validity of ops nested inside control or adjoint
         in_inverse, in_control = state
         in_inverse = _inv_op_checker(op, in_inverse)
-        in_control = _ctrl_op_checker(op, in_control, False)
+        in_control = _ctrl_op_checker(op, in_control)
 
         # check validity based on grad method if using
         if grad_method is not None:

--- a/frontend/catalyst/utils/toml.py
+++ b/frontend/catalyst/utils/toml.py
@@ -262,7 +262,7 @@ def get_operation_properties(config_props: dict) -> OperationProperties:
 
 def patch_schema1_collections(
     config, _device_name, native_gate_props, matrix_decomp_props, decomp_props, observable_props
-):  # pylint: disable=too-many-arguments, too-many-branches
+):  # pylint: disable=too-many-branches
     """For old schema1 config files we deduce some information which was not explicitly encoded."""
 
     # The deduction logic is the following:

--- a/frontend/catalyst/utils/toml.py
+++ b/frontend/catalyst/utils/toml.py
@@ -103,6 +103,11 @@ def pennylane_operation_set(config_ops: Dict[str, OperationProperties]) -> Set[s
         ops.update({g})
         if props.controllable:
             ops.update({f"C({g})"})
+        if props.invertible:
+            ops.update({f"Adjoint({g})"})
+        if props.controllable and props.invertible:
+            ops.update({f"Adjoint(C({g}))"})
+            ops.update({f"C(Adjoint({g}))"})
     return ops
 
 

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -1039,7 +1039,7 @@ class TestMiscMethods:
         op = CustomOp(1.2, 2.3, wires=0)
         adj_op = adjoint(op)
         data, metadata = adj_op._flatten()
-        assert len(data) == 2
+        assert len(data) == 1
         assert data[0] is op
 
         assert metadata == tuple()

--- a/frontend/test/pytest/test_preprocess.py
+++ b/frontend/test/pytest/test_preprocess.py
@@ -440,7 +440,7 @@ class TestPreprocessHybridOp:
         @qml.qnode(dev)
         def circuit(x: float, y: float):
             qml.RY(y, 0)
-            adjoint(OtherRX(x, 0))
+            adjoint(lambda: OtherRX(x, 0))()
             return qml.expval(qml.PauliZ(0))
 
         mlir = qml.qjit(circuit, target="mlir").mlir

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -479,9 +479,7 @@ class TestCatalystControlled:
             res_classical_tracers=[],
             trace=None,
         )
-        qctrl = HybridCtrl(
-            control_wires=[0], regions=[X], in_classical_tracers=[], out_classical_tracers=[0]
-        )
+        qctrl = HybridCtrl([], [], [X], control_wires=[0])
         new_qctrl = qctrl.map_wires({1: 0, 0: 1})
         assert new_qctrl._control_wires == [1]  # pylint: disable=protected-access
         assert new_qctrl.regions[0].quantum_tape.operations[0].wires == Wires([0])
@@ -840,13 +838,12 @@ class TestControlledMiscMethods:
         assert data[0] is target
         assert len(data) == 1
 
-        assert len(metadata[0]) == 3  # tracing_artifacts
-        assert metadata[1] == control_wires
-        assert metadata[2] == control_values
-        assert metadata[3] == work_wires
+        assert len(metadata) == 3
+        assert metadata[0] == control_wires
+        assert metadata[1] == control_values
+        assert metadata[2] == work_wires
 
-        # FIXME: 'HybridOpRegion` is not hashable
-        # assert hash(metadata)
+        assert hash(metadata)
 
         new_op = type(op)._unflatten(*op._flatten())
         assert qml.equal(op, new_op)
@@ -1667,12 +1664,9 @@ class TestDecomposition:
     def test_decomposition_nested(self):
         """Tests decompositions of nested controlled operations"""
 
-        ctrl_op = C_ctrl(C_ctrl(qml.RZ(0.123, wires=0), control=1), control=2)
+        ctrl_op = C_ctrl(C_ctrl(lambda: qml.RZ(0.123, wires=0), control=1), control=2)()
         expected = [
-            qml.ControlledPhaseShift(0.123 / 2, wires=[2, 0]),
-            qml.Toffoli(wires=[2, 1, 0]),
-            qml.ControlledPhaseShift(-0.123 / 2, wires=[2, 0]),
-            qml.Toffoli(wires=[2, 1, 0]),
+            qml.ops.Controlled(qml.RZ(0.123, wires=0), control_wires=[1, 2]),
         ]
         assert ctrl_op.decomposition() == expected
         assert ctrl_op.expand().circuit == expected

--- a/frontend/test/pytest/test_verification.py
+++ b/frontend/test/pytest/test_verification.py
@@ -218,7 +218,7 @@ class TestHybridOpVerification:
 
         @qml.qnode(get_custom_device(non_controllable_gates={"PauliZ"}, wires=3))
         def f(x: float):
-            ctrl(qml.PauliZ(wires=0), control=[1, 2])
+            ctrl(qml.PauliZ(wires=0), control=[1, 2, 3])
             return qml.expval(qml.PauliX(0))
 
         with pytest.raises(CompileError, match="PauliZ is not controllable"):


### PR DESCRIPTION
@lillian542 My proposal would be removing the (single-op) Adjoint class in Catalyst entirely, which would get rid of the issues we faced. Instead, we dispatch directly to PennyLane's Adjoint when a single op is received by Catalyst. 
It does requires that `Adjoint(gate)` can be lowered directly to a single operator in MLIR, which I've added. I also updated the verification to match.
It also relies on the addition of a `create_adjoint_op` function to PennyLane similar to the existing `create_controlled_op` function.

If you think this is a good direction I would update to the latest main branch to get the QCtrl changes in, and update them similarly to what I've done with Adjoint.

[sc-65586]