### PR TITLE
[build-system][tests] Add unittests for MLIR libraries

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -10,7 +10,7 @@ extension-pkg-allow-list=catalyst.utils.wrapper
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=pennylane.ops,jaxlib.mlir.ir,jaxlib.xla_extension
+ignored-modules=pennylane.ops,jaxlib.mlir.ir,jaxlib.xla_extension,lit.cfg
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work

--- a/.pylintrc
+++ b/.pylintrc
@@ -3,6 +3,7 @@
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code
 extension-pkg-allow-list=catalyst.utils.wrapper
+ignore-patterns=.*lit.cfg.*
 
 [TYPECHECK]
 
@@ -10,7 +11,7 @@ extension-pkg-allow-list=catalyst.utils.wrapper
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=pennylane.ops,jaxlib.mlir.ir,jaxlib.xla_extension,lit.cfg
+ignored-modules=pennylane.ops,jaxlib.mlir.ir,jaxlib.xla_extension
 
 # List of classes names for which member attributes should not be checked
 # (useful for classes with attributes dynamically set). This supports can work

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -72,6 +72,54 @@ add_definitions(${LLVM_DEFINITIONS})
 add_subdirectory(include)
 add_subdirectory(lib)
 add_subdirectory(tools)
+
+# Handle unittests when building out-of-tree against an installed version of
+# LLVM/MLIR (not a build tree). Adapted from `llvm/flang/CMakeLists.txt`.
+set(CATALYST_GTEST_AVAILABLE 0)
+if (TARGET llvm_gtest)
+  # Installed gtest, via LLVM_INSTALL_GTEST.  Preferred.
+  message(STATUS "LLVM GTest found, enabling unittests")
+  set(CATALYST_GTEST_AVAILABLE 1)
+else()
+    find_package(Threads REQUIRED)
+    set(LLVM_THIRD_PARTY_DIR llvm-project/third-party)
+    set(UNITTEST_DIR ${LLVM_THIRD_PARTY_DIR}/unittest)
+    if (NOT EXISTS ${UNITTEST_DIR}/googletest/include/gtest/gtest.h)
+      set(UNITTEST_DIR ${CMAKE_CURRENT_SOURCE_DIR}/llvm/third-party/unittest)
+    endif()
+    if (EXISTS ${UNITTEST_DIR}/googletest/include/gtest/gtest.h)
+      add_llvm_library(llvm_gtest
+        ${UNITTEST_DIR}/googletest/src/gtest-all.cc
+        ${UNITTEST_DIR}/googlemock/src/gmock-all.cc
+        LINK_COMPONENTS Support # llvm::raw_ostream
+        BUILDTREE_ONLY
+      )
+      target_include_directories(llvm_gtest
+        PUBLIC
+        "${UNITTEST_DIR}/googletest/include"
+        "${UNITTEST_DIR}/googlemock/include"
+        PRIVATE
+        "${UNITTEST_DIR}/googletest"
+        "${UNITTEST_DIR}/googlemock"
+      )
+      target_link_libraries(llvm_gtest PUBLIC Threads::Threads)
+      add_llvm_library(llvm_gtest_main
+        ${UNITTEST_DIR}/UnitTestMain/TestMain.cpp
+        LINK_LIBS llvm_gtest
+        LINK_COMPONENTS Support # llvm::cl
+        BUILDTREE_ONLY
+      )
+      set(CATALYST_GTEST_AVAILABLE 1)
+    else()
+      message(WARNING "Skipping unittests since LLVM install does not include \
+        gtest headers and libraries")
+      set(CATALYST_GTEST_AVAILABLE 0)
+    endif()
+endif()
+if (CATALYST_GTEST_AVAILABLE)
+  add_subdirectory(unittests)
+endif()
+
 add_subdirectory(test)
 
 if(QUANTUM_ENABLE_BINDINGS_PYTHON)

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -77,7 +77,7 @@ add_subdirectory(tools)
 # The following subsection of code                                           #
 # was taken from the CIRCT project: https://github.com/llvm/circt            #
 # Small alteration were made for Catalyst                                    #
-# The CIRCT project has a the following license:                             #
+# The CIRCT project has the following license:                               #
 #                                                                            #
 #   The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:  #
 #   As an incubator project with ambition to become part of the LLVM Project,#

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -73,6 +73,20 @@ add_subdirectory(include)
 add_subdirectory(lib)
 add_subdirectory(tools)
 
