### PR TITLE
Add automatic differentiation for accelerated functions

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,7 +2,7 @@
 
 <h3>New features</h3>
 
-* JAX-compatible functions which run on classical accelerators such as GPUs via catalyst.accelerate now support autodifferentiation.
+* JAX-compatible functions which run on classical accelerators such as GPUs via `catalyst.accelerate` now support autodifferentiation.
   [(#920)](https://github.com/PennyLaneAI/catalyst/pull/920)
 
   For example,

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,8 +2,25 @@
 
 <h3>New features</h3>
 
-* Automatic differentiation of `catalyst.accerate`-ed functions.
+* JAX-compatible functions which run on classical accelerators such as GPUs via catalyst.accelerate now support autodifferentiation.
   [(#920)](https://github.com/PennyLaneAI/catalyst/pull/920)
+
+  For example,
+
+  ```python
+  @qjit
+  @grad
+  def f(x):
+    expm = catalyst.accelerate(jax.scipy.linalg.expm)
+    return jnp.sum(expm(jnp.sin(x)) ** 2)
+  ```
+
+  ```pycon
+  >>> x = jnp.array([[0.1, 0.2], [0.3, 0.4]])
+  >>> f(x)
+  >>> array([[2.80120452, 1.67518663],
+      [1.61605839, 4.42856163]])
+  ```
 
 <h3>Improvements</h3>
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -2,6 +2,9 @@
 
 <h3>New features</h3>
 
+* Automatic differentiation of `catalyst.accerate`-ed functions.
+  [(#920)](https://github.com/PennyLaneAI/catalyst/pull/920)
+
 <h3>Improvements</h3>
 
 * Catalyst is now compatible with Enzyme `v0.0.130`

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -377,6 +377,7 @@ def pure_callback_impl(callback_fn: AnnotatedFunction):
     return CallbackWithPotentialCustomGrad(callback_fn)
 
 
+# pylint: disable-next=too-many-instance-attributes)
 class CallbackWithCustomGrad(AnnotatedFunction):
     """A callback with a custom grad"""
 

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -58,9 +58,10 @@ def accelerate(func=None, *, dev=None):
 
     .. note::
 
-        ``catalyst.accelerate`` doses not currently support
-        differentiation, and cannot be used inside functions that
-        :func:`catalyst.grad` is applied to.
+        ``catalyst.accelerate`` currently supports
+        differentiation, and can be used inside 
+        :func:`catalyst.grad` and :func:`catalyst.jacobian` without one having
+        to define its gradient.
 
     Args:
         func (Callable or PjitFunction): The function to be classically
@@ -103,6 +104,16 @@ def accelerate(func=None, *, dev=None):
         def hybrid_fn(x):
             y = accelerate(classical_fn)(x) # will be executed on a GPU
             return jnp.cos(y)
+
+    With gradients:
+
+    .. code-block:: python
+
+        @qjit
+        @grad
+        def f(x):
+            expm = catalyst.accelerate(jax.scipy.linalg.expm)
+            return jnp.sum(expm(jnp.sin(x)) ** 2)
     """
     # Setting default parameters
     if dev is None:

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -351,6 +351,7 @@ def accelerate_impl(users_func=None, *, dev=None):
         except Exception as e:
             name = users_func.__name__
             msg = f"Function {name} must be jax.jit-able."
+            msg += f"But failed with error message {str(e)}."
             raise ValueError(msg) from e
         annotated = AnnotatedFunctionImpl(jitted_fn, returnshape)
         with_custom_grad = CallbackWithPotentialCustomGrad(annotated, dev)

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -18,11 +18,11 @@ a compiled program. Host callbacks are able to run non-jittable code at runtime
 but require a Python interpreter instance.
 """
 
-from abc import ABC
 import copy
 import ctypes
 import functools
 import inspect
+from abc import ABC
 from typing import Any, Callable
 
 import jax
@@ -263,6 +263,7 @@ def pure_callback(callback_fn, result_type=None):
 ## IMPL ##
 class AnnotatedFunction(ABC):
     def getResultTypes(self): ...
+
 
 class AnnotatedFunctionImpl(AnnotatedFunction):
     """Callable with result_type field."""

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -59,7 +59,7 @@ def accelerate(func=None, *, dev=None):
     .. note::
 
         ``catalyst.accelerate`` currently supports
-        differentiation, and can be used inside 
+        differentiation, and can be used inside
         :func:`catalyst.grad` and :func:`catalyst.jacobian` without one having
         to define its gradient.
 

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -430,7 +430,12 @@ class CallbackWithPotentialCustomGrad:
 
     def __init__(self, func, device=None):
         self.func = func
-        #functools.update_wrapper(self, func, assigned=assigned)
+        # TODO: Investigate why we can't just use update_wrapper here
+        # It doesn't matter too much since we just use it for the name.
+        # But having update_wrapper here would change the type
+        # of self (or of self.func?) to just a function
+        # as opposed to an AnnotatedFunction
+        self.__name__ = func.__name__
         self.restype = func.getResultTypes()
         self._fwd = None
         self._bwd = None

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -266,8 +266,7 @@ class AnnotatedFunction(ABC):
 
     def getResultTypes(self):
         """Get result type of function"""
-        # pragma: nocover
-        ...
+        ...  # pragma: nocover
 
 
 class AnnotatedFunctionImpl(AnnotatedFunction):
@@ -399,10 +398,6 @@ class CallbackWithCustomGrad(AnnotatedFunction):
         return self.restype
 
     def __call__(self, *args, **kwargs):
-        if not EvaluationContext.is_tracing():
-            # If we are not in the tracing context, just evaluate the function.
-            return self.func(*args, **kwargs)
-
         if self.callback:
             return self.callback(*args, **kwargs)
 

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -377,7 +377,7 @@ def pure_callback_impl(callback_fn: AnnotatedFunction):
     return CallbackWithPotentialCustomGrad(callback_fn)
 
 
-# pylint: disable-next=too-many-instance-attributes)
+# pylint: disable=too-many-instance-attributes)
 class CallbackWithCustomGrad(AnnotatedFunction):
     """A callback with a custom grad"""
 

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -262,7 +262,11 @@ def pure_callback(callback_fn, result_type=None):
 
 ## IMPL ##
 class AnnotatedFunction(ABC):
-    def getResultTypes(self): ...
+    """Defining an interface"""
+
+    def getResultTypes(self):
+        """Get result type of function"""
+        ...
 
 
 class AnnotatedFunctionImpl(AnnotatedFunction):

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -22,7 +22,7 @@ import copy
 import ctypes
 import functools
 import inspect
-from abc import ABC
+from abc import ABC, abstractmethod
 from typing import Any, Callable
 
 import jax
@@ -267,8 +267,9 @@ def pure_callback(callback_fn, result_type=None):
 
 ## IMPL ##
 class AnnotatedFunction(ABC):
-    """Defining an interface"""
+    """Defining an interface for methods with result types."""
 
+    @abstractmethod
     def getResultTypes(self):
         """Get result type of function"""
         ...  # pragma: nocover

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -56,12 +56,6 @@ def accelerate(func=None, *, dev=None):
     """Execute a ``jax.jit`` accelerated function on classical
     accelerators such as GPUs from within a qjit-compiled function.
 
-    .. note::
-
-        ``catalyst.accelerate`` currently supports
-        differentiation, and can be used inside
-        :func:`catalyst.grad` and :func:`catalyst.jacobian` without one having
-        to define its gradient.
 
     Args:
         func (Callable or PjitFunction): The function to be classically

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -266,6 +266,7 @@ class AnnotatedFunction(ABC):
 
     def getResultTypes(self):
         """Get result type of function"""
+        # pragma: nocover
         ...
 
 
@@ -461,10 +462,6 @@ class CallbackWithPotentialCustomGrad:
         """Save reverse pass as implemented by the user"""
         self._bwd = func
 
-    def getResultTypes(self):
-        """Get result types"""
-        return self.restype
-
     def __call__(self, *args, **kwargs):
         if not EvaluationContext.is_tracing():
             # If we are not in the tracing context, just evaluate the function.
@@ -487,12 +484,6 @@ class CallbackWithPotentialCustomGrad:
 
         self.callback = base_callback_impl(self.func, device=self.device)
         return self.callback(*args, **kwargs)
-
-
-def jax_jit_callback(callback_fn: AnnotatedFunction, device=None, custom_grad=None):
-    """Wrapper around base callback that can accept a device as a parameter"""
-
-    return base_callback_impl(callback_fn, device=device, custom_grad=custom_grad)
 
 
 def base_callback_impl(func: AnnotatedFunction, device=None, custom_grad=None):

--- a/frontend/catalyst/api_extensions/differentiation.py
+++ b/frontend/catalyst/api_extensions/differentiation.py
@@ -619,7 +619,7 @@ class Grad:
                     gradients = results[len(jaxpr.out_avals) :]
 
                     vals = tree_unflatten(out_tree, vals)
-                    gradients = unflatten_derivatives(
+                    gradients = _unflatten_derivatives(
                         gradients, in_tree, out_tree, grad_params, len(jaxpr.out_avals)
                     )
                     results = (vals, gradients)

--- a/frontend/catalyst/api_extensions/differentiation.py
+++ b/frontend/catalyst/api_extensions/differentiation.py
@@ -619,7 +619,9 @@ class Grad:
                     gradients = results[len(jaxpr.out_avals) :]
 
                     vals = tree_unflatten(out_tree, vals)
-                    gradients = unflatten_derivatives(gradients, in_tree, out_tree, grad_params, len(jaxpr.out_avals))
+                    gradients = unflatten_derivatives(
+                        gradients, in_tree, out_tree, grad_params, len(jaxpr.out_avals)
+                    )
                     results = (vals, gradients)
                 else:  # use grad
                     args_argnum = tuple(args[i] for i in grad_params.argnum)

--- a/frontend/catalyst/api_extensions/differentiation.py
+++ b/frontend/catalyst/api_extensions/differentiation.py
@@ -40,7 +40,7 @@ from catalyst.jax_primitives import (
     vjp_p,
 )
 from catalyst.jax_tracer import Function, mark_gradient_tracing
-from catalyst.tracing.contexts import EvaluationContext
+from catalyst.tracing.contexts import EvaluationContext, GradContext
 from catalyst.utils.exceptions import DifferentiableCompileError
 
 Differentiable = Union[Function, QNode]
@@ -592,64 +592,63 @@ class Grad:
             args: the arguments to the differentiated function
         """
 
-        if EvaluationContext.is_tracing():
-            fn = _ensure_differentiable(self.fn)
+        with GradContext():
+            if EvaluationContext.is_tracing():
+                fn = _ensure_differentiable(self.fn)
 
-            args_data, in_tree = tree_flatten(args)
-            grad_params = _check_grad_params(
-                self.grad_params.method,
-                self.grad_params.scalar_out,
-                self.grad_params.h,
-                self.grad_params.argnum,
-                len(args_data),
-                in_tree,
-                self.grad_params.with_value,
-            )
-            jaxpr, out_tree = _make_jaxpr_check_differentiable(fn, grad_params, *args)
-            if self.grad_params.with_value:  # use value_and_grad
-                # It always returns list as required by catalyst control-flows
-                results = value_and_grad_p.bind(
-                    *args_data, jaxpr=jaxpr, fn=fn, grad_params=grad_params
+                args_data, in_tree = tree_flatten(args)
+                grad_params = _check_grad_params(
+                    self.grad_params.method,
+                    self.grad_params.scalar_out,
+                    self.grad_params.h,
+                    self.grad_params.argnum,
+                    len(args_data),
+                    in_tree,
+                    self.grad_params.with_value,
                 )
+                jaxpr, out_tree = _make_jaxpr_check_differentiable(fn, grad_params, *args)
+                if self.grad_params.with_value:  # use value_and_grad
+                    # It always returns list as required by catalyst control-flows
+                    results = value_and_grad_p.bind(
+                        *args_data, jaxpr=jaxpr, fn=fn, grad_params=grad_params
+                    )
 
-                # value_and_grad returns two results: the values and the gradients,
-                # hence we have to split the obtained results
-                vals = results[: len(jaxpr.out_avals)]
-                gradients = results[len(jaxpr.out_avals) :]
+                    # value_and_grad returns two results: the values and the gradients,
+                    # hence we have to split the obtained results
+                    vals = results[: len(jaxpr.out_avals)]
+                    gradients = results[len(jaxpr.out_avals) :]
 
-                vals = tree_unflatten(out_tree, vals)
-                gradients = _unflatten_derivatives(
-                    gradients, in_tree, out_tree, grad_params, len(jaxpr.out_avals)
-                )
-                results = (vals, gradients)
-            else:  # use grad
-                args_argnum = tuple(args[i] for i in grad_params.argnum)
-                _, in_tree = tree_flatten(args_argnum)
+                    vals = tree_unflatten(out_tree, vals)
+                    gradients = unflatten_derivatives(gradients, in_tree, out_tree, grad_params, len(jaxpr.out_avals))
+                    results = (vals, gradients)
+                else:  # use grad
+                    args_argnum = tuple(args[i] for i in grad_params.argnum)
+                    _, in_tree = tree_flatten(args_argnum)
 
-                # It always returns list as required by catalyst control-flows
-                results = grad_p.bind(*args_data, jaxpr=jaxpr, fn=fn, grad_params=grad_params)
+                    # It always returns list as required by catalyst control-flows
+                    results = grad_p.bind(*args_data, jaxpr=jaxpr, fn=fn, grad_params=grad_params)
 
-                # grad returns only the gradients,
-                # so there is no need to split the results.
+                    # grad returns only the gradients,
+                    # so there is no need to split the results.
 
-                results = _unflatten_derivatives(
-                    results, in_tree, out_tree, grad_params, len(jaxpr.out_avals)
-                )
-        else:
-            if argnums := self.grad_params.argnum is None:
-                argnums = 0
-            if self.grad_params.scalar_out:
-                if self.grad_params.with_value:
-                    results = jax.value_and_grad(self.fn, argnums=argnums)(*args)
-                else:
-                    results = jax.grad(self.fn, argnums=argnums)(*args)
+                    results = _unflatten_derivatives(
+                        results, in_tree, out_tree, grad_params, len(jaxpr.out_avals)
+                    )
             else:
-                assert (
-                    not self.grad_params.with_value
-                ), "value_and_grad cannot be used with a Jacobian"
-                results = jax.jacobian(self.fn, argnums=argnums)(*args)
+                if argnums := self.grad_params.argnum is None:
+                    argnums = 0
+                if self.grad_params.scalar_out:
+                    if self.grad_params.with_value:
+                        results = jax.value_and_grad(self.fn, argnums=argnums)(*args)
+                    else:
+                        results = jax.grad(self.fn, argnums=argnums)(*args)
+                else:
+                    assert (
+                        not self.grad_params.with_value
+                    ), "value_and_grad cannot be used with a Jacobian"
+                    results = jax.jacobian(self.fn, argnums=argnums)(*args)
 
-        return results
+            return results
 
 
 ## PRIVATE ##

--- a/frontend/catalyst/tracing/contexts.py
+++ b/frontend/catalyst/tracing/contexts.py
@@ -79,8 +79,6 @@ class GradContext:
     _grad_stack: int = 0
     # This message will be used in an assertion because it is not expected
     # to be a user facing error ever.
-    _error_msg: str = """This is an impossible state. One cannot derive to
-derive to a negative order / integrate"""
 
     def __init__(self, peel=False):
         """Peel is useful when we want to temporarily create a context
@@ -101,7 +99,9 @@ derive to a negative order / integrate"""
     @staticmethod
     def _pop():
         retval = GradContext._peek()
-        assert retval > 0, GradContext._error_msg
+        msg = "This is an impossible state. "
+        msg += "One cannot derive to derive to a negative order / integrate"
+        assert retval > 0, msg
         GradContext._grad_stack -= 1
         return retval
 

--- a/frontend/catalyst/tracing/contexts.py
+++ b/frontend/catalyst/tracing/contexts.py
@@ -88,10 +88,10 @@ derive to a negative order / integrate"""
         self.peel = peel
 
     def __enter__(self, peel=False):
-        GradContext._pop() if self.peel else GradContext._push()
+        _ = GradContext._pop() if self.peel else GradContext._push()
 
     def __exit__(self, _exc_type, _exc, _exc_tb):
-        GradContext._push() if self.peel else GradContext._pop()
+        _ = GradContext._push() if self.peel else GradContext._pop()
 
     @staticmethod
     def am_inside_grad():

--- a/frontend/catalyst/tracing/contexts.py
+++ b/frontend/catalyst/tracing/contexts.py
@@ -41,6 +41,79 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
+class GradContext:
+    """This class tells us the level of nestedness of grad."""
+
+    # Conceptually:
+    #
+    #   _grad_stack : List[bool] = []
+    #
+    # is a class member variable that reflects the level of
+    # nested-ness of the grad operation. If we have the following code:
+    #
+    #   grad(fun)(x)
+    #
+    # and we are inside fun, then List _grad_stack will contain [True]
+    # if we have:
+    #
+    #  grad(grad(fun))(x)
+    #
+    # and we are tracing fun, then _grad_stack will contain [True, True]
+    #
+    # I say conceptually because you can already tell that we don't need
+    # anything besides an integer that gets incremented and decremented
+    # each time you enter a grad or jacobian operation.
+    #
+    # The reason why we started with a stack is because I think it makes more sense.
+    #
+    # You might also ask, why do we need keep track of the order of the derivative?
+    # Isn't it enough to know that we are inside the grad context or outside?
+    # It is when you are only limited to the first order derivative, but once
+    # you have a higher order derivatives, it will be important to know whether
+    # you need the derivative of the derivative...
+    #
+    # The final question to be asked here is whether we need a new stack for this
+    # context or whether we should reuse the old one.
+    # I think we should keep it simple and this is simpler.
+
+    _grad_stack: int = 0
+    # This message will be used in an assertion because it is not expected
+    # to be a user facing error ever.
+    _error_msg: str = """This is an impossible state. One cannot derive to
+derive to a negative order / integrate"""
+
+    def __init__(self, peel=False):
+        """Peel is useful when we want to temporarily create a context
+        where we peel one order of the derivative"""
+        self.peel = peel
+
+    def __enter__(self, peel=False):
+        GradContext._pop() if self.peel else GradContext._push()
+
+    def __exit__(self, _exc_type, _exc, _exc_tb):
+        GradContext._push() if self.peel else GradContext._pop()
+
+    @staticmethod
+    def am_inside_grad():
+        """Return true if we are currently tracing inside a grad operation."""
+        return GradContext._peek() > 0
+
+    @staticmethod
+    def _pop():
+        retval = GradContext._peek()
+        assert retval > 0, GradContext._error_msg
+        GradContext._grad_stack -= 1
+        return retval
+
+    @staticmethod
+    def _push():
+        GradContext._grad_stack += 1
+
+    @staticmethod
+    def _peek():
+        return GradContext._grad_stack
+
+
 class EvaluationMode(Enum):
     """Enumerate the evaluation modes supported by Catalyst:
     INTERPRETATION - native Python execution of a Catalyst program

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -1389,6 +1389,15 @@ def test_vjp_as_residual(arg, order):
         obs = hypothesis(arg)
     assert np.allclose(obs, exp)
 
+def test_automatic_differentiation_of_accelerate():
+
+    @qml.qjit
+    @grad
+    def identity(x : float):
+        return x
+
+    assert identity(4.0) == 1.0
+
 
 def test_error_incomplete_grad_only_forward():
     """Test error about missing reverse pass"""

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -1391,8 +1391,10 @@ def test_vjp_as_residual(arg, order):
 
 def test_automatic_differentiation_of_accelerate():
 
-    @qml.qjit
+
+    @qml.qjit(keep_intermediate=True)
     @grad
+    @accelerate
     def identity(x : float):
         return x
 

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -1389,6 +1389,7 @@ def test_vjp_as_residual(arg, order):
         obs = hypothesis(arg)
     assert np.allclose(obs, exp)
 
+
 @pytest.mark.parametrize("arg", [jnp.array([[0.1, 0.2], [0.3, 0.4]])])
 @pytest.mark.parametrize("order", ["good", "bad"])
 def test_vjp_as_residual_automatic(arg, order):
@@ -1397,7 +1398,6 @@ def test_vjp_as_residual_automatic(arg, order):
     @jacobian
     def hypothesis(x):
         return accelerate(jax.scipy.linalg.expm)(x)
-
 
     @jax.jacobian
     def ground_truth(x):
@@ -1411,13 +1411,13 @@ def test_vjp_as_residual_automatic(arg, order):
         obs = hypothesis(arg)
     assert np.allclose(obs, exp)
 
-def test_automatic_differentiation_of_accelerate():
 
+def test_automatic_differentiation_of_accelerate():
 
     @qml.qjit
     @grad
     @accelerate
-    def identity(x : float):
+    def identity(x: float):
         return x
 
     assert identity(4.0) == 1.0

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -1389,6 +1389,28 @@ def test_vjp_as_residual(arg, order):
         obs = hypothesis(arg)
     assert np.allclose(obs, exp)
 
+@pytest.mark.parametrize("arg", [jnp.array([[0.1, 0.2], [0.3, 0.4]])])
+@pytest.mark.parametrize("order", ["good", "bad"])
+def test_vjp_as_residual_automatic(arg, order):
+
+    @qml.qjit
+    @jacobian
+    def hypothesis(x):
+        return accelerate(jax.scipy.linalg.expm)(x)
+
+
+    @jax.jacobian
+    def ground_truth(x):
+        return jax.scipy.linalg.expm(x)
+
+    if order == "bad":
+        obs = hypothesis(arg)
+        exp = ground_truth(arg)
+    else:
+        exp = ground_truth(arg)
+        obs = hypothesis(arg)
+    assert np.allclose(obs, exp)
+
 def test_automatic_differentiation_of_accelerate():
 
 

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -24,7 +24,7 @@ import pennylane as qml
 import pytest
 
 from catalyst import accelerate, debug, grad, jacobian, pure_callback
-from catalyst.api_extensions.callbacks import base_callback
+from catalyst.api_extensions.callbacks import base_callback, CallbackWithCustomGrad
 from catalyst.utils.exceptions import DifferentiableCompileError
 from catalyst.utils.patching import Patcher
 
@@ -52,27 +52,7 @@ def test_purecallback_no_tracing(arg):
     def identity(x) -> int:
         return x
 
-    assert identity(arg) == arg
-
-
-@pytest.mark.parametrize("arg", [(0.1), (0.2), (0.3)])
-def test_active_grad_no_tracing(arg):
-    """Test that pure callback can be differentiated no tape"""
-
-    @pure_callback
-    def identity(x) -> float:
-        return x
-
-    @identity.fwd
-    def fwd(x):
-        # Still needs to return a tuple.
-        return identity(x), None
-
-    @identity.bwd
-    def bwd(_res, cot):
-        return cot
-
-    assert identity(arg) == arg
+    assert pure_Callback(arg) == arg
 
 
 def test_callback_no_returns_no_params(capsys):

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -1424,8 +1424,10 @@ def test_vjp_as_residual_automatic(arg, order):
         obs = hypothesis(arg)
     assert np.allclose(obs, exp)
 
+
 @pytest.mark.parametrize("arg", [jnp.array([[0.1, 0.2], [0.3, 0.4]])])
 def test_example_from_epic(arg):
+    """Test example from epic"""
 
     @qml.qjit
     @grad

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -1392,7 +1392,7 @@ def test_vjp_as_residual(arg, order):
 def test_automatic_differentiation_of_accelerate():
 
 
-    @qml.qjit(keep_intermediate=True)
+    @qml.qjit
     @grad
     @accelerate
     def identity(x : float):

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -24,7 +24,7 @@ import pennylane as qml
 import pytest
 
 from catalyst import accelerate, debug, grad, jacobian, pure_callback
-from catalyst.api_extensions.callbacks import base_callback, CallbackWithCustomGrad
+from catalyst.api_extensions.callbacks import base_callback
 from catalyst.utils.exceptions import DifferentiableCompileError
 from catalyst.utils.patching import Patcher
 
@@ -52,7 +52,7 @@ def test_purecallback_no_tracing(arg):
     def identity(x) -> int:
         return x
 
-    assert pure_Callback(arg) == arg
+    assert identity(arg) == arg
 
 
 def test_callback_no_returns_no_params(capsys):

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -1364,6 +1364,7 @@ def test_vjp_as_residual(arg, order):
     """See https://github.com/PennyLaneAI/catalyst/issues/852"""
 
     if order == "bad":
+        # See https://github.com/PennyLaneAI/catalyst/issues/894
         pytest.skip("Bug")
 
     def jax_callback(fn, result_type):
@@ -1406,6 +1407,10 @@ def test_vjp_as_residual(arg, order):
 @pytest.mark.parametrize("order", ["good", "bad"])
 def test_vjp_as_residual_automatic(arg, order):
     """Test automatic differentiation of accelerated function"""
+
+    if order == "bad":
+        # See https://github.com/PennyLaneAI/catalyst/issues/894
+        pytest.skip("Bug")
 
     @qml.qjit
     @jacobian

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -1424,6 +1424,25 @@ def test_vjp_as_residual_automatic(arg, order):
         obs = hypothesis(arg)
     assert np.allclose(obs, exp)
 
+@pytest.mark.parametrize("arg", [jnp.array([[0.1, 0.2], [0.3, 0.4]])])
+def test_example_from_epic(arg):
+
+    @qml.qjit
+    @grad
+    def hypothesis(x):
+        expm = accelerate(jax.scipy.linalg.expm)
+        return jnp.sum(expm(jnp.sin(x) ** 2))
+
+    @jax.jit
+    @jax.grad
+    def ground_truth(x):
+        expm = jax.scipy.linalg.expm
+        return jnp.sum(expm(jnp.sin(x) ** 2))
+
+    obs = hypothesis(arg)
+    exp = ground_truth(arg)
+    assert np.allclose(obs, exp)
+
 
 def test_automatic_differentiation_of_accelerate():
     """Same but easier"""

--- a/frontend/test/pytest/test_contexts.py
+++ b/frontend/test/pytest/test_contexts.py
@@ -27,7 +27,7 @@ class TestGradContextUnitTests:
 
     def test_error_cannot_pop_from_empty_context(self):
         """Check that impossible state raises an assertion"""
-        msg = GradContext._error_msg
+        msg = "This is an impossible state."
         with pytest.raises(AssertionError, match=msg):
             GradContext._pop()
 

--- a/frontend/test/pytest/test_contexts.py
+++ b/frontend/test/pytest/test_contexts.py
@@ -21,6 +21,7 @@ from catalyst import cond, grad, jacobian, measure, qjit, while_loop
 from catalyst.tracing.contexts import EvaluationContext, EvaluationMode, GradContext
 
 
+# pylint: disable=protected-access
 class TestGradContextUnitTests:
     """Unit tests for grad context"""
 
@@ -72,6 +73,7 @@ class TestGradContextUnitTests:
 class TestGradContextIntegration:
 
     def test_assert_inside_grad(self):
+        """Test assertion of grad context with grad"""
 
         @qjit
         @grad
@@ -82,6 +84,7 @@ class TestGradContextIntegration:
         identity(1.0)
 
     def test_assert_inside_jacobian(self):
+        """Test assertion of grad context with jacobian"""
 
         arg = jnp.array([[1.0, 1.0], [1.0, 1.0]])
 
@@ -94,6 +97,7 @@ class TestGradContextIntegration:
         identity(arg)
 
     def test_assert_inside_grad_negative(self):
+        """Test negative"""
 
         msg = "verified fail"
 

--- a/frontend/test/pytest/test_contexts.py
+++ b/frontend/test/pytest/test_contexts.py
@@ -32,20 +32,24 @@ class TestGradContextUnitTests:
             GradContext._pop()
 
     def test_peek_base_case(self):
+        """Test peek"""
         assert GradContext._peek() == 0
 
     def test_push_peek_pop(self):
+        """Test push"""
         GradContext._push()
         assert GradContext._peek() == 1
         GradContext._pop()
 
     def test_context_management_nested_0(self):
+        """Test nested"""
         assert GradContext._peek() == 0
         with GradContext():
             assert GradContext._peek() == 1
         assert GradContext._peek() == 0
 
     def test_context_management_nested_1(self):
+        """Test nested twice"""
         assert GradContext._peek() == 0
         with GradContext():
             assert GradContext._peek() == 1
@@ -55,12 +59,14 @@ class TestGradContextUnitTests:
         assert GradContext._peek() == 0
 
     def test_context_manager_user_interface(self):
+        """Test all"""
         assert not GradContext.am_inside_grad()
         with GradContext():
             assert GradContext.am_inside_grad()
         assert not GradContext.am_inside_grad()
 
     def test_peel(self):
+        """Test peel"""
         assert not GradContext.am_inside_grad()
         with GradContext():
             assert GradContext.am_inside_grad()

--- a/frontend/test/pytest/test_contexts.py
+++ b/frontend/test/pytest/test_contexts.py
@@ -77,6 +77,7 @@ class TestGradContextUnitTests:
 
 
 class TestGradContextIntegration:
+    """Test integration with qjit"""
 
     def test_assert_inside_grad(self):
         """Test assertion of grad context with grad"""


### PR DESCRIPTION
**Context:** Functions that have been accelerated can be are compatible with JAX. This means that JAX can also auto-differentiate them. So, let's leverage JAX to auto-differentiate them.

**Description of the Change:** 

* Add a GradContext to determine when we are inside a grad statement
* If we are inside a GradContext then run a different path that will lead to defining the forward and reverse passes for accelerate.

**Benefits:** Better UI

**Possible Drawbacks:** Callback code is becoming harder to reason about with all the special cases, accelerate, pure_callback, with/without gradient.

**Related GitHub Issues:**

[sc-60775]
