### PR TITLE
Rename inactive_callback to __catalyst_inactive_callback

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -12,7 +12,7 @@
 
 <h3>Internal changes</h3>
 
-* The function `inactive_callback` was renamed `__catalyst_inactive_callaback`.
+* The function `inactive_callback` was renamed `__catalyst_inactive_callback`.
   [(#899)](https://github.com/PennyLaneAI/catalyst/pull/899)
 
 <h3>Contributors</h3>

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -12,10 +12,14 @@
 
 <h3>Internal changes</h3>
 
+* The function `inactive_callback` was renamed `__catalyst_inactive_callaback`.
+  [(#899)](https://github.com/PennyLaneAI/catalyst/pull/899)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
+Romain Moyard,
 Erick Ochoa,
 
 # Release 0.7.0

--- a/mlir/include/Catalyst/Transforms/Passes.td
+++ b/mlir/include/Catalyst/Transforms/Passes.td
@@ -132,7 +132,7 @@ def GEPInboundsPass : Pass<"gep-inbounds"> {
 }
 
 def RegisterInactiveCallbackPass : Pass<"register-inactive-callback", "ModuleOp"> {
-    let summary = "Register `inactive_callback` as inactive with Enzyme";
+    let summary = "Register `__catalyst_inactive_callback` as inactive with Enzyme";
 
     let dependentDialects = [
         "mlir::LLVM::LLVMDialect"

--- a/mlir/lib/Catalyst/Transforms/RegisterInactiveCallbackPass.cpp
+++ b/mlir/lib/Catalyst/Transforms/RegisterInactiveCallbackPass.cpp
@@ -33,7 +33,7 @@ struct RegisterInactiveCallbackPass
     void runOnOperation() final
     {
         auto mod = getOperation();
-        StringRef inactive_callbackFnName = "inactive_callback";
+        StringRef inactive_callbackFnName = "__catalyst_inactive_callback";
         auto fnDecl = mod.lookupSymbol<LLVM::LLVMFuncOp>(inactive_callbackFnName);
         if (!fnDecl) {
             return;

--- a/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
@@ -458,9 +458,9 @@ struct DefineCallbackOpPattern : public OpConversionPattern<CallbackOp> {
         bool isVarArg = true;
         ModuleOp mod = op->getParentOfType<ModuleOp>();
         auto typeConverter = getTypeConverter();
-        LLVM::LLVMFuncOp customCallFnOp =
-            mlir::LLVM::lookupOrCreateFn(mod, "__catalyst_inactive_callback", {/*args=*/i64, i64, i64},
-                                         /*ret_type=*/voidType, isVarArg);
+        LLVM::LLVMFuncOp customCallFnOp = mlir::LLVM::lookupOrCreateFn(
+            mod, "__catalyst_inactive_callback", {/*args=*/i64, i64, i64},
+            /*ret_type=*/voidType, isVarArg);
 
         // TODO: remove redundant alloca+store since ultimately we'll receive struct*
         for (auto arg : op.getArguments()) {

--- a/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
@@ -459,7 +459,7 @@ struct DefineCallbackOpPattern : public OpConversionPattern<CallbackOp> {
         ModuleOp mod = op->getParentOfType<ModuleOp>();
         auto typeConverter = getTypeConverter();
         LLVM::LLVMFuncOp customCallFnOp =
-            mlir::LLVM::lookupOrCreateFn(mod, "inactive_callback", {/*args=*/i64, i64, i64},
+            mlir::LLVM::lookupOrCreateFn(mod, "__catalyst_inactive_callback", {/*args=*/i64, i64, i64},
                                          /*ret_type=*/voidType, isVarArg);
 
         // TODO: remove redundant alloca+store since ultimately we'll receive struct*

--- a/mlir/test/Catalyst/ConversionTest.mlir
+++ b/mlir/test/Catalyst/ConversionTest.mlir
@@ -125,7 +125,7 @@ module @test0 {
   // CHECK-DAG: [[argc:%.+]] = llvm.mlir.constant(2
   // CHECK-DAG: [[resc:%.+]] = llvm.mlir.constant(3
 
-  // CHECK: llvm.call @inactive_callback([[id]], [[argc]], [[resc]]
+  // CHECK: llvm.call @__catalyst_inactive_callback([[id]], [[argc]], [[resc]]
   catalyst.callback @callback_4(memref<f64>, memref<f64>) attributes {argc = 2 : i64, id = 4 : i64, resc = 3 : i64}
 }
 

--- a/mlir/test/Catalyst/RegisterInactive.mlir
+++ b/mlir/test/Catalyst/RegisterInactive.mlir
@@ -42,15 +42,15 @@ module @test1 {
 
   // CHECK: llvm.mlir.global external @__enzyme_inactivefn
   // CHECK: [[undef:%.+]] = llvm.mlir.undef
-  // CHECK: [[ptr:%.+]] = llvm.mlir.addressof @inactive_callback
+  // CHECK: [[ptr:%.+]] = llvm.mlir.addressof @__catalyst_inactive_callback
   // CHECK: [[retval:%.+]] = llvm.insertvalue [[ptr]], [[undef]][0]
   // CHECK: llvm.return [[retval]]
 
-  llvm.func @inactive_callback(i64, i64, i64, ...)
+  llvm.func @__catalyst_inactive_callback(i64, i64, i64, ...)
   llvm.func @wrapper() {
     %0 = llvm.mlir.constant(139935726668624 : i64) : i64
     %1 = llvm.mlir.constant(0 : i64) : i64
-    llvm.call @inactive_callback(%0, %1, %1) vararg(!llvm.func<void (i64, i64, i64, ...)>) : (i64, i64, i64) -> ()
+    llvm.call @__catalyst_inactive_callback(%0, %1, %1) vararg(!llvm.func<void (i64, i64, i64, ...)>) : (i64, i64, i64) -> ()
     llvm.return
   }
 }

--- a/runtime/lib/capi/ExecutionContext.hpp
+++ b/runtime/lib/capi/ExecutionContext.hpp
@@ -33,7 +33,7 @@ extern void callbackCall(int64_t, int64_t, int64_t, va_list);
 
 namespace Catalyst::Runtime {
 
-extern "C" void inactive_callback(int64_t identifier, int64_t argc, int64_t retc, ...);
+extern "C" void __catalyst_inactive_callback(int64_t identifier, int64_t argc, int64_t retc, ...);
 
 class MemoryManager final {
   private:

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -108,7 +108,7 @@ extern "C" {
 using namespace Catalyst::Runtime;
 using timer = catalyst::utils::Timer;
 
-void inactive_callback(int64_t identifier, int64_t argc, int64_t retc, ...)
+void __catalyst_inactive_callback(int64_t identifier, int64_t argc, int64_t retc, ...)
 {
     // We need to guard calls to callback.
     // These are implemented in Python.


### PR DESCRIPTION
**Context:**
Currently Catalyst does not pass frontend test with newest version of Enzyme.
**Description of the Change:**
Rename this function in order to add it to Enzyme list of no free.
