### PR TITLE
[draft] Split each tape into a different jaxpr during trace_quantum_function

### DIFF
--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -996,13 +996,16 @@ def trace_post_processing(ctx, trace, post_processing: Callable, pp_args):
         #breakpoint()
         out_tracers = [trace.full_raise(t) for t in wffa.call_wrapped(*in_tracers)]
         #breakpoint()
-        jaxpr, out_type, consts = ctx.frames[trace].to_jaxpr2(out_tracers)
-        #_, out_type, consts = ctx.frames[trace].to_jaxpr2(out_tracers)
-        #jaxpr = jax.make_jaxpr(post_processing)(in_tracers).jaxpr
+        #jaxpr, out_type, consts = ctx.frames[trace].to_jaxpr2(out_tracers)
+        _, out_type, consts = ctx.frames[trace].to_jaxpr2(out_tracers)
         #breakpoint()
-        closed_jaxpr = ClosedJaxpr(jaxpr, consts)
-        return closed_jaxpr, out_type, out_tree_promise()
-        #return jaxpr, out_type, out_tree_promise()
+        jaxpr = jax.make_jaxpr(post_processing)(pp_args).jaxpr
+        #breakpoint()
+
+        #closed_jaxpr = ClosedJaxpr(jaxpr, consts)
+        #return closed_jaxpr, out_type, out_tree_promise()
+
+        return jaxpr, out_type, out_tree_promise()
 
 
 @debug_logger
