### PR TITLE
Replace JAXopt with Optax

### DIFF
--- a/demos/adaptive_circuits_demo.ipynb
+++ b/demos/adaptive_circuits_demo.ipynb
@@ -277,7 +277,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Final angle parameters: [0.18358525 0.18358525]\n"
+      "Final angle parameters: [0.18356278 0.1841571 ]\n"
      ]
     }
    ],
@@ -291,7 +291,7 @@
     "    @catalyst.for_loop(0, ntrials, 1)\n",
     "    def single_step(i, theta):\n",
     "        h = diff(theta)\n",
-    "        return theta - h[0] * stepsize\n",
+    "        return theta - h * stepsize\n",
     "\n",
     "    return single_step(theta)\n",
     "\n",
@@ -341,7 +341,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Final angle parameters: [0.18358525 0.18358525]\n"
+      "Final angle parameters: [0.18356278 0.1841571 ]\n"
      ]
     }
    ],
@@ -350,7 +350,7 @@
     "def workflow():\n",
     "    def gd_fun(params):\n",
     "        diff = catalyst.grad(catalyst_cost_func, argnum=0)\n",
-    "        return catalyst_cost_func(params), diff(params)[0]\n",
+    "        return catalyst_cost_func(params), diff(params)\n",
     "\n",
     "    opt = optax.sgd(learning_rate=0.4)\n",
     "    \n",
@@ -401,17 +401,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Step: 0, Energy: -1.26094183\n",
-      "--- Step: 1, Energy: -1.26779814\n",
-      "--- Step: 2, Energy: -1.27110183\n",
-      "--- Step: 3, Energy: -1.27268711\n",
-      "--- Step: 4, Energy: -1.27344701\n",
-      "--- Step: 5, Energy: -1.27381148\n",
-      "--- Step: 6, Energy: -1.27398658\n",
-      "--- Step: 7, Energy: -1.27407094\n",
-      "--- Step: 8, Energy: -1.27411173\n",
-      "--- Step: 9, Energy: -1.27413156\n",
-      "Final angle parameters: [0.18358525 0.18358525]\n"
+      "--- Step: 0, Energy: -1.26094188\n",
+      "--- Step: 1, Energy: -1.26779949\n",
+      "--- Step: 2, Energy: -1.27110529\n",
+      "--- Step: 3, Energy: -1.27269203\n",
+      "--- Step: 4, Energy: -1.27345238\n",
+      "--- Step: 5, Energy: -1.27381655\n",
+      "--- Step: 6, Energy: -1.27399097\n",
+      "--- Step: 7, Energy: -1.27407452\n",
+      "--- Step: 8, Energy: -1.27411455\n",
+      "--- Step: 9, Energy: -1.27413373\n",
+      "Final angle parameters: [0.18356278 0.1841571 ]\n"
      ]
     }
    ],
@@ -419,7 +419,7 @@
     "@qjit\n",
     "def grad_descent_step(params, stepsize: float):\n",
     "    diff = catalyst.grad(catalyst_cost_func, argnum=0)\n",
-    "    return params - diff(params)[0] * stepsize\n",
+    "    return params - diff(params) * stepsize\n",
     "\n",
     "theta = jnp.array([0.0, 0.0])\n",
     "\n",
@@ -451,17 +451,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Step: 0, Energy: -1.26094183\n",
-      "--- Step: 1, Energy: -1.26779814\n",
-      "--- Step: 2, Energy: -1.27110183\n",
-      "--- Step: 3, Energy: -1.27268711\n",
-      "--- Step: 4, Energy: -1.27344701\n",
-      "--- Step: 5, Energy: -1.27381148\n",
-      "--- Step: 6, Energy: -1.27398658\n",
-      "--- Step: 7, Energy: -1.27407094\n",
-      "--- Step: 8, Energy: -1.27411173\n",
-      "--- Step: 9, Energy: -1.27413156\n",
-      "Final angle parameters: [0.18358525 0.18358525]\n"
+      "--- Step: 0, Energy: -1.26094188\n",
+      "--- Step: 1, Energy: -1.26779949\n",
+      "--- Step: 2, Energy: -1.27110529\n",
+      "--- Step: 3, Energy: -1.27269203\n",
+      "--- Step: 4, Energy: -1.27345238\n",
+      "--- Step: 5, Energy: -1.27381655\n",
+      "--- Step: 6, Energy: -1.27399097\n",
+      "--- Step: 7, Energy: -1.27407452\n",
+      "--- Step: 8, Energy: -1.27411455\n",
+      "--- Step: 9, Energy: -1.27413373\n",
+      "Final angle parameters: [0.18356278 0.1841571 ]\n"
      ]
     }
    ],
