### PR TITLE
Set OMP vars before importing numpy when testing

### DIFF
--- a/frontend/test/conftest.py
+++ b/frontend/test/conftest.py
@@ -21,7 +21,7 @@ import os
 os.environ["OMP_PROC_BIND"] = "false"
 os.environ["OMP_NUM_THREADS"] = "2"
 
-# pylint: disable=unused-import
+# pylint: disable=unused-import,wrong-import-position
 import platform
 
 import numpy as np

--- a/frontend/test/conftest.py
+++ b/frontend/test/conftest.py
@@ -14,6 +14,13 @@
 """
 Pytest configuration file for Catalyst test suite.
 """
+
+import os
+
+# OMP env vars have to be set before importing numpy in order to have an effect
+os.environ["OMP_PROC_BIND"] = "false"
+os.environ["OMP_NUM_THREADS"] = "2"
+
 # pylint: disable=unused-import
 import platform
 

--- a/frontend/test/pytest/test_mid_circuit_measurement.py
+++ b/frontend/test/pytest/test_mid_circuit_measurement.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Tests for mid-circuit measurements in Catalyst"""
 
-import os
 from dataclasses import asdict
 from functools import reduce
 from typing import Iterable, Sequence

--- a/frontend/test/pytest/test_mid_circuit_measurement.py
+++ b/frontend/test/pytest/test_mid_circuit_measurement.py
@@ -29,8 +29,6 @@ import catalyst
 from catalyst import CompileError, cond, measure, qjit
 
 # TODO: add tests with other measurement processes (e.g. qml.sample, qml.probs, ...)
-os.environ["OMP_PROC_BIND"] = "false"
-os.environ["OMP_NUM_THREADS"] = "2"
 
 # pylint: disable=too-many-public-methods
 


### PR DESCRIPTION
**Context:** When testing Kokkos the OMP env vars were not having an effect because they were set after importing numpy, and were only set for one test file.

**Description of the Change:** Set the OMP env vars at the conftest.py file and before importing numpy.

**Benefits:** Faster testing times

**Possible Drawbacks:** The number of threads is fixed to 2. Different machines might support larger numbers and increase performance.