### PR TITLE
generalize `mitigate_with_zne` to accept arbitrary fitting functions

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -120,6 +120,12 @@
 
 <h3>Breaking changes</h3>
 
+* The `mitigate_with_zne` function no longer accepts a `degree` parameter for polynomial fitting
+  and instead accepts a callable to perform extrapolation. Any qjit-compatible extrapolation
+  function is valid. Keyword arguments can be passed to this function using the
+  `extrapolate_kwargs` keyword argument in `mitigate_with_zne`.
+  [(#806)](https://github.com/PennyLaneAI/catalyst/pull/806)
+
 * Binary distributions for Linux are now based on `manylinux_2_28` instead of `manylinux_2014`.
   As a result, Catalyst will only be compatible on systems with `glibc` versions `2.28` and above
   (e.g. Ubuntu 20.04 and above).

--- a/frontend/catalyst/api_extensions/error_mitigation.py
+++ b/frontend/catalyst/api_extensions/error_mitigation.py
@@ -32,9 +32,7 @@ from catalyst.jax_primitives import zne_p
 
 def polynomial_extrapolation(degree):
     """utility to generate polynomial fitting functions of arbitrary degree"""
-    return lambda scale_factors, results: qml.transforms.poly_extrapolate(
-        scale_factors, results, degree
-    )
+    return functools.partial(qml.transforms.poly_extrapolate, order=degree)
 
 
 ## API ##
@@ -53,7 +51,8 @@ def mitigate_with_zne(fn=None, *, scale_factors=None, extrapolate=None):
     Args:
         fn (qml.QNode): the circuit to be mitigated.
         scale_factors (array[int]): the range of noise scale factors used.
-        extrapoloate (Callable): A function to perform fitting.
+        extrapolate (Callable): A function taking two sequences as arguments (scale factors, and
+            results), and returning a float by performing a fitting procedure.
 
     Returns:
         Callable: A callable object that computes the mitigated of the wrapped :class:`qml.QNode`

--- a/frontend/catalyst/api_extensions/error_mitigation.py
+++ b/frontend/catalyst/api_extensions/error_mitigation.py
@@ -49,6 +49,8 @@ def mitigate_with_zne(fn=None, *, scale_factors=None, extrapolate=None, extrapol
         extrapolate (Callable): A qjit-compatible function taking two sequences as arguments (scale
             factors, and results), and returning a float by performing a fitting procedure.
             By default, perfect polynomial fitting will be used.
+        extrapolate_kwargs (dict[str, Any]): Keyword arguments to be passed to the extrapolation
+            function.
 
     Returns:
         Callable: A callable object that computes the mitigated of the wrapped :class:`qml.QNode`

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1221,7 +1221,7 @@ class TestGradientErrors:
             return qml.expval(qml.PauliX(0))
 
         def g(x):
-            return mitigate_with_zne(f, scale_factors=jax.numpy.array([1, 2, 3]), deg=2)(x)
+            return mitigate_with_zne(f, scale_factors=jax.numpy.array([1, 2, 3]))(x)
 
         with pytest.raises(CompileError, match=".*Compilation failed.*"):
 

--- a/frontend/test/pytest/test_mitigation.py
+++ b/frontend/test/pytest/test_mitigation.py
@@ -22,8 +22,7 @@ import pytest
 import catalyst
 from catalyst.api_extensions.error_mitigation import polynomial_extrapolation
 
-
-quadtratic_extrapolation = polynomial_extrapolation(2)
+quadratic_extrapolation = polynomial_extrapolation(2)
 
 
 @pytest.mark.parametrize("params", [0.1, 0.2, 0.3, 0.4, 0.5])
@@ -43,7 +42,7 @@ def test_single_measurement(params):
     @catalyst.qjit
     def mitigated_qnode(args):
         return catalyst.mitigate_with_zne(
-            circuit, scale_factors=jax.numpy.array([1, 2, 3]), extrapolate=quadtratic_extrapolation
+            circuit, scale_factors=jax.numpy.array([1, 2, 3]), extrapolate=quadratic_extrapolation
         )(args)
 
     assert np.allclose(mitigated_qnode(params), circuit(params))
@@ -66,7 +65,7 @@ def test_multiple_measurements(params):
     @catalyst.qjit
     def mitigated_qnode(args):
         return catalyst.mitigate_with_zne(
-            circuit, scale_factors=jax.numpy.array([1, 2, 3]), extrapolate=quadtratic_extrapolation
+            circuit, scale_factors=jax.numpy.array([1, 2, 3]), extrapolate=quadratic_extrapolation
         )(args)
 
     assert np.allclose(mitigated_qnode(params), circuit(params))
@@ -138,7 +137,7 @@ def test_dtype_error():
     @catalyst.qjit
     def mitigated_qnode(args):
         return catalyst.mitigate_with_zne(
-            circuit, scale_factors=jax.numpy.array([1, 2, 3]), extrapolate=quadtratic_extrapolation
+            circuit, scale_factors=jax.numpy.array([1, 2, 3]), extrapolate=quadratic_extrapolation
         )(args)
 
     with pytest.raises(
@@ -163,7 +162,7 @@ def test_dtype_not_float_error():
     @catalyst.qjit
     def mitigated_qnode(args):
         return catalyst.mitigate_with_zne(
-            circuit, scale_factors=jax.numpy.array([1, 2, 3]), extrapolate=quadtratic_extrapolation
+            circuit, scale_factors=jax.numpy.array([1, 2, 3]), extrapolate=quadratic_extrapolation
         )(args)
 
     with pytest.raises(
@@ -188,7 +187,7 @@ def test_shape_error():
     @catalyst.qjit
     def mitigated_qnode(args):
         return catalyst.mitigate_with_zne(
-            circuit, scale_factors=jax.numpy.array([1, 2, 3]), extrapolate=quadtratic_extrapolation
+            circuit, scale_factors=jax.numpy.array([1, 2, 3]), extrapolate=quadratic_extrapolation
         )(args)
 
     with pytest.raises(
@@ -214,17 +213,18 @@ def test_zne_usage_patterns(params):
     @catalyst.qjit
     def mitigated_qnode_fn_as_argument(args):
         return catalyst.mitigate_with_zne(
-            fn, scale_factors=jax.numpy.array([1, 2, 3]), extrapolate=quadtratic_extrapolation
+            fn, scale_factors=jax.numpy.array([1, 2, 3]), extrapolate=quadratic_extrapolation
         )(args)
 
     @catalyst.qjit
     def mitigated_qnode_partial(args):
         return catalyst.mitigate_with_zne(
-            scale_factors=jax.numpy.array([1, 2, 3]), extrapolate=quadtratic_extrapolation
+            scale_factors=jax.numpy.array([1, 2, 3]), extrapolate=quadratic_extrapolation
         )(fn)(args)
 
     assert np.allclose(mitigated_qnode_fn_as_argument(params), fn(params))
     assert np.allclose(mitigated_qnode_partial(params), fn(params))
+
 
 def test_zne_with_jax_polyfit():
     """test mitigate_with_zne works with jax polyfit"""
@@ -238,7 +238,7 @@ def test_zne_with_jax_polyfit():
         qml.CNOT(wires=[1, 0])
         qml.Hadamard(wires=1)
         return qml.expval(qml.PauliY(wires=0))
-    
+
     jax_extrap = lambda scale_factors, results: jax.numpy.polyfit(scale_factors, results, 2)[-1]
 
     @catalyst.qjit

--- a/frontend/test/pytest/test_mitigation.py
+++ b/frontend/test/pytest/test_mitigation.py
@@ -239,7 +239,8 @@ def test_zne_with_jax_polyfit():
         qml.Hadamard(wires=1)
         return qml.expval(qml.PauliY(wires=0))
 
-    jax_extrap = lambda scale_factors, results: jax.numpy.polyfit(scale_factors, results, 2)[-1]
+    def jax_extrap(scale_factors, results):
+        return jax.numpy.polyfit(scale_factors, results, 2)[-1]
 
     @catalyst.qjit
     def mitigated_qnode():


### PR DESCRIPTION
**Context:** As laid out in https://github.com/PennyLaneAI/catalyst/issues/754 we would like to add exponential fitting capabilities to the ZNE implementation in catalyst. As a first step, this PR generalizes the `mitigate_with_zne` function to accept a callable object. Adding exponential fitting after this goes through review will mean a concise follow on PR to add exponential fitting capabilities and further tests.

**Description of the Change:** The change can be summarized as
```diff
- def mitigate_with_zne(fn=None, *, scale_factors=None, deg=None):
+ def mitigate_with_zne(fn=None, *, scale_factors=None, extrapolate=None):
```

**Benefits:** This addition makes it easier to add new extrapolation techniques! The default behavior when (previously) not using the `deg` argument, and (currently) not using the `extrapolate` argument remain the same.

**Possible Drawbacks:** The work required by a `mitigate_with_zne` user is potentially more cumbersome as they can no longer _just_ pass a polynomial degree, and must specify a function to do the fitting. A utility is provided, but unsure how we want to expose that to the user or just point them to [`pennylane.transforms.poly_extrapolate`](https://docs.pennylane.ai/en/stable/code/api/pennylane.transforms.poly_extrapolate.html) in the documentation.

**Related GitHub Issues:** https://github.com/PennyLaneAI/catalyst/issues/754 (this PR is part 1 of a fix)
