### PR TITLE
Add JVP/VJP type checking in Catalyst frontend

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -303,6 +303,25 @@
   `catalyst.vjp` functions.
   [(#1031)](https://github.com/PennyLaneAI/catalyst/pull/1031)
 
+  ```python
+  from catalyst import qjit, jvp
+
+  def foo(x):
+      return 2 * x, x * x
+
+  @qjit()
+  def workflow(x: float):
+      return jvp(foo, (x,), (1,))
+  #                          ^
+  #                          Expected tangent dtype float, but got int
+  ```
+
+  ```
+  TypeError: function params and tangents arguments to catalyst.jvp do not match;
+  dtypes must be equal. Got function params dtype float64 and so expected tangent
+  dtype float64, but got tangent dtype int64 instead.
+  ```
+
 <h3>Breaking changes</h3>
 
 * Return values of qjit-compiled functions that were previously `numpy.ndarray` are now of type

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -299,6 +299,9 @@
   [(#1020)](https://github.com/PennyLaneAI/catalyst/pull/1020)
   [(#1030)](https://github.com/PennyLaneAI/catalyst/pull/1030)
 
+* Add type checking and improve error messaging in the frontend `catalyst.jvp` and
+  `catalyst.vjp` functions.
+
 <h3>Breaking changes</h3>
 
 * Return values of qjit-compiled functions that were previously `numpy.ndarray` are now of type

--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -301,6 +301,7 @@
 
 * Add type checking and improve error messaging in the frontend `catalyst.jvp` and
   `catalyst.vjp` functions.
+  [(#1031)](https://github.com/PennyLaneAI/catalyst/pull/1031)
 
 <h3>Breaking changes</h3>
 

--- a/frontend/catalyst/api_extensions/differentiation.py
+++ b/frontend/catalyst/api_extensions/differentiation.py
@@ -459,10 +459,10 @@ def jvp(f: DifferentiableLike, params, tangents, *, method=None, h=None, argnum=
 
         if len(tangents_flatten) != len(grad_params.expanded_argnum):
             raise TypeError(
-                "number of tangent operands and number of differentiable parameters in catalyst.jvp "
-                "do not match; number of parameters must be equal. "
-                f"Got {len(grad_params.expanded_argnum)} differentiable parameters and so expected as "
-                f"many tangent operands, but got {len(tangents_flatten)} instead."
+                "number of tangent and number of differentiable parameters in catalyst.jvp do not "
+                "match; the number of parameters must be equal. "
+                f"Got {len(grad_params.expanded_argnum)} differentiable parameters and so expected "
+                f"as many tangents, but got {len(tangents_flatten)} instead."
             )
 
         # Only check dtypes and shapes of parameters marked as differentiable by the `argnum` param
@@ -572,10 +572,10 @@ def vjp(f: DifferentiableLike, params, cotangents, *, method=None, h=None, argnu
 
         if len(jaxpr.out_avals) != len(cotangents_flatten):
             raise TypeError(
-                "number of cotangent operands and number of function output parameters in catalyst.vjp "
-                "do not match; number of parameters must be equal. "
-                f"Got {len(jaxpr.out_avals)} function output parameters and so expected as "
-                f"many cotangent operands, but got {len(cotangents_flatten)} instead."
+                "number of cotangent and number of function output parameters in catalyst.vjp do "
+                "not match; the number of parameters must be equal. "
+                f"Got {len(jaxpr.out_avals)} function output parameters and so expected as many "
+                f"cotangents, but got {len(cotangents_flatten)} instead."
             )
 
         for p, t in zip(jaxpr.out_avals, cotangents_flatten):
@@ -589,8 +589,9 @@ def vjp(f: DifferentiableLike, params, cotangents, *, method=None, h=None, argnu
 
             if jnp.shape(p) != jnp.shape(t):
                 raise ValueError(
-                    "catalyst.vjp called with different function output params and cotangent shapes; "
-                    f"got function output params shape {jnp.shape(p)} and cotangent shape {jnp.shape(t)}"
+                    "catalyst.vjp called with different function output params and cotangent "
+                    f"shapes; got function output params shape {jnp.shape(p)} and cotangent shape "
+                    f"{jnp.shape(t)}"
                 )
 
         cotangents, _ = tree_flatten(cotangents)

--- a/frontend/catalyst/api_extensions/differentiation.py
+++ b/frontend/catalyst/api_extensions/differentiation.py
@@ -24,6 +24,8 @@ import numbers
 from typing import Callable, Iterable, List, Optional, Union
 
 import jax
+import jax.numpy as jnp
+from jax._src.api import _dtype
 from jax._src.tree_util import PyTreeDef, tree_flatten, tree_unflatten
 from pennylane import QNode
 
@@ -455,6 +457,32 @@ def jvp(f: DifferentiableLike, params, tangents, *, method=None, h=None, argnum=
         tangents_flatten, _ = tree_flatten(tangents)
         grad_params = _check_grad_params(method, scalar_out, h, argnum, len(args_flatten), in_tree)
 
+        if len(tangents_flatten) != len(grad_params.expanded_argnum):
+            raise TypeError(
+                "number of tangent operands and number of differentiable parameters in catalyst.jvp "
+                "do not match; number of parameters must be equal. "
+                f"Got {len(grad_params.expanded_argnum)} differentiable parameters and so expected as "
+                f"many tangent operands, but got {len(tangents_flatten)} instead."
+            )
+
+        # Only check dtypes and shapes of parameters marked as differentiable by the `argnum` param
+        args_to_check = [args_flatten[i] for i in grad_params.argnum]
+
+        for p, t in zip(args_to_check, tangents_flatten):
+            if _dtype(p) != _dtype(t):
+                raise TypeError(
+                    "function params and tangents arguments to catalyst.jvp do not match; "
+                    "dtypes must be equal. "
+                    f"Got function params dtype {_dtype(p)} and so expected tangent dtype "
+                    f"{_dtype(p)}, but got tangent dtype {_dtype(t)} instead."
+                )
+
+            if jnp.shape(p) != jnp.shape(t):
+                raise ValueError(
+                    "catalyst.jvp called with different function params and tangent shapes; "
+                    f"got function params shape {jnp.shape(p)} and tangent shape {jnp.shape(t)}"
+                )
+
         jaxpr, out_tree = _make_jaxpr_check_differentiable(fn, grad_params, *params)
 
         results = jvp_p.bind(
@@ -541,6 +569,29 @@ def vjp(f: DifferentiableLike, params, cotangents, *, method=None, h=None, argnu
         _, in_tree = tree_flatten(args_argnum)
 
         jaxpr, out_tree = _make_jaxpr_check_differentiable(fn, grad_params, *params)
+
+        if len(jaxpr.out_avals) != len(cotangents_flatten):
+            raise TypeError(
+                "number of cotangent operands and number of function output parameters in catalyst.vjp "
+                "do not match; number of parameters must be equal. "
+                f"Got {len(jaxpr.out_avals)} function output parameters and so expected as "
+                f"many cotangent operands, but got {len(cotangents_flatten)} instead."
+            )
+
+        for p, t in zip(jaxpr.out_avals, cotangents_flatten):
+            if _dtype(p) != _dtype(t):
+                raise TypeError(
+                    "function output params and cotangents arguments to catalyst.vjp do not match; "
+                    "dtypes must be equal. "
+                    f"Got function output params dtype {_dtype(p)} and so expected cotangent dtype "
+                    f"{_dtype(p)}, but got cotangent dtype {_dtype(t)} instead."
+                )
+
+            if jnp.shape(p) != jnp.shape(t):
+                raise ValueError(
+                    "catalyst.vjp called with different function output params and cotangent shapes; "
+                    f"got function output params shape {jnp.shape(p)} and cotangent shape {jnp.shape(t)}"
+                )
 
         cotangents, _ = tree_flatten(cotangents)
 

--- a/frontend/test/pytest/test_jvpvjp.py
+++ b/frontend/test/pytest/test_jvpvjp.py
@@ -39,12 +39,13 @@ def circuit_rx(x1, x2):
     return qml.expval(qml.PauliY(0))
 
 
-def f(x):
+def f_R1_to_R2(x):
+    """A test function f : R1 -> R2"""
     return 2 * x, x * x
 
 
-def g(_n, x):
-    # `_n` is a dummy, non-differentiable parameter
+def g_R3_to_R2(_n, x):
+    """A test function g : R3 -> R2, where `_n` is a dummy, non-differentiable parameter"""
     return jnp.stack([1 + x[0] + 2 * x[1] + 3 * x[2], 1 + x[0] + 2 * x[1] ** 2 + 3 * x[2] ** 3])
 
 
@@ -849,13 +850,13 @@ def test_jvp_argument_type_checks_correct_inputs(diff_method):
     def C_workflow_f():
         x = (1.0,)
         tangents = (1.0,)
-        return C_jvp(f, x, tangents, method=diff_method, argnum=[0])
+        return C_jvp(f_R1_to_R2, x, tangents, method=diff_method, argnum=[0])
 
     @qjit
     def C_workflow_g():
         x = jnp.array([2.0, 3.0, 4.0])
         tangents = jnp.ones([3], dtype=float)
-        return C_jvp(g, [1, x], [tangents], method=diff_method, argnum=[1])
+        return C_jvp(g_R3_to_R2, [1, x], [tangents], method=diff_method, argnum=[1])
 
 
 @pytest.mark.parametrize("diff_method", diff_methods)
@@ -877,7 +878,7 @@ def test_jvp_argument_type_checks_incompatible_n_inputs(diff_method):
             # If `f` takes one differentiable param (argnum=[0]), then `tangents` must have length 1
             x = (1.0,)
             tangents = (1.0, 1.0)
-            return C_jvp(f, x, tangents, method=diff_method, argnum=[0])
+            return C_jvp(f_R1_to_R2, x, tangents, method=diff_method, argnum=[0])
 
 
 @pytest.mark.parametrize("diff_method", diff_methods)
@@ -895,7 +896,7 @@ def test_jvp_argument_type_checks_incompatible_input_types(diff_method):
             # If `x` has type float, then `tangents` should also have type float
             x = (1.0,)
             tangents = (1,)
-            return C_jvp(f, x, tangents, method=diff_method, argnum=[0])
+            return C_jvp(f_R1_to_R2, x, tangents, method=diff_method, argnum=[0])
 
 
 @pytest.mark.parametrize("diff_method", diff_methods)
@@ -914,7 +915,7 @@ def test_jvp_argument_type_checks_incompatible_input_shapes(diff_method):
             # but it has shape (4,)
             x = jnp.array([2.0, 3.0, 4.0])
             tangents = jnp.ones([4], dtype=float)
-            return C_jvp(g, [1, x], [tangents], method=diff_method, argnum=[1])
+            return C_jvp(g_R3_to_R2, [1, x], [tangents], method=diff_method, argnum=[1])
 
 
 @pytest.mark.parametrize("diff_method", diff_methods)
@@ -925,13 +926,13 @@ def test_vjp_argument_type_checks_correct_inputs(diff_method):
     def C_workflow_f():
         x = (1.0,)
         cotangents = (1.0, 1.0)
-        return C_vjp(f, x, cotangents, method=diff_method, argnum=[0])
+        return C_vjp(f_R1_to_R2, x, cotangents, method=diff_method, argnum=[0])
 
     @qjit
     def C_workflow_g():
         x = jnp.array([2.0, 3.0, 4.0])
         cotangents = jnp.ones([2], dtype=float)
-        return C_vjp(g, [1, x], [cotangents], method=diff_method, argnum=[1])
+        return C_vjp(g_R3_to_R2, [1, x], [cotangents], method=diff_method, argnum=[1])
 
 
 @pytest.mark.parametrize("diff_method", diff_methods)
@@ -953,7 +954,7 @@ def test_vjp_argument_type_checks_incompatible_n_inputs(diff_method):
             # If `f` returns two outputs, then `cotangents` must have length 2
             x = (1.0,)
             cotangents = (1.0,)
-            return C_vjp(f, x, cotangents, method=diff_method, argnum=[0])
+            return C_vjp(f_R1_to_R2, x, cotangents, method=diff_method, argnum=[0])
 
 
 @pytest.mark.parametrize("diff_method", diff_methods)
@@ -972,7 +973,7 @@ def test_vjp_argument_type_checks_incompatible_input_types(diff_method):
             # If `x` has type float, then `cotangents` should also have type float
             x = (1.0,)
             cotangents = (1, 1)
-            return C_vjp(f, x, cotangents, method=diff_method, argnum=[0])
+            return C_vjp(f_R1_to_R2, x, cotangents, method=diff_method, argnum=[0])
 
 
 @pytest.mark.parametrize("diff_method", diff_methods)
@@ -992,7 +993,7 @@ def test_vjp_argument_type_checks_incompatible_input_shapes(diff_method):
             # shape (2,), but it has shape (3,)
             x = jnp.array([2.0, 3.0, 4.0])
             cotangents = jnp.ones([3], dtype=float)
-            return C_vjp(g, [1, x], [cotangents], method=diff_method, argnum=[1])
+            return C_vjp(g_R3_to_R2, [1, x], [cotangents], method=diff_method, argnum=[1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Context:** Improve type checking and error messaging in the Catalyst JVP and VJP functions.

**Description of the Change:** Adds type checking to ensure the following for **JVP**:

* Number of tangent operands and number of differentiable parameters are equal.
* Data types of function params and tangents arguments are equal.
* Function params and tangent arguments are the same shape.

and for **VJP**:

* Number of cotangent operands and number of function output parameters are equal.
* Data types of function output params and cotangents arguments are equal.
* Function output params and cotangent arguments are the same shape.

Note that the equivalent type checking is also performed at the MLIR level.

**Benefits:** Checking functional parameters earlier in the frontend improves error messaging and usability rather than falling back to the MLIR error messages.

**Possible Drawbacks:** There's a small risk that stricter type checking in the frontend might break backward compatibility if users are calling these functions in unconventional or non-standard ways that are not captured by our unit/integration tests.

**Related GitHub Issues:**
