### PR TITLE
Fix lld flag for enzyme wheel builds

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -220,7 +220,7 @@ jobs:
               -DLLVM_DIR=$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm \
               -DENZYME_STATIC_LIB=ON \
               -DCMAKE_CXX_VISIBILITY_PRESET=protected \
-              -DLLVM_ENABLE_LLD=ON
+              -DCMAKE_CXX_FLAGS="-fuse-ld=lld"
 
         cmake --build enzyme-build --target EnzymeStatic-19
 

--- a/.github/workflows/scripts/linux_arm64/rh8/build_enzyme.sh
+++ b/.github/workflows/scripts/linux_arm64/rh8/build_enzyme.sh
@@ -10,7 +10,7 @@ export PYTHON_SUBVERSION=$3
 export PYTHON_PACKAGE=$4
 
 # Install system dependencies
-dnf update -y 
+dnf update -y
 dnf install -y libzstd-devel gcc-toolset-${GCC_VERSION}
 if [ "$PYTHON_VERSION" != "3.10" ]; then
     dnf install -y ${PYTHON_PACKAGE} ${PYTHON_PACKAGE}-devel
@@ -18,13 +18,13 @@ fi
 dnf clean all -y
 
 # Make GCC the default compiler
-source /opt/rh/gcc-toolset-${GCC_VERSION}/enable -y 
-export C_COMPILER=/opt/rh/gcc-toolset-${GCC_VERSION}/root/usr/bin/gcc 
+source /opt/rh/gcc-toolset-${GCC_VERSION}/enable -y
+export C_COMPILER=/opt/rh/gcc-toolset-${GCC_VERSION}/root/usr/bin/gcc
 export CXX_COMPILER=/opt/rh/gcc-toolset-${GCC_VERSION}/root/usr/bin/g++
 
 # Set the right Python interpreter
 rm -rf /usr/bin/python3
-ln -s /opt/_internal/cpython-${PYTHON_VERSION}.${PYTHON_SUBVERSION}/bin/python3 /usr/bin/python3 
+ln -s /opt/_internal/cpython-${PYTHON_VERSION}.${PYTHON_SUBVERSION}/bin/python3 /usr/bin/python3
 export PYTHON=/usr/bin/python3
 
 # Add LLVM, Python and GCC to the PATH env var
@@ -39,5 +39,6 @@ cmake -S /catalyst/mlir/Enzyme/enzyme -B /catalyst/enzyme-build -G Ninja \
     -DLLVM_DIR=/catalyst/llvm-build/lib/cmake/llvm \
     -DENZYME_STATIC_LIB=ON \
     -DCMAKE_CXX_VISIBILITY_PRESET=protected \
-    -DLLVM_ENABLE_LLD=ON
+    -DCMAKE_CXX_FLAGS="-fuse-ld=lld"
+
 cmake --build /catalyst/enzyme-build --target EnzymeStatic-19

--- a/.github/workflows/scripts/linux_arm64/rh8/build_llvm.sh
+++ b/.github/workflows/scripts/linux_arm64/rh8/build_llvm.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e -x
-cd /catalyst 
+cd /catalyst
 
 # Process args
 export GCC_VERSION=$1
@@ -10,7 +10,7 @@ export PYTHON_SUBVERSION=$3
 export PYTHON_PACKAGE=$4
 
 # Install system dependencies
-dnf update -y 
+dnf update -y
 dnf install -y libzstd-devel gcc-toolset-${GCC_VERSION}
 if [ "$PYTHON_VERSION" != "3.10" ]; then
     dnf install -y ${PYTHON_PACKAGE} ${PYTHON_PACKAGE}-devel
@@ -18,13 +18,13 @@ fi
 dnf clean all -y
 
 # Make GCC the default compiler