@@ -1071,7 +1074,7 @@ def trace_function(
         return res_expanded_tracers, in_sig, out_sig
 
 
-
+'''
 # main
 @debug_logger
 def trace_quantum_function(
@@ -1203,10 +1206,10 @@ def trace_quantum_function(
         # TODO: `check_jaxpr` complains about the `AbstractQreg` type. Consider fixing.
         # check_jaxpr(jaxpr)
     return closed_jaxpr, out_type, out_tree
-
-
-
 '''
+
+
+
 # mine
 @debug_logger
 def trace_quantum_function(
@@ -1284,8 +1287,8 @@ def trace_quantum_function(
 
 
         with EvaluationContext.frame_tracing_context(ctx, trace):
-            save_frame = EvaluationContext.find_jaxpr_frame().eqns
-            print("save_frame", save_frame)
+            #save_frame = EvaluationContext.find_jaxpr_frame().eqns
+            #print("save_frame", save_frame)
             #breakpoint()
             # Set up same device and quantum register for all tapes in the program.
 
@@ -1338,7 +1341,7 @@ def trace_quantum_function(
                 EvaluationContext.find_jaxpr_frame().eqns.clear()
         
 
-            EvaluationContext.find_jaxpr_frame().eqns = save_frame
+            #EvaluationContext.find_jaxpr_frame().eqns = save_frame
             #breakpoint()
 
         # trace post processing
@@ -1363,7 +1366,7 @@ def trace_quantum_function(
 
             # an initially empty jaxpr to hold the calls to each tape's jaxpr
             big_jaxpr = jax.core.Jaxpr(const_, in_, out_, [])
-
+            #breakpoint()
 
             from jax._src.core import new_jaxpr_eqn, no_effects
             post_processing_invars = []
@@ -1384,21 +1387,21 @@ def trace_quantum_function(
 
 
         #breakpoint()
-        def _f(*args, **kwargs):
-            return f(args, kwargs)
+        #def _f(*args, **kwargs):
+        #    return f(args, kwargs)
         big_jaxpr.eqns.append(
             new_jaxpr_eqn(
                 invars=post_processing_invars,
                 outvars=post_processing_jaxpr.outvars,
                 primitive=func_p,
-                params={'fn':_f, 'call_jaxpr':post_processing_jaxpr},
+                params={'fn':f, 'call_jaxpr':post_processing_jaxpr},
                 effects=no_effects,
             )
         )
 
-        breakpoint()
+        #breakpoint()
 
         # TODO: `check_jaxpr` complains about the `AbstractQreg` type. Consider fixing.
         # check_jaxpr(jaxpr)
     return jax.core.ClosedJaxpr(big_jaxpr, const_), out_type, out_tree
-'''
+

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -1061,7 +1061,141 @@ def trace_function(
 
         return res_expanded_tracers, in_sig, out_sig
 
+'''
+# main
+@debug_logger
+def trace_quantum_function(
+    f: Callable, device: QubitDevice, args, kwargs, qnode, static_argnums
+) -> Tuple[ClosedJaxpr, Any]:
+    """Trace quantum function in a way that allows building a nested quantum tape describing the
+    quantum algorithm.
 
+    The tracing is done as follows: (1) Classical tracing, producing the classical JAX tracers and
+    the quantum tape (2) Quantum tape tracing, producing the remaining quantum and classical JAX
+    tracers. With all the tracers in hands, the final JAXPR is produced. Note that caller can apply
+    tape transformations by using PennyLane's transformation API on the argument function.
+
+    Args:
+        f (Callable): a function to trace
+        device (QubitDevice): Quantum device to use for quantum computations
+        args: Positional arguments to pass to ``f``
+        kwargs: Keyword arguments to pass to ``f``
+        qnode: The quantum node to be traced, it contains user transforms.
+
+    Returns:
+        closed_jaxpr: JAXPR expression of the function ``f``.
+        out_type: JAXPR output type (list of abstract values with explicitness flags).
+        out_tree: PyTree shapen of the result
+    """
+    with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
+        # (1) - Classical tracing
+        quantum_tape = QuantumTape(shots=device.shots)
+        with EvaluationContext.frame_tracing_context(ctx) as trace:
+            wffa, in_avals, keep_inputs, out_tree_promise = deduce_avals(
+                f, args, kwargs, static_argnums
+            )
+            in_classical_tracers = _input_type_to_tracers(trace.new_arg, in_avals)
+            with QueuingManager.stop_recording(), quantum_tape:
+                # Quantum tape transformations happen at the end of tracing
+                in_classical_tracers = [t for t, k in zip(in_classical_tracers, keep_inputs) if k]
+                return_values_flat = wffa.call_wrapped(*in_classical_tracers)
+            # Ans contains the leaves of the pytree (empty for measurement without
+            # data https://github.com/PennyLaneAI/pennylane/pull/4607)
+            # Therefore we need to compute the tree with measurements as leaves and it comes
+            # with an extra computational cost
+
+            # 1. Recompute the original return
+            with QueuingManager.stop_recording():
+                return_values = tree_unflatten(out_tree_promise(), return_values_flat)
+
+            def is_leaf(obj):
+                return isinstance(obj, qml.measurements.MeasurementProcess)
+
+            # 2. Create a new tree that has measurements as leaves
+            return_values_flat, return_values_tree = jax.tree_util.tree_flatten(
+                return_values, is_leaf=is_leaf
+            )
+            if isinstance(device, qml.devices.Device):
+                config = _make_execution_config(qnode)
+                device_program, config = device.preprocess(ctx, config)
+                device_modify_measurements = config.device_options["transforms_modify_measurements"]
+            else:
+                device_program = TransformProgram()
+                device_modify_measurements = False  # this is only for the new API transform program
+
+            qnode_program = qnode.transform_program if qnode else TransformProgram()
+
+            tapes, post_processing = apply_transform(
+                qnode_program,
+                device_program,
+                device_modify_measurements,
+                quantum_tape,
+                return_values_flat,
+            )
+            #breakpoint()
+
+        # (2) - Quantum tracing
+        transformed_results = []
+
+        with EvaluationContext.frame_tracing_context(ctx, trace):
+            # Set up same device and quantum register for all tapes in the program.
+            # We just need to ensure the qubits are reset in between each.
+            qdevice_p.bind(
+                rtd_lib=device.backend_lib,
+                rtd_name=device.backend_name,
+                rtd_kwargs=str(device.backend_kwargs),
+            )
+            qreg_in = qalloc_p.bind(len(device.wires))
+
+            qnode_transformed = len(qnode_program) > 0
+            for i, tape in enumerate(tapes):
+                # If the program is batched, that means that it was transformed.
+                # If it was transformed, that means that the program might have
+                # changed the output. See `split_non_commuting`
+                if qnode_transformed or device_modify_measurements:
+                    # TODO: In the future support arbitrary output from the user function.
+                    output = tape.measurements
+                    _, trees = jax.tree_util.tree_flatten(output, is_leaf=is_leaf)
+                else:
+                    output = return_values_flat
+                    trees = return_values_tree
+
+                mcm_config = qnode.execute_kwargs["mcm_config"]
+                qrp_out = trace_quantum_operations(tape, device, qreg_in, ctx, trace, mcm_config)
+                meas, meas_trees = trace_quantum_measurements(device, qrp_out, output, trees)
+                qreg_out = qrp_out.actualize()
+
+                meas_tracers = [trace.full_raise(m) for m in meas]
+                meas_results = tree_unflatten(meas_trees, meas_tracers)
+
+                # TODO: Allow the user to return whatever types they specify.
+                if qnode_transformed or device_modify_measurements:
+                    assert isinstance(meas_results, list)
+                    if len(meas_results) == 1:
+                        transformed_results.append(meas_results[0])
+                    else:
+                        transformed_results.append(tuple(meas_results))
+                else:
+                    transformed_results.append(meas_results)
+
+                # Reset the qubits and update the register value for the next tape.
+                if len(tapes) > 1 and i < len(tapes) - 1:
+                    for w in device.wires:
+                        qreg_out = reset_qubit(qreg_out, w)
+                    qreg_in = qreg_out
+
+            # Deallocate the register before tracing the post-processing.
+            qdealloc_p.bind(qreg_out)
+
+        closed_jaxpr, out_type, out_tree = trace_post_processing(
+            ctx, trace, post_processing, transformed_results
+        )
+        # TODO: `check_jaxpr` complains about the `AbstractQreg` type. Consider fixing.
+        # check_jaxpr(jaxpr)
+    return closed_jaxpr, out_type, out_tree
+'''
+
+# mine
 @debug_logger
 def trace_quantum_function(
     f: Callable, device: QubitDevice, args, kwargs, qnode, static_argnums

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -569,6 +569,7 @@ def trace_quantum_operations(
     ctx: JaxTracingContext,
     trace: DynamicJaxprTrace,
     mcm_config: qml.devices.MCMConfig = qml.devices.MCMConfig(),
+    #in_classical_tracers_ = None
 ) -> QRegPromise:
     """Recursively trace ``quantum_tape``'s operations containing both PennyLane original and
     Catalyst extension operations. Produce ``QRegPromise`` object holding the resulting quantum
@@ -661,6 +662,7 @@ def trace_quantum_operations(
         assert qrp2 is not None
         qrp = qrp2
 
+    #breakpoint()
     ctx.frames[trace].eqns = sort_eqns(ctx.frames[trace].eqns, FORCED_ORDER_PRIMITIVES)  # [1]
     return qrp
 
@@ -1087,7 +1089,7 @@ def trace_function(
         return res_expanded_tracers, in_sig, out_sig
 
 
-'''
+
 # main
 @debug_logger
 def trace_quantum_function(
@@ -1187,7 +1189,10 @@ def trace_quantum_function(
                     trees = return_values_tree
 
                 mcm_config = qnode.execute_kwargs["mcm_config"]
-                qrp_out = trace_quantum_operations(tape, device, qreg_in, ctx, trace, mcm_config)
+                #print("hi!")
+                #breakpoint()
+                qrp_out = trace_quantum_operations(tape, device, qreg_in, ctx, trace, mcm_config)#, in_classical_tracers_=in_classical_tracers)
+                #print("hi too!")
                 meas, meas_trees = trace_quantum_measurements(device, qrp_out, output, trees)
                 qreg_out = qrp_out.actualize()
 
@@ -1220,8 +1225,9 @@ def trace_quantum_function(
         #breakpoint()
         # TODO: `check_jaxpr` complains about the `AbstractQreg` type. Consider fixing.
         # check_jaxpr(jaxpr)
+    #breakpoint()
     return closed_jaxpr, out_type, out_tree
-'''
+
 
 
 # mine
@@ -1260,7 +1266,7 @@ from jax._src.util import unzip2
 import copy
 
 @debug_logger
-def trace_quantum_function(
+def trace_quantum_function_(
     f: Callable, device: QubitDevice, args, kwargs, qnode, static_argnums
 ) -> Tuple[ClosedJaxpr, Any]:
     """Trace quantum function in a way that allows building a nested quantum tape describing the
@@ -1299,7 +1305,7 @@ def trace_quantum_function(
                 big_invars = (
                     EvaluationContext.find_jaxpr_frame().to_jaxpr(in_classical_tracers)[0].invars
                 )
-                # breakpoint()
+                #breakpoint()
             # Ans contains the leaves of the pytree (empty for measurement without
             # data https://github.com/PennyLaneAI/pennylane/pull/4607)
             # Therefore we need to compute the tree with measurements as leaves and it comes
@@ -1333,6 +1339,7 @@ def trace_quantum_function(
                 quantum_tape,
                 return_values_flat,
             )
+            #breakpoint()
 
         if len(tapes) > 1:
             # (2) - Quantum tracing
@@ -1392,6 +1399,7 @@ def trace_quantum_function(
                         out_tracers = [_ for _ in transformed_results[i]]
 
                     jp = EvaluationContext.find_jaxpr_frame().to_jaxpr(out_tracers)
+                    breakpoint()
 
                     EvaluationContext.find_jaxpr_frame().eqns.append(
                         new_jaxpr_eqn([], [], jax.core.Primitive("_tape_cut"), [], no_effects)

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -1469,7 +1469,6 @@ def trace_quantum_function(
                                 break
 
                         # go through the invars to the primitive
-                        # breakpoint()
                         for j, invar in enumerate(eqn.invars):
                             # if the primitive uses one of the jaxpr's invars,
                             # this invar use should be replaced by the corresponding new invar

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -552,29 +552,14 @@ class QJIT:
         if self.compile_options.autograph:
             processed_fn = run_autograph(self.original_function)
 
-        #return processed_fn
+        return processed_fn
 
         #breakpoint()
 
-        
+        '''
         if hasattr(processed_fn, "tape") and processed_fn.tape is not None and len(processed_fn.transform_program) != 0:
             dev = processed_fn.device
             #ops = processed_fn.tape.operations.copy()
-            '''
-            tapes = []
-            for i in range(len(processed_fn.tape.measurements)):
-                tapes.append(qml.tape.QuantumTape(ops, [processed_fn.tape.measurements[i]]))
-
-
-            funcs = []
-            for tape in tapes:
-                @qml.qnode(dev)
-                def _wrapper(*args, tape=tape):
-                    for op in tape.operations:
-                        qml.apply(op)
-                    return qml.apply(tape.measurements[0])
-                funcs.append(_wrapper)
-            '''
             
             #breakpoint()
             # only works for one transform now
@@ -628,7 +613,7 @@ class QJIT:
 
         else:
             return processed_fn
-        
+        '''
         
 
     @instrument(size_from=0)

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -554,9 +554,9 @@ class QJIT:
 
         return processed_fn
 
-        #breakpoint()
+        # breakpoint()
 
-        '''
+        """
         if hasattr(processed_fn, "tape") and processed_fn.tape is not None and len(processed_fn.transform_program) != 0:
             dev = processed_fn.device
             #ops = processed_fn.tape.operations.copy()
@@ -613,8 +613,7 @@ class QJIT:
 
         else:
             return processed_fn
-        '''
-        
+        """
 
     @instrument(size_from=0)
     @debug_logger

--- a/frontend/test/pytest/test_transform.py
+++ b/frontend/test/pytest/test_transform.py
@@ -113,7 +113,9 @@ def test_batch_params(backend):
     jax_jit = jax.jit(qnode_control)
     compiled = qjit(qnode_backend)
     expected = jax_jit(data, x, weights)
+    #breakpoint()
     observed = compiled(data, x, weights)
+    #breakpoint()
     assert np.allclose(expected, observed)
 
     _, expected_shape = jax.tree_util.tree_flatten(expected)

--- a/frontend/test/pytest/test_transform.py
+++ b/frontend/test/pytest/test_transform.py
@@ -275,11 +275,16 @@ class TestBroadcastExpand:
         qnode_backend = qnode_builder(backend)
 
         expected = jax.jit(qnode_control)(*params, obs)
-        observed = qjit(qnode_backend)(*params, obs)
-
+        #breakpoint()
+        qj = qjit(qnode_backend)
+        #breakpoint()
+        observed = qj(*params, obs)
+        #observed = qjit(qnode_backend)(*params, obs)
+        breakpoint()
         assert np.allclose(expected, observed)
         _, expected_shape = jax.tree_util.tree_flatten(expected)
         _, observed_shape = jax.tree_util.tree_flatten(observed)
+        breakpoint()
         # TODO: expected is tuple, observed is list
         assert expected_shape.num_leaves == observed_shape.num_leaves
 

--- a/frontend/test/pytest/test_transform.py
+++ b/frontend/test/pytest/test_transform.py
@@ -275,16 +275,10 @@ class TestBroadcastExpand:
         qnode_backend = qnode_builder(backend)
 
         expected = jax.jit(qnode_control)(*params, obs)
-        #breakpoint()
-        qj = qjit(qnode_backend)
-        #breakpoint()
-        observed = qj(*params, obs)
-        #observed = qjit(qnode_backend)(*params, obs)
-        breakpoint()
+        observed = qjit(qnode_backend)(*params, obs)
         assert np.allclose(expected, observed)
         _, expected_shape = jax.tree_util.tree_flatten(expected)
         _, observed_shape = jax.tree_util.tree_flatten(observed)
-        breakpoint()
         # TODO: expected is tuple, observed is list
         assert expected_shape.num_leaves == observed_shape.num_leaves
 


### PR DESCRIPTION
### Before submitting

TODO: changelog, tests, writeup of implementation

Please complete the following checklist when submitting a PR:

- [ ] All new functions and code must be clearly commented and documented.

- [ ] Ensure that code is properly formatted by running `make format`.
      The latest version of black and `clang-format-14` are used in CI/CD to check formatting.

- [ ] All new features must include a unit test.
      Integration and frontend tests should be added to [`frontend/test`](../frontend/test/),
      Quantum dialect and MLIR tests should be added to [`mlir/test`](../mlir/test/), and
      Runtime tests should be added to [`runtime/tests`](../runtime/tests/).

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Split each tape into a different jaxpr during trace_quantum_function
Returns an overall big jaxpr that calls these small "each_tape" jaxprs.

**_This is a preliminary design. There's still some problems_**, the most significant one being the tape order does not necessarily agree with the pre-transform qnode's return value order.

Also many pytests simply crash under the current design. 

An alternative is to apply the transform  before the tracing begins, circumventing the need to manually build jaxprs.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:** closes #442 
[sc-67125]