### PR TITLE
[MLIR] Fix JVP type-checking when used with argnum

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -297,6 +297,7 @@
   type are not compatible by performing type-checking at the MLIR level. Note that the
   equivalent type checking is already performed in `catalyst.vjp`.
   [(#1020)](https://github.com/PennyLaneAI/catalyst/pull/1020)
+  [(#1030)](https://github.com/PennyLaneAI/catalyst/pull/1030)
 
 <h3>Breaking changes</h3>
 

--- a/mlir/test/Gradient/VerifierTest.mlir
+++ b/mlir/test/Gradient/VerifierTest.mlir
@@ -294,8 +294,41 @@ func.func @foo(%arg0: tensor<f64>) -> (tensor<f64>, tensor<f64>) {
 
 %cst0 = arith.constant dense<1.0> : tensor<f64>
 %cst1 = arith.constant dense<1> : tensor<i64>
-// expected-error@+1 {{callee input type does not match the tangent type}}
+// expected-error@+1 {{callee input and tangent arguments to jvp do not match}}
 gradient.jvp "auto" @foo(%cst0) tangents(%cst1) : (tensor<f64>, tensor<i64>) -> (tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>)
+
+// -----
+
+func.func @foo(%arg0: tensor<i64>, %arg1: tensor<f64>) -> (tensor<f64>, tensor<f64>) {
+
+    %cst = stablehlo.constant dense<2.000000e+00> : tensor<f64>
+    %0 = stablehlo.multiply %cst, %arg1 : tensor<f64>
+    %1 = stablehlo.multiply %arg1, %arg1 : tensor<f64>
+    return %0, %1 : tensor<f64>, tensor<f64>
+
+}
+
+%cst0 = arith.constant dense<1> : tensor<i64>
+%cst1 = arith.constant dense<1.0> : tensor<f64>
+%cst2 = arith.constant dense<1.0> : tensor<f64>
+gradient.jvp "auto" @foo(%cst0, %cst1) tangents(%cst2) {diffArgIndices = dense<1> : tensor<1xi64>} : (tensor<i64>, tensor<f64>, tensor<f64>) -> (tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>)
+
+// -----
+
+func.func @foo(%arg0: tensor<i64>, %arg1: tensor<f64>) -> (tensor<f64>, tensor<f64>) {
+
+    %cst = stablehlo.constant dense<2.000000e+00> : tensor<f64>
+    %0 = stablehlo.multiply %cst, %arg1 : tensor<f64>
+    %1 = stablehlo.multiply %arg1, %arg1 : tensor<f64>
+    return %0, %1 : tensor<f64>, tensor<f64>
+
+}
+
+%cst0 = arith.constant dense<1> : tensor<i64>
+%cst1 = arith.constant dense<1.0> : tensor<f64>
+%cst2 = arith.constant dense<1> : tensor<i64>
+// expected-error@+1 {{callee input and tangent arguments to jvp do not match}}
+gradient.jvp "auto" @foo(%cst0, %cst1) tangents(%cst2) {diffArgIndices = dense<1> : tensor<1xi64>} : (tensor<i64>, tensor<f64>, tensor<i64>) -> (tensor<f64>, tensor<f64>, tensor<f64>, tensor<f64>)
 
 // -----
 
@@ -362,7 +395,7 @@ func.func @foo(%arg0: tensor<f64>) -> (tensor<f64>, tensor<f64>) {
 %cst0 = arith.constant dense<1.0> : tensor<f64>
 %cst1 = arith.constant dense<1> : tensor<i64>
 %cst2 = arith.constant dense<1> : tensor<i64>
-// expected-error@+1 {{callee result type does not match the cotangent type}}
+// expected-error@+1 {{callee result and cotangent argument to vjp do not match}}
 gradient.vjp "auto" @foo(%cst0) cotangents(%cst1, %cst2) {resultSegmentSizes = array<i32: 2, 1>} : (tensor<f64>, tensor<i64>, tensor<i64>) -> (tensor<f64>, tensor<f64>, tensor<f64>)
 
 // -----


### PR DESCRIPTION
**Context:** Improving the type-checking in the JVP and VJP operations at the MLIR level.

**Description of the Change:** This fixes a minor bug introduced in #1020, which resulted in the JVP type-checking to be overly strict when enforcing that the types of the primals and tangents be the same when using a mixture of differentiable and non-differentiable parameters (as specified by the `argnum` parameter). For example, in the code sample below (taken from the [Catalyst JVP documentation](https://docs.pennylane.ai/projects/catalyst/en/stable/code/api/catalyst.jvp.html)), the MLIR would enforce that the parameter `n` be a float, even though it is legal for it to be an integer:

```python
@qjit
@qml.qnode(qml.device("lightning.qubit", wires=2))
def circuit(n, params):
    qml.RX(params[n, 0], wires=n)
    qml.RY(params[n, 1], wires=n)
    return qml.expval(qml.PauliZ(1))

@qjit
def workflow(primals, tangents):
    return catalyst.jvp(circuit, [1, primals], [tangents], argnum=[1])
#                                 ^
#                                 Legal integer input for parameter `n`
```

This is now fixed by comparing only the types of the differentiable parameters (whose indices are given by `argnum`) to the types of their corresponding tangent arguments.

**Benefits:** Better error handling and messaging.

**Possible Drawbacks:** None.

**Related GitHub Issues:**
