### PR TITLE
[tests] Remove test for operator.expand

### DIFF
--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -1686,7 +1686,6 @@ class TestDecomposition:
         ctrl_op = C_ctrl(base_op, control=ctrl_wires, work_wires=Wires("aux"))
 
         assert ctrl_op.decomposition() == expected
-        assert ctrl_op.expand().circuit == expected
 
     def test_decomposition_nested(self):
         """Tests decompositions of nested controlled operations"""
@@ -1696,7 +1695,6 @@ class TestDecomposition:
             qml.ops.Controlled(qml.RZ(0.123, wires=0), control_wires=[1, 2]),
         ]
         assert ctrl_op.decomposition() == expected
-        assert ctrl_op.expand().circuit == expected
 
     def test_decomposition_undefined(self):
         """Tests error raised when decomposition is undefined"""
@@ -1721,18 +1719,16 @@ class TestDecomposition:
         base = TempOperator("a")
         op = C_ctrl(base, control, control_values)
 
-        decomp1 = op.decomposition()
-        decomp2 = op.expand().circuit
+        decomp = op.decomposition()
 
-        for decomp in [decomp1, decomp2]:
-            assert qml.equal(decomp[0], qml.PauliX(1))
-            assert qml.equal(decomp[1], qml.PauliX(2))
+        assert qml.equal(decomp[0], qml.PauliX(1))
+        assert qml.equal(decomp[1], qml.PauliX(2))
 
-            assert isinstance(decomp[2], Controlled)
-            assert decomp[2].control_values == [True, True, True]
+        assert isinstance(decomp[2], Controlled)
+        assert decomp[2].control_values == [True, True, True]
 
-            assert qml.equal(decomp[3], qml.PauliX(1))
-            assert qml.equal(decomp[4], qml.PauliX(2))
+        assert qml.equal(decomp[3], qml.PauliX(1))
+        assert qml.equal(decomp[4], qml.PauliX(2))
 
     @pytest.mark.parametrize(
         "base_cls, params, base_wires, ctrl_wires, _, expected",


### PR DESCRIPTION
Context:

PennyLaneDeprecationWarning: 'Operator.expand' is deprecated and will be removed in version 0.39. The same behaviour can be achieved simply through 'qml.tape.QuantumScript(self.decomposition())'.

Description of the Change: Some expand tests were missing from being deleted in a previous PR. I am now deleting these tests.

Benefits: No warnings.
