### PR TITLE
Make Autograph ``get_item`` handle list with jax index

### DIFF
--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -591,7 +591,7 @@ def get_item(target, i, opts):
     else:
         try:
             return jnp.array(target)[i]
-        except Exception as e:
+        except TypeError as e:
             print(str(target) + " cannot be converted into jax type.", e)
             return target[i]
 

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -578,11 +578,12 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
 
 def get_item(target, i, opts):
     """If target is not a jax array, TracerIntegerConversionError might be raised. To avoid
-    index a non-jax array with jax index, we convert it into jax array first. """
+    index a non-jax array with jax index, we convert it into jax array first."""
     if isinstance(target, DynamicJaxprTracer):
         return target[i]
     else:
         return jnp.array(target)[i]
+
 
 def set_item(target, i, x):
     """An implementation of the AutoGraph 'set_item' function. The interface is defined by

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -47,6 +47,7 @@ __all__ = [
     "or_",
     "not_",
     "set_item",
+    "get_item",
 ]
 
 
@@ -574,6 +575,14 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
 
         return ag_converted_call(fn, args, kwargs, caller_fn_scope, options)
 
+
+def get_item(target, i, opts):
+    """If target is not a jax array, TracerIntegerConversionError might be raised. To avoid
+    index a non-jax array with jax index, we convert it into jax array first. """
+    if isinstance(target, DynamicJaxprTracer):
+        return target[i]
+    else:
+        return jnp.array(target)[i]
 
 def set_item(target, i, x):
     """An implementation of the AutoGraph 'set_item' function. The interface is defined by

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -581,11 +581,15 @@ def get_item(target, i, opts):
     """If target is not a jax array, TracerIntegerConversionError might be raised. To avoid
     index a non-jax array with jax index, we convert it into jax array first."""
     assert isinstance(opts, GetItemOpts)
-
+    print(target)
     if isinstance(target, DynamicJaxprTracer):
         return target[i]
     else:
-        return jnp.array(target)[i]
+        try:
+            return jnp.array(target)[i]
+        except Exception as e:
+            print(str(target) + " cannot be converted into jax type.", e)
+            return target[i]
 
 
 def set_item(target, i, x):

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -28,6 +28,7 @@ from malt.core import config as ag_config
 from malt.impl import api as ag_api
 from malt.impl.api import converted_call as ag_converted_call
 from malt.operators import py_builtins as ag_py_builtins
+from malt.operators.slices import GetItemOpts
 from malt.operators.variables import Undefined
 from malt.pyct.origin_info import LineLocation
 from pennylane.queuing import AnnotatedQueue
@@ -579,6 +580,8 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
 def get_item(target, i, opts):
     """If target is not a jax array, TracerIntegerConversionError might be raised. To avoid
     index a non-jax array with jax index, we convert it into jax array first."""
+    assert isinstance(opts, GetItemOpts)
+
     if isinstance(target, DynamicJaxprTracer):
         return target[i]
     else:

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -581,8 +581,12 @@ def get_item(target, i, opts):
     """If target is not a jax array, TracerIntegerConversionError might be raised. To avoid
     index a non-jax array with jax index, we convert it into jax array first."""
     assert isinstance(opts, GetItemOpts)
-    print(target)
-    if isinstance(target, DynamicJaxprTracer):
+
+    if (
+        isinstance(target, DynamicJaxprTracer)
+        or isinstance(target, tuple)
+        and all(isinstance(item, DynamicJaxprTracer) for item in target)
+    ):
         return target[i]
     else:
         try:

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -15,6 +15,7 @@
 """PyTests for the AutoGraph source-to-source transformation feature."""
 
 import traceback
+import warnings
 from collections import defaultdict
 
 import jax
@@ -1882,6 +1883,21 @@ class TestJaxIndexAssignment:
             jnp.array(zero_last_element_python_array([5, 3, 4])), jnp.array([5, 3, 0])
         )
 
+    def test_dynamic_index_from_range(self):
+        """If UserWarning related to __index__ is raised."""
+
+        n = 2
+        wires = range(n)
+
+        with warnings.catch_warnings(record=True) as w:
+            @qjit(autograph=True)
+            @qml.qnode(qml.device("lightning.qubit", wires=n))
+            def circuit():
+                for i in range(n):
+                    qml.Hadamard(wires=wires[i])
+                return qml.expval(qml.PauliZ(wires=wires[1]))
+
+            assert(len(w) == 0)
 
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -1883,13 +1883,14 @@ class TestJaxIndexAssignment:
             jnp.array(zero_last_element_python_array([5, 3, 4])), jnp.array([5, 3, 0])
         )
 
-    def test_dynamic_index_from_range(self):
+    def test_dynamic_index_with_range(self):
         """If UserWarning related to __index__ is raised."""
 
         n = 2
         wires = range(n)
 
         with warnings.catch_warnings(record=True) as w:
+
             @qjit(autograph=True)
             @qml.qnode(qml.device("lightning.qubit", wires=n))
             def circuit():
@@ -1897,7 +1898,8 @@ class TestJaxIndexAssignment:
                     qml.Hadamard(wires=wires[i])
                 return qml.expval(qml.PauliZ(wires=wires[1]))
 
-            assert(len(w) == 0)
+            assert len(w) == 0
+
 
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -834,10 +834,9 @@ class TestForLoops:
                 qml.RY(params[i], wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        with pytest.warns(
-            match=r"TracerIntegerConversionError:    The __index__\(\) method was called"
-        ):
+        with pytest.warns(None) as record:
             qjit(autograph=True)(f)
+            assert len(record) == 0
 
     # This case is slightly problematic because there is no way for the user to compile this for
     # loop correctly. Fallback to a Python loop is always necessary, and will result in a warning.
@@ -901,11 +900,9 @@ class TestForLoops:
                 qml.RY(params[i], wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        with pytest.warns(
-            match=r"TracerIntegerConversionError:    The __index__\(\) method was called"
-        ):
-            with pytest.raises(jax.errors.TracerIntegerConversionError, match="__index__"):
-                qjit(autograph=True)(f)
+        with pytest.warns(None) as record:
+            qjit(autograph=True)(f)
+            assert len(record) == 0
 
     # This use case is never possible, regardless of whether AutoGraph is used or not.
     def test_for_in_dynamic_range_indexing_object_list(self):

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -1244,6 +1244,23 @@ class TestForLoops:
 
         assert f() == 9
 
+    def test_dynamic_index_with_range(self):
+        """If UserWarning related to __index__ is raised."""
+
+        n = 2
+        wires = range(n)
+
+        with warnings.catch_warnings(record=True) as w:
+
+            @qjit(autograph=True)
+            @qml.qnode(qml.device("lightning.qubit", wires=n))
+            def circuit():
+                for i in range(n):
+                    qml.Hadamard(wires=wires[i])
+                return qml.expval(qml.PauliZ(wires=wires[1]))
+
+            assert len(w) == 0
+
 
 class TestWhileLoops:
     """Test that the autograph transformations produce correct results on while loops."""
@@ -1882,23 +1899,6 @@ class TestJaxIndexAssignment:
         assert jnp.allclose(
             jnp.array(zero_last_element_python_array([5, 3, 4])), jnp.array([5, 3, 0])
         )
-
-    def test_dynamic_index_with_range(self):
-        """If UserWarning related to __index__ is raised."""
-
-        n = 2
-        wires = range(n)
-
-        with warnings.catch_warnings(record=True) as w:
-
-            @qjit(autograph=True)
-            @qml.qnode(qml.device("lightning.qubit", wires=n))
-            def circuit():
-                for i in range(n):
-                    qml.Hadamard(wires=wires[i])
-                return qml.expval(qml.PauliZ(wires=wires[1]))
-
-            assert len(w) == 0
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -834,9 +834,9 @@ class TestForLoops:
                 qml.RY(params[i], wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as w:
             qjit(autograph=True)(f)
-            assert len(record) == 0
+            assert len(w) == 0
 
     # This case is slightly problematic because there is no way for the user to compile this for
     # loop correctly. Fallback to a Python loop is always necessary, and will result in a warning.
@@ -900,9 +900,9 @@ class TestForLoops:
                 qml.RY(params[i], wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings(record=True) as w:
             qjit(autograph=True)(f)
-            assert len(record) == 0
+            assert len(w) == 0
 
     # This use case is never possible, regardless of whether AutoGraph is used or not.
     def test_for_in_dynamic_range_indexing_object_list(self):


### PR DESCRIPTION
**Context:**
Autograph passes jax index to list or range and raises the following error. 
```
UserWarning: Tracing of an AutoGraph converted for loop failed with an exception: TracerIntegerConversionError:  The __index__() method was called on traced array with shape int64[].
``` 
To fix this, we introduces a conversion in ``get_item`` in Autograph to convert list or range into a jax numpy array.

**Related GitHub Issues:**
[sc-67797]