@@ -471,7 +471,7 @@
     "@qjit\n",
     "def grad_descent_step_aot(params: ShapedArray([2], float), stepsize: float):\n",
     "    diff = catalyst.grad(catalyst_cost_func, argnum=0)\n",
-    "    return params - diff(params)[0] * stepsize\n",
+    "    return params - diff(params) * stepsize\n",
     "\n",
     "theta = jnp.array([0.0, 0.0])\n",
     "\n",
@@ -705,14 +705,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Excitation : [0, 2], Gradient: -0.005062544629162062\n",
+      "Excitation : [0, 2], Gradient: -0.005062544629162063\n",
       "Excitation : [0, 4], Gradient: 0.0\n",
       "Excitation : [0, 6], Gradient: 0.0\n",
-      "Excitation : [0, 8], Gradient: -0.0009448055879247696\n",
-      "Excitation : [1, 3], Gradient: 0.004926625112976855\n",
+      "Excitation : [0, 8], Gradient: -0.0009448055879247612\n",
+      "Excitation : [1, 3], Gradient: 0.004926625112976861\n",
       "Excitation : [1, 5], Gradient: 0.0\n",
       "Excitation : [1, 7], Gradient: 0.0\n",
-      "Excitation : [1, 9], Gradient: 0.0014535553867889648\n",
+      "Excitation : [1, 9], Gradient: 0.0014535553867889794\n",
       "singles_select: [[0, 2], [0, 8], [1, 3], [1, 9]]\n"
      ]
     }

--- a/demos/adaptive_circuits_demo.ipynb
+++ b/demos/adaptive_circuits_demo.ipynb
@@ -10,22 +10,24 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: jaxopt in /home/erick.ochoalopez/Code/catalyst-latest/env/lib/python3.10/site-packages (0.7)\n",
-      "Requirement already satisfied: numpy>=1.18.4 in /home/erick.ochoalopez/Code/catalyst-latest/env/lib/python3.10/site-packages (from jaxopt) (1.23.5)\n",
-      "Requirement already satisfied: scipy>=1.0.0 in /home/erick.ochoalopez/Code/catalyst-latest/env/lib/python3.10/site-packages (from jaxopt) (1.10.0)\n",
-      "Requirement already satisfied: jax>=0.2.18 in /home/erick.ochoalopez/Code/catalyst-latest/env/lib/python3.10/site-packages (from jaxopt) (0.4.13)\n",
-      "Requirement already satisfied: jaxlib>=0.1.69 in /home/erick.ochoalopez/Code/catalyst-latest/env/lib/python3.10/site-packages (from jaxopt) (0.4.13)\n",
-      "Requirement already satisfied: ml-dtypes>=0.1.0 in /home/erick.ochoalopez/Code/catalyst-latest/env/lib/python3.10/site-packages (from jax>=0.2.18->jaxopt) (0.2.0)\n",
-      "Requirement already satisfied: opt-einsum in /home/erick.ochoalopez/Code/catalyst-latest/env/lib/python3.10/site-packages (from jax>=0.2.18->jaxopt) (3.3.0)\n",
-      "\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m A new release of pip is available: \u001b[0m\u001b[31;49m23.0.1\u001b[0m\u001b[39;49m -> \u001b[0m\u001b[32;49m23.2.1\u001b[0m\n",
-      "\u001b[1m[\u001b[0m\u001b[34;49mnotice\u001b[0m\u001b[1;39;49m]\u001b[0m\u001b[39;49m To update, run: \u001b[0m\u001b[32;49mpip install --upgrade pip\u001b[0m\n",
+      "Defaulting to user installation because normal site-packages is not writeable\n",
+      "Requirement already satisfied: optax in /home/tzung-han.juang/.local/lib/python3.10/site-packages (0.2.2)\n",
+      "Requirement already satisfied: absl-py>=0.7.1 in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from optax) (2.1.0)\n",
+      "Requirement already satisfied: chex>=0.1.86 in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from optax) (0.1.86)\n",
+      "Requirement already satisfied: jax>=0.1.55 in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from optax) (0.4.23)\n",
+      "Requirement already satisfied: jaxlib>=0.1.37 in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from optax) (0.4.23)\n",
+      "Requirement already satisfied: numpy>=1.18.0 in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from optax) (1.26.4)\n",
+      "Requirement already satisfied: typing-extensions>=4.2.0 in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from chex>=0.1.86->optax) (4.12.2)\n",
+      "Requirement already satisfied: toolz>=0.9.0 in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from chex>=0.1.86->optax) (0.12.1)\n",
+      "Requirement already satisfied: ml-dtypes>=0.2.0 in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from jax>=0.1.55->optax) (0.4.0)\n",
+      "Requirement already satisfied: opt-einsum in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from jax>=0.1.55->optax) (3.3.0)\n",
+      "Requirement already satisfied: scipy>=1.9 in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from jax>=0.1.55->optax) (1.12.0)\n",
       "Note: you may need to restart the kernel to use updated packages.\n"
      ]
     }
    ],
    "source": [
-    "%pip install jaxopt"
+    "%pip install optax"
    ]
   },
   {
@@ -66,7 +68,10 @@
     "import pennylane as qml\n",
     "from pennylane import numpy as np\n",
     "\n",
-    "import jax.numpy as jnp"
+    "import jax.numpy as jnp\n",
+    "\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')"
    ]
   },
   {
@@ -272,7 +277,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Final angle parameters: [0.18356273 0.18415706]\n"
+      "Final angle parameters: [0.18358525 0.18358525]\n"
      ]
     }
    ],
