### PR TITLE
O2/Enzyme optional stage in LLVM

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -246,6 +246,10 @@
 
 <h3>Internal changes</h3>
 
+* llvm O2 and Enzyme passes are only run when needed (gradients presents). Async execution of QNodes triggers now triggers a
+   Coroutine lowering pass.
+  [(#968)](https://github.com/PennyLaneAI/catalyst/pull/968)
+
 * The function `inactive_callback` was renamed `__catalyst_inactive_callback`.
   [(#899)](https://github.com/PennyLaneAI/catalyst/pull/899)
 

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -532,6 +532,7 @@ class Compiler:
                 str(workspace),
                 module_name,
                 keep_intermediate=self.options.keep_intermediate,
+                async_qnodes=self.options.async_qnodes,
                 verbose=self.options.verbose,
                 pipelines=self.options.get_pipelines(),
                 lower_to_llvm=lower_to_llvm,

--- a/mlir/include/Driver/CompilerDriver.h
+++ b/mlir/include/Driver/CompilerDriver.h
@@ -71,6 +71,8 @@ struct CompilerOptions {
     llvm::raw_ostream &diagnosticStream;
     /// If true, the driver will output the module at intermediate points.
     bool keepIntermediate;
+    /// If true, the llvm.coroutine will be lowered.
+    bool asyncQnodes;
     /// Sets the verbosity level to use when printing messages.
     Verbosity verbosity;
     /// Ordered list of named pipelines to execute, each pipeline is described by a list of MLIR

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -257,8 +257,7 @@ OwningOpRef<ModuleOp> parseMLIRSource(MLIRContext *ctx, const llvm::SourceMgr &s
     return parseSourceFile<ModuleOp>(sourceMgr, parserConfig);
 }
 
-/// Parse an MLIR module given in textual ASM representation. Any errors during parsing will be
-/// output to diagnosticStream.
+/// From the MLIR module it checks if gradients operations are in the program.
 bool containsGradients(mlir::ModuleOp moduleOp)
 {
     bool contain = false;

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -709,6 +709,7 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
             }
 
             catalyst::utils::LinesCount::Module(*llvmModule.get());
+
             if (failed(timer::timer(runEnzymePasses, "runEnzymePasses", /* add_endl */ false,
                                     options, llvmModule, output))) {
                 return failure();

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -707,7 +707,6 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
                                     options, llvmModule, output))) {
                 return failure();
             }
-
             catalyst::utils::LinesCount::Module(*llvmModule.get());
 
             if (failed(timer::timer(runEnzymePasses, "runEnzymePasses", /* add_endl */ false,

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -39,6 +39,11 @@
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Transforms/Coroutines/CoroCleanup.h"
+#include "llvm/Transforms/Coroutines/CoroConditionalWrapper.h"
+#include "llvm/Transforms/Coroutines/CoroEarly.h"
+#include "llvm/Transforms/Coroutines/CoroSplit.h"
+#include "llvm/Transforms/IPO/GlobalDCE.h"
 
 #include "Catalyst/IR/CatalystDialect.h"
 #include "Catalyst/Transforms/Passes.h"
@@ -363,8 +368,53 @@ LogicalResult inferMLIRReturnTypes(MLIRContext *ctx, llvm::Type *returnType,
     return failure();
 }
 
-LogicalResult runLLVMPasses(const CompilerOptions &options,
-                            std::shared_ptr<llvm::Module> llvmModule, CompilerOutput &output)
+LogicalResult runCoroLLVMPasses(const CompilerOptions &options,
+                                std::shared_ptr<llvm::Module> llvmModule, CompilerOutput &output)
+{
+
+    auto &outputs = output.pipelineOutputs;
+
+    // Create a pass to lower LLVM coroutines (similar to what happens in O0)
+    llvm::ModulePassManager CoroPM;
+    CoroPM.addPass(llvm::CoroEarlyPass());
+    llvm::CGSCCPassManager CGPM;
+    CGPM.addPass(llvm::CoroSplitPass());
+    CoroPM.addPass(llvm::createModuleToPostOrderCGSCCPassAdaptor(std::move(CGPM)));
+    CoroPM.addPass(llvm::CoroCleanupPass());
+    CoroPM.addPass(llvm::GlobalDCEPass());
+
+    // Create the analysis managers.
+    llvm::LoopAnalysisManager LAM;
+    llvm::FunctionAnalysisManager FAM;
+    llvm::CGSCCAnalysisManager CGAM;
+    llvm::ModuleAnalysisManager MAM;
+
+    llvm::PassBuilder PB;
+    PB.registerModuleAnalyses(MAM);
+    PB.registerCGSCCAnalyses(CGAM);
+    PB.registerFunctionAnalyses(FAM);
+    PB.registerLoopAnalyses(LAM);
+    PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
+
+    // Create the pass manager.
+    llvm::ModulePassManager MPM;
+    MPM.addPass(llvm::CoroConditionalWrapper(std::move(CoroPM)));
+
+    // Optimize the IR!
+    MPM.run(*llvmModule.get(), MAM);
+
+    if (options.keepIntermediate) {
+        llvm::raw_string_ostream rawStringOstream{outputs["CoroOpt"]};
+        llvmModule->print(rawStringOstream, nullptr);
+        auto outFile = output.nextPipelineDumpFilename("CoroOpt", ".ll");
+        dumpToFile(options, outFile, outputs["CoroOpt"]);
+    }
+
+    return success();
+}
+
+LogicalResult runO2LLVMPasses(const CompilerOptions &options,
+                              std::shared_ptr<llvm::Module> llvmModule, CompilerOutput &output)
 {
     // opt -O2
     // As seen here:
@@ -396,10 +446,10 @@ LogicalResult runLLVMPasses(const CompilerOptions &options,
     MPM.run(*llvmModule.get(), MAM);
 
     if (options.keepIntermediate) {
-        llvm::raw_string_ostream rawStringOstream{outputs["PreEnzymeOpt"]};
+        llvm::raw_string_ostream rawStringOstream{outputs["O2Opt"]};
         llvmModule->print(rawStringOstream, nullptr);
-        auto outFile = output.nextPipelineDumpFilename("PreEnzymeOpt", ".ll");
-        dumpToFile(options, outFile, outputs["PreEnzymeOpt"]);
+        auto outFile = output.nextPipelineDumpFilename("O2Opt", ".ll");
+        dumpToFile(options, outFile, outputs["O2Opt"]);
     }
 
     return success();
@@ -619,9 +669,15 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
 
     if (llvmModule) {
 
+        if (options.asyncQnodes) {
+            if (failed(timer::timer(runCoroLLVMPasses, "runCoroLLVMPasses", /* add_endl */ false,
+                                    options, llvmModule, output))) {
+                return failure();
+            }
+        }
         if (enzymeRun) {
-            if (failed(timer::timer(runLLVMPasses, "runLLVMPasses", /* add_endl */ false, options,
-                                    llvmModule, output))) {
+            if (failed(timer::timer(runO2LLVMPasses, "runO2LLVMPasses", /* add_endl */ false,
+                                    options, llvmModule, output))) {
                 return failure();
             }
 

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -694,11 +694,6 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
         llvmModule->setDataLayout(targetMachine->createDataLayout());
         llvmModule->setTargetTriple(targetTriple);
 
-        if (failed(timer::timer(runLLVMPasses, "runLLVMPasses", /* add_endl */ false, options,
-                                llvmModule, output))) {
-            return failure();
-        }
-
         catalyst::utils::LinesCount::Module(*llvmModule.get());
 
         if (options.asyncQnodes) {

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -701,6 +701,7 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
                                     options, llvmModule, output))) {
                 return failure();
             }
+            catalyst::utils::LinesCount::Module(*llvmModule.get());
         }
         if (enzymeRun) {
             if (failed(timer::timer(runO2LLVMPasses, "runO2LLVMPasses", /* add_endl */ false,

--- a/mlir/python/PyCompilerDriver.cpp
+++ b/mlir/python/PyCompilerDriver.cpp
@@ -76,7 +76,7 @@ PYBIND11_MODULE(compiler_driver, m)
 
     m.def(
         "run_compiler_driver",
-        [](const char *source, const char *workspace, const char *moduleName, bool keepIntermediate,
+        [](const char *source, const char *workspace, const char *moduleName, bool keepIntermediate, bool asyncQnodes,
            bool verbose, py::list pipelines,
            bool lower_to_llvm) -> std::unique_ptr<CompilerOutput> {
             // Install signal handler to catch user interrupts (e.g. CTRL-C).
@@ -93,6 +93,7 @@ PYBIND11_MODULE(compiler_driver, m)
                                     .moduleName = moduleName,
                                     .diagnosticStream = errStream,
                                     .keepIntermediate = keepIntermediate,
+                                    .asyncQnodes = asyncQnodes,
                                     .verbosity = verbose ? Verbosity::All : Verbosity::Urgent,
                                     .pipelinesCfg = parseCompilerSpec(pipelines),
                                     .lowerToLLVM = lower_to_llvm};
@@ -105,6 +106,6 @@ PYBIND11_MODULE(compiler_driver, m)
             return output;
         },
         py::arg("source"), py::arg("workspace"), py::arg("module_name") = "jit source",
-        py::arg("keep_intermediate") = false, py::arg("verbose") = false,
+        py::arg("keep_intermediate") = false, py::arg("async_qnodes") = false, py::arg("verbose") = false,
         py::arg("pipelines") = py::list(), py::arg("lower_to_llvm") = true);
 }

--- a/mlir/python/PyCompilerDriver.cpp
+++ b/mlir/python/PyCompilerDriver.cpp
@@ -76,8 +76,8 @@ PYBIND11_MODULE(compiler_driver, m)
 
     m.def(
         "run_compiler_driver",
-        [](const char *source, const char *workspace, const char *moduleName, bool keepIntermediate, bool asyncQnodes,
-           bool verbose, py::list pipelines,
+        [](const char *source, const char *workspace, const char *moduleName, bool keepIntermediate,
+           bool asyncQnodes, bool verbose, py::list pipelines,
            bool lower_to_llvm) -> std::unique_ptr<CompilerOutput> {
             // Install signal handler to catch user interrupts (e.g. CTRL-C).
             signal(SIGINT,
@@ -106,6 +106,7 @@ PYBIND11_MODULE(compiler_driver, m)
             return output;
         },
         py::arg("source"), py::arg("workspace"), py::arg("module_name") = "jit source",
-        py::arg("keep_intermediate") = false, py::arg("async_qnodes") = false, py::arg("verbose") = false,
-        py::arg("pipelines") = py::list(), py::arg("lower_to_llvm") = true);
+        py::arg("keep_intermediate") = false, py::arg("async_qnodes") = false,
+        py::arg("verbose") = false, py::arg("pipelines") = py::list(),
+        py::arg("lower_to_llvm") = true);
 }


### PR DESCRIPTION
**Context:**
Currently we always run O2 and Enzyme, even without having gradients in the program.

**Description of the Change:**
- In the compiler driver, we check if the program contains gradients, if it is the case then we run O2 and Enzyme.
- We also now check if async is on, if yes then we run some Coro llvm passes. (similar to O0)

**Benefits:**
O2 only applied on program that contains gradients.
