### PR TITLE
Pin 'packaging' to version '<22' for compatibility with OQC client

### DIFF
--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -403,7 +403,7 @@ jobs:
     - name: Install OQC client
       if: ${{ matrix.python_version == '3.9' || matrix.python_version == '3.10'}}
       run: |
-        python${{ matrix.python_version }} -m pip install oqc-qcaas-client
+        python${{ matrix.python_version }} -m pip install 'packaging<22' oqc-qcaas-client
 
     - name: Install Catalyst
       run: |


### PR DESCRIPTION
**Context:** Newer versions of 'packaging' are incompatible with OQC client, which causes errors at testing the wheels.

**Description of the Change:** Pin 'packaging' to version '<22'.

**Benefits:** OQC Device gets installed.

**Possible Drawbacks:** Might need to unpin in the future.