### PR TITLE
[Build system] Allow quantum-opt to take plugins

### DIFF
--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -15,7 +15,8 @@ set(TEST_SUITES
     Quantum
     Gradient
     Mitigation
-    Catalyst)
+    Catalyst
+    PluginTest)
 
 
 if(QUANTUM_ENABLE_BINDINGS_PYTHON)

--- a/mlir/test/PluginTest/test.mlir
+++ b/mlir/test/PluginTest/test.mlir
@@ -12,7 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// RUN: machine="$(%PYTHON -c 'import platform; print(platform.system(), platform.machine())')" ; if [ "${machine}" == "Linux x86_64" ] ; then quantum-opt --load-dialect-plugin=$(dirname %s)/StandalonePlugin.so --load-pass-plugin=$(dirname %s)/StandalonePlugin.so --pass-pipeline='builtin.module(standalone-switch-bar-foo)' %s | FileCheck %s ; exit $? ; fi ; exit 0
+// RUN: machine="$(%PYTHON -c 'import platform; print(platform.system(), platform.machine())')" ; \
+// RUN:	if [ "${machine}" == "Linux x86_64" ] ; then \
+// RUN:		quantum-opt \
+// RUN:			--load-dialect-plugin=$(dirname %s)/StandalonePlugin.so \
+// RUN:			--load-pass-plugin=$(dirname %s)/StandalonePlugin.so \
+// RUN:			--pass-pipeline='builtin.module(standalone-switch-bar-foo)' %s \
+// RUN:		| FileCheck %s ; \
+// RUN:		exit $? ; \
+// RUN:	fi ; \
+// RUN:	exit 1
 
 
 module {

--- a/mlir/test/PluginTest/test.mlir
+++ b/mlir/test/PluginTest/test.mlir
@@ -21,7 +21,7 @@
 // RUN:		| FileCheck %s ; \
 // RUN:		exit $? ; \
 // RUN:	fi ; \
-// RUN:	exit 1
+// RUN:	exit 0
 
 
 module {

--- a/mlir/test/PluginTest/test.mlir
+++ b/mlir/test/PluginTest/test.mlir
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// RUN: quantum-opt --load-dialect-plugin=$(dirname %s)/StandalonePlugin.so --load-pass-plugin=$(dirname %s)/StandalonePlugin.so --pass-pipeline='builtin.module(standalone-switch-bar-foo)' %s | FileCheck %s
+// RUN: if [%PYTHON -c "import platform; print(platform.architecture())" == "x86_64" ] ; then quantum-opt --load-dialect-plugin=$(dirname %s)/StandalonePlugin.so --load-pass-plugin=$(dirname %s)/StandalonePlugin.so --pass-pipeline='builtin.module(standalone-switch-bar-foo)' %s | FileCheck %s ; exit $? ; fi ; exit 0
 
 
 module {

--- a/mlir/test/PluginTest/test.mlir
+++ b/mlir/test/PluginTest/test.mlir
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// RUN: if [%PYTHON -c "import platform; print(platform.architecture())" == "x86_64" ] ; then quantum-opt --load-dialect-plugin=$(dirname %s)/StandalonePlugin.so --load-pass-plugin=$(dirname %s)/StandalonePlugin.so --pass-pipeline='builtin.module(standalone-switch-bar-foo)' %s | FileCheck %s ; exit $? ; fi ; exit 0
+// RUN: machine="$(%PYTHON -c 'import platform; print(platform.system(), platform.machine())')" ; if [ "${machine}" == "Linux x86_64" ] ; then quantum-opt --load-dialect-plugin=$(dirname %s)/StandalonePlugin.so --load-pass-plugin=$(dirname %s)/StandalonePlugin.so --pass-pipeline='builtin.module(standalone-switch-bar-foo)' %s | FileCheck %s ; exit $? ; fi ; exit 0
 
 
 module {

--- a/mlir/test/PluginTest/test.mlir
+++ b/mlir/test/PluginTest/test.mlir
@@ -1,0 +1,23 @@
+// Copyright 2022-2023 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RUN: quantum-opt --load-dialect-plugin=$(dirname %s)/StandalonePlugin.so --load-pass-plugin=$(dirname %s)/StandalonePlugin.so --pass-pipeline='builtin.module(standalone-switch-bar-foo)' %s | FileCheck %s
+
+
+module {
+    // CHECK-LABEL: func.func @foo()
+    func.func @bar() { 
+     return
+    }
+}

--- a/mlir/tools/quantum-opt/CMakeLists.txt
+++ b/mlir/tools/quantum-opt/CMakeLists.txt
@@ -20,7 +20,8 @@ set(LIBS
     ${ALL_MHLO_PASSES}
 )
 
-add_llvm_executable(quantum-opt quantum-opt.cpp)
+add_mlir_tool(quantum-opt quantum-opt.cpp DEPENDS ${LIBS} SUPPORT_PLUGINS)
 target_link_libraries(quantum-opt PRIVATE ${LIBS})
 llvm_update_compile_flags(quantum-opt)
 mlir_check_all_link_libraries(quantum-opt)
+export_executable_symbols_for_plugins(quantum-opt)


### PR DESCRIPTION
**Context:** First step to allow plugins in Catalyst is to allow them in quantum-opt.

**Description of the Change:** Just make small changes in the build system to allow quantum-opt to take plugins as inputs from the command line.

**Benefits:** Easier integration with plugins.
