### PR TITLE
Introduce folding argument in ZNE mitigation

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -207,10 +207,16 @@
   instead of a tree. This means that we need to manually trace each term and
   finally multiply it with the coefficients to create a Hamiltonian.
 
+* The function `mitigate_with_zne` accomodates a `folding` input argument for specifying the type of
+  circuit folding technique to be used by the error-mitigation routine
+  (only `global` value is supported to date.)
+  [(#946)](https://github.com/PennyLaneAI/catalyst/pull/946)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):
 
+Alessandro Cosentino,
 Kunwar Maheep Singh,
 Mehrdad Malekmohammadi,
 Romain Moyard,

--- a/frontend/catalyst/api_extensions/error_mitigation.py
+++ b/frontend/catalyst/api_extensions/error_mitigation.py
@@ -32,7 +32,7 @@ from catalyst.jax_primitives import Folding, zne_p
 
 ## API ##
 def mitigate_with_zne(
-    fn=None, *, scale_factors=None, extrapolate=None, extrapolate_kwargs=None, folding="GLOBAL"
+    fn=None, *, scale_factors=None, extrapolate=None, extrapolate_kwargs=None, folding="global"
 ):
     """A :func:`~.qjit` compatible error mitigation of an input circuit using zero-noise
     extrapolation.
@@ -54,9 +54,7 @@ def mitigate_with_zne(
         extrapolate_kwargs (dict[str, Any]): Keyword arguments to be passed to the extrapolation
             function.
         folding (str): Unitary folding technique to be used to scale the circuit. Possible values:
-            - GLOBAL: global unitary of the input circuit is folded
-            - ALL: all gates locally folded
-            - RANDOM: random subset of gates of the input circuits locally folded
+            - global: the global unitary of the input circuit is folded
 
     Returns:
         Callable: A callable object that computes the mitigated of the wrapped :class:`qml.QNode`
@@ -146,9 +144,9 @@ class ZNE:
             raise TypeError("All expectation and classical values dtypes must match and be float.")
         args_data, _ = tree_flatten(args)
         try:
-            folding = Folding[self.folding]
-        except KeyError as e:
-            raise KeyError(f"Folding type must be one of {Folding._member_names_}") from e
+            folding = Folding(self.folding)
+        except ValueError as e:
+            raise ValueError(f"Folding type must be one of {list(map(str, Folding))}") from e
         # TODO: remove the following check once #755 is completed
         if folding != Folding.GLOBAL:
             raise NotImplementedError(f"Folding type {folding.name} is being developed")

--- a/frontend/catalyst/api_extensions/error_mitigation.py
+++ b/frontend/catalyst/api_extensions/error_mitigation.py
@@ -58,7 +58,10 @@ def mitigate_with_zne(
             By default, perfect polynomial fitting will be used.
         extrapolate_kwargs (dict[str, Any]): Keyword arguments to be passed to the extrapolation
             function.
-        folding (str): The unitary folding technique to be used to scale the circuit
+        folding (str): Unitary folding technique to be used to scale the circuit. Possible values:
+            - global: global unitary of the input circuit is folded
+            - all: all gates locally folded
+            - random: random subset of gates of the input circuits locally folded
 
     Returns:
         Callable: A callable object that computes the mitigated of the wrapped :class:`qml.QNode`
@@ -151,6 +154,10 @@ class ZNE:
             folding = Folding[self.folding]
         except KeyError as e:
             raise KeyError(f"Folding type must be one of {Folding._member_names_}") from e
+        # TODO: remove the following check once #755 is completed
+        if folding != Folding.global:
+            raise NotImplementedError(f"Folding type {folding.name}" is being developed")
+
         results = zne_p.bind(
             *args_data,
             self.scale_factors,

--- a/frontend/catalyst/api_extensions/error_mitigation.py
+++ b/frontend/catalyst/api_extensions/error_mitigation.py
@@ -31,7 +31,14 @@ from catalyst.jax_primitives import zne_p, Folding
 
 
 ## API ##
-def mitigate_with_zne(fn=None, *, scale_factors=None, extrapolate=None, extrapolate_kwargs=None, folding='global'):
+def mitigate_with_zne(
+    fn=None, 
+    *, 
+    scale_factors=None, 
+    extrapolate=None, 
+    extrapolate_kwargs=None, 
+    folding="global"
+):
     """A :func:`~.qjit` compatible error mitigation of an input circuit using zero-noise
     extrapolation.
 
@@ -141,14 +148,14 @@ class ZNE:
             raise TypeError("All expectation and classical values dtypes must match and be float.")
         args_data, _ = tree_flatten(args)
         try:
-            folding=Folding[self.folding]
+            folding = Folding[self.folding]
         except KeyError as e:
-            raise KeyError(f"Folding type must be one of {Folding._member_names_}") from e 
+            raise KeyError(f"Folding type must be one of {Folding._member_names_}") from e
         results = zne_p.bind(
-            *args_data, 
-            self.scale_factors, 
-            folding=folding, 
-            jaxpr=jaxpr, 
+            *args_data,
+            self.scale_factors,
+            folding=folding,
+            jaxpr=jaxpr,
             fn=self.fn
         )
         float_scale_factors = jnp.array(self.scale_factors, dtype=float)

--- a/frontend/catalyst/api_extensions/error_mitigation.py
+++ b/frontend/catalyst/api_extensions/error_mitigation.py
@@ -32,11 +32,11 @@ from catalyst.jax_primitives import zne_p, Folding
 
 ## API ##
 def mitigate_with_zne(
-    fn=None, 
-    *, 
-    scale_factors=None, 
-    extrapolate=None, 
-    extrapolate_kwargs=None, 
+    fn=None,
+    *,
+    scale_factors=None,
+    extrapolate=None,
+    extrapolate_kwargs=None,
     folding="global"
 ):
     """A :func:`~.qjit` compatible error mitigation of an input circuit using zero-noise
@@ -58,7 +58,7 @@ def mitigate_with_zne(
             By default, perfect polynomial fitting will be used.
         extrapolate_kwargs (dict[str, Any]): Keyword arguments to be passed to the extrapolation
             function.
-        folding (str): The unitary folding technique to be used to scale the circuit 
+        folding (str): The unitary folding technique to be used to scale the circuit
 
     Returns:
         Callable: A callable object that computes the mitigated of the wrapped :class:`qml.QNode`

--- a/frontend/catalyst/api_extensions/error_mitigation.py
+++ b/frontend/catalyst/api_extensions/error_mitigation.py
@@ -149,7 +149,7 @@ class ZNE:
             raise ValueError(f"Folding type must be one of {list(map(str, Folding))}") from e
         # TODO: remove the following check once #755 is completed
         if folding != Folding.GLOBAL:
-            raise NotImplementedError(f"Folding type {folding.name} is being developed")
+            raise NotImplementedError(f"Folding type {folding.value} is being developed")
 
         results = zne_p.bind(
             *args_data, self.scale_factors, folding=folding, jaxpr=jaxpr, fn=self.fn

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -17,7 +17,7 @@ of quantum operations, measurements, and observables to JAXPR.
 
 import sys
 from dataclasses import dataclass
-from enum import StrEnum
+from enum import Enum
 from itertools import chain
 from typing import Any, Dict, Iterable, List, Union
 
@@ -196,7 +196,7 @@ core.raise_to_shaped_mappings[AbstractObs] = lambda aval, _: aval
 mlir.ir_type_handlers[AbstractObs] = _obs_lowering
 
 
-class Folding(StrEnum):
+class Folding(Enum):
     """
     Folding types supported by ZNE mitigation
     """
@@ -750,7 +750,7 @@ def _folding_attribute(ctx, folding):
     ctx = ctx.module_context.context
     return ir.OpaqueAttr.get(
         "mitigation",
-        ("folding " + Folding(folding)).encode("utf-8"),
+        ("folding " + Folding(folding).value).encode("utf-8"),
         ir.NoneType.get(ctx),
         ctx,
     )

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -94,7 +94,6 @@ from catalyst.utils.calculate_grad_shape import Signature, calculate_grad_shape
 from catalyst.utils.extra_bindings import FromElementsOp, TensorExtractOp
 from catalyst.utils.types import convert_shaped_arrays_to_tensors
 
-
 # pylint: disable=unused-argument,too-many-lines,too-many-statements,protected-access
 
 #########
@@ -192,8 +191,7 @@ core.raise_to_shaped_mappings[AbstractObs] = lambda aval, _: aval
 mlir.ir_type_handlers[AbstractObs] = _obs_lowering
 
 
-
-Folding = IntEnum('Folding', ['global', 'random', 'all'])
+Folding = IntEnum("Folding", ["GLOBAL", "RANDOM", "ALL"])
 
 ##############
 # Primitives #
@@ -739,8 +737,9 @@ def _folding_attribute(ctx, folding):
         "mitigation",
         ("folding " + Folding(folding).name).encode("utf-8"),
         ir.NoneType.get(ctx),
-        ctx
+        ctx,
     )
+
 
 def _zne_lowering(ctx, *args, folding, jaxpr, fn):
     """Lowering function to the ZNE opearation.

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -728,6 +728,12 @@ def _zne_abstract_eval(*args, jaxpr, fn):  # pylint: disable=unused-argument
     return [core.ShapedArray(shape, jaxpr.out_avals[0].dtype)]
 
 
+def _folding_attribute(ctx, folding: str):
+    ctx = ctx.module_context.context
+    return ir.OpaqueAttr.get(
+        "mitigation", ("folding " + folding).encode("utf-8"), ir.NoneType.get(ctx), ctx
+    )
+
 def _zne_lowering(ctx, *args, jaxpr, fn):
     """Lowering function to the ZNE opearation.
     Args:
@@ -746,8 +752,9 @@ def _zne_lowering(ctx, *args, jaxpr, fn):
     return ZneOp(
         flat_output_types,
         ir.FlatSymbolRefAttr.get(symbol_name),
-        mlir.flatten_lowering_ir_args(args[0:-2]),
-        folding.value,
+        mlir.flatten_lowering_ir_args(args),
+        # TODO: Once this works, change hardcoded value to actual value from input
+        _folding_attribute(ctx, "global"),
         scale_factors,
     ).results
 

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -736,8 +736,8 @@ def _zne_abstract_eval(*args, folding, jaxpr, fn):  # pylint: disable=unused-arg
 def _folding_attribute(ctx, folding):
     ctx = ctx.module_context.context
     return ir.OpaqueAttr.get(
-        "mitigation", ("folding " + Folding(folding).name).encode("utf-8"), 
-        ir.NoneType.get(ctx), 
+        "mitigation", ("folding " + Folding(folding).name).encode("utf-8"),
+        ir.NoneType.get(ctx),
         ctx
     )
 

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -736,7 +736,8 @@ def _zne_abstract_eval(*args, folding, jaxpr, fn):  # pylint: disable=unused-arg
 def _folding_attribute(ctx, folding):
     ctx = ctx.module_context.context
     return ir.OpaqueAttr.get(
-        "mitigation", ("folding " + Folding(folding).name).encode("utf-8"),
+        "mitigation",
+        ("folding " + Folding(folding).name).encode("utf-8"),
         ir.NoneType.get(ctx),
         ctx
     )

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -197,6 +197,10 @@ mlir.ir_type_handlers[AbstractObs] = _obs_lowering
 
 
 class Folding(StrEnum):
+    """
+    Folding types supported by ZNE mitigation
+    """
+
     GLOBAL = "global"
     RANDOM = "random"
     ALL = "all"

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -736,7 +736,9 @@ def _zne_abstract_eval(*args, folding, jaxpr, fn):  # pylint: disable=unused-arg
 def _folding_attribute(ctx, folding):
     ctx = ctx.module_context.context
     return ir.OpaqueAttr.get(
-        "mitigation", ("folding " + Folding(folding).name).encode("utf-8"), ir.NoneType.get(ctx), ctx
+        "mitigation", ("folding " + Folding(folding).name).encode("utf-8"), 
+        ir.NoneType.get(ctx), 
+        ctx
     )
 
 def _zne_lowering(ctx, *args, folding, jaxpr, fn):

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -741,11 +741,14 @@ def _zne_lowering(ctx, *args, jaxpr, fn):
     symbol_name = func_op.name.value
     output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
     flat_output_types = util.flatten(output_types)
+    folding = args[-2]
+    scale_factors = args[-1]
     return ZneOp(
         flat_output_types,
         ir.FlatSymbolRefAttr.get(symbol_name),
-        mlir.flatten_lowering_ir_args(args[0:-1]),
-        args[-1],
+        mlir.flatten_lowering_ir_args(args[0:-2]),
+        folding.value,
+        scale_factors,
     ).results
 
 

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -17,7 +17,7 @@ of quantum operations, measurements, and observables to JAXPR.
 
 import sys
 from dataclasses import dataclass
-from enum import IntEnum
+from enum import StrEnum
 from itertools import chain
 from typing import Any, Dict, Iterable, List, Union
 
@@ -196,7 +196,11 @@ core.raise_to_shaped_mappings[AbstractObs] = lambda aval, _: aval
 mlir.ir_type_handlers[AbstractObs] = _obs_lowering
 
 
-Folding = IntEnum("Folding", ["GLOBAL", "RANDOM", "ALL"])
+class Folding(StrEnum):
+    GLOBAL = "global"
+    RANDOM = "random"
+    ALL = "all"
+
 
 ##############
 # Primitives #
@@ -742,7 +746,7 @@ def _folding_attribute(ctx, folding):
     ctx = ctx.module_context.context
     return ir.OpaqueAttr.get(
         "mitigation",
-        ("folding " + Folding(folding).name).encode("utf-8"),
+        ("folding " + Folding(folding)).encode("utf-8"),
         ir.NoneType.get(ctx),
         ctx,
     )

--- a/frontend/test/pytest/test_mitigation.py
+++ b/frontend/test/pytest/test_mitigation.py
@@ -196,7 +196,7 @@ def test_shape_error():
         mitigated_qnode(0.1)
 
 
-def test_folding_type_error():
+def test_folding_type_not_supported():
     """Test that value of folding argument is from allowed list"""
     dev = qml.device("lightning.qubit", wires=2)
 
@@ -204,14 +204,28 @@ def test_folding_type_error():
     def circuit():
         return 0.0
 
-    @catalyst.qjit
-    def mitigated_qnode(*args):  # unused dummy argument to force lazy evaluation of the function
+    def mitigated_qnode():
         return catalyst.mitigate_with_zne(
             circuit, scale_factors=[], folding="bad-folding-type-value"
         )()
 
-    with pytest.raises(KeyError, match="Folding type must be"):
-        mitigated_qnode()
+    with pytest.raises(ValueError, match="Folding type must be"):
+        catalyst.qjit(mitigated_qnode)
+
+
+def test_folding_type_not_implemented():
+    """Test value of folding argument supported but not yet developed"""
+    dev = qml.device("lightning.qubit", wires=2)
+
+    @qml.qnode(device=dev)
+    def circuit():
+        return 0.0
+
+    def mitigated_qnode():
+        return catalyst.mitigate_with_zne(circuit, scale_factors=[], folding="all")()
+
+    with pytest.raises(NotImplementedError):
+        catalyst.qjit(mitigated_qnode)
 
 
 @pytest.mark.parametrize("params", [0.1, 0.2, 0.3, 0.4, 0.5])

--- a/frontend/test/pytest/test_mitigation.py
+++ b/frontend/test/pytest/test_mitigation.py
@@ -205,7 +205,7 @@ def test_folding_type_error():
         return 0.0
 
     @catalyst.qjit
-    def mitigated_qnode(*args):
+    def mitigated_qnode(*args):  # unused dummy argument to force lazy evaluation of the function
         return catalyst.mitigate_with_zne(
             circuit, scale_factors=[], folding="bad-folding-type-value"
         )()

--- a/frontend/test/pytest/test_mitigation.py
+++ b/frontend/test/pytest/test_mitigation.py
@@ -196,6 +196,24 @@ def test_shape_error():
         mitigated_qnode(0.1)
 
 
+def test_folding_type_error():
+    """Test that value of folding argument is from allowed list"""
+    dev = qml.device("lightning.qubit", wires=2)
+
+    @qml.qnode(device=dev)
+    def circuit():
+        return 0.0
+
+    @catalyst.qjit
+    def mitigated_qnode(*args):
+        return catalyst.mitigate_with_zne(
+            circuit, scale_factors=[], folding="bad-folding-type-value"
+        )()
+
+    with pytest.raises(KeyError, match="Folding type must be"):
+        mitigated_qnode()
+
+
 @pytest.mark.parametrize("params", [0.1, 0.2, 0.3, 0.4, 0.5])
 def test_zne_usage_patterns(params):
     """Test usage patterns of catalyst.zne."""

--- a/mlir/include/Mitigation/IR/CMakeLists.txt
+++ b/mlir/include/Mitigation/IR/CMakeLists.txt
@@ -1,3 +1,10 @@
 add_mlir_dialect(MitigationOps mitigation)
 add_mlir_doc(MitigationDialect MitigationDialect Mitigation/ -gen-dialect-doc)
 add_mlir_doc(MitigationOps MitigationOps Mitigation/ -gen-op-doc)
+
+set(LLVM_TARGET_DEFINITIONS MitigationOps.td)
+mlir_tablegen(MitigationEnums.h.inc -gen-enum-decls)
+mlir_tablegen(MitigationEnums.cpp.inc -gen-enum-defs)
+mlir_tablegen(MitigationAttributes.h.inc -gen-attrdef-decls -attrdefs-dialect=mitigation)
+mlir_tablegen(MitigationAttributes.cpp.inc -gen-attrdef-defs -attrdefs-dialect=mitigation)
+add_public_tablegen_target(MLIRMitigationEnumsIncGen)

--- a/mlir/include/Mitigation/IR/MitigationDialect.td
+++ b/mlir/include/Mitigation/IR/MitigationDialect.td
@@ -34,7 +34,7 @@ def Mitigation_Dialect : Dialect {
 
     /// Use the default type printing/parsing hooks, otherwise we would explicitly define them.
     // let useDefaultTypePrinterParser = 1;
-    // let useDefaultAttributePrinterParser = 1;
+    let useDefaultAttributePrinterParser = 1;
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/Mitigation/IR/MitigationOps.h
+++ b/mlir/include/Mitigation/IR/MitigationOps.h
@@ -23,5 +23,8 @@
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 
+#include "Mitigation/IR/MitigationEnums.h.inc"
+#define GET_ATTRDEF_CLASSES
+#include "Mitigation/IR/MitigationAttributes.h.inc"
 #define GET_OP_CLASSES
 #include "Mitigation/IR/MitigationOps.h.inc"

--- a/mlir/include/Mitigation/IR/MitigationOps.h
+++ b/mlir/include/Mitigation/IR/MitigationOps.h
@@ -23,6 +23,7 @@
 
 #include "mlir/Bytecode/BytecodeOpInterface.h"
 
+#include "Mitigation/IR/MitigationDialect.h"
 #include "Mitigation/IR/MitigationEnums.h.inc"
 #define GET_ATTRDEF_CLASSES
 #include "Mitigation/IR/MitigationAttributes.h.inc"

--- a/mlir/include/Mitigation/IR/MitigationOps.td
+++ b/mlir/include/Mitigation/IR/MitigationOps.td
@@ -15,20 +15,20 @@
 #ifndef MITIGATION_OPS
 #define MITIGATION_OPS
 
+include "mlir/IR/BuiltinAttributes.td"
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpBase.td"
-include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/IR/SymbolInterfaces.td"
-include "mlir/IR/BuiltinAttributes.td"
+include "mlir/Interfaces/CallInterfaces.td"
 
 include "Mitigation/IR/MitigationDialect.td"
 
 def Folding : I32EnumAttr<"Folding",
     "Folding types",
     [
-        I32EnumAttrCase<"GLOBAL", 1>,
-        I32EnumAttrCase<"RANDOM", 2>,
-        I32EnumAttrCase<"ALL",    3>,
+        I32EnumAttrCase<"global", 1>,
+        I32EnumAttrCase<"random", 2>,
+        I32EnumAttrCase<"all",    3>,
     ]> {
     let cppNamespace = "catalyst::mitigation";
     let genSpecializedAttr = 0;

--- a/mlir/include/Mitigation/IR/MitigationOps.td
+++ b/mlir/include/Mitigation/IR/MitigationOps.td
@@ -26,9 +26,9 @@ include "Mitigation/IR/MitigationDialect.td"
 def Folding : I32EnumAttr<"Folding",
     "Folding types",
     [
-        I32EnumAttrCase<"global", 1>,
-        I32EnumAttrCase<"random", 2>,
-        I32EnumAttrCase<"all",    3>,
+        I32EnumAttrCase<"GLOBAL", 1>,
+        I32EnumAttrCase<"RANDOM", 2>,
+        I32EnumAttrCase<"ALL",    3>,
     ]> {
     let cppNamespace = "catalyst::mitigation";
     let genSpecializedAttr = 0;

--- a/mlir/include/Mitigation/IR/MitigationOps.td
+++ b/mlir/include/Mitigation/IR/MitigationOps.td
@@ -15,12 +15,27 @@
 #ifndef MITIGATION_OPS
 #define MITIGATION_OPS
 
+include "mlir/IR/EnumAttr.td"
+include "mlir/IR/OpBase.td"
 include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/IR/SymbolInterfaces.td"
 include "mlir/IR/BuiltinAttributes.td"
-include "mlir/IR/OpBase.td"
 
 include "Mitigation/IR/MitigationDialect.td"
+
+def Folding : I32EnumAttr<"Folding",
+    "Folding types",
+    [
+        I32EnumAttrCase<"global", 1>,
+        I32EnumAttrCase<"random", 2>,
+        I32EnumAttrCase<"all",    3>,
+    ]> {
+    let cppNamespace = "catalyst::mitigation";
+    let genSpecializedAttr = 0;
+}
+
+def FoldingAttr : EnumAttr<Mitigation_Dialect, Folding, "folding">;
+
 
 def ZneOp : Mitigation_Op<"zne", [DeclareOpInterfaceMethods<CallOpInterface>,
     DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
@@ -32,12 +47,13 @@ def ZneOp : Mitigation_Op<"zne", [DeclareOpInterfaceMethods<CallOpInterface>,
     let arguments = (ins
         FlatSymbolRefAttr:$callee,
         Variadic<AnyType>:$args,
+        FoldingAttr:$folding,
         RankedTensorOf<[AnySignlessIntegerOrIndex]>:$scaleFactors
     );
     let results = (outs Variadic<AnyTypeOf<[AnyFloat, RankedTensorOf<[AnyFloat]>]>>);
 
     let assemblyFormat = [{
-        $callee `(` $args `)` `scaleFactors` `(` $scaleFactors `:` type($scaleFactors) `)` attr-dict `:` functional-type($args, results)
+        $callee `(` $args `)` `folding` `(` $folding `)` `scaleFactors` `(` $scaleFactors `:` type($scaleFactors) `)` attr-dict `:` functional-type($args, results)
     }];
 }
 

--- a/mlir/lib/Mitigation/IR/CMakeLists.txt
+++ b/mlir/lib/Mitigation/IR/CMakeLists.txt
@@ -7,5 +7,5 @@ add_mlir_library(MLIRMitigation
 
     DEPENDS
     MLIRMitigationOpsIncGen
-
+    MLIRMitigationEnumsIncGen
 )

--- a/mlir/lib/Mitigation/IR/MitigationDialect.cpp
+++ b/mlir/lib/Mitigation/IR/MitigationDialect.cpp
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "mlir/IR/Builders.h"
-#include "mlir/Transforms/InliningUtils.h"
 #include "mlir/IR/DialectImplementation.h" // needed for generated type parser
-#include "llvm/ADT/TypeSwitch.h"           // needed for generated type parser
+#include "mlir/Transforms/InliningUtils.h"
+#include "llvm/ADT/TypeSwitch.h" // needed for generated type parser
 
 #include "Mitigation/IR/MitigationDialect.h"
 #include "Mitigation/IR/MitigationOps.h"

--- a/mlir/lib/Mitigation/IR/MitigationDialect.cpp
+++ b/mlir/lib/Mitigation/IR/MitigationDialect.cpp
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "mlir/IR/Builders.h"
 #include "mlir/Transforms/InliningUtils.h"
+#include "mlir/IR/DialectImplementation.h" // needed for generated type parser
+#include "llvm/ADT/TypeSwitch.h"           // needed for generated type parser
 
 #include "Mitigation/IR/MitigationDialect.h"
 #include "Mitigation/IR/MitigationOps.h"
@@ -44,9 +47,26 @@ struct MitigationInlinerInterface : public DialectInlinerInterface {
 
 void MitigationDialect::initialize()
 {
+    addTypes<
+#define GET_TYPEDEF_LIST
+#include "Mitigation/IR/MitigationOpsTypes.cpp.inc"
+        >();
+
+    addAttributes<
+#define GET_ATTRDEF_LIST
+#include "Mitigation/IR/MitigationAttributes.cpp.inc"
+        >();
+
     addOperations<
 #define GET_OP_LIST
 #include "Mitigation/IR/MitigationOps.cpp.inc"
         >();
+
     addInterface<MitigationInlinerInterface>();
 }
+
+#define GET_TYPEDEF_CLASSES
+#include "Mitigation/IR/MitigationOpsTypes.cpp.inc"
+
+#define GET_ATTRDEF_CLASSES
+#include "Mitigation/IR/MitigationAttributes.cpp.inc"

--- a/mlir/lib/Mitigation/IR/MitigationOps.cpp
+++ b/mlir/lib/Mitigation/IR/MitigationOps.cpp
@@ -21,12 +21,12 @@
 #include "Mitigation/IR/MitigationDialect.h"
 #include "Mitigation/IR/MitigationOps.h"
 
-using namespace mlir;
-using namespace catalyst::mitigation;
-
 #include "Mitigation/IR/MitigationEnums.cpp.inc"
 #define GET_OP_CLASSES
 #include "Mitigation/IR/MitigationOps.cpp.inc"
+
+using namespace mlir;
+using namespace catalyst::mitigation;
 
 //===----------------------------------------------------------------------===//
 // SymbolUserOpInterface

--- a/mlir/lib/Mitigation/IR/MitigationOps.cpp
+++ b/mlir/lib/Mitigation/IR/MitigationOps.cpp
@@ -28,7 +28,6 @@ using namespace catalyst::mitigation;
 #define GET_OP_CLASSES
 #include "Mitigation/IR/MitigationOps.cpp.inc"
 
-
 //===----------------------------------------------------------------------===//
 // SymbolUserOpInterface
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Mitigation/IR/MitigationOps.cpp
+++ b/mlir/lib/Mitigation/IR/MitigationOps.cpp
@@ -14,17 +14,20 @@
 
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OpImplementation.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 
 #include "Mitigation/IR/MitigationDialect.h"
 #include "Mitigation/IR/MitigationOps.h"
 
+using namespace mlir;
+using namespace catalyst::mitigation;
+
+#include "Mitigation/IR/MitigationEnums.cpp.inc"
 #define GET_OP_CLASSES
 #include "Mitigation/IR/MitigationOps.cpp.inc"
 
-using namespace mlir;
-using namespace catalyst::mitigation;
 
 //===----------------------------------------------------------------------===//
 // SymbolUserOpInterface

--- a/mlir/lib/Mitigation/Transforms/MitigationMethods/Zne.cpp
+++ b/mlir/lib/Mitigation/Transforms/MitigationMethods/Zne.cpp
@@ -152,7 +152,7 @@ FlatSymbolRefAttr ZneLowering::getOrInsertFoldedCircuit(Location loc, PatternRew
     func::FuncOp fnAllocOp =
         SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(op, quantumAllocRefAttr);
 
-    // Get the number of qubits 
+    // Get the number of qubits
     quantum::AllocOp allocOp = *fnOp.getOps<quantum::AllocOp>().begin();
     std::optional<int64_t> numberQubitsOptional = allocOp.getNqubitsAttr();
     int64_t numberQubits = numberQubitsOptional.value_or(0);

--- a/mlir/lib/Mitigation/Transforms/MitigationMethods/Zne.cpp
+++ b/mlir/lib/Mitigation/Transforms/MitigationMethods/Zne.cpp
@@ -45,9 +45,6 @@ void ZneLowering::rewrite(mitigation::ZneOp op, PatternRewriter &rewriter) const
     RankedTensorType scaleFactorType = scaleFactors.getType().cast<RankedTensorType>();
     const auto sizeInt = scaleFactorType.getDimSize(0);
 
-    // Folding type
-    auto folding = op.getFolding();
-
     // Create the folded circuit function
     FlatSymbolRefAttr foldedCircuitRefAttr =
         getOrInsertFoldedCircuit(loc, rewriter, op, scaleFactorType.getElementType());

--- a/mlir/lib/Mitigation/Transforms/MitigationMethods/Zne.cpp
+++ b/mlir/lib/Mitigation/Transforms/MitigationMethods/Zne.cpp
@@ -45,6 +45,9 @@ void ZneLowering::rewrite(mitigation::ZneOp op, PatternRewriter &rewriter) const
     RankedTensorType scaleFactorType = scaleFactors.getType().cast<RankedTensorType>();
     const auto sizeInt = scaleFactorType.getDimSize(0);
 
+    // Folding type
+    auto folding = op.getFolding();
+
     // Create the folded circuit function
     FlatSymbolRefAttr foldedCircuitRefAttr =
         getOrInsertFoldedCircuit(loc, rewriter, op, scaleFactorType.getElementType());
@@ -149,7 +152,7 @@ FlatSymbolRefAttr ZneLowering::getOrInsertFoldedCircuit(Location loc, PatternRew
     func::FuncOp fnAllocOp =
         SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(op, quantumAllocRefAttr);
 
-    // Get the number of qubits
+    // Get the number of qubits 
     quantum::AllocOp allocOp = *fnOp.getOps<quantum::AllocOp>().begin();
     std::optional<int64_t> numberQubitsOptional = allocOp.getNqubitsAttr();
     int64_t numberQubits = numberQubitsOptional.value_or(0);

--- a/mlir/test/Mitigation/zne.mlir
+++ b/mlir/test/Mitigation/zne.mlir
@@ -99,6 +99,6 @@ func.func @simpleCircuit(%arg0: tensor<3xf64>) -> f64 attributes {qnode} {
     // CHECK:    return [[results]] : tensor<5xf64>
 func.func @zneCallScalarScalar(%arg0: tensor<3xf64>) -> tensor<5xf64> {
     %scaleFactors = arith.constant dense<[1, 2, 3, 4, 5]> : tensor<5xindex>
-    %0 = mitigation.zne @simpleCircuit(%arg0) folding (GLOBAL) scaleFactors (%scaleFactors : tensor<5xindex>) : (tensor<3xf64>) -> tensor<5xf64>
+    %0 = mitigation.zne @simpleCircuit(%arg0) folding (global) scaleFactors (%scaleFactors : tensor<5xindex>) : (tensor<3xf64>) -> tensor<5xf64>
     func.return %0 : tensor<5xf64>
 }

--- a/mlir/test/Mitigation/zne.mlir
+++ b/mlir/test/Mitigation/zne.mlir
@@ -99,6 +99,6 @@ func.func @simpleCircuit(%arg0: tensor<3xf64>) -> f64 attributes {qnode} {
     // CHECK:    return [[results]] : tensor<5xf64>
 func.func @zneCallScalarScalar(%arg0: tensor<3xf64>) -> tensor<5xf64> {
     %scaleFactors = arith.constant dense<[1, 2, 3, 4, 5]> : tensor<5xindex>
-    %0 = mitigation.zne @simpleCircuit(%arg0) folding (global) scaleFactors (%scaleFactors : tensor<5xindex>) : (tensor<3xf64>) -> tensor<5xf64>
+    %0 = mitigation.zne @simpleCircuit(%arg0) folding (GLOBAL) scaleFactors (%scaleFactors : tensor<5xindex>) : (tensor<3xf64>) -> tensor<5xf64>
     func.return %0 : tensor<5xf64>
 }

--- a/mlir/test/Mitigation/zne.mlir
+++ b/mlir/test/Mitigation/zne.mlir
@@ -99,6 +99,6 @@ func.func @simpleCircuit(%arg0: tensor<3xf64>) -> f64 attributes {qnode} {
     // CHECK:    return [[results]] : tensor<5xf64>
 func.func @zneCallScalarScalar(%arg0: tensor<3xf64>) -> tensor<5xf64> {
     %scaleFactors = arith.constant dense<[1, 2, 3, 4, 5]> : tensor<5xindex>
-    %0 = mitigation.zne @simpleCircuit(%arg0) scaleFactors (%scaleFactors : tensor<5xindex>) : (tensor<3xf64>) -> tensor<5xf64>
+    %0 = mitigation.zne @simpleCircuit(%arg0) folding (global) scaleFactors (%scaleFactors : tensor<5xindex>) : (tensor<3xf64>) -> tensor<5xf64>
     func.return %0 : tensor<5xf64>
 }


### PR DESCRIPTION
**Context:**
We'd like to extend Zero-noise extrapolation (ZNE) with different folding techniques. For more details, see #755 and  https://mitiq.readthedocs.io/en/stable/guide/zne-3-options.html#unitary-folding.

**Description of the Change:**
In this PR a `folding` argument is added both to the ZNE mitigation routine in Catalyst API/frontend/MLIR dialect.
At the moment the argument is passed throughout the stack from the frontend all the way to the MLIR dialect. However it is mute, in the sense that it's not being used to change the behavior of the MLIR ZNE transform. 

**Benefits:**
This is an incremental change to discuss design and to accomodate follow-up pull requests where the argument will be used to branch off the ZNE mitigation code for different unitary folding techniques.

**Possible Drawbacks:**
The argument is left as `global` by default and it's not yet used in the MLIR transform, so the current behavior is unchanged. If one tries to use different value for the new argument, exceptions are raised. 

**Related GitHub Issues:**
This is an incremental change towards #755.