### PR TITLE
[build-system][quantum-opt] Link and register the test dialect in quantum-opt

### DIFF
--- a/mlir/test/Quantum/AdjointTest.mlir
+++ b/mlir/test/Quantum/AdjointTest.mlir
@@ -16,7 +16,7 @@
 
 // CHECK-LABEL:      @workflow_plain
 func.func private @workflow_plain() -> tensor<4xcomplex<f64>> attributes {} {
-  %c1_i64 = arith.constant 1 : i64
+  %val = "test.op" () : () -> (i64)
   %cst = arith.constant 4.000000e-01 : f64
   %c0_i64 = arith.constant 0 : i64
   quantum.device ["rtd_lightning.so", "LightningQubit", "{shots: 0}"]
@@ -37,15 +37,15 @@ func.func private @workflow_plain() -> tensor<4xcomplex<f64>> attributes {} {
     %11 = quantum.custom "PauliX"() %10 : !quantum.bit
     %12 = quantum.custom "PauliY"() %11 : !quantum.bit
     %13 = quantum.insert %arg0[%c0_i64], %12 : !quantum.reg, !quantum.bit
-    %15 = quantum.extract %13[%c1_i64] : !quantum.reg -> !quantum.bit
+    %15 = quantum.extract %13[%val] : !quantum.reg -> !quantum.bit
     %16 = quantum.custom "PauliZ"() %15 : !quantum.bit
-    %17 = quantum.insert %13[%c1_i64], %16 : !quantum.reg, !quantum.bit
+    %17 = quantum.insert %13[%val], %16 : !quantum.reg, !quantum.bit
     quantum.yield %17 : !quantum.reg
   }
   %5 = quantum.extract %4[%c0_i64] : !quantum.reg -> !quantum.bit
   // CHECK:        RY
   %6 = quantum.custom "RY"(%cst) %5 : !quantum.bit
-  %7 = quantum.extract %4[%c1_i64] : !quantum.reg -> !quantum.bit
+  %7 = quantum.extract %4[%val] : !quantum.reg -> !quantum.bit
   %8 = quantum.compbasis %6, %7 : !quantum.obs
   %9 = quantum.state %8 : tensor<4xcomplex<f64>>
   quantum.dealloc %0 : !quantum.reg

--- a/mlir/tools/quantum-opt/CMakeLists.txt
+++ b/mlir/tools/quantum-opt/CMakeLists.txt
@@ -17,6 +17,7 @@ set(LIBS
     MhloRegisterDialects
     StablehloRegister
     MLIRCatalystTest
+    MLIRTestDialect
     ${ALL_MHLO_PASSES}
 )
 

--- a/mlir/tools/quantum-opt/quantum-opt.cpp
+++ b/mlir/tools/quantum-opt/quantum-opt.cpp
@@ -33,6 +33,10 @@
 #include "Quantum/IR/QuantumDialect.h"
 #include "Quantum/Transforms/Passes.h"
 
+namespace test {
+void registerTestDialect(mlir::DialectRegistry &);
+} // namespace test
+
 int main(int argc, char **argv)
 {
     mlir::registerAllPasses();
@@ -41,6 +45,7 @@ int main(int argc, char **argv)
 
     mlir::DialectRegistry registry;
     mlir::registerAllDialects(registry);
+    test::registerTestDialect(registry);
     mlir::mhlo::registerAllMhloDialects(registry);
     mlir::stablehlo::registerAllDialects(registry);
     mlir::func::registerAllExtensions(registry);


### PR DESCRIPTION
**Context:** The test dialect in MLIR allows us to write more concise tests without needing to bring in other dialects for generating values. 

**Description of the Change:** This PR just registers the test dialect in quantum-opt and also sets up the build system to be link against it.

**Benefits:** More concise tests.

**Possible Drawbacks:** Slightly larger quantum-opt binary size.

**Related GitHub Issues:** 
