### PR TITLE
Add devices page to the documentation

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -244,6 +244,12 @@
       return y
   ```
 
+<h3>Documentation</h3>
+
+* A page has been added to the documentation, listing devices that are
+  Catalyst compatible.
+  [(#966)](https://github.com/PennyLaneAI/catalyst/pull/966)
+
 <h3>Internal changes</h3>
 
 * The function `inactive_callback` was renamed `__catalyst_inactive_callback`.
@@ -277,10 +283,11 @@ This release contains contributions from (in alphabetical order):
 
 Alessandro Cosentino,
 Lillian M. A. Frederiksen,
+Josh Izaac,
 Kunwar Maheep Singh,
 Mehrdad Malekmohammadi,
 Romain Moyard,
-Erick Ochoa,
+Erick Ochoa Lopez,
 Mudit Pandey,
 Raul Torres,
 Tzung-Han Juang,

--- a/doc/dev/devices.rst
+++ b/doc/dev/devices.rst
@@ -27,7 +27,8 @@ Supported backend devices include:
     - A fast state-vector qubit simulator written with a C++ backend. See the
       `Lightning documentation <https://docs.pennylane.ai/projects/lightning/en/stable/lightning_qubit/device.html>`__
       for more details, as well as its
-      `Catalyst configuration file <https://github.com/PennyLaneAI/pennylane-lightning/blob/master/pennylane_lightning/lightning_qubit/lightning_qubit.toml>`__.
+      `Catalyst configuration file <https://github.com/PennyLaneAI/pennylane-lightning/blob/master/pennylane_lightning/lightning_qubit/lightning_qubit.toml>`__
+      for natively supported instructions.
 
   * - ``lightning.kokkos``
 
@@ -35,7 +36,8 @@ Supported backend devices include:
       circuit simulation. See the
       `Lightning documentation <https://docs.pennylane.ai/projects/lightning/en/stable/lightning_kokkos/device.html>`__
       for more details, as well as its
-      `Catalyst configuration file <https://github.com/PennyLaneAI/pennylane-lightning/blob/master/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml>`__.
+      `Catalyst configuration file <https://github.com/PennyLaneAI/pennylane-lightning/blob/master/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml>`__
+      for natively supported instructions.
 
   * - ``braket.aws.qubit``
 
@@ -44,7 +46,7 @@ Supported backend devices include:
       `PennyLane-Braket plugin <https://amazon-braket-pennylane-plugin-python.readthedocs.io/en/latest/>`__.
       See the
       `Catalyst configuration file <https://github.com/PennyLaneAI/catalyst/blob/main/runtime/lib/backend/openqasm/braket_aws_qubit.toml>`__
-      for supported operations.
+      for natively supported instructions.
 
   * - ``braket.local.qubit``
 
@@ -53,7 +55,7 @@ Supported backend devices include:
       `PennyLane-Braket plugin <https://amazon-braket-pennylane-plugin-python.readthedocs.io/en/latest/>`__.
       See the
       `Catalyst configuration file <https://github.com/PennyLaneAI/catalyst/blob/main/runtime/lib/backend/openqasm/braket_local_qubit.toml>`__
-      for more details.
+      for natively supported instructions.
 
   * - ``qrack.simulator``
 
@@ -64,7 +66,7 @@ Supported backend devices include:
       the `QJIT compilation with Qrack and Catalyst tutorial <https://pennylane.ai/qml/demos/qrack/>`__.
 
       See the `Catalyst configuration file <https://github.com/unitaryfund/pennylane-qrack/blob/master/pennylane_qrack/QrackDeviceConfig.toml>`__
-      for more details.
+      for natively supported instructions.
 
   * - ``oqc.cloud``
 
@@ -83,5 +85,5 @@ Supported backend devices include:
           dev = qml.device("oqc.cloud", backend="lucy", shots=2012, wires=2)
 
       See the `Catalyst configuration file <https://github.com/PennyLaneAI/catalyst/blob/main/frontend/catalyst/third_party/oqc/src/oqc.toml>`__
-      for more details.
+      for natively supported instructions.
 

