### PR TITLE
Pin OQC client to version less than 3.6.0

### DIFF
--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -400,6 +400,7 @@ jobs:
         python${{ matrix.python_version }} -m pip install PennyLane-Lightning-Kokkos
         python${{ matrix.python_version }} -m pip install 'amazon-braket-pennylane-plugin>1.27.1'
 
+    # OQC Client versions 3.6.0 and above have a dependecy error
     - name: Install OQC client
       if: ${{ matrix.python_version == '3.9' || matrix.python_version == '3.10'}}
       run: |

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -403,7 +403,7 @@ jobs:
     - name: Install OQC client
       if: ${{ matrix.python_version == '3.9' || matrix.python_version == '3.10'}}
       run: |
-        python${{ matrix.python_version }} -m pip install oqc-qcaas-client
+        python${{ matrix.python_version }} -m pip install 'oqc-qcaas-client<3.6.0'
 
     - name: Install Catalyst
       run: |

--- a/frontend/catalyst/third_party/oqc/oqc_device.py
+++ b/frontend/catalyst/third_party/oqc/oqc_device.py
@@ -33,7 +33,9 @@ BACKENDS = ["lucy", "toshiko"]
 
 class OQCDevice(Device):
     """The OQC device allows to access the hardware devices from OQC using
-    Catalyst."""
+    Catalyst.
+    At the moment, OQC Client versions 3.6.0 and above have a dependecy error. 
+    Install version 3.5.0 instead."""
 
     config = get_lib_path("oqc_runtime", "OQC_LIB_DIR") + "/backend" + "/oqc.toml"
 


### PR DESCRIPTION
**Context:** From OQC client 3.6.0 and up, qutip is pinned to version 4.6.3, which introduces a dependency error.

**Description of the Change:** Pin OQC client to a version less than 3.6.0.

**Benefits:** The dependency error dissapears.

**Possible Drawbacks:** We might need to unpin it in the future.
