### PR TITLE
Adding precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,47 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+    - id: black
+      args: [
+              "--line-length=100",
+              "-t", "py39",
+              "-t", "py310",
+              "-t", "py311",
+            ]
+      files: frontend
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+    - id: isort
+      args:
+        [
+          "--py",
+          "311",
+          "--profile",
+          "black",
+          "-l",
+          "100",
+          "-o",
+          "autoray",
+          "-p",
+          "./frontend",
+          "--skip",
+          "__init__.py",
+          "--filter-files",
+        ]
+      files: frontend
+- repo: local
+  hooks:
+    - id: pylint
+      name: pylint
+      entry: pylint
+      language: system
+      types: [python]
+      args:
+        [
+          "-rn", # Only display messages
+          "-sn", # Don't display the score
+          "--rcfile=.pylintrc", # Link to your config file
+        ]
+      files: frontend

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1539,6 +1539,7 @@ def _cond_lowering(
         # the 'else' blocks of preceding IfOps.
         with ip:
             pred_extracted = TensorExtractOp(ir.IntegerType.get_signless(1), preds[0], []).result
+            # pylint: disable=unexpected-keyword-arg
             if_op_scf = IfOp(pred_extracted, result_types, hasElse=True)
             true_jaxpr = branch_jaxprs[0]
             if_block = if_op_scf.then_block
@@ -1783,6 +1784,7 @@ def _for_loop_lowering(
         num_iterations = CeilDivSIOp(distance, step_val)
         lower_bound, upper_bound, step = zero, num_iterations, one
 
+    # pylint: disable=unexpected-keyword-arg, no-value-for-parameter
     for_op_scf = ForOp(lower_bound, upper_bound, step, iter_args=loop_args)
 
     name_stack = jax_ctx.module_context.name_stack.extend("for")


### PR DESCRIPTION
**Context:**

Precommit hooks make it easier to follow black, pylint, and isort checks as they are run whenever a developer tries to commit changes.  This eliminates the back-and-forth with the CI failing because of an accidental extra blank space or missed docstrings.  Saves developer time, since they can fix the issue immediately, and saves CI time, since we won't have to have "I forgot black" commits to the PR.

**Description of the Change:**

Adds a `.pre-commit-config.yaml` similar to the one in pennylane.  At this current point, it only runs checks on the `frontend`, but I'd be happy to extend it to other parts of the code base too.

pre-commit hooks are opt in, with the developer needing to have precommit installed and run `pre-commit install` on the repository.  They can also be bypassed by including `--no-verify` when trying to commit.

**Benefits:**

Fewer failing CI runs due to formatting issues.

**Possible Drawbacks:**

**Related GitHub Issues:**