@@ -303,7 +308,7 @@
    "source": [
     "#### Using JAX Optimizer\n",
     "\n",
-    "So far, we've learned how to implement the gradient descent optimizer using Catalyst's control-flows and the `grad` operations. However, there's another way to calculate this optimizer using [JAXopt](https://jaxopt.github.io/stable/index.html). In the following example, we'll utilize the `jaxopt.GradientDescent` function to optimize the parameters of the `cost_func`.\" We start by importing the necessary tools from JAXopt:"
+    "So far, we've learned how to implement the gradient descent optimizer using Catalyst's control-flows and the `grad` operations. However, there's another way to calculate this optimizer using [Optax](https://optax.readthedocs.io/en/stable/index.html). In the following example, we'll utilize the `optax.sgd` function to optimize the parameters of the `cost_func`.\" We start by importing the necessary tools from Optax:"
    ]
   },
   {
@@ -313,7 +318,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from jaxopt import GradientDescent\n",
+    "import optax\n",
     "from jax.lax import fori_loop"
    ]
   },
@@ -323,7 +328,7 @@
    "id": "f62fe520",
    "metadata": {},
    "source": [
-    "The `GradientDescent` method helps compute the optimizer by taking a smooth function of the form `gd_fun(params, *args, **kwargs)` and computing its value, or its value <i>and</i> its gradient, depending on the value of `value_and_grad` argument. To optimize `params` iteratively, you need to use `jax.lax.fori_loop` to loop over the gradient descent steps:"
+    "The `sgd` method helps compute the optimizer by taking a smooth function of the form `gd_fun(params, *args, **kwargs)` and computing its value <i>and</i> its gradient. To optimize `params` iteratively, you need to use `jax.lax.fori_loop` to loop over the gradient descent steps:"
    ]
   },
   {
@@ -336,7 +341,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Final angle parameters: [0.19024097 0.19115274]\n"
+      "Final angle parameters: [0.18358525 0.18358525]\n"
      ]
     }
    ],
@@ -347,14 +352,17 @@
     "        diff = catalyst.grad(catalyst_cost_func, argnum=0)\n",
     "        return catalyst_cost_func(params), diff(params)[0]\n",
     "\n",
-    "    opt = GradientDescent(gd_fun, stepsize=0.4, value_and_grad=True)\n",
+    "    opt = optax.sgd(learning_rate=0.4)\n",
     "    \n",
     "    def gd_update(i, args):\n",
-    "        (params, state) = opt.update(*args)\n",
-    "        return (params, state)\n",
+    "        param, state = args\n",
+    "        _, gradient = gd_fun(param)\n",
+    "        (updates, state) = opt.update(gradient, state)\n",
+    "        param = optax.apply_updates(param, updates)\n",
+    "        return (param, state)\n",
     "\n",
     "    params = jnp.array([0.0, 0.0])\n",
-    "    state = opt.init_state(params)\n",
+    "    state = opt.init(params)\n",
     "    upper = 10\n",
     "    (params, _) = fori_loop(0, upper, gd_update, (params, state))\n",
     "    return params\n",