+##############################################################################
+# The following subsection of code                                           #
+# was taken from the CIRCT project: https://github.com/llvm/circt            #
+# Small alteration were made for Catalyst                                    #
+# The CIRCT project has a the following license:                             #
+#                                                                            #
+#   The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:  #
+#   As an incubator project with ambition to become part of the LLVM Project,#
+#   CIRCT is under the same license.                                         #
+#                                                                            #
+# https://github.com/llvm/circt/blob/                                        #
+#  930aabe70fe78965a153f6e936c5853e948873eb/CMakeLists.txt#L85-L126          #
+##############################################################################
+
 # Handle unittests when building out-of-tree against an installed version of
 # LLVM/MLIR (not a build tree). Adapted from `llvm/flang/CMakeLists.txt`.
 set(CATALYST_GTEST_AVAILABLE 0)
@@ -119,6 +133,10 @@ endif()
 if (CATALYST_GTEST_AVAILABLE)
   add_subdirectory(unittests)
 endif()
+
+######################
+# End of CIRCT code  #
+######################
 
 add_subdirectory(test)
 

--- a/mlir/Makefile
+++ b/mlir/Makefile
@@ -174,7 +174,7 @@ dialects:
 		-DLLVM_ENABLE_ZLIB=$(ENABLE_ZLIB) \
 		-DLLVM_ENABLE_ZSTD=$(ENABLE_ZSTD)
 
