### PR TITLE
[Frontend] Ensure the order of `set_basis_state_p` and `set_state_p` are preserved.

### DIFF
--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -183,7 +183,7 @@ KNOWN_NAMED_OBS = (qml.Identity, qml.PauliX, qml.PauliY, qml.PauliZ, qml.Hadamar
 # Take care when adding primitives to this set in order to avoid introducing a quadratic number of
 # edges to the jaxpr equation graph in ``sort_eqns()``. Each equation with a primitive in this set
 # is constrained to occur before all subsequent equations in the quantum operations trace.
-FORCED_ORDER_PRIMITIVES = {qdevice_p, gphase_p}
+FORCED_ORDER_PRIMITIVES = {qdevice_p, gphase_p, set_basis_state_p, set_state_p}
 
 PAULI_NAMED_MAP = {
     "I": "Identity",

--- a/frontend/test/lit/test_skip_initial_state_prep.py
+++ b/frontend/test/lit/test_skip_initial_state_prep.py
@@ -71,3 +71,17 @@ def state_prep_example_double():
 #       CHECK:   quantum.set_state
 #   CHECK-NOT:   quantum.set_state
 print(state_prep_example_double.mlir)
+
+@qml.qjit(target="mlir")
+@qml.qnode(qml.device("lightning.qubit", wires=5, shots=100))
+def multiple_basis_embedding():
+    """Ok, so we only have one, but we also need to guarantee that it is the first one"""
+    # CHECK-LABEL: func.func private @multiple_basis_embedding
+    # CHECK-NOT: quantum.custom
+    # CHECK: quantum.set_basis_state
+    qml.BasisEmbedding(2, wires=[0, 1, 2])
+    qml.BasisEmbedding(3, wires=[3, 4])
+    qml.ctrl(qml.X(0), control=[1, 2])
+    return qml.counts(wires=[3, 4])
+
+print(multiple_basis_embedding.mlir)


### PR DESCRIPTION
**Context:** When a tape contains two state preparation operations, it will decompose one. However, the order of the decomposed operations is no longer guaranteed to come after the first state preparation. This is due to how the tracing interacts with transforms and decomposition. The only order that JAXPR cares about is the use-def chain. However, if two state preparation operations occur on a different subset of wires, then the state preparation can be placed after the one that was decomposed.

**Description of the Change:** We add `set_basis_state_p` and `set_state_p` to the `FORCED_ORDER_PRIMITIVES` set to ensure that the order is preserved as they are traced.

**Benefits:** No logic errors.

**Possible Drawbacks:** More dependency on the topological sorting. I believe some time ago it was found out that topological sorting takes a long time and it takes longer the more `FORCED_ORDER_PRIMITIVES` there are. 

**Related GitHub Issues:**

TODO:

- [ ] MLIR Pass to analyze qnodes to make this a compile time guarantee.
