### PR TITLE
Split sharp bits documentation page into 3 pages

### DIFF
--- a/doc/dev/callbacks.rst
+++ b/doc/dev/callbacks.rst
@@ -1,0 +1,106 @@
+Callbacks and GPUs
+==================
+
+While Catalyst aims to support all classical processing functionality as provided by
+JAX, there are sometimes cases where you may need to perform a host callback to execute
+arbitrary Python-compatible code. This may include use-cases such as:
+
+- runtime debugging and logging,
+
+- executing classical subroutines on accelerators such as GPUs or TPUs, or
+
+- incorporating non-JAX compatible classical subroutines within a larger QJIT workflow.
+
+Catalyst supports all of these via a collection of callback functions.
+
+Overview
+--------
+
+Catalyst provides several callback functions:
+
+- :func:`~.debug.callback` supports callbacks of functions with **no** return values. This makes it
+  an easy entry point for debugging, for example via printing or logging at runtime.
+
+- :func:`~.pure_callback` supports callbacks of **pure** functions. That is, functions with no
+  side-effects that accept parameters and return values. However, the return type and shape of the
+  function must be known in advance, and is provided as a type signature.
+
+  Note that to use :func:`~.pure_callback` within functions that are being differentiated,
+  a custom VJP rule **must** be defined so that the Catalyst compiler knows how to
+  differentiate the callback. This can be done via the ``pure_callback.fwd`` and
+  ``pure_callback.bwd`` methods. See the :func:`~.pure_callback` documentation for
+  more details.
+
+- :func:`~.accelerate` is similar to :func:`~.pure_callback` above, but is designed to
+  work only with functions that are ``jax.jit`` compatible. As a result of this restriction,
+  return types do not have to be provided upfront, and support is provided for executing
+  these callbacks directly on classical accelerators such as GPUs and TPUs.
+
+In addition, :func:`~.catalyst.debug.print`, a convenient wrapper around the Python ``print`` function,
+is provided for runtime printing support.
+
+Callbacks to arbitrary Python
+-----------------------------
+
+When coming across functionality that is not yet supported by Catalyst, such as functions like
+``scipy.integrate.simpson``, Python callbacks can be used to call arbitrary Python code within
+a qjit-compiled function, as long as the return shape and type is known:
+
+.. code-block:: python
+
+    import scipy as sp
+
+    @pure_callback
+    def simpson(x, y) -> float:
+        return sp.integrate.simpson(y, x=x)
+
+    @qjit
+    def integrate_xsq(a, b):
+        x = jnp.linspace(a, b, 100)
+        return simpson(x, x ** 2)
+
+>>> integrate_xsq(-1, 1)
+array(0.66666667)
+>>> integrate_xsq(-1, 2)
+array(3.)
+
+Please see the docstring of :func:`~.pure_callback` for more details, including how to define
+vector-Jacobian product (VJP) rules for autodifferentiation, and for specifying the return-type
+of vector-valued functions.
+
+Callbacks to JIT-compatible code
+--------------------------------
+
+If a function is JIT-compatible, then :func:`~.accelerate` can be used, negating the need to manually
+provide return shape and dtype information:
+
+.. code-block:: python
+
+    @qjit
+    def fn(x):
+        x = jnp.sin(x)
+        y = catalyst.accelerate(jnp.fft.fft)(x)
+        return jnp.sum(y)
+
+>>> x = np.array([1.0, 2.0, 1.0, -1.0, 1.5])
+>>> fn(x)
+array(4.20735492+0.j)
+
+Accelerator (GPU and TPU) support
+---------------------------------
+
+:func:`~.accelerate` can also be used to execute classical subroutines on
+classical accelerators such as GPUs and TPUs:
+
+
+.. code-block:: python
+
+    @accelerate(dev=jax.devices("gpu")[0])
+    def classical_fn(x):
+        return jnp.sin(x) ** 2
+
+    @qjit
+    def hybrid_fn(x):
+        y = classical_fn(jnp.sqrt(x)) # will be executed on a GPU
+        return jnp.cos(y)
+

