### PR TITLE
Change EnzymeStatic-18 to -19 in all github build scripts

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -217,7 +217,7 @@ jobs:
               -DCMAKE_CXX_VISIBILITY_PRESET=protected \
               -DLLVM_ENABLE_LLD=ON
 
-        cmake --build enzyme-build --target EnzymeStatic-18
+        cmake --build enzyme-build --target EnzymeStatic-19
 
   catalyst-linux-wheels-x86-64:
     needs: [constants, build-dependencies, determine_runner]

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -204,7 +204,7 @@ jobs:
               -DENZYME_STATIC_LIB=ON \
               -DCMAKE_CXX_VISIBILITY_PRESET=hidden
 
-        cmake --build ${{ steps.setup_env.outputs.dependency_build_dir }}/enzyme-build --target EnzymeStatic-18
+        cmake --build ${{ steps.setup_env.outputs.dependency_build_dir }}/enzyme-build --target EnzymeStatic-19
 
   catalyst-macos-wheels-arm64:
     needs: [constants, build-dependencies]

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -176,7 +176,7 @@ jobs:
               -DENZYME_STATIC_LIB=ON \
               -DCMAKE_CXX_VISIBILITY_PRESET=hidden
 
-        cmake --build enzyme-build --target EnzymeStatic-18
+        cmake --build enzyme-build --target EnzymeStatic-19
 
   catalyst-macos-wheels-x86-64:
     needs: [constants, build-dependencies]

--- a/.github/workflows/scripts/linux_arm64/rh8/build_enzyme.sh
+++ b/.github/workflows/scripts/linux_arm64/rh8/build_enzyme.sh
@@ -39,4 +39,4 @@ cmake -S /catalyst/mlir/Enzyme/enzyme -B /catalyst/enzyme-build -G Ninja \
     -DLLVM_DIR=/catalyst/llvm-build/lib/cmake/llvm \
     -DENZYME_STATIC_LIB=ON \
     -DCMAKE_CXX_VISIBILITY_PRESET=hidden
-cmake --build /catalyst/enzyme-build --target EnzymeStatic-18
+cmake --build /catalyst/enzyme-build --target EnzymeStatic-19


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new functions and code must be clearly commented and documented.

- [ ] Ensure that code is properly formatted by running `make format`.
      The latest version of black and `clang-format-14` are used in CI/CD to check formatting.

- [ ] All new features must include a unit test.
      Integration and frontend tests should be added to [`frontend/test`](../frontend/test/),
      Quantum dialect and MLIR tests should be added to [`mlir/test`](../mlir/test/), and
      Runtime tests should be added to [`runtime/tests`](../runtime/tests/).

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:** In #931, in `mlir/Makefile` the enzyme target was updated, but the ones in the github build script are not, causing wheels failures.

**Description of the Change:** Update enzyme target from 18 to 19 in github build scripts.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
