### PR TITLE
Changing the `for (auto i = 0; ...)` in #822 to `for (size_t i = 0; ..` to silence warnings during building

### DIFF
--- a/mlir/lib/Gradient/Transforms/BufferizationPatterns.cpp
+++ b/mlir/lib/Gradient/Transforms/BufferizationPatterns.cpp
@@ -195,14 +195,14 @@ struct BufferizeForwardOp : public OpConversionPattern<ForwardOp> {
         rewriter.setInsertionPointToStart(block);
         auto params = op.getArguments();
 
-        for (auto i = 0; i < argc * 2; i++) {
+        for (size_t i = 0; i < argc * 2; i++) {
             bool isDup = (i % 2) != 0;
             Value val = params[i];
             isDup ? differentials.push_back(val) : inputs.push_back(val);
         }
 
         auto upperLimit = (argc * 2) + (resc * 2);
-        for (auto i = argc * 2; i < upperLimit; i++) {
+        for (size_t i = argc * 2; i < upperLimit; i++) {
             bool isDup = (i % 2) != 0;
             Value val = params[i];
             isDup ? cotangents.push_back(val) : outputs.push_back(val);
@@ -288,14 +288,14 @@ struct BufferizeReverseOp : public OpConversionPattern<ReverseOp> {
         rewriter.setInsertionPointToStart(block);
         auto params = op.getArguments();
 
-        for (auto i = 0; i < argc * 2; i++) {
+        for (size_t i = 0; i < argc * 2; i++) {
             bool isDup = (i % 2) != 0;
             Value val = params[i];
             isDup ? differentials.push_back(val) : inputs.push_back(val);
         }
 
         auto upperLimit = (argc * 2) + (resc * 2);
-        for (auto i = argc * 2; i < upperLimit; i++) {
+        for (size_t i = argc * 2; i < upperLimit; i++) {
             bool isDup = (i % 2) != 0;
             Value val = params[i];
             isDup ? cotangents.push_back(val) : outputs.push_back(val);
@@ -303,7 +303,7 @@ struct BufferizeReverseOp : public OpConversionPattern<ReverseOp> {
 
         auto tapeCount = op.getTape();
         auto uppestLimit = upperLimit + tapeCount;
-        for (auto i = upperLimit; i < uppestLimit; i++) {
+        for (size_t i = upperLimit; i < uppestLimit; i++) {
             tapeElements.push_back(params[i]);
         }
 

--- a/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
@@ -898,14 +898,14 @@ struct ReverseOpPattern : public ConvertOpToLLVMPattern<ReverseOp> {
         SmallVector<Value> tapeElements;
         auto params = op.getArguments();
 
-        for (auto i = 0; i < argc * 2; i++) {
+        for (size_t i = 0; i < argc * 2; i++) {
             bool isDup = (i % 2) != 0;
             Value val = params[i];
             isDup ? differentials.push_back(val) : inputs.push_back(val);
         }
 
         auto upperLimit = (argc * 2) + (resc * 2);
-        for (auto i = argc * 2; i < upperLimit; i++) {
+        for (size_t i = argc * 2; i < upperLimit; i++) {
             bool isDup = (i % 2) != 0;
             Value val = params[i];
             isDup ? cotangents.push_back(val) : outputs.push_back(val);
@@ -913,7 +913,7 @@ struct ReverseOpPattern : public ConvertOpToLLVMPattern<ReverseOp> {
 
         auto tapeCount = op.getTape();
         auto uppestLimit = upperLimit + tapeCount;
-        for (auto i = upperLimit; i < uppestLimit; i++) {
+        for (size_t i = upperLimit; i < uppestLimit; i++) {
             tapeElements.push_back(params[i]);
         }
 
@@ -968,7 +968,7 @@ struct ReverseOpPattern : public ConvertOpToLLVMPattern<ReverseOp> {
             Value wrappedStructValAgg = func.getArgument(lastIdx);
 
             SmallVector<Value> tapestructs;
-            for (auto i = 0; i < tapeCount; i++) {
+            for (size_t i = 0; i < tapeCount; i++) {
                 SmallVector<int64_t> pos = {0, static_cast<int64_t>(i)};
                 Value tapeStructIth =
                     rewriter.create<LLVM::ExtractValueOp>(loc, wrappedStructValAgg, pos);
@@ -987,7 +987,7 @@ struct ReverseOpPattern : public ConvertOpToLLVMPattern<ReverseOp> {
             }
         }
 
-        for (auto i = 0; i < upperLimit; i++) {
+        for (size_t i = 0; i < upperLimit; i++) {
             Value oldval = params[i];
             Value newval = func.getArgument(i);
             map.map(oldval, newval);


### PR DESCRIPTION
**Context:**
New warning when you `make all` #822 here: https://github.com/PennyLaneAI/catalyst/blob/main/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp#L908 (and a bunch of similar places)
```
[53/172] Building CXX object lib/Gradi...ransforms.dir/ConversionPatterns.cpp.o
/home/paul.wang/catalyst/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp:910:28: warning: comparison of integers of different signs: 'int' and 'unsigned long' [-Wsign-compare]
        for (auto i = 0; i < argc * 2; i++) {
```
Changing auto to uint64_t or size_t will silence this. (argc is i64 https://github.com/PennyLaneAI/catalyst/blob/main/mlir/include/Gradient/IR/GradientOps.td#L318)

