### PR TITLE
Replace non-portable 'cp -r' with portable 'cp -R' in script

### DIFF
--- a/setup_dev_from_wheel.sh
+++ b/setup_dev_from_wheel.sh
@@ -74,7 +74,7 @@ link_repo_to_wheel(){
     export CATALYST_WHEEL=$SITEPKGS/catalyst
 
     # Create hard links to the Wheel Python sources
-    cp -lrf $CATALYST_WHEEL $CATALYST_DIR/frontend/
+    cp -lRf $CATALYST_WHEEL $CATALYST_DIR/frontend/
 }
 
 restore_catalyst_config(){


### PR DESCRIPTION
**Context:** When executing the script for Frontend-Only development (`setup_dev_from_wheel.sh`) under MacOS Monterey (12.7.6) the `cp` command could not force-overwrite the repository files, because the `-r` option does not work (is not portable).

**Description of the Change:** Use the portable `-R` option instead.

**Benefits:** It will work under MacOS and Linux.