### PR TITLE
Add missing contributor to release notes

### DIFF
--- a/doc/releases/changelog-0.8.0.md
+++ b/doc/releases/changelog-0.8.0.md
@@ -686,6 +686,7 @@ This release contains contributions from (in alphabetical order):
 Joey Carter,
 Alessandro Cosentino,
 Lillian M. A. Frederiksen,
+David Ittah,
 Josh Izaac,
 Christina Lee,
 Kunwar Maheep Singh,


### PR DESCRIPTION
Seems I have forgotten about this part 😅 