### PR TITLE
[Frontend] Cast returned numpy arrays to jax.Array

### DIFF
--- a/frontend/catalyst/compiled_functions.py
+++ b/frontend/catalyst/compiled_functions.py
@@ -19,6 +19,7 @@ import logging
 from dataclasses import dataclass
 from typing import Tuple
 
+import jax.numpy as jnp
 import numpy as np
 from jax.interpreters import mlir
 from jax.tree_util import PyTreeDef, tree_flatten, tree_unflatten
@@ -167,6 +168,8 @@ class CompiledFunction:
         if out_type is not None:
             keep_outputs = [k for _, k in out_type]
             retval = [r for (k, r) in zip(keep_outputs, retval) if k]
+
+        retval = [jnp.asarray(arr) for arr in retval]
         return retval
 
     @staticmethod

--- a/frontend/test/pytest/test_buffer_args.py
+++ b/frontend/test/pytest/test_buffer_args.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import jax
 import jax.numpy as jnp
 import pennylane as qml
 import pytest
@@ -105,6 +106,15 @@ class TestReturnValues:
             return jnp.array(0, dtype=dtype)
 
         assert jnp.allclose(return_scalar(), complex(0, 0))
+
+    def test_returns_jax_array(self):
+        """Tests that the return value is a jax array"""
+
+        @qjit
+        def identity(x):
+            return x
+
+        assert isinstance(identity(1.0), jax.Array)
 
     @pytest.mark.parametrize("dtype", [(jnp.float16)])
     def test_types_which_are_unhandled(self, dtype):


### PR DESCRIPTION
**Context:** We should return `jax.Array`'s instead of `numpy.array`'s

**Description of the Change:** Call `jax.numpy.asarray()` before returning

**Benefits:** meets user expectations.

**Possible Drawbacks:**

**Related GitHub Issues:**
