### PR TITLE
Fix `BasisState` to work with both i32 and i64 input states

### DIFF
--- a/doc/changelog.md
+++ b/doc/changelog.md
@@ -370,6 +370,7 @@
   are no longer decomposed when using Catalyst, improving compilation and runtime performance.
   [(#955)](https://github.com/PennyLaneAI/catalyst/pull/955)
   [(#1047)](https://github.com/PennyLaneAI/catalyst/pull/1047)
+  [(#1062)](https://github.com/PennyLaneAI/catalyst/pull/1062)
 
 * Improved type validation and error messaging has been added to both the `catalyst.jvp`
   and `catalyst.vjp` functions to ensure that the (co)tangent and parameter types are compatible.

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -608,7 +608,9 @@ def trace_basis_state(op, qrp):
     if not jnp.can_cast(basis_state.dtype, jnp.dtype(jnp.int64)):
         raise ValueError(err_msg)
 
-    basis_state_invalid_bits = jax.lax.bitwise_and(basis_state, ~0b1)
+    neg_one = jax.lax.convert_element_type(~0b1, jnp.dtype(basis_state.dtype))
+    basis_state_invalid_bits = jax.lax.bitwise_and(basis_state, neg_one)
+
     is_basis_state_invalid = jnp.any(basis_state_invalid_bits)
     is_basis_state_valid = jnp.logical_not(is_basis_state_invalid)
     debug_assert(is_basis_state_valid, err_msg)

--- a/frontend/test/pytest/test_skip_initial_state_prep.py
+++ b/frontend/test/pytest/test_skip_initial_state_prep.py
@@ -68,6 +68,7 @@ class TestExamplesFromWebsite:
         Test state prep when the state array is type i32 instead of i64.
         """
         state = jnp.array([0, 1, 0, 0], dtype=jnp.int32)
+
         @qml.qnode(qml.device(backend, wires=2))
         def example_circuit():
             qml.StatePrep(state, wires=range(2))
@@ -120,6 +121,7 @@ class TestExamplesFromWebsite:
         Test basis state when the state array is type i32 instead of i64.
         """
         state = jnp.array([1, 1, 0, 0, 0, 0], dtype=jnp.int32)
+
         @qml.qnode(qml.device(backend, wires=6))
         def example_circuit():
             qml.BasisState(state, wires=range(6))

--- a/frontend/test/pytest/test_skip_initial_state_prep.py
+++ b/frontend/test/pytest/test_skip_initial_state_prep.py
@@ -63,6 +63,20 @@ class TestExamplesFromWebsite:
         observed = jnp.array(qml.qjit(main)())
         assert jnp.allclose(expected, observed)
 
+    def test_state_prep_i32_array(self, backend):
+        """
+        Test state prep when the state array is type i32 instead of i64.
+        """
+        state = jnp.array([0, 1, 0, 0], dtype=jnp.int32)
+        @qml.qnode(qml.device(backend, wires=2))
+        def example_circuit():
+            qml.StatePrep(state, wires=range(2))
+            return qml.state()
+
+        expected = example_circuit()
+        observed = qml.qjit(example_circuit)()
+        assert jnp.allclose(expected, observed)
+
     def test_basis_state(self, backend):
         """Test example from
         https://docs.pennylane.ai/en/stable/code/api/pennylane.BasisState.html
@@ -99,6 +113,20 @@ class TestExamplesFromWebsite:
 
         expected = jnp.array(main())
         observed = jnp.array(qml.qjit(main)())
+        assert jnp.allclose(expected, observed)
+
+    def test_basis_state_i32_array(self, backend):
+        """
+        Test basis state when the state array is type i32 instead of i64.
+        """
+        state = jnp.array([1, 1, 0, 0, 0, 0], dtype=jnp.int32)
+        @qml.qnode(qml.device(backend, wires=6))
+        def example_circuit():
+            qml.BasisState(state, wires=range(6))
+            return qml.state()
+
+        expected = example_circuit()
+        observed = qml.qjit(example_circuit)()
         assert jnp.allclose(expected, observed)
 
     @pytest.mark.parametrize("wires", [(0), (1), (2)])


### PR DESCRIPTION
**Context:**
When tracing `qml.BasisState`, the user can provide the state |abcd...> with the {abcd} values being either i32 or i64. The tracing should explicitly detect the type the user entered to avoid issues with `bitwise_and`.

**Description of the Change:**
`jax_tracer.py/trace_basis_state` now actively queries the integer type of the input state vector and adheres to the input type when doing `bitwise_and` with -1.

**Benefits:**
`qml.BasisState` works with arbitrary input interger types

