### PR TITLE
[MLIR] Fix async tests after the JAX update

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -184,7 +184,9 @@
   [(#945)](https://github.com/PennyLaneAI/catalyst/pull/945)
   [(#962)](https://github.com/PennyLaneAI/catalyst/pull/962)
 
-* Update JAX to `v0.4.28`. [(#931)](https://github.com/PennyLaneAI/catalyst/pull/931)
+* Update JAX to `v0.4.28`.
+  [(#931)](https://github.com/PennyLaneAI/catalyst/pull/931)
+  [(#995)](https://github.com/PennyLaneAI/catalyst/pull/995)
 
 <h3>Breaking changes</h3>
 

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -248,6 +248,14 @@ MLIR_TO_LLVM_PASS = (
         "convert-index-to-llvm",
         "convert-catalyst-to-llvm",
         "convert-quantum-to-llvm",
+        # There should be no identical code folding
+        # (`mergeIdenticalBlocks` in the MLIR source code)
+        # between convert-async-to-llvm and
+        # add-exception-handling.
+        # So, if there's a pass from the beginning
+        # of this list to here that does folding
+        # add-exception-handling will fail to add async.drop_ref
+        # correctly. See https://github.com/PennyLaneAI/catalyst/pull/995
         "add-exception-handling",
         "emit-catalyst-py-interface",
         # Remove any dead casts as the final pass expects to remove all existing casts,

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -248,13 +248,13 @@ MLIR_TO_LLVM_PASS = (
         "convert-index-to-llvm",
         "convert-catalyst-to-llvm",
         "convert-quantum-to-llvm",
+        "add-exception-handling",
         "emit-catalyst-py-interface",
         # Remove any dead casts as the final pass expects to remove all existing casts,
         # but only those that form a loop back to the original type.
         "canonicalize",
         "reconcile-unrealized-casts",
         "gep-inbounds",
-        "add-exception-handling",
         "register-inactive-callback",
     ],
 )

--- a/frontend/test/async_tests/test_async.py
+++ b/frontend/test/async_tests/test_async.py
@@ -26,7 +26,6 @@ from catalyst import adjoint, cond, for_loop, grad, measure, qjit, while_loop
 # pylint: disable=missing-function-docstring
 
 
-@pytest.mark.skip(reason="Skip mlir async destruction errors.")
 def test_qnode_execution(backend):
     """The two first QNodes are executed in parrallel."""
     dev = qml.device(backend, wires=2)
@@ -68,7 +67,6 @@ def test_qnode_execution(backend):
 # ("parameter-shift", "auto"), ("adjoint", "auto")]
 @pytest.mark.parametrize("diff_methods", [("finite-diff", "fd")])
 @pytest.mark.parametrize("inp", [(1.0), (2.0), (3.0), (4.0)])
-@pytest.mark.skip(reason="Skip mlir async destruction errors.")
 def test_gradient(inp, diff_methods, backend):
     """Parameter shift and finite diff generate multiple QNode that are run async."""
 
@@ -92,7 +90,6 @@ def test_gradient(inp, diff_methods, backend):
     assert np.allclose(compiled(inp), interpreted(inp))
 
 
-@pytest.mark.skip(reason="Skip mlir async destruction errors.")
 def test_exception(backend):
     "Test exception."
 
@@ -111,7 +108,6 @@ def test_exception(backend):
         wrapper()
 
 
-@pytest.mark.skip(reason="Skip mlir async destruction errors.")
 def test_exception2(backend):
     "Test exception in multiple async executions."
 
@@ -130,7 +126,6 @@ def test_exception2(backend):
         wrapper()
 
 
-@pytest.mark.skip(reason="Skip mlir async destruction errors.")
 def test_exception3(backend):
     "Test exception when not used in python."
 
@@ -150,7 +145,6 @@ def test_exception3(backend):
         wrapper()
 
 
-@pytest.mark.skip(reason="Skip mlir async destruction errors.")
 def test_exception4(backend):
     "Test exception happening on two different circuits."
 
@@ -176,7 +170,6 @@ def test_exception4(backend):
         wrapper()
 
 
-@pytest.mark.skip(reason="Skip mlir async destruction errors.")
 def test_exception_adjoint(backend):
     "Test exception happening on two different circuits both adjointed."
 
@@ -205,7 +198,6 @@ def test_exception_adjoint(backend):
         wrapper()
 
 
-@pytest.mark.skip(reason="Skip mlir async destruction errors.")
 def test_exception_conditional(backend):
     @qml.qnode(qml.device(backend, wires=2))
     def circuit(x: int):
@@ -230,7 +222,6 @@ def test_exception_conditional(backend):
         wrapper(0)
 
 
-@pytest.mark.skip(reason="Skip mlir async destruction errors.")
 def test_exception_conditional_1(backend):
     "Test exception happening in else and outside else."
 
@@ -259,7 +250,6 @@ def test_exception_conditional_1(backend):
         wrapper(0)
 
 
-@pytest.mark.skip(reason="Skip mlir async destruction errors.")
 def test_exception_conditional_2(backend):
     "Test exception happening in the presence of an if statement but in another."
 
@@ -288,7 +278,6 @@ def test_exception_conditional_2(backend):
         wrapper(0)
 
 
-@pytest.mark.skip(reason="Skip mlir async destruction errors.")
 @pytest.mark.parametrize(
     "order", [(0, 0, 1), (0, 1, 0), (1, 0, 0), (0, 1, 1), (1, 1, 0), (1, 0, 1), (1, 1, 1)]
 )
@@ -332,7 +321,6 @@ def test_qnode_exception_dependency(order, backend):
 
 # TODO: add the following diff_methods once issue #419 is fixed:
 # ("parameter-shift", "auto"), ("adjoint", "auto")]
-@pytest.mark.skip(reason="Skip mlir async destruction errors.")
 @pytest.mark.parametrize("diff_methods", [("finite-diff", "fd")])
 @pytest.mark.parametrize("inp", [(1.0)])
 def test_gradient_exception(inp, diff_methods, backend):
@@ -354,7 +342,6 @@ def test_gradient_exception(inp, diff_methods, backend):
         compiled(inp)
 
 
-@pytest.mark.skip(reason="Skip mlir async destruction errors.")
 def test_exception_in_loop(backend):
     "Test exception happening in a loop."
 
@@ -381,7 +368,6 @@ def test_exception_in_loop(backend):
         circuit(2)
 
 
-@pytest.mark.skip(reason="Skip mlir async destruction errors.")
 def test_exception_in_for_loop(backend):
     "Test exception happening in a loop."
 
@@ -400,7 +386,6 @@ def test_exception_in_for_loop(backend):
         circuit(1)
 
 
-@pytest.mark.skip(reason="Skip mlir async destruction errors.")
 def test_exception_in_loop2(backend):
     "Test exception happening in a loop while one qnode succeeds."
 

--- a/mlir/lib/Catalyst/Transforms/DetectQNodes.cpp
+++ b/mlir/lib/Catalyst/Transforms/DetectQNodes.cpp
@@ -886,7 +886,12 @@ struct AddExceptionHandlingPass : impl::AddExceptionHandlingPassBase<AddExceptio
 
         RewritePatternSet patterns1(context);
         patterns1.add<DetectCallsInAsyncRegionsTransform>(context);
-        if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns1)))) {
+
+        GreedyRewriteConfig config;
+        config.strictMode = GreedyRewriteStrictness::ExistingOps;
+        config.enableRegionSimplification = false;
+
+        if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns1), config))) {
             signalPassFailure();
         }
 
@@ -896,7 +901,7 @@ struct AddExceptionHandlingPass : impl::AddExceptionHandlingPassBase<AddExceptio
 
         RewritePatternSet patterns2(context);
         patterns2.add<AddExceptionHandlingTransform>(context);
-        if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns2)))) {
+        if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns2), config))) {
             signalPassFailure();
         }
 
