### PR TITLE
Autograph works when applied to a function decorated with vmap

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -588,6 +588,9 @@ Tzung-Han Juang,
   (array([0.5, 0. , 0.5, 0. ]),)
   ```
 
+* Autograph works when `qjit` is applied to a function decorated with `vmap`.
+  [(#835)](https://github.com/PennyLaneAI/catalyst/pull/835)
+
 <h3>Breaking changes</h3>
 
 * The `mitigate_with_zne` function no longer accepts a `degree` parameter for polynomial fitting

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -50,6 +50,9 @@
   >>> Array([0., 1., 0., 1., 0., 1., 0., 1., 0., 1.], dtype=float64)
   ```
 
+* Autograph works when `qjit` is applied to a function decorated with `vmap`.
+  [(#835)](https://github.com/PennyLaneAI/catalyst/pull/835)
+
 <h3>Breaking changes</h3>
 * Return values are `jax.Array` typed instead of `numpy.array`.
   [(#895)](https://github.com/PennyLaneAI/catalyst/pull/895)
@@ -77,6 +80,7 @@ This release contains contributions from (in alphabetical order):
 Mehrdad Malekmohammadi,
 Romain Moyard,
 Erick Ochoa,
+Raul Torres,
 Tzung-Han Juang,
 
 # Release 0.7.0
@@ -587,9 +591,6 @@ Tzung-Han Juang,
   [Hadamard(wires=[0]), ForLoop(tapes=[[Hadamard(wires=[0])]])]
   (array([0.5, 0. , 0.5, 0. ]),)
   ```
-
-* Autograph works when `qjit` is applied to a function decorated with `vmap`.
-  [(#835)](https://github.com/PennyLaneAI/catalyst/pull/835)
 
 <h3>Breaking changes</h3>
 

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -539,6 +539,7 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
             catalyst.jacobian,
             catalyst.vjp,
             catalyst.jvp,
+            catalyst.vmap,
         ):
             assert args and callable(args[0])
             wrapped_fn = args[0]

--- a/frontend/catalyst/autograph/transformer.py
+++ b/frontend/catalyst/autograph/transformer.py
@@ -56,6 +56,7 @@ class CatalystTransformer(PyToPy):
         elif inspect.isfunction(fn) or inspect.ismethod(fn):
             pass
         elif callable(obj):
+            # pylint: disable=unnecessary-lambda,unnecessary-lambda-assignment
             fn = lambda *args, **kwargs: obj(*args, **kwargs)
         else:
             raise AutoGraphError(f"Unsupported object for transformation: {type(fn)}")

--- a/frontend/catalyst/autograph/transformer.py
+++ b/frontend/catalyst/autograph/transformer.py
@@ -53,8 +53,11 @@ class CatalystTransformer(PyToPy):
         fn = obj
         if isinstance(obj, qml.QNode):
             fn = obj.func
-
-        if not (inspect.isfunction(fn) or inspect.ismethod(fn)):
+        elif inspect.isfunction(fn) or inspect.ismethod(fn):
+            pass
+        elif callable(obj):
+            fn = lambda *args, **kwargs: obj(*args, **kwargs)
+        else:
             raise AutoGraphError(f"Unsupported object for transformation: {type(fn)}")
 
         new_fn, module, source_map = self.transform_function(fn, user_context)

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -40,6 +40,7 @@ from catalyst import (
     measure,
     qjit,
     vjp,
+    vmap,
 )
 from catalyst.autograph.transformer import TRANSFORMER
 from catalyst.utils.dummy import dummy_func
@@ -156,9 +157,8 @@ class TestSourceCodeInfo:
 class TestIntegration:
     """Test that the autograph transformations trigger correctly in different settings."""
 
-    def test_unsupported_object(self):
-        """Check the error produced when attempting to convert an unsupported object (neither of
-        QNode, function, or method)."""
+    def test_callable_object(self):
+        """Test qjit applied to a callable object."""
 
         class FN:
             """Test object."""
@@ -170,8 +170,7 @@ class TestIntegration:
 
         fn = FN()
 
-        with pytest.raises(AutoGraphError, match="Unsupported object for transformation"):
-            qjit(autograph=True)(fn)
+        assert qjit(autograph=True)(fn)(3) == 9
 
     def test_lambda(self):
         """Test autograph on a lambda function."""
@@ -1986,6 +1985,23 @@ class TestJaxIndexAssignment:
             return result
 
         assert jnp.allclose(expand_by_two(jnp.array([5, 3, 4])), jnp.array([5, 0, 3, 0, 4, 0]))
+
+
+class TestDecorators:
+    """Test if Autograph works when applied to a decorated function"""
+
+    def test_vmap(self):
+        """Test if Autograph works when applied to a decorated function with vmap"""
+
+        def workflow(axes_dct):
+            return axes_dct["x"] + axes_dct["y"]
+
+        expected = jnp.array([1, 2, 3, 4, 5])
+
+        result = qjit(vmap(workflow, in_axes=({"x": None, "y": 0},)), autograph=True)(
+            {"x": 1, "y": jnp.arange(5)}
+        )
+        assert jnp.allclose(result, expected)
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -39,6 +39,7 @@ from catalyst import (
     jvp,
     measure,
     qjit,
+    run_autograph,
     vjp,
     vmap,
 )
@@ -156,6 +157,20 @@ class TestSourceCodeInfo:
 
 class TestIntegration:
     """Test that the autograph transformations trigger correctly in different settings."""
+
+    def test_unsupported_object(self):
+        """Check the error produced when attempting to convert an unsupported object (neither of
+        QNode, function, method or callable)."""
+
+        class FN:
+            """Test object."""
+
+            __name__ = "unknown"
+
+        fn = FN()
+
+        with pytest.raises(AutoGraphError, match="Unsupported object for transformation"):
+            run_autograph(fn)
 
     def test_callable_object(self):
         """Test qjit applied to a callable object."""


### PR DESCRIPTION
**Context:** We want to ensure that autograph still works properly when applied to vmap.

**Description of the Change:** Handle callable objects at the transform method of the CatalystTransformer class. 

[sc-60305]