### PR TITLE
Revert "Remove restriction on the number of jobs for the Linux Arm64 workflow"

### DIFF
--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -176,6 +176,7 @@ jobs:
     needs: [constants, build-dependencies]
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         python_version: [{official: "3.9",  subversion: "19", package: "python39",   alternative: "39"},
                          {official: "3.10", subversion: "14", package: "python3.10", alternative: "310"},
@@ -270,6 +271,7 @@ jobs:
     needs: [constants, catalyst-linux-wheels-arm64]
     strategy:
       fail-fast: false
+      max-parallel: 2
       matrix:
         python_version: [{official: "3.9",  subversion: "19", package: "python39"},
                          {official: "3.10", subversion: "14", package: "python3.10"},


### PR DESCRIPTION
We've been observing CI runs where the compiler gets killed `c++: fatal error: Killed signal terminated program cc1plus`. I suspect this is due to the runner running out of memory, so we reinstate the restriction on the number of parallel runners for Linux arm builds.

Reverts PennyLaneAI/catalyst#992