### PR TITLE
[tests] default.qubit.jax -> default.qubit

### DIFF
--- a/frontend/test/pytest/test_jvpvjp.py
+++ b/frontend/test/pytest/test_jvpvjp.py
@@ -175,7 +175,7 @@ def test_jvp_against_jax_full_argnum_case_S_SS(diff_method):
 
     @jax.jit
     def J_workflow():
-        f = qml.QNode(circuit_rx, device=qml.device("default.qubit.jax", wires=1), interface="jax")
+        f = qml.QNode(circuit_rx, device=qml.device("default.qubit", wires=1), interface="jax")
         return J_jvp(f, x, t)
 
     r1 = C_workflow()
@@ -423,7 +423,7 @@ def test_vjp_against_jax_full_argnum_case_S_SS(diff_method):
 
     @jax.jit
     def J_workflow():
-        f = qml.QNode(circuit_rx, device=qml.device("default.qubit.jax", wires=1), interface="jax")
+        f = qml.QNode(circuit_rx, device=qml.device("default.qubit", wires=1), interface="jax")
         y, ft = J_vjp(f, *x)
         ct2 = tree_unflatten(tree_flatten(y)[1], ct)
         return (y, ft(ct2))


### PR DESCRIPTION
**Context:** `default.qubit.jax` is being deprecated according to this warning:

```
  /home/ubuntu/code/env/lib/python3.10/site-packages/pennylane/devices/default_qubit_jax.py:173: PennyLaneDeprecationWarning: Use of 'default.qubit.jax' is deprecated. Instead, use 'default.qubit', which supports backpropagation. If you
 experience issues, reach out to the PennyLane team on the discussion forum: https://discuss.pennylane.ai/
    warnings.warn
```

**Description of the Change:** Use `default.qubit`

**Benefits:** No warning

No changelog since this is just in tests.

