### PR TITLE
[tests] Explicitly pass `ExecutionConfig` to qjit device in `test_qjit_device`

### DIFF
--- a/frontend/test/pytest/test_device_api.py
+++ b/frontend/test/pytest/test_device_api.py
@@ -60,8 +60,10 @@ class DummyDevice(Device):
         """Execution."""
         return circuits, execution_config
 
-    def preprocess(self, execution_config: ExecutionConfig = DefaultExecutionConfig):
+    def preprocess(self, execution_config=None):
         """Preprocessing."""
+        if execution_config is None:
+            execution_config = ExecutionConfig()
         transform_program = TransformProgram()
         transform_program.add_transform(split_non_commuting)
         return transform_program, execution_config
@@ -105,7 +107,8 @@ def test_qjit_device():
 
     # Check the preprocess of the new device
     with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
-        transform_program, _ = device_qjit.preprocess(ctx)
+        execution_config = ExecutionConfig()
+        transform_program, _ = device_qjit.preprocess(ctx, execution_config)
     assert transform_program
     assert len(transform_program) == 3
     assert transform_program[-2]._transform.__name__ == "verify_operations"

--- a/frontend/test/pytest/test_device_api.py
+++ b/frontend/test/pytest/test_device_api.py
@@ -19,7 +19,7 @@ import platform
 import pennylane as qml
 import pytest
 from pennylane.devices import Device
-from pennylane.devices.execution_config import DefaultExecutionConfig, ExecutionConfig
+from pennylane.devices.execution_config import ExecutionConfig
 from pennylane.transforms import split_non_commuting
 from pennylane.transforms.core import TransformProgram
 


### PR DESCRIPTION
**Context:** In certain contexts, the test `test_qjit_device` would fail in the "Test Wheels" CI action on some platforms, but not others. The test expects the `transform_program` object to have three items, i.e. `TransformProgram(catalyst_decompose, verify_operations, validate_measurements)`, but for the failing tests it has four items: the original three, plus `verify_no_state_variance_returns`. This item is added if the `gradient_method` of the config object is not `None` [here](https://github.com/PennyLaneAI/catalyst/blob/v0.8.0/frontend/catalyst/device/qjit_device.py#L498-L499).

I *suspect* the reason is that if the `preprocess` function is not explicitly given an `execution_config` object, then it defaults to `qml.devices.DefaultExecutionConfig`. `DefaultExecutionConfig` is a mutable object that may be altered by some other function, resulting in its `gradient_method` parameter to not be `None`. The failure on some platforms and not others may have been a result of running the tests in different orders (although this has not been confirmed).

**Description of the Change:** Explicitly pass a new `ExecutionConfig()` to the qjit device's `preprocess` function in the test `test_qjit_device`. This ensures that we are starting from a clean execution config and not defaulting to the `DefaultExecutionConfig` object, which may have been modified by another function.

**Benefits:** Improves testing robustness. Furthermore, this issue is blocking the merging of #1097; fixing this failing test will allow us to merge that PR.
