### PR TITLE
Prefer creating new `qml.devices.ExecutionConfig` objects over using the global `qml.devices.DefaultExecutionConfig`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -56,7 +56,9 @@
   [(#1130)](https://github.com/PennyLaneAI/catalyst/pull/1130)
 
 * Treat `qml.devices.DefaultExecutionConfig` as if it were immutable and make copies of it when
-  modifications are required.
+  modifications are required. Doing so helps avoid unexpected bugs and test failures when the
+  `DefaultExecutionConfig` object becomes modified from its original state.
+  [(#1137)](https://github.com/PennyLaneAI/catalyst/pull/1137)
 
 <h3>Contributors</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -55,6 +55,9 @@
   [(#1017)](https://github.com/PennyLaneAI/catalyst/pull/1017)
   [(#1130)](https://github.com/PennyLaneAI/catalyst/pull/1130)
 
+* Treat `qml.devices.DefaultExecutionConfig` as if it were immutable and make copies of it when
+  modifications are required.
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -55,9 +55,9 @@
   [(#1017)](https://github.com/PennyLaneAI/catalyst/pull/1017)
   [(#1130)](https://github.com/PennyLaneAI/catalyst/pull/1130)
 
-* Treat `qml.devices.DefaultExecutionConfig` as if it were immutable and make copies of it when
-  modifications are required. Doing so helps avoid unexpected bugs and test failures when the
-  `DefaultExecutionConfig` object becomes modified from its original state.
+* Prefer creating new `qml.devices.ExecutionConfig` objects over using the global
+  `qml.devices.DefaultExecutionConfig`. Doing so helps avoid unexpected bugs and test failures in
+  case the `DefaultExecutionConfig` object becomes modified from its original state.
   [(#1137)](https://github.com/PennyLaneAI/catalyst/pull/1137)
 
 <h3>Contributors</h3>

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -473,6 +473,9 @@ class QJITDeviceNewAPI(qml.devices.Device):
         # measurement transforms may change operations on the tape to accommodate
         # measurement transformations, so must occur before decomposition
         measurement_transforms = self._measurement_transform_program()
+        if config is qml.devices.DefaultExecutionConfig:
+            # Do not modify DefaultExecutionConfig; copy into new config and modify the copy
+            config = deepcopy(config)
         config.device_options["transforms_modify_measurements"] = bool(measurement_transforms)
         program = program + measurement_transforms
 

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -18,6 +18,7 @@ This module contains functions tracing and lowering JAX code to MLIR.
 
 import logging
 from contextlib import contextmanager
+from copy import deepcopy
 from dataclasses import dataclass
 from functools import partial, reduce
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
@@ -130,12 +131,12 @@ def _make_execution_config(qnode):
     used in preprocess to determine what decomposition and validation is needed."""
 
     if qnode:
-        _gradient_method = _in_gradient_tracing(qnode)
+        # Do not modify DefaultExecutionConfig; copy into new config and modify the copy
+        execution_config = deepcopy(qml.devices.DefaultExecutionConfig)
+        execution_config.gradient_method = _in_gradient_tracing(qnode)
     else:
-        _gradient_method = None
+        execution_config = qml.devices.DefaultExecutionConfig
 
-    execution_config = qml.devices.DefaultExecutionConfig
-    execution_config.gradient_method = _gradient_method
     return execution_config
 
 

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -18,7 +18,6 @@ This module contains functions tracing and lowering JAX code to MLIR.
 
 import logging
 from contextlib import contextmanager
-from copy import deepcopy
 from dataclasses import dataclass
 from functools import partial, reduce
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
@@ -130,12 +129,9 @@ def _make_execution_config(qnode):
     """Updates the execution_config object with information about execution. This is
     used in preprocess to determine what decomposition and validation is needed."""
 
+    execution_config = qml.devices.ExecutionConfig()
     if qnode:
-        # Do not modify DefaultExecutionConfig; copy into new config and modify the copy
-        execution_config = deepcopy(qml.devices.DefaultExecutionConfig)
         execution_config.gradient_method = _in_gradient_tracing(qnode)
-    else:
-        execution_config = qml.devices.DefaultExecutionConfig
 
     return execution_config
 

--- a/frontend/catalyst/third_party/oqc/oqc_device.py
+++ b/frontend/catalyst/third_party/oqc/oqc_device.py
@@ -15,8 +15,9 @@
 """This module contains the OQC device."""
 
 import os
+from typing import Optional
 
-from pennylane.devices import DefaultExecutionConfig, Device, ExecutionConfig
+from pennylane.devices import Device, ExecutionConfig
 from pennylane.transforms.core import TransformProgram
 
 try:
@@ -59,10 +60,13 @@ class OQCDevice(Device):
 
     def preprocess(
         self,
-        execution_config: ExecutionConfig = DefaultExecutionConfig,
+        execution_config: Optional[ExecutionConfig] = None,
     ):
         """This function defines the device transform program to be applied and an
         updated device configuration."""
+        if execution_config is None:
+            execution_config = ExecutionConfig()
+
         transform_program = TransformProgram()
         # TODO: Add transforms (check wires, check shots, no sample, only commuting measurements,
         # measurement from counts)

--- a/frontend/test/lit/test_device_api.py
+++ b/frontend/test/lit/test_device_api.py
@@ -17,10 +17,11 @@
 """Test for the device API.
 """
 import platform
+from typing import Optional
 
 import pennylane as qml
 from pennylane.devices import Device
-from pennylane.devices.execution_config import DefaultExecutionConfig, ExecutionConfig
+from pennylane.devices.execution_config import ExecutionConfig
 from pennylane.transforms.core import TransformProgram
 
 from catalyst import qjit
@@ -51,8 +52,11 @@ class DummyDevice(Device):
         """Execute"""
         return circuits, execution_config
 
-    def preprocess(self, execution_config: ExecutionConfig = DefaultExecutionConfig):
+    def preprocess(self, execution_config: Optional[ExecutionConfig] = None):
         """Preprocess"""
+        if execution_config is None:
+            execution_config = ExecutionConfig()
+
         transform_program = TransformProgram()
         transform_program.add_transform(qml.transforms.split_non_commuting)
         return transform_program, execution_config

--- a/frontend/test/pytest/test_device_api.py
+++ b/frontend/test/pytest/test_device_api.py
@@ -19,7 +19,7 @@ import platform
 import pennylane as qml
 import pytest
 from pennylane.devices import Device
-from pennylane.devices.execution_config import ExecutionConfig
+from pennylane.devices.execution_config import DefaultExecutionConfig, ExecutionConfig
 from pennylane.transforms import split_non_commuting
 from pennylane.transforms.core import TransformProgram
 
@@ -60,10 +60,8 @@ class DummyDevice(Device):
         """Execution."""
         return circuits, execution_config
 
-    def preprocess(self, execution_config=None):
+    def preprocess(self, execution_config: ExecutionConfig = DefaultExecutionConfig):
         """Preprocessing."""
-        if execution_config is None:
-            execution_config = ExecutionConfig()
         transform_program = TransformProgram()
         transform_program.add_transform(split_non_commuting)
         return transform_program, execution_config
@@ -107,8 +105,7 @@ def test_qjit_device():
 
     # Check the preprocess of the new device
     with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
-        execution_config = ExecutionConfig()
-        transform_program, _ = device_qjit.preprocess(ctx, execution_config)
+        transform_program, _ = device_qjit.preprocess(ctx)
     assert transform_program
     assert len(transform_program) == 3
     assert transform_program[-2]._transform.__name__ == "verify_operations"

--- a/frontend/test/pytest/test_device_api.py
+++ b/frontend/test/pytest/test_device_api.py
@@ -15,11 +15,12 @@
 """
 import pathlib
 import platform
+from typing import Optional
 
 import pennylane as qml
 import pytest
 from pennylane.devices import Device
-from pennylane.devices.execution_config import DefaultExecutionConfig, ExecutionConfig
+from pennylane.devices.execution_config import ExecutionConfig
 from pennylane.transforms import split_non_commuting
 from pennylane.transforms.core import TransformProgram
 
@@ -60,8 +61,11 @@ class DummyDevice(Device):
         """Execution."""
         return circuits, execution_config
 
-    def preprocess(self, execution_config: ExecutionConfig = DefaultExecutionConfig):
+    def preprocess(self, execution_config: Optional[ExecutionConfig] = None):
         """Preprocessing."""
+        if execution_config is None:
+            execution_config = ExecutionConfig()
+
         transform_program = TransformProgram()
         transform_program.add_transform(split_non_commuting)
         return transform_program, execution_config

--- a/frontend/test/pytest/test_measurement_transforms.py
+++ b/frontend/test/pytest/test_measurement_transforms.py
@@ -22,13 +22,14 @@ import platform
 import tempfile
 from dataclasses import replace
 from functools import partial
+from typing import Optional
 from unittest.mock import Mock, patch
 
 import numpy as np
 import pennylane as qml
 import pytest
 from pennylane.devices import Device
-from pennylane.devices.execution_config import DefaultExecutionConfig, ExecutionConfig
+from pennylane.devices.execution_config import ExecutionConfig
 from pennylane.transforms import split_non_commuting, split_to_single_terms
 from pennylane.transforms.core import TransformProgram
 
@@ -76,8 +77,11 @@ class DummyDevice(Device):
         """Execution."""
         return circuits, execution_config
 
-    def preprocess(self, execution_config: ExecutionConfig = DefaultExecutionConfig):
+    def preprocess(self, execution_config: Optional[ExecutionConfig] = None):
         """Preprocessing."""
+        if execution_config is None:
+            execution_config = ExecutionConfig()
+
         transform_program = TransformProgram()
         transform_program.add_transform(split_non_commuting)
         return transform_program, execution_config

--- a/frontend/test/pytest/test_preprocess.py
+++ b/frontend/test/pytest/test_preprocess.py
@@ -22,12 +22,13 @@ from functools import partial
 from os.path import join
 from tempfile import TemporaryDirectory
 from textwrap import dedent
+from typing import Optional
 
 import numpy as np
 import pennylane as qml
 import pytest
 from pennylane.devices import Device
-from pennylane.devices.execution_config import DefaultExecutionConfig, ExecutionConfig
+from pennylane.devices.execution_config import ExecutionConfig
 from pennylane.tape import QuantumScript
 from pennylane.transforms import split_non_commuting
 from pennylane.transforms.core import TransformProgram
@@ -108,8 +109,11 @@ class DummyDevice(Device):
         """Execution."""
         return circuits, execution_config
 
-    def preprocess(self, execution_config: ExecutionConfig = DefaultExecutionConfig):
+    def preprocess(self, execution_config: Optional[ExecutionConfig] = None):
         """Preprocessing."""
+        if execution_config is None:
+            execution_config = ExecutionConfig()
+
         transform_program = TransformProgram()
         transform_program.add_transform(split_non_commuting)
         return transform_program, execution_config

--- a/frontend/test/test_oqc/oqc/test_oqc_device.py
+++ b/frontend/test/test_oqc/oqc/test_oqc_device.py
@@ -70,6 +70,16 @@ class TestOQCDevice:
         tranform_program, _ = dev.preprocess()
         assert tranform_program == qml.transforms.core.TransformProgram()
 
+    def test_preprocess_with_config(self, set_dummy_oqc_env):
+        """Test the device preprocessing by explicitly passing an execution config"""
+        from catalyst.third_party.oqc import OQCDevice
+
+        dev = OQCDevice(backend="lucy", shots=1000, wires=8)
+        execution_config = qml.devices.ExecutionConfig()
+        tranform_program, config = dev.preprocess(execution_config)
+        assert tranform_program == qml.transforms.core.TransformProgram()
+        assert config == execution_config
+
     def test_get_c_interface(self, set_dummy_oqc_env):
         """Test the device get_c_interface method."""
         from catalyst.third_party.oqc import OQCDevice


### PR DESCRIPTION
**Context:** We modify the global execution config object `qml.devices.DefaultExecutionConfig` in a few places. This can lead to unexpected bugs and test failures, since many of the functions that use this object expect it to be in a "clean" state that has not been modified from its original state. There is a discussion happening in https://github.com/PennyLaneAI/pennylane/pull/6245 to make `DefaultExecutionConfig` immutable. In the meantime, we should be treating it as such in Catalyst, both for functional correctness and in preparation for this potential change. Better yet, we should prefer creating new `qml.devices.ExecutionConfig` objects over using the global variable to minimize risk of unintended modifications to it.

**Description of the Change:** For every function call where `DefaultExecutionConfig` is passed as a default argument, such as

```python
def preprocess(self, execution_config: ExecutionConfig = DefaultExecutionConfig):
    ...
```
replace it with the following pattern:

```python
def preprocess(self, execution_config: Optional[ExecutionConfig] = None):
    if execution_config is None:
        execution_config = ExecutionConfig()
    ...
```

In places where we explicitly create a new `ExecutionConfig` object, e.g. in `jax_tracer.py::_make_execution_config()`, we can make modifications to it directly. In places where we have implicitly created a new `ExecutionConfig` object, but leave the option open to pass in any `ExecutionConfig` object, we use `dataclasses.replace()` to make a shallow copy of the config (with a deep copy of any mutable attributes that need to be modified), and then modify the copy.

This change also partially reverts #1117 to use the original calls in `test_device_api.py`.

**Benefits:** Avoid unexpected bugs and test failures due to the `qml.devices.DefaultExecutionConfig` object being in an altered state.

**Possible Drawbacks:** `DefaultExecutionConfig` is still not inherently immutable, so we need to continue to be vigilant to not modify it.

**Related GitHub Issues:** Closes #1135.
