### PR TITLE
Remove 'validate_device_capabilities' function and uses

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -539,6 +539,9 @@
 * Catalyst's implementation of Lightning Kokkos plugin has been removed in favor of Lightning's one.
   [(#974)](https://github.com/PennyLaneAI/catalyst/pull/974)
 
+* The `validate_device_capabilities` function is considered obsolete. Hence, it has been removed.
+  [(#1045)](https://github.com/PennyLaneAI/catalyst/pull/1045)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/frontend/catalyst/device/__init__.py
+++ b/frontend/catalyst/device/__init__.py
@@ -24,7 +24,6 @@ from catalyst.device.qjit_device import (
     get_device_capabilities,
     get_device_shots,
     get_device_toml_config,
-    validate_device_capabilities,
 )
 
 __all__ = (
@@ -32,7 +31,6 @@ __all__ = (
     "QJITDeviceNewAPI",
     "BackendInfo",
     "extract_backend_info",
-    "validate_device_capabilities",
     "get_device_capabilities",
     "get_device_shots",
     "get_device_toml_config",

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -45,7 +45,6 @@ from catalyst.device import (
     extract_backend_info,
     get_device_capabilities,
     get_device_shots,
-    validate_device_capabilities,
 )
 from catalyst.jax_extras import (
     deduce_avals,
@@ -127,9 +126,6 @@ class QFunc:
         program_features = ProgramFeatures(shots_present=bool(self.device.shots))
         device_capabilities = get_device_capabilities(self.device, program_features)
         backend_info = QFunc.extract_backend_info(self.device, device_capabilities)
-
-        # Validate decive operations against the declared capabilities
-        validate_device_capabilities(self.device, device_capabilities)
 
         if isinstance(self.device, qml.devices.Device):
             qjit_device = QJITDeviceNewAPI(self.device, device_capabilities, backend_info)

--- a/frontend/test/pytest/test_config_functions.py
+++ b/frontend/test/pytest/test_config_functions.py
@@ -22,7 +22,6 @@ import pennylane as qml
 import pytest
 
 from catalyst.device import QJITDeviceNewAPI
-from catalyst.device.qjit_device import validate_device_capabilities
 from catalyst.utils.exceptions import CompileError
 from catalyst.utils.toml import (
     ALL_SUPPORTED_SCHEMAS,
@@ -69,28 +68,6 @@ def get_test_device_capabilities(
     config = get_test_config(config_text)
     device_capabilities = load_device_capabilities(config, program_features)
     return device_capabilities
-
-
-@pytest.mark.parametrize("schema", ALL_SUPPORTED_SCHEMAS)
-def test_config_qjit_incompatible_device(schema):
-    """Test error is raised if checking for qjit compatibility and field is false in toml file."""
-    device_capabilities = get_test_device_capabilities(
-        ProgramFeatures(False),
-        dedent(
-            f"""
-                schema = {schema}
-                [compilation]
-                qjit_compatible = false
-            """
-        ),
-    )
-
-    name = DeviceToBeTested.name
-    with pytest.raises(
-        CompileError,
-        match=f"Attempting to compile program for incompatible device '{name}'",
-    ):
-        validate_device_capabilities(DeviceToBeTested(), device_capabilities)
 
 
 @pytest.mark.parametrize("schema", ALL_SUPPORTED_SCHEMAS)


### PR DESCRIPTION
**Context:** Validating the simulator's TOML file has helped us catch cases where a capability was added but the update not propagated to the TOML file. However, this validation is a big crutch and the issue of synchronicity should be solved more fundamentally. Additionally, the extra sections in the TOML file do not work well with modifiers like adjoint/control, and attempting to encode logic (should a gate be decomposed or turned into a unitary) is not well suited for a static format

**Description of the Change:** Remove 'validate_device_capabilities' function and uses

**Benefits:** Progressively stop using obsolete features in favor of a more robust device capability system.

**Possible Drawbacks:** We might stop catching cases where a capability was added in the simulator but not in the TOML file.

[sc-67124]