### PR TITLE
Small documentation grammar fix for `frontend/passes.py`

### DIFF
--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 """
-This module contains which provides Python decorators
-for enabling and configuring individual Catalyst MLIR compiler passes.
+This module contains Python decorators for enabling and configuring
+individual Catalyst MLIR compiler passes.
 
 .. note::
 


### PR DESCRIPTION
**Context:**
Small documentation grammar fix for `frontend/passes.py`

