### PR TITLE
[test] Factor out `print_jaxpr/mlir` into a utility file in frontend lit tests

### DIFF
--- a/frontend/test/lit/lit.cfg.py
+++ b/frontend/test/lit/lit.cfg.py
@@ -23,7 +23,7 @@ config.test_format = lit.formats.ShTest(True)
 
 # Define the file extensions to treat as test files (with the exception of this file).
 config.suffixes = [".py"]
-config.excludes = ["lit.cfg.py"]
+config.excludes = ["lit.cfg.py", "lit_util_printers.py"]
 
 # Define the root path of where to look for tests.
 config.test_source_root = path.dirname(__file__)

--- a/frontend/test/lit/lit_util_printers.py
+++ b/frontend/test/lit/lit_util_printers.py
@@ -1,0 +1,39 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Utility for printing out jaxpr and mlir during frontend lit tests.
+"""
+
+
+def print_attr(f, attr, *args, aot: bool = False, **kwargs):
+    """Print function attribute"""
+    name = f"TEST {f.__name__}"
+    print("\n" + "-" * len(name))
+    print(f"{name}\n")
+    res = None
+    if not aot:
+        res = f(*args, **kwargs)
+    print(getattr(f, attr))
+    return res
+
+
+def print_jaxpr(f, *args, **kwargs):
+    """Print jaxpr code of a function"""
+    return print_attr(f, "jaxpr", *args, **kwargs)
+
+
+def print_mlir(f, *args, **kwargs):
+    """Print mlir code of a function"""
+    return print_attr(f, "mlir", *args, **kwargs)

--- a/frontend/test/lit/test_jax_dynamic_api.py
+++ b/frontend/test/lit/test_jax_dynamic_api.py
@@ -19,30 +19,9 @@
 import jax.numpy as jnp
 import pennylane as qml
 from jax.core import ShapedArray
+from lit_util_printers import print_jaxpr, print_mlir
 
 from catalyst import qjit
-
-
-def print_attr(f, attr, *args, aot: bool = False, **kwargs):
-    """Print function attribute"""
-    name = f"TEST {f.__name__}"
-    print("\n" + "-" * len(name))
-    print(f"{name}\n")
-    res = None
-    if not aot:
-        res = f(*args, **kwargs)
-    print(getattr(f, attr))
-    return res
-
-
-def print_jaxpr(f, *args, **kwargs):
-    """Print jaxpr code of a function"""
-    return print_attr(f, "jaxpr", *args, **kwargs)
-
-
-def print_mlir(f, *args, **kwargs):
-    """Print mlir code of a function"""
-    return print_attr(f, "mlir", *args, **kwargs)
 
 
 # CHECK-LABEL: test_qjit_dynamic_argument

--- a/frontend/test/lit/test_peephole_optimizations.py
+++ b/frontend/test/lit/test_peephole_optimizations.py
@@ -27,6 +27,7 @@ running -apply-transform-sequence.
 import shutil
 
 import pennylane as qml
+from lit_util_printers import print_jaxpr, print_mlir
 
 from catalyst import qjit
 from catalyst.debug import get_compilation_stage
@@ -43,28 +44,6 @@ def flush_peephole_opted_mlir_to_iostream(QJIT):
     """
     print(get_compilation_stage(QJIT, "QuantumCompilationPass"))
     shutil.rmtree(QJIT.__name__)
-
-
-def print_attr(f, attr, *args, aot: bool = False, **kwargs):
-    """Print function attribute"""
-    name = f"TEST {f.__name__}"
-    print("\n" + "-" * len(name))
-    print(f"{name}\n")
-    res = None
-    if not aot:
-        res = f(*args, **kwargs)
-    print(getattr(f, attr))
-    return res
-
-
-def print_jaxpr(f, *args, **kwargs):
-    """Print jaxpr code of a function"""
-    return print_attr(f, "jaxpr", *args, **kwargs)
-
-
-def print_mlir(f, *args, **kwargs):
-    """Print mlir code of a function"""
-    return print_attr(f, "mlir", *args, **kwargs)
 
 
 #

--- a/frontend/test/lit/test_split_multiple_tapes.py
+++ b/frontend/test/lit/test_split_multiple_tapes.py
@@ -25,30 +25,9 @@ from typing import Callable, Sequence
 
 import numpy as np
 import pennylane as qml
+from lit_util_printers import print_jaxpr, print_mlir
 
 from catalyst import qjit
-
-
-def print_attr(f, attr, *args, aot: bool = False, **kwargs):
-    """Print function attribute"""
-    name = f"TEST {f.__name__}"
-    print("\n" + "-" * len(name))
-    print(f"{name}\n")
-    res = None
-    if not aot:
-        res = f(*args, **kwargs)
-    print(getattr(f, attr))
-    return res
-
-
-def print_jaxpr(f, *args, **kwargs):
-    """Print jaxpr code of a function"""
-    return print_attr(f, "jaxpr", *args, **kwargs)
-
-
-def print_mlir(f, *args, **kwargs):
-    """Print mlir code of a function"""
-    return print_attr(f, "mlir", *args, **kwargs)
 
 
 def test_multiple_tape_transforms():


### PR DESCRIPTION
**Context:**
Multiple files in frontend python lit tests are now using the functions `print_jaxpr` and `print_mlir`; these functions also carry significant utility and are likely to be used in future lit tests as well.

**Description of the Change:**
Instead of repeating these functions in each file, we pull them out into a new file `lit_util_printers.py`.

**Benefits:**
No need to copy paste these functions into every lit test file.
