### PR TITLE
Bump Lightning-rc branch from 0.36.0 to 0.37.0

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -136,7 +136,7 @@ jobs:
         C_COMPILER=$(which gcc }}) \
         CXX_COMPILER=$(which g++ }}) \
         RT_BUILD_DIR="$(pwd)/runtime-build" \
-        LIGHTNING_GIT_TAG_VALUE=v0.36.0_rc \
+        LIGHTNING_GIT_TAG_VALUE=v0.37.0_rc \
         ENABLE_LIGHTNING_KOKKOS=ON \
         ENABLE_OPENQASM=ON \
         make runtime
@@ -156,8 +156,8 @@ jobs:
     - name: Install PennyLane-Lightning (release-candidate)
       if: ${{ inputs.lightning == 'release-candidate' }}
       run: |
-        pip install --upgrade git+https://github.com/PennyLaneAI/pennylane-lightning@v0.36.0_rc
-        PL_BACKEND="lightning_kokkos" pip install --upgrade git+https://github.com/PennyLaneAI/pennylane-lightning@v0.36.0_rc
+        pip install --upgrade git+https://github.com/PennyLaneAI/pennylane-lightning@v0.37.0_rc
+        PL_BACKEND="lightning_kokkos" pip install --upgrade git+https://github.com/PennyLaneAI/pennylane-lightning@v0.37.0_rc
 
     # PennyLane doesn't update its dev version number on every commit like Lightning, so we need to
     # force the package to be re-installed. First, handle potential dependency changes, then force


### PR DESCRIPTION
**Context:** We did not update the rc branch in the CI for Lightning before creating the rc branch. Needed for CPL rc/rc/rc workflow to pass.

**Description of the Change:** Bump Lightning-rc branch from 0.36.0 to 0.37.0

**Benefits:** CPL rc/rc/rc workflow will pass.

**Possible Drawbacks:** Being a cherry-picked commit, it is duplicated here in 'main' and 'v0.7.0-rc'.