@@ -370,7 +378,7 @@
    "id": "26ccdb58",
    "metadata": {},
    "source": [
-    "There is no significant difference between a custom implementation of the gradient descent algorithm and `jaxopt.GradientDescent`, since the underlying implementation is very similar."
+    "There is no significant difference between a custom implementation of the gradient descent algorithm and `optax.sgd`, since the underlying implementation is very similar."
    ]
   },
   {
@@ -393,17 +401,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Step: 0, Energy: -1.26094188\n",
-      "--- Step: 1, Energy: -1.26779949\n",
-      "--- Step: 2, Energy: -1.27110529\n",
-      "--- Step: 3, Energy: -1.27269202\n",
-      "--- Step: 4, Energy: -1.27345237\n",
-      "--- Step: 5, Energy: -1.27381655\n",
-      "--- Step: 6, Energy: -1.27399097\n",
-      "--- Step: 7, Energy: -1.27407452\n",
-      "--- Step: 8, Energy: -1.27411455\n",
-      "--- Step: 9, Energy: -1.27413373\n",
-      "Final angle parameters: [0.18356271 0.18415706]\n"
+      "--- Step: 0, Energy: -1.26094183\n",
+      "--- Step: 1, Energy: -1.26779814\n",
+      "--- Step: 2, Energy: -1.27110183\n",
+      "--- Step: 3, Energy: -1.27268711\n",
+      "--- Step: 4, Energy: -1.27344701\n",
+      "--- Step: 5, Energy: -1.27381148\n",
+      "--- Step: 6, Energy: -1.27398658\n",
+      "--- Step: 7, Energy: -1.27407094\n",
+      "--- Step: 8, Energy: -1.27411173\n",
+      "--- Step: 9, Energy: -1.27413156\n",
+      "Final angle parameters: [0.18358525 0.18358525]\n"
      ]
     }
    ],
@@ -443,17 +451,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--- Step: 0, Energy: -1.26094188\n",
-      "--- Step: 1, Energy: -1.26779949\n",
-      "--- Step: 2, Energy: -1.27110529\n",
-      "--- Step: 3, Energy: -1.27269202\n",
-      "--- Step: 4, Energy: -1.27345237\n",
-      "--- Step: 5, Energy: -1.27381655\n",
-      "--- Step: 6, Energy: -1.27399097\n",
-      "--- Step: 7, Energy: -1.27407452\n",
-      "--- Step: 8, Energy: -1.27411455\n",
-      "--- Step: 9, Energy: -1.27413373\n",
-      "Final angle parameters: [0.18356273 0.18415706]\n"
+      "--- Step: 0, Energy: -1.26094183\n",
+      "--- Step: 1, Energy: -1.26779814\n",
+      "--- Step: 2, Energy: -1.27110183\n",
+      "--- Step: 3, Energy: -1.27268711\n",
+      "--- Step: 4, Energy: -1.27344701\n",
+      "--- Step: 5, Energy: -1.27381148\n",
+      "--- Step: 6, Energy: -1.27398658\n",
+      "--- Step: 7, Energy: -1.27407094\n",
+      "--- Step: 8, Energy: -1.27411173\n",
+      "--- Step: 9, Energy: -1.27413156\n",
+      "Final angle parameters: [0.18358525 0.18358525]\n"
      ]
     }
    ],
@@ -563,22 +571,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Excitation: [0, 1, 2, 3], Gradient: -0.012782168180745632\n",
+      "Excitation: [0, 1, 2, 3], Gradient: -0.012782168180745743\n",
       "Excitation: [0, 1, 2, 5], Gradient: 0.0\n",
       "Excitation: [0, 1, 2, 7], Gradient: 0.0\n",
-      "Excitation: [0, 1, 2, 9], Gradient: 0.034264503599058194\n",
+      "Excitation: [0, 1, 2, 9], Gradient: 0.03426450359905824\n",
       "Excitation: [0, 1, 3, 4], Gradient: 0.0\n",
       "Excitation: [0, 1, 3, 6], Gradient: 0.0\n",
-      "Excitation: [0, 1, 3, 8], Gradient: -0.03426450359905819\n",
-      "Excitation: [0, 1, 4, 5], Gradient: -0.023581524379110937\n",
+      "Excitation: [0, 1, 3, 8], Gradient: -0.034264503599058235\n",
+      "Excitation: [0, 1, 4, 5], Gradient: -0.023581524379111044\n",
       "Excitation: [0, 1, 4, 7], Gradient: 0.0\n",
       "Excitation: [0, 1, 4, 9], Gradient: 0.0\n",
       "Excitation: [0, 1, 5, 6], Gradient: 0.0\n",
       "Excitation: [0, 1, 5, 8], Gradient: 0.0\n",
