### PR TITLE
[tests] Add unit tests for `AccelerateContext`

### DIFF
--- a/frontend/test/pytest/test_contexts.py
+++ b/frontend/test/pytest/test_contexts.py
@@ -17,11 +17,41 @@ import numpy as np
 import pennylane as qml
 import pytest
 
-from catalyst import cond, grad, jacobian, measure, qjit, while_loop
-from catalyst.tracing.contexts import EvaluationContext, EvaluationMode, GradContext
+from catalyst import accelerate, cond, grad, jacobian, measure, qjit, while_loop
+from catalyst.tracing.contexts import (
+    AccelerateContext,
+    EvaluationContext,
+    EvaluationMode,
+    GradContext,
+)
 
 
 # pylint: disable=protected-access
+class TestAccelerateContext:
+    """Unit tests for accelerate context"""
+
+    def test_in_accelerate_context(self):
+        """Test that AccelerateContext returns True when in an accelerate context."""
+
+        @qjit
+        @accelerate
+        def identity(x: float):
+            assert AccelerateContext.am_inside_accelerate()
+            return x
+
+        identity(1.0)
+
+    def test_not_in_accelerate_context(self):
+        """Test that AccelerateContext returns False when not in an accelerate context."""
+
+        @qjit
+        def identity(x: float):
+            assert not AccelerateContext.am_inside_accelerate()
+            return x
+
+        identity(1.0)
+
+
 class TestGradContextUnitTests:
     """Unit tests for grad context"""
 


### PR DESCRIPTION
**Context:** We are removing a warning related to JAX linear algebra support in #1097, originally added in #1082, that is no longer needed. An `AccelerateContext` class was added in #1082 for the purpose of this warning, but with the removal of this warning and its associated unit tests, we now have no unit test coverage of the `AccelerateContext` class.

**Description of the Change:** Adds unit tests for `AccelerateContext`.

**Benefits:** Improved unit test coverage.

**Possible Drawbacks:** None

**Related GitHub Issues:**
