### PR TITLE
[Tests] Avoid warning from PL.

### DIFF
--- a/frontend/test/pytest/test_transform.py
+++ b/frontend/test/pytest/test_transform.py
@@ -41,7 +41,7 @@ try:
 except:  # pylint: disable=bare-except
     from pennylane.transforms import qcut
 
-from pennylane.transforms import hamiltonian_expand, merge_rotations, sum_expand
+from pennylane.transforms import merge_rotations, sum_expand
 
 from catalyst import measure, qjit
 from catalyst.utils.exceptions import CompileError
@@ -343,7 +343,7 @@ class TestHamiltonianExpand:
         def qnode_builder(device_name):
             """Builder"""
 
-            @hamiltonian_expand
+            @qml.transforms.split_non_commuting
             @qml.qnode(qml.device(device_name, wires=3))
             def qfunc():
                 """Example taken from PL tests."""
@@ -500,7 +500,7 @@ class TestTransformValidity:
         with pytest.raises(CompileError, match=msg):
 
             @qjit
-            @hamiltonian_expand
+            @qml.transforms.split_non_commuting
             @qml.qnode(qml.device(backend, wires=3))
             def qfunc():
                 """Example taken from PL tests."""


### PR DESCRIPTION
**Context:** PennyLaneDeprecationWarning: qml.transforms.hamiltonian_expand is deprecated and will be removed in version 0.39.
Instead, use qml.transforms.split_non_commuting, which can handle the same measurement type.

**Description of the Change:** Change hamiltonian_expand for split_non_commuting

**Benefits:** No warning in tests.

**Possible Drawbacks:** We won't be testing hamiltonian_expand.
