### PR TITLE
Update Deallocation Pass

### DIFF
--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -240,7 +240,6 @@ BUFFERIZATION_PASS = (
         "func.func(buffer-hoisting)",
         "func.func(buffer-loop-hoisting)",
         "buffer-deallocation-pipeline",
-        "func.func(buffer-deallocation)",
         "convert-arraylist-to-memref",
         "convert-bufferization-to-memref",
         "canonicalize",  # Must be after convert-bufferization-to-memref

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -239,10 +239,7 @@ BUFFERIZATION_PASS = (
         # introduced during gradient-bufferize of callbacks
         "func.func(buffer-hoisting)",
         "func.func(buffer-loop-hoisting)",
-        #"buffer-results-to-out-params",
-        #"drop-equivalent-buffer-results",
-        #"func.func(promote-buffers-to-stack)",
-        #"buffer-deallocation-pipeline",
+        "buffer-deallocation-pipeline",
         "func.func(buffer-deallocation)",
         "convert-arraylist-to-memref",
         "convert-bufferization-to-memref",

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -239,6 +239,10 @@ BUFFERIZATION_PASS = (
         # introduced during gradient-bufferize of callbacks
         "func.func(buffer-hoisting)",
         "func.func(buffer-loop-hoisting)",
+        #"buffer-results-to-out-params",
+        #"drop-equivalent-buffer-results",
+        #"func.func(promote-buffers-to-stack)",
+        #"buffer-deallocation-pipeline",
         "func.func(buffer-deallocation)",
         "convert-arraylist-to-memref",
         "convert-bufferization-to-memref",

--- a/mlir/include/Catalyst/IR/CatalystOps.td
+++ b/mlir/include/Catalyst/IR/CatalystOps.td
@@ -26,7 +26,8 @@ include "mlir/IR/OpBase.td"
 
 include "Catalyst/IR/CatalystDialect.td"
 
-def ListInitOp : Catalyst_Op<"list_init"> {
+def ListInitOp : Catalyst_Op<"list_init",
+        [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
     let summary = "Initialize a dynamically resizable arraylist.";
     let results = (outs ArrayListType:$list);
     let assemblyFormat = [{ attr-dict `:` type($list) }];

--- a/mlir/include/Catalyst/IR/CatalystOps.td
+++ b/mlir/include/Catalyst/IR/CatalystOps.td
@@ -33,7 +33,8 @@ def ListInitOp : Catalyst_Op<"list_init",
     let assemblyFormat = [{ attr-dict `:` type($list) }];
 }
 
-def ListDeallocOp : Catalyst_Op<"list_dealloc"> {
+def ListDeallocOp : Catalyst_Op<"list_dealloc",
+        [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
     let summary = "Deallocate the underlying memory of an arraylist.";
     let arguments = (ins ArrayListType:$list);
     let assemblyFormat = [{ $list attr-dict `:` type($list) }];

--- a/mlir/include/Catalyst/IR/CatalystOps.td
+++ b/mlir/include/Catalyst/IR/CatalystOps.td
@@ -42,7 +42,8 @@ def ListDeallocOp : Catalyst_Op<"list_dealloc"> {
 def ListPushOp : Catalyst_Op<"list_push",
         [TypesMatchWith<"type of 'value' matches element type of 'list'",
                         "list", "value",
-                        "mlir::cast<ArrayListType>($_self).getElementType()">]> {
+                        "mlir::cast<ArrayListType>($_self).getElementType()">,
+        DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
     let summary = "Append an element to the end of an array list.";
     let arguments = (ins AnyType:$value, ArrayListType:$list);
     let assemblyFormat = [{ $value `,` $list attr-dict `:` type($list) }];

--- a/mlir/include/Catalyst/IR/CatalystOps.td
+++ b/mlir/include/Catalyst/IR/CatalystOps.td
@@ -52,7 +52,8 @@ def ListPushOp : Catalyst_Op<"list_push",
 def ListPopOp : Catalyst_Op<"list_pop",
         [TypesMatchWith<"type of 'result' matches element type of 'list'",
                         "list", "result",
-                        "mlir::cast<ArrayListType>($_self).getElementType()">]> {
+                        "mlir::cast<ArrayListType>($_self).getElementType()">,
+        DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
     let summary = "Remove an element from the end of an array list and return it.";
     let arguments = (ins ArrayListType:$list);
     let results = (outs AnyType:$result);

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -965,7 +965,8 @@ def ProbsOp : Measurement_Op<"probs"> {
     let hasVerifier = 1;
 }
 
-def StateOp : Measurement_Op<"state"> {
+def StateOp : Measurement_Op<"state",
+        [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
     let summary = "Return the current statevector";
     let description = [{
         The `quantum.state` operation represents the measurement process of returning the current

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -79,7 +79,8 @@ def FinalizeOp : Quantum_Op<"finalize"> {
     }];
 }
 
-def DeviceInitOp : Quantum_Op<"device"> {
+def DeviceInitOp : Quantum_Op<"device",
+    [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
     let summary = "Initialize a quantum device.";
 
     let arguments = (ins

--- a/mlir/lib/Catalyst/IR/CatalystOps.cpp
+++ b/mlir/lib/Catalyst/IR/CatalystOps.cpp
@@ -32,6 +32,13 @@ void ListInitOp::getEffects(
     effects.emplace_back(mlir::MemoryEffects::Allocate::get());
 }
 
+void ListPushOp::getEffects(
+    llvm::SmallVectorImpl<mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>> &effects)
+{
+    effects.emplace_back(mlir::MemoryEffects::Allocate::get());
+    effects.emplace_back(mlir::MemoryEffects::Write::get());
+}
+
 void CustomCallOp::getEffects(
     llvm::SmallVectorImpl<mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>> &effects)
 {

--- a/mlir/lib/Catalyst/IR/CatalystOps.cpp
+++ b/mlir/lib/Catalyst/IR/CatalystOps.cpp
@@ -39,6 +39,13 @@ void ListPushOp::getEffects(
     effects.emplace_back(mlir::MemoryEffects::Write::get());
 }
 
+void ListPopOp::getEffects(
+    llvm::SmallVectorImpl<mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>> &effects)
+{
+    effects.emplace_back(mlir::MemoryEffects::Free::get());
+    effects.emplace_back(mlir::MemoryEffects::Read::get());
+}
+
 void CustomCallOp::getEffects(
     llvm::SmallVectorImpl<mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>> &effects)
 {

--- a/mlir/lib/Catalyst/IR/CatalystOps.cpp
+++ b/mlir/lib/Catalyst/IR/CatalystOps.cpp
@@ -26,6 +26,12 @@ using namespace catalyst;
 #define GET_OP_CLASSES
 #include "Catalyst/IR/CatalystOps.cpp.inc"
 
+void ListInitOp::getEffects(
+    llvm::SmallVectorImpl<mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>> &effects)
+{
+    effects.emplace_back(mlir::MemoryEffects::Allocate::get());
+}
+
 void CustomCallOp::getEffects(
     llvm::SmallVectorImpl<mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>> &effects)
 {

--- a/mlir/lib/Catalyst/IR/CatalystOps.cpp
+++ b/mlir/lib/Catalyst/IR/CatalystOps.cpp
@@ -32,6 +32,12 @@ void ListInitOp::getEffects(
     effects.emplace_back(mlir::MemoryEffects::Allocate::get());
 }
 
+void ListDeallocOp::getEffects(
+    llvm::SmallVectorImpl<mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>> &effects)
+{
+    effects.emplace_back(mlir::MemoryEffects::Free::get());
+}
+
 void ListPushOp::getEffects(
     llvm::SmallVectorImpl<mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>> &effects)
 {

--- a/mlir/lib/Quantum/IR/QuantumOps.cpp
+++ b/mlir/lib/Quantum/IR/QuantumOps.cpp
@@ -306,3 +306,10 @@ LogicalResult AdjointOp::verify()
 
     return success();
 }
+
+void DeviceInitOp::getEffects(
+    llvm::SmallVectorImpl<mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>> &effects)
+{
+    // Assume all effects
+    effects.emplace_back(mlir::MemoryEffects::Allocate::get());
+}

--- a/mlir/lib/Quantum/IR/QuantumOps.cpp
+++ b/mlir/lib/Quantum/IR/QuantumOps.cpp
@@ -313,3 +313,10 @@ void DeviceInitOp::getEffects(
     // Assume all effects
     effects.emplace_back(mlir::MemoryEffects::Allocate::get());
 }
+
+void StateOp::getEffects(
+    llvm::SmallVectorImpl<mlir::SideEffects::EffectInstance<mlir::MemoryEffects::Effect>> &effects)
+{
+    // Assume all effects
+    effects.emplace_back(mlir::MemoryEffects::Read::get());
+}


### PR DESCRIPTION
**Context:**
Replace `bufferization-deallocation` with `bufferization-deallocation-pipeline`, which contains `ownership-based-deallocation` from MLIR. The pass requires each catalyst operation have a `getEffect` method.

**Related GitHub Issues:**
Follow up of #1027
