### PR TITLE
[frontend] Fix parameter annotation

### DIFF
--- a/doc/releases/changelog-0.8.0.md
+++ b/doc/releases/changelog-0.8.0.md
@@ -615,6 +615,9 @@
   function inputs.
   [(#1003)](https://github.com/PennyLaneAI/catalyst/pull/1003)
 
+* Bug fixed when parameter annotations return strings.
+  [(#1078)](https://github.com/PennyLaneAI/catalyst/pull/1078)
+
 <h3>Documentation</h3>
 
 * A page has been added to the documentation, listing devices that are

--- a/frontend/catalyst/tracing/type_signatures.py
+++ b/frontend/catalyst/tracing/type_signatures.py
@@ -37,14 +37,17 @@ def get_param_annotations(fn: Callable):
     assert isinstance(fn, Callable)
     signature = inspect.signature(fn)
     parameters = signature.parameters
-    return (p.annotation for p in parameters.values())
+    return [p.annotation for p in parameters.values()]
 
 
 def params_are_annotated(fn: Callable):
     """Return true if all parameters are typed-annotated, or no parameters are present."""
     assert isinstance(fn, Callable)
     annotations = get_param_annotations(fn)
-    return all(annotation is not inspect.Parameter.empty for annotation in annotations)
+    are_annotated = all(annotation is not inspect.Parameter.empty for annotation in annotations)
+    if not are_annotated:
+        return False
+    return all(isinstance(annotation, (type, jax.core.ShapedArray)) for annotation in annotations)
 
 
 def get_type_annotations(fn: Callable):

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -29,6 +29,7 @@ from catalyst.jax_primitives import _scalar_abstractify
 from catalyst.tracing.type_signatures import (
     TypeCompatibility,
     get_abstract_signature,
+    params_are_annotated,
     typecheck_signatures,
 )
 
@@ -977,6 +978,15 @@ class TestGradPartial:
         expected = jax.grad(partial_fn)(0.3)
 
         assert np.allclose(grad_partial_fn(0.3), expected)
+
+
+class TestParamsAnnotations:
+    """Test param annotations"""
+
+    def test_params_invalid_annotation(self):
+        def foo(hello: "BAD ANNOTATION"): ...
+
+        assert not params_are_annotated(foo)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Context:** It is not entirely clear why, but some [functions return strings in their function annotations](https://github.com/python/cpython/blob/3.10/Lib/inspect.py#L2117-L2120). This is not enough to perform AOT compilation, so we should not do AOT compilation in these cases.

**Description of the Change:** Limit AOT compilation to instances of type and jax.core.ShapedArray.

**Benefits:** `expm` (and similar functions) can be called as `qjit(expm)`

**Possible Drawbacks:** None

**Related GitHub Issues:** #1077 
