### PR TITLE
catalyst works with numpy 2.0

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.130
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt
-pennylane=0.39.0.dev10
+pennylane=0.39.0.dev16
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'. Also, update the 'LIGHTNING_GIT_TAG' at

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -86,6 +86,9 @@
   `qml.var` and `qml.probs` measurements in addiiton to `qml.sample`, using the `measurements_from_samples` transform.
   [(#1106)](https://github.com/PennyLaneAI/catalyst/pull/1106)
 
+* Catalyst now supports numpy 2.0
+  [(#1119)](https://github.com/PennyLaneAI/catalyst/pull/1119)
+
 <h3>Breaking changes</h3>
 
 * Remove `static_size` field from `AbstractQreg` class.
@@ -125,6 +128,7 @@ Joey Carter,
 Lillian M.A. Frederiksen,
 Romain Moyard,
 Erick Ochoa Lopez,
+Mehrdad Malekmohammadi,
 Paul Haochen Wang,
 Sengthai Heng,
 Daniel Strano,

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -32,4 +32,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.38.0
 pennylane-lightning==0.38.0
-pennylane==0.39.0.dev10
+pennylane==0.39.0.dev16

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ known_third_party = ["diastatic-malt", "jax", "jaxlib", "numpy", "pennylane"]
 skips = ["B607"]
 
 [build-system]
-requires = ["setuptools>=62", "wheel", "pybind11>=2.7.0", "numpy>=1.22,<2"]
+requires = ["setuptools>=62", "wheel", "pybind11>=2.7.0", "numpy>=1.22,<=2"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ known_third_party = ["diastatic-malt", "jax", "jaxlib", "numpy", "pennylane"]
 skips = ["B607"]
 
 [build-system]
-requires = ["setuptools>=62", "wheel", "pybind11>=2.7.0", "numpy>=1.22,<=2"]
+requires = ["setuptools>=62", "wheel", "pybind11>=2.12.0", "numpy==2.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ pip>=22.3
 numpy==2.0
 pybind11>=2.12.0
 PyYAML
+scipy==1.13
 
 # formatting/linting
 black

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@
 pip>=22.3
 
 # Build dependencies for non-Python components
-numpy==2
-pybind11>=2.8.0
+numpy==2.0
+pybind11>=2.12.0
 PyYAML
 
 # formatting/linting
@@ -26,5 +26,3 @@ nbmake
 # optional rt/test dependencies
 pennylane-lightning-kokkos
 amazon-braket-pennylane-plugin>1.27.1
-# TODO: remove pin once we support jax>=0.4.27
-# optax<0.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 pip>=22.3
 
 # Build dependencies for non-Python components
-numpy<2
+numpy==2
 pybind11>=2.8.0
 PyYAML
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ nbmake
 pennylane-lightning-kokkos
 amazon-braket-pennylane-plugin>1.27.1
 # TODO: remove pin once we support jax>=0.4.27
-optax<0.2.3
+# optax<0.2.3

--- a/setup.py
+++ b/setup.py
@@ -77,8 +77,8 @@ requirements = [
     f"jax=={jax_version}",
     f"jaxlib=={jax_version}",
     "tomlkit; python_version < '3.11'",
-    "scipy<1.13",
-    "numpy<2",
+    "scipy==1.13",
+    "numpy==2.0",
     "diastatic-malt>=2.15.2",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -77,8 +77,8 @@ requirements = [
     f"jax=={jax_version}",
     f"jaxlib=={jax_version}",
     "tomlkit; python_version < '3.11'",
-    "scipy==1.13",
-    "numpy==2.0",
+    "scipy<=1.13",
+    "numpy<=2.0",
     "diastatic-malt>=2.15.2",
 ]
 


### PR DESCRIPTION
**Context:** 
After [Pennylane support numpy 2.0](https://github.com/PennyLaneAI/pennylane/pull/6061), catalyst needs to add this support. 

**Description of the Change:**
1. Bump pennylane version to include the numpy 2.0 support
2. Since programs built using numpy 1.x would not readily work with numpy 2.0, we upgraded reuirements.txt to install numpy2.0. The reason is that wrapper.cpp uses the numpy C-API that should be built using numpy 2.x. 
3. pyblind11 dependency was upgraded to 2.12.0 which adds support to numpy 2.0
4. scipy dependency includes 1.13 which adds support for numpy 2.0
5. removed optax dependancy from requirements (it was a TODO and unrelated to numpy but would cause CI delay)

**Benefits:**
Adds support for numpy 2.0

**Related GitHub Issues:**

[sc-61401]