@@ -906,7 +911,7 @@ struct AddExceptionHandlingPass : impl::AddExceptionHandlingPassBase<AddExceptio
 
         RewritePatternSet patterns3(context);
         patterns3.add<RemoveAbortInsertCallTransform>(context);
-        if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns3)))) {
+        if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns3), config))) {
             signalPassFailure();
         }
 
@@ -916,7 +921,7 @@ struct AddExceptionHandlingPass : impl::AddExceptionHandlingPassBase<AddExceptio
 
         RewritePatternSet patterns4(context);
         patterns4.add<LivenessAnalysisDropRef>(context);
-        if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns4)))) {
+        if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns4), config))) {
             signalPassFailure();
         }
 
@@ -926,7 +931,7 @@ struct AddExceptionHandlingPass : impl::AddExceptionHandlingPassBase<AddExceptio
 
         RewritePatternSet patterns5(context);
         patterns5.add<CleanUpSourceTransform, BranchToUnreachableTransform>(context);
-        if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns5)))) {
+        if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns5), config))) {
             signalPassFailure();
         }
     }


### PR DESCRIPTION
**Context:** The asynchronous execution of QNodes is implemented via MLIR's async dialect. Each function call to a function annotated with the `qnode` attribute will be wrapped in an `async.execute` operation. Then the standard `async` lowering pipeline will be triggered.

