### PR TITLE
[docs] Removing `pip install` output dump in demo

### DIFF
--- a/demos/adaptive_circuits_demo.ipynb
+++ b/demos/adaptive_circuits_demo.ipynb
@@ -5,27 +5,7 @@
    "execution_count": 1,
    "id": "2fbc188e",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Defaulting to user installation because normal site-packages is not writeable\n",
-      "Requirement already satisfied: optax in /home/tzung-han.juang/.local/lib/python3.10/site-packages (0.2.2)\n",
-      "Requirement already satisfied: absl-py>=0.7.1 in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from optax) (2.1.0)\n",
-      "Requirement already satisfied: chex>=0.1.86 in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from optax) (0.1.86)\n",
-      "Requirement already satisfied: jax>=0.1.55 in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from optax) (0.4.23)\n",
-      "Requirement already satisfied: jaxlib>=0.1.37 in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from optax) (0.4.23)\n",
-      "Requirement already satisfied: numpy>=1.18.0 in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from optax) (1.26.4)\n",
-      "Requirement already satisfied: typing-extensions>=4.2.0 in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from chex>=0.1.86->optax) (4.12.2)\n",
-      "Requirement already satisfied: toolz>=0.9.0 in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from chex>=0.1.86->optax) (0.12.1)\n",
-      "Requirement already satisfied: ml-dtypes>=0.2.0 in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from jax>=0.1.55->optax) (0.4.0)\n",
-      "Requirement already satisfied: opt-einsum in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from jax>=0.1.55->optax) (3.3.0)\n",
-      "Requirement already satisfied: scipy>=1.9 in /home/tzung-han.juang/.local/lib/python3.10/site-packages (from jax>=0.1.55->optax) (1.12.0)\n",
-      "Note: you may need to restart the kernel to use updated packages.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%pip install optax"
    ]


### PR DESCRIPTION
**Context:**
There is some `pip install` dump in the documentation demo "Variational Quantum Eigensolver" https://docs.pennylane.ai/projects/catalyst/en/stable/demos/adaptive_circuits_demo.html. We remove it.

**Benefits:**
No `pip install` dump in documentation page.
