### PR TITLE
Marking the `std::mt19937 *gen` argument as `[[maybe_unused]]`in `runtime/include/QuantumD…

### DIFF
--- a/runtime/include/QuantumDevice.hpp
+++ b/runtime/include/QuantumDevice.hpp
@@ -122,7 +122,7 @@ struct QuantumDevice {
      *
      * @param gen The std::mt19937 PRNG object.
      */
-    virtual void SetDevicePRNG(std::mt19937 *gen){};
+    virtual void SetDevicePRNG([[maybe_unused]] std::mt19937 *gen){};
 
     /**
      * @brief Start recording a quantum tape if provided.


### PR DESCRIPTION
**Context:**
Marking the `std::mt19937 *gen` argument in `runtime/include/QuantumDevice.hpp/SetDevicePRNG(std::mt19937 *gen)` as `[[maybe_unused]]`, as some devices (e.g. openqasm and oqc) do not support seeding and this argument has no effect in the default implementation of this setter.

At a more superficial level, this is to make the tests in https://github.com/PennyLaneAI/pennylane-lightning/pull/819 pass.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
