### PR TITLE
Refactor device code around capabilities [NFC]

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -2,17 +2,17 @@
 
 <h3>New features</h3>
 
-* Experimental integration of the PennyLane capture module is available. It currently only supports 
+* Experimental integration of the PennyLane capture module is available. It currently only supports
   quantum gates, without control flow.
   [(#1109)](https://github.com/PennyLaneAI/catalyst/pull/1109)
 
   To trigger the PennyLane pipeline for capturing the program as a JaxPR, one needs to simply
   set `experimental_capture=True` in the qjit decorator.
-  
-  ```python 
+
+  ```python
   import pennylane as qml
   from catalyst import qjit
-  
+
   dev = qml.device("lightning.qubit", wires=1)
 
   @qjit(experimental_capture=True)
@@ -33,10 +33,10 @@
 
   For example,
 
-  ```python 
+  ```python
   import pennylane as qml
   from catalyst import qjit
-  
+
   dev = qml.device("lightning.qubit", wires=1, shots=((5, 2), 7))
 
   @qjit
@@ -144,8 +144,8 @@
 
 <h3>Improvements</h3>
 
-* Bufferization of `gradient.ForwardOp` and `gradient.ReverseOp` now requires 3 steps: `gradient-preprocessing`, 
-  `gradient-bufferize`, and `gradient-postprocessing`. `gradient-bufferize` has a new rewrite for `gradient.ReturnOp`. 
+* Bufferization of `gradient.ForwardOp` and `gradient.ReverseOp` now requires 3 steps: `gradient-preprocessing`,
+  `gradient-bufferize`, and `gradient-postprocessing`. `gradient-bufferize` has a new rewrite for `gradient.ReturnOp`.
   [(#1139)](https://github.com/PennyLaneAI/catalyst/pull/1139)
 
 * The decorator `self_inverses` now supports all Hermitian Gates.
@@ -167,11 +167,11 @@
 
   Three-bit Gates: Toffoli
   - [`qml.Toffoli`](https://docs.pennylane.ai/en/stable/code/api/pennylane.Toffoli.html)
-  
-  
 
-* Support is expanded for backend devices that exculsively return samples in the measurement 
-  basis. Pre- and post-processing now allows `qjit` to be used on these devices with `qml.expval`, 
+
+
+* Support is expanded for backend devices that exculsively return samples in the measurement
+  basis. Pre- and post-processing now allows `qjit` to be used on these devices with `qml.expval`,
   `qml.var` and `qml.probs` measurements in addiiton to `qml.sample`, using the `measurements_from_samples` transform.
   [(#1106)](https://github.com/PennyLaneAI/catalyst/pull/1106)
 
@@ -192,11 +192,11 @@
 * Update Enzyme to version `v0.0.149`.
   [(#1142)](https://github.com/PennyLaneAI/catalyst/pull/1142)
 
-* Remove the `MemMemCpyOptPass` in llvm O2 (applied for Enzyme), this reduces bugs when 
+* Remove the `MemMemCpyOptPass` in llvm O2 (applied for Enzyme), this reduces bugs when
   running gradient like functions.
   [(#1063)](https://github.com/PennyLaneAI/catalyst/pull/1063)
 
-* Functions with multiple tapes are now split with a new mlir pass `--split-multiple-tapes`, with one tape per function. 
+* Functions with multiple tapes are now split with a new mlir pass `--split-multiple-tapes`, with one tape per function.
   The reset routine that makes a maeasurement between tapes and inserts a X gate if measured one is no longer used.
   [(#1017)](https://github.com/PennyLaneAI/catalyst/pull/1017)
   [(#1130)](https://github.com/PennyLaneAI/catalyst/pull/1130)
@@ -211,6 +211,13 @@
 
 * The device capability loading mechanism has been moved into the `QJITDevice` constructor.
   [(#1141)](https://github.com/PennyLaneAI/catalyst/pull/1141)
+
+* Several functions related to device capabilities have been refactored.
+  [(#1149)](https://github.com/PennyLaneAI/catalyst/pull/1149)
+
+  In particular, the signatures of `get_device_capability`, `catalyst_decompose`,
+ `catalyst_acceptance`, and `QJITDevice.__init__` have changed, and the `pennylane_operation_set`
+  function has been removed entirely.
 
 <h3>Contributors</h3>
 

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -286,19 +286,12 @@ class QJITDevice(qml.devices.Device):
 
     @staticmethod
     @debug_logger
-    def extract_backend_info(
-        device: qml.QubitDevice, capabilities: DeviceCapabilities
-    ) -> BackendInfo:
+    def extract_backend_info(device, capabilities: DeviceCapabilities) -> BackendInfo:
         """Wrapper around extract_backend_info in the runtime module."""
         return extract_backend_info(device, capabilities)
 
     @debug_logger_init
-    def __init__(
-        self,
-        original_device,
-        original_device_capabilities: DeviceCapabilities = None,
-        backend: Optional[BackendInfo] = None,
-    ):
+    def __init__(self, original_device):
         self.original_device = original_device
 
         for key, value in original_device.__dict__.items():
@@ -309,10 +302,8 @@ class QJITDevice(qml.devices.Device):
         super().__init__(wires=original_device.wires, shots=original_device.shots)
 
         # Capability loading
-        if original_device_capabilities is None:
-            original_device_capabilities = get_device_capabilities(original_device)
-        if backend is None:
-            backend = QJITDevice.extract_backend_info(original_device, original_device_capabilities)
+        original_device_capabilities = get_device_capabilities(original_device)
+        backend = QJITDevice.extract_backend_info(original_device, original_device_capabilities)
 
         self.backend_name = backend.c_interface_name
         self.backend_lib = backend.lpath

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -403,14 +403,14 @@ class QJITDevice(qml.devices.Device):
             else:
                 raise RuntimeError("The device does not support observables or sample/counts")
 
-        elif self.measurement_processes in [{"Sample"}, {"Counts", "Sample"}, {"Counts"}]:
+        elif not self.capabilities.measurement_processes - {"Counts", "Sample"}:
             # ToDo: this branch should become unneccessary when selective conversion of
             # unsupported MPs is finished, see ToDo below
             if not split_non_commuting in measurement_program:
                 measurement_program.add_transform(split_non_commuting)
             mp_transform = (
                 measurements_from_samples
-                if "Sample" in self.measurement_processes
+                if "Sample" in self.capabilities.measurement_processes
                 else measurements_from_counts
             )
             measurement_program.add_transform(mp_transform, self.wires)

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -313,10 +313,7 @@ class QJITDevice(qml.devices.Device):
 
         # Capability loading
         if original_device_capabilities is None:
-            program_features = ProgramFeatures(shots_present=bool(original_device.shots))
-            original_device_capabilities = get_device_capabilities(
-                original_device, program_features
-            )
+            original_device_capabilities = get_device_capabilities(original_device)
         if backend is None:
             backend = QJITDevice.extract_backend_info(original_device, original_device_capabilities)
 
@@ -519,20 +516,18 @@ def get_device_toml_config(device) -> TOMLDocument:
     return config
 
 
-def get_device_capabilities(
-    device, program_features: Optional[ProgramFeatures] = None
-) -> DeviceCapabilities:
+def get_device_capabilities(device) -> DeviceCapabilities:
     """Get or load DeviceCapabilities structure from device"""
+    assert not isinstance(device, QJITDevice)
+
+    # TODO: This code exists purely for testing. Find another way to customize device
+    #       support easily without injecting code into the package.
     if hasattr(device, "qjit_capabilities"):
         return device.qjit_capabilities
-    else:
-        program_features = (
-            program_features
-            if program_features
-            else ProgramFeatures(shots_present=bool(device.shots))
-        )
-        device_config = get_device_toml_config(device)
-        return load_device_capabilities(device_config, program_features)
+
+    program_features = ProgramFeatures(shots_present=bool(device.shots))
+    device_config = get_device_toml_config(device)
+    return load_device_capabilities(device_config, program_features)
 
 
 def check_device_wires(wires):

--- a/frontend/catalyst/device/verification.py
+++ b/frontend/catalyst/device/verification.py
@@ -131,6 +131,7 @@ def verify_operations(tape: QuantumTape, grad_method, qjit_device):
         DifferentiableCompileError: gradient-related error
         CompileError: compilation error
     """
+    op_support = qjit_device.capabilities.native_ops
 
     def _paramshift_op_checker(op):
         if not isinstance(op, HybridOp):
@@ -148,9 +149,7 @@ def verify_operations(tape: QuantumTape, grad_method, qjit_device):
             op_name = op.base.name
         else:
             op_name = op.name
-        if not qjit_device.qjit_capabilities.native_ops.get(
-            op_name, EMPTY_PROPERTIES
-        ).differentiable:
+        if not op_support.get(op_name, EMPTY_PROPERTIES).differentiable:
             raise DifferentiableCompileError(
                 f"{op.name} is non-differentiable on '{qjit_device.original_device.name}' device"
             )
@@ -173,7 +172,7 @@ def verify_operations(tape: QuantumTape, grad_method, qjit_device):
         elif not in_control:
             return isinstance(op, HybridCtrl)
 
-        if not qjit_device.qjit_capabilities.native_ops.get(op.name, EMPTY_PROPERTIES).controllable:
+        if not op_support.get(op.name, EMPTY_PROPERTIES).controllable:
             raise CompileError(
                 f"{op.name} is not controllable on '{qjit_device.original_device.name}' device"
             )
@@ -198,7 +197,7 @@ def verify_operations(tape: QuantumTape, grad_method, qjit_device):
         elif not in_inverse:
             return isinstance(op, HybridAdjoint)
 
-        if not qjit_device.qjit_capabilities.native_ops.get(op.name, EMPTY_PROPERTIES).invertible:
+        if not op_support.get(op.name, EMPTY_PROPERTIES).invertible:
             raise CompileError(
                 f"{op.name} is not invertible on '{qjit_device.original_device.name}' device"
             )
@@ -215,11 +214,9 @@ def verify_operations(tape: QuantumTape, grad_method, qjit_device):
             pass
         # Don't check StatePrep since StatePrep is not in the list of device capabilities.
         # It is only valid when the TOML file has the initial_state_prep_flag.
-        elif (
-            isinstance(op, StatePrepBase) and qjit_device.qjit_capabilities.initial_state_prep_flag
-        ):
+        elif isinstance(op, StatePrepBase) and qjit_device.capabilities.initial_state_prep_flag:
             pass
-        elif not qjit_device.qjit_capabilities.native_ops.get(op.name):
+        elif not op.name in op_support:
             raise CompileError(
                 f"{op.name} is not supported on '{qjit_device.original_device.name}' device"
             )
@@ -272,9 +269,7 @@ def validate_observables_adjoint_diff(tape: QuantumTape, qjit_device):
     """Validate that the observables on the tape support adjoint differentiation"""
 
     def _obs_checker(obs):
-        if not qjit_device.qjit_capabilities.native_obs.get(
-            obs.name, EMPTY_PROPERTIES
-        ).differentiable:
+        if not qjit_device.capabilities.native_obs.get(obs.name, EMPTY_PROPERTIES).differentiable:
             raise DifferentiableCompileError(
                 f"{obs.name} is non-differentiable on "
                 f"'{qjit_device.original_device.name}' device"
@@ -289,14 +284,14 @@ def validate_observables_adjoint_diff(tape: QuantumTape, qjit_device):
 
 @transform
 def validate_measurements(
-    tape: QuantumTape, qjit_capabilities: dict, name: str, shots: Union[int, Shots]
+    tape: QuantumTape, capabilities: dict, name: str, shots: Union[int, Shots]
 ) -> (Sequence[QuantumTape], Callable):
     """Validates the observables and measurements for a circuit against the capabilites
     from the TOML file.
 
     Args:
         tape (QuantumTape or QNode or Callable): a quantum circuit.
-        qjit_capabilities (dict): specifies the capabilities of the qjitted device
+        capabilities (dict): specifies the capabilities of the qjitted device
         name: the name of the device to use in error messages
         shots: the shots on the device to use in error messages
 
@@ -310,7 +305,7 @@ def validate_measurements(
     """
 
     def _obs_checker(obs):
-        if not qjit_capabilities.native_obs.get(obs.name):
+        if not obs.name in capabilities.native_obs:
             raise CompileError(
                 f"{m.obs} is not supported as an observable on the '{name}' device with Catalyst"
             )
@@ -336,7 +331,7 @@ def validate_measurements(
                 "Please specify a finite number of shots."
             )
         mp_name = m.return_type.value if m.return_type else type(m).__name__
-        if not mp_name.title() in qjit_capabilities.measurement_processes:
+        if not mp_name.title() in capabilities.measurement_processes:
             raise CompileError(
                 f"{type(m)} is not a supported measurement process on '{name}' with Catalyst"
             )

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -50,7 +50,6 @@ from catalyst.jax_primitives import (
     state_p,
     var_p,
 )
-from catalyst.utils.toml import ProgramFeatures
 
 measurement_map = {
     "sample_wires": sample_p,

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -78,10 +78,9 @@ def _read(var, env: dict):
     return var.val if type(var) is jax.core.Literal else env[var]
 
 
-def _get_device_kwargs(device: "pennylane.devices.Device") -> dict:
+def _get_device_kwargs(device) -> dict:
     """Calulcate the params for a device equation."""
-    features = ProgramFeatures(device.shots is not None)
-    capabilities = get_device_capabilities(device, features)
+    capabilities = get_device_capabilities(device)
     info = extract_backend_info(device, capabilities)
     # Note that the value of rtd_kwargs is a string version of
     # the info kwargs, not the info kwargs itself
@@ -217,7 +216,7 @@ class QFuncPlxprInterpreter:
 
     wire_map: dict
     """A map from wire values to ``AbstractQbit`` instances.
-    
+
     If a value is not present in this dictionary, it needs to be extracted
     from the ``qreg`` property.
     """

--- a/frontend/catalyst/utils/toml.py
+++ b/frontend/catalyst/utils/toml.py
@@ -82,7 +82,7 @@ class DeviceCapabilities:  # pylint: disable=too-many-instance-attributes
     to_decomp_ops: Dict[str, OperationProperties] = field(default_factory=dict)
     to_matrix_ops: Dict[str, OperationProperties] = field(default_factory=dict)
     native_obs: Dict[str, OperationProperties] = field(default_factory=dict)
-    measurement_processes: Set[str] = field(default_factory=dict)
+    measurement_processes: Set[str] = field(default_factory=set)
     qjit_compatible_flag: bool = False
     mid_circuit_measurement_flag: bool = False
     runtime_code_generation_flag: bool = False
@@ -97,22 +97,6 @@ def intersect_operations(
 ) -> Dict[str, OperationProperties]:
     """Intersects two sets of oepration properties"""
     return {k: _intersect_properties(a[k], b[k]) for k in (a.keys() & b.keys())}
-
-
-def pennylane_operation_set(config_ops: Dict[str, OperationProperties]) -> Set[str]:
-    """Returns a config section into a set of strings using PennyLane syntax"""
-    ops = set()
-    # Back-mapping from class names to string names
-    for g, props in config_ops.items():
-        ops.update({g})
-        if props.controllable:
-            ops.update({f"C({g})"})
-        if props.invertible:
-            ops.update({f"Adjoint({g})"})
-        if props.controllable and props.invertible:
-            ops.update({f"Adjoint(C({g}))"})
-            ops.update({f"C(Adjoint({g}))"})
-    return ops
 
 
 @dataclass

--- a/frontend/test/lit/test_decomposition.py
+++ b/frontend/test/lit/test_decomposition.py
@@ -24,11 +24,7 @@ import pennylane as qml
 from catalyst import measure, qjit
 from catalyst.compiler import get_lib_path
 from catalyst.device import get_device_capabilities
-from catalyst.utils.toml import (
-    OperationProperties,
-    ProgramFeatures,
-    pennylane_operation_set,
-)
+from catalyst.utils.toml import OperationProperties, pennylane_operation_set
 
 
 def get_custom_device_without(num_wires, discards=frozenset(), force_matrix=frozenset()):
@@ -51,10 +47,7 @@ def get_custom_device_without(num_wires, discards=frozenset(), force_matrix=froz
 
         def __init__(self, shots=None, wires=None):
             super().__init__(wires=wires, shots=shots)
-            program_features = ProgramFeatures(shots_present=bool(self.shots))
-            lightning_capabilities = get_device_capabilities(
-                self.lightning_device, program_features
-            )
+            lightning_capabilities = get_device_capabilities(self.lightning_device)
             custom_capabilities = deepcopy(lightning_capabilities)
             for gate in discards:
                 custom_capabilities.native_ops.pop(gate, None)

--- a/frontend/test/lit/test_decomposition.py
+++ b/frontend/test/lit/test_decomposition.py
@@ -24,7 +24,7 @@ import pennylane as qml
 from catalyst import measure, qjit
 from catalyst.compiler import get_lib_path
 from catalyst.device import get_device_capabilities
-from catalyst.utils.toml import OperationProperties, pennylane_operation_set
+from catalyst.utils.toml import OperationProperties
 
 
 def get_custom_device_without(num_wires, discards=frozenset(), force_matrix=frozenset()):
@@ -62,20 +62,6 @@ def get_custom_device_without(num_wires, discards=frozenset(), force_matrix=froz
         def apply(self, operations, **kwargs):
             """Unused"""
             raise RuntimeError("Only C/C++ interface is defined")
-
-        @property
-        def operations(self):
-            """Return operations using PennyLane's C(.) syntax"""
-            return (
-                pennylane_operation_set(self.qjit_capabilities.native_ops)
-                | pennylane_operation_set(self.qjit_capabilities.to_decomp_ops)
-                | pennylane_operation_set(self.qjit_capabilities.to_matrix_ops)
-            )
-
-        @property
-        def observables(self):
-            """Return PennyLane observables"""
-            return pennylane_operation_set(self.qjit_capabilities.native_obs)
 
         @staticmethod
         def get_c_interface():

--- a/frontend/test/lit/test_quantum_control.py
+++ b/frontend/test/lit/test_quantum_control.py
@@ -22,7 +22,7 @@ import pennylane as qml
 
 from catalyst import qjit
 from catalyst.device import get_device_capabilities
-from catalyst.utils.toml import OperationProperties, pennylane_operation_set
+from catalyst.utils.toml import OperationProperties
 
 
 def get_custom_qjit_device(num_wires, discards, additions):
@@ -50,20 +50,6 @@ def get_custom_qjit_device(num_wires, discards, additions):
                 custom_capabilities.native_ops.pop(gate)
             custom_capabilities.native_ops.update(additions)
             self.qjit_capabilities = custom_capabilities
-
-        @property
-        def operations(self):
-            """Get PennyLane operations."""
-            return (
-                pennylane_operation_set(self.qjit_capabilities.native_ops)
-                | pennylane_operation_set(self.qjit_capabilities.to_decomp_ops)
-                | pennylane_operation_set(self.qjit_capabilities.to_matrix_ops)
-            )
-
-        @property
-        def observables(self):
-            """Get PennyLane observables."""
-            return pennylane_operation_set(self.qjit_capabilities.native_obs)
 
         def execute(self, circuits, execution_config):
             """Exececute the device (no)."""

--- a/frontend/test/lit/test_quantum_control.py
+++ b/frontend/test/lit/test_quantum_control.py
@@ -22,11 +22,7 @@ import pennylane as qml
 
 from catalyst import qjit
 from catalyst.device import get_device_capabilities
-from catalyst.utils.toml import (
-    OperationProperties,
-    ProgramFeatures,
-    pennylane_operation_set,
-)
+from catalyst.utils.toml import OperationProperties, pennylane_operation_set
 
 
 def get_custom_qjit_device(num_wires, discards, additions):
@@ -48,10 +44,7 @@ def get_custom_qjit_device(num_wires, discards, additions):
 
         def __init__(self, shots=None, wires=None):
             super().__init__(wires=wires, shots=shots)
-            program_features = ProgramFeatures(shots_present=bool(shots))
-            lightning_capabilities = get_device_capabilities(
-                self.lightning_device, program_features
-            )
+            lightning_capabilities = get_device_capabilities(self.lightning_device)
             custom_capabilities = deepcopy(lightning_capabilities)
             for gate in discards:
                 custom_capabilities.native_ops.pop(gate)

--- a/frontend/test/pytest/device/test_decomposition.py
+++ b/frontend/test/pytest/device/test_decomposition.py
@@ -25,11 +25,7 @@ from catalyst import CompileError, ctrl, qjit
 from catalyst.compiler import get_lib_path
 from catalyst.device import get_device_capabilities
 from catalyst.device.decomposition import catalyst_decomposer
-from catalyst.utils.toml import (
-    DeviceCapabilities,
-    OperationProperties,
-    pennylane_operation_set,
-)
+from catalyst.utils.toml import DeviceCapabilities, OperationProperties
 
 
 class TestGateAliases:
@@ -168,20 +164,6 @@ def get_custom_device_without(num_wires, discards=frozenset(), force_matrix=froz
         def apply(self, operations, **kwargs):
             """Unused"""
             raise RuntimeError("Only C/C++ interface is defined")
-
-        @property
-        def operations(self):
-            """Return operations using PennyLane's C(.) syntax"""
-            return (
-                pennylane_operation_set(self.qjit_capabilities.native_ops)
-                | pennylane_operation_set(self.qjit_capabilities.to_decomp_ops)
-                | pennylane_operation_set(self.qjit_capabilities.to_matrix_ops)
-            )
-
-        @property
-        def observables(self):
-            """Return PennyLane observables"""
-            return pennylane_operation_set(self.qjit_capabilities.native_obs)
 
         @staticmethod
         def get_c_interface():

--- a/frontend/test/pytest/device/test_decomposition.py
+++ b/frontend/test/pytest/device/test_decomposition.py
@@ -28,7 +28,6 @@ from catalyst.device.decomposition import catalyst_decomposer
 from catalyst.utils.toml import (
     DeviceCapabilities,
     OperationProperties,
-    ProgramFeatures,
     pennylane_operation_set,
 )
 
@@ -154,10 +153,7 @@ def get_custom_device_without(num_wires, discards=frozenset(), force_matrix=froz
 
         def __init__(self, shots=None, wires=None):
             super().__init__(wires=wires, shots=shots)
-            program_features = ProgramFeatures(shots_present=bool(self.shots))
-            lightning_capabilities = get_device_capabilities(
-                self.lightning_device, program_features
-            )
+            lightning_capabilities = get_device_capabilities(self.lightning_device)
             custom_capabilities = deepcopy(lightning_capabilities)
             for gate in discards:
                 custom_capabilities.native_ops.pop(gate, None)

--- a/frontend/test/pytest/test_config_functions.py
+++ b/frontend/test/pytest/test_config_functions.py
@@ -21,7 +21,6 @@ from textwrap import dedent
 import pennylane as qml
 import pytest
 
-from catalyst.device import BackendInfo, QJITDevice
 from catalyst.utils.exceptions import CompileError
 from catalyst.utils.toml import (
     ALL_SUPPORTED_SCHEMAS,
@@ -29,7 +28,6 @@ from catalyst.utils.toml import (
     ProgramFeatures,
     TOMLDocument,
     load_device_capabilities,
-    pennylane_operation_set,
     read_toml_file,
 )
 
@@ -83,7 +81,8 @@ def test_get_observables(schema):
             """
         ),
     )
-    assert {"PauliX"} == pennylane_operation_set(device_capabilities.native_obs)
+    assert len(device_capabilities.native_obs) == 1
+    assert "PauliX" in device_capabilities.native_obs
 
 
 @pytest.mark.parametrize("schema", ALL_SUPPORTED_SCHEMAS)
@@ -101,9 +100,9 @@ def test_get_native_ops(schema):
         ),
     )
 
-    assert {"PauliX", "C(PauliX)", "PauliY"} == pennylane_operation_set(
-        device_capabilities.native_ops
-    )
+    assert len(device_capabilities.native_ops) == 2
+    assert {"PauliX", "PauliY"}.issubset(device_capabilities.native_ops)
+    assert device_capabilities.native_ops["PauliX"].controllable
 
 
 @pytest.mark.parametrize("schema", ALL_SUPPORTED_SCHEMAS)
@@ -261,28 +260,6 @@ def test_config_invalid_condition_duplicate_false(schema):
                 """
             ),
         )
-
-
-@pytest.mark.parametrize("schema", ALL_SUPPORTED_SCHEMAS)
-def test_config_qjit_device_operations(schema):
-    """Check the gate condition handling logic"""
-    capabilities = get_test_device_capabilities(
-        ProgramFeatures(False),
-        dedent(
-            f"""
-                schema = {schema}
-                [operators.gates.native]
-                PauliX = {{}}
-                [operators.observables]
-                PauliY = {{}}
-            """
-        ),
-    )
-    backend = BackendInfo("default", "default", "", {})
-    device = qml.device("lightning.qubit", wires=2, shots=1000)
-    qjit_device = QJITDevice(device, capabilities, backend)
-    assert "PauliX" in qjit_device.operations
-    assert "PauliY" in qjit_device.observables
 
 
 @pytest.mark.parametrize("schema", [1, 999])

--- a/frontend/test/pytest/test_device_api.py
+++ b/frontend/test/pytest/test_device_api.py
@@ -122,11 +122,6 @@ def test_qjit_device():
     with pytest.raises(RuntimeError, match="QJIT devices cannot execute tapes"):
         device_qjit.execute(10, 2)
 
-    assert isinstance(device_qjit.operations, set)
-    assert len(device_qjit.operations) > 0
-    assert isinstance(device_qjit.observables, set)
-    assert len(device_qjit.observables) > 0
-
 
 def test_qjit_device_no_wires():
     """Test the qjit device from a device using the new api without wires set."""

--- a/frontend/test/pytest/test_measurement_transforms.py
+++ b/frontend/test/pytest/test_measurement_transforms.py
@@ -40,7 +40,7 @@ from catalyst.device.decomposition import (
     measurements_from_samples,
 )
 from catalyst.tracing.contexts import EvaluationContext, EvaluationMode
-from catalyst.utils.toml import OperationProperties, ProgramFeatures
+from catalyst.utils.toml import OperationProperties
 
 # pylint: disable=attribute-defined-outside-init
 
@@ -53,8 +53,7 @@ class DummyDevice(Device):
     def __init__(self, wires, shots=1024):
         print(pathlib.Path(__file__).parent.parent.parent.parent)
         super().__init__(wires=wires, shots=shots)
-        program_features = ProgramFeatures(bool(shots))
-        dummy_capabilities = get_device_capabilities(self, program_features)
+        dummy_capabilities = get_device_capabilities(self)
         dummy_capabilities.native_ops.pop("BlockEncode")
         dummy_capabilities.to_matrix_ops["BlockEncode"] = OperationProperties(False, False, False)
         self.qjit_capabilities = dummy_capabilities

--- a/frontend/test/pytest/test_measurement_transforms.py
+++ b/frontend/test/pytest/test_measurement_transforms.py
@@ -20,7 +20,6 @@ import pathlib
 # pylint: disable=unused-argument
 import platform
 import tempfile
-from dataclasses import replace
 from functools import partial
 from typing import Optional
 from unittest.mock import Mock, patch
@@ -692,26 +691,27 @@ class TestMeasurementTransforms:
         sum_observables_flag and the non_commuting_observables_flag"""
 
         dev = DummyDevice(wires=4, shots=1000)
-        dev_capabilities = get_device_capabilities(dev, ProgramFeatures(bool(dev.shots)))
 
         # dev1 supports non-commuting observables and sum observables - no splitting
-        assert "Sum" in dev_capabilities.native_obs
-        assert "Hamiltonian" in dev_capabilities.native_obs
-        assert dev_capabilities.non_commuting_observables_flag is True
-        qjit_dev1 = QJITDevice(dev, dev_capabilities)
+        qjit_dev1 = QJITDevice(dev)
+        assert "Sum" in qjit_dev1.qjit_capabilities.native_obs
+        assert "Hamiltonian" in qjit_dev1.qjit_capabilities.native_obs
+        assert qjit_dev1.qjit_capabilities.non_commuting_observables_flag is True
 
         # dev2 supports non-commuting observables but NOT sums - split_to_single_terms
-        del dev_capabilities.native_obs["Sum"]
-        del dev_capabilities.native_obs["Hamiltonian"]
-        qjit_dev2 = QJITDevice(dev, dev_capabilities)
+        qjit_dev2 = QJITDevice(dev)
+        del qjit_dev2.qjit_capabilities.native_obs["Sum"]
+        del qjit_dev2.qjit_capabilities.native_obs["Hamiltonian"]
 
         # dev3 supports does not support non-commuting observables OR sums - split_non_commuting
-        dev_capabilities = replace(dev_capabilities, non_commuting_observables_flag=False)
-        qjit_dev3 = QJITDevice(dev, dev_capabilities)
+        qjit_dev3 = QJITDevice(dev)
+        del qjit_dev3.qjit_capabilities.native_obs["Sum"]
+        del qjit_dev3.qjit_capabilities.native_obs["Hamiltonian"]
+        qjit_dev3.qjit_capabilities.non_commuting_observables_flag = False
 
         # dev4 supports sums but NOT non-commuting observables - split_non_commuting
-        dev_capabilities = replace(dev_capabilities, non_commuting_observables_flag=False)
-        qjit_dev4 = QJITDevice(dev, dev_capabilities)
+        qjit_dev4 = QJITDevice(dev)
+        qjit_dev4.qjit_capabilities.non_commuting_observables_flag = False
 
         # Check the preprocess
         with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:

--- a/frontend/test/pytest/test_measurement_transforms.py
+++ b/frontend/test/pytest/test_measurement_transforms.py
@@ -55,7 +55,7 @@ class DummyDevice(Device):
         dummy_capabilities = get_device_capabilities(self)
         dummy_capabilities.native_ops.pop("BlockEncode")
         dummy_capabilities.to_matrix_ops["BlockEncode"] = OperationProperties(False, False, False)
-        self.qjit_capabilities = dummy_capabilities
+        self.capabilities = dummy_capabilities
 
     @staticmethod
     def get_c_interface():
@@ -650,7 +650,7 @@ class TestMeasurementTransforms:
             qjit_dev = QJITDevice(dev)
 
         # dev1 supports non-commuting observables and sum observables - no splitting
-        assert qjit_dev.qjit_capabilities.non_commuting_observables_flag is non_commuting_flag
+        assert qjit_dev.capabilities.non_commuting_observables_flag is non_commuting_flag
 
         # Check the preprocess
         with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
@@ -677,7 +677,7 @@ class TestMeasurementTransforms:
             qjit_dev = QJITDevice(dev)
 
         # dev1 supports non-commuting observables and sum observables - no splitting
-        assert qjit_dev.qjit_capabilities.non_commuting_observables_flag is non_commuting_flag
+        assert qjit_dev.capabilities.non_commuting_observables_flag is non_commuting_flag
 
         # Check the preprocess
         with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
@@ -694,24 +694,24 @@ class TestMeasurementTransforms:
 
         # dev1 supports non-commuting observables and sum observables - no splitting
         qjit_dev1 = QJITDevice(dev)
-        assert "Sum" in qjit_dev1.qjit_capabilities.native_obs
-        assert "Hamiltonian" in qjit_dev1.qjit_capabilities.native_obs
-        assert qjit_dev1.qjit_capabilities.non_commuting_observables_flag is True
+        assert "Sum" in qjit_dev1.capabilities.native_obs
+        assert "Hamiltonian" in qjit_dev1.capabilities.native_obs
+        assert qjit_dev1.capabilities.non_commuting_observables_flag is True
 
         # dev2 supports non-commuting observables but NOT sums - split_to_single_terms
         qjit_dev2 = QJITDevice(dev)
-        del qjit_dev2.qjit_capabilities.native_obs["Sum"]
-        del qjit_dev2.qjit_capabilities.native_obs["Hamiltonian"]
+        del qjit_dev2.capabilities.native_obs["Sum"]
+        del qjit_dev2.capabilities.native_obs["Hamiltonian"]
 
         # dev3 supports does not support non-commuting observables OR sums - split_non_commuting
         qjit_dev3 = QJITDevice(dev)
-        del qjit_dev3.qjit_capabilities.native_obs["Sum"]
-        del qjit_dev3.qjit_capabilities.native_obs["Hamiltonian"]
-        qjit_dev3.qjit_capabilities.non_commuting_observables_flag = False
+        del qjit_dev3.capabilities.native_obs["Sum"]
+        del qjit_dev3.capabilities.native_obs["Hamiltonian"]
+        qjit_dev3.capabilities.non_commuting_observables_flag = False
 
         # dev4 supports sums but NOT non-commuting observables - split_non_commuting
         qjit_dev4 = QJITDevice(dev)
-        qjit_dev4.qjit_capabilities.non_commuting_observables_flag = False
+        qjit_dev4.capabilities.non_commuting_observables_flag = False
 
         # Check the preprocess
         with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:

--- a/frontend/test/pytest/test_preprocess.py
+++ b/frontend/test/pytest/test_preprocess.py
@@ -90,8 +90,7 @@ class DummyDevice(Device):
     def __init__(self, wires, shots=1024):
         print(pathlib.Path(__file__).parent.parent.parent.parent)
         super().__init__(wires=wires, shots=shots)
-        program_features = ProgramFeatures(bool(shots))
-        dummy_capabilities = get_device_capabilities(self, program_features)
+        dummy_capabilities = get_device_capabilities(self)
         dummy_capabilities.native_ops.pop("BlockEncode")
         dummy_capabilities.to_matrix_ops["BlockEncode"] = OperationProperties(False, False, False)
         self.qjit_capabilities = dummy_capabilities

--- a/frontend/test/pytest/test_preprocess.py
+++ b/frontend/test/pytest/test_preprocess.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 """Test for the device preprocessing.
 """
-# pylint: disable=unused-argument
-import pathlib
 
-# pylint: disable=unused-argument
+import pathlib
 import platform
-from functools import partial
+from dataclasses import replace
 from os.path import join
 from tempfile import TemporaryDirectory
 from textwrap import dedent
@@ -45,11 +43,7 @@ from catalyst.api_extensions.control_flow import (
 from catalyst.api_extensions.quantum_operators import HybridAdjoint, adjoint
 from catalyst.compiler import get_lib_path
 from catalyst.device import get_device_capabilities
-from catalyst.device.decomposition import (
-    catalyst_acceptance,
-    catalyst_decompose,
-    decompose_ops_to_unitary,
-)
+from catalyst.device.decomposition import catalyst_decompose, decompose_ops_to_unitary
 from catalyst.jax_tracer import HybridOpRegion
 from catalyst.tracing.contexts import EvaluationContext, EvaluationMode
 from catalyst.utils.toml import (
@@ -58,9 +52,10 @@ from catalyst.utils.toml import (
     ProgramFeatures,
     TOMLDocument,
     load_device_capabilities,
-    pennylane_operation_set,
     read_toml_file,
 )
+
+# pylint: disable=unused-argument
 
 
 def get_test_config(config_text: str) -> TOMLDocument:
@@ -275,8 +270,6 @@ capabilities = get_test_device_capabilities(
     ),
 )
 
-expected_ops = pennylane_operation_set(capabilities.native_ops)
-
 
 class TestPreprocessHybridOp:
     """Test that the operators on the tapes nested inside HybridOps are also decomposed"""
@@ -286,8 +279,6 @@ class TestPreprocessHybridOp:
         """Tests that for a tape containing a HybridOp that contains unsupported
         Operators, the unsupported Operators are decomposed"""
 
-        stopping_condition = partial(catalyst_acceptance, operations=expected_ops)
-
         # hack for unit test (since it doesn't create a full context)
         for region in op.regions:
             region.trace = None
@@ -295,7 +286,7 @@ class TestPreprocessHybridOp:
         # create and decompose the tape
         tape = QuantumScript([op, qml.X(0), qml.Hadamard(3)])
         with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
-            (new_tape,), _ = catalyst_decompose(tape, ctx, stopping_condition, capabilities)
+            (new_tape,), _ = catalyst_decompose(tape, ctx, capabilities)
 
         old_op = tape[0]
         new_op = new_tape[0]
@@ -307,6 +298,7 @@ class TestPreprocessHybridOp:
 
         # the HybridOp on the original tape is unmodified, i.e. continues to contain ops
         # not in `expected_ops`. The post-decomposition HybridOp tape does not
+        expected_ops = capabilities.native_ops
         for i in range(num_regions):
             if old_op.regions[i].quantum_tape:
                 assert not np.all(
@@ -455,8 +447,6 @@ class TestPreprocessHybridOp:
     def test_decomposition_of_nested_HybridOp(self):
         """Tests that HybridOps with HybridOps nested inside them are still decomposed correctly"""
 
-        stopping_condition = partial(catalyst_acceptance, operations=expected_ops)
-
         # make a weird nested op
         adjoint_op = HybridAdjoint([], [], [region1])
         ops = [qml.RY(1.23, 1), adjoint_op, qml.Hadamard(2)]  # Hadamard will decompose
@@ -478,7 +468,7 @@ class TestPreprocessHybridOp:
 
         # do the decomposition and get the new tape
         with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
-            (new_tape,), _ = catalyst_decompose(tape, ctx, stopping_condition, capabilities)
+            (new_tape,), _ = catalyst_decompose(tape, ctx, capabilities)
 
         # unsupported ops on the top-level tape have been decomposed (no more Hadamard)
         assert "Hadamard" not in [op.name for op in new_tape.operations]
@@ -499,7 +489,7 @@ class TestPreprocessHybridOp:
         )
         # unsupported ops in the subtape decomposed (original tapes contained Hadamard)
         for subtape in cond_subtapes:
-            assert np.all([op.name in expected_ops for op in subtape.operations])
+            assert np.all([op.name in capabilities.native_ops for op in subtape.operations])
             assert "Hadamard" not in [op.name for op in subtape.operations]
             assert "RZ" in [op.name for op in subtape.operations]
 
@@ -513,12 +503,10 @@ class TestPreprocessHybridOp:
     def test_controlled_decomposes_to_unitary_listed(self):
         """Test that a PennyLane toml-listed operation is decomposed to a QubitUnitary"""
 
-        stopping_condition = partial(catalyst_acceptance, operations=expected_ops)
-
         tape = qml.tape.QuantumScript([qml.PauliX(0), qml.S(0)])
 
         with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
-            (new_tape,), _ = catalyst_decompose(tape, ctx, stopping_condition, capabilities)
+            (new_tape,), _ = catalyst_decompose(tape, ctx, capabilities)
 
         assert len(new_tape.operations) == 2
         assert isinstance(new_tape.operations[0], qml.PauliX)
@@ -527,12 +515,10 @@ class TestPreprocessHybridOp:
     def test_controlled_decomposes_to_unitary_controlled(self):
         """Test that a PennyLane controlled operation is decomposed to a QubitUnitary"""
 
-        stopping_condition = partial(catalyst_acceptance, operations=expected_ops)
-
         tape = qml.tape.QuantumScript([qml.ctrl(qml.RX(1.23, 0), 1)])
 
         with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
-            (new_tape,), _ = catalyst_decompose(tape, ctx, stopping_condition, capabilities)
+            (new_tape,), _ = catalyst_decompose(tape, ctx, capabilities)
 
         assert len(new_tape.operations) == 1
         new_op = new_tape.operations[0]
@@ -543,8 +529,6 @@ class TestPreprocessHybridOp:
     def test_error_for_pennylane_midmeasure_decompose(self):
         """Test that an error is raised in decompose if a PennyLane mid-circuit measurement
         is encountered"""
-
-        stopping_condition = partial(catalyst_acceptance, operations=expected_ops)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(1.23, wires=0)
@@ -557,13 +541,11 @@ class TestPreprocessHybridOp:
             CompileError, match="Must use 'measure' from Catalyst instead of PennyLane."
         ):
             with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
-                _ = catalyst_decompose(tape, ctx, stopping_condition, capabilities)
+                _ = catalyst_decompose(tape, ctx, capabilities)
 
     def test_error_for_pennylane_midmeasure_decompose_nested(self):
         """Test that an error is raised in decompose if a PennyLane mid-circuit measurement
         is encountered"""
-
-        stopping_condition = partial(catalyst_acceptance, operations=expected_ops)
 
         with qml.queuing.AnnotatedQueue() as q:
             qml.RX(1.23, wires=0)
@@ -582,14 +564,11 @@ class TestPreprocessHybridOp:
             CompileError, match="Must use 'measure' from Catalyst instead of PennyLane."
         ):
             with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
-                _ = catalyst_decompose(tape, ctx, stopping_condition, capabilities)
+                _ = catalyst_decompose(tape, ctx, capabilities)
 
     def test_unsupported_op_with_no_decomposition_raises_error(self):
         """Test that an unsupported operator that doesn't provide a decomposition
         raises a CompileError"""
-
-        # operations=[], all ops are unsupported
-        stopping_condition = partial(catalyst_acceptance, operations=[])
 
         tape = qml.tape.QuantumScript([qml.Y(0)])
 
@@ -598,13 +577,10 @@ class TestPreprocessHybridOp:
             match="not supported with catalyst on this device and does not provide a decomposition",
         ):
             with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
-                _ = catalyst_decompose(tape, ctx, stopping_condition, capabilities)
+                _ = catalyst_decompose(tape, ctx, replace(capabilities, native_ops={}))
 
     def test_decompose_to_matrix_raises_error(self):
         """Test that _decompose_to_matrix raises a CompileError if the operator has no matrix"""
-
-        # operations=[], all ops are unsupported
-        stopping_condition = partial(catalyst_acceptance, operations=[])
 
         class NoMatrixMultiControlledX(qml.MultiControlledX):
             """A version of MulitControlledX with no matrix defined"""
@@ -617,7 +593,11 @@ class TestPreprocessHybridOp:
 
         with pytest.raises(CompileError, match="could not be decomposed, it might be unsupported"):
             with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
-                _ = catalyst_decompose(tape, ctx, stopping_condition, capabilities)
+                _ = catalyst_decompose(
+                    tape,
+                    ctx,
+                    replace(capabilities, native_ops={"QubitUnitary": OperationProperties()}),
+                )
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_verification.py
+++ b/frontend/test/pytest/test_verification.py
@@ -36,11 +36,7 @@ from catalyst.api_extensions import HybridAdjoint, HybridCtrl
 from catalyst.device import get_device_capabilities
 from catalyst.device.qjit_device import RUNTIME_OPERATIONS, get_qjit_device_capabilities
 from catalyst.device.verification import validate_measurements
-from catalyst.utils.toml import (
-    OperationProperties,
-    ProgramFeatures,
-    pennylane_operation_set,
-)
+from catalyst.utils.toml import OperationProperties, pennylane_operation_set
 
 # pylint: disable = unused-argument, unnecessary-lambda-assignment, unnecessary-lambda
 
@@ -70,8 +66,7 @@ def get_custom_device(
 
         def __init__(self, shots=None, wires=None):
             super().__init__(wires=wires, shots=shots)
-            program_features = ProgramFeatures(shots_present=bool(kwargs.get("shots")))
-            lightning_capabilities = get_device_capabilities(lightning_device, program_features)
+            lightning_capabilities = get_device_capabilities(lightning_device)
             custom_capabilities = deepcopy(lightning_capabilities)
             for gate in native_gates:
                 custom_capabilities.native_ops[gate] = OperationProperties(True, True, True)

--- a/frontend/test/pytest/test_verification.py
+++ b/frontend/test/pytest/test_verification.py
@@ -36,7 +36,7 @@ from catalyst.api_extensions import HybridAdjoint, HybridCtrl
 from catalyst.device import get_device_capabilities
 from catalyst.device.qjit_device import RUNTIME_OPERATIONS, get_qjit_device_capabilities
 from catalyst.device.verification import validate_measurements
-from catalyst.utils.toml import OperationProperties, pennylane_operation_set
+from catalyst.utils.toml import OperationProperties
 
 # pylint: disable = unused-argument, unnecessary-lambda-assignment, unnecessary-lambda
 
@@ -85,20 +85,6 @@ def get_custom_device(
             Raises: RuntimeError
             """
             raise RuntimeError("QJIT devices cannot execute tapes.")
-
-        @property
-        def operations(self):
-            """Return operations using PennyLane's C(.) syntax"""
-            return (
-                pennylane_operation_set(self.qjit_capabilities.native_ops)
-                | pennylane_operation_set(self.qjit_capabilities.to_decomp_ops)
-                | pennylane_operation_set(self.qjit_capabilities.to_matrix_ops)
-            )
-
-        @property
-        def observables(self):
-            """Return PennyLane observables"""
-            return pennylane_operation_set(self.qjit_capabilities.native_obs)
 
         def supports_derivatives(self, config, circuit=None):  # pylint: disable=unused-argument
             """Pretend we support any derivatives"""


### PR DESCRIPTION
Simplifies device related code around capability checks and decomposition, and eliminates the use of `"Adjoint(*)"` and `"C(*)"` declarations in favour of DeviceCapabilities and OperationProperties dataclasses.

Includes the following (non-functional) changes:
- simplify `get_device_capability` signature
- simplify `catalyst_decompose` signature
- simplify `QJITDevice.__init__` signature
- eliminate `pennylane_operation_set` and use `DeviceCapabilities` instead
- remove legacy-device `operations`, `observables`, and `measurement_processes` properties from our device classes

Some of the code seems to have been written solely to facilitate testing, which should be avoided. 

[sc-67124]