--- a/doc/dev/jax_integration.rst
+++ b/doc/dev/jax_integration.rst
@@ -1,0 +1,204 @@
+JAX integration
+===============
+
+Catalyst allows you to write hybrid quantum-classical functions in Python that are just-in-time
+compiled with the :func:`~.qjit` decorator, and ultimately leverages modern compilation tools to
+speed up quantum applications.
+
+To support this, the Catalyst frontend leverages PennyLane for representing quantum instructions,
+and utilizes JAX for classical processing and program capture, which means you are able to leverage
+the many functions accessible in ``jax`` and ``jax.numpy`` to write code that supports
+:func:`@qjit<~.qjit>` and dynamic variables.
+
+Here, we aim to provide an overview of the JAX integration, including the existing support
+and limitations.
+
+JAX 'sharp bits'
+----------------
+
+While leveraging ``jax.numpy`` makes it easy to port over NumPy-based
+PennyLane workflows to Catalyst, we also inherit `various restrictions
+and 'gotchas' from JAX
+<https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html>`__.
+This includes:
+
+* **Pure functions**: Compilation is primarily designed to only work on pure
+  functions. That is, functions that do not have any side-effects; the
+  output is purely dependent only on function inputs.
+
+* **Lack of stateful random number generators**: In JAX, random number
+  generators are stateless, and the key state must be explicitly updated each time you want to compute a random number. For more details, see the `JAX documentation <https://jax.readthedocs.io/en/latest/jax-101/05-random-numbers.html>`__.
+
+* **In-place array updates**: Rather than using in-place array updates, the
+  syntax ``new_array = jax_array.at[index].set(value)`` should be used. For
+  more details, see `jax.numpy.ndarray.at
+  <https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.ndarray.at.html>`__.
+
+  .. note::
+
+      Support is being added for automatically capturing native Python in-place array
+      update syntax, and automatically converting it to JAX-compatible syntax via our
+      :doc:`AutoGraph feature <autograph>`.
+
+For more details, please see the `JAX documentation
+<https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html>`__.
+
+JAX control flow
+----------------
+
+It is recommended to always use Catalyst control flow functions :func:`~.for_loop`, :func:`~.cond`,
+and :func:`~.while_loop` (or our experimental  :doc:`AutoGraph feature <autograph>`).
+
+However, JAX control flow functions, such as ``jax.lax.cond`` and ``jax.lax.fori_loop``, will work
+inside qjit-compiled functions **as long as they are not applied directly to quantum instructions**
+and only apply outside of QNodes:
+
+.. code-block:: python
+
+    dev = qml.device("lightning.qubit", wires=4, shots=10)
+
+    @qml.qnode(dev)
+    def circuit(j, x):
+
+        @catalyst.for_loop(0, x.shape[0], 1)
+        def loop_fn(i):
+            qml.RX(x[i], wires=i)
+
+        loop_fn()
+        return qml.expval(qml.PauliZ(0))
+
+    @qjit
+    def fn(x):
+        return jax.lax.fori_loop(0, 3, circuit, x)
+
+>>> fn(0.54)
+
+Function support
+----------------
+
+Currently, we are aiming to support as many JAX functions as possible, however
+there may be cases where there is missing coverage. Known JAX functionality
+that doesn't work with Catalyst includes:
+
+- ``jax.numpy.polyfit``
+- ``jax.numpy.fft``
+- ``jax.numpy.argsort``
+- ``jax.scipy.linalg``
+- ``jax.numpy.ndarray.at[index]`` when ``index`` corresponds to all array
+  indices.
+
+If you come across any other JAX functions that don't work with Catalyst
+(and don't already have a Catalyst equivalent), please let us know by opening
+a `GitHub issue <https://github.com/PennyLaneAI/catalyst/issues>`__.
+
+Note that there is certain JAX functionality we do not expect to or plan
+to support in Catalyst qjit-compiled functions. This includes:
+
+- ``jax.debug``. Please use instead the Catalyst provided :func:`~.print`, :func:`~.callback`,
+  and :func:`~.pure_callback` functions.
+
+- JAX device placement. Please use instead the :func:`~.accelerate` decorator.
+
+- Certain functions in the `jax.lax.debug module <https://jax.readthedocs.io/en/latest/jax.lax.html>`__
+  which are direct wrappers of XLA functionality with no LLVM/MLIR equivalent.
+
+Dynamically-shaped arrays
+-------------------------
+
+One common 'gotcha' of JAX jit-compiled functions is that they cannot create or return arrays with
+dynamic shape --- that is, arrays where their shape is determined by a dynamic variable at runtime.
+Typically, workarounds involve rewriting the code to utilize ``jnp.where`` where possible.
+
+In Catalyst, however, we have enabled support for dynamically-shaped arrays; qjit-compiled
+functions can accept, create, and return arrays of dynamic shape without triggering re-compilation:
+
+>>> @qjit
+... def func(size: int):
+...     print("Compiling")
+...     return jax.numpy.ones([size, size], dtype=float)
+>>> func(3)
+Compiling
+array([[1., 1., 1.],
+       [1., 1., 1.],
+       [1., 1., 1.]])
+>>> func(4)
+array([[1., 1., 1., 1.],
+       [1., 1., 1., 1.],
+       [1., 1., 1., 1.],
+       [1., 1., 1., 1.]])
+
+For more details, see :ref:`dynamic-arrays`.
+
+Calling JAX transforms on QJIT functions
+----------------------------------------
+
+Compiled functions remain JAX compatible, and you can call JAX transformations
+on them, such as ``jax.grad`` and ``jax.vmap``. You can even call ``jax.jit``
+on functions that call qjit-compiled functions:
+
+>>> dev = qml.device("lightning.qubit", wires=2)
+>>> @qjit
+... @qml.qnode(dev)
+... def circuit(x):
+...     qml.RX(x, wires=0)
+...     return qml.expval(qml.PauliZ(0))
+>>> @jax.jit
+... def workflow(y):
+...     return jax.grad(circuit)(jnp.sin(y))
+>>> workflow(0.6)
+Array(-0.53511382, dtype=float64, weak_type=True)
+
+However, a ``jax.jit`` function calling a ``qjit`` function will always result
+in a callback to Python, so will be slower than if the function was purely compiled
+using ``jax.jit`` or ``qjit``.
+
+If you want to compile some functionality that is not currently Catalyst
+compatible, or you want to make use of JAX-supported hardware such as TPUs
+for classical processing, mixing ``jax.jit`` and ``qjit`` will allow this.
+However, if possible, try to always use ``qjit`` to compile your entire
+workflow.
+
+
+Internal QJIT JAX transformations
+---------------------------------
+
+Inside of a qjit-compiled function, JAX transformations
+(``jax.grad``, ``jax.jacobian``, ``jax.vmap``, etc.)
+can be used **as long as they are not applied to quantum processing**.
+
+>>> @qjit
+... def f(x):
+...     def g(y):
+...         return -jnp.sin(y) ** 2
+...     return jax.grad(g)(x)
+>>> f(0.4)
+array(-0.71735609)
+
+If they are applied to quantum processing, an error will occur:
+
+>>> @qjit
+... def f(x):
+...     @qml.qnode(dev)
+...     def g(y):
+...         qml.RX(y, wires=0)
+...         return qml.expval(qml.PauliX(0))
+...     return jax.grad(lambda y: g(y) ** 2)(x)
+>>> f(0.4)
+NotImplementedError: must override
+
+Instead, only Catalyst transformations will work when applied to hybrid
+quantum-classical processing:
+
+>>> @qjit
+... def f(x):
+...     @qml.qnode(dev)
+...     def g(y):
+...         qml.RX(y, wires=0)
+...         return qml.expval(qml.PauliZ(0))
+...     return grad(lambda y: g(y) ** 2)(x)
+>>> f(0.4)
+array(-0.71735609)
+
+Always use the equivalent Catalyst transformation
+(:func:`catalyst.grad`, :func:`catalyst.jacobian`, :func:`catalyst.vjp`, :func:`catalyst.jvp`)
+inside of a qjit-compiled function.

--- a/doc/dev/sharp_bits.rst
+++ b/doc/dev/sharp_bits.rst
@@ -516,7 +516,7 @@ JAX functions and transforms
 
     For more details on JAX integrations and support, as well as details on
     'sharp bits' that we inherit from JAX, please see
-    :doc:`dev/jax_integration`.
+    :doc:`jax_integration`.
 
 Inside of a qjit-compiled function, JAX transformations
 (``jax.grad``, ``jax.jacobian``, ``jax.vmap``, etc.)

--- a/doc/dev/sharp_bits.rst
+++ b/doc/dev/sharp_bits.rst
@@ -509,133 +509,14 @@ The optimization now takes 574ms ± 43.1ms to complete when using 200 steps.
 Note that, to compute hybrid quantum-classical gradients within a qjit-compiled function,
 the :func:`catalyst.grad` function must be used.
 
-JAX support and restrictions
+JAX functions and transforms
 ----------------------------
 
-Catalyst utilizes JAX for program capture, which means you are able to
-leverage the many functions accessible in ``jax`` and ``jax.numpy`` to write
-code that supports :func:`@qjit <~.qjit>` and dynamic variables.
+.. note::
 
-Currently, we are aiming to support as many JAX functions as possible, however
-there may be cases where there is missing coverage. Known JAX functionality
-that doesn't work with Catalyst includes:
-
-- ``jax.numpy.polyfit``
-- ``jax.numpy.fft``
-- ``jax.numpy.argsort``
-- ``jax.debug``
-- ``jax.scipy.linalg.expm``
-- ``jax.numpy.ndarray.at[index]`` when ``index`` corresponds to all array
-  indices.
-
-If you come across any other JAX functions that don't work with Catalyst
-(and don't already have a Catalyst equivalent), please let us know by opening
-a `GitHub issue <https://github.com/PennyLaneAI/catalyst/issues>`__.
-
-While leveraging ``jax.numpy`` makes it easy to port over NumPy-based
-PennyLane workflows to Catalyst, we also inherit `various restrictions
-and 'gotchas' from JAX
-<https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html>`__.
-This includes:
-
-* **Pure functions**: Compilation is primarily designed to only work on pure
-  functions. That is, functions that do not have any side-effects; the
-  output is purely dependent only on function inputs.
-
-* **In-place array updates**: Rather than using in-place array updates, the
-  syntax ``new_array = jax_array.at[index].set(value)`` should be used. For
-  more details, see `jax.numpy.ndarray.at
-  <https://jax.readthedocs.io/en/latest/_autosummary /jax.numpy.ndarray.at.html>`__.
-
-* **Lack of stateful random number generators**: In JAX, random number
-  generators are stateless, and the key state must be explicitly updated each time you want to compute a random number. For more details, see the `JAX documentation <https://jax.readthedocs.io/en/latest/jax-101/05-random-numbers.html>`__.
-
-* **Dynamic-shaped arrays:** Functions that create or return arrays with
-  dynamic shape --- that is, arrays where their shape is determined by a
-  dynamic variable at runtime -- are currently not supported in JAX nor
-  Catalyst. Typically, workarounds involve rewriting the code to utilize
-  ``jnp.where`` where possible.
-
-For more details, please see the `JAX documentation
-<https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html>`__.
-
-Callbacks
----------
-
-When coming across functionality that is not yet supported by Catalyst, such as functions like
-``jax.scipy.linalg.expm``, Python callbacks can be used to call arbitrary Python code within
-a qjit-compiled function, as long as the return shape and type is known:
-
-.. code-block:: python
-
-    @qjit
-    def fn(x):
-
-        A = jnp.sin(x) * jnp.array([0.23, 0.2], [0.43, -0.54.])
-
-        @catalyst.pure_callback
-        @jax.jit # since the callback function is pure JAX, we can jit it
-        def callback_fn(A) -> jax.ShapeDtypeStruct(A.shape, A.dtype):
-            # here we call non-Catalyst compatible code
-            return jax.scipy.linalg.expm(A)
-
-        return jnp.cos(callback_fn(A))
-
->>> fn(0.654)
-array([[0.39385058, 0.99369752],
-       [0.97097762, 0.74283208]])
-
-Catalyst provides several callback functions:
-
-- :func:`~.pure_callback` supports callbacks of **pure** functions. That is, functions with no
-  side-effects that accept parameters and return values. However, the return type and shape of the
-  function must be known in advance, and is provided as a type signature.
-
-- :func:`~.accelerate` is similar to :func:`~.pure_callback` above, but is designed to
-  work only with functions that are ``jax.jit`` compatible. As a result of this restriction,
-  return types do not have to be provided upfront, and support is provided for executing
-  these callbacks directly on classical accelerators such as GPUs and TPUs.
-
-- :func:`~.debug.callback` supports callbacks of functions with **no** return values. This makes it
-  an easy entry point for debugging, for example via printing or logging at runtime.
-
-Note that to use :func:`~.pure_callback` within functions that are being differentiated,
-a custom VJP rule **must** be defined so that the Catalyst compiler knows how to
-differentiate the callback. This can be done via the ``pure_callback.fwd`` and
-``pure_callback.bwd`` methods. See the :func:`~.pure_callback` documentation for
-more details.
-
-JAX integration
----------------
-
-Compiled functions remain JAX compatible, and you can call JAX transformations
-on them, such as ``jax.grad`` and ``jax.vmap``. You can even call ``jax.jit``
-on functions that call qjit-compiled functions:
-
->>> dev = qml.device("lightning.qubit", wires=2)
->>> @qjit
-... @qml.qnode(dev)
-... def circuit(x):
-...     qml.RX(x, wires=0)
-...     return qml.expval(qml.PauliZ(0))
->>> @jax.jit
-... def workflow(y):
-...     return jax.grad(circuit)(jnp.sin(y))
->>> workflow(0.6)
-Array(-0.53511382, dtype=float64, weak_type=True)
-
-However, a ``jax.jit`` function calling a ``qjit`` function will always result
-in a callback to Python, so will be slower than if the function was purely compiled
-using ``jax.jit`` or ``qjit``.
-
-If you want to compile some functionality that is not currently Catalyst
-compatible, or you want to make use of JAX-supported hardware such as TPUs
-for classical processing, mixing ``jax.jit`` and ``qjit`` will allow this.
-However, if possible, try to always use ``qjit`` to compile your entire
-workflow.
-
-Internal QJIT transformations
------------------------------
+    For more details on JAX integrations and support, as well as details on
+    'sharp bits' that we inherit from JAX, please see
+    :doc:`dev/jax_integration`.
 
 Inside of a qjit-compiled function, JAX transformations
 (``jax.grad``, ``jax.jacobian``, ``jax.vmap``, etc.)
@@ -970,10 +851,15 @@ the decomposition as follows:
             return tape.operations
 
 
-Directly accessing QNode for PennyLane
---------------------------------------
+Directly accessing the QNode object
+-----------------------------------
 
-In cases where the :func:`@qjit <~.qjit>` decorator is directly applied to a QNode object, it can be useful to retrieve the wrapped entity when interacting with PennyLane functions. Note that the :func:`@qjit <~.qjit>` decorator changes the type of the wrapped object, for example from ``function`` to :class:`QJIT <~.QJIT>`, or in this case from ``QNode`` to :class:`QJIT <~.QJIT>`. The original entity is accessible via the ``.original_function`` attribute on the compiled function, and can be used as follows:
+In cases where the :func:`@qjit <~.qjit>` decorator is directly applied to a QNode object, it can be
+useful to retrieve the wrapped entity when interacting with PennyLane functions. Note that
+the :func:`@qjit <~.qjit>` decorator changes the type of the wrapped object, for example from
+``function`` to :class:`QJIT <~.QJIT>`, or in this case from ``QNode`` to :class:`QJIT <~.QJIT>`.
+The original entity is accessible via the ``.original_function`` attribute on the compiled
+function, and can be used as follows:
 
 .. code-block:: python
 
@@ -1092,6 +978,8 @@ array(0.2)
     re-compilation.
 
     The Catalyst ``@qjit`` decorator doesn't yet support this functionality.
+
+.. _dynamic-arrays:
 
 Dynamically-shaped arrays
 -------------------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -65,6 +65,8 @@ Catalyst
    dev/quick_start
    dev/autograph
    dev/sharp_bits
+   dev/jax_integration
+   dev/callbacks
    dev/release_notes
 
 .. toctree::


### PR DESCRIPTION
**Context:** The sharp bits documentation page is getting a little too long

**Description of the Change:**

The page has been split up into:

- Callbacks + GPUs
- Jax integration
- Sharp bits (everything else)

**Benefits:** Much easier to navigate and find what you're looking for. In particular, JAX integration and callbacks aren't really 'sharp bits', so don't really belong on that page.

**Possible Drawbacks:** n/a

**Related GitHub Issues:** n/a

[sc-60492] # Documentation for running callbacks on GPUs