--- a/doc/dev/devices.rst
+++ b/doc/dev/devices.rst
@@ -1,0 +1,138 @@
+Supported devices
+=================
+
+Not all PennyLane devices currently work with Catalyst, and for those that do, their supported
+feature set may not necessarily match supported features when used without :func:`~.qjit`.
+
+Supported backend devices include:
+
+.. list-table::
+  :widths: 20 80
+
+  * - ``lightning.qubit``
+
+    - A fast state-vector qubit simulator written with a C++ backend. See the
+      `Lightning documentation <https://docs.pennylane.ai/projects/lightning/en/stable/lightning_qubit/device.html>`__
+      for more details, as well as its
+      `Catalyst configuration file <https://github.com/PennyLaneAI/pennylane-lightning/blob/master/pennylane_lightning/lightning_qubit/lightning_qubit.toml>`__.
+
+  * - ``lightning.kokkos``
+
+    - A fast state-vector qubit simulator utilizing the Kokkos library for CPU and GPU accelerated
+      circuit simulation. See the
+      `Lightning documentation <https://docs.pennylane.ai/projects/lightning/en/stable/lightning_kokkos/device.html>`__
+      for more details, as well as its
+      `Catalyst configuration file <https://github.com/PennyLaneAI/pennylane-lightning/blob/master/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml>`__.
+
+  * - ``braket.aws.qubit``
+
+    - Interact with quantum computing hardware devices and simulators through Amazon Braket. To use
+      this device with Catalyst, make sure to install the
+      `PennyLane-Braket plugin <https://amazon-braket-pennylane-plugin-python.readthedocs.io/en/latest/>`__.
+      See the
+      `Catalyst configuration file <https://github.com/PennyLaneAI/catalyst/blob/main/runtime/lib/backend/openqasm/braket_aws_qubit.toml>`__
+      for supported operations.
+
+  * - ``braket.local.qubit``
+
+    - Run gate-based circuits on the Braket SDK's local simulator. To use
+      this device with Catalyst, make sure to install the
+      `PennyLane-Braket plugin <https://amazon-braket-pennylane-plugin-python.readthedocs.io/en/latest/>`__.
+      See the
+      `Catalyst configuration file <https://github.com/PennyLaneAI/catalyst/blob/main/runtime/lib/backend/openqasm/braket_local_qubit.toml>`__
+      for more details.
+
+  * - ``qrack.simulator``
+
+    - `Qrack <https://github.com/unitaryfund/qrack>`__ is a GPU-accelerated quantum computer
+      simulator with many novel optimizations including hybrid stabilizer simulation. To use this
+      device with Catalyst, make sure to install the
+      `PennyLane-Qrack plugin <https://pennylane-qrack.readthedocs.io/en/latest/>`__, and check out
+      the `QJIT compilation with Qrack and Catalyst tutorial <https://pennylane.ai/qml/demos/qrack/>`__.
+
+      See the `Catalyst configuration file <https://github.com/unitaryfund/pennylane-qrack/blob/master/pennylane_qrack/QrackDeviceConfig.toml>`__
+      for more details.
+
+  * - ``oqc.cloud``
+
+    - Execute on `Oxford Quantum Circuits (OQC) <https://www.oqc.tech/>`__ superconducting hardware,
+      via `OQC Cloud <https://docs.oqc.app>`__. To use OQC Cloud with Catalyst, simply `install the
+      client <https://docs.oqc.app/installation.html>`__, ensure your credentials are set as
+      environment variables, and use the ``backend`` argument to specify the OQC backend to use:
+
+      .. code-block:: python
+
+          import os
+          os.environ["OQC_EMAIL"] = "your_email"
+          os.environ["OQC_PASSWORD"] = "your_password"
+          os.environ["OQC_URL"] = "oqc_url"
+
+          dev = qml.device("oqc.cloud", backend="lucy", shots=2012, wires=2)
+
+      See the `Catalyst configuration file <https://github.com/PennyLaneAI/catalyst/blob/main/frontend/catalyst/third_party/oqc/src/oqc.toml>`__
+      for more details.
+
+
+
+Device features
+---------------
+
+The ``lightning,qubit``, ``lightning.kokkos``, ``braket.aws.qubit``, ``braket.local.qubit``,
+and ``oqc.cloud`` devices are currently provided by the Catalyst package. For these
+built-in devices, the following table shows supported features devices (for external
+qjit-compatible devices, please consult the corresponding device documentation):
+
+.. list-table::
+  :widths: 16 21 21 21 21
+  :header-rows: 0
+
+  * - **Features**
+    - ``lightning.qubit``
+    - ``lightning.kokkos``
+    - ``braket.aws.qubit``
+    - ``oqc.cloud``
+  * - Qubit Management
+    - Dynamic allocation/deallocation
+    - Static allocation/deallocation
+    - Static allocation/deallocation
+    - Static allocation/deallocation
+  * - Gate Operations
+    - `Lightning Qubit operations <https://github.com/PennyLaneAI/pennylane-lightning/blob/master/pennylane_lightning/lightning_qubit/lightning_qubit.toml>`__
+    - `Lightning Kokkos operations <https://github.com/PennyLaneAI/pennylane-lightning/blob/master/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml>`__
+    - `Braket operations <https://github.com/PennyLaneAI/catalyst/blob/main/runtime/lib/backend/openqasm/braket_aws_qubit.toml>`__
+    - `OQC operations <https://github.com/PennyLaneAI/catalyst/blob/main/frontend/catalyst/third_party/oqc/src/oqc.toml>`__
+  * - Quantum Observables
+    - ``Identity``, ``PauliX``, ``PauliY``, ``PauliZ``, ``Hadamard``, ``Hermitian``, ``Hamiltonian``, and Tensor Product of Observables
+    - ``Identity``, ``PauliX``, ``PauliY``, ``PauliZ``, ``Hadamard``, ``Hermitian``, ``Hamiltonian``, and Tensor Product of Observables
+    - ``Identity``, ``PauliX``, ``PauliY``, ``PauliZ``, ``Hadamard``, ``Hermitian``, and Tensor Product of Observables
+    - ``PauliX``, ``PauliY``, ``PauliZ``, and ``Hadamard``.
+  * - Expectation Value
+    - All observables; Finite-shots supported except for ``Hermitian``
+    - All observables; Finite-shots supported except for ``Hermitian``
+    - All observables; Finite-shots supported
+    - All observables; Finite-shots supported
+  * - Variance
+    - All observables; Finite-shots supported except for ``Hermitian``
+    - All observables; Finite-shots supported except for ``Hermitian``
+    - All observables; Finite-shots supported
+    - Not supported
+  * - Probability
+    - Only for the computational basis on the supplied qubits; Finite-shots supported except for ``Hermitian``
+    - Only for the computational basis on the supplied qubits; Finite-shots supported except for ``Hermitian``
+    - Not currently supported
+    - Only for the computational basis on the supplied qubits
+  * - Sampling
+    - Only for the computational basis on the supplied qubits
+    - Only for the computational basis on the supplied qubits
+    - The computational basis on all active qubits; Finite-shots supported
+    - The computational basis on all active qubits; Finite-shots supported
+  * - Mid-Circuit Measurement
+    - Only for the computational basis on the supplied qubit
+    - Only for the computational basis on the supplied qubit
+    - Not supported
+    - Not supported
+  * - Gradient
+    - The Adjoint-Jacobian method for expectation values on all observables
+    - The Adjoint-Jacobian method for expectation values on all observables
+    - Not supported
+    - Not supported

