### PR TITLE
Fixed a crash when using float32 in callbacks

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -23,7 +23,7 @@
 * Make Autograph copy `QNode` instead of creating new one from scratch to preserve information such as transforms and `mcm_method`. [(#900)](https://github.com/PennyLaneAI/catalyst/pull/900)
   
 * Using float32 in callback functions would not crash in compilation phase anymore,
-  but rather raise an assertion error.
+  but rather raise the appropriate type exception to the user.
   [(#916)]https://github.com/PennyLaneAI/catalyst/pull/916
 
 <h3>Internal changes</h3>

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -19,7 +19,12 @@
   [(#895)](https://github.com/PennyLaneAI/catalyst/pull/895)
 
 <h3>Bug fixes</h3>
+
 * Make Autograph copy `QNode` instead of creating new one from scratch to preserve information such as transforms and `mcm_method`. [(#900)](https://github.com/PennyLaneAI/catalyst/pull/900)
+  
+* Using float32 in callback functions would not crash in compilation phase anymore,
+  but rather raise an assertion error.
+  [(#916)]https://github.com/PennyLaneAI/catalyst/pull/916
 
 <h3>Internal changes</h3>
 

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -917,6 +917,63 @@ def test_scalar_in_array_out():
 
     # Array(0.4565774, dtype=float64)
 
+def test_scalar_in_array_out_float32_correct():
+    """Test scalar in array out"""
+
+    @pure_callback
+    def some_func(x) -> jax.ShapeDtypeStruct((2,), jnp.float32):
+        return np.array([np.sin(x), np.cos(x)], dtype=jnp.float32)
+
+    @some_func.fwd
+    def some_func_fwd(x):
+        return some_func(x), x
+
+    @some_func.bwd
+    def some_func_bws(res, dy):
+        x = res
+        return (jnp.array([jnp.cos(x), -jnp.sin(x)]) @ dy,)
+
+    @qml.qjit
+    @grad
+    def result(x):
+        return jnp.sum(some_func(jnp.sin(x)))
+
+    @jax.jit
+    @jax.grad
+    def expected(x):
+        x = jnp.sin(x)
+        return jnp.sin(x) + jnp.cos(x)
+
+    x = 0.435
+    assert np.allclose(result(x), expected(x))
+
+    # Array(0.4565774, dtype=float32)
+
+def test_scalar_in_array_out_float32_wrong():
+    """Test float32 support in pure callbacks"""
+
+    @pure_callback
+    def some_func(x) -> jax.ShapeDtypeStruct((2,), jnp.float32):
+        return np.array([np.sin(x), np.cos(x)])
+
+    @some_func.fwd
+    def some_func_fwd(x):
+        return some_func(x), x
+
+    @some_func.bwd
+    def some_func_bws(res, dy):
+        x = res
+        return (jnp.array([jnp.cos(x), -jnp.sin(x)]) @ dy,)
+
+    @qml.qjit
+    @grad
+    def result(x):
+        return jnp.sum(some_func(jnp.sin(x)))
+
+    x = 0.435
+    with pytest.raises(TypeError, match="Callback closure expected type"):
+        result(x)
+
 
 def test_scalar_in_tuple_scalar_array_out():
     """Test scalar in tuple scalar array out"""

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -918,7 +918,7 @@ def test_scalar_in_array_out():
     # Array(0.4565774, dtype=float64)
 
 def test_scalar_in_array_out_float32_correct():
-    """Test scalar in array out"""
+    """Test float32 support in pure callbacks"""
 
     @pure_callback
     def some_func(x) -> jax.ShapeDtypeStruct((2,), jnp.float32):
@@ -950,7 +950,7 @@ def test_scalar_in_array_out_float32_correct():
     # Array(0.4565774, dtype=float32)
 
 def test_scalar_in_array_out_float32_wrong():
-    """Test float32 support in pure callbacks"""
+    """Test float32 support in pure callbacks, result in type mismatch"""
 
     @pure_callback
     def some_func(x) -> jax.ShapeDtypeStruct((2,), jnp.float32):

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -917,12 +917,14 @@ def test_scalar_in_array_out():
 
     # Array(0.4565774, dtype=float64)
 
-def test_scalar_in_array_out_float32_correct():
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
+def test_scalar_in_array_out_float32_correct(dtype):
     """Test float32 support in pure callbacks"""
 
     @pure_callback
-    def some_func(x) -> jax.ShapeDtypeStruct((2,), jnp.float32):
-        return np.array([np.sin(x), np.cos(x)], dtype=jnp.float32)
+    def some_func(x) -> jax.ShapeDtypeStruct((2,), dtype):
+        return np.array([np.sin(x), np.cos(x)], dtype=dtype)
 
     @some_func.fwd
     def some_func_fwd(x):
@@ -949,6 +951,7 @@ def test_scalar_in_array_out_float32_correct():
 
     # Array(0.4565774, dtype=float32)
 
+
 def test_scalar_in_array_out_float32_wrong():
     """Test float32 support in pure callbacks, result in type mismatch"""
 
@@ -971,7 +974,7 @@ def test_scalar_in_array_out_float32_wrong():
         return jnp.sum(some_func(jnp.sin(x)))
 
     x = 0.435
-    with pytest.raises(TypeError, match="Callback closure expected type"):
+    with pytest.raises(TypeError, match="Callback some_func expected type"):
         result(x)
 
 

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -885,42 +885,9 @@ def test_array_in_scalar_out():
     # Array([-0.34893507,  0.49747506], dtype=float64)
 
 
-def test_scalar_in_array_out():
-    """Test scalar in array out"""
-
-    @pure_callback
-    def some_func(x) -> jax.ShapeDtypeStruct((2,), jnp.float64):
-        return np.array([np.sin(x), np.cos(x)])
-
-    @some_func.fwd
-    def some_func_fwd(x):
-        return some_func(x), x
-
-    @some_func.bwd
-    def some_func_bws(res, dy):
-        x = res
-        return (jnp.array([jnp.cos(x), -jnp.sin(x)]) @ dy,)
-
-    @qml.qjit
-    @grad
-    def result(x):
-        return jnp.sum(some_func(jnp.sin(x)))
-
-    @jax.jit
-    @jax.grad
-    def expected(x):
-        x = jnp.sin(x)
-        return jnp.sin(x) + jnp.cos(x)
-
-    x = 0.435
-    assert np.allclose(result(x), expected(x))
-
-    # Array(0.4565774, dtype=float64)
-
-
 @pytest.mark.parametrize("dtype", [jnp.float32, jnp.float64])
-def test_scalar_in_array_out_float32_correct(dtype):
-    """Test float32 support in pure callbacks"""
+def test_scalar_in_array_out(dtype):
+    """Test scalar in array out"""
 
     @pure_callback
     def some_func(x) -> jax.ShapeDtypeStruct((2,), dtype):
@@ -949,7 +916,7 @@ def test_scalar_in_array_out_float32_correct(dtype):
     x = 0.435
     assert np.allclose(result(x), expected(x))
 
-    # Array(0.4565774, dtype=float32)
+    # Array(0.4565774, dtype=float64)
 
 
 def test_scalar_in_array_out_float32_wrong():

--- a/mlir/lib/Gradient/Transforms/GradMethods/HybridGradient.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/HybridGradient.cpp
@@ -84,8 +84,10 @@ void initializeCotangents(TypeRange primalResultTypes, unsigned activeResult, Va
                             ? cast<RankedTensorType>(activeResultType).getElementType()
                             : activeResultType);
 
-    Value zero = builder.create<arith::ConstantFloatOp>(loc, APFloat(0.0), elementType);
-    Value one = builder.create<arith::ConstantFloatOp>(loc, APFloat(1.0), elementType);
+    Value zero = builder.create<arith::ConstantFloatOp>(
+        loc, APFloat(elementType.getFloatSemantics(), 0), elementType);
+    Value one = builder.create<arith::ConstantFloatOp>(
+        loc, APFloat(elementType.getFloatSemantics(), 1), elementType);
 
     Value zeroTensor;
     if (auto activeResultTensor = dyn_cast<RankedTensorType>(activeResultType)) {


### PR DESCRIPTION
**Context:**
This PR fixes an unexpected crash in initializeCotangents
when using float32 in callbacks.
The crash happens when creating ConstantFloatOp operation.
e.g. testcase `test_scalar_in_array_out_float32_wrong` in `frontend/test/pytest/test_callback.py`
would result in the following crash message:
`Assertion failed: (succeeded(ConcreteT::verify(getDefaultDiagnosticEmitFn(ctx), args...))), function get, file StorageUniquerSupport.h, line 181.`

**Description of the Change:**
Since APFloat(0.0) is always a float64, changed the
constructor to use the precision semantics of the
desired float

**Benefits:**
Will print better assertion error when using float32 in callbacks. The improved assertion error is:
```
File "/Users/mehrdad.malek/catalyst/frontend/catalyst/api_extensions/callbacks.py", line 415, in _check_types
    raise TypeError(msg)
TypeError: Callback closure expected type ShapedArray(float32[2]) but observed ShapedArray(float64[2]) in its return value
```

**Possible Drawbacks:**
callbacks will still raise an exception.
Although this happens only when value returned from pure_callback was not `dtype`d float32.
if both observed and expected output of the pure_callback are `dtype`d float32, 
there would be no assertion raised.

**Related GitHub Issues:**
https://github.com/PennyLaneAI/catalyst/issues/844

[sc-68042]