### PR TITLE
Convert to samples/counts based on available MPs

### DIFF
--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -441,7 +441,7 @@ class QJITDevice(qml.devices.Device):
                 raise RuntimeError("The device does not support observables or sample/counts")
 
         elif self.measurement_processes in [{"Sample"}, {"Counts", "Sample"}, {"Counts"}]:
-            # ToDo: this branch should become unneccessary when selective conversion of 
+            # ToDo: this branch should become unneccessary when selective conversion of
             # unsupported MPs is finished, see ToDo below
             if not split_non_commuting in measurement_program:
                 measurement_program.add_transform(split_non_commuting)

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -441,7 +441,8 @@ class QJITDevice(qml.devices.Device):
                 raise RuntimeError("The device does not support observables or sample/counts")
 
         elif self.measurement_processes in [{"Sample"}, {"Counts", "Sample"}, {"Counts"}]:
-            # ToDo: this branch should become unneccessary when selective conversion of unsupported MPs is finished, see ToDo below
+            # ToDo: this branch should become unneccessary when selective conversion of 
+            # unsupported MPs is finished, see ToDo below
             if not split_non_commuting in measurement_program:
                 measurement_program.add_transform(split_non_commuting)
             mp_transform = (

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -440,6 +440,17 @@ class QJITDevice(qml.devices.Device):
             else:
                 raise RuntimeError("The device does not support observables or sample/counts")
 
+        elif self.measurement_processes in [{"Sample"}, {"Counts", "Sample"}, {"Counts"}]:
+            # ToDo: this branch should become unneccessary when selective conversion of unsupported MPs is finished, see ToDo below
+            if not split_non_commuting in measurement_program:
+                measurement_program.add_transform(split_non_commuting)
+            mp_transform = (
+                measurements_from_samples
+                if "Sample" in self.measurement_processes
+                else measurements_from_counts
+            )
+            measurement_program.add_transform(mp_transform, self.wires)
+
         # if only some observables are supported, we try to diagonalize those that aren't
         elif not {"PauliX", "PauliY", "PauliZ", "Hadamard"}.issubset(self.observables):
             if not split_non_commuting in measurement_program:
@@ -463,7 +474,7 @@ class QJITDevice(qml.devices.Device):
             )
 
         # ToDo: if some measurement types are unsupported, convert the unsupported MPs to
-        # samples or counts (without diagonalizing or modifying observables)
+        # samples or counts (without diagonalizing or modifying observables). See ToDo above.
 
         return measurement_program
 

--- a/frontend/test/pytest/test_measurement_transforms.py
+++ b/frontend/test/pytest/test_measurement_transforms.py
@@ -240,62 +240,111 @@ class TestMeasurementTransforms:
         assert set(np.array(sample_res)) == set(sample_expected)
 
     @pytest.mark.parametrize(
-        "device_measurements, measurement_transform, target_measurement",
+        "unsupported_measurement, measurement_transform, target_measurement",
         [
-            (["counts"], measurements_from_counts, "counts"),
-            (["sample"], measurements_from_samples, "sample"),
-            (["counts", "sample"], measurements_from_samples, "sample"),
+            ("Sample", measurements_from_counts, "counts"),
+            ("Counts", measurements_from_samples, "sample"),
+            (None, measurements_from_samples, "sample"),
         ],
     )
