### PR TITLE
Fix setState unused arguments

### DIFF
--- a/runtime/include/QuantumDevice.hpp
+++ b/runtime/include/QuantumDevice.hpp
@@ -165,7 +165,7 @@ struct QuantumDevice {
      * @param state A state vector of size 2**len(wires)
      * @param wires The wire(s) the operation acts on
      */
-    virtual void SetState(DataView<std::complex<double>, 1> &state, std::vector<QubitIdType> &wires)
+    virtual void SetState(DataView<std::complex<double>, 1> &, std::vector<QubitIdType> &)
     {
         RT_FAIL("Unsupported functionality");
     }
@@ -176,7 +176,7 @@ struct QuantumDevice {
      * @param n Prepares the basis state |n>, where n is an array of integers from the set {0, 1}
      * @param wires The wire(s) the operation acts on
      */
-    virtual void SetBasisState(DataView<int8_t, 1> &n, std::vector<QubitIdType> &wires)
+    virtual void SetBasisState(DataView<int8_t, 1> &, std::vector<QubitIdType> &)
     {
         RT_FAIL("Unsupported functionality");
     }


### PR DESCRIPTION
**Context:**
SetState and SetBasisState cause [failures](https://github.com/PennyLaneAI/pennylane-lightning/actions/runs/10404526771/job/28813218681?pr=834#step:7:102) in L-Kokkos tests because they have unused arguments.

**Description of the Change:**
Remove argument names.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