Values returned by `async.execute` are referenced counted by the AsyncRuntime. When the AsyncRuntime is destroyed, there is an assertion to guarantee that there are no values that are still alive.

```c++
  ~AsyncRuntime() {
    threadPool.wait(); // wait for the completion of all async tasks
    assert(getNumRefCountedObjects() == 0 &&
           "all ref counted objects must be destroyed");
  }
```

These values that are referenced counted must have their count updated by the compiler. [This is achieved via the `async.dropref` operation.](https://mlir.llvm.org/docs/Dialects/AsyncDialect/#asyncruntimedrop_ref-asyncruntimedroprefop)

The algorithm that determines where to place the `async.dropref` operations is implemented in the `DetectQNode.cpp` files. Each value returned by the AsyncRuntime is labeled as a source and a special function called `catalyst__host__rt__unrecoverable_error` is labeled as a sink. The sources are expected to be in different basic blocks. We calculate which values are alive in each sink using liveness and insert a dropRef just before the sink for each source that is alive. Each sink is removed as a sink after the pattern is applied.

During the migration to the newer version of MLIR. We noticed that the assertion above was being triggered. After investigating for a little while, it was found that MLIR implemented identical code folding for basic blocks was now being executed during simplification. Simplification happens when using the GreedyRewriter (that's the fold in applyPatternsAndFold). 

Left is after the update right is before the update.

```
  ^bb2:  // pred: ^bb1                                            ^bb2:  // pred: ^bb1
    llvm.call @mlirAsyncRuntimeDropRef(%9, %5) : (!llvm.ptr,  |     llvm.call @mlirAsyncRuntimeDropRef(%7, %2) : (!llvm.ptr, 
    llvm.call @mlirAsyncRuntimeDropRef(%10, %5) : (!llvm.ptr, |     llvm.call @mlirAsyncRuntimeDropRef(%8, %2) : (!llvm.ptr, 
    llvm.return                                                     llvm.return
  ^bb3(%18: !llvm.ptr):  // 2 preds: ^bb0, ^bb1               |   ^bb3:  // pred: ^bb0
    llvm.call @puts(%18) : (!llvm.ptr) -> ()                  |     %16 = llvm.mlir.addressof @assert_msg : !llvm.ptr
                                                              >     llvm.call @puts(%16) : (!llvm.ptr) -> ()
                                                              >     llvm.call @abort() : () -> ()
                                                              >     llvm.unreachable
                                                              >   ^bb4:  // pred: ^bb1
                                                              >     %17 = llvm.mlir.addressof @assert_msg_0 : !llvm.ptr
                                                              >     llvm.call @puts(%17) : (!llvm.ptr) -> ()
    llvm.call @abort() : () -> ()                                   llvm.call @abort() : () -> ()
    llvm.unreachable                                                llvm.unreachable
  }                                                               }
  ```

This change breaks the analysis of placement of dropRefs. Because the basic block with the abort (which will later have the `catalyst__host__rt__unrecoverable_error`) will need to have different calls to `dropRef` depending on which predecessor is called. This is what the code looked like before the update:

```
    llvm.call @mlirAsyncRuntimeAwaitToken(%12) : (!llvm.ptr) -> ()
    %14 = llvm.call @mlirAsyncRuntimeIsTokenError(%12) : (!llvm.ptr) -> i1
    %15 = llvm.xor %14, %6  : i1
    llvm.cond_br %15, ^bb1, ^bb3
  ^bb1:  // pred: ^bb0   // First success
    llvm.call @mlirAsyncRuntimeDropRef(%12, %5) : (!llvm.ptr, i64) -> ()
    llvm.call @mlirAsyncRuntimeDropRef(%13, %5) : (!llvm.ptr, i64) -> ()
    llvm.call @mlirAsyncRuntimeAwaitToken(%9) : (!llvm.ptr) -> ()
    %16 = llvm.call @mlirAsyncRuntimeIsTokenError(%9) : (!llvm.ptr) -> i1
    %17 = llvm.xor %16, %6  : i1
    llvm.cond_br %17, ^bb2, ^bb4
  ^bb2:  // pred: ^bb1 // Second success
    llvm.call @mlirAsyncRuntimeDropRef(%9, %5) : (!llvm.ptr, i64) -> ()
    llvm.call @mlirAsyncRuntimeDropRef(%10, %5) : (!llvm.ptr, i64) -> ()
    llvm.return
  ^bb3:  // pred: ^bb0 // First error
    llvm.call @puts(%1) : (!llvm.ptr) -> ()
    llvm.call @mlirAsyncRuntimeAwaitToken(%9) : (!llvm.ptr) -> ()
    llvm.call @mlirAsyncRuntimeAwaitToken(%12) : (!llvm.ptr) -> ()
    llvm.call @mlirAsyncRuntimeDropRef(%9, %5) : (!llvm.ptr, i64) -> ()
    llvm.call @mlirAsyncRuntimeDropRef(%12, %5) : (!llvm.ptr, i64) -> ()
    llvm.call @mlirAsyncRuntimeDropRef(%10, %5) : (!llvm.ptr, i64) -> ()
    llvm.call @mlirAsyncRuntimeDropRef(%13, %5) : (!llvm.ptr, i64) -> ()
    llvm.call @__catalyst__host__rt__unrecoverable_error() : () -> ()
    llvm.unreachable
  ^bb4:  // pred: ^bb1 // Second error
    llvm.call @puts(%0) : (!llvm.ptr) -> ()
    llvm.call @mlirAsyncRuntimeAwaitToken(%9) : (!llvm.ptr) -> ()
    llvm.call @mlirAsyncRuntimeDropRef(%9, %5) : (!llvm.ptr, i64) -> ()
    llvm.call @mlirAsyncRuntimeDropRef(%10, %5) : (!llvm.ptr, i64) -> ()
    llvm.call @__catalyst__host__rt__unrecoverable_error() : () -> ()
    llvm.unreachable
```

When the basic block is merged into one, it is not possible to have different dropref depending on the success and failure.


**Description of the Change:**


To prevent identical basic block folding, we can use the greedy rewriter configuration to avoid region simplification:

```
+        GreedyRewriteConfig config;
+        config.strictMode = GreedyRewriteStrictness::ExistingOps;
+        config.enableRegionSimplification = false;
```

We also move the generation of drop-ref analysis to before canonicalization, since canonicalization will run identical basic block code folding.

There might be some other alternative that would allow us to keep basic block code folding and modify the placement of drop refs. Thinking about it :thinking: 

**Benefits:** Tests pass again.

**Possible Drawbacks:** We need to keep the two basic blocks separated between `--convert-async-to-llvm` and `add-exception-handling-pass`. 

**Related GitHub Issues:** Fixes #971

[sc-70684]
