### PR TITLE
Support `jax.Partial` as input to `catalyst.accelerate`.

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -162,6 +162,7 @@
   [(#782)](https://github.com/PennyLaneAI/catalyst/pull/782)
   [(#822)](https://github.com/PennyLaneAI/catalyst/pull/822)
   [(#834)](https://github.com/PennyLaneAI/catalyst/pull/834)
+  [(#882)](https://github.com/PennyLaneAI/catalyst/pull/882)
 
   Parameters to `debug.callback`s are marked as inactive. This means that the
   This means that the partial derivative of `debug.callback`s does not need to

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -108,12 +108,11 @@ def accelerate(func=None, *, dev=None):
     context = []
     if is_partial:
         context = tree_leaves(func)
-        func = tree_map(shaped_abstractify, func)
 
     def total(context, *args, **kwargs):
         nonlocal func
         if is_partial:
-            _tracers, shape = tree_flatten(func)
+            shape = tree_structure(func)
             func = tree_unflatten(shape, context)
             return func(*args, **kwargs)
         else:

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -108,6 +108,7 @@ def accelerate(func=None, *, dev=None):
     context = []
     if is_partial:
         context = tree_leaves(func)
+        func = tree_shape(func)
 
     def total(context, *args, **kwargs):
         nonlocal func

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -108,12 +108,11 @@ def accelerate(func=None, *, dev=None):
     context = []
     if is_partial:
         context = tree_leaves(func)
-        func = tree_shape(func)
 
     def total(context, *args, **kwargs):
         nonlocal func
         if is_partial:
-            shape = tree_structure(func)
+            _, shape = tree_flatten(func)
             func = tree_unflatten(shape, context)
             return func(*args, **kwargs)
         else:

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -27,8 +27,9 @@ from typing import Any, Callable
 import jax
 import jax.numpy as jnp
 from jax._src.api_util import shaped_abstractify
-from jax._src.tree_util import tree_flatten, tree_leaves, tree_map, tree_unflatten
+from jax._src.tree_util import tree_flatten, tree_leaves, tree_map, tree_unflatten, Partial
 
+from catalyst.jax_extras import transient_jax_config
 from catalyst.jax_primitives import python_callback_p
 from catalyst.tracing.contexts import EvaluationContext
 from catalyst.utils.exceptions import DifferentiableCompileError
@@ -102,20 +103,39 @@ def accelerate(func=None, *, dev=None):
         kwargs.pop("func")
         return functools.partial(accelerate, **kwargs)
 
-    jitted_fn = jax.jit(func)
+    # If this is a partial, we need to make the tracers part of the input
+    is_partial = isinstance(func, Partial)
+    context = []
+    if is_partial:
+        context = tree_leaves(func)
+        func = tree_map(shaped_abstractify, func)
+
+    def total(context, *args, **kwargs):
+        nonlocal func
+        if is_partial:
+            _tracers, shape = tree_flatten(func)
+            func = tree_unflatten(shape, context)
+            return func(*args, **kwargs)
+        else:
+            return func(*args, **kwargs)
+
+    with transient_jax_config({"jax_dynamic_shapes": False}):
+        jitted_fn = jax.jit(total)
 
     @functools.wraps(func)
     def defer(*args, **kwargs):
-        # Make abstract variables from input tracers.
-        absargs, abskwargs = tree_map(shaped_abstractify, (args, kwargs))
+        absextra, absargs, abskwargs = tree_map(shaped_abstractify, (context, args, kwargs))
         try:
             # Find the shape of the return value
-            _, returnshape = jax.make_jaxpr(func, return_shape=True)(*absargs, **abskwargs)
+            with transient_jax_config({"jax_dynamic_shapes": False}):
+                _, returnshape = jax.make_jaxpr(total, return_shape=True)(
+                    absextra, *absargs, **abskwargs
+                )
         except Exception as e:
             name = func.__name__
             msg = f"Function {name} must be jax.jit-able."
             raise ValueError(msg) from e
-        return jax_jit_callback(jitted_fn, returnshape, device=dev)(*args, **kwargs)
+        return jax_jit_callback(jitted_fn, returnshape, device=dev)(context, *args, **kwargs)
 
     return defer
 
@@ -247,13 +267,17 @@ class CallbackWithCustomGrad:
         cotangents = tree_map(shaped_abstractify, self.restype)
 
         # The forward pass must have the same input types as the original function
-        self._fwd_jaxpr, shape = jax.make_jaxpr(self._fwd, return_shape=True)(*absargs, **abskwargs)
+        with transient_jax_config({"jax_dynamic_shapes": False}):
+            self._fwd_jaxpr, shape = jax.make_jaxpr(self._fwd, return_shape=True)(
+                *absargs, **abskwargs
+            )
 
         # But its output is always going to be two pairs.
         _primal, residuals = shape
 
         # The input for the bwd pass is the residuals and the cotangents.
-        self._bwd_jaxpr = jax.make_jaxpr(self._bwd)(residuals, cotangents)
+        with transient_jax_config({"jax_dynamic_shapes": False}):
+            self._bwd_jaxpr = jax.make_jaxpr(self._bwd)(residuals, cotangents)
 
         return self.callback(*args, **kwargs)
 

--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -168,11 +168,10 @@ map, unsafe_map = safe_map, map  # pylint: disable=redefined-builtin
 
 
 @contextmanager
-def transient_jax_config() -> Generator[None, None, None]:
+def transient_jax_config(want_vals) -> Generator[None, None, None]:
     """Context manager which updates transient JAX configuration options,
     yields, and then restores the original configuration values.
     """
-    want_vals = {"jax_dynamic_shapes": True}
     prev_vals = {}
 
     try:

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -522,7 +522,7 @@ def trace_to_jaxpr(func, static_argnums, abstracted_axes, args, kwargs):
         PyTreeDef: PyTree-shape of the return values in ``PyTreeDef``
     """
 
-    with transient_jax_config():
+    with transient_jax_config({"jax_dynamic_shapes": True}):
         with EvaluationContext(EvaluationMode.CLASSICAL_COMPILATION):
             make_jaxpr_kwargs = {
                 "static_argnums": static_argnums,
@@ -554,7 +554,7 @@ def lower_jaxpr_to_mlir(jaxpr, func_name):
     MemrefCallable.clearcache()
     CALLBACK_OP_CACHE.clear()
 
-    with transient_jax_config():
+    with transient_jax_config({"jax_dynamic_shapes": True}):
         mlir_module, ctx = jaxpr_to_mlir(func_name, jaxpr)
 
     return mlir_module, ctx

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -1347,8 +1347,12 @@ def test_multiply_two_matrices_to_get_something_with_different_dimensions3():
 
 
 @pytest.mark.parametrize("arg", [jnp.array([[0.1, 0.2], [0.3, 0.4]])])
-def test_vjp_as_residual(arg):
+@pytest.mark.parametrize("order", ["good", "bad"])
+def test_vjp_as_residual(arg, order):
     """See https://github.com/PennyLaneAI/catalyst/issues/852"""
+
+    if order == "bad":
+        pytest.skip("Bug")
 
     def jax_callback(fn, result_type):
 
@@ -1377,12 +1381,12 @@ def test_vjp_as_residual(arg):
     def ground_truth(x):
         return jax.scipy.linalg.expm(x)
 
-    # BAD ORDER
-    # obs = hypothesis(arg)
-    # exp = ground_truth(arg)
-    # GOOD ORDER
-    exp = ground_truth(arg)
-    obs = hypothesis(arg)
+    if order == "bad":
+        obs = hypothesis(arg)
+        exp = ground_truth(arg)
+    else:
+        exp = ground_truth(arg)
+        obs = hypothesis(arg)
     assert np.allclose(obs, exp)
 
 

--- a/frontend/test/pytest/test_jax_config.py
+++ b/frontend/test/pytest/test_jax_config.py
@@ -25,7 +25,7 @@ def test_transient_jax_config():
     """
     jax.config.update("jax_dynamic_shapes", False)
 
-    with transient_jax_config():
+    with transient_jax_config({"jax_dynamic_shapes": True}):
         assert jax.config.jax_dynamic_shapes is True  # type: ignore
 
     assert jax.config.jax_dynamic_shapes is False  # type: ignore


### PR DESCRIPTION
**Context:** `catalyst.accelerate` should be able to `jax.jit` a function of type `jax.Partial`. This pattern comes from using `catalyst.accelerate` with `jax.jvp` returning a `jax.Partial`.

**Description of the Change:** [`jax.Partial`](https://jax.readthedocs.io/en/latest/_autosummary/jax.tree_util.Partial.html) is JAX's pytree compatible re-implementation of [Python's `partial`](https://docs.python.org/3/library/functools.html#functools.partial). As a recap

> Return a new [partial object](https://docs.python.org/3/library/functools.html#partial-objects) which when called will behave like func called with the positional arguments args and keyword arguments keywords.

Using `tree_flatten(partial)` will return a list of tree nodes and a shape, just like any call to `tree_flatten`. Calling `tree_unflatten(shape, data)` will reconstruct `jax.Partial`. This means that during tracing, `tree_flatten(partial)` will unflatten to a list of tracers and a shape. We can construct a total function by passing the parameters that would normally be embedded in the Partial.

```python
def total(context, *args, **kwargs): # This is the expected signature at runtime.
  _traced_context, shape = tree_flatten(partial)
  new_partial = tree_unflatten(context, shape)
  return new_partial(*args, **kwargs)
```

Now this `total` function is what is `jax.jit`ed.

**Benefits:** Support for the pattern in #852

**Possible Drawbacks:** We can generalize this even more as `jax.Partial` can be an argument to a callback. However, we leave that as future work.

**Related GitHub Issues:**  Closes #852 

This should also be cherry-picked to main.