### PR TITLE
Skipping `test_dynamic_one_shot_several_mcms` again

### DIFF
--- a/frontend/test/pytest/test_mid_circuit_measurement.py
+++ b/frontend/test/pytest/test_mid_circuit_measurement.py
@@ -569,6 +569,9 @@ class TestDynamicOneShotIntegration:
         assert result.shape == (shots,)
         assert jnp.allclose(result, 1.0)
 
+    @pytest.mark.skip(
+        reason="Midcircuit measurements with sampling is unseeded and hence this test is flaky"
+    )
     @pytest.mark.parametrize("shots", [10000])
     @pytest.mark.parametrize("postselect", [None, 0, 1])
     @pytest.mark.parametrize("measure_f", [qml.counts, qml.expval, qml.probs, qml.sample, qml.var])

--- a/frontend/test/pytest/test_mid_circuit_measurement.py
+++ b/frontend/test/pytest/test_mid_circuit_measurement.py
@@ -17,8 +17,8 @@ from dataclasses import asdict
 from functools import reduce
 from typing import Iterable, Sequence
 
-import jax.numpy as jnp
 import numpy as np
+import jax.numpy as jnp
 import pennylane as qml
 import pytest
 from jax.tree_util import tree_flatten

--- a/frontend/test/pytest/test_mid_circuit_measurement.py
+++ b/frontend/test/pytest/test_mid_circuit_measurement.py
@@ -569,7 +569,7 @@ class TestDynamicOneShotIntegration:
         assert result.shape == (shots,)
         assert jnp.allclose(result, 1.0)
 
-    @pytest.mark.skip(
+    @pytest.mark.xfail(
         reason="Midcircuit measurements with sampling is unseeded and hence this test is flaky"
     )
     @pytest.mark.parametrize("shots", [10000])

--- a/frontend/test/pytest/test_mid_circuit_measurement.py
+++ b/frontend/test/pytest/test_mid_circuit_measurement.py
@@ -17,8 +17,8 @@ from dataclasses import asdict
 from functools import reduce
 from typing import Iterable, Sequence
 
-import numpy as np
 import jax.numpy as jnp
+import numpy as np
 import pennylane as qml
 import pytest
 from jax.tree_util import tree_flatten


### PR DESCRIPTION
**Context:**
Seeding for qjit was added in #936 , but only measurements were seeded, and samples were not. Hence this test is still flaky. Sample seeding needs to be done in Lightning. #999 

**Description of the Change:**
Marking the test test_mid_circuit_measurement.py/test_dynamic_one_shot_several_mcms as skipped.
