### PR TITLE
[tests] Remove warning from complex to float cast

### DIFF
--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -88,7 +88,6 @@ class TestDifferentPrecisions:
         assert jnp.allclose(res_float32, res_float64)
 
 
-@pytest.mark.filterwarnings("ignore:Casting complex")
 class TestJittedWithOneTypeRunWithAnother:
     @pytest.mark.parametrize(
         "from_type,to_type",
@@ -245,7 +244,6 @@ class TestJittedWithOneTypeRunWithAnother:
         assert jnp.allclose(res_from, res_to)
 
 
-@pytest.mark.filterwarnings("ignore:Casting complex")
 class TestTypePromotion:
     @pytest.mark.parametrize(
         "promote_from,val",

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -113,7 +113,7 @@ class TestJittedWithOneTypeRunWithAnother:
         @qjit
         @qml.qnode(qml.device(backend, wires=1))
         def f(x):
-            if (x.dtype == jnp.dtype(jnp.complex64)):
+            if x.dtype == jnp.dtype(jnp.complex64):
                 x = jnp.real(x)
             qml.RX(x.astype(float), wires=0)
             return qml.state()
@@ -170,7 +170,7 @@ class TestJittedWithOneTypeRunWithAnother:
         @qjit
         @qml.qnode(qml.device(backend, wires=1))
         def f(x: jax.core.ShapedArray([], jnp.int8)):
-            if (x.dtype == jnp.dtype(jnp.complex64)):
+            if x.dtype == jnp.dtype(jnp.complex64):
                 x = jnp.real(x)
             qml.RX(x.astype(float), wires=0)
             return qml.state()
@@ -200,7 +200,7 @@ class TestJittedWithOneTypeRunWithAnother:
         @qjit
         @qml.qnode(qml.device(backend, wires=1))
         def f(x):
-            if (x.dtype == jnp.dtype(jnp.complex128)):
+            if x.dtype == jnp.dtype(jnp.complex128):
                 x = jnp.real(x)
             qml.RX(x.astype(float), wires=0)
             return qml.state()
@@ -296,7 +296,7 @@ class TestTypePromotion:
         @qjit
         @qml.qnode(qml.device(backend, wires=1))
         def f(x):
-            if (x.dtype == jnp.dtype(jnp.complex128)):
+            if x.dtype == jnp.dtype(jnp.complex128):
                 x = jnp.real(x)
             qml.RX(x.astype(float), wires=0)
             return qml.state()

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -113,6 +113,8 @@ class TestJittedWithOneTypeRunWithAnother:
         @qjit
         @qml.qnode(qml.device(backend, wires=1))
         def f(x):
+            if (x.dtype == jnp.dtype(jnp.complex64)):
+                x = jnp.real(x)
             qml.RX(x.astype(float), wires=0)
             return qml.state()
 
@@ -168,6 +170,8 @@ class TestJittedWithOneTypeRunWithAnother:
         @qjit
         @qml.qnode(qml.device(backend, wires=1))
         def f(x: jax.core.ShapedArray([], jnp.int8)):
+            if (x.dtype == jnp.dtype(jnp.complex64)):
+                x = jnp.real(x)
             qml.RX(x.astype(float), wires=0)
             return qml.state()
 
@@ -196,6 +200,8 @@ class TestJittedWithOneTypeRunWithAnother:
         @qjit
         @qml.qnode(qml.device(backend, wires=1))
         def f(x):
+            if (x.dtype == jnp.dtype(jnp.complex128)):
+                x = jnp.real(x)
             qml.RX(x.astype(float), wires=0)
             return qml.state()
 
@@ -290,6 +296,8 @@ class TestTypePromotion:
         @qjit
         @qml.qnode(qml.device(backend, wires=1))
         def f(x):
+            if (x.dtype == jnp.dtype(jnp.complex128)):
+                x = jnp.real(x)
             qml.RX(x.astype(float), wires=0)
             return qml.state()
 


### PR DESCRIPTION
**Context:**

```
  /home/ubuntu/code/env/lib/python3.10/site-packages/jax/_src/numpy/array_methods.py:68: DeprecationWarning: Casting from complex to real dtypes will soon raise a ValueError. Please first use jnp.real or jnp.imag to take the real/imaginary component of your input.
```

**Description of the Change:** Use `jnp.real` when necessary.

**Benefits:** No warning.