--- a/doc/dev/devices.rst
+++ b/doc/dev/devices.rst
@@ -1,3 +1,16 @@
+
+.. raw:: html
+
+    <style>
+    tr {
+        border-top: #d3d3d3 1px solid;
+        border-bottom: #d3d3d3 1px solid;
+    }
+    .row-odd {
+        background-color: #f7f7f7;
+    }
+    </style>
+
 Supported devices
 =================
 
@@ -72,67 +85,3 @@ Supported backend devices include:
       See the `Catalyst configuration file <https://github.com/PennyLaneAI/catalyst/blob/main/frontend/catalyst/third_party/oqc/src/oqc.toml>`__
       for more details.
 
-
-
-Device features
----------------
-
-The ``lightning,qubit``, ``lightning.kokkos``, ``braket.aws.qubit``, ``braket.local.qubit``,
-and ``oqc.cloud`` devices are currently provided by the Catalyst package. For these
-built-in devices, the following table shows supported features devices (for external
-qjit-compatible devices, please consult the corresponding device documentation):
-
-.. list-table::
-  :widths: 16 21 21 21 21
-  :header-rows: 0
-
-  * - **Features**
-    - ``lightning.qubit``
-    - ``lightning.kokkos``
-    - ``braket.aws.qubit``
-    - ``oqc.cloud``
-  * - Qubit Management
-    - Dynamic allocation/deallocation
-    - Static allocation/deallocation
-    - Static allocation/deallocation
-    - Static allocation/deallocation
-  * - Gate Operations
-    - `Lightning Qubit operations <https://github.com/PennyLaneAI/pennylane-lightning/blob/master/pennylane_lightning/lightning_qubit/lightning_qubit.toml>`__
-    - `Lightning Kokkos operations <https://github.com/PennyLaneAI/pennylane-lightning/blob/master/pennylane_lightning/lightning_kokkos/lightning_kokkos.toml>`__
-    - `Braket operations <https://github.com/PennyLaneAI/catalyst/blob/main/runtime/lib/backend/openqasm/braket_aws_qubit.toml>`__
-    - `OQC operations <https://github.com/PennyLaneAI/catalyst/blob/main/frontend/catalyst/third_party/oqc/src/oqc.toml>`__
-  * - Quantum Observables
-    - ``Identity``, ``PauliX``, ``PauliY``, ``PauliZ``, ``Hadamard``, ``Hermitian``, ``Hamiltonian``, and Tensor Product of Observables
-    - ``Identity``, ``PauliX``, ``PauliY``, ``PauliZ``, ``Hadamard``, ``Hermitian``, ``Hamiltonian``, and Tensor Product of Observables
-    - ``Identity``, ``PauliX``, ``PauliY``, ``PauliZ``, ``Hadamard``, ``Hermitian``, and Tensor Product of Observables
-    - ``PauliX``, ``PauliY``, ``PauliZ``, and ``Hadamard``.
-  * - Expectation Value
-    - All observables; Finite-shots supported except for ``Hermitian``
-    - All observables; Finite-shots supported except for ``Hermitian``
-    - All observables; Finite-shots supported
-    - All observables; Finite-shots supported
-  * - Variance
-    - All observables; Finite-shots supported except for ``Hermitian``
-    - All observables; Finite-shots supported except for ``Hermitian``
-    - All observables; Finite-shots supported
-    - Not supported
-  * - Probability
-    - Only for the computational basis on the supplied qubits; Finite-shots supported except for ``Hermitian``
-    - Only for the computational basis on the supplied qubits; Finite-shots supported except for ``Hermitian``
-    - Not currently supported
-    - Only for the computational basis on the supplied qubits
-  * - Sampling
-    - Only for the computational basis on the supplied qubits
-    - Only for the computational basis on the supplied qubits
-    - The computational basis on all active qubits; Finite-shots supported
-    - The computational basis on all active qubits; Finite-shots supported
-  * - Mid-Circuit Measurement
-    - Only for the computational basis on the supplied qubit
-    - Only for the computational basis on the supplied qubit
-    - Not supported
-    - Not supported
-  * - Gradient
-    - The Adjoint-Jacobian method for expectation values on all observables
-    - The Adjoint-Jacobian method for expectation values on all observables
-    - Not supported
-    - Not supported

