### PR TITLE
Limit the number of parallel jobs to 2 when building Linux Arm64 wheels

### DIFF
--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -163,6 +163,7 @@ jobs:
     needs: [constants, build-dependencies]
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         python_version: [{official: "3.9",  subversion: "19", package: "python39",   alternative: "39"},
                          {official: "3.10", subversion: "14", package: "python3.10", alternative: "310"},
@@ -257,6 +258,7 @@ jobs:
     needs: [constants, catalyst-linux-wheels-arm64]
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         python_version: [{official: "3.9",  subversion: "19", package: "python39"},
                          {official: "3.10", subversion: "14", package: "python3.10"},

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -403,7 +403,7 @@ jobs:
     - name: Install OQC client
       if: ${{ matrix.python_version == '3.9' || matrix.python_version == '3.10'}}
       run: |
-        python${{ matrix.python_version }} -m pip install oqc-qcaas-client
+        python${{ matrix.python_version }} -m pip install packaging<22 oqc-qcaas-client
 
     - name: Install Catalyst
       run: |

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -403,7 +403,7 @@ jobs:
     - name: Install OQC client
       if: ${{ matrix.python_version == '3.9' || matrix.python_version == '3.10'}}
       run: |
-        python${{ matrix.python_version }} -m pip install packaging<22 oqc-qcaas-client
+        python${{ matrix.python_version }} -m pip install 'packaging<22' oqc-qcaas-client
 
     - name: Install Catalyst
       run: |


### PR DESCRIPTION
**Context:** The Mac Runner might reach capacity, for it might be building wheels for MacOS and Linux at the same time. This causes that some linking processes ran out of resources and fail. When manually restarted, they pass. 

**Description of the Change:** Limit the number of parallel jobs to 2.

**Benefits:** Avoid failures at link time.

**Possible Drawbacks:** Increased times for having all wheels available.