### PR TITLE
[DOCS] Changelog and documentation update

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -11,29 +11,47 @@
   @qjit
   @grad
   def f(x):
-    expm = catalyst.accelerate(jax.scipy.linalg.expm)
-    return jnp.sum(expm(jnp.sin(x)) ** 2)
+      expm = catalyst.accelerate(jax.scipy.linalg.expm)
+      return jnp.sum(expm(jnp.sin(x)) ** 2)
   ```
 
   ```pycon
   >>> x = jnp.array([[0.1, 0.2], [0.3, 0.4]])
   >>> f(x)
-  >>> array([[2.80120452, 1.67518663],
-      [1.61605839, 4.42856163]])
+  Array([[2.80120452, 1.67518663],
+         [1.61605839, 4.42856163]], dtype=float64)
   ```
 
-* Runtime validation within QJIT functions using `catalyst.debug_assert`.
+* Assertions can now be raised at runtime via the `catalyst.debug_assert` function.
   [(#925)](https://github.com/PennyLaneAI/catalyst/pull/925)
 
-  Can be turned off by setting compile time flag `disable_assertions=True`.
+  Python-based exceptions (via `raise`) and assertions (via `assert`)
+  will always be evaluated at program capture time, before certain runtime information
+  may be available.
+
+  Use `debug_assert` to instead raise assertions at runtime, including
+  assertions that depend on values of dynamic variables.
 
   For example,
+
   ```python
   @qjit
   def f(x):
       debug_assert(x < 5, "x was greater than 5")
       return x * 8
+  ```
 
+  ```pycon
+  >>> f(4)
+  Array(32, dtype=int64)
+  >>> f(6)
+  RuntimeError: x was greater than 5
+  ```
+
+  Assertions can be disabled globally for a qjit-compiled function
+  via the ``disable_assertions`` keyword argument:
+
+  ```python
   @qjit(disable_assertions=True)
   def g(x):
       debug_assert(x < 5, "x was greater than 5")
@@ -41,12 +59,8 @@
   ```
 
   ```pycon
-  >>> f(4)
-  >>> Array(32, dtype=int64)
-  >>> f(6)
-  >>> RuntimeError: x was greater than 5
   >>> g(6)
-  >>> Array(48, dtype=int64)
+  Array(48, dtype=int64)
   ```
 
 <h3>Improvements</h3>
@@ -54,14 +68,12 @@
 * Catalyst is now compatible with Enzyme `v0.0.130`
   [(#898)](https://github.com/PennyLaneAI/catalyst/pull/898)
 
-* Added support for the jax.numpy.argsort function so it works when compiled with qjit.
+* Support has been added for the `jax.numpy.argsort`
+  function within qjit-compiled functions.
   [(#901)](https://github.com/PennyLaneAI/catalyst/pull/901)
 
-* Callbacks now have nicer identifiers. The identifiers include the name of
-  the python function being called back into.
-  [(#919)](https://github.com/PennyLaneAI/catalyst/pull/919)
-
-* Static_argnums now can be passed through a QNode
+* Static arguments can now be passed through a QNode when specified
+  with the `static_argnums` keyword argument.
   [(#932)](https://github.com/PennyLaneAI/catalyst/pull/932)
 
   ```python
@@ -78,48 +90,62 @@
 
   ```pycon
   >>> circuit(0.5, 0.5)
-  >>> "Inside QNode: 0.5"
+  "Inside QNode: 0.5"
+  Array(0.77015115, dtype=float64)
   ```
 
