### PR TITLE
Add missing backtick

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -514,7 +514,7 @@ Tzung-Han Juang,
   [(#730)](https://github.com/PennyLaneAI/catalyst/pull/730)
 
 * All decorators in Catalyst, including `vmap`, `qjit`, `mitigate_with_zne`,
-  as well as gradient decorators `grad`, `jacobian`, jvp`, and `vjp`, can now be used
+  as well as gradient decorators `grad`, `jacobian`, `jvp`, and `vjp`, can now be used
   both with and without keyword arguments as a decorator without the need for
   `functools.partial`:
   [(#758)](https://github.com/PennyLaneAI/catalyst/pull/758)


### PR DESCRIPTION
**Context:** jvp mention is missing opening backtick

**Description of the Change:** Add the backtick

**Benefits:** Proper rendering.

**Related GitHub Issues:** https://github.com/PennyLaneAI/catalyst/issues/912
