### PR TITLE
Minor device decomposition refactor and bug fix

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -38,7 +38,7 @@
 
   ```python
   from catalyst import debug_assert
-  
+
   @qjit
   def f(x):
       debug_assert(x < 5, "x was greater than 5")
@@ -59,7 +59,7 @@
   @qjit(disable_assertions=True)
   def g(x):
       debug_assert(x < 5, "x was greater than 5")
-      return x * 8      
+      return x * 8
   ```
 
   ```pycon
@@ -70,9 +70,9 @@
 * A `qjit` run for `lightning.qubit` and `lightning.kokkos` can now be seeded.
   [(#936)](https://github.com/PennyLaneAI/catalyst/pull/936)
 
-  The `qjit` decorator now can take in an argument `seed`, which is an unsigned 32-bit integer. 
+  The `qjit` decorator now can take in an argument `seed`, which is an unsigned 32-bit integer.
   Different `qjit` objects with the same seed (including repeated calls to the same `qjit`)
-  will return the same sequence of measurement results everytime. 
+  will return the same sequence of measurement results everytime.
 
   ```python
   dev = qml.device("lightning.qubit", wires=1)
@@ -107,7 +107,7 @@
   print(workflow())
   print(workflow_another())
 
-  >>> 
+  >>>
   (Array([1., 0.], dtype=float64), Array([1., 0.], dtype=float64), Array([1., 0.], dtype=float64), Array([0.5, 0.5], dtype=float64))
   (Array([1., 0.], dtype=float64), Array([1., 0.], dtype=float64), Array([1., 0.], dtype=float64), Array([0.5, 0.5], dtype=float64))
   (Array([1., 0.], dtype=float64), Array([1., 0.], dtype=float64), Array([1., 0.], dtype=float64), Array([0.5, 0.5], dtype=float64))