-source /opt/rh/gcc-toolset-${GCC_VERSION}/enable -y 
-export C_COMPILER=/opt/rh/gcc-toolset-${GCC_VERSION}/root/usr/bin/gcc 
+source /opt/rh/gcc-toolset-${GCC_VERSION}/enable -y
+export C_COMPILER=/opt/rh/gcc-toolset-${GCC_VERSION}/root/usr/bin/gcc
 export CXX_COMPILER=/opt/rh/gcc-toolset-${GCC_VERSION}/root/usr/bin/g++
 
 # Set the right Python interpreter
 rm -rf /usr/bin/python3
-ln -s /opt/_internal/cpython-${PYTHON_VERSION}.${PYTHON_SUBVERSION}/bin/python3 /usr/bin/python3 
+ln -s /opt/_internal/cpython-${PYTHON_VERSION}.${PYTHON_SUBVERSION}/bin/python3 /usr/bin/python3
 export PYTHON=/usr/bin/python3
 
 # Add Python and GCC to the PATH env var
@@ -48,4 +48,5 @@ cmake -S /catalyst/mlir/llvm-project/llvm -B /catalyst/llvm-build -G Ninja \
     -DPython3_EXECUTABLE=/usr/bin/python3 \
     -DPython3_NumPy_INCLUDE_DIRS=/opt/_internal/cpython-${PYTHON_VERSION}.${PYTHON_SUBVERSION}/lib/python${PYTHON_VERSION}/site-packages/numpy/core/include \
     -DCMAKE_CXX_VISIBILITY_PRESET=protected
+
 LIT_FILTER_OUT="Bytecode|tosa-to-tensor" cmake --build /catalyst/llvm-build --target check-mlir llvm-symbolizer

--- a/.github/workflows/scripts/linux_arm64/rh8/build_mhlo.sh
+++ b/.github/workflows/scripts/linux_arm64/rh8/build_mhlo.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e -x
-cd /catalyst 
+cd /catalyst
 
 # Process args
 export GCC_VERSION=$1
@@ -10,7 +10,7 @@ export PYTHON_SUBVERSION=$3
 export PYTHON_PACKAGE=$4
 
 # Install system dependencies
-dnf update -y 
+dnf update -y
 dnf install -y libzstd-devel gcc-toolset-${GCC_VERSION}
 if [ "$PYTHON_VERSION" != "3.10" ]; then
     dnf install -y ${PYTHON_PACKAGE} ${PYTHON_PACKAGE}-devel
@@ -18,13 +18,13 @@ fi
 dnf clean all -y
 
 # Make GCC the default compiler
-source /opt/rh/gcc-toolset-${GCC_VERSION}/enable -y 
-export C_COMPILER=/opt/rh/gcc-toolset-${GCC_VERSION}/root/usr/bin/gcc 
+source /opt/rh/gcc-toolset-${GCC_VERSION}/enable -y
+export C_COMPILER=/opt/rh/gcc-toolset-${GCC_VERSION}/root/usr/bin/gcc
 export CXX_COMPILER=/opt/rh/gcc-toolset-${GCC_VERSION}/root/usr/bin/g++
 
 # Set the right Python interpreter
 rm -rf /usr/bin/python3
-ln -s /opt/_internal/cpython-${PYTHON_VERSION}.${PYTHON_SUBVERSION}/bin/python3 /usr/bin/python3 
+ln -s /opt/_internal/cpython-${PYTHON_VERSION}.${PYTHON_SUBVERSION}/bin/python3 /usr/bin/python3
 export PYTHON=/usr/bin/python3
 
 # Add LLVM, Python and GCC to the PATH env var
@@ -50,4 +50,5 @@ cmake -S /catalyst/mlir/mlir-hlo -B /catalyst/mhlo-build -G Ninja \
     -DLLVM_ENABLE_ZLIB=OFF \
     -DLLVM_ENABLE_ZSTD=FORCE_ON \
     -DCMAKE_CXX_VISIBILITY_PRESET=protected
+
 LIT_FILTER_OUT="chlo_legalize_to_mhlo" cmake --build /catalyst/mhlo-build --target check-mlir-hlo


### PR DESCRIPTION
Since it doesn't use the LLVM_ENABLE_LLD flag, use compiler flag `fuse-ld=lld` directly.

(+ formatting)

Follow-up on #986
[sc-70624]