### PR TITLE
Fix `catalyst.value_and_grad` to differentiate functions with multiple arguments

### DIFF
--- a/frontend/catalyst/api_extensions/differentiation.py
+++ b/frontend/catalyst/api_extensions/differentiation.py
@@ -610,6 +610,9 @@ class Grad:
                 input_data_flat, _ = tree_flatten((args, kwargs))
                 jaxpr, out_tree = _make_jaxpr_check_differentiable(fn, grad_params, *args, **kwargs)
                 if self.grad_params.with_value:  # use value_and_grad
+                    args_argnum = tuple(args[i] for i in grad_params.argnum)
+                    _, in_arg_tree = tree_flatten(args_argnum)
+                    
                     # It always returns list as required by catalyst control-flows
                     results = value_and_grad_p.bind(
                         *input_data_flat, jaxpr=jaxpr, fn=fn, grad_params=grad_params

--- a/frontend/catalyst/api_extensions/differentiation.py
+++ b/frontend/catalyst/api_extensions/differentiation.py
@@ -612,7 +612,7 @@ class Grad:
                 if self.grad_params.with_value:  # use value_and_grad
                     args_argnum = tuple(args[i] for i in grad_params.argnum)
                     _, in_arg_tree = tree_flatten(args_argnum)
-                    
+
                     # It always returns list as required by catalyst control-flows
                     results = value_and_grad_p.bind(
                         *input_data_flat, jaxpr=jaxpr, fn=fn, grad_params=grad_params

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -262,8 +262,8 @@ def test_value_and_grad_on_qjit_classical():
     assert np.allclose(result[1]["helloworld"], expected[1]["helloworld"])
 
     @qjit
-    def f4(x: float, y: float, z:float):
-        return 100*x + 200*y + 300*z
+    def f4(x: float, y: float, z: float):
+        return 100 * x + 200 * y + 300 * z
 
     result = qjit(value_and_grad(f4))(0.1, 0.2, 0.3)
     expected = (140, 100)

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -261,6 +261,14 @@ def test_value_and_grad_on_qjit_classical():
     assert np.allclose(result[0]["helloworld"], expected[0]["helloworld"])
     assert np.allclose(result[1]["helloworld"], expected[1]["helloworld"])
 
+    @qjit
+    def f4(x: float, y: float, z:float):
+        return 100*x + 200*y + 300*z
+
+    result = qjit(value_and_grad(f4))(0.1, 0.2, 0.3)
+    expected = (140, 100)
+    assert np.allclose(result, expected)
+
 
 def test_value_and_grad_on_qjit_classical_vector():
     """Check that value_and_grad works when called on an qjit object that does not wrap a QNode

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -357,7 +357,10 @@ def test_value_and_grad_on_qjit_quantum_variant():
     assert np.allclose(result, expected)
 
 
-def test_value_and_grad_on_qjit_quantum_variant_argnum():
+@pytest.mark.parametrize(
+    "argnum", [(0, 1, 2), (0), (1), (2), (0, 1), (0, 2), (1, 2), (1, 0, 2), (2, 0, 1)]
+)
+def test_value_and_grad_on_qjit_quantum_variant_argnum(argnum):
     """
     Check that value_and_grad works when called on an qjit object that does wrap a QNode
     with multiple trainable parameters.
@@ -374,10 +377,10 @@ def test_value_and_grad_on_qjit_quantum_variant_argnum():
 
         return circuit(x, y, z)[0]
 
-    result = qjit(value_and_grad(qjit(workflow_variant), argnum=[0, 1, 2]))(1.1, 2.2, 3.3)
+    result = qjit(value_and_grad(qjit(workflow_variant), argnum=argnum))(1.1, 2.2, 3.3)
     expected = (
         workflow_variant(1.1, 2.2, 3.3),
-        qjit(grad(workflow_variant, argnum=[0, 1, 2]))(1.1, 2.2, 3.3),
+        qjit(grad(workflow_variant, argnum=argnum))(1.1, 2.2, 3.3),
     )
     assert np.allclose(result[0], expected[0])
     assert np.allclose(result[1], expected[1])

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -339,8 +339,7 @@ def test_value_and_grad_on_qjit_quantum():
 
 def test_value_and_grad_on_qjit_quantum_variant():
     """
-    Check that value_and_grad works when called on an qjit object that does wrap a QNode
-    with trainable parameters.
+    Check that value_and_grad works when called on a QNode with trainable parameters.
     """
 
     def workflow_variant(x: float):
@@ -352,7 +351,7 @@ def test_value_and_grad_on_qjit_quantum_variant():
 
         return circuit(x)[0]
 
-    result = qjit(value_and_grad(qjit(workflow_variant)))(1.1)
+    result = qjit(value_and_grad(workflow_variant))(1.1)
     expected = (workflow_variant(1.1), qjit(grad(workflow_variant))(1.1))
     assert np.allclose(result, expected)
 
@@ -362,8 +361,7 @@ def test_value_and_grad_on_qjit_quantum_variant():
 )
 def test_value_and_grad_on_qjit_quantum_variant_argnum(argnum):
     """
-    Check that value_and_grad works when called on an qjit object that does wrap a QNode
-    with multiple trainable parameters.
+    Check that value_and_grad works when called on a QNode with multiple trainable parameters.
     """
 
     def workflow_variant(x: float, y: float, z: float):
@@ -377,7 +375,7 @@ def test_value_and_grad_on_qjit_quantum_variant_argnum(argnum):
 
         return circuit(x, y, z)[0]
 
-    result = qjit(value_and_grad(qjit(workflow_variant), argnum=argnum))(1.1, 2.2, 3.3)
+    result = qjit(value_and_grad(workflow_variant, argnum=argnum))(1.1, 2.2, 3.3)
     expected = (
         workflow_variant(1.1, 2.2, 3.3),
         qjit(grad(workflow_variant, argnum=argnum))(1.1, 2.2, 3.3),

--- a/mlir/include/Gradient/IR/GradientOps.td
+++ b/mlir/include/Gradient/IR/GradientOps.td
@@ -69,7 +69,7 @@ def GradOp : Gradient_Op<"grad", [
 }
 
 def ValueAndGradOp : Gradient_Op<"value_and_grad", [
-        SameVariadicResultSize,
+        AttrSizedResultSegments,
         DeclareOpInterfaceMethods<CallOpInterface>,
         DeclareOpInterfaceMethods<SymbolUserOpInterface>,
         GradientOpInterface

--- a/mlir/test/Gradient/VerifierTest.mlir
+++ b/mlir/test/Gradient/VerifierTest.mlir
@@ -441,7 +441,7 @@ func.func @measure(%arg0: f64) -> f64 {
 
 %f0 = arith.constant 0.0 : f64
 // expected-error@+1 {{An operation without a valid gradient was found}}
-gradient.value_and_grad "auto" @measure(%f0) : (f64) -> (f64, f64)
+gradient.value_and_grad "auto" @measure(%f0) {resultSegmentSizes = array<i32: 1, 1>} : (f64) -> (f64, f64)
 
 // -----
 
@@ -457,5 +457,5 @@ func.func @measure(%arg0: f64) -> f64 {
 }
 
 %f0 = arith.constant 0.0 : f64
-gradient.value_and_grad "fd" @measure(%f0) : (f64) -> (f64, f64)
+gradient.value_and_grad "fd" @measure(%f0) {resultSegmentSizes = array<i32: 1, 1>} : (f64) -> (f64, f64)
 


### PR DESCRIPTION
**Context:** Fix `catalyst.value_and_grad` to differentiate functions with multiple arguments

**Description of the Change:**
In the frontend, correctly calculate the argument shapes when `value_and_grad` is called 
In mlir, correctly split `ValueAndGradOp`'s return across val's and grad's `Variadic`s. Original it was split evenly, which doesn't make sense. See https://mlir.llvm.org/docs/DefiningDialects/Operations/#variadic-operands

**Related GitHub Issues:** closes #1015 

[sc-71346]