### PR TITLE
Add install ccache step for MacOS

### DIFF
--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -111,7 +111,10 @@ The essential steps are:
 
         # Install XCode Command Line Tools and common requirements
         xcode-select --install
-        pip install cmake ninja
+        pip install cmake ninja rust
+
+        # Install Homebrew before using it for installing other packages
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         brew install libomp
 
         # Clone the Catalyst repository  
@@ -200,7 +203,8 @@ They can be installed via:
       .. code-block:: console
 
         xcode-select --install
-        pip install cmake ninja
+        pip install cmake ninja rust
+        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
         brew install libomp
 
 

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -111,10 +111,9 @@ The essential steps are:
 
         # Install XCode Command Line Tools and common requirements
         xcode-select --install
-        pip install cmake ninja rust
+        pip install cmake ninja
 
-        # Install Homebrew before using it for installing other packages
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        # If not present yet, install Homebrew (https://brew.sh/)
         brew install libomp ccache
 
         # Add ccache drop-in compiler replacements to the PATH
@@ -201,13 +200,14 @@ They can be installed via:
 
    .. group-tab:: macOS
 
-      On **macOS**, it is strongly recommended to install the official XCode Command Line Tools (for ``clang`` & ``make``). The remaining packages can then be installed via ``pip`` and ``brew``:
+      On **macOS**, it is strongly recommended to install the official XCode Command Line Tools (for ``clang`` & ``make``).
+      The remaining packages can then be installed via ``pip`` and ``brew``.
+      If ``brew`` is not present yet, install it from https://brew.sh/:
 
       .. code-block:: console
 
         xcode-select --install
-        pip install cmake ninja rust
-        /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        pip install cmake ninja
         brew install libomp ccache
         export PATH=/usr/local/opt/ccache/libexec:$PATH
 

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -115,7 +115,10 @@ The essential steps are:
 
         # Install Homebrew before using it for installing other packages
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-        brew install libomp
+        brew install libomp ccache
+
+        # Add ccache drop-in compiler replacements to the PATH
+        export PATH=/usr/local/opt/ccache/libexec:$PATH
 
         # Clone the Catalyst repository  
         git clone --recurse-submodules --shallow-submodules https://github.com/PennyLaneAI/catalyst.git
@@ -205,7 +208,8 @@ They can be installed via:
         xcode-select --install
         pip install cmake ninja rust
         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-        brew install libomp
+        brew install libomp ccache
+        export PATH=/usr/local/opt/ccache/libexec:$PATH
 
 
 


### PR DESCRIPTION
**Context:** Installing `ccache `via `brew `can avoid long build times.

**Description of the Change:** Add `ccache `installation via `brew`. Add hint on how to install `brew`.

**Benefits:** Shorter build times on MacOS.

Partially solves #382 

Closes #665 

[sc-67079]