### PR TITLE
Fix missing transfroms caused by Autograph

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -9,7 +9,7 @@
   [(#895)](https://github.com/PennyLaneAI/catalyst/pull/895)
 
 <h3>Bug fixes</h3>
-* Make `autograph` copy `QNode` instead of creating new one from scratch to preserve information such as transforms and `mcm_method`. [(#900)](https://github.com/PennyLaneAI/catalyst/pull/900)
+* Make Autograph copy `QNode` instead of creating new one from scratch to preserve information such as transforms and `mcm_method`. [(#900)](https://github.com/PennyLaneAI/catalyst/pull/900)
 
 <h3>Internal changes</h3>
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -9,6 +9,7 @@
   [(#895)](https://github.com/PennyLaneAI/catalyst/pull/895)
 
 <h3>Bug fixes</h3>
+* Make `autograph` copy `QNode` instead of creating new one from scratch to preserve information such as transforms and `mcm_method`. [(#900)](https://github.com/PennyLaneAI/catalyst/pull/900)
 
 <h3>Internal changes</h3>
 
@@ -17,6 +18,7 @@
 This release contains contributions from (in alphabetical order):
 
 Erick Ochoa,
+Tzung-Han Juang,
 
 # Release 0.7.0
 

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -571,7 +571,7 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
 
             new_qnode = qml.QNode(qnode_call_wrapper, device=fn.device, diff_method=fn.diff_method)
 
-            for program in fn.transform_program._transform_program:
+            for program in fn._transform_program:
                 new_qnode.add_transform(program)
             return new_qnode()
 

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -31,7 +31,6 @@ from malt.operators import py_builtins as ag_py_builtins
 from malt.operators.variables import Undefined
 from malt.pyct.origin_info import LineLocation
 from pennylane.queuing import AnnotatedQueue
-from pennylane.transforms.core.transform_dispatcher import TransformContainer
 
 import catalyst
 from catalyst.jax_extras import DynamicJaxprTracer, ShapedArray
@@ -572,8 +571,8 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
 
             new_qnode = qml.QNode(qnode_call_wrapper, device=fn.device, diff_method=fn.diff_method)
 
-            if len(fn.transform_program._transform_program) > 0:
-                new_qnode.add_transform(fn.transform_program._transform_program[0])
+            for program in fn.transform_program._transform_program:
+                new_qnode.add_transform(program)
             return new_qnode()
 
         return ag_converted_call(fn, args, kwargs, caller_fn_scope, options)

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -569,7 +569,7 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
             def qnode_call_wrapper():
                 return ag_converted_call(fn.func, args, kwargs, caller_fn_scope, options)
 
-            new_qnode = qml.QNode(qnode_call_wrapper, device=fn.device, diff_method=fn.diff_method)
+            new_qnode = qml.QNode(qnode_call_wrapper, device=fn.device, diff_method=fn.diff_method, transform_program=fn.transform_program)
             return new_qnode()
 
         return ag_converted_call(fn, args, kwargs, caller_fn_scope, options)

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -31,6 +31,7 @@ from malt.operators import py_builtins as ag_py_builtins
 from malt.operators.variables import Undefined
 from malt.pyct.origin_info import LineLocation
 from pennylane.queuing import AnnotatedQueue
+from pennylane.transforms.core.transform_dispatcher import TransformContainer
 
 import catalyst
 from catalyst.jax_extras import DynamicJaxprTracer, ShapedArray
@@ -569,7 +570,10 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
             def qnode_call_wrapper():
                 return ag_converted_call(fn.func, args, kwargs, caller_fn_scope, options)
 
-            new_qnode = qml.QNode(qnode_call_wrapper, device=fn.device, diff_method=fn.diff_method, transform_program=fn.transform_program)
+            new_qnode = qml.QNode(qnode_call_wrapper, device=fn.device, diff_method=fn.diff_method)
+
+            if len(fn.transform_program._transform_program) > 0:
+                new_qnode.add_transform(fn.transform_program._transform_program[0])
             return new_qnode()
 
         return ag_converted_call(fn, args, kwargs, caller_fn_scope, options)

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -569,10 +569,9 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
             def qnode_call_wrapper():
                 return ag_converted_call(fn.func, args, kwargs, caller_fn_scope, options)
 
-            new_qnode = qml.QNode(qnode_call_wrapper, device=fn.device, diff_method=fn.diff_method)
-
-            for program in fn._transform_program:  # pylint: disable=protected-access
-                new_qnode.add_transform(program)
+            # Copy the original qnode but replace its function.
+            new_qnode = fn.__copy__()
+            new_qnode.func = qnode_call_wrapper
             return new_qnode()
 
         return ag_converted_call(fn, args, kwargs, caller_fn_scope, options)

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -571,7 +571,7 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
 
             new_qnode = qml.QNode(qnode_call_wrapper, device=fn.device, diff_method=fn.diff_method)
 
-            for program in fn._transform_program:
+            for program in fn._transform_program:  # pylint: disable=protected-access
                 new_qnode.add_transform(program)
             return new_qnode()
 

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -16,7 +16,7 @@
 This module provides the implementation of AutoGraph primitives in terms of traceable Catalyst
 functions. The purpose is to convert imperative style code to functional or graph-style code.
 """
-
+import copy
 import functools
 import warnings
 from typing import Any, Callable, Iterator, SupportsIndex, Tuple, Union
@@ -570,7 +570,7 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
                 return ag_converted_call(fn.func, args, kwargs, caller_fn_scope, options)
 
             # Copy the original qnode but replace its function.
-            new_qnode = fn.__copy__()
+            new_qnode = copy.copy(fn)
             new_qnode.func = qnode_call_wrapper
             return new_qnode()
 

--- a/frontend/catalyst/autograph/transformer.py
+++ b/frontend/catalyst/autograph/transformer.py
@@ -63,6 +63,10 @@ class CatalystTransformer(PyToPy):
         if isinstance(obj, qml.QNode):
             new_obj = qml.QNode(new_fn, device=obj.device, diff_method=obj.diff_method)
 
+        # Pass mcm_config and the other arguments to new function.
+        if hasattr(obj, "execute_kwargs"):
+            new_obj.execute_kwargs = obj.execute_kwargs
+
         return new_obj, module, source_map
 
     def get_extra_locals(self):
@@ -121,10 +125,6 @@ def run_autograph(fn):
     new_fn.ag_module = module
     new_fn.ag_source_map = source_map
     new_fn.ag_unconverted = fn
-
-    # Pass mcm_config and the other arguments to new function.
-    if hasattr(fn, "execute_kwargs"):
-        new_fn.execute_kwargs = fn.execute_kwargs
 
     return new_fn
 

--- a/frontend/catalyst/autograph/transformer.py
+++ b/frontend/catalyst/autograph/transformer.py
@@ -20,7 +20,7 @@ Here, we integrate AutoGraph into Catalyst to improve the UX and allow programme
 Python control flow and other imperative expressions rather than the functional equivalents provided
 by Catalyst.
 """
-
+import copy
 import inspect
 from contextlib import ContextDecorator
 
@@ -61,11 +61,8 @@ class CatalystTransformer(PyToPy):
         new_obj = new_fn
 
         if isinstance(obj, qml.QNode):
-            new_obj = qml.QNode(new_fn, device=obj.device, diff_method=obj.diff_method)
-
-        # Pass mcm_config and the other arguments to new function.
-        if hasattr(obj, "execute_kwargs"):
-            new_obj.execute_kwargs = obj.execute_kwargs
+            new_obj = copy.copy(obj)
+            new_obj.func = new_fn
 
         return new_obj, module, source_map
 

--- a/frontend/catalyst/autograph/transformer.py
+++ b/frontend/catalyst/autograph/transformer.py
@@ -122,6 +122,7 @@ def run_autograph(fn):
     new_fn.ag_source_map = source_map
     new_fn.ag_unconverted = fn
 
+    # Pass mcm_config and the other arguments to new function.
     if hasattr(fn, "execute_kwargs"):
         new_fn.execute_kwargs = fn.execute_kwargs
 

--- a/frontend/catalyst/autograph/transformer.py
+++ b/frontend/catalyst/autograph/transformer.py
@@ -122,6 +122,9 @@ def run_autograph(fn):
     new_fn.ag_source_map = source_map
     new_fn.ag_unconverted = fn
 
+    if hasattr(fn, "execute_kwargs"):
+        new_fn.execute_kwargs = fn.execute_kwargs
+
     return new_fn
 
 

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -396,6 +396,29 @@ class TestIntegration:
         assert np.allclose(fn(3)[0], tuple([jnp.array(6.0), jnp.array(9.0)]))
         assert np.allclose(fn(3)[1], tuple([jnp.array(2.0), jnp.array(6.0)]))
 
+    def test_tape_transform(self):
+        """Test if tape transform is applied when autograph is on."""
+
+        dev = dev = qml.device("lightning.qubit", wires=1)
+
+        @qml.transform
+        def my_quantum_transform(tape):
+            raise NotImplementedError
+
+        @qml.qjit(autograph=True)
+        def f(x):
+            @my_quantum_transform
+            @qml.qnode(dev)
+            def circuit(x):
+                qml.RY(x, wires=0)
+                qml.RX(x, wires=0)
+                return qml.expval(qml.PauliZ(0))
+
+            return circuit(x)
+
+        # with pytest.raises(NotImplementedError):
+        #    f(0.5)
+
 
 class TestCodePrinting:
     """Test that the transformed source code can be printed in different settings."""

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -420,7 +420,7 @@ class TestIntegration:
             f(0.5)
 
     def test_mcm_one_shot(self):
-        """Test if mcm one-shot miss transformation."""
+        """Test if mcm one-shot miss transforms."""
         dev = qml.device("lightning.qubit", wires=5, shots=20)
 
         @qml.qjit(autograph=True)
@@ -430,14 +430,8 @@ class TestIntegration:
             m_0 = measure(0, postselect=1)
             return qml.sample(wires=0)
 
-        @qml.qjit
-        @qml.qnode(dev, mcm_method="one-shot", postselect_mode="hw-like")
-        def func_no_autograph(x):
-            qml.RX(x, wires=0)
-            m_0 = measure(0, postselect=1)
-            return qml.sample(wires=0)
-
-        assert func(0.9) == func_no_autograph(0.9)
+        # If transforms are missed, the output will be all ones.
+        assert not np.all(func(0.9) == 1)
 
 
 class TestCodePrinting:

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -427,7 +427,7 @@ class TestIntegration:
         @qml.qnode(dev, mcm_method="one-shot", postselect_mode="hw-like")
         def func(x):
             qml.RX(x, wires=0)
-            m_0 = measure(0, postselect=1)
+            measure(0, postselect=1)
             return qml.sample(wires=0)
 
         # If transforms are missed, the output will be all ones.

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -416,8 +416,21 @@ class TestIntegration:
 
             return circuit(x)
 
-        # with pytest.raises(NotImplementedError):
-        #    f(0.5)
+        with pytest.raises(NotImplementedError):
+            f(0.5)
+
+    def test_mcm_one_shot(self):
+        "Test if mcm one-shot miss transformation."
+        dev = qml.device("lightning.qubit", wires=5, shots=20)
+
+        @qml.qjit(autograph=True)
+        @qml.qnode(dev, mcm_method="one-shot", postselect_mode="hw-like")
+        def func(x):
+            qml.RX(x, wires=0)
+            m_0 = measure(0, postselect=1)
+            return qml.sample(wires=0)
+
+        print(func(0.9))
 
 
 class TestCodePrinting:

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -420,7 +420,7 @@ class TestIntegration:
             f(0.5)
 
     def test_mcm_one_shot(self):
-        "Test if mcm one-shot miss transformation."
+        """Test if mcm one-shot miss transformation."""
         dev = qml.device("lightning.qubit", wires=5, shots=20)
 
         @qml.qjit(autograph=True)
@@ -430,7 +430,14 @@ class TestIntegration:
             m_0 = measure(0, postselect=1)
             return qml.sample(wires=0)
 
-        print(func(0.9))
+        @qml.qjit
+        @qml.qnode(dev, mcm_method="one-shot", postselect_mode="hw-like")
+        def func_no_autograph(x):
+            qml.RX(x, wires=0)
+            m_0 = measure(0, postselect=1)
+            return qml.sample(wires=0)
+
+        assert func(0.9) == func_no_autograph(0.9)
 
 
 class TestCodePrinting:


### PR DESCRIPTION
**Context:**
This PR aims to fix missing transform issue when using autograph with custom transform or ``mcm_config`` flags.
The main reason is that Autograph tries to create new qnode but forget to include extra args.

**Description of the Change:**
Make sure `TransformContainer`s and `execute_kwargs` (which contains mcm_config) are passed to new qnode in `Autograph.transformer`.

**Possible Drawbacks:**
- ~~Maybe there are some other flags working like ``mcm_method``. We should do that same for them.~~
- ~~`TransformContainer`s are included in `QNode._transform_program`, which is a protected member (and fails formatting check). I have not yet found the other way to fetch them.~~

Fixed. Now we directly copy `QNode` so that the flags can be preserved.

**Related GitHub Issues:**
#434 
[sc-55080]
[[epic-65351](https://app.shortcut.com/xanaduai/epic/65351/p0-bug-enabling-autograph-respects-transforms-on-qjit-compiled-qnodes?group_by=none&vc_group_by=day&ct_workflow=all&cf_workflow=500000005)]