### PR TITLE
[Frontend] Callbacks can return pytrees.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -174,6 +174,9 @@
 * Correctly recording types of constant array when lowering `catalyst.grad` to mlir
   [(#778)](https://github.com/PennyLaneAI/catalyst/pull/778)
 
+* Callbacks can now return types which can be flattened and unflattened.
+  [(#812)](https://github.com/PennyLaneAI/catalyst/pull/812)
+
 <h3>Internal changes</h3>
 
 * Catalyst uses the `collapse` method of Lightning simulators in `Measure` to select a state vector branch and normalize.

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -20,7 +20,6 @@ but require a Python interpreter instance.
 
 import ctypes
 import inspect
-from collections.abc import Sequence
 from functools import wraps
 from typing import Any, Callable
 

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -199,7 +199,8 @@ class MemrefCallable(FlatCallable):
         results_aval_sequence = (
             self.results_aval if isinstance(self.results_aval, Sequence) else [self.results_aval]
         )
-        for retval, exp_aval in zip(retvals, results_aval_sequence):
+        flat_res_avals, _ = tree_flatten(results_aval_sequence)
+        for retval, exp_aval in zip(retvals, flat_res_avals):
             self._check_types(retval, exp_aval)
             ranked_memref = get_ranked_memref_descriptor(retval)
             element_size = ctypes.sizeof(ranked_memref.aligned.contents)
@@ -215,6 +216,7 @@ class MemrefCallable(FlatCallable):
     def _check_types(self, obs, exp_aval):
         """Raise error if observed value is different than expected abstract value"""
         obs_aval = shaped_abstractify(obs)
+        obs_aval = obs_aval.strip_weak_type()
         if obs_aval != exp_aval:
             # pylint: disable-next=line-too-long
             msg = f"Callback {self.func.__name__} expected type {exp_aval} but observed {obs_aval} in its return value"

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -196,11 +196,8 @@ class MemrefCallable(FlatCallable):
         jnpargs = self.asarrays(args)
         retvals = super().__call__(jnpargs)
         return_values = []
-        results_aval_sequence = (
-            self.results_aval if isinstance(self.results_aval, Sequence) else [self.results_aval]
-        )
-        flat_res_avals, _ = tree_flatten(results_aval_sequence)
-        for retval, exp_aval in zip(retvals, flat_res_avals):
+        flat_results_aval, _ = tree_flatten(self.results_aval)
+        for retval, exp_aval in zip(retvals, flat_results_aval):
             self._check_types(retval, exp_aval)
             ranked_memref = get_ranked_memref_descriptor(retval)
             element_size = ctypes.sizeof(ranked_memref.aligned.contents)
@@ -216,7 +213,6 @@ class MemrefCallable(FlatCallable):
     def _check_types(self, obs, exp_aval):
         """Raise error if observed value is different than expected abstract value"""
         obs_aval = shaped_abstractify(obs)
-        obs_aval = obs_aval.strip_weak_type()
         if obs_aval != exp_aval:
             # pylint: disable-next=line-too-long
             msg = f"Callback {self.func.__name__} expected type {exp_aval} but observed {obs_aval} in its return value"

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -373,7 +373,7 @@ def test_no_return_list(arg):
     [0.1, jnp.array(0.1)],
 )
 def test_dictionary(arg):
-    """Test pytrees. Specifying the tape is easier for accelerate sice it is
+    """Test pytrees. Specifying the type is easier for accelerate since it is
     not needed. But here, we just use the same trick as above where
     we can use any value with the same type as the return to specify
     the return type in a callback.

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -368,6 +368,28 @@ def test_no_return_list(arg):
     f(arg)
 
 
+@pytest.mark.parametrize(
+    "arg",
+    [0.1, jnp.array(0.1)],
+)
+def test_dictionary(arg):
+    """Test pytrees. Specifying the tape is easier for accelerate sice it is
+    not needed. But here, we just use the same trick as above where
+    we can use any value with the same type as the return to specify
+    the return type in a callback.
+    """
+
+    @pure_callback
+    def callback_fn(x) -> {"helloworld": arg}:
+        return {"helloworld": x}
+
+    @qml.qjit
+    def f(x):
+        return callback_fn(x)["helloworld"]
+
+    assert np.allclose(f(arg), arg)
+
+
 def test_tuple_out():
     """Test with multiple tuples."""
 


### PR DESCRIPTION
**Context:**  Just adding extra tests here. And a small fix.

**Description of the Change:** Compare against the flattened expected types.

**Benefits:** Callbacks can return dictionaries, or any other type which implements the pytrees' flatten and unflatten interface.

**Possible Drawbacks:** None

Note: The same will be possible with `accelerate` #805 
