### PR TITLE
[tests] Some intermediate dump cleanup

### DIFF
--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -14,9 +14,6 @@
 
 """Test built-in differentiation support in Catalyst."""
 
-import os
-import shutil
-
 import jax
 import numpy as np
 import pennylane as qml
@@ -1623,22 +1620,12 @@ def test_forloop_vmap_worflow_derivation(backend):
 
         return body(transposed_result)
 
-    cat_res_func = qjit(
+    cat_res = qjit(
         jacobian(
             my_model,
             argnums=1,
-        ),
-        keep_intermediate=True,
-    )
-
-    # Since the above compilation fails and this test is xfail, the intermediate
-    # will not be properly cleaned up, so we delete it manually
-    try:
-        cat_res = cat_res_func(data, params["weights"])
-    finally:
-        if os.path.isdir("grad.my_model"):
-            shutil.rmtree("grad.my_model")
-
+        )
+    )(data, params["weights"])
     jax_res = jax.jacobian(my_model, argnums=1)(data, params["weights"])
 
     data_cat, pytree_enzyme = tree_flatten(jax_res)

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -14,6 +14,7 @@
 
 """Test built-in differentiation support in Catalyst."""
 
+import os
 import shutil
 
 import jax
@@ -1629,7 +1630,11 @@ def test_forloop_vmap_worflow_derivation(backend):
         ),
         keep_intermediate=True,
     )
-    shutil.rmtree("grad.my_model")
+    # Since the above compilation fails and this test is xfail, the intermediate
+    # will not be properly cleaned up, so we delete it manually
+    if os.path.isdir("grad.my_model"):
+        shutil.rmtree("grad.my_model")
+
     cat_res = cat_res_func(data, params["weights"])
     jax_res = jax.jacobian(my_model, argnums=1)(data, params["weights"])
 

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -14,6 +14,8 @@
 
 """Test built-in differentiation support in Catalyst."""
 
+import shutil
+
 import jax
 import numpy as np
 import pennylane as qml
@@ -1620,13 +1622,15 @@ def test_forloop_vmap_worflow_derivation(backend):
 
         return body(transposed_result)
 
-    cat_res = qjit(
+    cat_res_func = qjit(
         jacobian(
             my_model,
             argnums=1,
         ),
         keep_intermediate=True,
-    )(data, params["weights"])
+    )
+    shutil.rmtree("grad.my_model")
+    cat_res = cat_res_func(data, params["weights"])
     jax_res = jax.jacobian(my_model, argnums=1)(data, params["weights"])
 
     data_cat, pytree_enzyme = tree_flatten(jax_res)

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1630,12 +1630,15 @@ def test_forloop_vmap_worflow_derivation(backend):
         ),
         keep_intermediate=True,
     )
+
     # Since the above compilation fails and this test is xfail, the intermediate
     # will not be properly cleaned up, so we delete it manually
-    if os.path.isdir("grad.my_model"):
-        shutil.rmtree("grad.my_model")
+    try:
+        cat_res = cat_res_func(data, params["weights"])
+    finally:
+        if os.path.isdir("grad.my_model"):
+            shutil.rmtree("grad.my_model")
 
-    cat_res = cat_res_func(data, params["weights"])
     jax_res = jax.jacobian(my_model, argnums=1)(data, params["weights"])
 
     data_cat, pytree_enzyme = tree_flatten(jax_res)


### PR DESCRIPTION
**Context:**
The test `test_gradient.py/test_forloop_vmap_worflow_derivation` leaves a keep_intermediate but does not clean it up (because its compilation is xfail and its program flow is interrupted after the failure).

This causes a `grad.my_model` intermediate to be left after `make test`.

We remove it manually.


**Benefits:**
Cleaner directory after `make test` (or similar actions).

