### PR TITLE
Move minimum Python version from 3.9 to 3.10

### DIFF
--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: [{major_minor: "3.9",  patch: "19", package: "python39"}]
+        python_version: [{major_minor: "3.10", patch: "14", package: "python3.10"}]
         container_img: ["quay.io/pypa/manylinux_2_28_aarch64"]
         container_name: ["manylinux_2_28_aarch64"]
 
@@ -206,8 +206,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        python_version: [{major_minor: "3.9",  patch: "19", package: "python39",   alternative: "39"},
-                         {major_minor: "3.10", patch: "14", package: "python3.10", alternative: "310"},
+        python_version: [{major_minor: "3.10", patch: "14", package: "python3.10", alternative: "310"},
                          {major_minor: "3.11", patch: "9",  package: "python3.11", alternative: "311"},
                          {major_minor: "3.12", patch: "3",  package: "python3.12", alternative: "312"}]
         container_img: ["quay.io/pypa/manylinux_2_28_aarch64"]
@@ -302,8 +301,7 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        python_version: [{major_minor: "3.9",  patch: "19", package: "python39"},
-                         {major_minor: "3.10", patch: "14", package: "python3.10"},
+        python_version: [{major_minor: "3.10", patch: "14", package: "python3.10"},
                          {major_minor: "3.11", patch: "9",  package: "python3.11"},
                          {major_minor: "3.12", patch: "3",  package: "python3.12"}]
         container_img: ["quay.io/pypa/manylinux_2_28_aarch64"]

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: [3.9]
+        python_version: ["3.10"]
         container_img: ["manylinux_2_28_x86_64"]
 
     name: Build Dependencies (Python ${{ matrix.python_version }})
@@ -296,7 +296,7 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path:  llvm-build
-        key: ${{ matrix.container_img }}-llvm-${{ needs.constants.outputs.llvm_version }}-3.9-wheel-build
+        key: ${{ matrix.container_img }}-llvm-${{ needs.constants.outputs.llvm_version }}-3.10-wheel-build
         fail-on-cache-miss: True
 
     - name: Get Cached MHLO Source

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: [3.9]
+        python_version: ["3.10"]
 
     name: Build Dependencies (Python ${{ matrix.python_version }})
     runs-on: macos-latest
@@ -124,7 +124,7 @@ jobs:
         lookup-only: True
 
     - name: Setup Python version
-      # There are multiple Python versions installed on the GitHub image, 3.9 - 3.12 is already
+      # There are multiple Python versions installed on the GitHub image, 3.10 - 3.12 is already
       # available under /Library/Frameworks/Python.framework/Versions/, but homebrew also provides
       # 3.11 and 3.12. Make sure to consistently use the system versions.
       run: |
@@ -232,7 +232,7 @@ jobs:
         brew install libomp
 
     - name: Setup Python version
-      # There are multiple Python versions installed on the GitHub image, 3.9 - 3.12 is already
+      # There are multiple Python versions installed on the GitHub image, 3.10 - 3.12 is already
       # available under /Library/Frameworks/Python.framework/Versions/, but homebrew also provides
       # 3.11 and 3.12. Make sure to consistently use the system versions.
       run: |
@@ -256,7 +256,7 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path:  llvm-build
-        key: ${{ runner.os }}-${{ runner.arch }}-llvm-${{ needs.constants.outputs.llvm_version }}-3.9-wheel-build
+        key: ${{ runner.os }}-${{ runner.arch }}-llvm-${{ needs.constants.outputs.llvm_version }}-3.10-wheel-build
         fail-on-cache-miss: True
 
     - name: Get Cached MHLO Source
@@ -391,7 +391,7 @@ jobs:
         path: dist
 
     - name: Setup Python version
-      # There are multiple Python versions installed on the GitHub image, 3.9 - 3.12 is already
+      # There are multiple Python versions installed on the GitHub image, 3.10 - 3.12 is already
       # available under /Library/Frameworks/Python.framework/Versions/, but homebrew also provides
       # 3.11 and 3.12. Make sure to consistently use the system versions.
       run: |

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python_version: [3.9]
+        python_version: ["3.10"]
 
     name: Build Dependencies (Python ${{ matrix.python_version }})
     runs-on: macos-12
@@ -246,7 +246,7 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path:  llvm-build
-        key: ${{ runner.os }}-${{ runner.arch }}-llvm-${{ needs.constants.outputs.llvm_version }}-3.9-wheel-build
+        key: ${{ runner.os }}-${{ runner.arch }}-llvm-${{ needs.constants.outputs.llvm_version }}-3.10-wheel-build
         fail-on-cache-miss: True
 
     - name: Get Cached MHLO Source

--- a/.github/workflows/constants.yaml
+++ b/.github/workflows/constants.yaml
@@ -74,7 +74,7 @@ jobs:
       - name: Python versions
         id: python_versions
         run: |
-          echo 'python_versions=["3.9", "3.10", "3.11", "3.12"]' >> $GITHUB_OUTPUT
+          echo 'python_versions=["3.10", "3.11", "3.12"]' >> $GITHUB_OUTPUT
 
       - name: Primary Python version
         id: primary_python_version

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ In addition, we also provide a Python frontend for [PennyLane](https://pennylane
 ## Installation
 
 Catalyst is officially supported on Linux (aarch64/arm64, x86_64) and macOS (aarch64/arm64, x86_64) platforms, 
-and pre-built binaries are being distributed via the Python Package Index (PyPI) for Python versions 3.9 and
+and pre-built binaries are being distributed via the Python Package Index (PyPI) for Python versions 3.10 and
 higher. To install it, simply run the following ``pip`` command:
 
 ```console

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -4,7 +4,7 @@ Installation
 
 Catalyst is officially supported on Linux (x86_64, aarch64) and macOS (arm64, x86_64) 
 platforms, and pre-built binaries are being distributed via the Python Package Index (PyPI) for 
-Python versions 3.9 and higher. To install it, simply run the following ``pip`` command:
+Python versions 3.10 and higher. To install it, simply run the following ``pip`` command:
 
 .. code-block:: console
 
@@ -161,7 +161,7 @@ installed and available on the path (depending on the platform):
 - The `Ninja <https://ninja-build.org/>`_, `Make <https://www.gnu.org/software/make/>`_, and
   `CMake <https://cmake.org/download/>`_ (v3.20 or greater) build tools.
 
-- `Python <https://www.python.org/>`_ 3.9 or higher for the Python frontend.
+- `Python <https://www.python.org/>`_ 3.10 or higher for the Python frontend.
 
 - The Python package manager ``pip`` must be version 22.3 or higher.
 

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,6 @@ classifiers = [
     "Operating System :: POSIX",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -216,7 +215,7 @@ setup(
     name="PennyLane-Catalyst",
     provides=["catalyst"],
     version=version,
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     entry_points=entry_points,
     install_requires=requirements,
     packages=find_namespace_packages(


### PR DESCRIPTION
**Context:** This PR removes support for Python 3.9 and migrates to 3.10 as the oldest supported version.

**Description of the Change:**

**Benefits:** 

**Possible Drawbacks:**

**Related GitHub Issues:** https://github.com/PennyLaneAI/pennylane-lightning/pull/891 https://github.com/PennyLaneAI/pennylane/pull/6223
