### PR TITLE
[WIP] Add QubitUnitaryFusion pass from development tutorial

### DIFF
--- a/mlir/include/Quantum/Transforms/Passes.h
+++ b/mlir/include/Quantum/Transforms/Passes.h
@@ -27,5 +27,6 @@ std::unique_ptr<mlir::Pass> createCopyGlobalMemRefPass();
 std::unique_ptr<mlir::Pass> createAdjointLoweringPass();
 std::unique_ptr<mlir::Pass> createRemoveChainedSelfInversePass();
 std::unique_ptr<mlir::Pass> createAnnotateFunctionPass();
+std::unique_ptr<mlir::Pass> createQubitUnitaryFusionPass();
 
 } // namespace catalyst

--- a/mlir/include/Quantum/Transforms/Passes.td
+++ b/mlir/include/Quantum/Transforms/Passes.td
@@ -77,6 +77,12 @@ def RemoveChainedSelfInversePass : Pass<"remove-chained-self-inverse"> {
     let constructor = "catalyst::createRemoveChainedSelfInversePass()";
 }
 
+def QubitUnitaryFusionPass : Pass<"qubit-unitary-fusion"> {
+    let summary = "Perform merging of two chained QubitUnitary operators acting on the same wire";
+
+    let constructor = "catalyst::createQubitUnitaryFusionPass()";
+}
+
 def AnnotateFunctionPass : Pass<"annotate-function"> {
     let summary = "Annotate functions that contain a measurement operation.";
 

--- a/mlir/lib/Catalyst/Transforms/RegisterAllPasses.cpp
+++ b/mlir/lib/Catalyst/Transforms/RegisterAllPasses.cpp
@@ -41,4 +41,5 @@ void catalyst::registerAllCatalystPasses()
     mlir::registerPass(catalyst::createRemoveChainedSelfInversePass);
     mlir::registerPass(catalyst::createAnnotateFunctionPass);
     mlir::registerPass(catalyst::createRegisterInactiveCallbackPass);
+    mlir::registerPass(catalyst::createQubitUnitaryFusionPass);
 }

--- a/mlir/lib/Quantum/Transforms/CMakeLists.txt
+++ b/mlir/lib/Quantum/Transforms/CMakeLists.txt
@@ -12,6 +12,8 @@ file(GLOB SRC
     AdjointPatterns.cpp
     ChainedHadamard.cpp
     remove_chained_self_inverse.cpp
+    qubit_unitary_fusion.cpp
+    QubitUnitaryFusion.cpp
 )
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)

