### PR TITLE
Autograph automatic conversion of in-place operator-based array updates

### DIFF
--- a/doc/dev/autograph.rst
+++ b/doc/dev/autograph.rst
@@ -1001,7 +1001,7 @@ update (which uses the array `at` and the `add`, `multiply`, etc. methods) must 
 ...
 ...     return result
 
-Again, if updating a single index or slice of the array, Autograph supports conversion of
+Again, if updating a single index or slice of the array, then Autograph supports conversion of
 standard Python array operator assignment syntax for the equivalent in-place expressions
 listed in the `JAX documentation for jax.numpy.ndarray.at
 <https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.ndarray.at.html#jax.numpy.ndarray.at>`__:

--- a/doc/dev/autograph.rst
+++ b/doc/dev/autograph.rst
@@ -1001,7 +1001,7 @@ update (which uses the array `at` and the `add`, `multiply`, etc. methods) must 
 ...
 ...     return result
 
-Again, if updating a single index of the array, Autograph supports conversion of
+Again, if updating a single index or slice of the array, Autograph supports conversion of
 standard Python array operator assignment syntax for the equivalent in-place expressions
 listed in the `JAX documentation for jax.numpy.ndarray.at
 <https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.ndarray.at.html#jax.numpy.ndarray.at>`__:
@@ -1017,3 +1017,11 @@ listed in the `JAX documentation for jax.numpy.ndarray.at
 ...     return result
 
 Under the hood, Catalyst converts anything coming in the latter notation into the former one.
+
+The list of supported operators includes:
+- ``=`` (set)
+- ``+=`` (add)
+- ``-=`` (add with negation)
+- ``*=`` (multiply)
+- ``/=`` (divide)
+- ``**=`` (power)

--- a/doc/dev/autograph.rst
+++ b/doc/dev/autograph.rst
@@ -948,8 +948,8 @@ Notice that ``autograph=True`` must be set in order to process the
 ``autograph_include`` list, otherwise an error will be reported.
 
 
-In-place JAX array assignments
-------------------------------
+In-place JAX array updates
+--------------------------
 
 To update array values when using JAX, the `JAX syntax for array assignment
 <https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html#array-updates-x-at-idx-set-y>`__
@@ -985,5 +985,35 @@ of standard Python array assignment syntax:
 >>> y = jnp.zeros([11])
 >>> f(x, y)
 Array([25.,  2.,  0.,  2.75,  0.,  3.5,  0.,  4.25,  0., 5.,  0.], dtype=float64)
+
+Under the hood, Catalyst converts anything coming in the latter notation into the former one.
+
+Similarly, to update array values with an operation when using JAX, the JAX syntax for array
+update (which uses the array `at` and the `add`, `multiply`, etc. methods) must be used:
+
+>>> @qjit(autograph=True)
+... def f(x):
+...     first_dim = x.shape[0]
+...     result = jnp.copy(x)
+...
+...     for i in range(first_dim):
+...         result = result.at[i].multiply(2)
+...
+...     return result
+
+Again, if updating a single index of the array, Autograph supports conversion of
+standard Python array operator assignment syntax for the equivalent in-place expressions
+listed in the `JAX documentation for jax.numpy.ndarray.at
+<https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.ndarray.at.html#jax.numpy.ndarray.at>`__:
+
+>>> @qjit(autograph=True)
+... def f(x):
+...     first_dim = x.shape[0]
+...     result = jnp.copy(x)
+...
+...     for i in range(first_dim):
+...         result[i] *= 2
+...
+...     return result
 
 Under the hood, Catalyst converts anything coming in the latter notation into the former one.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -124,7 +124,7 @@
     * `x[i] /= y` in favor of `x.at[i].divide(y)`
     * `x[i] **= y` in favor of `x.at[i].power(y)`
 
-    ```py
+    ```python
     @qjit(autograph=True)
     def f(x):
       first_dim = x.shape[0]
@@ -134,6 +134,11 @@
         result[i] *= 2  # This is now supported
 
       return result
+    ```
+
+    ```pycon
+    >>> f(jnp.array([1, 2, 3]))
+    Array([2, 4, 6], dtype=int64)
     ```
 
 <h3>Improvements</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -118,7 +118,7 @@
   [(#769)](https://github.com/PennyLaneAI/catalyst/pull/769)
   [(#1143)](https://github.com/PennyLaneAI/catalyst/pull/1143)
 
-  Using operator assignment syntax in favor of at...operation expressions is now possible for the following operations:
+  Using operator assignment syntax in favor of at...op expressions is now possible for the following operations:
   * `x[i] += y` in favor of `x.at[i].add(y)`
   * `x[i] -= y` in favor of `x.at[i].add(-y)`
   * `x[i] *= y` in favor of `x.at[i].multiply(y)`

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -113,33 +113,34 @@
 
   Available MLIR passes are now documented and available within the
   [catalyst.passes module documentation](https://docs.pennylane.ai/projects/catalyst/en/stable/code/__init__.html#module-catalyst.passes).
-  * Support for usage of single index JAX array operator update
-    inside Autograph annotated functions.
-    [(#769)](https://github.com/PennyLaneAI/catalyst/pull/769)
 
-    Using operator assignment syntax in favor of at...operation expressions is now possible for the following operations:
-    * `x[i] += y` in favor of `x.at[i].add(y)`
-    * `x[i] -= y` in favor of `x.at[i].add(-y)`
-    * `x[i] *= y` in favor of `x.at[i].multiply(y)`
-    * `x[i] /= y` in favor of `x.at[i].divide(y)`
-    * `x[i] **= y` in favor of `x.at[i].power(y)`
+* Support for usage of single index JAX array operator update inside Autograph annotated functions.
+  [(#769)](https://github.com/PennyLaneAI/catalyst/pull/769)
+  [(#1143)](https://github.com/PennyLaneAI/catalyst/pull/1143)
 
-    ```python
-    @qjit(autograph=True)
-    def f(x):
-      first_dim = x.shape[0]
-      result = jnp.copy(x)
+  Using operator assignment syntax in favor of at...operation expressions is now possible for the following operations:
+  * `x[i] += y` in favor of `x.at[i].add(y)`
+  * `x[i] -= y` in favor of `x.at[i].add(-y)`
+  * `x[i] *= y` in favor of `x.at[i].multiply(y)`
+  * `x[i] /= y` in favor of `x.at[i].divide(y)`
+  * `x[i] **= y` in favor of `x.at[i].power(y)`
 
-      for i in range(first_dim):
-        result[i] *= 2  # This is now supported
+  ```python
+  @qjit(autograph=True)
+  def f(x):
+    first_dim = x.shape[0]
+    result = jnp.copy(x)
 
-      return result
-    ```
+    for i in range(first_dim):
+      result[i] *= 2  # This is now supported
 