-      "Excitation: [0, 1, 6, 7], Gradient: -0.02358152437912184\n",
+      "Excitation: [0, 1, 6, 7], Gradient: -0.02358152437912195\n",
       "Excitation: [0, 1, 6, 9], Gradient: 0.0\n",
       "Excitation: [0, 1, 7, 8], Gradient: 0.0\n",
-      "Excitation: [0, 1, 8, 9], Gradient: -0.12362273289626591\n"
+      "Excitation: [0, 1, 8, 9], Gradient: -0.12362273289626559\n"
      ]
     }
    ],
@@ -697,14 +705,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Excitation : [0, 2], Gradient: -0.005062544629162211\n",
+      "Excitation : [0, 2], Gradient: -0.005062544629162062\n",
       "Excitation : [0, 4], Gradient: 0.0\n",
       "Excitation : [0, 6], Gradient: 0.0\n",
-      "Excitation : [0, 8], Gradient: -0.0009448055879243297\n",
-      "Excitation : [1, 3], Gradient: 0.004926625112977063\n",
+      "Excitation : [0, 8], Gradient: -0.0009448055879247696\n",
+      "Excitation : [1, 3], Gradient: 0.004926625112976855\n",
       "Excitation : [1, 5], Gradient: 0.0\n",
       "Excitation : [1, 7], Gradient: 0.0\n",
-      "Excitation : [1, 9], Gradient: 0.0014535553867885554\n",
+      "Excitation : [1, 9], Gradient: 0.0014535553867889648\n",
       "singles_select: [[0, 2], [0, 8], [1, 3], [1, 9]]\n"
      ]
     }
@@ -876,22 +884,22 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Excitation: [0 1 2 3], Gradient: -0.012782157554624973\n",
-      "Excitation: [0 1 2 5], Gradient: 0.0\n",
-      "Excitation: [0 1 2 7], Gradient: 0.0\n",
-      "Excitation: [0 1 2 9], Gradient: 0.03426451122834351\n",
-      "Excitation: [0 1 3 4], Gradient: 8.881784197001252e-09\n",
-      "Excitation: [0 1 3 6], Gradient: 2.6645352591003757e-08\n",
-      "Excitation: [0 1 3 8], Gradient: -0.03426446681942252\n",
-      "Excitation: [0 1 4 5], Gradient: -0.02358147455083781\n",
-      "Excitation: [0 1 4 7], Gradient: 2.6645352591003757e-08\n",
-      "Excitation: [0 1 4 9], Gradient: 8.881784197001252e-09\n",
-      "Excitation: [0 1 5 6], Gradient: 8.881784197001252e-09\n",
-      "Excitation: [0 1 5 8], Gradient: 8.881784197001252e-09\n",
-      "Excitation: [0 1 6 7], Gradient: -0.023581483432622008\n",
-      "Excitation: [0 1 6 9], Gradient: -8.881784197001252e-09\n",
-      "Excitation: [0 1 7 8], Gradient: -8.881784197001252e-09\n",
-      "Excitation: [0 1 8 9], Gradient: -0.12362274759425418\n"
+      "Excitation: [0 1 2 3], Gradient: -0.012782148672840776\n",
+      "Excitation: [0 1 2 5], Gradient: 1.7763568394002505e-08\n",
+      "Excitation: [0 1 2 7], Gradient: 1.7763568394002505e-08\n",
+      "Excitation: [0 1 2 9], Gradient: 0.034264520110127705\n",
+      "Excitation: [0 1 3 4], Gradient: 1.7763568394002505e-08\n",
+      "Excitation: [0 1 3 6], Gradient: 1.7763568394002505e-08\n",
+      "Excitation: [0 1 3 8], Gradient: -0.03426448458299092\n",
+      "Excitation: [0 1 4 5], Gradient: -0.023581492314406205\n",
+      "Excitation: [0 1 4 7], Gradient: 1.7763568394002505e-08\n",
+      "Excitation: [0 1 4 9], Gradient: 1.7763568394002505e-08\n",
+      "Excitation: [0 1 5 6], Gradient: 1.7763568394002505e-08\n",
+      "Excitation: [0 1 5 8], Gradient: 1.7763568394002505e-08\n",
+      "Excitation: [0 1 6 7], Gradient: -0.023581501196190402\n",
+      "Excitation: [0 1 6 9], Gradient: 8.881784197001252e-09\n",
+      "Excitation: [0 1 7 8], Gradient: 8.881784197001252e-09\n",
+      "Excitation: [0 1 8 9], Gradient: -0.1236227031853332\n"
      ]
     }
    ],