-    def test_measurement_from_readout_integration_multiple_measurements_device(
-        self, device_measurements, measurement_transform, target_measurement
+    def test_measurement_from_readout_integration_if_no_observables_supported(
+        self, unsupported_measurement, measurement_transform, target_measurement
     ):
         """Test that for devices without observable support,  measurment_from_samples transform
         is applied as part of the Catalyst pipeline if the device only supports sample, and
         measurement_from_counts transform is applied if the device only supports counts. If
         both are supported, sample takes precedence."""
 
-        allow_sample = "sample" in device_measurements
-        allow_counts = "counts" in device_measurements
+        dev = qml.device("lightning.qubit", wires=4, shots=100)
 
-        with DummyDeviceLimitedMPs(
-            wires=4, shots=1000, allow_counts=allow_counts, allow_samples=allow_sample
-        ) as dev:
+        config = get_device_toml_config(dev)
+        config["operators"]["observables"] = {}
+        if unsupported_measurement:
+            del config["measurement_processes"][unsupported_measurement]
 
-            config = get_device_toml_config(dev)
-            config["operators"]["observables"] = {}
+        with patch("catalyst.device.qjit_device.get_device_toml_config", Mock(return_value=config)):
+            # transform is added to transform program
+            qjit_dev = QJITDevice(dev)
 
-            with patch(
-                "catalyst.device.qjit_device.get_device_toml_config", Mock(return_value=config)
-            ):
-                # transform is added to transform program
-                qjit_dev = QJITDevice(dev)
+            with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
+                transform_program, _ = qjit_dev.preprocess(ctx)
 
-                with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
-                    transform_program, _ = qjit_dev.preprocess(ctx)
+            assert measurement_transform in transform_program
 
-                assert measurement_transform in transform_program
+            # MLIR only contains target measurement
+            @qml.qjit
+            @qml.qnode(dev)
+            def circuit(theta: float):
+                qml.X(0)
+                qml.X(1)
+                qml.X(2)
+                qml.X(3)
+                return (
+                    qml.expval(qml.PauliX(wires=0) @ qml.PauliX(wires=1)),
+                    qml.var(qml.PauliX(wires=0) @ qml.PauliX(wires=2)),
+                    qml.probs(wires=[3, 4]),
+                )
 
-                # MLIR only contains target measurement
-                @qml.qjit
-                @qml.qnode(dev)
-                def circuit(theta: float):
-                    qml.X(0)
-                    qml.X(1)
-                    qml.X(2)
-                    qml.X(3)
-                    return (
-                        qml.expval(qml.PauliX(wires=0) @ qml.PauliX(wires=1)),
-                        qml.var(qml.PauliX(wires=0) @ qml.PauliX(wires=2)),
-                        qml.probs(wires=[3, 4]),
-                    )
+            mlir = qml.qjit(circuit, target="mlir").mlir
 
-                mlir = qml.qjit(circuit, target="mlir").mlir
+        assert "expval" not in mlir
+        assert "quantum.var" not in mlir
+        assert "probs" not in mlir
+        assert target_measurement in mlir
 
-            assert "expval" not in mlir
-            assert "quantum.var" not in mlir
-            assert "probs" not in mlir
-            assert target_measurement in mlir
+        @pytest.mark.parametrize(
+            "device_measurements, measurement_transform, target_measurement",
+            [
+                (["counts"], measurements_from_counts, "counts"),
+                (["sample"], measurements_from_samples, "sample"),
+                (["counts", "sample"], measurements_from_samples, "sample"),
+            ],
+        )
+        def test_measurement_from_readout_if_only_readout_measurements_supported(
+            self, device_measurements, measurement_transform, target_measurement
+        ):
+            """Test the measurment_from_samples transform is applied as part of the Catalyst pipeline
+            if the device only supports sample, and measurement_from_counts transform is applied if
+            the device only supports counts. If both are supported, sample takes precedence."""
+
+            allow_sample = "sample" in device_measurements
+            allow_counts = "counts" in device_measurements
+
+            with DummyDeviceLimitedMPs(
+                wires=4, shots=1000, allow_counts=allow_counts, allow_samples=allow_sample
+            ) as dev:
+
+                with patch(
+                    "catalyst.device.qjit_device.get_device_toml_config", Mock(return_value=config)
+                ):
+                    # transform is added to transform program
+                    qjit_dev = QJITDevice(dev)
+
+                    with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
+                        transform_program, _ = qjit_dev.preprocess(ctx)
+
+                    assert measurement_transform in transform_program
+
+                    # MLIR only contains target measurement
+                    @qml.qjit
+                    @qml.qnode(dev)
+                    def circuit(theta: float):
+                        qml.X(0)
+                        qml.X(1)
+                        qml.X(2)
+                        qml.X(3)
+                        return (
+                            qml.expval(qml.PauliX(wires=0) @ qml.PauliX(wires=1)),
+                            qml.var(qml.PauliX(wires=0) @ qml.PauliX(wires=2)),
+                            qml.probs(wires=[3, 4]),
+                        )
+
+                    mlir = qml.qjit(circuit, target="mlir").mlir
+
+                assert "expval" not in mlir
+                assert "quantum.var" not in mlir
+                assert "probs" not in mlir
+                assert target_measurement in mlir
 
     def test_error_is_raised_if_no_observables_and_no_samples_or_counts(self, mocker):
         """Test that for a device that doesn't support observables, if counts


### PR DESCRIPTION
**Context:**

In #1123 we changed the criteria for applying `measurements_from_samples` and `measurements_from_counts` to be based on whether or not there are supported `observables`. Previously the decision in preprocess had been based on supported measurement processes instead of supported observables. The reason for this change is that those transforms don't only change the measurement type - they also go a step further and diagonalize the observables to the readout basis. This is potentially a separate functionality from modifying measurement types. 

There was discussion of this being handled by a future transform that is more specific to selectively transforming unsupported MPs without changing the observables. However, that isn't implemented yet, and the QRack plugin in analytic mode only supports Counts and Samples, so its needed now.

**Description of the Change:**
This PR reintroduces the check for supported measurement types being limited to a subset of {"Counts", "Samples"} in when adding measurement transforms to the device TransformProgram.

**Benefits:**
The QRack device keeps working.

**Possible Drawbacks:**
Depending what the backend supports, arguably the TOML file loading is what should change here - if the observables are only supported in `analytic` mode, then the `qjit_capabilities` in finite-shots mode should have an empty list of `observables`, and then this change would be unnecessary. So maybe I'm not fixing this in the most logical place? But I'm not sure about that, and I'm sure this will work.
