### PR TITLE
Fix nested verification

### DIFF
--- a/frontend/catalyst/device/verification.py
+++ b/frontend/catalyst/device/verification.py
@@ -62,7 +62,9 @@ def _verify_nested(
             for region in nested_quantum_regions(op):
                 if region.trace is not None:
                     with EvaluationContext.frame_tracing_context(ctx, region.trace):
-                        inner_state = _verify_nested(region.quantum_tape, inner_state, op_checker_fn)
+                        inner_state = _verify_nested(
+                            region.quantum_tape, inner_state, op_checker_fn
+                        )
                 else:
                     inner_state = _verify_nested(region.quantum_tape, inner_state, op_checker_fn)
     return state

--- a/frontend/catalyst/device/verification.py
+++ b/frontend/catalyst/device/verification.py
@@ -57,14 +57,14 @@ def _verify_nested(
 
     ctx = EvaluationContext.get_main_tracing_context()
     for op in tape.operations:
-        state = op_checker_fn(op, state)
+        inner_state = op_checker_fn(op, state)
         if has_nested_tapes(op):
             for region in nested_quantum_regions(op):
                 if region.trace is not None:
                     with EvaluationContext.frame_tracing_context(ctx, region.trace):
-                        state = _verify_nested(region.quantum_tape, state, op_checker_fn)
+                        inner_state = _verify_nested(region.quantum_tape, inner_state, op_checker_fn)
                 else:
-                    state = _verify_nested(region.quantum_tape, state, op_checker_fn)
+                    inner_state = _verify_nested(region.quantum_tape, inner_state, op_checker_fn)
     return state
 
 

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -25,7 +25,7 @@ import pytest
 from numpy.testing import assert_allclose
 from pennylane.ops.op_math.adjoint import Adjoint, AdjointOperation
 
-from catalyst import adjoint, cond, debug, for_loop, qjit, while_loop
+from catalyst import adjoint, cond, debug, for_loop, measure, qjit, while_loop
 
 # pylint: disable=too-many-lines,missing-class-docstring,missing-function-docstring,too-many-public-methods
 
@@ -1683,6 +1683,30 @@ class TestAdjointConstructorIntegration:
         expected_grad = jnp.cos(x)
         assert qml.math.allclose(circ(x), expected_res)
         assert qml.math.allclose(jax.grad(circ)(x), expected_grad)
+
+
+class TestMidCircuitMeasurementAfterAdjoint:
+
+    def test_issue_1055(self, backend):
+        """See https://github.com/PennyLaneAI/catalyst/issues/1055"""
+
+        def subroutine():
+            qml.Hadamard(wires=1)
+
+        @qml.qjit()
+        @qml.qnode(qml.device("lightning.qubit", wires=2))
+        def circuit():
+            # Comment/uncomment to toggle bug
+            adjoint(subroutine)()
+
+            res = measure(0)
+
+            # This call is just to show that it works after the measurement
+            adjoint(subroutine)()
+
+            return res
+
+        assert not circuit()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Context:** Nested verification is incorrectly applied.

**Description of the Change:** Avoids overwriting the variable `state` with another scope's `state`.

**Related GitHub Issues:** Fixes #1055

[sc-72156]