@@ -978,7 +986,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "params_doubles: [ 0.04758607 -0.09855445  0.09865958  0.05330061  0.05331783  0.22938123]\n"
+      "params_doubles: [0.03152985 0.03152985 0.03152985 0.03152985 0.03152985 0.03152985]\n"
      ]
     }
    ],
@@ -1086,7 +1094,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Energy: -7.88202350\n"
+      "Energy: -7.86725593\n"
      ]
     }
    ],
@@ -1139,7 +1147,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "catalyst-env",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1153,7 +1161,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8 (main, Nov 24 2022, 14:13:03) [GCC 11.2.0]"
+   "version": "3.10.12"
   },
   "vscode": {
    "interpreter": {

--- a/demos/adaptive_circuits_demo.ipynb
+++ b/demos/adaptive_circuits_demo.ipynb
@@ -986,7 +986,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "params_doubles: [0.03152985 0.03152985 0.03152985 0.03152985 0.03152985 0.03152985]\n"
+      "params_doubles: [ 0.04758599 -0.09855459  0.09865966  0.05330077  0.05331789  0.22938115]\n"
      ]
     }
    ],
@@ -1007,7 +1007,7 @@
     "                double_gates, single_gates,\n",
     "                selected_double_gates, selected_single_gates,\n",
     "                gates_verifier, selected_verifier, apply_selected)\n",
-    "        return theta - h[0] * stepsize\n",
+    "        return theta - h * stepsize\n",
     "\n",
     "    return catalyst.for_loop(0, ntrials, 1)(grad_step)(params)\n",
     "\n",
@@ -1094,7 +1094,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Energy: -7.86725593\n"
+      "Energy: -7.88202350\n"
      ]
     }
    ],

--- a/demos/qml/tutorial_qubit_rotation.ipynb
+++ b/demos/qml/tutorial_qubit_rotation.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install jaxopt"
+    "%pip install optax"
    ]
   },
   {
@@ -307,7 +307,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[-0.51043869 -0.10267824]\n"
+      "[-0.51043865 -0.1026782 ]\n"
      ]
     }
    ],
@@ -362,7 +362,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[array(-0.51043869), array(-0.10267824)]\n"
+      "(array(-0.51043865), array(-0.1026782))\n"
      ]
     }
    ],
@@ -462,8 +462,8 @@
      "output_type": "stream",
      "text": [
       "Cost after step     5:  0.9961778\n",
-      "Cost after step    10:  0.8974935\n",
-      "Cost after step    15:  0.1440475\n",
+      "Cost after step    10:  0.8974944\n",
+      "Cost after step    15:  0.1440490\n",
       "Cost after step    20: -0.1536720\n",
       "Cost after step    25: -0.9152496\n",
       "Cost after step    30: -0.9994046\n",
@@ -481,7 +481,7 @@
       "Cost after step    90: -1.0000000\n",
       "Cost after step    95: -1.0000000\n",
       "Cost after step   100: -1.0000000\n",
-      "Optimized rotation angles: [-4.9759957e-08  3.1415926e+00]\n"
+      "Optimized rotation angles: [8.14739648e-17 3.14159265e+00]\n"
      ]
     }
    ],
@@ -544,7 +544,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[-4.9759957e-08  3.1415926e+00]\n"
+      "[8.14739648e-17 3.14159265e+00]\n"
      ]
     }
    ],
@@ -577,7 +577,7 @@
     "Using third-party JAX libraries\n",
     "------------------------------\n",
     "\n",
