### PR TITLE
Support for some non-boolean types as predicates of a conditional with Autograph

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -77,6 +77,22 @@
 * Compile time conditionals on Python types work with Autograph.
   [(#944)](https://github.com/PennyLaneAI/catalyst/pull/944)
 
+  Using a value as a predicate of a condition will no longer fail with Autograph enabled,
+  as the value is now internally converted to `bool`:
+
+  ```python
+  @qml.qjit(autograph=True)
+  def workflow(x):
+      n = 1
+
+      if n:
+          y = x ** 2
+      else:
+          y = x
+
+      return y
+  ```
+
 <h3>Internal changes</h3>
 
 * The function `inactive_callback` was renamed `__catalyst_inactive_callback`.

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -74,6 +74,9 @@
   instead of a tree. This means that we need to manually trace each term and
   finally multiply it with the coefficients to create a Hamiltonian.
 
+* Compile time conditionals on Python types work with Autograph.
+  [(#944)](https://github.com/PennyLaneAI/catalyst/pull/944)
+
 <h3>Internal changes</h3>
 
 * The function `inactive_callback` was renamed `__catalyst_inactive_callback`.

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -86,7 +86,7 @@
       n = 1
 
       if n:
-          y = x ** 2
+          y = x**2
       else:
           y = x
 

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -121,7 +121,7 @@
   instead of a tree. This means that we need to manually trace each term and
   finally multiply it with the coefficients to create a Hamiltonian.
 
-* Compile time conditionals on Python types work with Autograph.
+* Support for some non-boolean types as predicates of a conditional with Autograph.
   [(#944)](https://github.com/PennyLaneAI/catalyst/pull/944)
 
   Using a value as a predicate of a condition will no longer fail with Autograph enabled,

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -549,7 +549,8 @@ class CondCallable:
     """
 
     def __init__(self, pred, true_fn):
-        self.preds = [pred]
+        # Make sure the predicate is a boolean
+        self.preds = [jnp.astype(pred, bool)]
         self.branch_fns = [true_fn]
         self.otherwise_fn = lambda: None
         self._operation = None

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -616,7 +616,7 @@ class CondCallable:
 
         if not isinstance(pred, bool):
             try:
-                pred = jnp.astype(pred, bool)
+                pred = jnp.astype(pred, bool, copy=False)
             except:
                 raise TypeError(
                     "Conditional predicates are required to be of bool, integer or float type"

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -21,6 +21,7 @@ with control flow, including conditionals, for loops, and while loops.
 
 from typing import Any, Callable, List
 
+import jax
 import jax.numpy as jnp
 from jax._src.tree_util import PyTreeDef, tree_unflatten, treedef_is_leaf
 from jax.core import AbstractValue
@@ -549,8 +550,7 @@ class CondCallable:
     """
 
     def __init__(self, pred, true_fn):
-        # Make sure the predicate is a boolean
-        self.preds = [jnp.astype(pred, bool)]
+        self.preds = [self._convert_predicate_to_bool(pred)]
         self.branch_fns = [true_fn]
         self.otherwise_fn = lambda: None
         self._operation = None
@@ -588,7 +588,7 @@ class CondCallable:
                 raise TypeError(
                     "Conditional 'else if' function is not allowed to have any arguments"
                 )
-            self.preds.append(jnp.astype(pred, bool))
+            self.preds.append(self._convert_predicate_to_bool(pred))
             self.branch_fns.append(branch_fn)
             return self
 
@@ -607,6 +607,22 @@ class CondCallable:
             raise TypeError("Conditional 'False' function is not allowed to have any arguments")
         self.otherwise_fn = otherwise_fn
         return self
+
+    def _convert_predicate_to_bool(self, pred):
+        """Convert predicate to bool if necessary."""
+
+        if isinstance(pred, jax.Array) and pred.shape not in ((), (1,)):
+            raise TypeError("Array with multiple elements is not a valid predicate")
+
+        if not isinstance(pred, bool):
+            try:
+                pred = jnp.astype(pred, bool)
+            except:
+                raise TypeError(
+                    "Conditional predicates are required to be of bool, integer or float type"
+                )
+
+        return pred
 
     def _call_with_quantum_ctx(self, ctx):
         outer_trace = ctx.trace

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -588,7 +588,7 @@ class CondCallable:
                 raise TypeError(
                     "Conditional 'else if' function is not allowed to have any arguments"
                 )
-            self.preds.append(pred)
+            self.preds.append(jnp.astype(pred, bool))
             self.branch_fns.append(branch_fn)
             return self
 

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -614,7 +614,7 @@ class CondCallable:
         if isinstance(pred, jax.Array) and pred.shape not in ((), (1,)):
             raise TypeError("Array with multiple elements is not a valid predicate")
 
-        if not isinstance(pred, bool):
+        if not self._is_any_boolean(pred):
             try:
                 pred = jnp.astype(pred, bool, copy=False)
             except TypeError as e:
@@ -623,6 +623,17 @@ class CondCallable:
                 ) from e
 
         return pred
+
+    def _is_any_boolean(self, pred):
+        """Check if a variable represents a type of boolean"""
+
+        if isinstance(pred, bool):
+            return True
+
+        if hasattr(pred, "dtype"):
+            return pred.dtype == bool
+
+        return False
 
     def _call_with_quantum_ctx(self, ctx):
         outer_trace = ctx.trace

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -617,10 +617,10 @@ class CondCallable:
         if not isinstance(pred, bool):
             try:
                 pred = jnp.astype(pred, bool, copy=False)
-            except:
+            except TypeError as e:
                 raise TypeError(
                     "Conditional predicates are required to be of bool, integer or float type"
-                )
+                ) from e
 
         return pred
 

--- a/frontend/test/lit/test_if_else.py
+++ b/frontend/test/lit/test_if_else.py
@@ -25,9 +25,13 @@ from catalyst import cond, measure, qjit
 @qml.qnode(qml.device("lightning.qubit", wires=1))
 def circuit(n: int):
     # CHECK-DAG:   [[c5:%[a-zA-Z0-9_]+]] = stablehlo.constant dense<5> : tensor<i64>
-    # CHECK:       [[b_t:%[a-zA-Z0-9_]+]] = stablehlo.compare  LE, %arg0, [[c5]], SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    # CHECK-DAG:   [[b_t_2:%[a-zA-Z0-9_]+]] = stablehlo.constant dense<false> : tensor<i1>
+    # CHECK:       [[b_t_1:%[a-zA-Z0-9_]+]] = stablehlo.compare  LE, %arg0, [[c5]], SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    # CHECK:       [[b_t_3:%[a-zA-Z0-9_]+]] = stablehlo.broadcast_in_dim [[b_t_2]], dims = [] : (tensor<i1>) -> tensor<i1>
+    # CHECK:       [[b_t_4:%[a-zA-Z0-9_]+]] = stablehlo.compare  NE, [[b_t_1]], [[b_t_3]],  UNSIGNED : (tensor<i1>, tensor<i1>) -> tensor<i1>
+    # CHECK:       [[b_t_5:%[a-zA-Z0-9_]+]] = stablehlo.convert [[b_t_4]] : tensor<i1>
     # CHECK-DAG:   [[qreg_0:%[a-zA-Z0-9_]+]] = quantum.alloc
-    # CHECK:       [[b:%[a-zA-Z0-9_]+]] = tensor.extract [[b_t]]
+    # CHECK:       [[b:%[a-zA-Z0-9_]+]] = tensor.extract [[b_t_5]]    
     @cond(n <= 5)
     # CHECK:       [[qreg_2:%.+]]:2 = scf.if [[b]]
     def cond_fn():
@@ -64,6 +68,7 @@ def test_convert_element_type(i: int, f: float):
     """Test the presence of convert_element_type JAX primitive when the type conversion is
     required."""
 
+    # CHECK: convert_element_type
     # CHECK: cond[
     @cond(i <= 3)
     def cond_fn():
@@ -92,6 +97,7 @@ print(test_convert_element_type.jaxpr)
 def test_no_convert_element_type(i: int):
     """Test the absense of convert_element_type JAX primitive when no type conversion is required"""
 
+    # CHECK: convert_element_type
     # CHECK: cond[
     @cond(i <= 3)
     def cond_fn():

--- a/frontend/test/lit/test_if_else.py
+++ b/frontend/test/lit/test_if_else.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint: disable=line-too-long
+
 # RUN: %PYTHON %s | FileCheck --implicit-check-not convert_element_type %s
 
 import pennylane as qml
@@ -31,7 +33,7 @@ def circuit(n: int):
     # CHECK:       [[b_t_4:%[a-zA-Z0-9_]+]] = stablehlo.compare  NE, [[b_t_1]], [[b_t_3]],  UNSIGNED : (tensor<i1>, tensor<i1>) -> tensor<i1>
     # CHECK:       [[b_t_5:%[a-zA-Z0-9_]+]] = stablehlo.convert [[b_t_4]] : tensor<i1>
     # CHECK-DAG:   [[qreg_0:%[a-zA-Z0-9_]+]] = quantum.alloc
-    # CHECK:       [[b:%[a-zA-Z0-9_]+]] = tensor.extract [[b_t_5]]    
+    # CHECK:       [[b:%[a-zA-Z0-9_]+]] = tensor.extract [[b_t_5]]
     @cond(n <= 5)
     # CHECK:       [[qreg_2:%.+]]:2 = scf.if [[b]]
     def cond_fn():

--- a/frontend/test/lit/test_if_else.py
+++ b/frontend/test/lit/test_if_else.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# pylint: disable=line-too-long
-
 # RUN: %PYTHON %s | FileCheck --implicit-check-not convert_element_type %s
 
 import pennylane as qml
@@ -27,13 +25,9 @@ from catalyst import cond, measure, qjit
 @qml.qnode(qml.device("lightning.qubit", wires=1))
 def circuit(n: int):
     # CHECK-DAG:   [[c5:%[a-zA-Z0-9_]+]] = stablehlo.constant dense<5> : tensor<i64>
-    # CHECK-DAG:   [[b_t_2:%[a-zA-Z0-9_]+]] = stablehlo.constant dense<false> : tensor<i1>
-    # CHECK:       [[b_t_1:%[a-zA-Z0-9_]+]] = stablehlo.compare  LE, %arg0, [[c5]], SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
-    # CHECK:       [[b_t_3:%[a-zA-Z0-9_]+]] = stablehlo.broadcast_in_dim [[b_t_2]], dims = [] : (tensor<i1>) -> tensor<i1>
-    # CHECK:       [[b_t_4:%[a-zA-Z0-9_]+]] = stablehlo.compare  NE, [[b_t_1]], [[b_t_3]],  UNSIGNED : (tensor<i1>, tensor<i1>) -> tensor<i1>
-    # CHECK:       [[b_t_5:%[a-zA-Z0-9_]+]] = stablehlo.convert [[b_t_4]] : tensor<i1>
+    # CHECK:       [[b_t:%[a-zA-Z0-9_]+]] = stablehlo.compare  LE, %arg0, [[c5]], SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
     # CHECK-DAG:   [[qreg_0:%[a-zA-Z0-9_]+]] = quantum.alloc
-    # CHECK:       [[b:%[a-zA-Z0-9_]+]] = tensor.extract [[b_t_5]]
+    # CHECK:       [[b:%[a-zA-Z0-9_]+]] = tensor.extract [[b_t]]
     @cond(n <= 5)
     # CHECK:       [[qreg_2:%.+]]:2 = scf.if [[b]]
     def cond_fn():
@@ -70,7 +64,6 @@ def test_convert_element_type(i: int, f: float):
     """Test the presence of convert_element_type JAX primitive when the type conversion is
     required."""
 
-    # CHECK: convert_element_type
     # CHECK: cond[
     @cond(i <= 3)
     def cond_fn():
@@ -99,7 +92,6 @@ print(test_convert_element_type.jaxpr)
 def test_no_convert_element_type(i: int):
     """Test the absense of convert_element_type JAX primitive when no type conversion is required"""
 
-    # CHECK: convert_element_type
     # CHECK: cond[
     @cond(i <= 3)
     def cond_fn():

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -35,12 +35,13 @@ class TestCondToJaxpr:
             """
             { lambda ; a:i64[]. let
                 b:bool[] = eq a 5
-                c:i64[] = cond[
+                c:bool[] = convert_element_type[new_dtype=bool weak_type=False] b
+                d:i64[] = cond[
                   branch_jaxprs=[{ lambda ; a:i64[] b_:i64[]. let c:i64[] = integer_pow[y=2] a in (c,) },
                                  { lambda ; a_:i64[] b:i64[]. let c:i64[] = integer_pow[y=3] b in (c,) }]
                   nimplicit_outputs=0
-                ] b a a
-              in (c,) }
+                ] c a a
+              in (d,) }
             """
         )
 

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -766,6 +766,27 @@ class TestCondPredicateConversion:
 
         assert workflow(3) == 9
 
+    def test_conversion_failed(self):
+        """Test failure at converting to bool using Autograph."""
+
+        class BoolFail:
+            def __bool__(self):
+                 return 'Fail'
+
+        @qml.qjit(autograph=True)
+        def workflow(x):
+            n = BoolFail()
+
+            if n:
+                y = x**2
+            else:
+                y = 0
+
+            return y
+
+        with pytest.raises(TypeError, match="Cannot determine dtype"):
+            workflow(3)
+
 
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -715,7 +715,7 @@ class TestCondPredicateConversion:
             n = 1
 
             if n:
-                y = x ** 2
+                y = x**2
             else:
                 y = x
 

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -664,5 +664,49 @@ class TestCondOperatorAccess:
         assert func(False) == 0
 
 
+class TestCondPredicateConversion:
+    """Test suite for checking predicate conversion to bool."""
+
+    def test_conversion_integer(self):
+        """Test predicate conversion from integer to bool"""
+
+        @qml.qjit()
+        def workflow(x):
+            n = 1
+
+            # n is an integer but it gets converted to bool
+            @cond(n)
+            def cond_fn():
+                return x**2
+
+            @cond_fn.otherwise
+            def else_fn():
+                return x
+
+            return cond_fn()
+
+        assert workflow(3) == 9
+
+    def test_conversion_float(self):
+        """Test predicate conversion from float to bool."""
+
+        @qml.qjit()
+        def workflow(x):
+            n = 2.0
+
+            # n is a float but it gets converted to bool
+            @cond(n)
+            def cond_fn():
+                return x**2
+
+            @cond_fn.otherwise
+            def else_fn():
+                return x
+
+            return cond_fn()
+
+        assert workflow(3) == 9
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -668,7 +668,7 @@ class TestCondPredicateConversion:
     """Test suite for checking predicate conversion to bool."""
 
     def test_conversion_integer(self):
-        """Test predicate conversion from integer to bool"""
+        """Test predicate conversion from integer to bool."""
 
         @qml.qjit()
         def workflow(x):
@@ -704,6 +704,22 @@ class TestCondPredicateConversion:
                 return x
 
             return cond_fn()
+
+        assert workflow(3) == 9
+
+    def test_conversion_int_autograph(self):
+        """Test predicate conversion from integer to bool using Autograph."""
+
+        @qml.qjit(autograph=True)
+        def workflow(x):
+            n = 1
+
+            if n:
+                y = x ** 2
+            else:
+                y = x
+
+            return y
 
         assert workflow(3) == 9
 

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -766,16 +766,12 @@ class TestCondPredicateConversion:
 
         assert workflow(3) == 9
 
-    def test_conversion_failed(self):
-        """Test failure at converting to bool using Autograph."""
-
-        class BoolFail:
-            def __bool__(self):
-                 return 'Fail'
+    def test_string_conversion_failed(self):
+        """Test failure at converting string to bool using Autograph."""
 
         @qml.qjit(autograph=True)
         def workflow(x):
-            n = BoolFail()
+            n = "fail"
 
             if n:
                 y = x**2
@@ -784,7 +780,29 @@ class TestCondPredicateConversion:
 
             return y
 
-        with pytest.raises(TypeError, match="Cannot determine dtype"):
+        with pytest.raises(
+            TypeError,
+            match="Conditional predicates are required to be of bool, integer or float type",
+        ):
+            workflow(3)
+
+    def test_array_conversion_failed(self):
+        """Test failure at converting array to bool using Autograph."""
+
+        @qml.qjit(autograph=True)
+        def workflow(x):
+            n = jnp.array([[1], [2]])
+
+            if n:
+                y = x**2
+            else:
+                y = 0
+
+            return y
+
+        with pytest.raises(
+            TypeError, match="Array with multiple elements is not a valid predicate"
+        ):
             workflow(3)
 
 

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -669,7 +669,7 @@ class TestCondPredicateConversion:
     """Test suite for checking predicate conversion to bool."""
 
     def test_conversion_integer(self):
-        """Test predicate conversion from integer to bool."""
+        """Test entry predicate conversion from integer to bool."""
 
         @qml.qjit()
         def workflow(x):
@@ -689,7 +689,7 @@ class TestCondPredicateConversion:
         assert workflow(3) == 9
 
     def test_conversion_float(self):
-        """Test predicate conversion from float to bool."""
+        """Test entry predicate conversion from float to bool."""
 
         @qml.qjit()
         def workflow(x):
@@ -708,8 +708,32 @@ class TestCondPredicateConversion:
 
         assert workflow(3) == 9
 
+    def test_else_if_conversion_integer(self):
+        """Test else_if predicate conversion from integer to bool."""
+
+        @qml.qjit()
+        def workflow(x):
+            n = 1
+
+            @cond(n < 0)
+            def cond_fn():
+                return -x
+
+            # n is an integer but it gets converted to bool
+            @cond_fn.else_if(n)
+            def else_if_fn():
+                return x**2
+
+            @cond_fn.otherwise
+            def else_fn():
+                return x
+
+            return cond_fn()
+
+        assert workflow(3) == 9
+
     def test_conversion_int_autograph(self):
-        """Test predicate conversion from integer to bool using Autograph."""
+        """Test entry predicate conversion from integer to bool using Autograph."""
 
         @qml.qjit(autograph=True)
         def workflow(x):
@@ -719,6 +743,24 @@ class TestCondPredicateConversion:
                 y = x**2
             else:
                 y = x
+
+            return y
+
+        assert workflow(3) == 9
+
+    def test_conversion_int_autograph_elif(self):
+        """Test elif predicate conversion from integer to bool using Autograph."""
+
+        @qml.qjit(autograph=True)
+        def workflow(x):
+            n = 1
+
+            if n < 0:
+                y = -x
+            elif n:
+                y = x**2
+            else:
+                y = 0
 
             return y
 


### PR DESCRIPTION
**Context:** CondCallable class was assuming boolean values for its predicate, but other types can be passed as predicates as well. 

**Description of the Change:** Convert the predicate into boolean at the constructor site.

**Benefits:** Predicate is in proper type.

**Possible Drawbacks:** Are there types that cannot be converted (correctly) to booleans?

**Related GitHub Issues:** https://github.com/PennyLaneAI/catalyst/issues/940

**TODO:**

- [x] Check the shape of the predicates
- [x] Skip conversion for anything with dtype == bool

closes #940 

[sc-69070]
