### PR TITLE
Track PL new stateprep error message

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.130
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt
-pennylane=0.38.0.dev21
+pennylane=0.38.0.dev24
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'. Also, update the 'LIGHTNING_GIT_TAG' at

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -32,4 +32,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.38.0-dev50
 pennylane-lightning==0.38.0-dev50
-pennylane==0.38.0.dev21
+pennylane==0.38.0.dev24

--- a/frontend/test/pytest/test_skip_initial_state_prep.py
+++ b/frontend/test/pytest/test_skip_initial_state_prep.py
@@ -184,11 +184,10 @@ class TestPossibleErrors:
 
     def test_array_less_than_size_basis_state(self):
         """Test what happens when the array is less than the size required.
-        In PennyLane the error raised is a ValueError, but all errors
-        in Catalyst that happen during runtime are RuntimeErrors.
+        In PennyLane the error raised is a ValueError.
         """
 
-        with pytest.raises(RuntimeError, match="State must be of length 2; got length 1"):
+        with pytest.raises(ValueError, match="State must be of length 2; got length 1"):
 
             @qml.qjit
             @qml.qnode(qml.device("lightning.qubit", wires=2))

--- a/frontend/test/pytest/test_skip_initial_state_prep.py
+++ b/frontend/test/pytest/test_skip_initial_state_prep.py
@@ -188,7 +188,7 @@ class TestPossibleErrors:
         in Catalyst that happen during runtime are RuntimeErrors.
         """
 
-        with pytest.raises(RuntimeError, match="must be of equal length"):
+        with pytest.raises(RuntimeError, match="State must be of length 2; got length 1"):
 
             @qml.qjit
             @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -200,7 +200,7 @@ class TestPossibleErrors:
 
     def test_different_shape_state_prep(self):
         """Test that the same error is raised"""
-        with pytest.raises(ValueError, match="State vector must have shape"):
+        with pytest.raises(ValueError, match="State must be of length 2; got length 1"):
 
             @qml.qjit
             @qml.qnode(qml.device("lightning.qubit", wires=2))


### PR DESCRIPTION
**Context:**
    PL recently changed error messages for bad stateprep/basisstate use cases (https://github.com/PennyLaneAI/pennylane/pull/6021).
    We update our tests to agree with them.

**Benefits:** Frontend tests `test_skip_initial_stateprep/TestPossibleErrors` can pass
