### PR TITLE
[CI] Automatically release nightly Catalyst builds on TestPyPI

### DIFF
--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -51,6 +51,8 @@ jobs:
     name: Prepare & Upload wheels to TestPyPI
     needs: [linux-x86, linux-aarch, macos-arm, macos-x86]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
     - name: Download wheels
@@ -72,7 +74,5 @@ jobs:
     # - name: Upload wheels
     #   uses: pypa/gh-action-pypi-publish@release/v1
     #   with:
-    #     user: __token__
-    #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
     #     repository-url: https://test.pypi.org/legacy/
     #     packages-dir: dist

--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -4,7 +4,6 @@ on:
   schedule:
     - cron: "40 23 * * 1-5"
   workflow_dispatch:
-  pull_request:
 
 jobs:
   setup:

--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -26,7 +26,7 @@ jobs:
         git config --global user.name "ringo-but-quantum"
         git add $GITHUB_WORKSPACE/frontend/catalyst/_version.py
         git commit -m "bump nightly version"
-        # git push
+        git push
 
   linux-x86:
     name: Build on Linux x86-64

--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -72,8 +72,8 @@ jobs:
         rename "s/macosx_14/macosx_13/" dist/PennyLane_Catalyst-*
         rename "s/_universal2/_x86_64/" dist/PennyLane_Catalyst-*
 
-    # - name: Upload wheels
-    #   uses: pypa/gh-action-pypi-publish@release/v1
-    #   with:
-    #     repository-url: https://test.pypi.org/legacy/
-    #     packages-dir: dist
+    - name: Upload wheels
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        packages-dir: dist

--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -1,0 +1,78 @@
+name: Build nightly Catalyst releases for TestPyPI
+
+on:
+  schedule:
+    - cron: "40 23 * * 1-5"
+  workflow_dispatch:
+
+jobs:
+  setup:
+    name: Setup the release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Catalyst repo
+      uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.AUTO_UPDATE_VERSION_RINGO_TOKEN }}
+
+    - name: Bump dev version
+      run: |
+        python $GITHUB_WORKSPACE/.github/workflows/set_nightly_version.py
+
+    - name: Push new version
+      run: |
+        git config --global user.email '${{ secrets.AUTO_UPDATE_VERSION_RINGO_EMAIL }}'
+        git config --global user.name "ringo-but-quantum"
+        git add $GITHUB_WORKSPACE/frontend/catalyst/_version.py
+        git commit -m "bump nightly version"
+        # git push
+
+  linux-x86:
+    name: Build on Linux x86-64
+    needs: [setup]
+    uses: ./.github/workflows/build-wheel-linux-x86_64.yaml
+
+  linux-aarch:
+    name: Build on Linux aarch64
+    needs: [setup]
+    uses: ./.github/workflows/build-wheel-linux-arm64.yaml
+
+  macos-arm:
+    name: Build on macOS arm64
+    needs: [setup]
+    uses: ./.github/workflows/build-wheel-macos-arm64.yaml
+
+  macos-x86:
+    name: Build on macOS x86-64
+    needs: [setup]
+    uses: ./.github/workflows/build-wheel-macos-x86_64.yaml
+
+  upload:
+    name: Prepare & Upload wheels to TestPyPI
+    needs: [linux-x86, linux-aarch, macos-arm, macos-x86]
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Download wheels
+      uses: actions/download-artifact@v4
+      with:
+        merge-multiple: true
+        path: dist
+
+    - name: Install rename
+      run: |
+        sudo apt install rename
+
+    - name: Prepare wheels
+      run: |
+        rename "s/linux/manylinux_2_28/" dist/PennyLane_Catalyst-*
+        rename "s/macosx_14/macosx_13/" dist/PennyLane_Catalyst-*
+        rename "s/_universal2/_x86_64/" dist/PennyLane_Catalyst-*
+
+    # - name: Upload wheels
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     user: __token__
+    #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+    #     repository-url: https://test.pypi.org/legacy/
+    #     packages-dir: dist

--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: "40 23 * * 1-5"
   workflow_dispatch:
+  pull_request:
 
 jobs:
   setup:

--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -2,6 +2,7 @@ name: Build nightly Catalyst releases for TestPyPI
 
 on:
   schedule:
+    # Run every weekday at 23:40
     - cron: "40 23 * * 1-5"
   workflow_dispatch:
 

