### PR TITLE
Add LDCXXSHARED to setup.py after setuptools release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -185,6 +185,8 @@ elif system_platform == "Darwin":
     variables = sysconfig.get_config_vars()
     # Here we need to switch the deault to MacOs dynamic lib
     variables["LDSHARED"] = variables["LDSHARED"].replace("-bundle", "-dynamiclib")
+    if sysconfig.get_config_var("LDCXXSHARED"):
+        variables["LDCXXSHARED"] = variables["LDCXXSHARED"].replace("-bundle", "-dynamiclib")
     custom_calls_extension = Extension(
         "catalyst.utils.libcustom_calls",
         sources=["frontend/catalyst/utils/libcustom_calls.cpp"],


### PR DESCRIPTION
**Context:**
New release of setuptools adds the system variable `LDCXXSHARED`

**Description of the Change:**

For MacOs we change LDCXXSHARED from bundle to dynamiclibrary.
