### PR TITLE
[CI] Fix GH action race condition and demo tests

### DIFF
--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -2,8 +2,8 @@ name: Build nightly Catalyst releases for TestPyPI
 
 on:
   schedule:
-    # Run every weekday at 23:40
-    - cron: "40 23 * * 1-5"
+    # Run every weekday at 23:40 EDT (cron is in UTC)
+    - cron: "40 3 * * 2-6"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -25,7 +25,7 @@ jobs:
         git config --global user.email '${{ secrets.AUTO_UPDATE_VERSION_RINGO_EMAIL }}'
         git config --global user.name "ringo-but-quantum"
         git add $GITHUB_WORKSPACE/frontend/catalyst/_version.py
-        git commit -m "bump nightly version"
+        git commit -m "[no ci] bump nightly version"
         git push
 
   linux-x86:

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -455,9 +455,7 @@ jobs:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}
 
-    # TODO: Find fix for randomly failing demos due to package imports
     - name: Check Catalyst Demos
-      if: false
       run: |
         MDD_BENCHMARK_PRECISION=1 \
         pytest demos --nbmake -n auto

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -456,9 +456,9 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Check Catalyst Demos
-      run: |
+      run: | # Do not run demos in parallel, seems to cause package issues with numpy.
         MDD_BENCHMARK_PRECISION=1 \
-        pytest demos --nbmake -n auto
+        python3 -m pytest demos --nbmake
 
   frontend-tests-lightning-kokkos:
     name: Frontend Tests (backend="lightning.kokkos")

--- a/.github/workflows/check-formatting.yaml
+++ b/.github/workflows/check-formatting.yaml
@@ -14,15 +14,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install "click==8.0.4" black isort pylint
+        run: pip install black isort pylint
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -44,7 +37,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get -y install clang-format-14 python3
+          sudo apt-get -y install clang-format-14
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/check-formatting.yaml
+++ b/.github/workflows/check-formatting.yaml
@@ -20,7 +20,7 @@ jobs:
           python-version: '3.10'
 
       - name: Install dependencies
-        run:
+        run: |
           python -m pip install --upgrade pip
           pip install "click==8.0.4" black isort pylint
 

--- a/.github/workflows/check-formatting.yaml
+++ b/.github/workflows/check-formatting.yaml
@@ -27,7 +27,7 @@ jobs:
         run: isort --check --diff .
 
       - name: Run pylint
-        run: pylint frontend
+        run: pylint --errors-only frontend
 
   format-cpp:
     name: C++ Formatting

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -198,5 +198,6 @@ jobs:
         make pytest TEST_BRAKET=LOCAL
 
     - name: Run Demos
-      run: |
-        make test-demos
+      run: | # Do not run demos in parallel, seems to cause package issues with numpy.
+        MDD_BENCHMARK_PRECISION=1 \
+        python3 -m pytest demos --nbmake

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,5 @@ nbmake
 # optional rt/test dependencies
 pennylane-lightning-kokkos
 amazon-braket-pennylane-plugin>1.27.1
+# TODO: remove once we support jax>=0.4.27
+optax<0.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,5 +26,5 @@ nbmake
 # optional rt/test dependencies
 pennylane-lightning-kokkos
 amazon-braket-pennylane-plugin>1.27.1
-# TODO: remove once we support jax>=0.4.27
+# TODO: remove pin once we support jax>=0.4.27
 optax<0.2.3


### PR DESCRIPTION
This PR implements two fixes in the github actions:
- avoids nightly wheel build race condition by adjusting cron to the right timezone and skipping CI on the version bump commit
- fixes the failing demo tests by pinning the optax version and preventing them from running in parallel

[sc-68989]