-    ```pycon
-    >>> f(jnp.array([1, 2, 3]))
-    Array([2, 4, 6], dtype=int64)
-    ```
+    return result
+  ```
+
+  ```pycon
+  >>> f(jnp.array([1, 2, 3]))
+  Array([2, 4, 6], dtype=int64)
+  ```
 
 <h3>Improvements</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -220,5 +220,6 @@ Erick Ochoa Lopez,
 Mehrdad Malekmohammadi,
 Paul Haochen Wang,
 Sengthai Heng,
+Spencer Comin,
 Daniel Strano,
 Raul Torres.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -114,7 +114,7 @@
   Available MLIR passes are now documented and available within the
   [catalyst.passes module documentation](https://docs.pennylane.ai/projects/catalyst/en/stable/code/__init__.html#module-catalyst.passes).
 
-* Support for usage of single index JAX array operator update inside Autograph annotated functions.
+* Catalyst Autograph now supports updating a single index or a slice of JAX arrays using Python's array assignment operator syntax.
   [(#769)](https://github.com/PennyLaneAI/catalyst/pull/769)
   [(#1143)](https://github.com/PennyLaneAI/catalyst/pull/1143)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -118,7 +118,7 @@
   [(#769)](https://github.com/PennyLaneAI/catalyst/pull/769)
   [(#1143)](https://github.com/PennyLaneAI/catalyst/pull/1143)
 
-  Using operator assignment syntax in favor of at...op expressions is now possible for the following operations:
+  Using operator assignment syntax in favor of `at...op` expressions is now possible for the following operations:
   * `x[i] += y` in favor of `x.at[i].add(y)`
   * `x[i] -= y` in favor of `x.at[i].add(-y)`
   * `x[i] *= y` in favor of `x.at[i].multiply(y)`

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -113,6 +113,28 @@
 
   Available MLIR passes are now documented and available within the
   [catalyst.passes module documentation](https://docs.pennylane.ai/projects/catalyst/en/stable/code/__init__.html#module-catalyst.passes).
+  * Support for usage of single index JAX array operator update
+    inside Autograph annotated functions.
+    [(#769)](https://github.com/PennyLaneAI/catalyst/pull/769)
+
+    Using operator assignment syntax in favor of at...operation expressions is now possible for the following operations:
+    * `x[i] += y` in favor of `x.at[i].add(y)`
+    * `x[i] -= y` in favor of `x.at[i].add(-y)`
+    * `x[i] *= y` in favor of `x.at[i].multiply(y)`
+    * `x[i] /= y` in favor of `x.at[i].divide(y)`
+    * `x[i] **= y` in favor of `x.at[i].power(y)`
+
+    ```py
+    @qjit(autograph=True)
+    def f(x):
+      first_dim = x.shape[0]
+      result = jnp.copy(x)
+
+      for i in range(first_dim):
+        result[i] *= 2  # This is now supported
+
+      return result
+    ```
 
 <h3>Improvements</h3>
 

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -18,6 +18,7 @@ functions. The purpose is to convert imperative style code to functional or grap
 """
 import copy
 import functools
+import operator
 import warnings
 from typing import Any, Callable, Iterator, SupportsIndex, Tuple, Union
 
@@ -47,11 +48,7 @@ __all__ = [
     "or_",
     "not_",
     "set_item",
-    "update_item_with_add",
-    "update_item_with_sub",
-    "update_item_with_mult",
-    "update_item_with_div",
-    "update_item_with_pow",
+    "update_item_with_op",
 ]
 
 
@@ -587,9 +584,8 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
 def set_item(target, i, x):
     """An implementation of the AutoGraph 'set_item' function. The interface is defined by
     AutoGraph, here we merely provide an implementation of it in terms of Catalyst primitives.
-    The idea is to accept the much simpler single index assigment syntax for Jax arrays,
-    to subsequently transform it under the hood into the set of 'at' and 'set' calls that
-    Autograph supports. E.g.:
+    The idea is to accept a simple assigment syntax for Jax arrays, to subsequently transform
+    it under the hood into the set of 'at' and 'set' calls that Autograph supports. E.g.:
         target[i] = x -> target = target.at[i].set(x)
 
     .. note::
@@ -612,112 +608,12 @@ def set_item(target, i, x):
     return target
 
 
-def update_item_with_add(target, i, x):
-    """An implementation of the 'update_item_with_add' function from operator_update. The interface
+def update_item_with_op(target, index, x, op):
+    """An implementation of the 'update_item_with_op' function from operator_update. The interface
     is defined in operator_update.SingleIndexArrayOperatorUpdateTransformer, here we provide an
-    implementation in terms of Catalyst primitives. The idea is to accept the simpler single index
-    operator assignment syntax for Jax arrays, to subsequently transform it under the hood into the
-    set of 'at' and 'add' calls that Autograph supports. E.g.:
-        target[i] += x -> target = target.at[i].add(x)
-
-    .. note::
-        For this feature to work, 'converter.Feature.LISTS' had to be added to the
-        TOP_LEVEL_OPTIONS and NESTED_LEVEL_OPTIONS conversion options of our own Catalyst
-        Autograph transformer. If you create a new transformer and want to support this feature,
-        make sure you enable such option there as well.
-    """
-
-    # Apply the 'at...add' transformation only to Jax arrays.
-    # Otherwise, fallback to Python's default syntax.
-    if isinstance(target, DynamicJaxprTracer):
-        target = target.at[i].add(x)
-    else:
-        target[i] += x
-
-    return target
-
-
-def update_item_with_sub(target, i, x):
-    """An implementation of the 'update_item_with_sub' function from operator_update. The interface
-    is defined in operator_update.SingleIndexArrayOperatorUpdateTransformer, here we provide an
-    implementation in terms of Catalyst primitives. The idea is to accept the simpler single index
-    operator assignment syntax for Jax arrays, to subsequently transform it under the hood into the
-    set of 'at' and 'add' calls that Autograph supports. E.g.:
-        target[i] -= x -> target = target.at[i].add(-x)
-
-    .. note::
-        For this feature to work, 'converter.Feature.LISTS' had to be added to the
-        TOP_LEVEL_OPTIONS and NESTED_LEVEL_OPTIONS conversion options of our own Catalyst
-        Autograph transformer. If you create a new transformer and want to support this feature,
-        make sure you enable such option there as well.
-    """
-
-    # Apply the 'at...add' transformation only to Jax arrays.
-    # Otherwise, fallback to Python's default syntax.
-    if isinstance(target, DynamicJaxprTracer):
-        target = target.at[i].add(-x)
-    else:
-        target[i] -= x
-
-    return target
-
-
-def update_item_with_mult(target, i, x):
-    """An implementation of the 'update_item_with_mult' function from operator_update. The interface
-    is defined in operator_update.SingleIndexArrayOperatorUpdateTransformer, here we provide an
-    implementation in terms of Catalyst primitives. The idea is to accept the simpler single index
-    operator assignment syntax for Jax arrays, to subsequently transform it under the hood into the
-    set of 'at' and 'multiply' calls that Autograph supports. E.g.:
-        target[i] *= x -> target = target.at[i].multiply(x)
-
-    .. note::
-        For this feature to work, 'converter.Feature.LISTS' had to be added to the
-        TOP_LEVEL_OPTIONS and NESTED_LEVEL_OPTIONS conversion options of our own Catalyst
-        Autograph transformer. If you create a new transformer and want to support this feature,
-        make sure you enable such option there as well.
-    """
-
-    # Apply the 'at...multiply' transformation only to Jax arrays.
-    # Otherwise, fallback to Python's default syntax.
-    if isinstance(target, DynamicJaxprTracer):
-        target = target.at[i].multiply(x)
-    else:
-        target[i] *= x
-
-    return target
-
-
-def update_item_with_div(target, i, x):
-    """An implementation of the 'update_item_with_div' function from operator_update. The interface
-    is defined in operator_update.SingleIndexArrayOperatorUpdateTransformer, here we provide an
-    implementation in terms of Catalyst primitives. The idea is to accept the simpler single index
-    operator assignment syntax for Jax arrays, to subsequently transform it under the hood into the
-    set of 'at' and 'divide' calls that Autograph supports. E.g.:
-        target[i] /= x -> target = target.at[i].divide(x)
-
-    .. note::
-        For this feature to work, 'converter.Feature.LISTS' had to be added to the
-        TOP_LEVEL_OPTIONS and NESTED_LEVEL_OPTIONS conversion options of our own Catalyst
-        Autograph transformer. If you create a new transformer and want to support this feature,
-        make sure you enable such option there as well.
-    """
-
-    # Apply the 'at...divide' transformation only to Jax arrays.
-    # Otherwise, fallback to Python's default syntax.
-    if isinstance(target, DynamicJaxprTracer):
-        target = target.at[i].divide(x)
-    else:
-        target[i] /= x
-
-    return target
-
-
-def update_item_with_pow(target, i, x):
-    """An implementation of the 'update_item_with_pow' function from operator_update. The interface
-    is defined in operator_update.SingleIndexArrayOperatorUpdateTransformer, here we provide an
-    implementation in terms of Catalyst primitives. The idea is to accept the simpler single index
-    operator assignment syntax for Jax arrays, to subsequently transform it under the hood into the
-    set of 'at' and 'power' calls that Autograph supports. E.g.:
+    implementation in terms of Catalyst primitives. The idea is to accept an operator assignment
+    syntax for Jax arrays, to subsequently transform it under the hood into the set of 'at' and
+    operator calls that Autograph supports. E.g.:
         target[i] **= x -> target = target.at[i].power(x)
 
     .. note::
@@ -726,14 +622,30 @@ def update_item_with_pow(target, i, x):
         Autograph transformer. If you create a new transformer and want to support this feature,
         make sure you enable such option there as well.
     """
+    # Mapping of the gast attributes to the corresponding JAX operation
+    gast_op_map = {"mult": "multiply", "div": "divide", "add": "add", "sub": "add", "pow": "power"}
+    # Mapping of the gast attributes to the corresponding in-place operation
+    inplace_operation_map = {
+        "mult": "mul",
+        "div": "truediv",
+        "add": "add",
+        "sub": "add",
+        "pow": "pow",
+    }
+    ## For sub, we need to use add and negate the value of x
+    if op == "sub":
+        x = -x
 
-    # Apply the 'at...power' transformation only to Jax arrays.
+    # Apply the 'at...op' transformation only to Jax arrays.
     # Otherwise, fallback to Python's default syntax.
     if isinstance(target, DynamicJaxprTracer):
-        target = target.at[i].power(x)
+        if isinstance(index, slice):
+            target = getattr(target.at[index.start : index.stop : index.step], gast_op_map[op])(x)
+        else:
+            target = getattr(target.at[index], gast_op_map[op])(x)
     else:
-        target[i] **= x
-
+        # Use Python's in-place operator
+        target[index] = getattr(operator, f"__i{inplace_operation_map[op]}__")(target[index], x)
     return target
 
 

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -47,6 +47,11 @@ __all__ = [
     "or_",
     "not_",
     "set_item",
+    "update_item_with_add",
+    "update_item_with_sub",
+    "update_item_with_mult",
+    "update_item_with_div",
+    "update_item_with_pow",
 ]
 
 
@@ -603,6 +608,131 @@ def set_item(target, i, x):
             target = target.at[i].set(x)
     else:
         target[i] = x
+
+    return target
+
+
+def update_item_with_add(target, i, x):
+    """An implementation of the 'update_item_with_add' function from operator_update. The interface
+    is defined in operator_update.SingleIndexArrayOperatorUpdateTransformer, here we provide an
+    implementation in terms of Catalyst primitives. The idea is to accept the simpler single index
+    operator assignment syntax for Jax arrays, to subsequently transform it under the hood into the
+    set of 'at' and 'add' calls that Autograph supports. E.g.:
+        target[i] += x -> target = target.at[i].add(x)
+
+    .. note::
+        For this feature to work, 'converter.Feature.LISTS' had to be added to the
+        TOP_LEVEL_OPTIONS and NESTED_LEVEL_OPTIONS conversion options of our own Catalyst
+        Autograph transformer. If you create a new transformer and want to support this feature,
+        make sure you enable such option there as well.
+    """
+
+    # Apply the 'at...add' transformation only to Jax arrays.
+    # Otherwise, fallback to Python's default syntax.
+    if isinstance(target, DynamicJaxprTracer):
+        target = target.at[i].add(x)
+    else:
+        target[i] += x
+
+    return target
+
+
+def update_item_with_sub(target, i, x):
+    """An implementation of the 'update_item_with_sub' function from operator_update. The interface
+    is defined in operator_update.SingleIndexArrayOperatorUpdateTransformer, here we provide an
+    implementation in terms of Catalyst primitives. The idea is to accept the simpler single index
+    operator assignment syntax for Jax arrays, to subsequently transform it under the hood into the
+    set of 'at' and 'add' calls that Autograph supports. E.g.:
+        target[i] -= x -> target = target.at[i].add(-x)
+
+    .. note::
+        For this feature to work, 'converter.Feature.LISTS' had to be added to the
+        TOP_LEVEL_OPTIONS and NESTED_LEVEL_OPTIONS conversion options of our own Catalyst
+        Autograph transformer. If you create a new transformer and want to support this feature,
+        make sure you enable such option there as well.
+    """
+
+    # Apply the 'at...add' transformation only to Jax arrays.
+    # Otherwise, fallback to Python's default syntax.
+    if isinstance(target, DynamicJaxprTracer):
+        target = target.at[i].add(-x)
+    else:
+        target[i] -= x
+
+    return target
+
+
+def update_item_with_mult(target, i, x):
+    """An implementation of the 'update_item_with_mult' function from operator_update. The interface
+    is defined in operator_update.SingleIndexArrayOperatorUpdateTransformer, here we provide an
+    implementation in terms of Catalyst primitives. The idea is to accept the simpler single index
+    operator assignment syntax for Jax arrays, to subsequently transform it under the hood into the
+    set of 'at' and 'multiply' calls that Autograph supports. E.g.:
+        target[i] *= x -> target = target.at[i].multiply(x)
+
+    .. note::
+        For this feature to work, 'converter.Feature.LISTS' had to be added to the
+        TOP_LEVEL_OPTIONS and NESTED_LEVEL_OPTIONS conversion options of our own Catalyst
+        Autograph transformer. If you create a new transformer and want to support this feature,
+        make sure you enable such option there as well.
+    """
+
+    # Apply the 'at...multiply' transformation only to Jax arrays.
+    # Otherwise, fallback to Python's default syntax.
+    if isinstance(target, DynamicJaxprTracer):
+        target = target.at[i].multiply(x)
+    else:
+        target[i] *= x
+
+    return target
+
+
+def update_item_with_div(target, i, x):
+    """An implementation of the 'update_item_with_div' function from operator_update. The interface
+    is defined in operator_update.SingleIndexArrayOperatorUpdateTransformer, here we provide an
+    implementation in terms of Catalyst primitives. The idea is to accept the simpler single index
+    operator assignment syntax for Jax arrays, to subsequently transform it under the hood into the
+    set of 'at' and 'divide' calls that Autograph supports. E.g.:
+        target[i] /= x -> target = target.at[i].divide(x)
+
+    .. note::
+        For this feature to work, 'converter.Feature.LISTS' had to be added to the
+        TOP_LEVEL_OPTIONS and NESTED_LEVEL_OPTIONS conversion options of our own Catalyst
+        Autograph transformer. If you create a new transformer and want to support this feature,
+        make sure you enable such option there as well.
+    """
+
+    # Apply the 'at...divide' transformation only to Jax arrays.
+    # Otherwise, fallback to Python's default syntax.
+    if isinstance(target, DynamicJaxprTracer):
+        target = target.at[i].divide(x)
+    else:
+        target[i] /= x
+
+    return target
+
+
+def update_item_with_pow(target, i, x):
+    """An implementation of the 'update_item_with_pow' function from operator_update. The interface
+    is defined in operator_update.SingleIndexArrayOperatorUpdateTransformer, here we provide an
+    implementation in terms of Catalyst primitives. The idea is to accept the simpler single index
+    operator assignment syntax for Jax arrays, to subsequently transform it under the hood into the
+    set of 'at' and 'power' calls that Autograph supports. E.g.:
+        target[i] **= x -> target = target.at[i].power(x)
+
+    .. note::
+        For this feature to work, 'converter.Feature.LISTS' had to be added to the
+        TOP_LEVEL_OPTIONS and NESTED_LEVEL_OPTIONS conversion options of our own Catalyst
+        Autograph transformer. If you create a new transformer and want to support this feature,
+        make sure you enable such option there as well.
+    """
+
+    # Apply the 'at...power' transformation only to Jax arrays.
+    # Otherwise, fallback to Python's default syntax.
+    if isinstance(target, DynamicJaxprTracer):
+        target = target.at[i].power(x)
+    else:
+        target[i] **= x
 
     return target
 

--- a/frontend/catalyst/autograph/operator_update.py
+++ b/frontend/catalyst/autograph/operator_update.py
@@ -1,0 +1,74 @@
+# Copyright 2024 Spencer Comin
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Converter for array element operator assignment."""
+
+import gast
+from malt.core import converter
+from malt.pyct import templates
+
+
+# The methods from this class should be migrated to the SliceTransformer class in DiastaticMalt
+class SingleIndexArrayOperatorUpdateTransformer(converter.Base):
+    """Converts array element operator assignment statements into calls to update_item_with_{op},
+    where op is one of the following:
+
+    - `add` corresponding to `+=`
+    - `sub` to `-=`
+    - `mult` to `*=`
+    - `div` to `/=`
+    - `pow` to `**=`
+    """
+
+    def _process_single_update(self, target, op, value):
+        if not isinstance(target, gast.Subscript):
+            return None
+        s = target.slice
+        if isinstance(s, (gast.Tuple, gast.Slice)):
+            return None
+        if not isinstance(op, (gast.Mult, gast.Add, gast.Sub, gast.Div, gast.Pow)):
+            return None
+
+        template = f"""
+            target = ag__.update_item_with_{type(op).__name__.lower()}(target, i, x)
+        """
+
+        return templates.replace(template, target=target.value, i=target.slice, x=value)
+
+    def visit_AugAssign(self, node):
+        """The AugAssign node is replaced with a call to ag__.update_item_with_{op}
+        when its target is a single index array subscript and its op is an arithmetic
+        operator (i.e. Add, Sub, Mult, Div, or Pow), otherwise the node is left as is.
+
+        Example:
+            `x[i] += y` is replaced with `x = ag__.update_item_with(x, i, y)`
+            `x[i] ^= y` remains unchanged
+        """
+        node = self.generic_visit(node)
+        replacement = self._process_single_update(node.target, node.op, node.value)
+        if replacement is not None:
+            return replacement
+        return node
+
+
+def transform(node, ctx):
+    """Replace an AugAssign node with a call to ag__.update_item_with_{op}
+    when the its target is a single index array subscript and its op is an arithmetic
+    operator (i.e. Add, Sub, Mult, Div, or Pow), otherwise the node is left as is.
+
+    Example:
+        `x[i] += y` is replaced with `x = ag__.update_item_with(x, i, y)`
+        `x[i] ^= y` remains unchanged
+    """
+    return SingleIndexArrayOperatorUpdateTransformer(ctx).visit(node)

--- a/frontend/catalyst/autograph/operator_update.py
+++ b/frontend/catalyst/autograph/operator_update.py
@@ -1,4 +1,4 @@
-# Copyright 2024 Spencer Comin
+# Copyright 2024 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/frontend/catalyst/autograph/operator_update.py
+++ b/frontend/catalyst/autograph/operator_update.py
@@ -46,8 +46,8 @@ class SingleIndexArrayOperatorUpdateTransformer(converter.Base):
         lower, upper, step = None, None, None
 
         if isinstance(s, (gast.Slice)):
-            # Replace unused arguments in the string template with "None" to preserve each arguments' position.
-            # malt.pyct.templates.replace ignores None and does not accept string so the change need to be applied here.
+            # Replace unused arguments in template with "None" to preserve each arguments' position.
+            # templates.replace ignores None and does not accept string so change is applied here.
             lower_str = "lower" if s.lower is not None else "None"
             upper_str = "upper" if s.upper is not None else "None"
             step_str = "step" if s.step is not None else "None"

--- a/frontend/catalyst/autograph/operator_update.py
+++ b/frontend/catalyst/autograph/operator_update.py
@@ -35,7 +35,7 @@ class SingleIndexArrayOperatorUpdateTransformer(converter.Base):
         if not isinstance(target, gast.Subscript):
             return None
         s = target.slice
-        if isinstance(s, (gast.Tuple)):
+        if isinstance(s, (gast.Tuple, gast.Call)):
             return None
         if not isinstance(op, (gast.Mult, gast.Add, gast.Sub, gast.Div, gast.Pow)):
             return None

--- a/frontend/catalyst/autograph/operator_update.py
+++ b/frontend/catalyst/autograph/operator_update.py
@@ -19,7 +19,7 @@ from malt.core import converter
 from malt.pyct import templates
 
 
-# The methods from this class should be migrated to the SliceTransformer class in DiastaticMalt
+# TODO: The methods from this class should be migrated to the SliceTransformer class in DiastaticMalt
 class SingleIndexArrayOperatorUpdateTransformer(converter.Base):
     """Converts array element operator assignment statements into calls to update_item_with_{op},
     where op is one of the following:

--- a/frontend/catalyst/autograph/transformer.py
+++ b/frontend/catalyst/autograph/transformer.py
@@ -29,7 +29,7 @@ from malt.core import ag_ctx, converter
 from malt.impl.api import PyToPy
 
 import catalyst
-from catalyst.autograph import ag_primitives
+from catalyst.autograph import ag_primitives, operator_update
 from catalyst.utils.exceptions import AutoGraphError
 
 
@@ -115,6 +115,21 @@ class CatalystTransformer(PyToPy):
         )
 
         return new_fn
+
+    def transform_ast(self, node, ctx):
+        """Overload of PyToPy.transform_ast from DiastaticMalt
+
+        .. note::
+            Once the operator_update interface has been migrated to the
+            DiastaticMalt project, this overload can be deleted."""
+        # The operator_update transform would be more correct if placed with
+        # slices.transform in PyToPy.transform_ast in DiastaticMalt rather than
+        # at the beginning of the transformation. operator_update.transform
+        # should come after the unsupported features check and intial analysis,
+        # but it fails if it does not come before variables.transform.
+        node = operator_update.transform(node, ctx)
+        node = super().transform_ast(node, ctx)
+        return node
 
 
 def run_autograph(fn):

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -241,6 +241,7 @@ def qjit(
 
     .. details::
         :title: In-place JAX array updates with Autograph
+
         To update array values when using JAX, the JAX syntax for array modification
         (which uses methods like ``at``, ``set``, ``multiply``, etc) must be used:
         .. code-block:: python

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -240,65 +240,6 @@ def qjit(
         appearing as is.
 
 
-    .. details::
-        :title: Adding modules for Autograph conversion
-
-        Library code is not meant to be targeted by Autograph conversion, hence
-        ``pennylane``, ``catalyst`` and ``jax`` modules have been excluded from it.
-        But sometimes it might make sense enabling specific submodules from the
-        excluded modules for which conversion may be appropriate. For these cases
-        one can use the ``autograph_include`` parameter, which provides a list
-        of modules/submodules that will always be enabled for conversion no matter
-        if the default conversion rules were excluding them before.
-
-        .. code-block:: python
-
-            import excluded_module
-
-            @qjit(autograph=True, autograph_include=["excluded_module.submodule"])
-            def g(x: int):
-                return excluded_module.submodule.f(x)
-
-        Notice that ``autograph=True`` must be set in order to process the
-        ``autograph_include`` list. Otherwise an error will be reported.
-
-
-    .. details::
-        :title: In-place JAX array updates with Autograph
-
-        To update array values when using JAX, the JAX syntax for array assignment
-        (which uses the array ``at`` and ``set`` methods) must be used:
-
-        .. code-block:: python
-
-            @qjit(autograph=True)
-            def f(x):
-            first_dim = x.shape[0]
-            result = jnp.empty((first_dim,), dtype=x.dtype)
-
-            for i in range(first_dim):
-                result = result.at[i].set(x[i]* 2)
-
-            return result
-
-        However, if updating a single index of the array, Autograph supports conversion of
-        standard Python array assignment syntax:
-
-        .. code-block:: python
-
-            @qjit(autograph=True)
-            def f(x):
-            first_dim = x.shape[0]
-            result = jnp.empty((first_dim,), dtype=x.dtype)
-
-            for i in range(first_dim):
-                result[i] = x[i] * 2
-
-            return result
-
-        Under the hood, Catalyst converts anything coming in the latter notation into the
-        former one.
-
         Similarly, to update array values with an operation when using JAX, the JAX syntax for array
         update (which uses the array ``at`` and the ``add``, ``sub``, etc. methods) must be used:
 

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -239,6 +239,102 @@ def qjit(
         be unrolled during tracing, "copy-pasting" the body 5 times into the program rather than
         appearing as is.
 
+
+    .. details::
+        :title: Adding modules for Autograph conversion
+
+        Library code is not meant to be targeted by Autograph conversion, hence
+        ``pennylane``, ``catalyst`` and ``jax`` modules have been excluded from it.
+        But sometimes it might make sense enabling specific submodules from the
+        excluded modules for which conversion may be appropriate. For these cases
+        one can use the ``autograph_include`` parameter, which provides a list
+        of modules/submodules that will always be enabled for conversion no matter
+        if the default conversion rules were excluding them before.
+
+        .. code-block:: python
+
+            import excluded_module
+
+            @qjit(autograph=True, autograph_include=["excluded_module.submodule"])
+            def g(x: int):
+                return excluded_module.submodule.f(x)
+
+        Notice that ``autograph=True`` must be set in order to process the
+        ``autograph_include`` list. Otherwise an error will be reported.
+
+
+    .. details::
+        :title: In-place JAX array updates with Autograph
+
+        To update array values when using JAX, the JAX syntax for array assignment
+        (which uses the array ``at`` and ``set`` methods) must be used:
+
+        .. code-block:: python
+
+            @qjit(autograph=True)
+            def f(x):
+            first_dim = x.shape[0]
+            result = jnp.empty((first_dim,), dtype=x.dtype)
+
+            for i in range(first_dim):
+                result = result.at[i].set(x[i]* 2)
+
+            return result
+
+        However, if updating a single index of the array, Autograph supports conversion of
+        standard Python array assignment syntax:
+
+        .. code-block:: python
+
+            @qjit(autograph=True)
+            def f(x):
+            first_dim = x.shape[0]
+            result = jnp.empty((first_dim,), dtype=x.dtype)
+
+            for i in range(first_dim):
+                result[i] = x[i] * 2
+
+            return result
+
+        Under the hood, Catalyst converts anything coming in the latter notation into the
+        former one.
+
+        Similarly, to update array values with an operation when using JAX, the JAX syntax for array
+        update (which uses the array ``at`` and the ``add``, ``sub``, etc. methods) must be used:
+
+        .. code-block:: python
+
+            @qjit(autograph=True)
+            def f(x):
+                first_dim = x.shape[0]
+                result = jnp.copy(x)
+
+                for i in range(first_dim):
+                    result = result.at[i].multiply(2)
+
+                return result
+
+        Again, if updating a single index of the array, Autograph supports conversion of
+        standard Python array operator assignment syntax for the equivalent in-place expressions
+        listed in the JAX documentation for ``jax.numpy.ndarray.at``:
+
+        .. code-block:: python
+
+            @qjit(autograph=True)
+            def f(x):
+                first_dim = x.shape[0]
+                result = jnp.copy(x)
+
+                for i in range(first_dim):
+                    result[i] *= 2
+
+                return result
+
+        Under the hood, Catalyst converts anything coming in the latter notation into the
+        former one.
+
+
+
     .. details::
         :title: Static arguments
 

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -239,42 +239,38 @@ def qjit(
         be unrolled during tracing, "copy-pasting" the body 5 times into the program rather than
         appearing as is.
 
-
-        Similarly, to update array values with an operation when using JAX, the JAX syntax for array
-        update (which uses the array ``at`` and the ``add``, ``sub``, etc. methods) must be used:
-
+    .. details::
+        :title: In-place JAX array updates with Autograph
+        To update array values when using JAX, the JAX syntax for array modification
+        (which uses methods like ``at``, ``set``, ``multiply``, etc) must be used:
         .. code-block:: python
-
             @qjit(autograph=True)
             def f(x):
                 first_dim = x.shape[0]
-                result = jnp.copy(x)
-
+                result = jnp.empty((first_dim,), dtype=x.dtype)
                 for i in range(first_dim):
-                    result = result.at[i].multiply(2)
+                    result = result.at[i].set(x[i])
+                    result = result.at[i].multiply(10)
+                    result = result.at[i].add(5)
 
                 return result
 
-        Again, if updating a single index of the array, Autograph supports conversion of
-        standard Python array operator assignment syntax for the equivalent in-place expressions
+        However, if updating a single index of the array, Autograph supports conversion of
+        standard Python array assignment operators to the equivalent in-place expressions
         listed in the JAX documentation for ``jax.numpy.ndarray.at``:
-
         .. code-block:: python
-
             @qjit(autograph=True)
             def f(x):
                 first_dim = x.shape[0]
-                result = jnp.copy(x)
-
+                result = jnp.empty((first_dim,), dtype=x.dtype)
                 for i in range(first_dim):
-                    result[i] *= 2
+                    result[i] = x[i]
+                    result[i] *= 10
+                    result[i] += 5
 
                 return result
-
         Under the hood, Catalyst converts anything coming in the latter notation into the
         former one.
-
-
 
     .. details::
         :title: Static arguments

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -244,7 +244,9 @@ def qjit(
 
         To update array values when using JAX, the JAX syntax for array modification
         (which uses methods like ``at``, ``set``, ``multiply``, etc) must be used:
+
         .. code-block:: python
+
             @qjit(autograph=True)
             def f(x):
                 first_dim = x.shape[0]
@@ -259,7 +261,9 @@ def qjit(
         However, if updating a single index or slice of the array, Autograph supports conversion of
         Python's standard arithmatic array assignment operators to the equivalent in-place
         expressions listed in the JAX documentation for ``jax.numpy.ndarray.at``:
+
         .. code-block:: python
+
             @qjit(autograph=True)
             def f(x):
                 first_dim = x.shape[0]
@@ -270,6 +274,7 @@ def qjit(
                     result[i] += 5
 
                 return result
+
         Under the hood, Catalyst converts anything coming in the latter notation into the
         former one.
 

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -278,13 +278,7 @@ def qjit(
         Under the hood, Catalyst converts anything coming in the latter notation into the
         former one.
 
-        The list of supported operators includes:
-        - ``=`` (set)
-        - ``+=`` (add)
-        - ``-=`` (add with negation)
-        - ``*=`` (multiply)
-        - ``/=`` (divide)
-        - ``**=`` (power)
+        The list of supported operators includes: ``=``, ``+=``, ``-=``, ``*=``, ``/=``, and ``**=``.
 
     .. details::
         :title: Static arguments

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -255,9 +255,9 @@ def qjit(
 
                 return result
 
-        However, if updating a single index of the array, Autograph supports conversion of
-        standard Python array assignment operators to the equivalent in-place expressions
-        listed in the JAX documentation for ``jax.numpy.ndarray.at``:
+        However, if updating a single index or slice of the array, Autograph supports conversion of
+        Python's standard arithmatic array assignment operators to the equivalent in-place
+        expressions listed in the JAX documentation for ``jax.numpy.ndarray.at``:
         .. code-block:: python
             @qjit(autograph=True)
             def f(x):
@@ -271,6 +271,14 @@ def qjit(
                 return result
         Under the hood, Catalyst converts anything coming in the latter notation into the
         former one.
+
+        The list of supported operators includes:
+        - ``=`` (set)
+        - ``+=`` (add)
+        - ``-=`` (add with negation)
+        - ``*=`` (multiply)
+        - ``/=`` (divide)
+        - ``**=`` (power)
 
     .. details::
         :title: Static arguments

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -2328,6 +2328,32 @@ class TestJaxIndexOperatorUpdate:
         assert jnp.allclose(result, jnp.array([10, 4, 6, 2, 2]))
         assert jnp.allclose(result, expected)
 
-
+    def test_unsopported_cases(self):
+        """Test that TypeError is raised in unsopported cases."""
+        @qjit(autograph=True)
+        def workflow(x):
+            """Test that TypeError is raised when updating a JAX array with multi-dimensional indexing."""
+            def test_multi_dimensional_index(x):
+                x[0, 1] += 5
+                return x
+            x = jnp.array([[1, 2], [3, 4]])
+            with pytest.raises(TypeError, match="JAX arrays are immutable"):
+                result = test_multi_dimensional_index(x)
+            
+            """Test that TypeError is raised when updating a JAX array using an unsupported operator."""
+            def test_unsupported_operator(x, i, y):
+                x[i] %= y
+                return x
+            x = jnp.array([4, 2, 3])
+            with pytest.raises(TypeError, match="JAX arrays are immutable"):
+                result = test_multi_dimensional_index(x)
+            
+            """Test that TypeError is raised when updating a JAX array using an array as index."""
+            def test_array_index(x, i):
+                x[np.array([1,2])] += 3
+                return x
+            with pytest.raises(TypeError, match="JAX arrays are immutable"):
+                result = test_multi_dimensional_index(x)
+                
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -2065,227 +2065,223 @@ class TestJaxIndexOperatorUpdate:
         """Test single index operator update for Jax arrays for one array item."""
 
         @qjit(autograph=True)
-        def double_first_element_single_operator_assignment_syntax(x):
-            """Double the first element of x using single index assignment"""
+        def workflow(x):
+            def f(x):
+                """Double the first element of x using single index assignment"""
 
-            x[0] *= 2
-            return x
+                x[0] *= 2
+                return x
 
-        @qjit(autograph=True)
-        def double_first_element_at_multiply_syntax(x):
-            """Double the first element of x using at and multiply"""
+            def g(x):
+                """Double the first element of x using at and multiply"""
 
-            x = x.at[0].multiply(2)
-            return x
+                x = x.at[0].multiply(2)
+                return x
 
-        result_assignment_syntax = double_first_element_single_operator_assignment_syntax(
-            jnp.array([5, 3, 4])
-        )
+            result = f(x)
+            expected = g(x)
+            return result, expected
 
-        assert jnp.allclose(result_assignment_syntax, jnp.array([10, 3, 4]))
-        assert jnp.allclose(
-            result_assignment_syntax,
-            double_first_element_at_multiply_syntax(jnp.array([5, 3, 4])),
-        )
+        result, expected = workflow(np.array([5, 3, 4]))
+        assert jnp.allclose(result, jnp.array([10, 3, 4]))
+        assert jnp.allclose(result, expected)
 
     def test_single_index_operator_update_one_item(self):
         """Test single index operator update for Jax arrays for one array item."""
 
         @qjit(autograph=True)
-        def double_last_element_single_operator_assignment_syntax(x):
-            """Double the last element of x using single index assignment"""
+        def workflow(x):
+            def f(x):
+                """Double the last element of x using single index assignment"""
 
-            last_element = x.shape[0] - 1
-            x[last_element] *= 2
-            return x
+                last_element = x.shape[0] - 1
+                x[last_element] *= 2
+                return x
 
-        @qjit(autograph=True)
-        def double_last_element_at_multiply_syntax(x):
-            """Double the last element of x using at and multiply"""
+            def g(x):
+                """Double the last element of x using at and multiply"""
 
-            last_element = x.shape[0] - 1
-            x = x.at[last_element].multiply(2)
-            return x
+                last_element = x.shape[0] - 1
+                x = x.at[last_element].multiply(2)
+                return x
 
-        result_assignment_syntax = double_last_element_single_operator_assignment_syntax(
-            jnp.array([5, 3, 4])
-        )
+            result = f(x)
+            expected = g(x)
+            return result, expected
 
-        assert jnp.allclose(result_assignment_syntax, jnp.array([5, 3, 8]))
-        assert jnp.allclose(
-            result_assignment_syntax,
-            double_last_element_at_multiply_syntax(jnp.array([5, 3, 4])),
-        )
+        result, expected = workflow(np.array([5, 3, 4]))
+        assert jnp.allclose(result, jnp.array([5, 3, 8]))
+        assert jnp.allclose(result, expected)
 
     def test_single_index_mult_update_all_items(self):
         """Test single index mult update for Jax arrays for all array items."""
 
         @qjit(autograph=True)
-        def double_all_operator_update_syntax(x):
-            """Create a new array that is equal to 2 * x using single index mult update"""
+        def workflow(x):
+            def f(x):
+                """Create a new array that is equal to 2 * x using single index mult update"""
 
-            first_dim = x.shape[0]
+                first_dim = x.shape[0]
 
-            for i in range(first_dim):
-                x[i] *= 2
+                for i in range(first_dim):
+                    x[i] *= 2
 
-            return x
+                return x
 
-        @qjit(autograph=True)
-        def double_all_at_multiply_syntax(x):
-            """Create a new array that is equal to 2 * x using at and multiply"""
+            def g(x):
+                """Create a new array that is equal to 2 * x using at and multiply"""
 
-            first_dim = x.shape[0]
-            result = jnp.copy(x)
+                first_dim = x.shape[0]
+                result = jnp.copy(x)
 
-            for i in range(first_dim):
-                result = result.at[i].multiply(2)
+                for i in range(first_dim):
+                    result = result.at[i].multiply(2)
 
-            return result
+                return result
 
-        result_assignment_syntax = double_all_operator_update_syntax(jnp.array([5, 3, 4]))
+            result = f(x)
+            expected = g(x)
+            return result, expected
 
-        assert jnp.allclose(result_assignment_syntax, jnp.array([10, 6, 8]))
-        assert jnp.allclose(
-            result_assignment_syntax,
-            double_all_at_multiply_syntax(jnp.array([5, 3, 4])),
-        )
+        result, expected = workflow(np.array([5, 3, 4]))
+        assert jnp.allclose(result, jnp.array([10, 6, 8]))
+        assert jnp.allclose(result, expected)
 
     def test_single_index_add_update_all_items(self):
         """Test single index add update for Jax arrays for all array items."""
 
         @qjit(autograph=True)
-        def inc_all_operator_update_syntax(x):
-            """Create a new array that is equal to x + 1 using single index add update"""
+        def workflow(x):
+            def f(x):
+                """Create a new array that is equal to x + 1 using single index add update"""
 
-            first_dim = x.shape[0]
+                first_dim = x.shape[0]
 
-            for i in range(first_dim):
-                x[i] += 1
+                for i in range(first_dim):
+                    x[i] += 1
 
-            return x
+                return x
 
-        @qjit(autograph=True)
-        def inc_all_at_multiply_syntax(x):
-            """Create a new array that is equal to x + 1 using at and multiply"""
+            def g(x):
+                """Create a new array that is equal to x + 1 using at and multiply"""
 
-            first_dim = x.shape[0]
-            result = jnp.copy(x)
+                first_dim = x.shape[0]
+                result = jnp.copy(x)
 
-            for i in range(first_dim):
-                result = result.at[i].add(1)
+                for i in range(first_dim):
+                    result = result.at[i].add(1)
 
-            return result
+                return result
 
-        result_assignment_syntax = inc_all_operator_update_syntax(jnp.array([5, 3, 4]))
+            result = f(x)
+            expected = g(x)
+            return result, expected
 
-        assert jnp.allclose(result_assignment_syntax, jnp.array([6, 4, 5]))
-        assert jnp.allclose(
-            result_assignment_syntax,
-            inc_all_at_multiply_syntax(jnp.array([5, 3, 4])),
-        )
+        result, expected = workflow(np.array([5, 3, 4]))
+        assert jnp.allclose(result, jnp.array([6, 4, 5]))
+        assert jnp.allclose(result, expected)
 
     def test_single_index_sub_update_all_items(self):
         """Test single index sub update for Jax arrays for all array items."""
 
         @qjit(autograph=True)
-        def dec_all_operator_update_syntax(x):
-            """Create a new array that is equal to x - 1 using single index sub update"""
+        def workflow(x):
+            def f(x):
+                """Create a new array that is equal to x - 1 using single index sub update"""
 
-            first_dim = x.shape[0]
+                first_dim = x.shape[0]
 
-            for i in range(first_dim):
-                x[i] -= 1
+                for i in range(first_dim):
+                    x[i] -= 1
 
-            return x
+                return x
 
-        @qjit(autograph=True)
-        def dec_all_at_multiply_syntax(x):
-            """Create a new array that is equal to x - 1 using at and add"""
+            def g(x):
+                """Create a new array that is equal to x - 1 using at and add"""
 
-            first_dim = x.shape[0]
-            result = jnp.copy(x)
+                first_dim = x.shape[0]
+                result = jnp.copy(x)
 
-            for i in range(first_dim):
-                result = result.at[i].add(-1)
+                for i in range(first_dim):
+                    result = result.at[i].add(-1)
 
-            return result
+                return result
 
-        result_assignment_syntax = dec_all_operator_update_syntax(jnp.array([5, 3, 4]))
+            result = f(x)
+            expected = g(x)
+            return result, expected
 
-        assert jnp.allclose(result_assignment_syntax, jnp.array([4, 2, 3]))
-        assert jnp.allclose(
-            result_assignment_syntax,
-            dec_all_at_multiply_syntax(jnp.array([5, 3, 4])),
-        )
+        result, expected = workflow(np.array([5, 3, 4]))
+        assert jnp.allclose(result, jnp.array([4, 2, 3]))
+        assert jnp.allclose(result, expected)
 
     def test_single_index_div_update_all_items(self):
         """Test single index div update for Jax arrays for all array items."""
 
         @qjit(autograph=True)
-        def half_all_operator_update_syntax(x):
-            """Create a new array that is equal to x / 2 using single index div update"""
+        def workflow(x):
+            def f(x):
+                """Create a new array that is equal to x / 2 using single index div update"""
 
-            first_dim = x.shape[0]
+                first_dim = x.shape[0]
 
-            for i in range(first_dim):
-                x[i] /= 2
+                for i in range(first_dim):
+                    x[i] /= 2
 
-            return x
+                return x
 
-        @qjit(autograph=True)
-        def half_all_at_multiply_syntax(x):
-            """Create a new array that is equal to x / 2 using at and divide"""
+            def g(x):
+                """Create a new array that is equal to x / 2 using at and divide"""
 
-            first_dim = x.shape[0]
-            result = jnp.copy(x)
+                first_dim = x.shape[0]
+                result = jnp.copy(x)
 
-            for i in range(first_dim):
-                result = result.at[i].divide(2)
+                for i in range(first_dim):
+                    result = result.at[i].divide(2)
 
-            return result
+                return result
 
-        result_assignment_syntax = half_all_operator_update_syntax(jnp.array([5, 3, 4]))
+            result = f(x)
+            expected = g(x)
+            return result, expected
 
-        assert jnp.allclose(result_assignment_syntax, jnp.array([2.5, 1.5, 2]))
-        assert jnp.allclose(
-            result_assignment_syntax,
-            half_all_at_multiply_syntax(jnp.array([5, 3, 4])),
-        )
+        result, expected = workflow(np.array([5, 3, 4]))
+        assert jnp.allclose(result, jnp.array([2.5, 1.5, 2]))
+        assert jnp.allclose(result, expected)
 
     def test_single_index_pow_update_all_items(self):
         """Test single index pow update for Jax arrays for all array items."""
 
         @qjit(autograph=True)
-        def square_all_operator_update_syntax(x):
-            """Create a new array that is equal to x ** 2 using single index sub update"""
+        def workflow(x):
+            def f(x):
+                """Create a new array that is equal to x ** 2 using single index sub update"""
 
-            first_dim = x.shape[0]
+                first_dim = x.shape[0]
 
-            for i in range(first_dim):
-                x[i] **= 2
+                for i in range(first_dim):
+                    x[i] **= 2
 
-            return x
+                return x
 
-        @qjit(autograph=True)
-        def square_all_at_multiply_syntax(x):
-            """Create a new array that is equal to x ** 2 using at and pow"""
+            def g(x):
+                """Create a new array that is equal to x ** 2 using at and pow"""
 
-            first_dim = x.shape[0]
-            result = jnp.copy(x)
+                first_dim = x.shape[0]
+                result = jnp.copy(x)
 
-            for i in range(first_dim):
-                result = result.at[i].power(2)
+                for i in range(first_dim):
+                    result = result.at[i].power(2)
 
-            return result
+                return result
 
-        result_assignment_syntax = square_all_operator_update_syntax(jnp.array([5, 3, 4]))
+            result = f(x)
+            expected = g(x)
+            return result, expected
 
-        assert jnp.allclose(result_assignment_syntax, jnp.array([25, 9, 16]))
-        assert jnp.allclose(
-            result_assignment_syntax,
-            square_all_at_multiply_syntax(jnp.array([5, 3, 4])),
-        )
+        result, expected = workflow(np.array([5, 3, 4]))
+        assert jnp.allclose(result, jnp.array([25, 9, 16]))
+        assert jnp.allclose(result, expected)
 
     def test_single_index_operator_update_python_array(self):
         """Test single index operator update for Non-Jax arrays for one array item."""
@@ -2301,6 +2297,36 @@ class TestJaxIndexOperatorUpdate:
         assert jnp.allclose(
             jnp.array(double_last_element_python_array([5, 3, 4])), jnp.array([5, 3, 8])
         )
+
+    def test_single_index_mult_update_slice(self):
+        """Test slice (start, None, None)x mult update for Jax arrays."""
+
+        @qjit(autograph=True)
+        def workflow(x):
+
+            def f(x):
+                """Create a new array that is equal to 2 * x for even indecies"""
+
+                first_dim = x.shape[0]
+                x[0:first_dim:2] *= 2
+
+                return x
+
+            def g(x):
+                """Create a new array that is equal to 2 * x using at and multiply"""
+
+                first_dim = x.shape[0]
+                x = x.at[0:first_dim:2].multiply(2)
+
+                return x
+
+            result = f(x)
+            expected = g(x)
+            return result, expected
+
+        result, expected = workflow(jnp.array([5, 4, 3, 2, 1]))
+        assert jnp.allclose(result, jnp.array([10, 4, 6, 2, 2]))
+        assert jnp.allclose(result, expected)
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -2333,9 +2333,9 @@ class TestJaxIndexOperatorUpdate:
 
         @qjit(autograph=True)
         def workflow(x):
-            """Test that TypeError is raised when updating a JAX array with multi-dimensional indexing."""
 
             def test_multi_dimensional_index(x):
+                """Test that TypeError is raised when updating a JAX array with multi-dimx indexing."""
                 x[0, 1] += 5
                 return x
 
@@ -2343,24 +2343,24 @@ class TestJaxIndexOperatorUpdate:
             with pytest.raises(TypeError, match="JAX arrays are immutable"):
                 result = test_multi_dimensional_index(x)
 
-            """Test that TypeError is raised when updating a JAX array using an unsupported operator."""
-
             def test_unsupported_operator(x, i, y):
-                x[i] %= y
+                """Test that TypeError is raised when updating a JAX array using an unsupported operator."""
+                x[1] %= y
                 return x
 
             x = jnp.array([4, 2, 3])
             with pytest.raises(TypeError, match="JAX arrays are immutable"):
-                result = test_multi_dimensional_index(x)
+                result = test_unsupported_operator(x)
 
             """Test that TypeError is raised when updating a JAX array using an array as index."""
 
             def test_array_index(x, i):
+                """Test that TypeError is raised when updating a JAX array using an array as index."""
                 x[np.array([1, 2])] += 3
                 return x
 
             with pytest.raises(TypeError, match="JAX arrays are immutable"):
-                result = test_multi_dimensional_index(x)
+                result = test_array_index(x)
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -2335,7 +2335,7 @@ class TestJaxIndexOperatorUpdate:
         def workflow(x):
 
             def test_multi_dimensional_index(x):
-                """Test that TypeError is raised when updating a JAX array with multi-dimx indexing."""
+                """Test that TypeError is raised when using multi-dim indexing."""
                 x[0, 1] += 5
                 return x
 
@@ -2343,8 +2343,8 @@ class TestJaxIndexOperatorUpdate:
             with pytest.raises(TypeError, match="JAX arrays are immutable"):
                 result = test_multi_dimensional_index(x)
 
-            def test_unsupported_operator(x, i, y):
-                """Test that TypeError is raised when updating a JAX array using an unsupported operator."""
+            def test_unsupported_operator(x):
+                """Test that TypeError is raised when using an unsupported operator."""
                 x[1] %= y
                 return x
 
@@ -2352,10 +2352,10 @@ class TestJaxIndexOperatorUpdate:
             with pytest.raises(TypeError, match="JAX arrays are immutable"):
                 result = test_unsupported_operator(x)
 
-            """Test that TypeError is raised when updating a JAX array using an array as index."""
+            """Test that TypeError is raised when using an array as index."""
 
             def test_array_index(x, i):
-                """Test that TypeError is raised when updating a JAX array using an array as index."""
+                """Test that TypeError is raised when using an array as index."""
                 x[np.array([1, 2])] += 3
                 return x
 

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -2354,7 +2354,7 @@ class TestJaxIndexOperatorUpdate:
 
             """Test that TypeError is raised when using an array as index."""
 
-            def test_array_index(x, i):
+            def test_array_index(x):
                 """Test that TypeError is raised when using an array as index."""
                 x[np.array([1, 2])] += 3
                 return x

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -2341,18 +2341,16 @@ class TestJaxIndexOperatorUpdate:
 
             x = jnp.array([[1, 2], [3, 4]])
             with pytest.raises(TypeError, match="JAX arrays are immutable"):
-                result = test_multi_dimensional_index(x)
+                test_multi_dimensional_index(x)
 
             def test_unsupported_operator(x):
                 """Test that TypeError is raised when using an unsupported operator."""
-                x[1] %= y
+                x[1] %= 2
                 return x
 
             x = jnp.array([4, 2, 3])
             with pytest.raises(TypeError, match="JAX arrays are immutable"):
-                result = test_unsupported_operator(x)
-
-            """Test that TypeError is raised when using an array as index."""
+                test_unsupported_operator(x)
 
             def test_array_index(x):
                 """Test that TypeError is raised when using an array as index."""
@@ -2360,7 +2358,7 @@ class TestJaxIndexOperatorUpdate:
                 return x
 
             with pytest.raises(TypeError, match="JAX arrays are immutable"):
-                result = test_array_index(x)
+                test_array_index(x)
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -2058,5 +2058,250 @@ class TestDecorators:
         assert qjit(loop, autograph=True)(0) == n
 
 
+class TestJaxIndexOperatorUpdate:
+    """Test Jax index operator update"""
+
+    def test_single_static_index_operator_update_one_item(self):
+        """Test single index operator update for Jax arrays for one array item."""
+
+        @qjit(autograph=True)
+        def double_first_element_single_operator_assignment_syntax(x):
+            """Double the first element of x using single index assignment"""
+
+            x[0] *= 2
+            return x
+
+        @qjit(autograph=True)
+        def double_first_element_at_multiply_syntax(x):
+            """Double the first element of x using at and multiply"""
+
+            x = x.at[0].multiply(2)
+            return x
+
+        result_assignment_syntax = double_first_element_single_operator_assignment_syntax(
+            jnp.array([5, 3, 4])
+        )
+
+        assert jnp.allclose(result_assignment_syntax, jnp.array([10, 3, 4]))
+        assert jnp.allclose(
+            result_assignment_syntax,
+            double_first_element_at_multiply_syntax(jnp.array([5, 3, 4])),
+        )
+
+    def test_single_index_operator_update_one_item(self):
+        """Test single index operator update for Jax arrays for one array item."""
+
+        @qjit(autograph=True)
+        def double_last_element_single_operator_assignment_syntax(x):
+            """Double the last element of x using single index assignment"""
+
+            last_element = x.shape[0] - 1
+            x[last_element] *= 2
+            return x
+
+        @qjit(autograph=True)
+        def double_last_element_at_multiply_syntax(x):
+            """Double the last element of x using at and multiply"""
+
+            last_element = x.shape[0] - 1
+            x = x.at[last_element].multiply(2)
+            return x
+
+        result_assignment_syntax = double_last_element_single_operator_assignment_syntax(
+            jnp.array([5, 3, 4])
+        )
+
+        assert jnp.allclose(result_assignment_syntax, jnp.array([5, 3, 8]))
+        assert jnp.allclose(
+            result_assignment_syntax,
+            double_last_element_at_multiply_syntax(jnp.array([5, 3, 4])),
+        )
+
+    def test_single_index_mult_update_all_items(self):
+        """Test single index mult update for Jax arrays for all array items."""
+
+        @qjit(autograph=True)
+        def double_all_operator_update_syntax(x):
+            """Create a new array that is equal to 2 * x using single index mult update"""
+
+            first_dim = x.shape[0]
+
+            for i in range(first_dim):
+                x[i] *= 2
+
+            return x
+
+        @qjit(autograph=True)
+        def double_all_at_multiply_syntax(x):
+            """Create a new array that is equal to 2 * x using at and multiply"""
+
+            first_dim = x.shape[0]
+            result = jnp.copy(x)
+
+            for i in range(first_dim):
+                result = result.at[i].multiply(2)
+
+            return result
+
+        result_assignment_syntax = double_all_operator_update_syntax(jnp.array([5, 3, 4]))
+
+        assert jnp.allclose(result_assignment_syntax, jnp.array([10, 6, 8]))
+        assert jnp.allclose(
+            result_assignment_syntax,
+            double_all_at_multiply_syntax(jnp.array([5, 3, 4])),
+        )
+
+    def test_single_index_add_update_all_items(self):
+        """Test single index add update for Jax arrays for all array items."""
+
+        @qjit(autograph=True)
+        def inc_all_operator_update_syntax(x):
+            """Create a new array that is equal to x + 1 using single index add update"""
+
+            first_dim = x.shape[0]
+
+            for i in range(first_dim):
+                x[i] += 1
+
+            return x
+
+        @qjit(autograph=True)
+        def inc_all_at_multiply_syntax(x):
+            """Create a new array that is equal to x + 1 using at and multiply"""
+
+            first_dim = x.shape[0]
+            result = jnp.copy(x)
+
+            for i in range(first_dim):
+                result = result.at[i].add(1)
+
+            return result
+
+        result_assignment_syntax = inc_all_operator_update_syntax(jnp.array([5, 3, 4]))
+
+        assert jnp.allclose(result_assignment_syntax, jnp.array([6, 4, 5]))
+        assert jnp.allclose(
+            result_assignment_syntax,
+            inc_all_at_multiply_syntax(jnp.array([5, 3, 4])),
+        )
+
+    def test_single_index_sub_update_all_items(self):
+        """Test single index sub update for Jax arrays for all array items."""
+
+        @qjit(autograph=True)
+        def dec_all_operator_update_syntax(x):
+            """Create a new array that is equal to x - 1 using single index sub update"""
+
+            first_dim = x.shape[0]
+
+            for i in range(first_dim):
+                x[i] -= 1
+
+            return x
+
+        @qjit(autograph=True)
+        def dec_all_at_multiply_syntax(x):
+            """Create a new array that is equal to x - 1 using at and add"""
+
+            first_dim = x.shape[0]
+            result = jnp.copy(x)
+
+            for i in range(first_dim):
+                result = result.at[i].add(-1)
+
+            return result
+
+        result_assignment_syntax = dec_all_operator_update_syntax(jnp.array([5, 3, 4]))
+
+        assert jnp.allclose(result_assignment_syntax, jnp.array([4, 2, 3]))
+        assert jnp.allclose(
+            result_assignment_syntax,
+            dec_all_at_multiply_syntax(jnp.array([5, 3, 4])),
+        )
+
+    def test_single_index_div_update_all_items(self):
+        """Test single index div update for Jax arrays for all array items."""
+
+        @qjit(autograph=True)
+        def half_all_operator_update_syntax(x):
+            """Create a new array that is equal to x / 2 using single index div update"""
+
+            first_dim = x.shape[0]
+
+            for i in range(first_dim):
+                x[i] /= 2
+
+            return x
+
+        @qjit(autograph=True)
+        def half_all_at_multiply_syntax(x):
+            """Create a new array that is equal to x / 2 using at and divide"""
+
+            first_dim = x.shape[0]
+            result = jnp.copy(x)
+
+            for i in range(first_dim):
+                result = result.at[i].divide(2)
+
+            return result
+
+        result_assignment_syntax = half_all_operator_update_syntax(jnp.array([5, 3, 4]))
+
+        assert jnp.allclose(result_assignment_syntax, jnp.array([2.5, 1.5, 2]))
+        assert jnp.allclose(
+            result_assignment_syntax,
+            half_all_at_multiply_syntax(jnp.array([5, 3, 4])),
+        )
+
+    def test_single_index_pow_update_all_items(self):
+        """Test single index pow update for Jax arrays for all array items."""
+
+        @qjit(autograph=True)
+        def square_all_operator_update_syntax(x):
+            """Create a new array that is equal to x ** 2 using single index sub update"""
+
+            first_dim = x.shape[0]
+
+            for i in range(first_dim):
+                x[i] **= 2
+
+            return x
+
+        @qjit(autograph=True)
+        def square_all_at_multiply_syntax(x):
+            """Create a new array that is equal to x ** 2 using at and pow"""
+
+            first_dim = x.shape[0]
+            result = jnp.copy(x)
+
+            for i in range(first_dim):
+                result = result.at[i].power(2)
+
+            return result
+
+        result_assignment_syntax = square_all_operator_update_syntax(jnp.array([5, 3, 4]))
+
+        assert jnp.allclose(result_assignment_syntax, jnp.array([25, 9, 16]))
+        assert jnp.allclose(
+            result_assignment_syntax,
+            square_all_at_multiply_syntax(jnp.array([5, 3, 4])),
+        )
+
+    def test_single_index_operator_update_python_array(self):
+        """Test single index operator update for Non-Jax arrays for one array item."""
+
+        @qjit(autograph=True)
+        def double_last_element_python_array(x):
+            """Double the last element of a python array"""
+
+            last_element = len(x) - 1
+            x[last_element] *= 2
+            return x
+
+        assert jnp.allclose(
+            jnp.array(double_last_element_python_array([5, 3, 4])), jnp.array([5, 3, 8])
+        )
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -2330,30 +2330,38 @@ class TestJaxIndexOperatorUpdate:
 
     def test_unsopported_cases(self):
         """Test that TypeError is raised in unsopported cases."""
+
         @qjit(autograph=True)
         def workflow(x):
             """Test that TypeError is raised when updating a JAX array with multi-dimensional indexing."""
+
             def test_multi_dimensional_index(x):
                 x[0, 1] += 5
                 return x
+
             x = jnp.array([[1, 2], [3, 4]])
             with pytest.raises(TypeError, match="JAX arrays are immutable"):
                 result = test_multi_dimensional_index(x)
-            
+
             """Test that TypeError is raised when updating a JAX array using an unsupported operator."""
+
             def test_unsupported_operator(x, i, y):
                 x[i] %= y
                 return x
+
             x = jnp.array([4, 2, 3])
             with pytest.raises(TypeError, match="JAX arrays are immutable"):
                 result = test_multi_dimensional_index(x)
-            
+
             """Test that TypeError is raised when updating a JAX array using an array as index."""
+
             def test_array_index(x, i):
-                x[np.array([1,2])] += 3
+                x[np.array([1, 2])] += 3
                 return x
+
             with pytest.raises(TypeError, match="JAX arrays are immutable"):
                 result = test_multi_dimensional_index(x)
-                
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])


### PR DESCRIPTION
**Context:** 

https://github.com/PennyLaneAI/catalyst/pull/717 added support for converting in-place array updates (`arr[i] = x`) into the equivalent JAX traceable code (`arr.at[i].set(x)`). This PR extends that support to operator assignment array updates.

**Description of the Change:**

- Add new Autograph converter to map `AugAssign` ast nodes assigning to a single index or a slice subscript to calls to `update_item_with_op`
- Implement `update_item_with_op` method that map to the corresponding `jax.numpy.ndarray.at` equivalent methods for JAX arrays and the normal Python operator assignment otherwise
- Overload `transform_ast` in `CatalystTransformer` to invoke the new converter

**Benefits:** We can use `arr[i] += x` instead of `arr.at[i].add(x)`.

**Possible Drawbacks:** It would be cleaner to have the new converter live in the DiastaticMalt project.

**Related GitHub Issues:** https://github.com/PennyLaneAI/catalyst/issues/757

**Based on the solution presented in this PR:** https://github.com/PennyLaneAI/catalyst/pull/769
Note that this PR was originally implemented externally by https://github.com/PennyLaneAI/catalyst/pull/769. This PR aims to revisit that PR.