### PR TITLE
Fix nested accelerate with grad

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -211,6 +211,9 @@
 * Fix error message displayed when using `qml.cond` on callables with arguments.
   [(#1151)](https://github.com/PennyLaneAI/catalyst/pull/1151)
 
+* Fixes taking gradient of nested accelerate callbacks.
+  [(#1156)](https://github.com/PennyLaneAI/catalyst/pull/1156)
+
 <h3>Internal changes</h3>
 
 * Update Enzyme to version `v0.0.149`.

--- a/frontend/catalyst/api_extensions/callbacks.py
+++ b/frontend/catalyst/api_extensions/callbacks.py
@@ -364,18 +364,19 @@ def accelerate_impl(users_func=None, *, dev=None):
     # wraps total which wraps user
     @functools.wraps(total, assigned=WRAPPER_ASSIGNMENTS)
     def back_to_user(*args, **kwargs):
-        absextra, absargs, abskwargs = tree_map(shaped_abstractify, (context, args, kwargs))
-        try:
-            # Find the shape of the return value
-            with transient_jax_config({"jax_dynamic_shapes": False}):
-                _, returnshape = jax.make_jaxpr(jitted_fn, return_shape=True)(
-                    absextra, *absargs, **abskwargs
-                )
-        except Exception as e:
-            name = users_func.__name__
-            msg = f"Function {name} must be jax.jit-able."
-            msg += f"But failed with error message {str(e)}."
-            raise ValueError(msg) from e
+        with AccelerateContext():
+            absextra, absargs, abskwargs = tree_map(shaped_abstractify, (context, args, kwargs))
+            try:
+                # Find the shape of the return value
+                with transient_jax_config({"jax_dynamic_shapes": False}):
+                    _, returnshape = jax.make_jaxpr(jitted_fn, return_shape=True)(
+                        absextra, *absargs, **abskwargs
+                    )
+            except Exception as e:
+                name = users_func.__name__
+                msg = f"Function {name} must be jax.jit-able."
+                msg += f"But failed with error message {str(e)}."
+                raise ValueError(msg) from e
         annotated = AnnotatedFunctionImpl(jitted_fn, returnshape)
         with_custom_grad = CallbackWithPotentialCustomGrad(annotated, dev)
 
@@ -512,7 +513,7 @@ def base_callback_impl(func: AnnotatedFunction, device=None, custom_grad=None):
     # Since we are building this feature step by step.
     @functools.wraps(func, assigned=WRAPPER_ASSIGNMENTS)
     def bind_callback(*args, **kwargs):
-        if not EvaluationContext.is_tracing():
+        if not EvaluationContext.is_tracing() or AccelerateContext.am_inside_accelerate():
             # If we are not in the tracing context, just evaluate the function.
             return func(*args, **kwargs)
 

--- a/frontend/catalyst/tracing/contexts.py
+++ b/frontend/catalyst/tracing/contexts.py
@@ -115,17 +115,17 @@ class GradContext:
 
 
 class AccelerateContext:
-    _am_inside_accelerate: bool = False
+    _am_inside_accelerate: int = 0
 
     def __enter__(self):
-        AccelerateContext._am_inside_accelerate = True
+        AccelerateContext._am_inside_accelerate += 1
 
     def __exit__(self, _exc_type, _exc, _exc_tb):
-        AccelerateContext._am_inside_accelerate = False
+        AccelerateContext._am_inside_accelerate -= 1
 
     @staticmethod
     def am_inside_accelerate():
-        return AccelerateContext._am_inside_accelerate
+        return AccelerateContext._am_inside_accelerate > 0
 
 
 class EvaluationMode(Enum):

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -1522,5 +1522,21 @@ def test_error_incomplete_grad_only_reverse():
         wrapper(1.0)
 
 
+def test_nested_accelerate_grad():
+    """https://github.com/PennyLaneAI/catalyst/issues/1086"""
+
+    @qml.qjit
+    @grad
+    def hypothesis(x):
+        return accelerate(accelerate(jnp.sin))(x)
+
+    @jax.jit
+    @jax.grad
+    def ground_truth(x):
+        return jax.jit(jax.jit(jnp.sin))(x)
+
+    assert np.allclose(hypothesis(0.43), ground_truth(0.43))
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])


### PR DESCRIPTION
**Context:** Fixes taking the gradient of nested accelerate calls.

**Description of the Change:** Takes advantage of accelerate context to let JAX do its thing.

**Benefits:** Fixes bug.

**Possible Drawbacks:** I think a better way to do this would be to have `is_tracing` to return False. However, that would involve refactoring the current tracing context. Maybe a possible follow up.

**Related GitHub Issues:** Fixes #1086 
