### PR TITLE
Use GCC-12 when compiling LLVM for x86_64

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -141,9 +141,9 @@ jobs:
       run: |
         # Reduce wait time for repos not responding
         cat /etc/dnf.conf | sed "s/\[main\]/\[main\]\ntimeout=5/g" > /etc/dnf.conf
-        dnf update -y && dnf install -y libzstd-devel gcc-toolset-13
+        dnf update -y && dnf install -y libzstd-devel gcc-toolset-12
         # Update env vars valid for all tasks of this job
-        echo '/opt/rh/gcc-toolset-13/root/usr/bin' >> $GITHUB_PATH
+        echo '/opt/rh/gcc-toolset-12/root/usr/bin' >> $GITHUB_PATH
 
     - name: Install Dependencies (Python)
       run: |
@@ -241,9 +241,9 @@ jobs:
       run: |
         # Reduce wait time for repos not responding
         cat /etc/dnf.conf | sed "s/\[main\]/\[main\]\ntimeout=5/g" > /etc/dnf.conf
-        dnf update -y && dnf install -y openmpi-devel libzstd-devel gcc-toolset-13
+        dnf update -y && dnf install -y openmpi-devel libzstd-devel gcc-toolset-12
         # Update env vars valid for all tasks of this job
-        echo '/opt/rh/gcc-toolset-13/root/usr/bin' >> $GITHUB_PATH
+        echo '/opt/rh/gcc-toolset-12/root/usr/bin' >> $GITHUB_PATH
 
     - name: Install Dependencies (Python)
       run: |


### PR DESCRIPTION


Link to action: https://github.com/PennyLaneAI/catalyst/actions/runs/10044575840

**Context:** It looks like the container updated GCC and LLVM does not like being compiled with GCC-13 (but is ok with GCC-12). 

**Description of the Change:** Explicitly used GCC 12 when building the wheel

**Benefits:** Building the wheel.

