### PR TITLE
Fix broken link in slack notification

### DIFF
--- a/.github/workflows/notify-failed-jobs.yaml
+++ b/.github/workflows/notify-failed-jobs.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           status: ${{ github.event.workflow_run.conclusion }}
           notification_title: " ${{github.event.workflow_run.name}} - ${{github.event.workflow_run.conclusion}} on ${{github.event.workflow_run.head_branch}} - <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure>"
-          message_format: ":fire: *${{github.event.workflow_run.name}}* ${{github.event.workflow_run.conclusion}} in <${{github.server_url}}/${{github.repository}}/${{github.event.workflow_run.head_branch}}|${{github.repository}}>"
+          message_format: ":fire: *${{github.event.workflow_run.name}}* ${{github.event.workflow_run.conclusion}} in <${{github.server_url}}/${{github.repository}}/tree/${{github.event.workflow_run.head_branch}}|${{github.repository}}>"
           footer: "Linked Repo <${{github.server_url}}/${{github.repository}}|${{github.repository}}> | <${{github.server_url}}/${{github.repository}}/actions/runs/${{github.event.workflow_run.id}}|View Failure>"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFICATIONS_WEBHOOK_URL }}


### PR DESCRIPTION
The current notification includes a [PennyLaneAI/catalyst](https://github.com/PennyLaneAI/catalyst/main) link which does not work.