--- a/doc/dev/quick_start.rst
+++ b/doc/dev/quick_start.rst
@@ -102,14 +102,14 @@ PennyLane are also supported via the decomposition mechanism in Catalyst. For ex
         qml.adjoint(qml.SingleExcitation(jnp.pi / 3, wires=[0, 1]))
         return qml.state()
 
-In addition, you can qjit most of :doc:`PennyLane templates <introduction/templates>` to easily construct and evaluate
+In addition, you can qjit most :doc:`PennyLane templates <introduction/templates>` to easily construct and evaluate
 more complex quantum circuits.
 
 .. important::
 
    Decomposition will generally happen in accordance with the specification provided by devices,
    which can vary from device to device (e.g., ``default.qubit`` and ``lightning.qubit`` might
-   decompose quite differently.)
+   decompose quite differently).
    However, Catalyst's decomposition logic will differ in the following cases:
 
    1. All :class:`qml.Controlled <pennylane.ops.op_math.Controlled>` operations will decompose to :class:`qml.QubitUnitary <pennylane.QubitUnitary>` operations.

--- a/doc/dev/quick_start.rst
+++ b/doc/dev/quick_start.rst
@@ -41,7 +41,7 @@ PennyLane. However, some of PennyLane's features may not be fully supported yet,
 .. warning::
 
     Not all PennyLane devices currently work with Catalyst. Supported backend devices include
