### PR TITLE
Run `cancel_inverses` on a clone of the qnode instead of the qnode itself

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -451,6 +451,13 @@
       return y
   ```
 
+* `value_and_grad` will now correctly differentiate functions with multiple arguments.
+  [(#1034)](https://github.com/PennyLaneAI/catalyst/pull/1034)
+
+* `cancel_inverses` will now no longer mutate the original qnode, and instead it will perform
+  the mlir pass on a cloned copy of the qnode.
+  [(#1037)](https://github.com/PennyLaneAI/catalyst/pull/1037)
+
 <h3>Documentation</h3>
 
 * A page has been added to the documentation, listing devices that are
@@ -510,7 +517,7 @@ Mehrdad Malekmohammadi,
 Romain Moyard,
 Erick Ochoa Lopez,
 Mudit Pandey,
-nate stemen,
+Nate Stemen,
 Raul Torres,
 Tzung-Han Juang,
 Paul Haochen Wang,

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -153,13 +153,13 @@ def cancel_inverses(fn=None):  # pylint: disable=line-too-long
 
         apply_registered_pass_p.bind(
             pass_name="remove-chained-self-inverse",
-            options=f"func-name={funcname}" + "_cancel_inverse",
+            options=f"func-name={funcname}" + "_cancel_inverses",
         )
         return wrapped_qnode_function(*args, **kwrags)
 
     fn_clone = copy.copy(fn)
     fn_clone.func = wrapper
-    fn_clone.__name__ = funcname + "_cancel_inverse"
+    fn_clone.__name__ = funcname + "_cancel_inverses"
 
     return fn_clone
 

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -37,6 +37,8 @@ a unified user interface for all the passes will be available.
 
 """
 
+import copy
+
 import pennylane as qml
 
 from catalyst.jax_primitives import apply_registered_pass_p, transform_named_sequence_p
@@ -144,8 +146,9 @@ def cancel_inverses(fn=None):  # pylint: disable=line-too-long
         )
         return wrapped_qnode_function(*args, **kwrags)
 
-    fn.func = wrapper
-    return fn
+    fn_clone = copy.copy(fn)
+    fn_clone.func = wrapper
+    return fn_clone
 
 
 ## IMPL and helpers ##

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -139,15 +139,28 @@ def cancel_inverses(fn=None):  # pylint: disable=line-too-long
         raise TypeError(f"A QNode is expected, got the classical function {fn}")
 
     wrapped_qnode_function = fn.func
+    funcname = fn.__name__
 
     def wrapper(*args, **kwrags):
+        # TODO: hint the compiler which qnodes to run the pass on via an func attribute,
+        # instead of the qnode name. That way the clone can have this attribute and
+        # the original can just not have it.
+        # We are not doing this right now and passing by name because this would
+        # be a discardable attribute (i.e. a user/developer wouldn't know that this
+        # attribute exists just by looking at qnode's documentation)
+        # But when we add the full peephole pipeline in the future, the attribute
+        # could get properly documented.
+
         apply_registered_pass_p.bind(
-            pass_name="remove-chained-self-inverse", options=f"func-name={fn.__name__}"
+            pass_name="remove-chained-self-inverse",
+            options=f"func-name={funcname}" + "_cancel_inverse",
         )
         return wrapped_qnode_function(*args, **kwrags)
 
     fn_clone = copy.copy(fn)
     fn_clone.func = wrapper
+    fn_clone.__name__ = funcname + "_cancel_inverse"
+
     return fn_clone
 
 

--- a/frontend/test/lit/test_peephole_optimizations.py
+++ b/frontend/test/lit/test_peephole_optimizations.py
@@ -284,6 +284,7 @@ def test_cancel_inverses_keep_original():
     @qjit(keep_intermediate=True)
     def test_cancel_inverses_keep_original_workflow0():
         return f(1.0)
+
     test_cancel_inverses_keep_original_workflow0()
     flush_peephole_opted_mlir_to_iostream(test_cancel_inverses_keep_original_workflow0)
 
@@ -298,6 +299,7 @@ def test_cancel_inverses_keep_original():
     @qjit(keep_intermediate=True)
     def test_cancel_inverses_keep_original_workflow1():
         return g(1.0)
+
     test_cancel_inverses_keep_original_workflow1()
     flush_peephole_opted_mlir_to_iostream(test_cancel_inverses_keep_original_workflow1)
 
@@ -315,7 +317,9 @@ def test_cancel_inverses_keep_original():
     @qjit(keep_intermediate=True)
     def test_cancel_inverses_keep_original_workflow2():
         return f(1.0), g(1.0)
+
     test_cancel_inverses_keep_original_workflow2()
-    flush_peephole_opted_mlir_to_iostream(test_cancel_inverses_keep_original_workflow2)  
+    flush_peephole_opted_mlir_to_iostream(test_cancel_inverses_keep_original_workflow2)
+
 
 test_cancel_inverses_keep_original()

--- a/frontend/test/lit/test_peephole_optimizations.py
+++ b/frontend/test/lit/test_peephole_optimizations.py
@@ -139,23 +139,23 @@ def test_cancel_inverses_tracing_and_lowering():
 
     # CHECK: transform_named_sequence
     # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK:   options=func-name=f
+    # CHECK:   options=func-name=f_cancel_inverses
     # CHECK:   pass_name=remove-chained-self-inverse
     # CHECK: ]
     # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK:   options=func-name=g
+    # CHECK:   options=func-name=g_cancel_inverses
     # CHECK:   pass_name=remove-chained-self-inverse
     # CHECK: ]
     # CHECK-NOT: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK-NOT:   options=func-name=h
+    # CHECK-NOT:   options=func-name=h_cancel_inverses
     # CHECK-NOT:   pass_name=remove-chained-self-inverse
     print_jaxpr(test_cancel_inverses_tracing_and_lowering_workflow, 1.1)
 
     # CHECK: module @test_cancel_inverses_tracing_and_lowering_workflow
     # CHECK: transform.named_sequence @__transform_main
-    # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "remove-chained-self-inverse" to {{%.+}} {options = "func-name=f"}
-    # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "remove-chained-self-inverse" to {{%.+}} {options = "func-name=g"}
-    # CHECK-NOT: {{%.+}} = transform.apply_registered_pass "remove-chained-self-inverse" to {{%.+}} {options = "func-name=h"}
+    # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "remove-chained-self-inverse" to {{%.+}} {options = "func-name=f_cancel_inverses"}
+    # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "remove-chained-self-inverse" to {{%.+}} {options = "func-name=g_cancel_inverses"}
+    # CHECK-NOT: {{%.+}} = transform.apply_registered_pass "remove-chained-self-inverse" to {{%.+}} {options = "func-name=h_cancel_inverses"}
     # CHECK-NEXT: transform.yield
     print_mlir(test_cancel_inverses_tracing_and_lowering_workflow, 1.1)
 
@@ -183,14 +183,14 @@ def test_cancel_inverses_tracing_and_lowering_outside_qjit():
 
     # CHECK: transform_named_sequence
     # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK:   options=func-name=f
+    # CHECK:   options=func-name=f_cancel_inverses
     # CHECK:   pass_name=remove-chained-self-inverse
     # CHECK: ]
     print_jaxpr(test_cancel_inverses_tracing_and_lowering_outside_qjit_workflow, 1.1)
 
     # CHECK: module @test_cancel_inverses_tracing_and_lowering_outside_qjit_workflow
     # CHECK: transform.named_sequence @__transform_main
-    # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "remove-chained-self-inverse" to {{%.+}} {options = "func-name=f"}
+    # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "remove-chained-self-inverse" to {{%.+}} {options = "func-name=f_cancel_inverses"}
     # CHECK-NEXT: transform.yield
     print_mlir(test_cancel_inverses_tracing_and_lowering_outside_qjit_workflow, 1.1)
 

--- a/frontend/test/lit/test_peephole_optimizations.py
+++ b/frontend/test/lit/test_peephole_optimizations.py
@@ -257,3 +257,65 @@ def test_cancel_inverses_lowering_transform_applied():
 
 
 test_cancel_inverses_lowering_transform_applied()
+
+
+def test_cancel_inverses_keep_original():
+    """
+    Test cancel_inverses does not unexpectedly mutate the original qnode.
+    """
+
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    def f(x: float):
+        qml.RX(x, wires=0)
+        qml.Hadamard(wires=0)
+        qml.Hadamard(wires=0)
+        return qml.expval(qml.PauliZ(0))
+
+    g = cancel_inverses(f)
+
+    # CHECK-LABEL: public @jit_test_cancel_inverses_keep_original_workflow0
+    # CHECK: {{%.+}} = call @f({{%.+}})
+    # CHECK-NOT: {{%.+}} = call @f_cancel_inverses({{%.+}})
+    # CHECK-LABEL: private @f({{%.+}})
+    # CHECK: {{%.+}} = quantum.custom "RX"({{%.+}}) {{%.+}} : !quantum.bit
+    # CHECK-NEXT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
+    # CHECK-NEXT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
+    # CHECK-NOT: private @f_cancel_inverses
+    @qjit(keep_intermediate=True)
+    def test_cancel_inverses_keep_original_workflow0():
+        return f(1.0)
+    test_cancel_inverses_keep_original_workflow0()
+    flush_peephole_opted_mlir_to_iostream(test_cancel_inverses_keep_original_workflow0)
+
+    # CHECK-LABEL: public @jit_test_cancel_inverses_keep_original_workflow1
+    # CHECK: {{%.+}} = call @f_cancel_inverses({{%.+}})
+    # CHECK-NOT: {{%.+}} = call @f({{%.+}})
+    # CHECK-LABEL: private @f_cancel_inverses({{%.+}})
+    # CHECK: {{%.+}} = quantum.custom "RX"({{%.+}}) {{%.+}} : !quantum.bit
+    # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
+    # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
+    # CHECK-NOT: private @f
+    @qjit(keep_intermediate=True)
+    def test_cancel_inverses_keep_original_workflow1():
+        return g(1.0)
+    test_cancel_inverses_keep_original_workflow1()
+    flush_peephole_opted_mlir_to_iostream(test_cancel_inverses_keep_original_workflow1)
+
+    # CHECK-LABEL: public @jit_test_cancel_inverses_keep_original_workflow2
+    # CHECK: {{%.+}} = call @f({{%.+}})
+    # CHECK: {{%.+}} = call @f_cancel_inverses({{%.+}})
+    # CHECK-LABEL: private @f({{%.+}})
+    # CHECK: {{%.+}} = quantum.custom "RX"({{%.+}}) {{%.+}} : !quantum.bit
+    # CHECK-NEXT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
+    # CHECK-NEXT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
+    # CHECK-LABEL: private @f_cancel_inverses({{%.+}})
+    # CHECK: {{%.+}} = quantum.custom "RX"({{%.+}}) {{%.+}} : !quantum.bit
+    # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
+    # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
+    @qjit(keep_intermediate=True)
+    def test_cancel_inverses_keep_original_workflow2():
+        return f(1.0), g(1.0)
+    test_cancel_inverses_keep_original_workflow2()
+    flush_peephole_opted_mlir_to_iostream(test_cancel_inverses_keep_original_workflow2)  
+
+test_cancel_inverses_keep_original()


### PR DESCRIPTION
**Context:**
Run `cancel_inverses` on a clone of the qnode instead of the qnode itself, in order to keep the original unoptimized qnode accessible.

**Description of the Change:**
In `passes.py`, the `cancel_inverse` decorator would create a clone of the qnode and leave the input qnode completely unchanged. The injection of a `apply_registered_pass("remove-chained-self-inverse")` primitive would happen on a clone of the qnode. 

**Related GitHub Issues:** closes #1032 

[sc-71569]
