### PR TITLE
Fix batch size calculation with vmap and static_argnums

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -187,6 +187,9 @@
 
 <h3>Bug fixes</h3>
 
+* Resolve a bug in the `vmap` function when passing shape-less values to the target. 
+  [(#1150)](https://github.com/PennyLaneAI/catalyst/pull/1150)
+
 <h3>Internal changes</h3>
 
 * Update Enzyme to version `v0.0.149`.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -187,7 +187,7 @@
 
 <h3>Bug fixes</h3>
 
-* Resolve a bug in the `vmap` function when passing shape-less values to the target. 
+* Resolve a bug in the `vmap` function when passing shapeless values to the target. 
   [(#1150)](https://github.com/PennyLaneAI/catalyst/pull/1150)
 
 <h3>Internal changes</h3>

--- a/frontend/catalyst/api_extensions/function_maps.py
+++ b/frontend/catalyst/api_extensions/function_maps.py
@@ -320,7 +320,7 @@ class VmapCallable:
 
         batch_sizes = []
         for arg, d in zip(args_flat, axes_flat):
-            shape = np.shape(arg) if arg.shape else (1,)
+            shape = np.shape(arg)
             if d is not None and len(shape) > d:
                 batch_sizes.append(shape[d])
 

--- a/frontend/catalyst/api_extensions/function_maps.py
+++ b/frontend/catalyst/api_extensions/function_maps.py
@@ -319,10 +319,17 @@ class VmapCallable:
         """
 
         batch_sizes = []
-        for arg, d in zip(args_flat, axes_flat):
+        for i, (arg, d) in enumerate(zip(args_flat, axes_flat)):
             shape = np.shape(arg)
-            if d is not None and len(shape) > d:
+            if d is None:
+                continue
+            elif len(shape) > d:
                 batch_sizes.append(shape[d])
+            else:
+                raise ValueError(
+                    f"Axis specifier {d} is out of bounds for argument {i}. "
+                    f"The argument only has {len(shape)} dimensions."
+                )
 
         if any(size != batch_sizes[0] for size in batch_sizes[1:]):
             raise ValueError(

--- a/frontend/catalyst/api_extensions/function_maps.py
+++ b/frontend/catalyst/api_extensions/function_maps.py
@@ -320,10 +320,11 @@ class VmapCallable:
 
         batch_sizes = []
         for i, (arg, d) in enumerate(zip(args_flat, axes_flat)):
-            shape = np.shape(arg)
             if d is None:
                 continue
-            elif len(shape) > d:
+
+            shape = np.shape(arg)
+            if len(shape) > d:
                 batch_sizes.append(shape[d])
             else:
                 raise ValueError(

--- a/frontend/test/pytest/test_vmap.py
+++ b/frontend/test/pytest/test_vmap.py
@@ -797,7 +797,7 @@ class TestVectorizeMap:
         assert batch_size == 2
 
     def test_vmap_axis_out_of_bounds(self):
-        """Confirm that vmap works when used with shape-less values."""
+        """Confirm that vmap works when used with shapeless values."""
 
         @vmap(in_axes=(0, 2))
         def f(a, b):

--- a/frontend/test/pytest/test_vmap.py
+++ b/frontend/test/pytest/test_vmap.py
@@ -21,7 +21,7 @@ import pytest
 
 from catalyst import qjit, vmap
 
-# pylint: disable=bug-vmap-shape
+# pylint: disable=protected-access
 
 
 class TestVectorizeMap:

--- a/frontend/test/pytest/test_vmap.py
+++ b/frontend/test/pytest/test_vmap.py
@@ -782,3 +782,13 @@ class TestVectorizeMap:
         expected = jnp.array([0.93005586, 0.00498127, -0.88789978])
         assert jnp.allclose(result[0], expected)
         assert jnp.allclose(result[1], expected)
+
+    def test_vmap_with_static_args(self):
+        """Confirm that vmap works when used with shape-less values."""
+
+        @vmap(in_axes=(None, 0))
+        def f(n, arr):
+            return n * arr
+
+        batch_size = f._get_batch_size((10, jnp.zeros((2, 5))), (None, 0), None)
+        assert batch_size == 2

--- a/frontend/test/pytest/test_vmap.py
+++ b/frontend/test/pytest/test_vmap.py
@@ -21,6 +21,8 @@ import pytest
 
 from catalyst import qjit, vmap
 
+# pylint: disable=bug-vmap-shape
+
 
 class TestVectorizeMap:
     """Test QJIT compatibility with JAX vectorization."""

--- a/frontend/test/pytest/test_vmap.py
+++ b/frontend/test/pytest/test_vmap.py
@@ -783,12 +783,23 @@ class TestVectorizeMap:
         assert jnp.allclose(result[0], expected)
         assert jnp.allclose(result[1], expected)
 
-    def test_vmap_with_static_args(self):
+    @pytest.mark.parametrize("arg", [10, "no", object()])
+    def test_vmap_with_shapeless_args(self, arg):
         """Confirm that vmap works when used with shape-less values."""
 
         @vmap(in_axes=(None, 0))
         def f(n, arr):
             return n * arr
 
-        batch_size = f._get_batch_size((10, jnp.zeros((2, 5))), (None, 0), None)
+        batch_size = f._get_batch_size((arg, jnp.zeros((2, 5))), (None, 0), None)
         assert batch_size == 2
+
+    def test_vmap_axis_out_of_bounds(self):
+        """Confirm that vmap works when used with shape-less values."""
+
+        @vmap(in_axes=(0, 2))
+        def f(a, b):
+            return a * b
+
+        with pytest.raises(ValueError, match="2 is out of bounds for argument 1"):
+            f._get_batch_size((jnp.zeros(5), jnp.zeros((2, 5))), (0, 2), None)


### PR DESCRIPTION
Resolves a bug accessing argument shapes in the vmap function when those arguments don't have a shape. This might happen when using vmap together with `static_argnums` for example:

```py
@qjit(static_argnums=0)
@vmap(in_axes=(None, 0))
def test(n, array):
    for _ in range(n):
        array = array * 2
    return array

test(10, np.random.rand(3,2))
```

Also improves error message for out of bounds axis specifier.

[sc-74291]