### PR TITLE
Bump Catalyst RC version from 0.6 to 0.7

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -39,7 +39,7 @@ jobs:
         git checkout $(git tag | sort -V | tail -1)
     - if: ${{ inputs.catalyst == 'release-candidate' }}
       run: |
-        git checkout v0.6.0-rc
+        git checkout v0.7.0-rc
 
     - name: Install deps
       run: |


### PR DESCRIPTION
**Context:** GitHub action must point to the latest Catalyst RC branch.

**Description of the Change:** Change RC branch from 0.6 to 0.7.