-	cmake --build $(DIALECTS_BUILD_DIR) --target check-dialects quantum-lsp-server catalyst-cli
+	cmake --build $(DIALECTS_BUILD_DIR) --target check-dialects quantum-lsp-server catalyst-cli check-unit-tests
 
 .PHONY: test
 test:

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -55,7 +55,7 @@ add_custom_target(check-all
 
 add_lit_testsuite(check-unit-tests "Just run unit tests"
     ${CMAKE_CURRENT_BINARY_DIR}/Unit
-    DEPENDS ${DIALECT_TEST_DEPENDS}
+    DEPENDS ${DIALECT_TEST_DEPENDS} check-dialects
 )
 
 set_target_properties(check-unit-tests PROPERTIES FOLDER "Unit Tests")

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -5,6 +5,13 @@ configure_lit_site_cfg(
     ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
 )
 
+configure_lit_site_cfg(
+    ${CMAKE_CURRENT_SOURCE_DIR}/Unit/lit.site.cfg.py.in
+    ${CMAKE_CURRENT_BINARY_DIR}/Unit/lit.site.cfg.py
+    MAIN_CONFIG
+    ${CMAKE_CURRENT_SOURCE_DIR}/Unit/lit.cfg.py
+)
+
 set(DIALECT_TESTS_DEPEND
     FileCheck
     quantum-opt
@@ -26,10 +33,16 @@ if(QUANTUM_ENABLE_BINDINGS_PYTHON)
     list(APPEND DIALECT_TESTS_DEPEND QuantumPythonModules)
 endif()
 
+if (CATALYST_GTEST_AVAILABLE)
+  list(APPEND DIALECT_TESTS_DEPEND CatalystUnitTests)
+endif()
+
 add_lit_testsuite(check-dialects "Run the regression tests for mlir dialects"
     ${TEST_SUITES}
     DEPENDS ${DIALECT_TESTS_DEPEND}
 )
+
+set_target_properties(check-dialects PROPERTIES FOLDER "Tests")
 
 add_subdirectory(frontend)
 
@@ -38,3 +51,12 @@ add_custom_target(check-all
     check-dialects
     check-frontend
 )
+
+
+add_lit_testsuite(check-unit-tests "Just run unit tests"
+    ${CMAKE_CURRENT_BINARY_DIR}/Unit
+    DEPENDS ${DIALECT_TEST_DEPENDS}
+)
+
+set_target_properties(check-unit-tests PROPERTIES FOLDER "Unit Tests")
+

--- a/mlir/test/Unit/lit.cfg.py
+++ b/mlir/test/Unit/lit.cfg.py
@@ -2,6 +2,20 @@
 
 # Configuration file for the 'lit' test runner.
 
+##############################################################################
+# The following subsection of code                                           #
+# was taken from the CIRCT project: https://github.com/llvm/circt            #
+# Small alteration were made for Catalyst                                    #
+# The CIRCT project has a the following license:                             #
+#                                                                            #
+#   The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:  #
+#   As an incubator project with ambition to become part of the LLVM Project,#
+#   CIRCT is under the same license.                                         #
+#                                                                            #
+#  https://github.com/llvm/circt/blob                                        #
+#  /a50540ecdbb2db641d14ffb682c9165c206dea26/test/Unit/lit.cfg.py            #
+##############################################################################
+
 import os
 import subprocess
 

--- a/mlir/test/Unit/lit.cfg.py
+++ b/mlir/test/Unit/lit.cfg.py
@@ -8,32 +8,32 @@ import subprocess
 import lit.formats
 
 # name: The name of this test suite.
-config.name = 'Catalyst-Unit'
+config.name = "Catalyst-Unit"
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = []
 
 # test_source_root: The root path where tests are located.
 # test_exec_root: The root path where tests should be run.
-config.test_exec_root = os.path.join(config.proj_obj_root, 'unittests')
+config.test_exec_root = os.path.join(config.proj_obj_root, "unittests")
 config.test_source_root = config.test_exec_root
 
 # testFormat: The test format to use to interpret tests.
-config.test_format = lit.formats.GoogleTest(config.llvm_build_mode, 'Tests')
+config.test_format = lit.formats.GoogleTest(config.llvm_build_mode, "Tests")
 
 # Propagate the temp directory. Windows requires this because it uses \Windows\
 # if none of these are present.
-if 'TMP' in os.environ:
-  config.environment['TMP'] = os.environ['TMP']
-if 'TEMP' in os.environ:
-  config.environment['TEMP'] = os.environ['TEMP']
+if "TMP" in os.environ:
+    config.environment["TMP"] = os.environ["TMP"]
+if "TEMP" in os.environ:
+    config.environment["TEMP"] = os.environ["TEMP"]
 
 # Propagate HOME as it can be used to override incorrect homedir in passwd
 # that causes the tests to fail.
-if 'HOME' in os.environ:
-  config.environment['HOME'] = os.environ['HOME']
+if "HOME" in os.environ:
+    config.environment["HOME"] = os.environ["HOME"]
 
 # Propagate path to symbolizer for ASan/MSan.
-for symbolizer in ['ASAN_SYMBOLIZER_PATH', 'MSAN_SYMBOLIZER_PATH']:
-  if symbolizer in os.environ:
-    config.environment[symbolizer] = os.environ[symbolizer]
+for symbolizer in ["ASAN_SYMBOLIZER_PATH", "MSAN_SYMBOLIZER_PATH"]:
+    if symbolizer in os.environ:
+        config.environment[symbolizer] = os.environ[symbolizer]

--- a/mlir/test/Unit/lit.cfg.py
+++ b/mlir/test/Unit/lit.cfg.py
@@ -6,7 +6,7 @@
 # The following subsection of code                                           #
 # was taken from the CIRCT project: https://github.com/llvm/circt            #
 # Small alteration were made for Catalyst                                    #
-# The CIRCT project has a the following license:                             #
+# The CIRCT project has the following license:                               #
 #                                                                            #
 #   The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:  #
 #   As an incubator project with ambition to become part of the LLVM Project,#

--- a/mlir/test/Unit/lit.cfg.py
+++ b/mlir/test/Unit/lit.cfg.py
@@ -1,0 +1,39 @@
+# -*- Python -*-
+
+# Configuration file for the 'lit' test runner.
+
+import os
+import subprocess
+
+import lit.formats
+
+# name: The name of this test suite.
+config.name = 'Catalyst-Unit'
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = []
+
+# test_source_root: The root path where tests are located.
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = os.path.join(config.proj_obj_root, 'unittests')
+config.test_source_root = config.test_exec_root
+
+# testFormat: The test format to use to interpret tests.
+config.test_format = lit.formats.GoogleTest(config.llvm_build_mode, 'Tests')
+
+# Propagate the temp directory. Windows requires this because it uses \Windows\
+# if none of these are present.
+if 'TMP' in os.environ:
+  config.environment['TMP'] = os.environ['TMP']
+if 'TEMP' in os.environ:
+  config.environment['TEMP'] = os.environ['TEMP']
+
+# Propagate HOME as it can be used to override incorrect homedir in passwd
+# that causes the tests to fail.
+if 'HOME' in os.environ:
+  config.environment['HOME'] = os.environ['HOME']
+
+# Propagate path to symbolizer for ASan/MSan.
+for symbolizer in ['ASAN_SYMBOLIZER_PATH', 'MSAN_SYMBOLIZER_PATH']:
+  if symbolizer in os.environ:
+    config.environment[symbolizer] = os.environ[symbolizer]

--- a/mlir/test/Unit/lit.site.cfg.py.in
+++ b/mlir/test/Unit/lit.site.cfg.py.in
@@ -1,0 +1,27 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+import sys
+
+config.llvm_src_root = "@LLVM_SOURCE_DIR@"
+config.llvm_obj_root = "@LLVM_BINARY_DIR@"
+config.llvm_tools_dir = "@LLVM_TOOLS_DIR@"
+config.llvm_build_mode = "@LLVM_BUILD_MODE@"
+config.enable_shared = "@ENABLE_SHARED@"
+config.shlibdir = "@SHLIBDIR@"
+config.proj_src_root = "@PROJECT_SOURCE_DIR@"
+config.proj_obj_root = "@PROJECT_BINARY_DIR@"
+config.proj_tools_dir = "@PROJECT_TOOLS_DIR@"
+
+# Support substitution of the tools_dir and build_mode with user parameters.
+# This is used when we can't determine the tool dir at configuration time.
+try:
+    config.llvm_tools_dir = config.llvm_tools_dir % lit_config.params
+    config.llvm_build_mode = config.llvm_build_mode % lit_config.params
+    config.shlibdir = config.shlibdir % lit_config.params
+except KeyError:
+    e = sys.exc_info()[1]
+    key, = e.args
+    lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
+
+# Let the main config do the real work.
+lit_config.load_config(config, "@PROJECT_SOURCE_DIR@/test/Unit/lit.cfg.py")

--- a/mlir/test/Unit/lit.site.cfg.py.in
+++ b/mlir/test/Unit/lit.site.cfg.py.in
@@ -5,7 +5,7 @@
 # The following subsection of code                                           #
 # was taken from the CIRCT project: https://github.com/llvm/circt            #
 # Small alteration were made for Catalyst                                    #
-# The CIRCT project has a the following license:                             #
+# The CIRCT project has the following license:                               #
 #                                                                            #
 #   The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:  #
 #   As an incubator project with ambition to become part of the LLVM Project,#

--- a/mlir/test/Unit/lit.site.cfg.py.in
+++ b/mlir/test/Unit/lit.site.cfg.py.in
@@ -1,5 +1,20 @@
 @LIT_SITE_CFG_IN_HEADER@
 
+
+##############################################################################
+# The following subsection of code                                           #
+# was taken from the CIRCT project: https://github.com/llvm/circt            #
+# Small alteration were made for Catalyst                                    #
+# The CIRCT project has a the following license:                             #
+#                                                                            #
+#   The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:  #
+#   As an incubator project with ambition to become part of the LLVM Project,#
+#   CIRCT is under the same license.                                         #
+#                                                                            #
+# https://github.com/llvm/circt/blob/                                        #
+#   a50540ecdbb2db641d14ffb682c9165c206dea26/test/Unit/lit.site.cfg.py.in    #
+##############################################################################
+
 import sys
 
 config.llvm_src_root = "@LLVM_SOURCE_DIR@"

--- a/mlir/unittests/CMakeLists.txt
+++ b/mlir/unittests/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_custom_target(CatalystUnitTests)
+set_target_properties(CatalystUnitTests PROPERTIES FOLDER "Catalyst Tests")
+
+if (CXX_SUPPORTS_SUGGEST_OVERRIDE_FLAG)
+  add_compile_options("-Wno-suggest-override")
+endif()
+
+function(add_catalyst_unittest test_dirname)
+  add_unittest(CatalystUnitTests ${test_dirname} ${ARGN})
+endfunction()
+
+add_subdirectory(Example)

--- a/mlir/unittests/Example/CMakeLists.txt
+++ b/mlir/unittests/Example/CMakeLists.txt
@@ -1,3 +1,10 @@
 add_catalyst_unittest(CatalystExampleTests
   Example.cpp
 )
+
+target_link_libraries(CatalystExampleTests PRIVATE
+  MLIRFuncDialect
+  MLIRQuantum
+  MLIRIR
+  MLIRParser
+)

--- a/mlir/unittests/Example/CMakeLists.txt
+++ b/mlir/unittests/Example/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_catalyst_unittest(CatalystExampleTests
+  Example.cpp
+)

--- a/mlir/unittests/Example/CMakeLists.txt
+++ b/mlir/unittests/Example/CMakeLists.txt
@@ -3,6 +3,7 @@ add_catalyst_unittest(CatalystExampleTests
 )
 
 target_link_libraries(CatalystExampleTests PRIVATE
+  MLIRArithDialect
   MLIRFuncDialect
   MLIRQuantum
   MLIRIR

--- a/mlir/unittests/Example/Example.cpp
+++ b/mlir/unittests/Example/Example.cpp
@@ -1,10 +1,34 @@
+#include "mlir/Parser/Parser.h"
+#include "mlir/AsmParser/AsmParser.h"
+#include "mlir/AsmParser/AsmParserState.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "Quantum/IR/QuantumOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Verifier.h"
+#include "llvm/Support/SourceMgr.h"
+
 #include "gtest/gtest.h"
-#include <unistd.h>
+
+using namespace mlir;
 
 namespace {
-TEST(Example, example)
-{
-    sleep(10);
-    ASSERT_TRUE(true);
+TEST(MLIRParser, ParseQuantumIR) {
+  std::string moduleStr = R"mlir(
+func.func @test_alloc_dealloc_no_fold() -> !quantum.bit {
+  %r = quantum.alloc(3) : !quantum.reg
+  %q = quantum.extract %r[0] : !quantum.reg -> !quantum.bit
+  quantum.dealloc %r : !quantum.reg
+  return %q : !quantum.bit
 }
-} // namespace
+  )mlir";
+
+  DialectRegistry registry;
+  registry.insert<func::FuncDialect, catalyst::quantum::QuantumDialect>();
+  MLIRContext context(registry);
+
+  ParserConfig config(&context, /*verifyAfterParse=*/false);
+
+  OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(moduleStr, config);
+  ASSERT_TRUE(module);
+}
+}

--- a/mlir/unittests/Example/Example.cpp
+++ b/mlir/unittests/Example/Example.cpp
@@ -2,8 +2,9 @@
 #include <unistd.h>
 
 namespace {
-TEST(Example, example) {
-     sleep(10);
-     ASSERT_TRUE(true);
+TEST(Example, example)
+{
+    sleep(10);
+    ASSERT_TRUE(true);
 }
-}
+} // namespace

--- a/mlir/unittests/Example/Example.cpp
+++ b/mlir/unittests/Example/Example.cpp
@@ -1,0 +1,9 @@
+#include "gtest/gtest.h"
+#include <unistd.h>
+
+namespace {
+TEST(Example, example) {
+     sleep(10);
+     ASSERT_TRUE(true);
+}
+}

--- a/mlir/unittests/Example/Example.cpp
+++ b/mlir/unittests/Example/Example.cpp
@@ -1,10 +1,24 @@
-#include "mlir/Parser/Parser.h"
+// Copyright 2024 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Quantum/IR/QuantumOps.h"
 #include "mlir/AsmParser/AsmParser.h"
 #include "mlir/AsmParser/AsmParserState.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "Quantum/IR/QuantumOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Verifier.h"
+#include "mlir/Parser/Parser.h"
 #include "llvm/Support/SourceMgr.h"
 
 #include "gtest/gtest.h"
@@ -12,8 +26,9 @@
 using namespace mlir;
 
 namespace {
-TEST(MLIRParser, ParseQuantumIR) {
-  std::string moduleStr = R"mlir(
+TEST(MLIRParser, ParseQuantumIR)
+{
+    std::string moduleStr = R"mlir(
 func.func @test_alloc_dealloc_no_fold() -> !quantum.bit {
   %r = quantum.alloc(3) : !quantum.reg
   %q = quantum.extract %r[0] : !quantum.reg -> !quantum.bit
@@ -22,13 +37,13 @@ func.func @test_alloc_dealloc_no_fold() -> !quantum.bit {
 }
   )mlir";
 
-  DialectRegistry registry;
-  registry.insert<func::FuncDialect, catalyst::quantum::QuantumDialect>();
-  MLIRContext context(registry);
+    DialectRegistry registry;
+    registry.insert<func::FuncDialect, catalyst::quantum::QuantumDialect>();
+    MLIRContext context(registry);
 
-  ParserConfig config(&context, /*verifyAfterParse=*/false);
+    ParserConfig config(&context, /*verifyAfterParse=*/false);
 
-  OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(moduleStr, config);
-  ASSERT_TRUE(module);
+    OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(moduleStr, config);
+    ASSERT_TRUE(module);
 }
-}
+} // namespace


### PR DESCRIPTION
**Context:** Sometimes we might need to develop our own library in MLIR which is not suitable for testing via passes.

**Description of the Change:** Add support for adding unittests for MLIR libraries.

**Benefits:** Tests.