--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -10,12 +10,13 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+  workflow_call:
 
 env:
   MACOSX_DEPLOYMENT_TARGET: 14.0
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: Build Catalyst Wheel on Linux (arm64)-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -70,7 +71,7 @@ jobs:
         path: mlir/mlir-hlo
         key: ${{ runner.os }}-${{ matrix.container_name }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-generic-source
         enableCrossOsArchive: True
-        
+
     - name: Cache Enzyme Source
       id: cache-enzyme-source
       uses: actions/cache@v4
@@ -271,7 +272,7 @@ jobs:
     name: Test Wheels (Python ${{ matrix.python_version.official }})
     runs-on:
       group: 'Office 24th floor M2 Mac'
-    
+
     steps:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v4
@@ -287,7 +288,7 @@ jobs:
       with:
         name: catalyst-linux_arm64-wheel-py-${{ matrix.python_version.official }}.zip
         path: dist
-    
+
     # Needed for accessing llvm-symbolizer
     - name: Get Cached LLVM Build
       id: cache-llvm-build
@@ -296,7 +297,7 @@ jobs:
         path:  llvm-build
         key: ${{ runner.os }}-${{ runner.arch }}-${{ matrix.container_name }}-llvm-${{ needs.constants.outputs.llvm_version }}-generic-build
         fail-on-cache-miss: True
-    
+
     - name: Run Python Pytest Tests
       run: |
         set -x

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -10,9 +10,10 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+  workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: Build Catalyst Wheel on Linux (x86_64)-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -398,7 +398,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Download Wheel Artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: catalyst-manylinux_2_28_x86_64-wheel-py-${{ matrix.python_version }}.zip
         path: dist

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -375,7 +375,7 @@ jobs:
         auditwheel repair dist/*.whl -w ./wheel --no-update-tags --exclude libopenblasp-r0-23e5df77.3.21.dev.so
 
     - name: Upload Wheel Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: catalyst-manylinux_2_28_x86_64-wheel-py-${{ matrix.python_version }}.zip
         path: wheel/

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -10,12 +10,13 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+  workflow_call:
 
 env:
   MACOSX_DEPLOYMENT_TARGET: 14.0
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: Build Catalyst Wheel on macOS (arm64)-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -10,12 +10,13 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+  workflow_call:
 
 env:
   MACOSX_DEPLOYMENT_TARGET: 12
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: Build Catalyst Wheel on macOS (x86_64)-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/set_nightly_version.py
+++ b/.github/workflows/set_nightly_version.py
@@ -1,0 +1,43 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module bumps the Catalyst development version by one unit.
+"""
+
+import os
+import re
+
+version_file_path = os.path.join(os.path.dirname(__file__), "../../frontend/catalyst/_version.py")
+
+assert os.path.isfile(version_file_path)
+
+with open(version_file_path, "r+", encoding="UTF-8") as f:
+    lines = f.readlines()
+
+    version_line = lines[-1]
+    assert "__version__ = " in version_line
+
+    pattern = r"(\d+).(\d+).(\d+)-dev(\d+)"
+    match = re.search(pattern, version_line)
+    assert match
+
+    major, minor, bug, dev = match.groups()
+
+    replacement = f'__version__ = "{major}.{minor}.{bug}-dev{int(dev)+1}"\n'
+    lines[-1] = replacement
+
+    f.seek(0)
+    f.writelines(lines)
+    f.truncate()

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.8.0-dev"
+__version__ = "0.8.0-dev0"


### PR DESCRIPTION
Other developers, projects, CI tools, and users have often needed to use a recent development version of Catalyst, without being able to do so. The main avenue of obtaining a development version of Catalyst has been building from source.

This PR adds a new action that automatically releases a snapshot of Catalyst on schedule (every night). The package version is automatically bumped (e.g. from `0.8.0-dev0` to `0.8.0-dev1`) each time this happens and the main branch updated accordingly.

Testing procedure:
- ~(pre-PR): test action on local fork~
- ~temporarily enable action run on PRs~
- ~(1): test action without branch push or upload~ https://github.com/PennyLaneAI/catalyst/actions/runs/9894753620
- ~(2): test action with upload~ https://github.com/PennyLaneAI/catalyst/actions/runs/9896594944
- ~(3): test action with push to branch~ (I won't be testing this one since since PR workflows don't run on a branch, but it worked on the fork.)
- ~remove all temporary elements from PR~ & merge

[sc-66377]