### PR TITLE
Correct make docs instruction

### DIFF
--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -411,6 +411,6 @@ To generate html files for the documentation for Catalyst:
 
 .. code-block:: console
 
-  pip install -r doc/requirements.txt
+  make docs
 
 The generated files are located in ``doc/_build/html``


### PR DESCRIPTION
**Context:**
Correct ``make docs`` instruction.