@@ -132,9 +132,9 @@
   [(#911)](https://github.com/PennyLaneAI/catalyst/pull/911)
 
   A new module, `catalyst.passes` (file `frontend/catalyst/passes.py`), is added to
-  provide UI access for pass decorators. This PR adds the `cancel_inverses` decorator, 
-  which runs the `-removed-chained-self-inverse` mlir pass that cancels two neighbouring 
-  Hadamard gates. 
+  provide UI access for pass decorators. This PR adds the `cancel_inverses` decorator,
+  which runs the `-removed-chained-self-inverse` mlir pass that cancels two neighbouring
+  Hadamard gates.
 
   ```python
   from catalyst.debug import print_compilation_stage
@@ -235,8 +235,8 @@
   >>> qjit(vmap(circuit), autograph=True)(x)
   Array([0.99500417, 0.98006658, 0.95533649], dtype=float64)
   ```
-  
-* Verification is now performed before compilation to confirm that the measurements included in the quantum tape 
+
+* Verification is now performed before compilation to confirm that the measurements included in the quantum tape
   are compatible with the device.
   [(#945)](https://github.com/PennyLaneAI/catalyst/pull/945)
   [(#962)](https://github.com/PennyLaneAI/catalyst/pull/962)
@@ -263,6 +263,11 @@
 
 <h3>Bug fixes</h3>
 
+* Catalyst no longer generates a `QubitUnitary` operation during decomposition if a device doesn't
+  support it. Instead, the operation that would lead to a `QubitUnitary` is either decomposed or
+  raises an error.
+  [(#1002)](https://github.com/PennyLaneAI/catalyst/pull/1002)
+
 * Fix a bug where scatter did not work correctly with list indices.
   [(#982)](https://github.com/PennyLaneAI/catalyst/pull/982)
 
@@ -287,7 +292,7 @@
 
   ```python
   dev = qml.device("lightning.qubit", wires=1)
-  
+
   @qjit(static_argnums=(1,))
   @qml.qnode(dev)
   def circuit(x, c):
@@ -318,7 +323,7 @@
   QNode configuration settings when Autograph was enabled.
   [(#900)](https://github.com/PennyLaneAI/catalyst/pull/900)
 
-  
+
 * `pure_callback` will no longer cause a crash in the compiler if the return type
   signature is declared incorrectly and the callback function is differentiated.
   [(#916)](https://github.com/PennyLaneAI/catalyst/pull/916)
@@ -442,10 +447,10 @@ Paul Haochen Wang,
 
     ```python
     import logging
-  
+
     log = logging.getLogger(__name__)
     log.setLevel(logging.INFO)
-  
+
     @qml.qjit
     @catalyst.grad
     def f(x):
@@ -454,7 +459,7 @@ Paul Haochen Wang,
         catalyst.debug.callback(lambda _: log.info("Value of y = %s", _))(y)
         return y ** 2
     ```
-  
+
     ```pycon
     >>> f(0.54)
     INFO:__main__:Value of y = 0.8577086813638242
@@ -580,7 +585,7 @@ Paul Haochen Wang,
 
   ```python
   dev = qml.device("lightning.qubit", wires=2, shots=10)
-  
+
   @qml.qjit
   @qml.qnode(dev, mcm_method="one-shot")
   def func(x):
@@ -705,13 +710,13 @@ Paul Haochen Wang,
           fac *= i
           num += 1. / fac
       return num
-  
+
   @qml.qjit(autograph=True)
   def g(x: float, N: int):
-  
+
       for i in range(N):
           x = x + catalyst.disable_autograph(approximate_e)(10) / x ** i
-  
+
       return x
   ```
 
@@ -730,11 +735,11 @@ Paul Haochen Wang,
   ```python
   @qml.qjit(autograph=True)
   def g(x: float, N: int):
-  
+
       for i in range(N):
           with catalyst.disable_autograph:
             x = x + approximate_e(10) / x ** i
-  
+
       return x
   ```
 
@@ -925,7 +930,7 @@ Paul Haochen Wang,
   [(#751)](https://github.com/PennyLaneAI/catalyst/pull/751)
 
 * An issue in the Lightning backend for the Catalyst runtime has been fixed that would only compute
-  approximate probabilities when implementing mid-circuit measurements. As a result, low shot numbers 
+  approximate probabilities when implementing mid-circuit measurements. As a result, low shot numbers
   would lead to unexpected behaviours or projections on zero probability states.
   Probabilities for mid-circuit measurements are now always computed analytically.
   [(#801)](https://github.com/PennyLaneAI/catalyst/pull/801)

--- a/frontend/catalyst/device/decomposition.py
+++ b/frontend/catalyst/device/decomposition.py
@@ -47,92 +47,16 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-def check_alternative_control_support(op, capabilities):
-    """Verify that aliased controlled operations aren't supported via alternative definitions."""
-
-    if (
-        isinstance(op, qml.ControlledQubitUnitary)
-        and capabilities.native_ops.get("QubitUnitary")
-        and capabilities.native_ops.get("QubitUnitary").controllable
-    ):
-        decomp = qml.ops.Controlled(
-            qml.QubitUnitary(*op.data, wires=op.target_wires), op.control_wires, op.control_values
-        )
-    elif (
-        isinstance(op, qml.ControlledPhaseShift)
-        and capabilities.native_ops.get("PhaseShift")
-        and capabilities.native_ops.get("PhaseShift").controllable
-    ):
-        decomp = qml.ops.Controlled(
-            qml.PhaseShift(*op.data, wires=op.target_wires), op.control_wires
-        )
-    elif (
-        isinstance(op, (qml.CNOT, qml.Toffoli, qml.MultiControlledX))
-        and capabilities.native_ops.get("PauliX")
-        and capabilities.native_ops.get("PauliX").controllable
-    ):
-        decomp = qml.ops.Controlled(
-            qml.PauliX(wires=op.target_wires), op.control_wires, op.control_values, op.work_wires
-        )
-    elif (
-        isinstance(op, qml.CY)
-        and capabilities.native_ops.get("PauliY")
-        and capabilities.native_ops.get("PauliY").controllable
-    ):
-        decomp = qml.ops.Controlled(qml.PauliY(wires=op.target_wires), op.control_wires)
-    elif (
-        isinstance(op, (qml.CZ, qml.CCZ))
-        and capabilities.native_ops.get("PauliZ")
-        and capabilities.native_ops.get("PauliZ").controllable
-    ):
-        decomp = qml.ops.Controlled(qml.PauliZ(wires=op.target_wires), op.control_wires)
-    elif (
-        isinstance(op, qml.CRX)
-        and capabilities.native_ops.get("RX")
-        and capabilities.native_ops.get("RX").controllable
-    ):
-        decomp = qml.ops.Controlled(qml.RX(*op.data, wires=op.target_wires), op.control_wires)
-    elif (
-        isinstance(op, qml.CRY)
-        and capabilities.native_ops.get("RY")
-        and capabilities.native_ops.get("RY").controllable
-    ):
-        decomp = qml.ops.Controlled(qml.RY(*op.data, wires=op.target_wires), op.control_wires)
-    elif (
-        isinstance(op, qml.CRZ)
-        and capabilities.native_ops.get("RZ")
-        and capabilities.native_ops.get("RZ").controllable
-    ):
-        decomp = qml.ops.Controlled(qml.RZ(*op.data, wires=op.target_wires), op.control_wires)
-    elif (
-        isinstance(op, qml.CRot)
-        and capabilities.native_ops.get("Rot")
-        and capabilities.native_ops.get("Rot").controllable
-    ):
-        decomp = qml.ops.Controlled(qml.Rot(*op.data, wires=op.target_wires), op.control_wires)
-    elif (
-        isinstance(op, qml.CH)
-        and capabilities.native_ops.get("Hadamard")
-        and capabilities.native_ops.get("Hadamard").controllable
-    ):
-        decomp = qml.ops.Controlled(qml.Hadamard(wires=op.target_wires), op.control_wires)
-    elif (
-        isinstance(op, qml.CSWAP)
-        and capabilities.native_ops.get("SWAP")
-        and capabilities.native_ops.get("SWAP").controllable
-    ):
-        decomp = qml.ops.Controlled(qml.SWAP(wires=op.target_wires), op.control_wires)
-    else:
-        decomp = None
-
-    return [decomp] if decomp else decomp
-
-
 def check_alternative_support(op, capabilities):
     """Verify that aliased operations aren't supported via alternative definitions."""
 
     if isinstance(op, qml.ops.Controlled):
-        return check_alternative_control_support(op, capabilities)
+        # "Cast" away the specialized class for gates like Toffoli, ControlledQubitUnitary, etc.
+        if (
+            capabilities.native_ops.get(op.base.name)
+            and capabilities.native_ops.get(op.base.name).controllable
+        ):
+            return [qml.ops.Controlled(op.base, op.control_wires, op.control_values, op.work_wires)]
 
     return None
 

--- a/frontend/catalyst/device/decomposition.py
+++ b/frontend/catalyst/device/decomposition.py
@@ -72,10 +72,12 @@ def catalyst_decomposer(op, capabilities: DeviceCapabilities):
     if alternative_decomp is not None:
         return alternative_decomp
 
-    if capabilities.to_matrix_ops.get(op.name) or (
-        op.has_matrix and isinstance(op, qml.ops.Controlled)
-    ):
-        return _decompose_to_matrix(op)
+    if capabilities.native_ops.get("QubitUnitary"):
+        # If the device supports unitary matrices, apply the relevant conversions and fallbacks.
+        if capabilities.to_matrix_ops.get(op.name) or (
+            op.has_matrix and isinstance(op, qml.ops.Controlled)
+        ):
+            return _decompose_to_matrix(op)
 
     return op.decomposition()
 

--- a/frontend/test/pytest/device/test_decomposition.py
+++ b/frontend/test/pytest/device/test_decomposition.py
@@ -14,12 +14,15 @@
 
 """Unit test module for catalyst/device/decomposition.py"""
 
+import platform
 from copy import deepcopy
 
+import numpy as np
 import pennylane as qml
 import pytest
 
 from catalyst import CompileError, ctrl, qjit
+from catalyst.compiler import get_lib_path
 from catalyst.device import get_device_capabilities
 from catalyst.device.decomposition import catalyst_decomposer
 from catalyst.utils.toml import (
@@ -28,50 +31,6 @@ from catalyst.utils.toml import (
     ProgramFeatures,
     pennylane_operation_set,
 )
-
-
-class CustomDevice(qml.QubitDevice):
-    """Custom Gate Set Device"""
-
-    name = "Custom Device"
-    short_name = "lightning.qubit"
-    pennylane_requires = "0.35.0"
-    version = "0.0.2"
-    author = "Tester"
-
-    lightning_device = qml.device("lightning.qubit", wires=0)
-
-    backend_name = "default"
-    backend_lib = "default"
-    backend_kwargs = {}
-
-    def __init__(self, shots=None, wires=None):
-        super().__init__(wires=wires, shots=shots)
-        program_features = ProgramFeatures(shots_present=bool(self.shots))
-        lightning_capabilities = get_device_capabilities(self.lightning_device, program_features)
-        custom_capabilities = deepcopy(lightning_capabilities)
-        custom_capabilities.native_ops.pop("Rot")
-        custom_capabilities.native_ops.pop("S")
-        custom_capabilities.to_decomp_ops.pop("MultiControlledX")
-        self.qjit_capabilities = custom_capabilities
-
-    def apply(self, operations, **kwargs):
-        """Unused"""
-        raise RuntimeError("Only C/C++ interface is defined")
-
-    @property
-    def operations(self):
-        """Get PennyLane operations."""
-        return (
-            pennylane_operation_set(self.qjit_capabilities.native_ops)
-            | pennylane_operation_set(self.qjit_capabilities.to_decomp_ops)
-            | pennylane_operation_set(self.qjit_capabilities.to_matrix_ops)
-        )
-
-    @property
-    def observables(self):
-        """Get PennyLane observables."""
-        return pennylane_operation_set(self.qjit_capabilities.native_obs)
 
 
 class TestGateAliases:
@@ -146,6 +105,104 @@ class TestControlledDecomposition:
 
         with pytest.raises(CompileError, match="could not be decomposed, it might be unsupported."):
             qjit(f, target="jaxpr")
+
+    def test_no_unitary_support(self):
+        """Test that unknown controlled operations without QubitUnitary support raise an error."""
+
+        class UnknownOp(qml.operation.Operation):
+            num_wires = qml.operation.AnyWires
+
+            def matrix(self):
+                return np.array(
+                    [
+                        [1.0, 0.0, 0.0, 0.0],
+                        [0.0, 1.0, 0.0, 0.0],
+                        [0.0, 0.0, 1.0, 0.0],
+                        [0.0, 0.0, 0.0, 1.0],
+                    ],
+                    dtype=np.complex128,
+                )
+
+        dev = get_custom_device_without(4, {"QubitUnitary"})
+
+        @qml.qnode(dev)
+        def f():
+            ctrl(UnknownOp(wires=[0, 1]), control=[2, 3])
+            return qml.probs()
+
+        with pytest.raises(CompileError, match="not supported with catalyst on this device"):
+            qjit(f, target="jaxpr")
+
+
+def get_custom_device_without(num_wires, discards=frozenset(), force_matrix=frozenset()):
+    """Generate a custom device without gates in discards."""
+
+    class CustomDevice(qml.devices.Device):
+        """Custom Gate Set Device"""
+
+        name = "Custom Device"
+        pennylane_requires = "0.35.0"
+        version = "0.0.2"
+        author = "Tester"
+
+        lightning_device = qml.device("lightning.qubit", wires=0)
+
+        config = None
+        backend_name = "default"
+        backend_lib = "default"
+        backend_kwargs = {}
+
+        def __init__(self, shots=None, wires=None):
+            super().__init__(wires=wires, shots=shots)
+            program_features = ProgramFeatures(shots_present=bool(self.shots))
+            lightning_capabilities = get_device_capabilities(
+                self.lightning_device, program_features
+            )
+            custom_capabilities = deepcopy(lightning_capabilities)
+            for gate in discards:
+                custom_capabilities.native_ops.pop(gate, None)
+                custom_capabilities.to_decomp_ops.pop(gate, None)
+                custom_capabilities.to_matrix_ops.pop(gate, None)
+            for gate in force_matrix:
+                custom_capabilities.native_ops.pop(gate, None)
+                custom_capabilities.to_decomp_ops.pop(gate, None)
+                custom_capabilities.to_matrix_ops[gate] = OperationProperties(False, False, False)
+            self.qjit_capabilities = custom_capabilities
+
+        def apply(self, operations, **kwargs):
+            """Unused"""
+            raise RuntimeError("Only C/C++ interface is defined")
+
+        @property
+        def operations(self):
+            """Return operations using PennyLane's C(.) syntax"""
+            return (
+                pennylane_operation_set(self.qjit_capabilities.native_ops)
+                | pennylane_operation_set(self.qjit_capabilities.to_decomp_ops)
+                | pennylane_operation_set(self.qjit_capabilities.to_matrix_ops)
+            )
+
+        @property
+        def observables(self):
+            """Return PennyLane observables"""
+            return pennylane_operation_set(self.qjit_capabilities.native_obs)
+
+        @staticmethod
+        def get_c_interface():
+            """Returns a tuple consisting of the device name, and
+            the location to the shared object with the C/C++ device implementation.
+            """
+            system_extension = ".dylib" if platform.system() == "Darwin" else ".so"
+            lib_path = (
+                get_lib_path("runtime", "RUNTIME_LIB_DIR") + "/librtd_dummy" + system_extension
+            )
+            return "dummy.remote", lib_path
+
+        def execute(self, circuits, execution_config):
+            """Execution."""
+            return circuits, execution_config
+
+    return CustomDevice(wires=num_wires)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Thanks to @astralcai for suggesting this refactor which massively simplifies the alternative decomposition for specialized controlled operations!

Guard against decomposing to `QubitUnitary` if the device doesn't support it.

[sc-70742]