-    "We can combine our quantum functions with any Python libraries supporting JAX. In this section we use [jaxopt.GradientDescent](https://jaxopt.github.io/stable/_autosummary/jaxopt.GradientDescent.html#jaxopt.GradientDescent) optimizer to solve the same optimization task."
+    "We can combine our quantum functions with any Python libraries supporting JAX. In this section we use [optax.sgd](https://optax.readthedocs.io/en/stable/api/optimizers.html#optax.sgd) optimizer to solve the same optimization task."
    ]
   },
   {
@@ -589,12 +589,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[-4.85367987e-08  3.14159261e+00]\n"
+      "[8.14739648e-17 3.14159265e+00]\n"
      ]
     }
    ],
    "source": [
-    "from jaxopt import GradientDescent\n",
+    "import optax\n",
     "\n",
     "@qjit\n",
     "def jit_opt_thirdparty():\n",
@@ -605,17 +605,17 @@
     "        c = circuit(p)\n",
     "        return c,(g[0],g[1])\n",
     "\n",
-    "    opt = GradientDescent(_target,\n",
-    "                          stepsize=0.4,\n",
-    "                          value_and_grad=True)\n",
+    "    opt = optax.sgd(learning_rate=0.4)\n",
     "\n",
     "    steps = 100\n",
     "    params = init_params[0],init_params[1]\n",
-    "    state = opt.init_state(params)\n",
+    "    state = opt.init(params)\n",
     "    \n",
     "    def loop(i,arg):\n",
     "        (p, s) = arg\n",
-    "        (p2, s2) = opt.update(p, s)\n",
+    "        _, g = _target(p)\n",
+    "        (u, s2) = opt.update(g, s)\n",
+    "        p2 = optax.apply_updates(p, u)\n",
     "        return (p2, s2)\n",
     "      \n",
     "    (params, _) = fori_loop(0, steps, loop, (params,state))\n",
@@ -659,9 +659,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/doc/dev/quick_start.rst
+++ b/doc/dev/quick_start.rst
@@ -744,31 +744,3 @@ as well as vectorized using ``jax.vmap``:
 
 >>> jax.vmap(cost_fn)(jnp.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]]))
 Array([1.32269195, 1.53905377], dtype=float64)
-
-
-In particular, this allows for a reduction in boilerplate when using
-JAX-compatible optimizers such as ``optax``.
-
-We first define `update_step` function to compute the gradient and update the parameters of the optimizer.
-After that, `opt_run` introduces an optimization loop with `update_step`.
-
-.. code-block:: python
-
-    opt = optax.sgd(learning_rate=0.4)
-
-    def update_step(i, args):
-        param, state = args
-        gradient = jax.grad(cost_fn)(param)
-        (updates, state) = opt.update(gradient, state)
-        param = optax.apply_updates(param, updates)
-        return (param, state)
-
-    def opt_run(param):
-        state = opt.init(param)
-        (param, state) = fori_loop(0, 100, update_step, (param, state))
-        return (param, state)
-
->>> params = jnp.array([0.1, 0.2, 0.3])
->>> (final_params, _) = jax.jit(opt_run)(params)
->>> final_params
-Array([-0.00320799,  0.03475223,  0.29362844], dtype=float64)

--- a/doc/dev/sharp_bits.rst
+++ b/doc/dev/sharp_bits.rst
@@ -381,6 +381,8 @@ circuit, are measuring an expectation value, and are optimizing the result:
 
 .. code-block:: python
 
+    import numpy as np
+
     dev = qml.device("default.qubit", wires=4)
 
     @qml.qnode(dev)
@@ -404,13 +406,15 @@ circuit, are measuring an expectation value, and are optimizing the result:
     weights = jnp.array(2 * np.random.random([5, 4]) - 1)
     data = jnp.array(np.random.random([4]))
 
-    opt = jaxopt.GradientDescent(cost, stepsize=0.4, jit=False)
+    opt = optax.sgd(learning_rate=0.4)
 
     params = weights
-    state = opt.init_state(params)
+    state = opt.init(params)
 
     for i in range(200):
-        (params, _) = tuple(opt.update(params, state, data))
+        value = cost(params, data)
+        (updates, state) = opt.update(value, state)
+        params = optax.apply_updates(params, updates)
 
 Using PennyLane v0.32 on Google Colab with the Python 3 Google Compute Engine
 backend, this optimization takes 3min 28s ± 2.05s to complete.
@@ -458,13 +462,15 @@ it using Catalyst:
         for_loop(0, jnp.shape(weights)[0], 1)(layer_loop)()
         return qml.expval(qml.PauliZ(0) + qml.PauliZ(3))
 
-    opt = jaxopt.GradientDescent(cost, stepsize=0.4)
+    opt = optax.sgd(learning_rate=0.4)
 
     params = weights
-    state = opt.init_state(params)
+    state = opt.init(params)
 
     for i in range(200):
-        (params, _) = tuple(opt.update(params, state, data))
+        value = cost(params, data)
+        (updates, state) = opt.update(value, state)
+        params = optax.apply_updates(params, updates)
 
 With the quantum function qjit-compiled, the optimization loop
 now takes 16.4s ± 1.51s.
@@ -485,11 +491,16 @@ optimization to take place within Catalyst:
             dy = grad(cost, argnum=0)(x, data)
             return (cost(x, data), dy)
 
