### PR TITLE
Fix wheel rename on macOS dev wheel uploads

### DIFF
--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -71,8 +71,9 @@ jobs:
     - name: Prepare wheels
       run: |
         rename "s/linux/manylinux_2_28/" dist/PennyLane_Catalyst-*
+        rename "s/macosx_12_0_universal2/macosx_12_0_x86_64/" dist/PennyLane_Catalyst-*
+        rename "s/macosx_14_0_universal2/macosx_13_0_arm64/" dist/PennyLane_Catalyst-*
         rename "s/macosx_14/macosx_13/" dist/PennyLane_Catalyst-*
-        rename "s/_universal2/_x86_64/" dist/PennyLane_Catalyst-*
         # Discard the 3.9 wheels to save space on nightly builds.
         rm dist/PennyLane_Catalyst-*-cp39-cp39-*
 


### PR DESCRIPTION
A recent change in the build environment means macOS 14 builds (for arm64) are also labeled as universal2 wheels, whereas before it would only be _some_ macOS 12 builds (for x86) that were labeled as such.

Ensure universal2 wheels are labeled correctly for each architecture.