-    ``lightning.qubit``, ``lightning.kokkos``, ``lightning.gpu``, and ``braket.aws.qubit``. For
+    ``lightning.qubit``, ``lightning.kokkos``, and ``braket.aws.qubit``. For
     a full of supported devices, please see :doc:`/dev/devices`.
 
 PennyLane tapes are still used internally by Catalyst and you can express your circuits in the

--- a/doc/dev/quick_start.rst
+++ b/doc/dev/quick_start.rst
@@ -40,8 +40,9 @@ PennyLane. However, some of PennyLane's features may not be fully supported yet,
 
 .. warning::
 
-    The supported backend devices are currently ``lightning.qubit``, ``lightning.kokkos``,
-    ``braket.local.qubit``, ``braket.aws.qubit``, and ``oqc.cloud`` but future plans include the addition of more.
+    Not all PennyLane devices currently work with Catalyst. Supported backend devices include
+    ``lightning.qubit``, ``lightning.kokkos``, ``lightning.gpu``, and ``braket.aws.qubit``. For
+    a full of supported devices, please see :doc:`/dev/devices`.
 
 PennyLane tapes are still used internally by Catalyst and you can express your circuits in the
 way you are used to, as long as you ensure that all operations are added to the main tape.
@@ -101,101 +102,19 @@ PennyLane are also supported via the decomposition mechanism in Catalyst. For ex
         qml.adjoint(qml.SingleExcitation(jnp.pi / 3, wires=[0, 1]))
         return qml.state()
 
-In addition, you can jit most of :doc:`PennyLane templates <introduction/templates>` to easily construct and evaluate
-more complex quantum circuits; see below for the list of currently supported operations and templates.
+In addition, you can qjit most of :doc:`PennyLane templates <introduction/templates>` to easily construct and evaluate
+more complex quantum circuits.
 
 .. important::
 
    Decomposition will generally happen in accordance with the specification provided by devices,