--- a/mlir/lib/Quantum/Transforms/QubitUnitaryFusion.cpp
+++ b/mlir/lib/Quantum/Transforms/QubitUnitaryFusion.cpp
@@ -1,0 +1,110 @@
+// Copyright 2023 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define DEBUG_TYPE "qubit-unitary-fusion"
+
+#include "mlir/Dialect/Linalg/Ops.h"
+
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Errc.h"
+
+#include "Quantum/IR/QuantumOps.h"
+#include "Quantum/Transforms/Patterns.h"
+
+using llvm::dbgs;
+using namespace mlir;
+using namespace catalyst;
+using namespace catalyst::quantum;
+
+namespace {
+
+struct QubitUnitaryFusionOpRewritePattern : public mlir::OpRewritePattern<CustomOp> {
+    using mlir::OpRewritePattern<CustomOp>::OpRewritePattern;
+
+    mlir::LogicalResult matchAndRewrite(CustomOp op, mlir::PatternRewriter &rewriter) const override
+    {
+        LLVM_DEBUG(dbgs() << "Simplifying the following hadamard operation:\n" << op << "\n");
+        if (op.getGateName().str() != "Hadamard")
+            return failure();
+
+        ValueRange qbs = op.getInQubits();
+        auto parentHadamard = dyn_cast<CustomOp>(qbs[0].getDefiningOp());
+
+        if (parentHadamard == nullptr)
+            return failure();
+
+        if (parentHadamard.getGateName().str() != "Hadamard")
+            return failure();
+
+        Value simplifiedVal = parentHadamard.getInQubits()[0];
+        rewriter.replaceOp(op, simplifiedVal);
+        return success();
+    }
+};
+
+struct QubitUnitaryFusion : public OpRewritePattern<QubitUnitaryOp>
+{
+    using mlir::OpRewritePattern<CustomOp>::OpRewritePattern;
+
+    LogicalResult match(QubitUnitaryOp op)
+    {
+        ValueRange qbs = op.getInQubits();
+        Operation *parent = qbs[0].getDefiningOp();
+
+        if (!isa<QubitUnitaryOp>(parent))
+            return failure();
+
+        QubitUnitaryOp parentOp = cast<QubitUnitaryOp>(parent);
+        ValueRange parentQbs = parentOp.getOutQubits();
+
+        if (qbs.size() != parentQbs.size())
+            return failure();
+
+        for (auto [qb1, qb2] : llvm::zip(qbs, parentQbs))
+            if (qb1 != qb2)
+                return failure();
+
+        return success();
+    }
+
+    void rewrite(QubitUnitaryOp op, PatternRewriter &rewriter)
+    {
+        ValueRange qbs = op.getInQubits();
+        QubitUnitaryOp parentOp = cast<QubitUnitaryOp>(qbs[0].getDefiningOp());
+
+        Value m1 = op.getMatrix();
+        Value m2 = parentOp.getMatrix();
+
+        linalg::MatmulOp matmul = rewriter.create<linalg::MatmulOp>(op.getLoc(), {m1, m2}, {});
+        Value res = matmul.getResult(0);
+
+        rewriter.updateRootInPlace(op, [&] {
+            op->setOperand(0, res);
+        });
+        rewriter.replaceOp(parentOp, parentOp.getResults());
+    }
+};
+
+} // namespace
+
+namespace catalyst {
+namespace quantum {
+
+void populateQubitUnitaryFusionPatterns(RewritePatternSet &patterns)
+{
+    patterns.add<QubitUnitaryFusionOpRewritePattern>(patterns.getContext(), 1);
+}
+
+} // namespace quantum
+} // namespace catalyst

--- a/mlir/lib/Quantum/Transforms/qubit_unitary_fusion.cpp
+++ b/mlir/lib/Quantum/Transforms/qubit_unitary_fusion.cpp
@@ -1,0 +1,69 @@
+// Copyright 2023 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define DEBUG_TYPE "qubit-unitary-fusion"
+
+#include <memory>
+#include <vector>
+
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Errc.h"
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "Catalyst/IR/CatalystDialect.h"
+#include "Quantum/IR/QuantumOps.h"
+#include "Quantum/Transforms/Patterns.h"
+
+using namespace llvm;
+using namespace mlir;
+using namespace catalyst::quantum;
+
+namespace catalyst {
+namespace quantum {
+
+#define GEN_PASS_DEF_QubitUnitaryFusionPASS
+#include "Quantum/Transforms/Passes.h.inc"
+
+struct QubitUnitaryFusionPass
+    : impl::QubitUnitaryFusionPassBase<QubitUnitaryFusionPass> {
+    using QubitUnitaryFusionPassBase::QubitUnitaryFusionPassBase;
+
+    void runOnOperation() {
+        // Get the current operation being operated on.
+        ModuleOp op = getOperation();
+        MLIRContext *ctx = &getContext();
+
+        // Define the set of patterns to use.
+        RewritePatternSet quantumPatterns(ctx);
+        quantumPatterns.add<QubitUnitaryFusion>(ctx);
+
+        // Apply patterns in an iterative and greedy manner.
+        if (failed(applyPatternsAndFoldGreedily(op, std::move(quantumPatterns)))) {
+            return signalPassFailure();
+        }
+    }
+};
+
+} // namespace quantum
+
+std::unique_ptr<Pass> createQubitUnitaryFusionPass()
+{
+    return std::make_unique<quantum::QubitUnitaryFusionPass>();
+}
+
+} // namespace catalyst


### PR DESCRIPTION
Trying to add the `QubitUnitaryFusion` pass from the [compiler passes](https://docs.pennylane.ai/projects/catalyst/en/stable/dev/transforms.html) development site. Struggling with the very basics and boilerplate 🫠 

My approach: mimick behavior from `ChainedHadamard.cpp` and `remove_chained_self_inverse.cpp`, take on advice added in https://github.com/PennyLaneAI/catalyst/pull/872/ and use code snippets from [compiler passes](https://docs.pennylane.ai/projects/catalyst/en/stable/dev/transforms.html). The error messages are rather cryptic at this point so not sure how to continue.