### PR TITLE
Make ``jax_tracer`` handle ``__name__`` for ``functools.partial``

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -180,6 +180,9 @@
 * Callbacks can now return types which can be flattened and unflattened.
   [(#812)](https://github.com/PennyLaneAI/catalyst/pull/812)
 
+* `catalyst.qjit` and `catalyst.grad` can now get `__name__` from `functools.partial`.
+  [(#820)](https://github.com/PennyLaneAI/catalyst/pull/820)
+
 <h3>Internal changes</h3>
 
 * Catalyst uses the `collapse` method of Lightning simulators in `Measure` to select a state vector branch and normalize.
@@ -314,7 +317,8 @@ Mehrdad Malekmohammadi,
 Vincent Michaud-Rioux,
 Mudit Pandey,
 Raul Torres,
-Sergei Mironov.
+Sergei Mironov,
+Tzung-Han Juang.
 
 # Release 0.6.0
 

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -151,7 +151,10 @@ class Function:
     @debug_logger_init
     def __init__(self, fn):
         self.fn = fn
-        self.__name__ = fn.__name__
+        if isinstance(fn, partial):
+            self.__name__ = fn.func.__name__
+        else:
+            self.__name__ = fn.__name__
 
     @debug_logger
     def __call__(self, *args, **kwargs):

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -15,6 +15,7 @@
 import random
 import warnings
 from timeit import default_timer as timer
+from functools import partial
 
 import jax
 import numpy as np
@@ -957,6 +958,24 @@ class TestQJITUsagePatterns:
         assert res_pattern_fn_as_argument == expected
         assert res_pattern_partial == expected
 
+class TestGradPartial:
+    """Test functools.partial with catalyst.qjit and catalyst.qjit."""
+
+    def test_partial_func_grad(self):
+        """Test if partial triggers function name error with gjit and grad."""
+        
+        def fn(x, y):
+             return x * y
+
+        partial_fn = partial(fn, y= 1)
+
+        @qjit
+        def grad_partial_fn(x):
+            return grad(partial_fn)(x)
+    
+        expected = jax.grad(partial_fn)(0.3)
+
+        assert np.allclose(grad_partial_fn(0.3), expected)
 
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -14,8 +14,8 @@
 
 import random
 import warnings
-from timeit import default_timer as timer
 from functools import partial
+from timeit import default_timer as timer
 
 import jax
 import numpy as np
@@ -958,24 +958,26 @@ class TestQJITUsagePatterns:
         assert res_pattern_fn_as_argument == expected
         assert res_pattern_partial == expected
 
+
 class TestGradPartial:
     """Test functools.partial with catalyst.qjit and catalyst.qjit."""
 
     def test_partial_func_grad(self):
         """Test if partial triggers function name error with gjit and grad."""
-        
-        def fn(x, y):
-             return x * y
 
-        partial_fn = partial(fn, y= 1)
+        def fn(x, y):
+            return x * y
+
+        partial_fn = partial(fn, y=1)
 
         @qjit
         def grad_partial_fn(x):
             return grad(partial_fn)(x)
-    
+
         expected = jax.grad(partial_fn)(0.3)
 
         assert np.allclose(grad_partial_fn(0.3), expected)
+
 
 if __name__ == "__main__":
     pytest.main(["-x", __file__])


### PR DESCRIPTION
**Context:** 
Add if-else case to get ``__name__`` from ``functools.partial`` in ``jax_tracer.py``.

**Related GitHub Issues:** #815 
[sc-66088]