### PR TITLE
Remove unnecessary in-between variables for runtime/LightningSimulator.cpp/`SetState` (and `SetBasisState`)

### DIFF
--- a/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.cpp
+++ b/runtime/lib/backend/lightning/lightning_dynamic/LightningSimulator.cpp
@@ -108,17 +108,13 @@ void LightningSimulator::SetState(DataView<std::complex<double>, 1> &data,
                                   std::vector<QubitIdType> &wires)
 {
     std::vector<std::complex<double>> data_vector(data.begin(), data.end());
-    auto &&dev_wires = getDeviceWires(wires);
-    std::vector<std::size_t> wires_size_t(dev_wires.begin(), dev_wires.end());
-    this->device_sv->setStateVector(data_vector, wires_size_t);
+    this->device_sv->setStateVector(data_vector, getDeviceWires(wires));
 }
 
 void LightningSimulator::SetBasisState(DataView<int8_t, 1> &data, std::vector<QubitIdType> &wires)
 {
     std::vector<std::size_t> data_vector(data.begin(), data.end());
-    auto &&dev_wires = getDeviceWires(wires);
-    std::vector<std::size_t> wires_size_t(dev_wires.begin(), dev_wires.end());
-    this->device_sv->setBasisState(data_vector, wires_size_t);
+    this->device_sv->setBasisState(data_vector, getDeviceWires(wires));
 }
 
 auto LightningSimulator::Zero() const -> Result


### PR DESCRIPTION
**Context:**
    Eliminating an unnecessary in-between variable in runtime/LightningSimulator.cpp/setstate and setbasisstate, when getting dev_wires from sim_wires in the qubit manager's map. See https://github.com/PennyLaneAI/pennylane-lightning/pull/869#discussion_r1731715987, and https://github.com/PennyLaneAI/catalyst/pull/1047#discussion_r1733034395

**Benefits:** One less object initialization
