### PR TITLE
[tests] Remove control_wires from MultiControlledX

### DIFF
--- a/frontend/test/pytest/test_operations.py
+++ b/frontend/test/pytest/test_operations.py
@@ -233,7 +233,7 @@ def test_multicontrolledx_via_paulix():
         qml.Hadamard(0)
         qml.Hadamard(1)
         qml.Hadamard(2)
-        qml.MultiControlledX(control_wires=[0, 1, 2], wires=[3], control_values=[True, False, True])
+        qml.MultiControlledX(wires=[0, 1, 2, 3], control_values=[True, False, True])
         return qml.state()
 
     assert "QubitUnitary" not in str(circuit.jaxpr)


### PR DESCRIPTION
**Context:** UserWarning is being triggered in one of the tests:

```
The control_wires keyword for MultiControlledX is deprecated, and will be removed soon. Use wires = (*control_wires, target_
wire) instead.
```

**Description of the Change:** Implement changes suggested by the warning

No changelog because this is only for tests.
