### PR TITLE
[NFC] Correct module description at __init__.py

### DIFF
--- a/frontend/catalyst/api_extensions/__init__.py
+++ b/frontend/catalyst/api_extensions/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-This module is a collection of public API extensions for pragramming with Catalyst frontends.
+This module is a collection of public API extensions for programming with Catalyst frontends.
 """
 
 from catalyst.api_extensions.callbacks import accelerate, pure_callback


### PR DESCRIPTION
**Context:** Description says "pragramming" instead of "programming" 

**Description of the Change:** Write "programming" instead of "pragramming"