### PR TITLE
Added support for the jax.numpy.argsort 

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -4,6 +4,9 @@
 
 <h3>Improvements</h3>
 
+* Added support for the jax.numpy.argsort function so it works when compiled with qjit.
+  [(#901)](https://github.com/PennyLaneAI/catalyst/pull/901)
+
 <h3>Breaking changes</h3>
 
 <h3>Bug fixes</h3>
@@ -13,6 +16,8 @@
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
+
+Mehrdad Malekmohammadi
 
 # Release 0.7.0
 

--- a/doc/dev/sharp_bits.rst
+++ b/doc/dev/sharp_bits.rst
@@ -522,7 +522,6 @@ that doesn't work with Catalyst includes:
 
 - ``jax.numpy.polyfit``
 - ``jax.numpy.fft``
-- ``jax.numpy.argsort``
 - ``jax.debug``
 - ``jax.scipy.linalg.expm``
 - ``jax.numpy.ndarray.at[index]`` when ``index`` corresponds to all array

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -137,6 +137,7 @@ HLO_LOWERING_PASS = (
         "func.func(hlo-legalize-shapeops-to-standard)",
         "func.func(hlo-legalize-to-linalg)",
         "func.func(mhlo-legalize-to-std)",
+        "func.func(hlo-legalize-sort)",
         "convert-to-signless",
         "canonicalize",
         "scatter-lowering",

--- a/frontend/test/pytest/test_jax_numerical.py
+++ b/frontend/test/pytest/test_jax_numerical.py
@@ -71,5 +71,31 @@ class TestExpmInCircuit:
         assert np.allclose(res, expected)
 
 
+class TestArgsortNumerical:
+    """Test jax.numpy.argsort sort arrays correctly when being qjit compiled"""
+
+    @pytest.mark.parametrize(
+        "inp",
+        [
+            jnp.array([1.2, 0.1, 2.7, 0.6]),
+            jnp.array([-1.2, -0.1, -2.7, -0.6]),
+            jnp.array([[0.1, 0.2], [5.3, 1.2]]),
+            jnp.array([[1, 2], [-3, -4]]),
+            jnp.array([[1.0, -1.0, 1.0], [1.0, -1.0, -1.0]]),
+        ],
+    )
+    def test_expm_numerical(self, inp):
+        """jax.numpy.argsort sort arrays correctly when being qjit compiled"""
+
+        @qjit
+        def f(x):
+            return jnp.argsort(x)
+
+        observed = f(inp)
+        expected = jsp.argsort(inp)
+
+        assert np.allclose(observed, expected)
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_jax_numerical.py
+++ b/frontend/test/pytest/test_jax_numerical.py
@@ -92,7 +92,7 @@ class TestArgsortNumerical:
             return jnp.argsort(x)
 
         observed = f(inp)
-        expected = jsp.argsort(inp)
+        expected = jnp.argsort(inp)
 
         assert np.allclose(observed, expected)
 


### PR DESCRIPTION
**Context:**

- jax.numpy.argsort is currently not supported in Catalyst, therefore compiling a function with @qjit that includes argsort would result in an error, see issue #810

**Description of the Change:**

- Added hlo-legalize-sort to the HLO_LOWERING_PASS pipeline.

- Added a pytest to confirm the functionality of jax.numpy.argsort

- Removed jax.numpy.argsort from the unsopported jax functions

Fixes #810 