-* Autograph now supports in-place array assignments with static slices. [(#843)](https://github.com/PennyLaneAI/catalyst/pull/843)
+* Autograph now supports in-place array assignments with static slices.
+  [(#843)](https://github.com/PennyLaneAI/catalyst/pull/843)
 
   For example,
 
   ```python
   @qjit(autograph=True)
   def f(x, y):
-    y[1:10:2] = x
-    return y
+      y[1:10:2] = x
+      return y
   ```
 
   ```pycon
   >>> f(jnp.ones(5), jnp.zeros(10))
-  >>> Array([0., 1., 0., 1., 0., 1., 0., 1., 0., 1.], dtype=float64)
+  Array([0., 1., 0., 1., 0., 1., 0., 1., 0., 1.], dtype=float64)
   ```
 
-* Autograph works when `qjit` is applied to a function decorated with `vmap`, `cond`, `for_loop` or `while_loop`.
+* Autograph now works when `qjit` is applied to a function decorated with `vmap`, `cond`, `for_loop` or `while_loop`.
   [(#835)](https://github.com/PennyLaneAI/catalyst/pull/835)
   [(#938)](https://github.com/PennyLaneAI/catalyst/pull/938)
   [(#942)](https://github.com/PennyLaneAI/catalyst/pull/942)
 
+  ```python
+  dev = qml.device("lightning.qubit", wires=2)
+
+  @qml.qnode(dev)
+  def circuit(x):
+      qml.RX(x, wires=0)
+      return qml.expval(qml.PauliZ(0))
+  ```
+
+  ```pycon
+  >>> x = jnp.array([0.1, 0.2, 0.3])
+  >>> qjit(vmap(circuit), autograph=True)(x)
+  Array([0.99500417, 0.98006658, 0.95533649], dtype=float64)
+  ```
+
 <h3>Breaking changes</h3>
-* Return values are `jax.Array` typed instead of `numpy.array`.
+
+* Return values of qjit-compiled functions are now of type `jax.Array` instead of `numpy.ndarray`.
+  This should have minimal impact, but code that depends on the output of qjit-compiled function
+  being NumPy arrays will need to be updated.
   [(#895)](https://github.com/PennyLaneAI/catalyst/pull/895)
 
 <h3>Bug fixes</h3>
 
-* Make Autograph copy `QNode` instead of creating new one from scratch to preserve information such as transforms and `mcm_method`. [(#900)](https://github.com/PennyLaneAI/catalyst/pull/900)
+* Fixes a bug where Catalyst would fail to apply quantum transforms and preserve QNode configuration settings when Autograph was enabled.
+  [(#900)](https://github.com/PennyLaneAI/catalyst/pull/900)
   
-* Using float32 in callback functions would not crash in compilation phase anymore,
-  but rather raise the appropriate type exception to the user.
+* Passing arrays with `float32` dtype to callback functions will no longer cause compilation to
+  crash, but rather will raise the appropriate type exception.
   [(#916)](https://github.com/PennyLaneAI/catalyst/pull/916)
-
-* Fix tracing of `SProd` operations
-  [(#935)](https://github.com/PennyLaneAI/catalyst/pull/935)
-
-  After some changes in PennyLane, `Sprod.terms()` returns the terms as leaves
-  instead of a tree. This means that we need to manually trace each term and
-  finally multiply it with the coefficients to create a Hamiltonian.
 
 <h3>Internal changes</h3>
 
@@ -128,6 +154,17 @@
 
 * The function `__catalyst_inactive_callback` has the nofree attribute.
   [(#898)](https://github.com/PennyLaneAI/catalyst/pull/898)
+
+* Callbacks now have nicer identifiers. The identifiers include the name of
+  the Python function being called back into.
+  [(#919)](https://github.com/PennyLaneAI/catalyst/pull/919)
+
+* Fix tracing of `SProd` operations to bring Catalyst in line with PennyLane v0.38.
+  [(#935)](https://github.com/PennyLaneAI/catalyst/pull/935)
+
+  After some changes in PennyLane, `Sprod.terms()` returns the terms as leaves
+  instead of a tree. This means that we need to manually trace each term and
+  finally multiply it with the coefficients to create a Hamiltonian.
 
 <h3>Contributors</h3>
 

--- a/doc/dev/autograph.rst
+++ b/doc/dev/autograph.rst
@@ -61,7 +61,7 @@ To enable AutoGraph in Catalyst, simply pass ``autograph=True`` to the ``@qjit``
 >>> weights = jnp.linspace(-1, 1, 20).reshape([5, 4])
 >>> data = jnp.ones([4])
 >>> cost(weights, data)
-array(0.30455313)
+Array(0.30455313, dtype=float64)
 
 This would be equivalent to writing the following program, without using
 AutoGraph, but instead using :func:`~.cond` and :func:`~.for_loop`:
@@ -97,7 +97,7 @@ AutoGraph, but instead using :func:`~.cond` and :func:`~.for_loop`:
         return qml.expval(qml.PauliZ(0) + qml.PauliZ(3))
 
 >>> cost(weights, data)
-array(0.30455313)
+Array(0.30455313, dtype=float64)
 
 Currently, AutoGraph supports converting the following Python statements:
 
@@ -136,7 +136,7 @@ within the qjit-compiled function.
         return x
 
 >>> g(0.4, 6)
-array(22.14135448)
+Array(22.14135448, dtype=float64)
 
 One way to verify that the control flow is being correctly captured and
 converted is to examine the jaxpr representation of the compiled
@@ -241,10 +241,10 @@ AssertionError: Expected matching shapes
 ...         y = jnp.array([0.4, 0.5, -0.1])
 ...     return jnp.sum(y)
 >>> f(0.5)
-array(0.8)
+Array(0.8, dtype=float64)
 
 More generally, this also applies to common container classes such as
-`dict`, `list`, and `tuple`. If one branch assigns an external variable,
+``dict``, ``list``, and ``tuple``. If one branch assigns an external variable,
 then all other branches must also assign the external variable with the same
 type, nested structure, number of elements, element types, and array shapes.
 
@@ -256,7 +256,7 @@ type, nested structure, number of elements, element types, and array shapes.
 ...         y = {"a": jnp.array([0.5, 0., -0.2]), "b": -1}
 ...     return y
 >>> f(1.5)
-{'a': array([0.1, 0.2, 0.3]), 'b': array(6)}
+{'a': Array([0.1, 0.2, 0.3], dtype=float64), 'b': Array(6, dtype=int64)}
 
 Automatic data type promotion in branches
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -272,7 +272,7 @@ Catalyst will automatically perform data type promotion (such as converting inte
 ...         y = 4
 ...     return y
 >>> f(0.5)
-array(4.)
+Array(4., dtype=float64)
 
 New variable assignments
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -299,7 +299,7 @@ does not apply **as long as you don't change the type**:
 ...         y = 0.4
 ...     return y
 >>> f(0.5)
-array(0.4)
+Array(0.4, dtype=float64)
 
 If we change the type of the ``y``, however, we will need to include an
 ``else`` statement to also change the type:
@@ -313,7 +313,7 @@ If we change the type of the ``y``, however, we will need to include an
 ...         y = -1
 ...     return y
 >>> f(0.5)
-array(-1)
+Array(-1, dtype=int64)
 
 Compatible type assignments
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -348,14 +348,14 @@ This includes automatic unpacking and enumeration through JAX arrays:
 ...     return z
 >>> weights = jnp.array([[0.1, 0.2, 0.3, 0.4], [0.5, 0.6, 0.7, 0.8]]).T
 >>> f(weights)
-array(8.4)
+Array(8.4, dtype=float64)
 
 This also works when looping through Python containers, **as long as the containers
 can be converted to a JAX array**:
 
 >>> weights = [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]]
 >>> f(weights)
-array(3.4)
+Array(3.4, dtype=float64)
 
 If the container cannot be converted to a JAX array (e.g., a list of strings),
 then AutoGraph will **not** capture the for loop; instead, AutoGraph will
@@ -374,7 +374,7 @@ fallback to Python, and the loop will be unrolled at compile-time:
         return qml.expval(qml.PauliZ(0))
 
 >>> f()
-array(-0.70710678)
+Array(-0.70710678, dtype=float64)
 
 The Python ``range`` function is also fully supported by AutoGraph, even when
 its input is a **dynamic variable** (i.e., its numeric value is only known at
@@ -387,7 +387,7 @@ runtime):
 ...         x = x + 1 / k
 ...     return x
 >>> f(100000)
-array(0.57722066)
+Array(0.57722066, dtype=float64)
 
 Indexing within a loop
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -405,7 +405,7 @@ For example, using a for loop with static bounds to index a JAX array is straigh
 ...     return qml.expval(qml.PauliZ(0))
 >>> weights = jnp.array([0.1, 0.2, 0.3])
 >>> f(weights)
-array(0.99500417)
+Array(0.99500417, dtype=float64)
 
 However, for optimal performance, indexing within a for loop with AutoGraph will require
 that the object indexed is a JAX array or dynamic runtime variable.
@@ -431,7 +431,7 @@ The compiled function will still execute, but has been compiled without the for
 loop (the for loop was unrolled at compilation):
 
 >>> f()
-array(0.99500417)
+Array(0.99500417, dtype=float64)
 
 To allow AutoGraph conversion to work in this case, simply convert the list to
 a JAX array:
@@ -444,7 +444,7 @@ a JAX array:
 ...         qml.RX(x[i], wires=i)
 ...     return qml.expval(qml.PauliZ(0))
 >>> f()
-array(0.99500417)
+Array(0.99500417, dtype=float64)
 
 
 What if the object you are indexing **cannot** be converted to a JAX
@@ -486,9 +486,9 @@ as the object indexed is a JAX array:
 ...         qml.RY(x[i], wires=0)
 ...     return qml.expval(qml.PauliZ(0))
 >>> f(2)
-array(0.70710678)
+Array(0.70710678, dtype=float64)
 >>> f(3)
-array(-0.70710678)
+Array(-0.70710678, dtype=float64)
 
 However AutoGraph conversion will fail if the object being indexed by the
 loop with dynamic bounds is **not** a JAX array, because you cannot index
@@ -538,7 +538,7 @@ For loops that update variables can also be converted with AutoGraph:
 ...         x = x + y
 ...     return x
 >>> f(4)
-array(13)
+Array(13, dtype=int64)
 
 However, like with conditionals, a similar restriction applies: variables
 which are updated across iterations of the loop must have a JAX compilable
@@ -553,7 +553,7 @@ You can also utilize temporary variables within a for loop:
 ...         x = x + y * c
 ...     return x
 >>> f(4)
-array(22)
+Array(22, dtype=int64)
 
 Temporary variables used inside a loop --- and that are **not** passed to a
 function within the loop --- do not have any type restrictions.
@@ -572,7 +572,7 @@ AutoGraph:
 ...         n += 1
 ...     return n
 >>> f(0.1)
-array(9.)
+Array(9., dtype=float64)
 
 Break and continue
 ~~~~~~~~~~~~~~~~~~
@@ -602,7 +602,7 @@ As with for loops, while loops that update variables can also be converted with 
 ...         x = x + 2
 ...     return x
 >>> f(4)
-array(6.4)
+Array(6.4, dtype=float64)
 
 However, like with conditionals, a similar restriction applies: variables
 which are updated across iterations of the loop must have a JAX compilable
@@ -617,7 +617,7 @@ You can also utilize temporary variables within a while loop:
 ...         x = x + 2 * len(c)
 ...     return x
 >>> f(4)
-array(8.4)
+Array(8.4, dtype=float64)
 
 Temporary variables used inside a loop --- and that are **not** passed to a
 function within the loop --- do not have any type restrictions.
@@ -635,9 +635,9 @@ computed at runtime.
 ...     b = not y >= 1.0
 ...     return a or b
 >>> f(0.5, 1.1)
-array(True)
+Array(True, dtype=bool)
 >>> f(1.5, 1.6)
-array(False)
+Array(False, dtype=bool)
 
 Internally, logical statements are converted as follows:
 
@@ -671,7 +671,7 @@ of multiple measurements. For example,
         return qml.expval(qml.PauliZ(1))
 
 >>> circuit()
-array(0.87758256)
+Array(0.87758256, dtype=float64)
 
 Note that there are a couple of important constraints and restrictions that must be
 considered when working with logical statements.
@@ -702,9 +702,9 @@ and ``jnp.logical_not(x)`` explicitly if one of your arguments is static:
 ... def f(x):
 ...     return jnp.logical_and(x, True)
 >>> f(False)
-array(False)
+Array(False, dtype=bool)
 >>> f(True)
-array(True)
+Array(True, dtype=bool)
 
 Array arguments
 ~~~~~~~~~~~~~~~
@@ -715,7 +715,7 @@ Note that, like with NumPy and JAX, logical operators apply elementwise to array
 ... def f(x, y):
 ...     return x and y
 >>> f(jnp.array([0, 1]), jnp.array([1, 1]))
-array([False,  True])
+Array([False,  True], dtype=bool)
 
 Care must therefore be taken when using logical operators within conditional branches;
 ``jnp.all`` and ``jnp.any`` can be used to generate a single boolean for conditionals:
@@ -728,7 +728,7 @@ Care must therefore be taken when using logical operators within conditional bra
 ...         z = -1
 ...     return z
 >>> f(jnp.array([0, 1]), jnp.array([1, 1]))
-array(-1)
+Array(-1, dtype=int64)
 
 .. _debugging:
 
@@ -792,7 +792,7 @@ silence AutoGraph warnings; this can be done via ``autograph_ignore_fallbacks``:
 ...         qml.RX(float(x[i]), wires=i)
 ...     return qml.expval(qml.PauliZ(0))
 >>> f()
-array(0.99500417)
+Array(0.99500417, dtype=float64)
 
 Finally, we've seen examples above where we have used the JAXPR representation
 of the compiled function in order to verify that AutoGraph is correctly capturing
@@ -844,7 +844,7 @@ Let's consider an example where a for loop is evaluated at compile time:
 >>> f(2.)
 0 Traced<ShapedArray(float64[], weak_type=True)>with<DynamicJaxprTrace(level=1/0)>
 1 Traced<ShapedArray(float64[], weak_type=True)>with<DynamicJaxprTrace(level=1/0)>
-array(0.25)
+Array(0.25, dtype=float64)
 
 Here, the for loop is evaluated at compile time (notice the multiple tracers
 that have been printed out during program capture --- one for each loop!),
@@ -880,7 +880,7 @@ function with ``autograph=True``:
       return x
 
 >>> g(0.1, 10)
-array(4.02997319)
+Array(4.02997319, dtype=float64)
 
 Note that for Autograph to be disabled, the decorated function must be
 defined **outside** the qjit-compiled function. If it is defined within
@@ -955,27 +955,35 @@ To update array values when using JAX, the `JAX syntax for array assignment
 <https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#array-updates-x-at-idx-set-y>`__
 (which uses the array ``at`` and ``set`` methods) must be used:
 
->>> @qjit(autograph=True)
-... def f(x):
-...     first_dim = x.shape[0]
-...     result = jnp.empty((first_dim,), dtype=x.dtype)
-...
-...     for i in range(first_dim):
-...         result = result.at[i].set(x[i]* 2)
-...
-...     return result
+.. code-block:: python
 
-However, if updating a single index of the array, Autograph supports conversion of
-standard Python array assignment syntax:
+    @qjit(autograph=True, abstracted_axes=(0,))
+    def f(x):
+        first_dim = x.shape[0]
+        result = jnp.empty((first_dim,), dtype=x.dtype)
 
->>> @qjit(autograph=True)
-... def f(x):
-...     first_dim = x.shape[0]
-...     result = jnp.empty((first_dim,), dtype=x.dtype)
-...
-...     for i in range(first_dim):
-...         result[i] = x[i] * 2
-...
-...     return result
+        for i in range(first_dim):
+            result = result.at[i].set(x[i] * 2)
+
+        return result
+
+>>> f(jnp.array([0.1, 0.2, 0.3]))
+Array([0.2, 0.4, 0.6], dtype=float64)
+
+However, if updating a single static index or slice of the array, then Autograph supports conversion
+of standard Python array assignment syntax:
+
+.. code-block:: python
+
+    @qjit(autograph=True)
+    def f(x, y):
+        y[1:10:2] = x  # static slice index
+        y[0] = x[-1] ** 2   # single integer index
+        return y
+
+>>> x = jnp.linspace(2, 5, 5)
+>>> y = jnp.zeros([11])
+>>> f(x, y)
+Array([25.,  2.,  0.,  2.75,  0.,  3.5,  0.,  4.25,  0., 5.,  0.], dtype=float64)
 
 Under the hood, Catalyst converts anything coming in the latter notation into the former one.

--- a/doc/dev/callbacks.rst
+++ b/doc/dev/callbacks.rst
@@ -60,9 +60,9 @@ a qjit-compiled function, as long as the return shape and type is known:
         return simpson(x, x ** 2)
 
 >>> integrate_xsq(-1, 1)
-array(0.66666667)
+Array(0.66666667, dtype=float64)
 >>> integrate_xsq(-1, 2)
-array(3.)
+Array(3., dtype=float64)
 
 Please see the docstring of :func:`~.pure_callback` for more details, including how to define
 vector-Jacobian product (VJP) rules for autodifferentiation, and for specifying the return-type
@@ -84,7 +84,7 @@ provide return shape and dtype information:
 
 >>> x = np.array([1.0, 2.0, 1.0, -1.0, 1.5])
 >>> fn(x)
-array(4.20735492+0.j)
+Array(4.20735492+0.j, dtype=complex128)
 
 Accelerator (GPU and TPU) support
 ---------------------------------

--- a/doc/dev/jax_integration.rst
+++ b/doc/dev/jax_integration.rst
@@ -77,7 +77,7 @@ and only apply outside of QNodes:
         return jax.lax.fori_loop(0, 10, cost, x)
 
 >>> fn(jnp.array([0.1, 0.2, 0.3, 0.5]))
-array([0.6, 0.6, 0.8, 1. ])
+Array([0.6, 0.6, 0.8, 1. ], dtype=float64)
 
 Function support
 ----------------
@@ -88,7 +88,6 @@ that doesn't work with Catalyst includes:
 
 - ``jax.numpy.polyfit``
 - ``jax.numpy.fft``
-- ``jax.numpy.argsort``
 - ``jax.scipy.linalg``
 - ``jax.numpy.ndarray.at[index]`` when ``index`` corresponds to all array
   indices.
@@ -124,14 +123,14 @@ functions can accept, create, and return arrays of dynamic shape without trigger
 ...     return jax.numpy.ones([size, size], dtype=float)
 >>> func(3)
 Compiling
-array([[1., 1., 1.],
+Array([[1., 1., 1.],
        [1., 1., 1.],
-       [1., 1., 1.]])
+       [1., 1., 1.]], dtype=float64)
 >>> func(4)
-array([[1., 1., 1., 1.],
+Array([[1., 1., 1., 1.],
        [1., 1., 1., 1.],
        [1., 1., 1., 1.],
-       [1., 1., 1., 1.]])
+       [1., 1., 1., 1.]], dtype=float64)
 
 Dynamic arrays can be created using ``jnp.ones`` and ``jnp.zeros``. Note that ``jnp.arange``
 and ``jnp.linspace`` do not currently support generating dynamically-shaped arrays (however, unlike
@@ -186,7 +185,7 @@ can be used **as long as they are not applied to quantum processing**.
 ...         return -jnp.sin(y) ** 2
 ...     return jax.grad(g)(x)
 >>> f(0.4)
-array(-0.71735609)
+Array(-0.71735609, dtype=float64)
 
 If they are applied to quantum processing, an error will occur:
 
@@ -211,7 +210,7 @@ quantum-classical processing:
 ...         return qml.expval(qml.PauliZ(0))
 ...     return grad(lambda y: g(y) ** 2)(x)
 >>> f(0.4)
-array(-0.71735609)
+Array(-0.71735609, dtype=float64)
 
 Always use the equivalent Catalyst transformation
 (:func:`catalyst.grad`, :func:`catalyst.jacobian`, :func:`catalyst.vjp`, :func:`catalyst.jvp`)

--- a/doc/dev/quick_start.rst
+++ b/doc/dev/quick_start.rst
@@ -67,7 +67,7 @@ The :func:`.qjit` decorator can be used to jit a workflow of quantum functions:
     jitted_circuit = qjit(circuit)
 
 >>> jitted_circuit(0.7)
-array(0.)
+Array(0., dtype=float64)
 
 In Catalyst, dynamic wire values are fully supported for operations, observables and measurements.
 For example, the following circuit can be jitted with wires as arguments:
@@ -83,7 +83,7 @@ For example, the following circuit can be jitted with wires as arguments:
         return qml.probs(wires=[arg1 + 1])
 
 >>> circuit(jnp.pi / 3, 1, 2)
-array([0.625, 0.375])
+Array([0.625, 0.375], dtype=float64)
 
 
 Operations
@@ -311,22 +311,22 @@ In the following example, the number of shots is set to :math:`500` in the devic
         )
 
 >>> circuit([0.3, 0.5, 0.7])
-[array([[0., 0., 0.],
-        [0., 0., 0.],
-        [0., 0., 0.],
+(Array([[0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0],
         ...,
-        [0., 0., 0.],
-        [0., 0., 0.],
-        [0., 0., 0.]]),
-array([0., 1., 2., 3., 4., 5., 6., 7.]),
-array([458,   7,  35,   0,   0,   0,   0,   0]),
-array(0.95533649),
-array(0.08733219),
-array([0.91782642, 0.05984182, 0.02096486, 0.0013669 ]),
-array([ 0.89994966-0.32850727j,  0.        +0.j        ,
+        [0, 0, 0],
+        [0, 0, 0],
+        [0, 0, 0]], dtype=int64),
+ (Array([0, 1, 2, 3, 4, 5, 6, 7], dtype=int64),
+  Array([453,   0,  31,   0,  16,   0,   0,   0], dtype=int64)),
+ Array(0.936, dtype=float64),
+ Array(0.138816, dtype=float64),
+ Array([0.926, 0.048, 0.026, 0.   ], dtype=float64),
+ Array([ 0.89994966-0.32850727j,  0.        +0.j        ,
         -0.08388168-0.22979488j,  0.        +0.j        ,
         -0.04964902-0.13601409j,  0.        +0.j        ,
-        -0.0347301 +0.01267748j,  0.        +0.j        ])]
+        -0.0347301 +0.01267748j,  0.        +0.j        ],      dtype=complex128))
 
 The PennyLane projective mid-circuit measurement is also supported in Catalyst.
 :func:`.measure` is a QJIT compatible mid-circuit measurement for Catalyst that only
@@ -352,9 +352,9 @@ In the following example, ``m`` will be equal to ``True`` if wire :math:`0` is r
         return m
 
 >>> circuit(jnp.pi)
-True
+Array(True, dtype=bool)
 >>> circuit(0.0)
-False
+Array(False, dtype=bool)
 
 Compilation Modes
 =================
@@ -379,9 +379,9 @@ the quantum function is executed. For example, ``circuit`` is compiled as early 
         return qml.expval(qml.PauliZ(wires=1))
 
 >>> circuit(0.5)  # the first call, compilation occurs here
-array(0.)
+Array(0., dtype=float64)
 >>> circuit(0.5)  # the precompiled quantum function is called
-array(0.)
+Array(0., dtype=float64)
 
 .. _ahead_of_time:
 
@@ -407,8 +407,8 @@ and data type of a tensor:
         return qml.state()
 
 >>> circuit(0.2j, jnp.array([0.3, 0.6, 0.9]))  # calls precompiled function
-array([0.75634905-0.52801002j, 0. +0.j,
-   0.35962678+0.14074839j, 0. +0.j])
+Array([0.75634905-0.52801002j, 0. +0.j,
+   0.35962678+0.14074839j, 0. +0.j], dtype=complex128)
 
 At this stage the compilation already happened, so the execution of ``circuit`` calls the compiled function directly on
 the first call, resulting in faster initial execution. Note that implicit type promotion for most datatypes are allowed
@@ -574,7 +574,7 @@ This decorator accepts the function to differentiate, a differentiation strategy
         return g(x)
 
 >>> workflow(2.0)
-array(-3.14159265)
+Array(-3.14159265, dtype=float64)
 
 To specify the differentiation strategy, the ``method`` argument can be passed
 to the ``grad`` function:
@@ -619,7 +619,7 @@ also feasible.
         return grad(circuit, argnum=0)(params)
 
 >>> workflow(jnp.array([2.0, 3.0]))
-array([-2.88051099, -1.92034063])
+Array([-2.88051099, -1.92034063], dtype=float64)
 
 The :func:`.grad` decorator works for functions that return a scalar value. You can also use the :func:`.jacobian`
 decorator to compute Jacobian matrices of general hybrid functions with multiple or multivariate results.
@@ -638,10 +638,10 @@ decorator to compute Jacobian matrices of general hybrid functions with multiple
         return g(x)
 
 >>> workflow(jnp.array([2.0, 1.0]))
-array([[ 3.48786850e-16 -4.20735492e-01]
-       [-8.71967125e-17  4.20735492e-01]])
+Array([[ 3.48786850e-16 -4.20735492e-01]
+       [-8.71967125e-17  4.20735492e-01]], dtype=float64)
 
-This decorator has the same methods and API as `grad`. See the documentation for more details.
+This decorator has the same methods and API as ``grad``. See the documentation for more details.
 
 Optimizers
 ----------
@@ -697,7 +697,7 @@ the value of ``value_and_grad`` argument. To optimize params iteratively, you la
         return param
 
 >>> workflow()
-array(1.57079633)
+Array(1.57079633, dtype=float64)
 
 JAX Integration
 ===============

--- a/doc/dev/sharp_bits.rst
+++ b/doc/dev/sharp_bits.rst
@@ -67,9 +67,9 @@ our :func:`@qjit <~.qjit>` compiled function:
 ...     return x ** 2
 >>> f(2.)
 x = Traced<ShapedArray(float64[], weak_type=True)>with<DynamicJaxprTrace(level=1/0)>
-array(4.)
+Array(4., dtype=float64)
 >>> f(3.)
-array(9.)
+Array(9., dtype=float64)
 
 We can see that on the first execution, program capture/tracing occurs, and we
 can see the dynamic variable is printed (tracers capture *type*
@@ -144,9 +144,9 @@ Instead, we can use Catalyst control flow :func:`~.cond` here:
 ...         return x
 ...     return g() ** 2
 >>> f(2.)
-array(4.)
+Array(4., dtype=float64)
 >>> f(6.)
-array(9.)
+Array(9., dtype=float64)
 
 Here, both conditional branches are compiled, and only evaluated at runtime
 when the value of ``x`` is known.
@@ -166,7 +166,7 @@ Let's consider an example where a for loop is evaluated at compile time:
 >>> f(2.)
 0 Traced<ShapedArray(float64[], weak_type=True)>with<DynamicJaxprTrace(level=1/0)>
 1 Traced<ShapedArray(float64[], weak_type=True)>with<DynamicJaxprTrace(level=1/0)>
-array(0.25)
+Array(0.25, dtype=float64)
 
 Here, the for loop is evaluated at compile time (notice the multiple tracers
 that have been printed out during program capture --- one for each loop!),
@@ -186,9 +186,9 @@ rather than runtime.
     ...         x = x / 2
     ...     return x ** 2
     >>> Traced<ShapedArray(float64[], weak_type=True)>with<DynamicJaxprTrace(level=1/0)>
-    ... array(4.)
+    ... Array(4., dtype=float64)
     >>> f(6.)
-    ... array(9.)
+    ... Array(9., dtype=float64)
 
     For more details, see the :doc:`AutoGraph guide <autograph>`.
 
@@ -210,7 +210,7 @@ If we wish to print the value of variables at *runtime*, we can instead use the
 ...     return x ** 2
 >>> g(2.)
 Value of x = 2.0
-array(4.)
+Array(4., dtype=float64)
 
 Avoiding recompilation
 ----------------------
@@ -227,9 +227,9 @@ For example, consider the following:
 ...     return x ** 2 + y
 >>> f(0.4, 1)
 Tracing occurring
-array(1.16)
+Array(1.16, dtype=float64)
 >>> f(0.2, 3)
-array(3.04)
+Array(3.04, dtype=float64)
 
 However, if we change the argument types in a way where Catalyst can't perform
 auto-type promotion before passing the argument to the compiled function
@@ -237,23 +237,23 @@ auto-type promotion before passing the argument to the compiled function
 
 >>> f(0.15, 0.65)
 Tracing occurring
-array(0.6725)
+Array(0.6725, dtype=float64)
 
 However, changing a float to an integer will not cause recompilation:
 
 >>> f(2, 4.65)
-array(8.65)
+Array(8.65, dtype=float64)
 
 Similarly, changing the shape of an array will also trigger recompilation:
 
 >>> f(jnp.array([0.2]), jnp.array([0.6]))
 Tracing occurring
-array([0.64])
+Array([0.64], dtype=float64)
 >>> f(jnp.array([0.8]), jnp.array([1.6]))
-array([2.24])
+Array([2.24], dtype=float64)
 >>> f(jnp.array([0.8, 0.1]), jnp.array([1.6, -2.0]))
 Tracing occurring
-array([ 2.24, -1.99])
+Array([ 2.24, -1.99], dtype=float64)
 
 This is something to be aware of, especially when porting existing PennyLane
 code to work with Catalyst. For example, consider the following, where the
@@ -279,10 +279,10 @@ function execution:
 
 >>> circuit(jnp.array([0.1, 0.2]))
 Tracing occurring
-array(0.99500417)
+Array(0.99500417, dtype=float64)
 >>> circuit(jnp.array([0.1, 0.2, 0.3]))
 Tracing occurring
-array(0.99500417)
+Array(0.99500417, dtype=float64)
 
 To be explicitly warned about recompilation, you can use ahead-of-time
 (AOT) mode, by specifying types and shapes in the function signature
@@ -303,16 +303,16 @@ the compiled function as long as the arguments match the specified shapes and
 type:
 
 >>> circuit(jnp.array([0.1, 0.2, 0.3]))
-array(0.99500417)
+Array(0.99500417, dtype=float64)
 >>> circuit(jnp.array([1.4, 1.4, 0.3]))
-array(0.16996714)
+Array(0.16996714, dtype=float64)
 
 However, deviating from this will result in recompilation and a warning message:
 
 >>> circuit(jnp.array([1.4, 1.4, 0.3, 0.1]))
 UserWarning: Provided arguments did not match declared signature, recompiling...
 Tracing occurring
-array(0.16996714)
+Array(0.16996714, dtype=float64)
 
 Specifying compile-time constants
 ---------------------------------
@@ -330,12 +330,12 @@ Otherwise, re-using previous static argument values will result in no re-compila
 ...   return x + y
 >>> f(0.5, 0.3)
 Compiling with y=0.3
-array(0.8)
+Array(0.8, dtype=float64)
 >>> f(0.1, 0.3)  # no re-compilation occurs
-array(0.4)
+Array(0.4, dtype=float64)
 >>> f(0.1, 0.4)  # y changes, re-compilation
 Compiling with y=0.4
-array(0.5)
+Array(0.5, dtype=float64)
 
 This functionality can be used to support passing arbitrary Python objects to QJIT-compiled
 functions, as long as they are hashable:
@@ -346,21 +346,21 @@ functions, as long as they are hashable:
 
     @dataclass
     class MyClass:
-      val: int
+        val: int
 
-      def __hash__(self):
-          return hash(str(self))
+        def __hash__(self):
+            return hash(str(self))
 
     @qjit(static_argnums=(1,))
     def f(x: int, y: MyClass):
-      return x + y.val
+        return x + y.val
 
 >>> f(1, MyClass(5))
-array(6)
+Array(6, dtype=int64)
 >>> f(1, MyClass(6))  # re-compilation
-array(7)
+Array(7, dtype=int64)
 >>> f(2, MyClass(5))  # no re-compilation
-array(7)
+Array(7, dtype=int64)
 
 Note that when ``static_argnums`` is used in conjunction with type hinting,
 ahead-of-time compilation will not be possible since the static argument values
@@ -528,7 +528,7 @@ can be used **as long as they are not applied to quantum processing**.
 ...         return -jnp.sin(y) ** 2
 ...     return jax.grad(g)(x)
 >>> f(0.4)
-array(-0.71735609)
+Array(-0.71735609, dtype=float64)
 
 If they are applied to quantum processing, an error will occur:
 
@@ -553,7 +553,7 @@ quantum-classical processing:
 ...         return qml.expval(qml.PauliZ(0))
 ...     return grad(lambda y: g(y) ** 2)(x)
 >>> f(0.4)
-array(-0.71735609)
+Array(-0.71735609, dtype=float64)
 
 Always use the equivalent Catalyst transformation
 (:func:`catalyst.grad`, :func:`catalyst.jacobian`, :func:`catalyst.vjp`, :func:`catalyst.jvp`)
@@ -633,7 +633,7 @@ when working with classical control in Catalyst.
   ...         return 6.  # float
   ...     return cond_fn()
   >>> f(1.5)
-  array(6.)
+  Array(6., dtype=float64)
 
 - There may be some cases where automatic type promotion cannot be applied; for example,
   omitting a return value in one branch (e.g., which by default in Python is equivalent
@@ -661,7 +661,7 @@ when working with classical control in Catalyst.
   ...         return x
   ...     return cond_fn()
   >>> f(1.6)
-  array(2.56)
+  Array(2.56, dtype=float64)
 
 - Finally, a reminder that conditional functions provided to :func:`~.cond` cannot
   accept any arguments.
@@ -699,7 +699,7 @@ This includes transforms that generate many circuits,
         return [qml.expval(qml.PauliY(0)), qml.expval(qml.PauliZ(0))]
 
 >>> circuit(0.4)
-[array(-0.51413599), array(0.85770868)]
+(Array(-0.38941834, dtype=float64), Array(0.92106099, dtype=float64))
 
 as well as transforms that simply map the circuit to another:
 
@@ -714,7 +714,7 @@ as well as transforms that simply map the circuit to another:
         return qml.expval(qml.PauliZ(0))
 
 >>> circuit(0.5)
-array(0.73168887)
+Array(0.73168887, dtype=float64)
 
 We can inspect the jaxpr representation of the compiled program, to verify that only
 a single RX gate is being applied due to the rotation gate merger:
@@ -817,7 +817,7 @@ Instead, Catalyst control flow (such as :func:`~.cond` and :func:`.for_loop`) mu
         return qml.expval(qml.PauliZ(0))
 
 >>> circuit(0.3)
-array(0.95533649)
+Array(0.95533649, dtype=float64)
 
 Note that here we make sure to include the Catalyst control flow within a ``QuantumTape`` context.
 This is because :func:`~.cond` cannot return operations, only capture queued/instantiated
@@ -926,7 +926,8 @@ dictionaries as input to the compiled function:
 >>> x = qml.RX(0.4, wires=0)
 >>> y = {"apple": (True, jnp.array([0.1, 0.2, 0.3]))}
 >>> f(x, y)
-(RX(array(0.4), wires=[0]), {'apple': (array(True), array([0.1, 0.2, 0.3]))})
+(RX(Array(0.4, dtype=float64), wires=[0]),
+ {'apple': (Array(True, dtype=bool), Array([0.1, 0.2, 0.3], dtype=float64))}))
 
 Arbitrary objects cannot be passed as function arguments, unless they
 are registered as Pytrees with compatible data types.
@@ -963,12 +964,12 @@ dynamic part of the custom object (``MyObject.x``) changes:
 ...     return my_object.x
 >>> f(MyObject(jnp.array(0.1), name="test1"))
 Compiling: name=test1
-array(0.1)
+Array(0.1, dtype=float64)
 >>> f(MyObject(jnp.array(0.2), name="test1"))
-array(0.2)
+Array(0.2, dtype=float64)
 >>> f(MyObject(jnp.array(0.2), name="test2"))
 Compiling: name=test2
-array(0.2)
+Array(0.2, dtype=float64)
 
 .. note::
 
@@ -997,14 +998,14 @@ of a tensor created within (or returned by) the compiled function:
 ...     return jax.numpy.ones([size, size], dtype=float)
 >>> func(3)
 Compiling
-array([[1., 1., 1.],
+Array([[1., 1., 1.],
        [1., 1., 1.],
-       [1., 1., 1.]])
+       [1., 1., 1.]], dtype=float64)
 >>> func(4)
-array([[1., 1., 1., 1.],
+Array([[1., 1., 1., 1.],
        [1., 1., 1., 1.],
        [1., 1., 1., 1.],
-       [1., 1., 1., 1.]])
+       [1., 1., 1., 1.]], dtype=float64)
 
 Dynamic arrays can be created using ``jnp.ones``, ``jnp.zeros``. Note that ``jnp.arange``
 and ``jnp.linspace`` do not currently support generating dynamically-shaped arrays (however, unlike
@@ -1021,9 +1022,9 @@ to specify which axes of the tensors should be considered dynamic during compila
 ...     return jnp.sum(x)
 >>> sum_fn(jnp.array([1., 0.5]))
 Compiling
-array(1.5)
+Array(1.5, dtype=float64)
 >>> sum_fn(jnp.array([1., 0.5, 0.6]))
-array(2.1)
+Array(2.1, dtype=float64)
 
 Note that failure to specify this argument will cause re-compilation each time
 input tensor arguments change shape:
@@ -1034,10 +1035,10 @@ input tensor arguments change shape:
 ...     return jnp.sum(x)
 >>> sum_fn(jnp.array([1., 0.5]))
 Compiling
-array(1.5)
+Array(1.5, dtype=float64)
 >>> sum_fn(jnp.array([1., 0.5, 0.6]))
 Compiling
-array(2.1)
+Array(2.1, dtype=float64)
 
 For more details on using ``abstracted_axes``, please see the :func:`~.qjit` documentation.
 
@@ -1055,7 +1056,7 @@ conditional statements, are also supported:
 ...         return a + i
 ...     return loop(a)
 >>> f(5)
-array([21., 21., 21., 21., 21.])
+Array([21., 21., 21., 21., 21.], dtype=float64)
 
 By default, Catalyst for loops and while loops will automatically
 
@@ -1088,7 +1089,7 @@ iterations, the ``allow_array_resizing`` argument can be used:
 ...         return jnp.ones([i], dtype=float) # return array of new dimensions
 ...     return loop(a)
 >>> f(5)
-array([1., 1., 1., 1., 1., 1., 1., 1., 1.])
+Array([1., 1., 1., 1., 1., 1., 1., 1., 1.], dtype=float64)
 
 However, outer-scope dynamically-shaped arrays can no longer be captured and used
 within the loop in this mode:
@@ -1160,17 +1161,17 @@ returned, or alternatively using a single return statement with multiple measure
 ...     qml.RX(x, wires=0)
 ...     return {"samples": qml.sample(), "expval": qml.expval(qml.PauliZ(0))}
 >>> circuit(0.3)
-{'expval': array(-0.9899925),
- 'samples': array([[1., 0.],
-        [1., 0.],
-        [1., 0.],
-        [1., 0.],
-        [1., 0.],
-        [1., 0.],
-        [1., 0.],
-        [0., 0.],
-        [1., 0.],
-        [1., 0.]])}
+{'expval': Array(1., dtype=float64),
+ 'samples': Array([[0, 0],
+        [0, 0],
+        [0, 0],
+        [0, 0],
+        [0, 0],
+        [0, 0],
+        [0, 0],
+        [0, 0],
+        [1, 0],
+        [0, 0]], dtype=int64)}
 
 
 Recursion
@@ -1213,7 +1214,7 @@ we can use a while loop:
         return result
 
 >>> fibonacci(10)
-array(89)
+Array(89, dtype=int64)
 
 Compatibility with broadcasting
 -------------------------------

--- a/frontend/catalyst/__init__.py
+++ b/frontend/catalyst/__init__.py
@@ -183,6 +183,7 @@ __all__ = (
     "AutoGraphError",
     "CompileError",
     "DifferentiableCompileError",
+    "debug_assert",
     "CompileOptions",
     "debug",
     *_api_extension_list,

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -108,15 +108,21 @@ def accelerate(func=None, *, dev=None):
             y = accelerate(classical_fn)(x) # will be executed on a GPU
             return jnp.cos(y)
 
-    With gradients:
+    Accelerated functions also fully support autodifferentiation with
+    :func:`~.grad`, :func:`~.jacobian`, and other Catalyst differentiation functions:
 
     .. code-block:: python
 
         @qjit
         @grad
         def f(x):
-            expm = catalyst.accelerate(jax.scipy.linalg.expm)
+            expm = accelerate(jax.scipy.linalg.expm)
             return jnp.sum(expm(jnp.sin(x)) ** 2)
+
+    >>> x = jnp.array([[0.1, 0.2], [0.3, 0.4]])
+    >>> f(x)
+    Array([[2.80120452, 1.67518663],
+           [1.61605839, 4.42856163]], dtype=float64)
     """
     # Setting default parameters
     if dev is None:
@@ -181,7 +187,7 @@ def pure_callback(callback_fn, result_type=None):
             return jnp.cos(callback_fn(x ** 2))
 
     >>> fn(0.654)
-    array(0.9151995)
+    Array(0.9151995, dtype=float64)
 
     It can also be used functionally:
 
@@ -189,7 +195,7 @@ def pure_callback(callback_fn, result_type=None):
     >>> def add_one(x):
     ...     return catalyst.pure_callback(lambda x: x + 1, int)(x)
     >>> add_one(2)
-    array(3)
+    Array(3, dtype=int64)
 
     For callback functions that return arrays, a ``jax.ShapeDtypeStruct``
     object can be created to specify the expected return shape and data type:
@@ -210,7 +216,7 @@ def pure_callback(callback_fn, result_type=None):
             return x
 
     >>> fn(jnp.array([0.1, 0.2]))
-    array([1.97507074+0.j, 0.01493759+0.j])
+    Array([1.97507074+0.j, 0.01493759+0.j], dtype=complex128)
 
     .. details::
         :title: Differentiating callbacks with custom VJP rules
@@ -252,7 +258,7 @@ def pure_callback(callback_fn, result_type=None):
         ...     y = jnp.array([jnp.cos(x[0]), x[1]])
         ...     return jnp.sin(callback_fn(y))
         >>> f(jnp.array([0.1, 0.2]))
-        array([-0.01071923,  0.82698717])
+        Array([-0.01071923,  0.82698717], dtype=float64)
     """
 
     # Verify inputs

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -124,9 +124,9 @@ def cond(pred: DynamicJaxprTracer):
             return qml.expval(qml.PauliZ(0))
 
     >>> circuit(1.4)
-    array(0.16996714)
+    Array(0.16996714, dtype=float64)
     >>> circuit(1.6)
-    array(0.)
+    Array(0., dtype=float64)
 
     Additional 'else-if' clauses can also be included via the ``else_if`` method:
 
@@ -204,7 +204,7 @@ def cond(pred: DynamicJaxprTracer):
         ...         return 6.  # float
         ...     return cond_fn()
         >>> f(1.5)
-        array(6.)
+        Array(6., dtype=float64)
 
         Similarly, the else (``my_cond_fn.otherwise``) may be omitted **as long as
         other branches do not return any values**. If other branches do return values,
@@ -231,7 +231,7 @@ def cond(pred: DynamicJaxprTracer):
         ...         return x
         ...     return cond_fn()
         >>> f(1.6)
-        array(2.56)
+        Array(2.56, dtype=float64)
     """
 
     def _decorator(true_fn: Callable):
@@ -322,7 +322,7 @@ def for_loop(lower_bound, upper_bound, step, allow_array_resizing=False):
             return qml.expval(qml.PauliZ(0)), final_x
 
     >>> circuit(7, 1.6)
-    [array(0.97926626), array(0.55395718)]
+    (Array(0.97926626, dtype=float64), Array(0.55395718, dtype=float64))
 
     Note that using dynamically-shaped arrays within for loops, while loops, and
     conditional statements, are also supported:
@@ -335,7 +335,7 @@ def for_loop(lower_bound, upper_bound, step, allow_array_resizing=False):
     ...         return a + i
     ...     return loop(a)
     >>> f(5)
-    array([21., 21., 21., 21., 21.])
+    Array([21., 21., 21., 21., 21.], dtype=float64)
 
     By default, ``allow_array_resizing`` is ``False``, allowing dynamically-shaped
     arrays from outside the for loop to be correctly captured, and arrays of the
@@ -352,7 +352,7 @@ def for_loop(lower_bound, upper_bound, step, allow_array_resizing=False):
     >>> a = jnp.ones([1,3], dtype=float)
     >>> b = jnp.ones([1,3], dtype=float)
     >>> g(a, b)
-    array(3.)
+    Array(3., dtype=float64)
 
     However, if you wish to have the for loop return differently sized arrays
     at each iteration, set ``allow_array_resizing`` to ``True``:
@@ -365,7 +365,7 @@ def for_loop(lower_bound, upper_bound, step, allow_array_resizing=False):
     ...         return jnp.ones([i], dtype=float) # return array of new dimensions
     ...     return loop(a)
     >>> f(5)
-    array([1., 1., 1., 1., 1., 1., 1., 1., 1.])
+    Array([1., 1., 1., 1., 1., 1., 1., 1., 1.], dtype=float64)
 
     Note that when ``allow_array_resizing=True``, dynamically-shaped arrays
     can no longer be captured from outer-scopes by the for loop, and binary operations
@@ -447,7 +447,7 @@ def while_loop(cond_fn, allow_array_resizing: bool = False):
             return qml.expval(qml.PauliZ(0)), final_x
 
     >>> circuit(1.6)
-    [array(-0.02919952), array(2.56)]
+    (Array(-0.02919952, dtype=float64), Array(2.56, dtype=float64))
 
     By default, ``allow_array_resizing`` is ``False``, allowing dynamically-shaped
     arrays from outside the for loop to be correctly captured, and arrays of the
@@ -464,7 +464,7 @@ def while_loop(cond_fn, allow_array_resizing: bool = False):
     >>> x = jnp.array([0.1, 0.2, 0.3])
     >>> y = jnp.array([5.2, 10.3, 2.4])
     >>> g(x, y)
-    array([0.052, 0.412, 0.216])
+    Array([0.052, 0.412, 0.216], dtype=float64)
 
     However, if you wish to have the for loop return differently sized arrays
     at each iteration, set ``allow_array_resizing`` to ``True``:
@@ -480,7 +480,7 @@ def while_loop(cond_fn, allow_array_resizing: bool = False):
     ...         return (a, b, i) # return array of new dimensions
     ...     return loop(a0, b0, 0)
     >>> f(2)
-    (array([1., 1.]), array([1., 1., 1., 1.]), array(3))
+    (Array([1., 1.], dtype=float64), Array([1., 1., 1., 1.], dtype=float64), Array(3, dtype=int64))
 
     Note that when ``allow_array_resizing=True``, dynamically-shaped arrays
     can no longer be captured from outer-scopes by the for loop, and binary operations
@@ -545,7 +545,7 @@ class CondCallable:
     >>> main()
     Traced<ShapedArray(int64[], weak_type=True)>with<DynamicJaxprTrace(level=2/1)>
     [Hadamard(wires=[0]), Cond(tapes=[[Hadamard(wires=[1])], [T(wires=[0])]])]
-    (array([0.25, 0.25, 0.25, 0.25]),)
+    (Array([0.25, 0.25, 0.25, 0.25], dtype=float64),)
     """
 
     def __init__(self, pred, true_fn):
@@ -753,7 +753,7 @@ class ForLoopCallable:
     >>> main()
     Traced<ShapedArray(int64[], weak_type=True)>with<DynamicJaxprTrace(level=2/1)>
     [Hadamard(wires=[0]), ForLoop(tapes=[[Hadamard(wires=[0])]])]
-    (array([0.5, 0. , 0.5, 0. ]),)
+    (Array([0.5, 0. , 0.5, 0. ], dtype=float64),)
     """
 
     def __init__(
@@ -928,7 +928,7 @@ class WhileLoopCallable:
     >>> main()
     Traced<ShapedArray(int64[], weak_type=True)>with<DynamicJaxprTrace(level=2/1)>
     [X(0), WhileLoop(tapes=[[X(0)]])]
-    (array([0., 0., 1., 0.]),)
+    (Array([0., 0., 1., 0.], dtype=float64),)
     """
 
     def __init__(self, cond_fn, body_fn, experimental_preserve_dimensions):

--- a/frontend/catalyst/api_extensions/differentiation.py
+++ b/frontend/catalyst/api_extensions/differentiation.py
@@ -111,7 +111,7 @@ def grad(fn=None, *, method=None, h=None, argnum=None):
             return g(x)
 
     >>> workflow(2.0)
-    array(-3.14159265)
+    Array(-3.14159265, dtype=float64)
 
     **Example 2 (Classical preprocessing and postprocessing)**
 
@@ -132,7 +132,7 @@ def grad(fn=None, *, method=None, h=None, argnum=None):
             return catalyst.grad(loss, method="auto")(theta)
 
     >>> grad_loss(1.0)
-    array(-1.90958669)
+    Array(-1.90958669, dtype=float64)
 
     **Example 3 (Multiple QNodes with their own differentiation methods)**
 
@@ -158,7 +158,7 @@ def grad(fn=None, *, method=None, h=None, argnum=None):
             return catalyst.grad(loss)(theta)
 
     >>> grad_loss(jnp.array([1.0, 2.0]))
-    array([ 0.57367285, 44.4911605 ])
+    Array([ 0.57367285, 44.4911605 ], dtype=float64)
 
     **Example 4 (Purely classical functions)**
 
@@ -172,7 +172,7 @@ def grad(fn=None, *, method=None, h=None, argnum=None):
             return catalyst.grad(square)(x)
 
     >>> dsquare(2.3)
-    array(4.6)
+    Array(4.6, dtype=float64)
     """
     kwargs = copy.copy(locals())
     kwargs.pop("fn")
@@ -247,12 +247,11 @@ def value_and_grad(fn=None, *, method=None, h=None, argnum=None):
             def circuit(x):
                 qml.RX(jnp.pi * x, wires=0)
                 return qml.expval(qml.PauliY(0))
+            return value_and_grad(circuit)(x)
 
-            g = value_and_grad(circuit)
-            return g(x)
-
-    >>> workflow(2.0)
-    (array(0.2), array(-3.14159265))
+    >>> workflow(0.2)
+    (Array(-0.58778525, dtype=float64),
+    (Array(-0.58778525, dtype=float64), Array(-2.54160185, dtype=float64)))
 
     **Example 2 (Classical preprocessing and postprocessing)**
 
@@ -273,7 +272,7 @@ def value_and_grad(fn=None, *, method=None, h=None, argnum=None):
             return catalyst.value_and_grad(loss, method="auto")(theta)
 
     >>> value_and_grad_loss(1.0)
-    (array(-4.12502201), array(4.34374983))
+    (Array(-4.2622289, dtype=float64), Array(5.04324559, dtype=float64))
 
     **Example 3 (Purely classical functions)**
 
@@ -287,7 +286,7 @@ def value_and_grad(fn=None, *, method=None, h=None, argnum=None):
             return catalyst.value_and_grad(square)(x)
 
     >>> dsquare(2.3)
-    (array(5.29), array(4.6))
+    (Array(5.29, dtype=float64), Array(4.6, dtype=float64))
     """
     kwargs = copy.copy(locals())
     kwargs.pop("fn")
@@ -358,8 +357,8 @@ def jacobian(fn=None, *, method=None, h=None, argnum=None):
             return g(x)
 
     >>> workflow(jnp.array([2.0, 1.0]))
-    array([[ 3.48786850e-16 -4.20735492e-01]
-           [-8.71967125e-17  4.20735492e-01]])
+    Array([[ 3.48786850e-16 -4.20735492e-01]
+           [-8.71967125e-17  4.20735492e-01]], dtype=float64)
     """
     kwargs = copy.copy(locals())
     kwargs.pop("fn")
@@ -414,7 +413,7 @@ def jvp(f: DifferentiableLike, params, tangents, *, method=None, h=None, argnum=
     >>> x = jnp.array([0.1, 0.2])
     >>> tangent = jnp.array([0.3, 0.6])
     >>> jvp(x, tangent)
-    (array([0.09983342, 0.04      , 0.02      ]), array([0.29850125, 0.24      , 0.12      ]))
+    (Array([0.09983342, 0.04      , 0.02      ], dtype=float64), Array([0.29850125, 0.24      , 0.12      ], dtype=float64))
 
     **Example 2 (argnum usage)**
 
@@ -438,7 +437,7 @@ def jvp(f: DifferentiableLike, params, tangents, *, method=None, h=None, argnum=
     >>> params = jnp.array([[0.54, 0.3154], [0.654, 0.123]])
     >>> dy = jnp.array([[1.0, 1.0], [1.0, 1.0]])
     >>> workflow(params, dy)
-    (array(0.78766064), array(-0.7011436))
+    (Array(0.78766064, dtype=float64), Array(-0.7011436, dtype=float64))
     """
 
     def check_is_iterable(x, hint):
@@ -517,7 +516,7 @@ def vjp(f: DifferentiableLike, params, cotangents, *, method=None, h=None, argnu
     >>> x = jnp.array([0.1, 0.2])
     >>> dy = jnp.array([-0.5, 0.1, 0.3])
     >>> vjp(x, dy)
-    (array([0.09983342, 0.04      , 0.02      ]), (array([-0.43750208,  0.07      ]),))
+    (Array([0.09983342, 0.04      , 0.02      ], dtype=float64), (Array([-0.43750208,  0.07      ], dtype=float64),))
     """
 
     def check_is_iterable(x, hint):

--- a/frontend/catalyst/api_extensions/function_maps.py
+++ b/frontend/catalyst/api_extensions/function_maps.py
@@ -86,7 +86,7 @@ def vmap(
     ...                [0.7, 0.8, 0.9]])
     >>> y = jnp.array([jnp.pi, jnp.pi / 2, jnp.pi / 4])
     >>> qjit(vmap(circuit))(x, y)
-    array([-0.93005586, -0.97165424, -0.6987465 ])
+    Array([-0.93005586, -0.97165424, -0.6987465 ], dtype=float64)
 
     ``catalyst.vmap()`` has been implemented to match the same behaviour of
     ``jax.vmap``, so should be a drop-in replacement in most cases.

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -106,9 +106,9 @@ def measure(
             return qml.expval(qml.PauliZ(0)), m2
 
     >>> circuit(0.43)
-    [array(1.), array(False)]
+    [Array(1., dtype=float64), Array(False, dtype=bool)]
     >>> circuit(0.43)
-    [array(-1.), array(True)]
+    [Array(-1., dtype=float64), Array(True, dtype=bool)]
 
     **Example with post-selection**
 
@@ -124,7 +124,7 @@ def measure(
             return qml.expval(qml.PauliZ(0))
 
     >>> circuit()
-    -1.0
+    Array(-1., dtype=float64)
 
     **Example with reset**
 
@@ -140,7 +140,7 @@ def measure(
             return qml.expval(qml.PauliZ(0))
 
     >>> circuit()
-    1.0
+    Array(1., dtype=float64)
     """
     EvaluationContext.check_is_tracing("catalyst.measure can only be used from within @qjit.")
     EvaluationContext.check_is_quantum_tracing(
@@ -226,7 +226,7 @@ def adjoint(f: Union[Callable, Operator], lazy=True) -> Union[Callable, Operator
             return qml.probs()
 
     >>> workflow(jnp.pi/2, wires=0)
-    array([0.5, 0.5])
+    Array([0.5, 0.5], dtype=float64)
 
     **Example 2 (with Catalyst control flow)**
 
@@ -304,7 +304,7 @@ def ctrl(
             return qml.probs()
 
     >>> workflow(jnp.pi/4, 1, 0)
-    array([0.25, 0.25, 0.03661165, 0.46338835])
+    Array([0.25, 0.25, 0.03661165, 0.46338835], dtype=float64)
     """
     if control_values is not None and (
         (len(control) if isinstance(control, Sized) else 1)

--- a/frontend/catalyst/debug/assertion.py
+++ b/frontend/catalyst/debug/assertion.py
@@ -11,12 +11,46 @@ def debug_assert(condition: bool, error: str):
     Asserts at runtime that the given condition holds, raising an error with the
     provided message if it does not.
 
+    Note that Python-based exceptions (via ``raise``) and assertions (via ``assert``)
+    will always be evaluated at program capture time, before certain runtime information
+    may be available.
+
+    Use ``debug_assert`` to instead raise assertions at runtime, including
+    assertions that depend on values of dynamic variables.
+
     Args:
         condition (bool): The condition to assert.
         message (str): The error message to raise if the condition is False.
 
     Raises:
-        RuntimeError: $message.
+        RuntimeError: raised if the condition evaluates to ``False``
+
+    **Example**
+
+    .. code-block:: python
+
+        @qjit
+        def f(x):
+            debug_assert(x < 5, "x was greater than 5")
+            return x * 8
+
+    >>> f(4)
+    Array(32, dtype=int64)
+    >>> f(6)
+    RuntimeError: x was greater than 5
+
+    Assertions can be disabled globally for a qjit-compiled function
+    via the ``disable_assertions`` keyword argument:
+
+    .. code-block:: python
+
+        @qjit(disable_assertions=True)
+        def g(x):
+            debug_assert(x < 5, "x was greater than 5")
+            return x * 8
+
+    >>> g(6)
+    Array(48, dtype=int64)
     """
 
     return assert_p.bind(condition, error=error)

--- a/frontend/catalyst/debug/callback.py
+++ b/frontend/catalyst/debug/callback.py
@@ -53,10 +53,10 @@ def callback(callback_fn):
 
     >>> fn(0.54)
     Value of y = 0.5141359916531132
-    array(0.26433582)
+    Array(0.26433582, dtype=float64)
     >>> fn(1.52)
     Value of y = 0.998710143975583
-    array(0.99742195)
+    Array(0.99742195, dtype=float64)
 
     It can also be used functionally:
 
@@ -75,7 +75,7 @@ def callback(callback_fn):
 
     >>> fn(0.543)
     INFO:__main__:Value of y = 0.5167068002272901
-    array(0.88476988)
+    Array(0.88476988, dtype=float64)
 
     Note that during differentiation, the callback function will only be executed
     during the forward pass.

--- a/frontend/catalyst/debug/compiler_functions.py
+++ b/frontend/catalyst/debug/compiler_functions.py
@@ -45,6 +45,8 @@ def print_compilation_stage(fn, stage):
         fn (QJIT): a qjit-decorated function
         stage (str): string corresponding with the name of the stage to be printed
 
+    .. seealso:: :doc:`/dev/debugging`
+
     **Example**
 
     .. code-block:: python
@@ -53,7 +55,20 @@ def print_compilation_stage(fn, stage):
         def func(x: float):
             return x
 
-        debug.print_compilation_stage(func, "HLOLoweringPass")
+    >>> debug.print_compilation_stage(func, "HLOLoweringPass")
+    module @func {
+      func.func public @jit_func(%arg0: tensor<f64>) -> tensor<f64> attributes {llvm.emit_c_interface} {
+        return %arg0 : tensor<f64>
+      }
+      func.func @setup() {
+        quantum.init
+        return
+      }
+      func.func @teardown() {
+        quantum.finalize
+        return
+      }
+    }
     """
     EvaluationContext.check_is_not_tracing("C interface cannot be generated from tracing context.")
 

--- a/frontend/catalyst/debug/printing.py
+++ b/frontend/catalyst/debug/printing.py
@@ -65,7 +65,7 @@ def print(fmt, *args, **kwargs):
     ...     return x * jnp.sin(y)
     >>> f(0.543, 0.23)
     Value of x = 0.54
-    array(0.22797752)
+    Array(0.22797752, dtype=float64)
 
     Note that during differentiation, printing will only be executed
     during the forward pass.


### PR DESCRIPTION
**Context:** An early update of the docs and changelog _early_ in the release cycle, to reduce work later on :)

**Description of the Change:**

- Updates to documentation based on new changelog updates
- Improvements to changelog updates
- Typos and syntax fixes
- qjit output types are updated across the documentation examples from `np.ndarray` to `jax.Array`.

**Benefits:** Less work/worry during feature freeze :)

**Possible Drawbacks:** This PR looks a bit bigger than it is, since #895 requires that a large number of docstring and documentation examples are updated.

**Related GitHub Issues:** n/a
