### PR TITLE
Mark back a qubitunitary gradient test as xfailed 

### DIFF
--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1151,6 +1151,7 @@ def test_pytrees_args_return_classical():
     assert np.allclose(flatten_res_jax, flatten_res_catalyst)
 
 
+@pytest.mark.xfail(reason="QubitUnitrary is not support with catalyst.grad")
 @pytest.mark.parametrize("inp", [(1.0), (2.0), (3.0), (4.0)])
 def test_adj_qubitunitary(inp, backend):
     """Test the adjoint method."""

--- a/frontend/test/pytest/test_operations.py
+++ b/frontend/test/pytest/test_operations.py
@@ -199,5 +199,28 @@ def test_hybrid_op_repr(backend):
     qjit()(qml.qnode(qml.device(backend, wires=4))(circuit))(1)
 
 
+@pytest.mark.parametrize("inp", [(1.0), (2.0), (3.0), (4.0)])
+def test_qubitunitary_complex(inp, backend):
+    """Test qubitunitary with complex matrix."""
+
+    def f(x):
+        qml.RX(x, wires=0)
+        U1 = np.array([[0.5 + 0.5j, -0.5 - 0.5j], [0.5 - 0.5j, 0.5 - 0.5j]], dtype=complex)
+        qml.QubitUnitary(U1, wires=0)
+        return qml.expval(qml.PauliY(0))
+
+    @qjit()
+    def compiled(x: float):
+        g = qml.qnode(qml.device(backend, wires=1))(f)
+        return g(x)
+
+    def interpreted(x):
+        device = qml.device("default.qubit", wires=1)
+        g = qml.QNode(f, device)
+        return g(x)
+
+    assert np.allclose(compiled(inp), interpreted(inp))
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])


### PR DESCRIPTION
**Context:**
In PR #778, the support for complex matrices under qubitunitary was added.

It was mistakenly belived that an old test, `test_adj_qubitunitary` in test_gradient.py, was marked xfailed because complex under qubitunitary was not supported, and the PR removed the xfailed.

However, the xfailed was because qubitunitary should not be differentiable at all. 

**Description of the Change:**
The test is now marked back to xfailed, and a new test for complex numbers under qubitunitary, with no gradients in the test, is added

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-66151]