### PR TITLE
[tests] Seed to avoid nondeterminism

### DIFF
--- a/frontend/test/pytest/test_measurement_transforms.py
+++ b/frontend/test/pytest/test_measurement_transforms.py
@@ -374,7 +374,7 @@ class TestMeasurementTransforms:
             return measurement()
 
         theta = 2.5
-        res = qml.qjit(measurements_from_samples(circuit, dev.wires))(theta)
+        res = qml.qjit(seed=42)(measurements_from_samples(circuit, dev.wires))(theta)
 
         if len(measurement().wires) == 1:
             samples_expected = qml.qjit(circuit)(theta)


### PR DESCRIPTION
**Context:** Test `test_measurement_from_samples_with_sample_measurement` is noisy [\[0\]](https://github.com/PennyLaneAI/catalyst/actions/runs/10891653508/job/30224075414)[ \[1\]](https://github.com/PennyLaneAI/catalyst/actions/runs/10904718006)

**Description of the Change:** Seed test to avoid noise

**Benefits:** No noisy wheel failures

Notes: no changelog since this is only a change in tests.
