### PR TITLE
Restore accidentally deleted fenced code delimiter at changelog.md

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -320,6 +320,7 @@
   TypeError: function params and tangents arguments to catalyst.jvp do not match;
   dtypes must be equal. Got function params dtype float64 and so expected tangent
   dtype float64, but got tangent dtype int64 instead.
+  ```
 
 * Add a script for setting up a Frontend-Only Development Environment that does not require
   compilation, as it uses the TestPyPI wheel shared libraries.


### PR DESCRIPTION
**Context:** When solving a merge conflict I accidentally removed the delimiters of a fenced code section at the changelog.md file.

**Description of the Change:** Place the delimiters back.