### PR TITLE
[Frontend] Nice identifiers for callbacks in the IR

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -10,6 +10,10 @@
 * Added support for the jax.numpy.argsort function so it works when compiled with qjit.
   [(#901)](https://github.com/PennyLaneAI/catalyst/pull/901)
 
+* Callbacks now have nicer identifiers. The identifiers include the name of
+  the python function being called back into.
+  [(#919)](https://github.com/PennyLaneAI/catalyst/pull/919)
+
 <h3>Breaking changes</h3>
 * Return values are `jax.Array` typed instead of `numpy.array`.
   [(#895)](https://github.com/PennyLaneAI/catalyst/pull/895)

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -331,11 +331,11 @@ def pure_callback_impl(callback_fn: AnnotatedFunction):
 class CallbackWithCustomGrad:
     """A callback with a custom grad"""
 
-    def __init__(self, func, restype, forward, reverse):
+    def __init__(self, func, forward, reverse):
         assert isinstance(func, AnnotatedFunction)
         assert func and forward and reverse
         self.func = func
-        self.restype = restype
+        self.restype = func.getResultTypes()
         self._fwd = forward
         self._fwd_jaxpr = None
         self._bwd = reverse
@@ -410,7 +410,7 @@ class CallbackWithPotentialCustomGrad:
             return self.callback(*args, **kwargs)
 
         if self._fwd and self._bwd:
-            self.callback = CallbackWithCustomGrad(self.func, self.restype, self._fwd, self._bwd)
+            self.callback = CallbackWithCustomGrad(self.func, self._fwd, self._bwd)
             return self.callback(*args, **kwargs)
 
         def closure(*args, **kwargs) -> self.restype:

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -258,6 +258,7 @@ def pure_callback(callback_fn, result_type=None):
 
 ## IMPL ##
 class AnnotatedFunction:
+    """Callable with result_type field."""
 
     def __init__(self, func, result_type):
         self.func = func
@@ -268,6 +269,7 @@ class AnnotatedFunction:
         return self.func(*args, **kwargs)
 
     def getResultTypes(self):
+        """Get the result types."""
         return self.result_type
 
 
@@ -287,6 +289,22 @@ def base_callback(func):
 
 
 def accelerate_impl(users_func=None, *, dev=None):
+    """Logic for handling jax.Partial
+    obtaining the result type from a user provided function
+    and creating a jax_jit_callback.
+
+
+    Args:
+        users_func (Callable or PjitFunction): The user provided function
+
+        dev (jax.Device): the classical accelerator device the JIT-compiled
+            function will run on.
+
+    Returns:
+        Callable: a function that when trace, will bind the arguments
+             to a callback primitive. When it is not traced, it will
+             just called the wrapped function.
+    """
 
     # If this is a partial, we need to make the tracers part of the input
     is_partial = isinstance(users_func, Partial)
@@ -329,6 +347,7 @@ def accelerate_impl(users_func=None, *, dev=None):
 
 
 def pure_callback_impl(callback_fn: AnnotatedFunction):
+    """Wrapper around CallbackWithPotentialCustomGrad"""
     return CallbackWithPotentialCustomGrad(callback_fn)
 
 
@@ -425,7 +444,7 @@ def jax_jit_callback(callback_fn: AnnotatedFunction, device=None):
 
 
 def base_callback_impl(func: AnnotatedFunction, device=None, custom_grad=None):
-    retty = func.getResultTypes()
+    """The most general way to obtain a callback"""
 
     # We just disable inconsistent return statements
     # Since we are building this feature step by step.

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -253,7 +253,7 @@ def pure_callback(callback_fn, result_type=None):
     # to be annotated with the correct result types
     annotated = AnnotatedFunction(callback_fn, result_type)
 
-    return pure_callback_impl(annotated, result_type=result_type)
+    return pure_callback_impl(annotated)
 
 
 ## IMPL ##
@@ -324,15 +324,15 @@ def accelerate_impl(users_func=None, *, dev=None):
     return back_to_user
 
 
-def pure_callback_impl(callback_fn: AnnotatedFunction, result_type=None):
-
-    return CallbackWithPotentialCustomGrad(callback_fn, result_type)
+def pure_callback_impl(callback_fn: AnnotatedFunction):
+    return CallbackWithPotentialCustomGrad(callback_fn)
 
 
 class CallbackWithCustomGrad:
     """A callback with a custom grad"""
 
     def __init__(self, func, restype, forward, reverse):
+        assert isinstance(func, AnnotatedFunction)
         assert func and forward and reverse
         self.func = func
         self.restype = restype
@@ -382,9 +382,9 @@ class CallbackWithPotentialCustomGrad:
     to have a custom grad if it is never differentiated, but a user
     may register one. A debug.callback will never have a custom grad."""
 
-    def __init__(self, func, restype):
+    def __init__(self, func):
         self.func = func
-        self.restype = restype
+        self.restype = func.getResultTypes()
         self._fwd = None
         self._bwd = None
         self.callback = None

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -448,6 +448,7 @@ class FlatCallable:
 
     def __init__(self, func, *params, **kwparams):
         self.func = func
+        functools.update_wrapper(self, func)
         self.flat_params, self.shape = tree_flatten((params, kwparams))
 
     def __call__(self, flat_args):

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -294,7 +294,9 @@ def _python_callback_lowering(
     ip = module.body
     attrs = [fn_ty_attr, callback_id, len(args), len(results_ty)]
     with ir.InsertionPoint(ip):
-        callbackOp = CallbackOp(f"callback_{callback_id}", *attrs)
+        # TODO: Name mangling for callbacks
+        name = callback.__name__
+        callbackOp = CallbackOp(f"callback_{name}_{callback_id}", *attrs)
     CALLBACK_OP_CACHE[cache_key] = callbackOp
     callbackOp = CALLBACK_OP_CACHE[cache_key]
     symbol = callbackOp.sym_name.value

--- a/frontend/test/lit/test_callback.py
+++ b/frontend/test/lit/test_callback.py
@@ -69,11 +69,13 @@ print(test2.mlir)
 @pure_callback
 # CHECK-LABEL func.func private @callback_custom_name
 def custom_name(x) -> float:
+    """A function with a custom name"""
     return x
 
 
 @qml.qjit
 def test3(x: float) -> float:
+    """Tests that custom_name will be in the IR"""
     return custom_name(x)
 
 

--- a/frontend/test/lit/test_callback.py
+++ b/frontend/test/lit/test_callback.py
@@ -63,3 +63,18 @@ def test2():
 # CHECK-NOT: catalyst.callback @callback
 
 print(test2.mlir)
+
+
+# CHECK-LABEL: module @test3
+@pure_callback
+# CHECK-LABEL func.func private @callback_custom_name
+def custom_name(x) -> float:
+    return x
+
+
+@qml.qjit
+def test3(x: float) -> float:
+    return custom_name(x)
+
+
+print(test3.mlir)


### PR DESCRIPTION
**Context:** Instead of a numeric identifier, callbacks now include the python attribute `__name__` in their IR.

**Description of the Change:** Cleaning up a little bit of code, made AnnotatedFunction class to avoid using many closures, used `functools.wraps` and `functools.update_wrapper` where necessary. As an important note, we do not use the `__module__` key in `wraps` nor `update_wrapper`. Otherwise, autograph would transform the functions returned from callbacks leading to errors.

**Benefits:** Easier debugging in the IR.

**Possible Drawbacks:** None.

**Related GitHub Issues:**

[sc-68128]
