### PR TITLE
Add a check validating that only Expval and Var contain observables

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -168,6 +168,7 @@
 * Verification is now performed before compilation to confirm that the measurements included in the quantum tape 
   are compatible with the device.
   [(#945)](https://github.com/PennyLaneAI/catalyst/pull/945)
+  [(#962)](https://github.com/PennyLaneAI/catalyst/pull/962)
 
 <h3>Breaking changes</h3>
 

--- a/frontend/catalyst/device/verification.py
+++ b/frontend/catalyst/device/verification.py
@@ -21,6 +21,7 @@ from typing import Any, Callable, Sequence, Union
 
 from pennylane import transform
 from pennylane.measurements import (
+    ExpectationMP,
     MutualInfoMP,
     SampleMeasurement,
     StateMeasurement,
@@ -309,6 +310,11 @@ def validate_measurements(
     for m in tape.measurements:
         # verify observable is supported
         if m.obs:
+            if not isinstance(m, (ExpectationMP, VarianceMP)):
+                raise CompileError(
+                    "Only expectation value and variance measurements can "
+                    "accept observables with Catalyst"
+                )
             _verify_observable(m.obs, _obs_checker)
         # verify measurement process type is supported
         if shots and not isinstance(m, SampleMeasurement):

--- a/frontend/test/lit/test_measurements.py
+++ b/frontend/test/lit/test_measurements.py
@@ -19,38 +19,46 @@ import pennylane as qml
 
 from catalyst import qjit
 
+# TODO: NOTE:
+# The tests sample1 and sample2 below used to pass before verification steps were added in the 
+# device processing. Now that the measurement validation is run, the circuit below complains 
+# (observables with MeasurementProcess types other than ExpectationMP and VarianceMP are not 
+# currently supported).
+#
+# This test is commented out and the expected output is also commented out using the FileCheck
+# comments (COM:).
 
-# CHECK-LABEL: private @sample1(
+# COM: CHECK-LABEL: private @sample1(
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2, shots=1000))
 def sample1(x: float, y: float):
     qml.RX(x, wires=0)
     qml.RY(y, wires=1)
-    # CHECK: [[q0:%.+]] = quantum.custom "RZ"
+    # COM: CHECK: [[q0:%.+]] = quantum.custom "RZ"
     qml.RZ(0.1, wires=0)
 
-    # CHECK: [[obs:%.+]] = quantum.namedobs [[q0]][ PauliZ]
-    # CHECK: quantum.sample [[obs]] {shots = 1000 : i64} : tensor<1000xf64>
+    # COM: CHECK: [[obs:%.+]] = quantum.namedobs [[q0]][ PauliZ]
+    # COM: CHECK: quantum.sample [[obs]] {shots = 1000 : i64} : tensor<1000xf64>
     return qml.sample(qml.PauliZ(0))
 
 
 print(sample1.mlir)
 
 
-# CHECK-LABEL: private @sample2(
+# COM: CHECK-LABEL: private @sample2(
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2, shots=1000))
 def sample2(x: float, y: float):
     qml.RX(x, wires=0)
-    # CHECK: [[q1:%.+]] = quantum.custom "RY"
+    # COM: CHECK: [[q1:%.+]] = quantum.custom "RY"
     qml.RY(y, wires=1)
-    # CHECK: [[q0:%.+]] = quantum.custom "RZ"
+    # COM: CHECK: [[q0:%.+]] = quantum.custom "RZ"
     qml.RZ(0.1, wires=0)
 
-    # CHECK: [[obs1:%.+]] = quantum.namedobs [[q1]][ PauliX]
-    # CHECK: [[obs2:%.+]] = quantum.namedobs [[q0]][ Identity]
-    # CHECK: [[obs3:%.+]] = quantum.tensor [[obs1]], [[obs2]]
-    # CHECK: quantum.sample [[obs3]] {shots = 1000 : i64} : tensor<1000xf64>
+    # COM: CHECK: [[obs1:%.+]] = quantum.namedobs [[q1]][ PauliX]
+    # COM: CHECK: [[obs2:%.+]] = quantum.namedobs [[q0]][ Identity]
+    # COM: CHECK: [[obs3:%.+]] = quantum.tensor [[obs1]], [[obs2]]
+    # COM: CHECK: quantum.sample [[obs3]] {shots = 1000 : i64} : tensor<1000xf64>
     return qml.sample(qml.PauliX(1) @ qml.Identity(0))
 
 

--- a/frontend/test/lit/test_measurements.py
+++ b/frontend/test/lit/test_measurements.py
@@ -25,7 +25,7 @@ from catalyst import CompileError, qjit
 # (observables with MeasurementProcess types other than ExpectationMP and VarianceMP are not
 # currently supported).
 #
-# This test is commented out and the expected output is also commented out using the FileCheck
+# These tests are commented out and the expected output is also commented out using the FileCheck
 # comments (COM:).
 
 try:
@@ -82,33 +82,30 @@ def sample3(x: float, y: float):
 
 print(sample3.mlir)
 
-
-# CHECK-LABEL: private @counts1(
-@qjit(target="mlir")
-@qml.qnode(qml.device("lightning.qubit", wires=2, shots=1000))
-def counts1(x: float, y: float):
-    qml.RX(x, wires=0)
-    qml.RY(y, wires=1)
-    # CHECK: [[q0:%.+]] = quantum.custom "RZ"
-    qml.RZ(0.1, wires=0)
-
-    # CHECK: [[obs:%.+]] = quantum.namedobs [[q0]][ PauliZ]
-    # CHECK: quantum.counts [[obs]] {shots = 1000 : i64} : tensor<2xf64>, tensor<2xi64>
-    return qml.counts(qml.PauliZ(0))
-
-
-print(counts1.mlir)
-
 # TODO: NOTE:
-# The test below used to pass before the compiler driver. This is because before the compiler
-# driver, "target='mlir'" would not run the verifier. Now that the verifier is run, the circuit
-# below complains.
+# The tests below used to pass before the compiler driver (in the case of counts2) and device
+# preprocessing verification (in the case of counts1). Now that the validation is run, the circuits
+# below complain.
 #
-# This test is commented out and the expected output is also commented out using the FileCheck
+# These tests are commented out and the expected output is also commented out using the FileCheck
 # comments (COM:).
 #
-# COM: CHECK-LABEL: private @counts2(
 try:
+
+    # COM: CHECK-LABEL: private @counts1(
+    @qjit(target="mlir")
+    @qml.qnode(qml.device("lightning.qubit", wires=2, shots=1000))
+    def counts1(x: float, y: float):
+        qml.RX(x, wires=0)
+        qml.RY(y, wires=1)
+        # COM: CHECK: [[q0:%.+]] = quantum.custom "RZ"
+        qml.RZ(0.1, wires=0)
+
+        # COM: CHECK: [[obs:%.+]] = quantum.namedobs [[q0]][ PauliZ]
+        # COM: CHECK: quantum.counts [[obs]] {shots = 1000 : i64} : tensor<2xf64>, tensor<2xi64>
+        return qml.counts(qml.PauliZ(0))
+
+    print(counts1.mlir)
 
     @qjit(target="mlir")
     @qml.qnode(qml.device("lightning.qubit", wires=2, shots=1000))

--- a/frontend/test/lit/test_measurements.py
+++ b/frontend/test/lit/test_measurements.py
@@ -17,12 +17,12 @@
 import numpy as np
 import pennylane as qml
 
-from catalyst import qjit
+from catalyst import CompileError, qjit
 
 # TODO: NOTE:
-# The tests sample1 and sample2 below used to pass, before verification steps were added in the 
-# device preprocessing. Now that the measurement validation is run, the circuit below complains 
-# (observables with MeasurementProcess types other than ExpectationMP and VarianceMP are not 
+# The tests sample1 and sample2 below used to pass, before verification steps were added in the
+# device preprocessing. Now that the measurement validation is run, the circuit below complains
+# (observables with MeasurementProcess types other than ExpectationMP and VarianceMP are not
 # currently supported).
 #
 # This test is commented out and the expected output is also commented out using the FileCheck
@@ -42,9 +42,7 @@ try:
         # COM: CHECK: quantum.sample [[obs]] {shots = 1000 : i64} : tensor<1000xf64>
         return qml.sample(qml.PauliZ(0))
 
-
     print(sample1.mlir)
-
 
     # COM: CHECK-LABEL: private @sample2(
     @qjit(target="mlir")
@@ -62,10 +60,10 @@ try:
         # COM: CHECK: quantum.sample [[obs3]] {shots = 1000 : i64} : tensor<1000xf64>
         return qml.sample(qml.PauliX(1) @ qml.Identity(0))
 
-
     print(sample2.mlir)
-except:
+except CompileError:
     ...
+
 
 # CHECK-LABEL: private @sample3(
 @qjit(target="mlir")

--- a/frontend/test/lit/test_measurements.py
+++ b/frontend/test/lit/test_measurements.py
@@ -20,50 +20,52 @@ import pennylane as qml
 from catalyst import qjit
 
 # TODO: NOTE:
-# The tests sample1 and sample2 below used to pass before verification steps were added in the 
-# device processing. Now that the measurement validation is run, the circuit below complains 
+# The tests sample1 and sample2 below used to pass, before verification steps were added in the 
+# device preprocessing. Now that the measurement validation is run, the circuit below complains 
 # (observables with MeasurementProcess types other than ExpectationMP and VarianceMP are not 
 # currently supported).
 #
 # This test is commented out and the expected output is also commented out using the FileCheck
 # comments (COM:).
 
-# COM: CHECK-LABEL: private @sample1(
-@qjit(target="mlir")
-@qml.qnode(qml.device("lightning.qubit", wires=2, shots=1000))
-def sample1(x: float, y: float):
-    qml.RX(x, wires=0)
-    qml.RY(y, wires=1)
-    # COM: CHECK: [[q0:%.+]] = quantum.custom "RZ"
-    qml.RZ(0.1, wires=0)
+try:
+    # COM: CHECK-LABEL: private @sample1(
+    @qjit(target="mlir")
+    @qml.qnode(qml.device("lightning.qubit", wires=2, shots=1000))
+    def sample1(x: float, y: float):
+        qml.RX(x, wires=0)
+        qml.RY(y, wires=1)
+        # COM: CHECK: [[q0:%.+]] = quantum.custom "RZ"
+        qml.RZ(0.1, wires=0)
 
-    # COM: CHECK: [[obs:%.+]] = quantum.namedobs [[q0]][ PauliZ]
-    # COM: CHECK: quantum.sample [[obs]] {shots = 1000 : i64} : tensor<1000xf64>
-    return qml.sample(qml.PauliZ(0))
-
-
-print(sample1.mlir)
+        # COM: CHECK: [[obs:%.+]] = quantum.namedobs [[q0]][ PauliZ]
+        # COM: CHECK: quantum.sample [[obs]] {shots = 1000 : i64} : tensor<1000xf64>
+        return qml.sample(qml.PauliZ(0))
 
 
-# COM: CHECK-LABEL: private @sample2(
-@qjit(target="mlir")
-@qml.qnode(qml.device("lightning.qubit", wires=2, shots=1000))
-def sample2(x: float, y: float):
-    qml.RX(x, wires=0)
-    # COM: CHECK: [[q1:%.+]] = quantum.custom "RY"
-    qml.RY(y, wires=1)
-    # COM: CHECK: [[q0:%.+]] = quantum.custom "RZ"
-    qml.RZ(0.1, wires=0)
-
-    # COM: CHECK: [[obs1:%.+]] = quantum.namedobs [[q1]][ PauliX]
-    # COM: CHECK: [[obs2:%.+]] = quantum.namedobs [[q0]][ Identity]
-    # COM: CHECK: [[obs3:%.+]] = quantum.tensor [[obs1]], [[obs2]]
-    # COM: CHECK: quantum.sample [[obs3]] {shots = 1000 : i64} : tensor<1000xf64>
-    return qml.sample(qml.PauliX(1) @ qml.Identity(0))
+    print(sample1.mlir)
 
 
-print(sample2.mlir)
+    # COM: CHECK-LABEL: private @sample2(
+    @qjit(target="mlir")
+    @qml.qnode(qml.device("lightning.qubit", wires=2, shots=1000))
+    def sample2(x: float, y: float):
+        qml.RX(x, wires=0)
+        # COM: CHECK: [[q1:%.+]] = quantum.custom "RY"
+        qml.RY(y, wires=1)
+        # COM: CHECK: [[q0:%.+]] = quantum.custom "RZ"
+        qml.RZ(0.1, wires=0)
 
+        # COM: CHECK: [[obs1:%.+]] = quantum.namedobs [[q1]][ PauliX]
+        # COM: CHECK: [[obs2:%.+]] = quantum.namedobs [[q0]][ Identity]
+        # COM: CHECK: [[obs3:%.+]] = quantum.tensor [[obs1]], [[obs2]]
+        # COM: CHECK: quantum.sample [[obs3]] {shots = 1000 : i64} : tensor<1000xf64>
+        return qml.sample(qml.PauliX(1) @ qml.Identity(0))
+
+
+    print(sample2.mlir)
+except:
+    ...
 
 # CHECK-LABEL: private @sample3(
 @qjit(target="mlir")

--- a/frontend/test/pytest/test_verification.py
+++ b/frontend/test/pytest/test_verification.py
@@ -632,7 +632,7 @@ class TestObservableValidation:
         "measurement", [qml.expval(qml.X(0)), qml.var(qml.X(0)), qml.sample(qml.X(0))]
     )
     def test_only_expval_and_var_allow_observables(self, measurement):
-        """Test that the validate_measurements transform catches measurements other 
+        """Test that the validate_measurements transform catches measurements other
         than expval and var that include observables, and raises an error"""
 
         dev = qml.device("lightning.qubit", wires=1)

--- a/frontend/test/pytest/test_verification.py
+++ b/frontend/test/pytest/test_verification.py
@@ -554,14 +554,16 @@ class TestObservableValidation:
             ([qml.expval(qml.ops.Hamiltonian([2, 3], [qml.Y(0), PauliX2(1)]))], "PauliX2"),
             ([qml.sample(), qml.expval(qml.X(0))], None),  # with empty sample
             ([qml.sample(), qml.expval(qml.RX(1.2, 0))], "RX"),
-            ([qml.sample(qml.X(0)), qml.expval(qml.X(0))], None),  # with sample with observable
-            ([qml.sample(qml.RX(1.2, 0)), qml.expval(qml.X(0))], "RX"),
+            # sample with observable is currently unsupported
+            # ([qml.sample(qml.X(0)), qml.expval(qml.X(0))], None),  
+            # ([qml.sample(qml.RX(1.2, 0)), qml.expval(qml.X(0))], "RX"),
             ([qml.probs(wires=0), qml.var(qml.X(1) + qml.Y(2))], None),  # with probs
             ([qml.probs(wires=0), qml.var(qml.RX(1.23, 1) + qml.Y(2))], "RX"),
             ([qml.counts(), qml.expval(qml.X(0))], None),  # with empty counts
             ([qml.counts(), qml.expval(qml.RX(1.2, 0))], "RX"),
-            ([qml.counts(qml.Y(0)), qml.expval(qml.X(0))], None),  # with counts with observable
-            ([qml.counts(qml.RX(1.23, 0)), qml.expval(qml.X(0))], "RX"),
+            # counts with observable is currently unsupported
+            # ([qml.counts(qml.Y(0)), qml.expval(qml.X(0))], None),  # with counts with observable
+            # ([qml.counts(qml.RX(1.23, 0)), qml.expval(qml.X(0))], "RX"),
         ],
     )
     def test_validate_measurements_transform(self, backend, measurements, invalid_op):

--- a/frontend/test/pytest/test_verification.py
+++ b/frontend/test/pytest/test_verification.py
@@ -555,7 +555,7 @@ class TestObservableValidation:
             ([qml.sample(), qml.expval(qml.X(0))], None),  # with empty sample
             ([qml.sample(), qml.expval(qml.RX(1.2, 0))], "RX"),
             # sample with observable is currently unsupported
-            # ([qml.sample(qml.X(0)), qml.expval(qml.X(0))], None),  
+            # ([qml.sample(qml.X(0)), qml.expval(qml.X(0))], None),
             # ([qml.sample(qml.RX(1.2, 0)), qml.expval(qml.X(0))], "RX"),
             ([qml.probs(wires=0), qml.var(qml.X(1) + qml.Y(2))], None),  # with probs
             ([qml.probs(wires=0), qml.var(qml.RX(1.23, 1) + qml.Y(2))], "RX"),

--- a/frontend/test/pytest/test_verification.py
+++ b/frontend/test/pytest/test_verification.py
@@ -632,6 +632,8 @@ class TestObservableValidation:
         "measurement", [qml.expval(qml.X(0)), qml.var(qml.X(0)), qml.sample(qml.X(0))]
     )
     def test_only_expval_and_var_allow_observables(self, measurement):
+        """Test that the validate_measurements transform catches measurements other 
+        than expval and var that include observables, and raises an error"""
 
         dev = qml.device("lightning.qubit", wires=1)
         dev_capabilities = get_device_capabilities(dev)

--- a/frontend/test/pytest/test_verification.py
+++ b/frontend/test/pytest/test_verification.py
@@ -19,8 +19,8 @@ from unittest.mock import patch
 
 import pennylane as qml
 import pytest
-from pennylane.ops import Adjoint, Controlled
 from pennylane.measurements import ExpectationMP, VarianceMP
+from pennylane.ops import Adjoint, Controlled
 
 from catalyst import (
     CompileError,


### PR DESCRIPTION
Follow-up to #945 , adding an additional verification check ensuring that only expectation values and variances contain observables.

**Related GitHub Issues:**
closes #828 