-   which can vary from device to device (e.g. ``default.qubit`` and ``lightning.qubit`` might
+   which can vary from device to device (e.g., ``default.qubit`` and ``lightning.qubit`` might
    decompose quite differently.)
    However, Catalyst's decomposition logic will differ in the following cases:
 
    1. All :class:`qml.Controlled <pennylane.ops.op_math.Controlled>` operations will decompose to :class:`qml.QubitUnitary <pennylane.QubitUnitary>` operations.
    2. The set of operations supported by Catalyst itself can in some instances lead to additional decompositions compared to the device itself.
 
-.. raw:: html
-
-    <div class="summary-table">
-
-.. details::
-    :title: List of supported native operations
-
-    .. autosummary::
-        :nosignatures:
-
-        ~pennylane.Identity
-        ~pennylane.PauliX
-        ~pennylane.PauliY
-        ~pennylane.PauliZ
-        ~pennylane.Hadamard
-        ~pennylane.S
-        ~pennylane.T
-        ~pennylane.PhaseShift
-        ~pennylane.RX
-        ~pennylane.RY
-        ~pennylane.RZ
-        ~pennylane.CNOT
-        ~pennylane.CY
-        ~pennylane.CZ
-        ~pennylane.SWAP
-        ~pennylane.IsingXX
-        ~pennylane.IsingYY
-        ~pennylane.IsingXY
-        ~pennylane.IsingZZ
-        ~pennylane.ControlledPhaseShift
-        ~pennylane.CRX
-        ~pennylane.CRY
-        ~pennylane.CRZ
-        ~pennylane.CRot
-        ~pennylane.CSWAP
-        ~pennylane.MultiRZ
-        ~pennylane.QubitUnitary
-
-.. raw:: html
-
-    </div>
-    <div class="summary-table">
-
-.. details::
-    :title: List of supported templates
-
-    .. autosummary::
-        :nosignatures:
-
-        ~pennylane.AllSinglesDoubles
-        ~pennylane.AmplitudeEmbedding
-        ~pennylane.AngleEmbedding
-        ~pennylane.ApproxTimeEvolution
-        ~pennylane.ArbitraryStatePreparation
-        ~pennylane.BasicEntanglerLayers
-        ~pennylane.BasisEmbedding
-        ~pennylane.BasisStatePreparation
-        ~pennylane.broadcast
-        ~pennylane.FermionicDoubleExcitation
-        ~pennylane.FermionicSingleExcitation
-        ~pennylane.FlipSign
-        ~pennylane.GateFabric
-        ~pennylane.GroverOperator
-        ~pennylane.IQPEmbedding
-        ~pennylane.kUpCCGSD
-        ~pennylane.MERA
-        ~pennylane.MottonenStatePreparation
-        ~pennylane.MPS
-        ~pennylane.Permute
-        ~pennylane.QAOAEmbedding
-        ~pennylane.QFT
-        ~pennylane.QuantumMonteCarlo
-        ~pennylane.QuantumPhaseEstimation
-        ~pennylane.RandomLayers
-        ~pennylane.SimplifiedTwoDesign
-        ~pennylane.StronglyEntanglingLayers
-        ~pennylane.TTN
-        ~pennylane.UCCSD
-
-.. raw:: html
-
-    </div>
 
 Observables
 -----------
@@ -217,28 +136,6 @@ a tensor product of a :class:`qml.PauliX <pennylane.PauliX>`, :class:`qml.Hadama
             [complex(2.0, 0.0), complex(-1.0, 0.0)]]
         )
         return qml.expval(qml.PauliX(0) @ qml.Hadamard(1) @ qml.Hermitian(h_matrix, 2))
-
-.. raw:: html
-
-    <div class="summary-table">
-
-.. details::
-    :title: List of supported observables
-
-    .. autosummary::
-        :nosignatures:
-
-        ~pennylane.Identity
-        ~pennylane.PauliX
-        ~pennylane.PauliY
-        ~pennylane.PauliZ
-        ~pennylane.Hadamard
-        ~pennylane.Hermitian
-        ~pennylane.Hamiltonian
-
-.. raw:: html
-
-    </div>
 
 Measurements
 ------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -67,6 +67,7 @@ Catalyst
 
    dev/installation
    dev/quick_start
+   dev/devices
    dev/autograph
    dev/sharp_bits
    dev/jax_integration

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -91,7 +91,7 @@ def qjit(
     .. note::
 
         Not all PennyLane devices currently work with Catalyst. Supported backend devices include
-        ``lightning.qubit``, ``lightning.kokkos``, ``lightning.gpu``, and ``braket.aws.qubit``. For
+        ``lightning.qubit``, ``lightning.kokkos``, and ``braket.aws.qubit``. For
         a full of supported devices, please see :doc:`/dev/devices`.
 
     Args:

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -90,9 +90,9 @@ def qjit(
 
     .. note::
 
-        The supported backend devices are currently ``lightning.qubit``, ``lightning.kokkos``,
-        ``braket.local.qubit``, ``braket.aws.qubit``, and ``oqc.cloud``. For a list of supported
-        operations, observables, and measurements, please see the :doc:`/dev/quick_start`.
+        Not all PennyLane devices currently work with Catalyst. Supported backend devices include
+        ``lightning.qubit``, ``lightning.kokkos``, ``lightning.gpu``, and ``braket.aws.qubit``. For
+        a full of supported devices, please see :doc:`/dev/devices`.
 
     Args:
         fn (Callable): the quantum or classical function


### PR DESCRIPTION
**Context:** There is currently no clear place in the Catalyst docs that lists supported devices.

**Description of the Change:**

- Adds a page to the docs listing supported devices.
- Removes lists of supported ops/observables from the quick start (since supported ops might differ per device)
- Updated `qjit` docstring to point to the new device page

**Benefits:**

- Easier to see in one place all supported devices

**Possible Drawbacks:**

- I noticed the table in the runtime README (https://github.com/PennyLaneAI/catalyst/blob/main/runtime/README.rst#backend-devices) is no longer up to date.

- For each of the devices, I linked to the TOML files so that a reader can easily see what is supported. However, the TOML file is not one-to-one in terms of what a user might experience, since Catalyst may decompose a unsupported operation to a supported one. 

**Related GitHub Issues:** n/a
