### PR TITLE
Extend QuantumGate interface with set methods

### DIFF
--- a/frontend/test/pytest/test_global_phase.py
+++ b/frontend/test/pytest/test_global_phase.py
@@ -74,3 +74,7 @@ def test_global_phase_control(backend):
     expected = qnn()
     observed = qjit(qnn)()
     assert np.allclose(expected, observed)
+
+
+if __name__ == "__main__":
+    pytest.main(["-x", __file__])

--- a/mlir/include/Quantum/IR/QuantumInterfaces.td
+++ b/mlir/include/Quantum/IR/QuantumInterfaces.td
@@ -64,16 +64,24 @@ def QuantumGate : OpInterface<"QuantumGate"> {
 
     let methods = [
         InterfaceMethod<
-            "Return all operands which are considered input qubit values.",
+            "Return all operands which are considered input qubit values (including controls).",
             "std::vector<mlir::Value>", "getQubitOperands"
         >,
         InterfaceMethod<
-            "Return all results which are considered output qubit values.",
+            "Set all operands which are considered input qubit values (including controls).",
+            "void", "setQubitOperands", (ins "mlir::ValueRange":$replacements)
+        >,
+        InterfaceMethod<
+            "Return all results which are considered output qubit values (including controls).",
             "std::vector<mlir::Value>", "getQubitResults"
         >,
         InterfaceMethod<
             "Return operands which are considered non-controlled input qubit values.",
             "mlir::ValueRange", "getNonCtrlQubitOperands"
+        >,
+        InterfaceMethod<
+            "Set all operands which are considered non-controlled input qubit values.",
+            "void", "setNonCtrlQubitOperands", (ins "mlir::ValueRange":$replacements)
         >,
         InterfaceMethod<
             "Return results which are considered non-controlled output qubit values.",
@@ -84,8 +92,16 @@ def QuantumGate : OpInterface<"QuantumGate"> {
             "mlir::ValueRange", "getCtrlQubitOperands"
         >,
         InterfaceMethod<
+            "Set all operands which are considered controlling input qubit values.",
+            "void", "setCtrlQubitOperands", (ins "mlir::ValueRange":$replacements)
+        >,
+        InterfaceMethod<
             "Return all operands which are considered controlling input boolean values.",
             "mlir::ValueRange", "getCtrlValueOperands"
+        >,
+        InterfaceMethod<
+            "Set all operands which are considered controlling input boolean values.",
+            "void", "setCtrlValueOperands", (ins "mlir::ValueRange":$replacements)
         >,
         InterfaceMethod<
             "Return all operands which are considered controlling output qubit values.",

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -194,7 +194,7 @@ def InsertOp : Memory_Op<"insert", [NoMemoryEffect]> {
 // -----
 
 class Gate_Op<string mnemonic, list<Trait> traits = []> :
-        Quantum_Op<mnemonic, traits # [NoMemoryEffect, QuantumGate, Unitary]> {
+        Quantum_Op<mnemonic, traits # [QuantumGate, Unitary]> {
 
     code extraBaseClassDeclaration = [{
         std::vector<mlir::Value> getQubitOperands() {
@@ -333,7 +333,7 @@ def SetBasisStateOp : Quantum_Op<"set_basis_state", []> {
     }];
 }
 
-def CustomOp : Gate_Op<"custom", [DifferentiableGate,
+def CustomOp : Gate_Op<"custom", [DifferentiableGate, NoMemoryEffect,
                                   AttrSizedOperandSegments, AttrSizedResultSegments]> {
     let summary = "A generic quantum gate on n qubits with m floating point parameters.";
     let description = [{
@@ -402,7 +402,8 @@ def GlobalPhaseOp : Gate_Op<"gphase", [DifferentiableGate, AttrSizedOperandSegme
     }];
 }
 
-def MultiRZOp : Gate_Op<"multirz", [DifferentiableGate, AttrSizedOperandSegments, AttrSizedResultSegments ]> {
+def MultiRZOp : Gate_Op<"multirz", [DifferentiableGate, NoMemoryEffect,
+                                    AttrSizedOperandSegments, AttrSizedResultSegments]> {
     let summary = "Apply an arbitrary multi Z rotation";
     let description = [{
         The `quantum.multirz` operation applies an arbitrary multi Z rotation to the state-vector.
@@ -433,8 +434,8 @@ def MultiRZOp : Gate_Op<"multirz", [DifferentiableGate, AttrSizedOperandSegments
     }];
 }
 
-def QubitUnitaryOp : Gate_Op<"unitary", [ParametrizedGate, AttrSizedOperandSegments,
-                                         AttrSizedResultSegments]> {
+def QubitUnitaryOp : Gate_Op<"unitary", [ParametrizedGate, NoMemoryEffect,
+                                         AttrSizedOperandSegments, AttrSizedResultSegments]> {
     let summary = "Apply an arbitrary fixed unitary matrix";
     let description = [{
         The `quantum.unitary` operation applies an arbitrary fixed unitary matrix to the

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -206,6 +206,16 @@ class Gate_Op<string mnemonic, list<Trait> traits = []> :
             return values;
         }
 
+        void setQubitOperands(mlir::ValueRange replacements) {
+            mlir::MutableOperandRange qubits = getInQubitsMutable();
+            mlir::MutableOperandRange ctrls = getInCtrlQubitsMutable();
+            assert(qubits.size() + ctrls.size() == replacements.size() &&
+                   "must provide values for all qubits (including controls)");
+
+            qubits.assign(replacements.take_front(qubits.size()));
+            ctrls.assign(replacements.take_back(ctrls.size()));
+        }
+
         std::vector<mlir::Value> getQubitResults() {
             std::vector<mlir::Value> values;
             values.insert(values.end(), getOutQubits().begin(),
@@ -225,11 +235,29 @@ class Gate_Op<string mnemonic, list<Trait> traits = []> :
         mlir::ValueRange getCtrlValueOperands() {
             return getInCtrlValues();
         }
+        void setCtrlValueOperands(mlir::ValueRange replacements) {
+            mlir::MutableOperandRange ctrlValues = getInCtrlValuesMutable();
+            assert(ctrlValues.size() == replacements.size() &&
+                   "must provide values for all control values");
+            ctrlValues.assign(replacements);
+        }
         mlir::ValueRange getNonCtrlQubitOperands() {
             return getInQubits();
         }
+        void setNonCtrlQubitOperands(mlir::ValueRange replacements) {
+            mlir::MutableOperandRange qubits = getInQubitsMutable();
+            assert(qubits.size() == replacements.size() &&
+                   "must provide values for all qubit values");
+            qubits.assign(replacements);
+        }
         mlir::ValueRange getCtrlQubitOperands() {
             return getInCtrlQubits();
+        }
+        void setCtrlQubitOperands(mlir::ValueRange replacements) {
+            mlir::MutableOperandRange ctrls = getInCtrlQubitsMutable();
+            assert(ctrls.size() == replacements.size() &&
+                   "must provide values for all control qubit values");
+            ctrls.assign(replacements);
         }
         mlir::ValueRange getNonCtrlQubitResults() {
             return getOutQubits();
@@ -306,7 +334,7 @@ def SetBasisStateOp : Quantum_Op<"set_basis_state", []> {
 }
 
 def CustomOp : Gate_Op<"custom", [DifferentiableGate,
-                                  AttrSizedOperandSegments, AttrSizedResultSegments ]> {
+                                  AttrSizedOperandSegments, AttrSizedResultSegments]> {
     let summary = "A generic quantum gate on n qubits with m floating point parameters.";
     let description = [{
     }];
@@ -336,7 +364,7 @@ def CustomOp : Gate_Op<"custom", [DifferentiableGate,
     }];
 }
 
-def GlobalPhaseOp : Quantum_Op<"gphase", [DifferentiableGate, AttrSizedOperandSegments]> {
+def GlobalPhaseOp : Gate_Op<"gphase", [DifferentiableGate, AttrSizedOperandSegments]> {
     let summary = "Global Phase.";
     let description = [{
     }];
@@ -356,51 +384,22 @@ def GlobalPhaseOp : Quantum_Op<"gphase", [DifferentiableGate, AttrSizedOperandSe
         `(` $params `)` attr-dict ( `ctrls` `(` $in_ctrl_qubits^ `)` )?  ( `ctrlvals` `(` $in_ctrl_values^ `)` )? `:` (`ctrls` type($out_ctrl_qubits)^ )?
     }];
 
-    code extraBaseClassDeclaration = [{
+    let extraClassDeclaration = extraBaseClassDeclaration # [{
         mlir::ValueRange getAllParams() {
             return getODSOperands(getParamOperandIdx());
         }
 
-        std::vector<mlir::Value> getQubitOperands() {
-            std::vector<mlir::Value> values;
-            values.insert(values.end(), getInCtrlQubits().begin(),
-                          getInCtrlQubits().end());
-            return values;
+        // Simulate missing operands and results for the default impl of the quantum gate interface.
+        mlir::OperandRange getInQubits() {
+            return {getOperands().begin(), getOperands().begin()};
         }
-
-        std::vector<mlir::Value> getQubitResults() {
-            std::vector<mlir::Value> values;
-            values.insert(values.end(), getOutCtrlQubits().begin(),
-                          getOutCtrlQubits().end());
-            return values;
+        mlir::MutableOperandRange getInQubitsMutable() {
+            return mlir::MutableOperandRange(getOperation(), 0, 0);
         }
-
-        bool getAdjointFlag() {
-            return getAdjoint().has_value() ? getAdjoint().value() : false;
-        }
-        void setAdjointFlag(bool adjoint) {
-            setAdjoint(adjoint);
-        };
-
-        mlir::ValueRange getCtrlValueOperands() {
-            return getInCtrlValues();
-        }
-        mlir::ValueRange getNonCtrlQubitOperands() {
-            return mlir::ValueRange();
-        }
-        mlir::ValueRange getCtrlQubitOperands() {
-            return getInCtrlQubits();
-        }
-        mlir::ValueRange getNonCtrlQubitResults() {
-            return mlir::ValueRange();
-        }
-        mlir::ValueRange getCtrlQubitResults() {
-            return getOutCtrlQubits();
+        mlir::ResultRange getOutQubits() {
+            return {getResults().begin(), getResults().begin()};
         }
     }];
-
-    let extraClassDeclaration = extraBaseClassDeclaration;
-
 }
 
 def MultiRZOp : Gate_Op<"multirz", [DifferentiableGate, AttrSizedOperandSegments, AttrSizedResultSegments ]> {
@@ -434,10 +433,8 @@ def MultiRZOp : Gate_Op<"multirz", [DifferentiableGate, AttrSizedOperandSegments
     }];
 }
 
-def QubitUnitaryOp : Gate_Op<"unitary", [ParametrizedGate
-        , AttrSizedOperandSegments
-        , AttrSizedResultSegments
-        ]> {
+def QubitUnitaryOp : Gate_Op<"unitary", [ParametrizedGate, AttrSizedOperandSegments,
+                                         AttrSizedResultSegments]> {
     let summary = "Apply an arbitrary fixed unitary matrix";
     let description = [{
         The `quantum.unitary` operation applies an arbitrary fixed unitary matrix to the


### PR DESCRIPTION
This facilitates operation manipulation for quantum transforms, like the local folding work in #1006.

[sc-71848]