### PR TITLE
Move capability loading to QJITDevice constructor

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -88,6 +88,9 @@
 * Remove the old `QJITDevice` API.
   [(#1138)](https://github.com/PennyLaneAI/catalyst/pull/1138)
 
+* The device capability loading mechanism has been moved into the `QJITDevice` constructor.
+  [(#1141)](https://github.com/PennyLaneAI/catalyst/pull/1141)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -282,6 +282,14 @@ class QJITDevice(qml.devices.Device):
         backend_kwargs (Dict(str, AnyType)): An optional dictionary of the device specifications
     """
 
+    @staticmethod
+    @debug_logger
+    def extract_backend_info(
+        device: qml.QubitDevice, capabilities: DeviceCapabilities
+    ) -> BackendInfo:
+        """Wrapper around extract_backend_info in the runtime module."""
+        return extract_backend_info(device, capabilities)
+
     @debug_logger_init
     def __init__(
         self,
@@ -305,7 +313,7 @@ class QJITDevice(qml.devices.Device):
                 original_device, program_features
             )
         if backend is None:
-            backend = extract_backend_info(original_device, original_device_capabilities)
+            backend = QJITDevice.extract_backend_info(original_device, original_device_capabilities)
 
         self.backend_name = backend.c_interface_name
         self.backend_lib = backend.lpath

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -98,14 +98,6 @@ class QFunc:
     def __new__(cls):
         raise NotImplementedError()  # pragma: no-cover
 
-    @staticmethod
-    @debug_logger
-    def extract_backend_info(
-        device: qml.QubitDevice, capabilities: DeviceCapabilities
-    ) -> BackendInfo:
-        """Wrapper around extract_backend_info in the runtime module."""
-        return extract_backend_info(device, capabilities)
-
     # pylint: disable=no-member
     @debug_logger
     def __call__(self, *args, **kwargs):
@@ -122,13 +114,7 @@ class QFunc:
                 mcm_config.postselect_mode = mcm_config.postselect_mode or "hw-like"
                 return dynamic_one_shot(self, mcm_config=mcm_config)(*args, **kwargs)
 
-        # TODO: Move the capability loading and validation to the device constructor when the
-        # support for old device api is dropped.
-        program_features = ProgramFeatures(shots_present=bool(self.device.shots))
-        device_capabilities = get_device_capabilities(self.device, program_features)
-        backend_info = QFunc.extract_backend_info(self.device, device_capabilities)
-
-        qjit_device = QJITDevice(self.device, device_capabilities, backend_info)
+        qjit_device = QJITDevice(self.device)
 
         static_argnums = kwargs.pop("static_argnums", ())
         out_tree_expected = kwargs.pop("_out_tree_expected", [])

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -40,13 +40,7 @@ from pennylane.transforms.dynamic_one_shot import (
 
 import catalyst
 from catalyst.api_extensions import MidCircuitMeasure
-from catalyst.device import (
-    BackendInfo,
-    QJITDevice,
-    extract_backend_info,
-    get_device_capabilities,
-    get_device_shots,
-)
+from catalyst.device import QJITDevice, get_device_shots
 from catalyst.jax_extras import (
     deduce_avals,
     get_implicit_and_explicit_flat_args,
@@ -56,7 +50,6 @@ from catalyst.jax_primitives import func_p
 from catalyst.jax_tracer import trace_quantum_function
 from catalyst.logging import debug_logger
 from catalyst.tracing.type_signatures import filter_static_args
-from catalyst.utils.toml import DeviceCapabilities, ProgramFeatures
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/frontend/catalyst/third_party/cuda/catalyst_to_cuda_interpreter.py
+++ b/frontend/catalyst/third_party/cuda/catalyst_to_cuda_interpreter.py
@@ -39,7 +39,7 @@ import jax
 import pennylane as qml
 from jax.tree_util import tree_unflatten
 
-from catalyst.device import BackendInfo
+from catalyst.device import BackendInfo, QJITDevice
 from catalyst.jax_primitives import (
     AbstractObs,
     adjoint_p,
@@ -837,7 +837,7 @@ class QJIT_CUDAQ:
             return BackendInfo(device_name, interface_name, "", {})
 
         with Patcher(
-            (QFunc, "extract_backend_info", cudaq_backend_info),
+            (QJITDevice, "extract_backend_info", cudaq_backend_info),
             (qml.QNode, "__call__", QFunc.__call__),
         ):
             func = self.user_function

--- a/frontend/test/pytest/test_config_functions.py
+++ b/frontend/test/pytest/test_config_functions.py
@@ -21,7 +21,7 @@ from textwrap import dedent
 import pennylane as qml
 import pytest
 
-from catalyst.device import QJITDevice
+from catalyst.device import BackendInfo, QJITDevice
 from catalyst.utils.exceptions import CompileError
 from catalyst.utils.toml import (
     ALL_SUPPORTED_SCHEMAS,
@@ -278,8 +278,9 @@ def test_config_qjit_device_operations(schema):
             """
         ),
     )
+    backend = BackendInfo("default", "default", "", {})
     device = qml.device("lightning.qubit", wires=2, shots=1000)
-    qjit_device = QJITDevice(device, capabilities)
+    qjit_device = QJITDevice(device, capabilities, backend)
     assert "PauliX" in qjit_device.operations
     assert "PauliY" in qjit_device.observables
 

--- a/frontend/test/pytest/test_device_api.py
+++ b/frontend/test/pytest/test_device_api.py
@@ -28,13 +28,11 @@ from catalyst import qjit
 from catalyst.compiler import get_lib_path
 from catalyst.device import (
     QJITDevice,
-    extract_backend_info,
     get_device_capabilities,
     get_device_toml_config,
     qjit_device,
 )
 from catalyst.tracing.contexts import EvaluationContext, EvaluationMode
-from catalyst.utils.toml import ProgramFeatures
 
 # pylint:disable = protected-access,attribute-defined-outside-init
 

--- a/frontend/test/pytest/test_device_api.py
+++ b/frontend/test/pytest/test_device_api.py
@@ -99,9 +99,7 @@ def test_qjit_device():
     device = DummyDevice(wires=10, shots=2032)
 
     # Create qjit device
-    capabilities = get_device_capabilities(device, ProgramFeatures(bool(device.shots)))
-    backend_info = extract_backend_info(device, capabilities)
-    device_qjit = QJITDevice(device, capabilities, backend_info)
+    device_qjit = QJITDevice(device)
 
     # Check attributes of the new device
     assert device_qjit.shots == qml.measurements.Shots(2032)
@@ -136,14 +134,11 @@ def test_qjit_device_no_wires():
     """Test the qjit device from a device using the new api without wires set."""
     device = DummyDeviceNoWires(shots=2032)
 
-    # Create qjit device
-    capabilities = get_device_capabilities(device, ProgramFeatures(bool(device.shots)))
-    backend_info = extract_backend_info(device, capabilities)
-
     with pytest.raises(
         AttributeError, match="Catalyst does not support device instances without set wires."
     ):
-        QJITDevice(device, capabilities, backend_info)
+        # Create qjit device
+        QJITDevice(device)
 
 
 @pytest.mark.parametrize(
@@ -159,14 +154,11 @@ def test_qjit_device_invalid_wires(wires):
     device = DummyDeviceNoWires(shots=2032)
     device._wires = wires
 
-    # Create qjit device
-    capabilities = get_device_capabilities(device, ProgramFeatures(bool(device.shots)))
-    backend_info = extract_backend_info(device, capabilities)
-
     with pytest.raises(
         AttributeError, match="Catalyst requires continuous integer wire labels starting at 0"
     ):
-        QJITDevice(device, capabilities, backend_info)
+        # Create qjit device
+        QJITDevice(device)
 
 
 @pytest.mark.parametrize("shots", [2048, None])

--- a/frontend/test/pytest/test_measurement_transforms.py
+++ b/frontend/test/pytest/test_measurement_transforms.py
@@ -34,12 +34,7 @@ from pennylane.transforms import split_non_commuting, split_to_single_terms
 from pennylane.transforms.core import TransformProgram
 
 from catalyst.compiler import get_lib_path
-from catalyst.device import (
-    QJITDevice,
-    extract_backend_info,
-    get_device_capabilities,
-    get_device_toml_config,
-)
+from catalyst.device import QJITDevice, get_device_capabilities, get_device_toml_config
 from catalyst.device.decomposition import (
     measurements_from_counts,
     measurements_from_samples,

--- a/frontend/test/pytest/test_measurement_transforms.py
+++ b/frontend/test/pytest/test_measurement_transforms.py
@@ -267,9 +267,7 @@ class TestMeasurementTransforms:
         ) as dev:
 
             # transform is added to transform program
-            dev_capabilities = get_device_capabilities(dev, ProgramFeatures(bool(dev.shots)))
-            backend_info = extract_backend_info(dev, dev_capabilities)
-            qjit_dev = QJITDevice(dev, dev_capabilities, backend_info)
+            qjit_dev = QJITDevice(dev)
 
             with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
                 transform_program, _ = qjit_dev.preprocess(ctx)
@@ -542,24 +540,20 @@ class TestMeasurementTransforms:
         assert "Sum" in dev_capabilities.native_obs
         assert "Hamiltonian" in dev_capabilities.native_obs
         assert dev_capabilities.non_commuting_observables_flag is True
-        backend_info = extract_backend_info(dev, dev_capabilities)
-        qjit_dev1 = QJITDevice(dev, dev_capabilities, backend_info)
+        qjit_dev1 = QJITDevice(dev, dev_capabilities)
 
         # dev2 supports non-commuting observables but NOT sums - split_to_single_terms
         del dev_capabilities.native_obs["Sum"]
         del dev_capabilities.native_obs["Hamiltonian"]
-        backend_info = extract_backend_info(dev, dev_capabilities)
-        qjit_dev2 = QJITDevice(dev, dev_capabilities, backend_info)
+        qjit_dev2 = QJITDevice(dev, dev_capabilities)
 
         # dev3 supports does not support non-commuting observables OR sums - split_non_commuting
         dev_capabilities = replace(dev_capabilities, non_commuting_observables_flag=False)
-        backend_info = extract_backend_info(dev, dev_capabilities)
-        qjit_dev3 = QJITDevice(dev, dev_capabilities, backend_info)
+        qjit_dev3 = QJITDevice(dev, dev_capabilities)
 
         # dev4 supports sums but NOT non-commuting observables - split_non_commuting
         dev_capabilities = replace(dev_capabilities, non_commuting_observables_flag=False)
-        backend_info = extract_backend_info(dev, dev_capabilities)
-        qjit_dev4 = QJITDevice(dev, dev_capabilities, backend_info)
+        qjit_dev4 = QJITDevice(dev, dev_capabilities)
 
         # Check the preprocess
         with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:


### PR DESCRIPTION
**Context:** Now that we support the new device API only, we can move the device capability loading inside de QJITDevice constructor.

**Description of the Change:** Move the device capability loading inside de QJITDevice constructor.

**Benefits:** Less boiler-plate code.

[sc-67124]