### PR TITLE
Update check Catalyst (upload-artifact downgrade && OQC unpin)

### DIFF
--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -249,7 +249,7 @@ jobs:
             bash /catalyst/.github/workflows/scripts/linux_arm64/rh8/build_catalyst.sh $GCC_VERSION ${{ matrix.python_version.official }} ${{ matrix.python_version.subversion }} ${{ matrix.python_version.package }} ${{ matrix.python_version.alternative }}
 
     - name: Upload Wheel Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: catalyst-linux_arm64-wheel-py-${{ matrix.python_version.official}}.zip
         path: wheel/

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -363,7 +363,7 @@ jobs:
         delocate-wheel --require-archs=arm64 -w ./wheel -v dist/*.whl --ignore-missing-dependencies -vv
 
     - name: Upload Wheel Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: catalyst-macos_arm64-wheel-py-${{ matrix.python_version }}.zip
         path: wheel/
@@ -410,7 +410,7 @@ jobs:
     - name: Install OQC client
       if: ${{ matrix.python_version == '3.9' || matrix.python_version == '3.10'}}
       run: |
-        python${{ matrix.python_version }} -m pip install 'oqc-qcaas-client<3.6.0'
+        python${{ matrix.python_version }} -m pip install oqc-qcaas-client
 
     - name: Install Catalyst
       run: |

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -333,7 +333,7 @@ jobs:
         delocate-wheel --require-archs=x86_64 -w ./wheel -v dist/*.whl --ignore-missing-dependencies -vv
 
     - name: Upload Wheel Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: catalyst-macos_x86_64-wheel-py-${{ matrix.python_version }}.zip
         path: wheel/

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -69,7 +69,7 @@ jobs:
 
 
       - name: Upload Catalyst-Runtime Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: runtime-build-${{ matrix.compiler }}
           path: |
@@ -78,7 +78,7 @@ jobs:
           retention-days: 1
 
       - name: Upload OQC-Runtime Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: oqc-build-${{ matrix.compiler }}
           path: |
@@ -378,17 +378,13 @@ jobs:
         make dialects
 
     - name: Upload Quantum Build Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: quantum-build-${{ matrix.compiler }}
         path: |
           quantum-build/bin
-          quantum-build/lib/lib*.a*
           quantum-build/python_packages/*
         retention-days: 1
-
-    - name: Debugging with ssh
-      uses: lhotari/action-upterm@v1
 
   frontend-tests:
     name: Frontend Tests

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -497,9 +497,6 @@ jobs:
         name: quantum-build-${{ matrix.compiler }}
         path: quantum-build
 
-    - name: Debugging with ssh
-      uses: lhotari/action-upterm@v1
-
     - name: Download Catalyst-Runtime Artifact
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -368,7 +368,6 @@ jobs:
 
     - name: Build MLIR Dialects
       run: |
-        CCACHE_DIR="$(pwd)/.ccache" \
         C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
         CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
         LLVM_BUILD_DIR="$(pwd)/llvm-build" \

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -368,6 +368,7 @@ jobs:
 
     - name: Build MLIR Dialects
       run: |
+        CCACHE_DIR="$(pwd)/.ccache" \
         C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
         CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
         LLVM_BUILD_DIR="$(pwd)/llvm-build" \
@@ -382,7 +383,7 @@ jobs:
         name: quantum-build-${{ matrix.compiler }}
         path: |
           quantum-build/bin
-          quantum-build/lib/lib*.so*
+          quantum-build/lib/lib*.a*
           quantum-build/python_packages/*
         retention-days: 1
 


### PR DESCRIPTION
**Description of the Change:**
Downgrade upload-artifact to 4.3.4 and unpin OQC for Mac OS