### PR TITLE
Fix enzyme skipping if input ir is optimized by `O2Opt`

### DIFF
--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -648,7 +648,7 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
     catalyst::utils::LinesCount::ModuleOp(*op);
     output.isCheckpointFound = options.checkpointStage == "mlir";
 
-    bool enzymeRun = false;
+    bool enzymeRun = options.checkpointStage == "O2Opt";
     if (op) {
         enzymeRun = containsGradients(*op);
         if (failed(runLowering(options, &ctx, *op, output))) {


### PR DESCRIPTION
**Context:**
Run enzyme pass if checkpoint stage is set to `O2Opt`
