### PR TITLE
Remove support for TOML Schema 1

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -129,6 +129,9 @@
   qjit-compiled function being NumPy arrays will need to be updated.
   [(#895)](https://github.com/PennyLaneAI/catalyst/pull/895)
 
+* Support for TOML files in Schema 1 has been deprecated.
+  [(#960)](https://github.com/PennyLaneAI/catalyst/pull/960)
+
 <h3>Bug fixes</h3>
 
 * Static arguments can now be passed through a QNode when specified

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -177,7 +177,7 @@
   qjit-compiled function being NumPy arrays will need to be updated.
   [(#895)](https://github.com/PennyLaneAI/catalyst/pull/895)
 
-* Support for TOML files in Schema 1 has been deprecated.
+* Support for TOML files in Schema 1 has been disabled.
   [(#960)](https://github.com/PennyLaneAI/catalyst/pull/960)
 
 <h3>Bug fixes</h3>

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -649,11 +649,8 @@ def get_device_capabilities(
             if program_features
             else ProgramFeatures(shots_present=bool(device.shots))
         )
-        device_name = (
-            device.short_name if isinstance(device, qml.devices.LegacyDevice) else device.name
-        )
         device_config = get_device_toml_config(device)
-        return load_device_capabilities(device_config, program_features, device_name)
+        return load_device_capabilities(device_config, program_features)
 
 
 def check_device_wires(wires):

--- a/frontend/catalyst/utils/toml.py
+++ b/frontend/catalyst/utils/toml.py
@@ -239,7 +239,7 @@ def _validate_schema_version(schema):
 
 
 def load_device_capabilities(
-    config: TOMLDocument, program_features: ProgramFeatures, device_name: str
+    config: TOMLDocument, program_features: ProgramFeatures
 ) -> DeviceCapabilities:
     """Load device capabilities from device config"""
 

--- a/frontend/catalyst/utils/toml.py
+++ b/frontend/catalyst/utils/toml.py
@@ -46,6 +46,9 @@ else:  # pragma: nocover
     from tomlkit import load as toml_load
     from tomlkit.exceptions import TOMLKitError as TOMLException
 
+ALL_SUPPORTED_SCHEMAS = [2]
+ALL_DEPRECATED_SCHEMAS = [1]
+
 
 def read_toml_file(toml_file: str) -> TOMLDocument:
     """Helper function opening toml file properly and reading it into a document"""
@@ -63,7 +66,7 @@ class OperationProperties:
     differentiable: bool = False
 
 
-def intersect_properties(a: OperationProperties, b: OperationProperties) -> OperationProperties:
+def _intersect_properties(a: OperationProperties, b: OperationProperties) -> OperationProperties:
     """Calculate the intersection of OperationProperties"""
     return OperationProperties(
         invertible=a.invertible and b.invertible,
@@ -93,7 +96,7 @@ def intersect_operations(
     a: Dict[str, OperationProperties], b: Dict[str, OperationProperties]
 ) -> Dict[str, OperationProperties]:
     """Intersects two sets of oepration properties"""
-    return {k: intersect_properties(a[k], b[k]) for k in (a.keys() & b.keys())}
+    return {k: _intersect_properties(a[k], b[k]) for k in (a.keys() & b.keys())}
 
 
 def pennylane_operation_set(config_ops: Dict[str, OperationProperties]) -> Set[str]:
@@ -119,26 +122,17 @@ class ProgramFeatures:
     shots_present: bool
 
 
-def get_compilation_flag(config: TOMLDocument, flag_name: str) -> bool:
+def _get_compilation_flag(config: TOMLDocument, flag_name: str) -> bool:
     """Get the flag in the toml document 'compilation' section."""
     return bool(config.get("compilation", {}).get(flag_name, False))
 
 
-def get_options(config: TOMLDocument) -> Dict[str, str]:
+def _get_options(config: TOMLDocument) -> Dict[str, str]:
     """Get custom options sections"""
     return {str(k): str(v) for k, v in config.get("options", {}).items()}
 
 
-def check_quantum_control_flag(config: TOMLDocument) -> bool:
-    """Check the control flag. Only exists in toml config schema 1"""
-    schema = int(config["schema"])
-    if schema == 1:
-        return bool(config.get("compilation", {}).get("quantum_control", False))
-
-    raise CompileError("quantum_control flag is not supported in TOMLs schema >= 2")
-
-
-def parse_toml_section(
+def _parse_toml_section(
     config: TOMLDocument, path: List[str], program_features: ProgramFeatures
 ) -> Dict[str, dict]:
     """Parses the section of toml config file specified by `path`. Filters-out gates which don't
@@ -186,38 +180,24 @@ def parse_toml_section(
     return gates
 
 
-def get_observables(config: TOMLDocument, program_features: ProgramFeatures) -> Dict[str, dict]:
+def _get_observables(config: TOMLDocument, program_features: ProgramFeatures) -> Dict[str, dict]:
     """Override the set of supported observables."""
-    return parse_toml_section(config, ["operators", "observables"], program_features)
+    return _parse_toml_section(config, ["operators", "observables"], program_features)
 
 
-def get_measurement_processes(
+def _get_measurement_processes(
     config: TOMLDocument, program_features: ProgramFeatures
 ) -> Dict[str, dict]:
     """Get the measurements processes from the `native` section of the config."""
-    schema = int(config["schema"])
-    if schema == 1:
-        shots_string = "finiteshots" if program_features.shots_present else "exactshots"
-        return parse_toml_section(config, ["measurement_processes", shots_string], program_features)
-    if schema == 2:
-        return parse_toml_section(config, ["measurement_processes"], program_features)
-
-    raise CompileError(f"Unsupported config schema {schema}")
+    return _parse_toml_section(config, ["measurement_processes"], program_features)
 
 
-def get_native_ops(config: TOMLDocument, program_features: ProgramFeatures) -> Dict[str, dict]:
+def _get_native_ops(config: TOMLDocument, program_features: ProgramFeatures) -> Dict[str, dict]:
     """Get the gates from the `native` section of the config."""
-
-    schema = int(config["schema"])
-    if schema == 1:
-        return parse_toml_section(config, ["operators", "gates", 0, "native"], program_features)
-    elif schema == 2:
-        return parse_toml_section(config, ["operators", "gates", "native"], program_features)
-
-    raise CompileError(f"Unsupported config schema {schema}")
+    return _parse_toml_section(config, ["operators", "gates", "native"], program_features)
 
 
-def get_decomposable_gates(
+def _get_decomposable_gates(
     config: TOMLDocument, program_features: ProgramFeatures
 ) -> Dict[str, dict]:
     """Get gates that will be decomposed according to PL's decomposition rules.
@@ -225,16 +205,10 @@ def get_decomposable_gates(
     Args:
         config (TOMLDocument): Configuration dictionary
     """
-    schema = int(config["schema"])
-    if schema == 1:
-        return parse_toml_section(config, ["operators", "gates", 0, "decomp"], program_features)
-    elif schema == 2:
-        return parse_toml_section(config, ["operators", "gates", "decomp"], program_features)
-
-    raise CompileError(f"Unsupported config schema {schema}")
+    return _parse_toml_section(config, ["operators", "gates", "decomp"], program_features)
 
 
-def get_matrix_decomposable_gates(
+def _get_matrix_decomposable_gates(
     config: TOMLDocument, program_features: ProgramFeatures
 ) -> Dict[str, dict]:
     """Get gates that will be decomposed to QubitUnitary.
@@ -242,16 +216,10 @@ def get_matrix_decomposable_gates(
     Args:
         config (TOMLDocument): Configuration dictionary
     """
-    schema = int(config["schema"])
-    if schema == 1:
-        return parse_toml_section(config, ["operators", "gates", 0, "matrix"], program_features)
-    elif schema == 2:
-        return parse_toml_section(config, ["operators", "gates", "matrix"], program_features)
-
-    raise CompileError(f"Unsupported config schema {schema}")
+    return _parse_toml_section(config, ["operators", "gates", "matrix"], program_features)
 
 
-def get_operation_properties(config_props: dict) -> OperationProperties:
+def _get_operation_properties(config_props: dict) -> OperationProperties:
     """Load operation properties from config"""
     properties = config_props.get("properties", {})
     return OperationProperties(
@@ -261,74 +229,13 @@ def get_operation_properties(config_props: dict) -> OperationProperties:
     )
 
 
-def patch_schema1_collections(
-    config, _device_name, native_gate_props, matrix_decomp_props, decomp_props, observable_props
-):  # pylint: disable=too-many-branches
-    """For old schema1 config files we deduce some information which was not explicitly encoded."""
+def _validate_schema_version(schema):
+    """Pass on supported schema versions. Otherwise, raise an error"""
 
-    # The deduction logic is the following:
-    # * Most of the gates have their `C(Gate)` controlled counterparts.
-    # * Some gates have to be decomposed if controlled version is used. Typically these are
-    #   gates which are already controlled but have well-known names.
-    # * Few gates, like `QubitUnitary`, have separate classes for their controlled versions.
-    gates_to_be_decomposed_if_controlled = [
-        "Identity",
-        "CNOT",
-        "CY",
-        "CZ",
-        "CSWAP",
-        "CRX",
-        "CRY",
-        "CRZ",
-        "CRot",
-        "ControlledPhaseShift",
-        "QubitUnitary",
-        "ControlledQubitUnitary",
-        "Toffoli",
-    ]
+    # TODO: remove deprecation message when appropriate
+    assert schema not in ALL_DEPRECATED_SCHEMAS, f"Schema {schema} is deprecated"
 
-    supports_controlled = check_quantum_control_flag(config)
-    if supports_controlled:
-        # Add ControlledQubitUnitary as a controlled version of QubitUnitary
-        if "QubitUnitary" in native_gate_props:
-            native_gate_props["ControlledQubitUnitary"] = OperationProperties(
-                invertible=False, controllable=False, differentiable=True
-            )
-        # By default, enable the `C(gate)` version for most `gates`.
-        for op, props in native_gate_props.items():
-            props.controllable = op not in gates_to_be_decomposed_if_controlled
-
-    supports_adjoint = get_compilation_flag(config, "quantum_adjoint")
-    if supports_adjoint:
-        # Makr all gates as invertibles
-        for props in native_gate_props.values():
-            props.invertible = True
-
-    # Mark all gates as differentiable
-    for props in native_gate_props.values():
-        props.differentiable = True
-    # Mark all observables as differentiable
-    for props in observable_props.values():
-        props.differentiable = True
-
-    # For toml schema 1 configs, the following condition is possible: (1) `QubitUnitary` gate is
-    # supported, (2) native quantum control flag is enabled and (3) `ControlledQubitUnitary` is
-    # listed in either matrix or decomposable sections. This is a contradiction, because
-    # condition (1) means that `ControlledQubitUnitary` is also in the native set. We solve it
-    # here by applying a fixup.
-    # TODO: remove after PR #642 is merged in lightning
-    if "ControlledQubitUnitary" in native_gate_props:  # pragma: nocover
-        if "ControlledQubitUnitary" in matrix_decomp_props:
-            matrix_decomp_props.pop("ControlledQubitUnitary")
-        if "ControlledQubitUnitary" in decomp_props:
-            decomp_props.pop("ControlledQubitUnitary")
-
-    # Fix a bug in device toml schema 1
-    if "ControlledPhaseShift" in native_gate_props:  # pragma: nocover
-        if "ControlledPhaseShift" in matrix_decomp_props:
-            matrix_decomp_props.pop("ControlledPhaseShift")
-        if "ControlledPhaseShift" in decomp_props:
-            decomp_props.pop("ControlledPhaseShift")
+    assert schema in ALL_SUPPORTED_SCHEMAS, f"Unsupported config schema {schema}"
 
 
 def load_device_capabilities(
@@ -336,37 +243,27 @@ def load_device_capabilities(
 ) -> DeviceCapabilities:
     """Load device capabilities from device config"""
 
-    schema = int(config["schema"])
+    _validate_schema_version(int(config["schema"]))
 
     native_gate_props = {}
-    for g, props in get_native_ops(config, program_features).items():
-        native_gate_props[g] = get_operation_properties(props)
+    for g, props in _get_native_ops(config, program_features).items():
+        native_gate_props[g] = _get_operation_properties(props)
 
     matrix_decomp_props = {}
-    for g, props in get_matrix_decomposable_gates(config, program_features).items():
-        matrix_decomp_props[g] = get_operation_properties(props)
+    for g, props in _get_matrix_decomposable_gates(config, program_features).items():
+        matrix_decomp_props[g] = _get_operation_properties(props)
 
     decomp_props = {}
-    for g, props in get_decomposable_gates(config, program_features).items():
-        decomp_props[g] = get_operation_properties(props)
+    for g, props in _get_decomposable_gates(config, program_features).items():
+        decomp_props[g] = _get_operation_properties(props)
 
     observable_props = {}
-    for g, props in get_observables(config, program_features).items():
-        observable_props[g] = get_operation_properties(props)
+    for g, props in _get_observables(config, program_features).items():
+        observable_props[g] = _get_operation_properties(props)
 
     measurements_props = set()
-    for g, props in get_measurement_processes(config, program_features).items():
+    for g, props in _get_measurement_processes(config, program_features).items():
         measurements_props.add(g)
-
-    if schema == 1:
-        patch_schema1_collections(
-            config,
-            device_name,
-            native_gate_props,
-            matrix_decomp_props,
-            decomp_props,
-            observable_props,
-        )
 
     return DeviceCapabilities(
         native_ops=native_gate_props,
@@ -374,10 +271,10 @@ def load_device_capabilities(
         to_matrix_ops=matrix_decomp_props,
         native_obs=observable_props,
         measurement_processes=measurements_props,
-        qjit_compatible_flag=get_compilation_flag(config, "qjit_compatible"),
-        mid_circuit_measurement_flag=get_compilation_flag(config, "mid_circuit_measurement"),
-        runtime_code_generation_flag=get_compilation_flag(config, "runtime_code_generation"),
-        dynamic_qubit_management_flag=get_compilation_flag(config, "dynamic_qubit_management"),
-        non_commuting_observables_flag=get_compilation_flag(config, "non_commuting_observables"),
-        options=get_options(config),
+        qjit_compatible_flag=_get_compilation_flag(config, "qjit_compatible"),
+        mid_circuit_measurement_flag=_get_compilation_flag(config, "mid_circuit_measurement"),
+        runtime_code_generation_flag=_get_compilation_flag(config, "runtime_code_generation"),
+        dynamic_qubit_management_flag=_get_compilation_flag(config, "dynamic_qubit_management"),
+        non_commuting_observables_flag=_get_compilation_flag(config, "non_commuting_observables"),
+        options=_get_options(config),
     )

--- a/frontend/catalyst/utils/toml.py
+++ b/frontend/catalyst/utils/toml.py
@@ -47,7 +47,6 @@ else:  # pragma: nocover
     from tomlkit.exceptions import TOMLKitError as TOMLException
 
 ALL_SUPPORTED_SCHEMAS = [2]
-ALL_DEPRECATED_SCHEMAS = [1]
 
 
 def read_toml_file(toml_file: str) -> TOMLDocument:
@@ -229,21 +228,13 @@ def _get_operation_properties(config_props: dict) -> OperationProperties:
     )
 
 
-def _validate_schema_version(schema):
-    """Pass on supported schema versions. Otherwise, raise an error"""
-
-    # TODO: remove deprecation message when appropriate
-    assert schema not in ALL_DEPRECATED_SCHEMAS, f"Schema {schema} is deprecated"
-
-    assert schema in ALL_SUPPORTED_SCHEMAS, f"Unsupported config schema {schema}"
-
-
 def load_device_capabilities(
     config: TOMLDocument, program_features: ProgramFeatures
 ) -> DeviceCapabilities:
     """Load device capabilities from device config"""
 
-    _validate_schema_version(int(config["schema"]))
+    schema = int(config["schema"])
+    assert schema in ALL_SUPPORTED_SCHEMAS, f"Unsupported config schema {schema}"
 
     native_gate_props = {}
     for g, props in _get_native_ops(config, program_features).items():

--- a/frontend/test/pytest/test_config_functions.py
+++ b/frontend/test/pytest/test_config_functions.py
@@ -68,7 +68,7 @@ def get_test_device_capabilities(
 ) -> DeviceCapabilities:
     """Parse test config into the DeviceCapabilities structure"""
     config = get_test_config(config_text)
-    device_capabilities = load_device_capabilities(config, program_features, "dummy")
+    device_capabilities = load_device_capabilities(config, program_features)
     return device_capabilities
 
 

--- a/frontend/test/pytest/test_config_functions.py
+++ b/frontend/test/pytest/test_config_functions.py
@@ -25,7 +25,6 @@ from catalyst.device import QJITDeviceNewAPI
 from catalyst.device.qjit_device import validate_device_capabilities
 from catalyst.utils.exceptions import CompileError
 from catalyst.utils.toml import (
-    ALL_DEPRECATED_SCHEMAS,
     ALL_SUPPORTED_SCHEMAS,
     DeviceCapabilities,
     ProgramFeatures,
@@ -308,7 +307,7 @@ def test_config_qjit_device_operations(schema):
     assert "PauliY" in qjit_device.observables
 
 
-@pytest.mark.parametrize("schema", [999])
+@pytest.mark.parametrize("schema", [1, 999])
 def test_config_unsupported_schema(schema):
     """Test unsupported schema version."""
     program_features = ProgramFeatures(False)
@@ -319,20 +318,6 @@ def test_config_unsupported_schema(schema):
     )
 
     with pytest.raises(AssertionError, match="Unsupported config schema"):
-        get_test_device_capabilities(program_features, config_text)
-
-
-@pytest.mark.parametrize("schema", ALL_DEPRECATED_SCHEMAS)
-def test_config_deprecated_schema(schema):
-    """Test deprecated schema version."""
-    program_features = ProgramFeatures(False)
-    config_text = dedent(
-        f"""
-            schema = {schema}
-        """
-    )
-
-    with pytest.raises(AssertionError, match="is deprecated"):
         get_test_device_capabilities(program_features, config_text)
 
 

--- a/frontend/test/pytest/test_config_functions.py
+++ b/frontend/test/pytest/test_config_functions.py
@@ -25,13 +25,11 @@ from catalyst.device import QJITDeviceNewAPI
 from catalyst.device.qjit_device import validate_device_capabilities
 from catalyst.utils.exceptions import CompileError
 from catalyst.utils.toml import (
+    ALL_DEPRECATED_SCHEMAS,
+    ALL_SUPPORTED_SCHEMAS,
     DeviceCapabilities,
     ProgramFeatures,
     TOMLDocument,
-    check_quantum_control_flag,
-    get_decomposable_gates,
-    get_matrix_decomposable_gates,
-    get_native_ops,
     load_device_capabilities,
     pennylane_operation_set,
     read_toml_file,
@@ -55,9 +53,6 @@ class DeviceToBeTested(qml.QubitDevice):
         raise RuntimeError("Only C/C++ interface is defined")
 
 
-ALL_SCHEMAS = [1, 2]
-
-
 def get_test_config(config_text: str) -> TOMLDocument:
     """Parse test config into the TOMLDocument structure"""
     with TemporaryDirectory() as d:
@@ -77,7 +72,7 @@ def get_test_device_capabilities(
     return device_capabilities
 
 
-@pytest.mark.parametrize("schema", ALL_SCHEMAS)
+@pytest.mark.parametrize("schema", ALL_SUPPORTED_SCHEMAS)
 def test_config_qjit_incompatible_device(schema):
     """Test error is raised if checking for qjit compatibility and field is false in toml file."""
     device_capabilities = get_test_device_capabilities(
@@ -99,98 +94,33 @@ def test_config_qjit_incompatible_device(schema):
         validate_device_capabilities(DeviceToBeTested(), device_capabilities)
 
 
-def test_get_observables_schema1():
-    """Test observables are properly obtained from the toml schema 1."""
+@pytest.mark.parametrize("schema", ALL_SUPPORTED_SCHEMAS)
+def test_get_observables(schema):
+    """Test observables are properly obtained."""
     device_capabilities = get_test_device_capabilities(
         ProgramFeatures(False),
         dedent(
-            r"""
-                schema = 1
-                [operators]
-                observables = [ "PauliX" ]
-            """
-        ),
-    )
-    assert {"PauliX"} == pennylane_operation_set(device_capabilities.native_obs)
-
-
-def test_get_observables_schema2():
-    """Test observables are properly obtained from the toml schema 2."""
-    device_capabilities = get_test_device_capabilities(
-        ProgramFeatures(False),
-        dedent(
-            r"""
-                schema = 2
+            f"""
+                schema = {schema}
                 [operators.observables]
-                PauliX = { }
+                PauliX = {{ }}
             """
         ),
     )
     assert {"PauliX"} == pennylane_operation_set(device_capabilities.native_obs)
 
 
-def test_get_native_ops_schema1_no_qcontrol():
+@pytest.mark.parametrize("schema", ALL_SUPPORTED_SCHEMAS)
+def test_get_native_ops(schema):
     """Test native gates are properly obtained from the toml."""
     device_capabilities = get_test_device_capabilities(
         ProgramFeatures(False),
         dedent(
-            r"""
-                schema = 1
-                [[operators.gates]]
-                native = [ "PauliX" ]
-                [compilation]
-                quantum_control = false
-            """
-        ),
-    )
-    assert {"PauliX"} == pennylane_operation_set(device_capabilities.native_ops)
-
-
-def test_get_native_ops_schema1_qcontrol():
-    """Test native gates are properly obtained from the toml."""
-    device_capabilities = get_test_device_capabilities(
-        ProgramFeatures(False),
-        dedent(
-            r"""
-                schema = 1
-                [[operators.gates]]
-                native = [ "PauliZ" ]
-                [compilation]
-                quantum_control = true
-            """
-        ),
-    )
-    assert {"PauliZ", "C(PauliZ)"} == pennylane_operation_set(device_capabilities.native_ops)
-
-
-@pytest.mark.parametrize("qadjoint", [True, False])
-def test_get_native_ops_schema1_qadjoint(qadjoint):
-    """Test native gates are properly obtained from the toml."""
-    device_capabilities = get_test_device_capabilities(
-        ProgramFeatures(False),
-        dedent(
-            rf"""
-                schema = 1
-                [[operators.gates]]
-                native = [ "PauliZ" ]
-                [compilation]
-                quantum_adjoint = {str(qadjoint).lower()}
-            """
-        ),
-    )
-    assert device_capabilities.native_ops["PauliZ"].invertible is qadjoint
-
-
-def test_get_native_ops_schema2():
-    """Test native gates are properly obtained from the toml."""
-    device_capabilities = get_test_device_capabilities(
-        ProgramFeatures(False),
-        dedent(
-            r"""
-                schema = 2
+            f"""
+                schema = {schema}
                 [operators.gates.native]
-                PauliX = { properties = [ 'controllable' ] }
-                PauliY = { }
+                PauliX = {{ properties = [ 'controllable' ] }}
+                PauliY = {{ }}
             """
         ),
     )
@@ -200,16 +130,17 @@ def test_get_native_ops_schema2():
     )
 
 
-def test_get_native_ops_schema2_optional_shots():
+@pytest.mark.parametrize("schema", ALL_SUPPORTED_SCHEMAS)
+def test_get_native_ops_optional_shots(schema):
     """Test native gates are properly obtained from the toml."""
     device_capabilities = get_test_device_capabilities(
         ProgramFeatures(True),
         dedent(
-            r"""
-                schema = 2
+            f"""
+                schema = {schema}
                 [operators.gates.native]
-                PauliX = { condition = ['finiteshots'] }
-                PauliY = { condition = ['analytic'] }
+                PauliX = {{ condition = ['finiteshots'] }}
+                PauliY = {{ condition = ['analytic'] }}
             """
         ),
     )
@@ -217,16 +148,17 @@ def test_get_native_ops_schema2_optional_shots():
     assert "PauliY" not in device_capabilities.native_ops
 
 
-def test_get_native_ops_schema2_optional_noshots():
+@pytest.mark.parametrize("schema", ALL_SUPPORTED_SCHEMAS)
+def test_get_native_ops_optional_noshots(schema):
     """Test native gates are properly obtained from the toml."""
     device_capabilities = get_test_device_capabilities(
         ProgramFeatures(False),
         dedent(
-            r"""
-                schema = 2
+            f"""
+                schema = {schema}
                 [operators.gates.native]
-                PauliX = { condition = ['finiteshots'] }
-                PauliY = { condition = ['analytic'] }
+                PauliX = {{ condition = ['finiteshots'] }}
+                PauliY = {{ condition = ['analytic'] }}
             """
         ),
     )
@@ -234,31 +166,14 @@ def test_get_native_ops_schema2_optional_noshots():
     assert "PauliY" in device_capabilities.native_ops
 
 
-def test_get_decomp_gates_schema1():
+@pytest.mark.parametrize("schema", ALL_SUPPORTED_SCHEMAS)
+def test_get_decomp_gates(schema):
     """Test native decomposition gates are properly obtained from the toml."""
     device_capabilities = get_test_device_capabilities(
         ProgramFeatures(False),
         dedent(
-            """
-                schema = 1
-                [[operators.gates]]
-                decomp = ["PauliX", "PauliY"]
-            """
-        ),
-    )
-
-    assert "PauliX" in device_capabilities.to_decomp_ops
-    assert "PauliY" in device_capabilities.to_decomp_ops
-    assert "PauliZ" not in device_capabilities.to_decomp_ops
-
-
-def test_get_decomp_gates_schema2():
-    """Test native decomposition gates are properly obtained from the toml."""
-    device_capabilities = get_test_device_capabilities(
-        ProgramFeatures(False),
-        dedent(
-            """
-            schema = 2
+            f"""
+            schema = {schema}
             [operators.gates]
             decomp = ["PauliX", "PauliY"]
         """
@@ -269,32 +184,16 @@ def test_get_decomp_gates_schema2():
     assert "PauliY" in device_capabilities.to_decomp_ops
 
 
-def test_get_matrix_decomposable_gates_schema1():
+@pytest.mark.parametrize("schema", ALL_SUPPORTED_SCHEMAS)
+def test_get_matrix_decomposable_gates(schema):
     """Test native matrix gates are properly obtained from the toml."""
     device_capabilities = get_test_device_capabilities(
         ProgramFeatures(False),
         dedent(
-            """
-            schema = 1
-            [[operators.gates]]
-            matrix = ["PauliX", "PauliY"]
-        """
-        ),
-    )
-
-    assert "PauliX" in device_capabilities.to_matrix_ops
-    assert "PauliY" in device_capabilities.to_matrix_ops
-
-
-def test_get_matrix_decomposable_gates_schema2():
-    """Test native matrix gates are properly obtained from the toml."""
-    device_capabilities = get_test_device_capabilities(
-        ProgramFeatures(False),
-        dedent(
-            r"""
-            schema = 2
+            f"""
+            schema = {schema}
             [operators.gates.matrix]
-            PauliZ = {}
+            PauliZ = {{}}
         """
         ),
     )
@@ -302,7 +201,8 @@ def test_get_matrix_decomposable_gates_schema2():
     assert "PauliZ" in device_capabilities.to_matrix_ops
 
 
-def test_config_invalid_attr():
+@pytest.mark.parametrize("schema", ALL_SUPPORTED_SCHEMAS)
+def test_config_invalid_attr(schema):
     """Check the gate condition handling logic"""
     with pytest.raises(
         CompileError, match="Configuration for gate 'TestGate' has unknown attributes"
@@ -310,16 +210,17 @@ def test_config_invalid_attr():
         get_test_device_capabilities(
             ProgramFeatures(False),
             dedent(
-                r"""
-                    schema = 2
+                f"""
+                    schema = {schema}
                     [operators.gates.native]
-                    TestGate = { unknown_attribute = 33 }
+                    TestGate = {{ unknown_attribute = 33 }}
                 """
             ),
         )
 
 
-def test_config_invalid_condition_unknown():
+@pytest.mark.parametrize("schema", ALL_SUPPORTED_SCHEMAS)
+def test_config_invalid_condition_unknown(schema):
     """Check the gate condition handling logic"""
     with pytest.raises(
         CompileError, match="Configuration for gate 'TestGate' has unknown conditions"
@@ -327,16 +228,17 @@ def test_config_invalid_condition_unknown():
         get_test_device_capabilities(
             ProgramFeatures(True),
             dedent(
-                r"""
-                    schema = 2
+                f"""
+                    schema = {schema}
                     [operators.gates.native]
-                    TestGate = { condition = ["unknown", "analytic"] }
+                    TestGate = {{ condition = ["unknown", "analytic"] }}
                 """
             ),
         )
 
 
-def test_config_invalid_property_unknown():
+@pytest.mark.parametrize("schema", ALL_SUPPORTED_SCHEMAS)
+def test_config_invalid_property_unknown(schema):
     """Check the gate condition handling logic"""
     with pytest.raises(
         CompileError, match="Configuration for gate 'TestGate' has unknown properties"
@@ -344,42 +246,59 @@ def test_config_invalid_property_unknown():
         get_test_device_capabilities(
             ProgramFeatures(True),
             dedent(
-                r"""
-                    schema = 2
+                f"""
+                    schema = {schema}
                     [operators.gates.native]
-                    TestGate = { properties = ["unknown", "invertible"] }
+                    TestGate = {{ properties = ["unknown", "invertible"] }}
                 """
             ),
         )
 
 
-@pytest.mark.parametrize("shots", [True, False])
-def test_config_invalid_condition_duplicate(shots):
-    """Check the gate condition handling logic"""
+@pytest.mark.parametrize("schema", ALL_SUPPORTED_SCHEMAS)
+def test_config_invalid_condition_duplicate_true(schema):
+    """Check the gate condition handling logic for True"""
     with pytest.raises(CompileError, match="Configuration for gate 'TestGate'"):
         get_test_device_capabilities(
-            ProgramFeatures(shots),
+            ProgramFeatures(True),
             dedent(
-                r"""
-                    schema = 2
+                f"""
+                    schema = {schema}
                     [operators.gates.native]
-                    TestGate = { condition = ["finiteshots", "analytic"] }
+                    TestGate = {{ condition = ["finiteshots", "analytic"] }}
                 """
             ),
         )
 
 
-def test_config_qjit_device_operations():
+@pytest.mark.parametrize("schema", ALL_SUPPORTED_SCHEMAS)
+def test_config_invalid_condition_duplicate_false(schema):
+    """Check the gate condition handling logic for False"""
+    with pytest.raises(CompileError, match="Configuration for gate 'TestGate'"):
+        get_test_device_capabilities(
+            ProgramFeatures(False),
+            dedent(
+                f"""
+                    schema = {schema}
+                    [operators.gates.native]
+                    TestGate = {{ condition = ["finiteshots", "analytic"] }}
+                """
+            ),
+        )
+
+
+@pytest.mark.parametrize("schema", ALL_SUPPORTED_SCHEMAS)
+def test_config_qjit_device_operations(schema):
     """Check the gate condition handling logic"""
     capabilities = get_test_device_capabilities(
         ProgramFeatures(False),
         dedent(
-            r"""
-                schema = 2
+            f"""
+                schema = {schema}
                 [operators.gates.native]
-                PauliX = {}
+                PauliX = {{}}
                 [operators.observables]
-                PauliY = {}
+                PauliY = {{}}
             """
         ),
     )
@@ -389,30 +308,32 @@ def test_config_qjit_device_operations():
     assert "PauliY" in qjit_device.observables
 
 
-def test_config_unsupported_schema():
-    """Test native matrix gates are properly obtained from the toml."""
+@pytest.mark.parametrize("schema", [999])
+def test_config_unsupported_schema(schema):
+    """Test unsupported schema version."""
     program_features = ProgramFeatures(False)
     config_text = dedent(
-        r"""
-            schema = 999
+        f"""
+            schema = {schema}
         """
     )
-    config = get_test_config(config_text)
 
-    with pytest.raises(CompileError):
+    with pytest.raises(AssertionError, match="Unsupported config schema"):
         get_test_device_capabilities(program_features, config_text)
 
-    with pytest.raises(CompileError):
-        get_matrix_decomposable_gates(config, program_features)
 
-    with pytest.raises(CompileError):
-        get_decomposable_gates(config, program_features)
+@pytest.mark.parametrize("schema", ALL_DEPRECATED_SCHEMAS)
+def test_config_deprecated_schema(schema):
+    """Test deprecated schema version."""
+    program_features = ProgramFeatures(False)
+    config_text = dedent(
+        f"""
+            schema = {schema}
+        """
+    )
 
-    with pytest.raises(CompileError):
-        get_native_ops(config, program_features)
-
-    with pytest.raises(CompileError):
-        check_quantum_control_flag(config)
+    with pytest.raises(AssertionError, match="is deprecated"):
+        get_test_device_capabilities(program_features, config_text)
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_preprocess.py
+++ b/frontend/test/pytest/test_preprocess.py
@@ -87,7 +87,7 @@ def get_test_device_capabilities(
 ) -> DeviceCapabilities:
     """Parse test config into the DeviceCapabilities structure"""
     config = get_test_config(config_text)
-    device_capabilities = load_device_capabilities(config, program_features, "dummy")
+    device_capabilities = load_device_capabilities(config, program_features)
     return device_capabilities
 
 


### PR DESCRIPTION
**Context:** We no longer use TOML Schema 1 files

**Description of the Change:** 

- Refactor schema validation to be performed only once
- There is only one logic for valid schemas

**Benefits:** Unifying the validation entry point reduces boiler plate code and improves maintainability  

**Possible Drawbacks:** Future schemas might require different logic.
[sc-67112]