### PR TITLE
Specify PennyLane dependency via version strings

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -5,4 +5,4 @@ llvm=3a8316216807d64a586b971f51695e23883331f7
 enzyme=v0.0.130
 
 # Always remove custom PL/LQ versions before release.
-pennylane=eb7c349795804c1e5df72980a81e4b1e1c4be4f0
+pennylane=0.38.0.dev4

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -28,7 +28,8 @@ sphinxext-opengraph==0.9.0
 matplotlib==3.8.0
 lxml_html_clean
 
-# Pre-install development lightning wheels
+# Pre-install PL development wheels
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.37.0
 pennylane-lightning==0.37.0
+pennylane==0.38.0.dev4

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -1577,7 +1577,6 @@ special_par_op_decomps = [
 custom_ctrl_op_decomps = special_non_par_op_decomps + special_par_op_decomps
 
 pauli_x_based_op_decomps = [
-    (qml.PauliX, [0], [1], [qml.CNOT([1, 0])]),
     (
         qml.PauliX,
         [2],

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ pl_min_release = 0.37
 lq_min_release = pl_min_release
 
 if pl_version is not None:
-    pennylane_dep = f"pennylane @ git+https://github.com/pennylaneai/pennylane@{pl_version}"
+    pennylane_dep = f"pennylane=={pl_version}"  # use TestPyPI wheels, git is not allowed on PyPI
 else:
     pennylane_dep = f"pennylane>={pl_min_release}"
 if lq_version is not None:


### PR DESCRIPTION
Specify the PennyLane dependency during development cycles via package version strings.

The previous system download an exact commit from PennyLane's main branch. However, wheels uploaded to PyPI are not allowed to have repo dependencies like that, only dependencies on other released packages are allowed.

This unblocks our failing development wheel uploads introduced by the PennyLane dependency.