-        opt = jaxopt.GradientDescent(loss, stepsize=0.4, value_and_grad=True)
-        update_step = lambda i, *args: tuple(opt.update(*args))
+        opt = optax.sgd(learning_rate=0.4)
+    
+        def update_step(i, params, state):
+            (_, gradient) = loss(params)
+            (updates, state) = opt.update(gradient, state)
+            params = optax.apply_updates(params, updates)
+            return (params, state)
 
         params = init_weights
-        state = opt.init_state(params)
+        state = opt.init(params)
 
         return for_loop(0, steps, 1)(update_step)(params, state)
 

--- a/doc/dev/sharp_bits.rst
+++ b/doc/dev/sharp_bits.rst
@@ -382,6 +382,7 @@ circuit, are measuring an expectation value, and are optimizing the result:
 .. code-block:: python
 
     import numpy as np
+    import jax
 
     dev = qml.device("default.qubit", wires=4)
 
@@ -412,8 +413,8 @@ circuit, are measuring an expectation value, and are optimizing the result:
     state = opt.init(params)
 
     for i in range(200):
-        value = cost(params, data)
-        (updates, state) = opt.update(value, state)
+        gradient = jax.grad(cost)(params, data)
+        (updates, state) = opt.update(gradient, state)
         params = optax.apply_updates(params, updates)
 
 Using PennyLane v0.32 on Google Colab with the Python 3 Google Compute Engine
@@ -468,8 +469,8 @@ it using Catalyst:
     state = opt.init(params)
 
     for i in range(200):
-        value = cost(params, data)
-        (updates, state) = opt.update(value, state)
+        gradient = jax.grad(cost)(params, data)
+        (updates, state) = opt.update(gradient, state)
         params = optax.apply_updates(params, updates)
 
 With the quantum function qjit-compiled, the optimization loop

--- a/frontend/catalyst/api_extensions/differentiation.py
+++ b/frontend/catalyst/api_extensions/differentiation.py
@@ -86,8 +86,8 @@ def grad(fn=None, *, method=None, h=None, argnum=None):
 
     .. note::
 
-        Any JAX-compatible optimization library, such as `JAXopt
-        <https://jaxopt.github.io/stable/index.html>`_, can be used
+        Any JAX-compatible optimization library, such as `Optax
+        <https://optax.readthedocs.io/en/stable/index.html>`_, can be used
         alongside ``grad`` for JIT-compatible variational workflows.
         See the :doc:`/dev/quick_start` for examples.
 
@@ -224,8 +224,8 @@ def value_and_grad(fn=None, *, method=None, h=None, argnum=None):
 
     .. note::
 
-        Any JAX-compatible optimization library, such as `JAXopt
-        <https://jaxopt.github.io/stable/index.html>`_, can be used
+        Any JAX-compatible optimization library, such as `Optax
+        <https://optax.readthedocs.io/en/stable/index.html>`_, can be used
         alongside ``value_and_grad`` for JIT-compatible variational workflows.
         See the :doc:`/dev/quick_start` for examples.
 
@@ -329,8 +329,8 @@ def jacobian(fn=None, *, method=None, h=None, argnum=None):
 
     .. note::
 
-        Any JAX-compatible optimization library, such as `JAXopt
-        <https://jaxopt.github.io/stable/index.html>`_, can be used
+        Any JAX-compatible optimization library, such as `Optax
+        <https://optax.readthedocs.io/en/stable/index.html>`_, can be used
         alongside ``jacobian`` for JIT-compatible variational workflows.
         See the :doc:`/dev/quick_start` for examples.
 


### PR DESCRIPTION
**Context:** 

Google is merging JAXopt into Optax. However, Some JAXopt classes and methods (e.g., ``jaxopt.GradientDescent``) still have no their counterparts in Optax.  Moreover, the interface of Optax's methods is different from that of JAXopt's.

**Description of the Change:**

- Replace ``jaxopt.GradientDescent`` with ``optax.sgd``.
- Remove the examples with ``jaxopt.GradientDescent.run`` method since it has no counterpart in optax.

**Benefits:**

**Possible Drawbacks:**

- The results of ``optax.sgd`` can be different from those of ``jaxopt.GradientDescent``.
- ~~I cannot reproduce some results (which are not related to jaxopt and optax) in demos. Might be the issues of environment setup and random seeds.~~

**Related GitHub Issues:** https://github.com/PennyLaneAI/catalyst/issues/499
[sc-65610]
