### PR TITLE
Remove restriction on the number of jobs for the Linux Arm64 workflow

### DIFF
--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -176,7 +176,6 @@ jobs:
     needs: [constants, build-dependencies]
     strategy:
       fail-fast: false
-      max-parallel: 2
       matrix:
         python_version: [{official: "3.9",  subversion: "19", package: "python39",   alternative: "39"},
                          {official: "3.10", subversion: "14", package: "python3.10", alternative: "310"},
@@ -271,7 +270,6 @@ jobs:
     needs: [constants, catalyst-linux-wheels-arm64]
     strategy:
       fail-fast: false
-      max-parallel: 2
       matrix:
         python_version: [{official: "3.9",  subversion: "19", package: "python39"},
                          {official: "3.10", subversion: "14", package: "python3.10"},


### PR DESCRIPTION
**Context:** Now that the Mac Arm64 wheels are being built on a GitHub runner, we can dedicate the resources of our local runner to the Linux Arm64 wheels.

**Description of the Change:** Remove the 'max_parallel=2' restriction.

**Benefits:** Faster wheel creation.