### PR TITLE
Removes Catalyst dev label from version

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -1,4 +1,4 @@
-# Release 0.8.0-dev
+# Release 0.8.0
 
 <h3>New features</h3>
 

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.8.0-dev18"
+__version__ = "0.8.0"


### PR DESCRIPTION
**Context:** `dev` label must be removed from the released code.