### PR TITLE
[Frontend] Remove static_size from AbstractQreg

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -30,6 +30,11 @@
 
 <h3>Breaking changes</h3>
 
+* Remove `static_size` field from `AbstractQreg` class.
+  [(#1113)](https://github.com/PennyLaneAI/catalyst/pull/1113)
+
+  This reverts a previous breaking change.
+
 <h3>Bug fixes</h3>
 
 * Those functions calling the `gather_p` primitive (like `jax.scipy.linalg.expm`)
@@ -48,5 +53,6 @@
 This release contains contributions from (in alphabetical order):
 
 Romain Moyard,
+Erick Ochoa Lopez,
 Paul Haochen Wang,
 Sengthai Heng,

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -1107,8 +1107,7 @@ class Cond(HybridOp):
         op = self
         for region in op.regions:
             with EvaluationContext.frame_tracing_context(ctx, region.trace):
-                reg_len = qrp.base.length
-                new_qreg = AbstractQreg(reg_len)
+                new_qreg = AbstractQreg()
                 qreg_in = _input_type_to_tracers(region.trace.new_arg, [new_qreg])[0]
                 qreg_out = trace_quantum_operations(
                     region.quantum_tape, device, qreg_in, ctx, region.trace
@@ -1167,8 +1166,7 @@ class ForLoop(HybridOp):
         expansion_strategy = self.expansion_strategy
 
         with EvaluationContext.frame_tracing_context(ctx, inner_trace):
-            reg_len = qrp.base.length
-            new_qreg = AbstractQreg(reg_len)
+            new_qreg = AbstractQreg()
             qreg_in = _input_type_to_tracers(inner_trace.new_arg, [new_qreg])[0]
             qrp_out = trace_quantum_operations(inner_tape, device, qreg_in, ctx, inner_trace)
             qreg_out = qrp_out.actualize()
@@ -1249,7 +1247,7 @@ class WhileLoop(HybridOp):
                 res_classical_tracers,
                 expansion_strategy=expansion_strategy,
             )
-            _input_type_to_tracers(cond_trace.new_arg, [AbstractQreg(qrp.base.length)])
+            _input_type_to_tracers(cond_trace.new_arg, [AbstractQreg()])
             cond_jaxpr, _, cond_consts = trace_to_jaxpr(
                 cond_trace, arg_expanded_classical_tracers, res_expanded_classical_tracers
             )
@@ -1260,7 +1258,7 @@ class WhileLoop(HybridOp):
         with EvaluationContext.frame_tracing_context(ctx, body_trace):
             region = self.regions[1]
             res_classical_tracers = region.res_classical_tracers
-            qreg_in = _input_type_to_tracers(body_trace.new_arg, [AbstractQreg(qrp.base.length)])[0]
+            qreg_in = _input_type_to_tracers(body_trace.new_arg, [AbstractQreg()])[0]
             qrp_out = trace_quantum_operations(body_tape, device, qreg_in, ctx, body_trace)
             qreg_out = qrp_out.actualize()
             arg_expanded_tracers = expand_args(

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -465,7 +465,7 @@ class HybridAdjoint(HybridOp):
             frame_ctx = EvaluationContext.frame_tracing_context(ctx, body_trace)
 
         with frame_ctx as body_trace:
-            qreg_in = _input_type_to_tracers(body_trace.new_arg, [AbstractQreg(qrp.base.length)])[0]
+            qreg_in = _input_type_to_tracers(body_trace.new_arg, [AbstractQreg()])[0]
             qrp_out = trace_quantum_operations(body_tape, device, qreg_in, ctx, body_trace)
             qreg_out = qrp_out.actualize()
             body_jaxpr, _, body_consts = ctx.frames[body_trace].to_jaxpr2(

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -235,7 +235,7 @@ class QFuncPlxprInterpreter:
         resets the wire map.
         """
         qdevice_p.bind(**_get_device_kwargs(self._device))
-        self.qreg = qalloc_p.bind(len(self._device.wires), static_size=len(self._device.wires))
+        self.qreg = qalloc_p.bind(len(self._device.wires))
         self.wire_map = {}
 
     def cleanup(self):

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -145,9 +145,6 @@ class AbstractQreg(AbstractValue):
 
     hash_value = hash("AbstractQreg")
 
-    def __init__(self, length):
-        self.length = length
-
     def __eq__(self, other):
         return isinstance(other, AbstractQreg)
 
@@ -987,17 +984,17 @@ def _qdevice_lowering(jax_ctx: mlir.LoweringRuleContext, rtd_lib, rtd_name, rtd_
 # qalloc
 #
 @qalloc_p.def_impl
-def _qalloc_def_impl(ctx, size_value, static_size=None):  # pragma: no cover
+def _qalloc_def_impl(ctx, size_value):  # pragma: no cover
     raise NotImplementedError()
 
 
 @qalloc_p.def_abstract_eval
-def _qalloc_abstract_eval(size, static_size=None):
+def _qalloc_abstract_eval(size):
     """This function is called with abstract arguments for tracing."""
-    return AbstractQreg(static_size)
+    return AbstractQreg()
 
 
-def _qalloc_lowering(jax_ctx: mlir.LoweringRuleContext, size_value: ir.Value, static_size=None):
+def _qalloc_lowering(jax_ctx: mlir.LoweringRuleContext, size_value: ir.Value):
     ctx = jax_ctx.module_context.context
     ctx.allow_unregistered_dialects = True
 
@@ -1083,7 +1080,7 @@ def _qinsert_abstract_eval(qreg_old, qubit_idx, qubit):
     """This function is called with abstract arguments for tracing."""
     assert isinstance(qreg_old, AbstractQreg)
     assert isinstance(qubit, AbstractQbit)
-    return AbstractQreg(qreg_old.length)
+    return AbstractQreg()
 
 
 def _qinsert_lowering(

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -249,7 +249,7 @@ def _apply_result_type_conversion(
         OutputSignature: new output signature of the function
     """
     with_qreg = len(target_types) > 0 and isinstance(target_types[-1], AbstractQreg)
-    args = [AbstractQreg(target_types[-1].length)] if with_qreg else []
+    args = [AbstractQreg()] if with_qreg else []
 
     def _fun(*in_tracers):
         out_tracers = eval_jaxpr(jaxpr, consts, *in_tracers)
@@ -289,12 +289,9 @@ def _promote_jaxpr_types(types: List[List[Any]]) -> List[Any]:
         all_ends_with_qreg or all_not_ends_with_qreg
     ), "We require either all-qregs or all-non-qregs as last items of the type lists"
     if all_ends_with_qreg:  # [1]
-        length = types[-1][-1].length
         types = [t[:-1] for t in types]
-    else:
-        length = None
     results = list(map(partial(reduce, jnp.promote_types), zip(*types)))
-    return results + ([AbstractQreg(length)] if all_ends_with_qreg else [])
+    return results + ([AbstractQreg()] if all_ends_with_qreg else [])
 
 
 @debug_logger
@@ -1223,7 +1220,7 @@ def trace_quantum_function(
                 rtd_name=device.backend_name,
                 rtd_kwargs=str(device.backend_kwargs),
             )
-            qreg_in = qalloc_p.bind(len(device.wires), static_size=len(device.wires))
+            qreg_in = qalloc_p.bind(len(device.wires))
 
             qnode_transformed = len(qnode_program) > 0
             for i, tape in enumerate(tapes):


### PR DESCRIPTION
**Context:** `AbstractQreg`'s `static_size` field is a remnant of an implementation of `StatePrep` optimization that was ultimately not implemented.

**Description of the Change:** Remove `AbstractQreg`'s `static_size` field

**Benefits:** Qrisp does not have to change their `AbstractQreg`'s initializations
