### PR TITLE
[Frontend] Raise RuntimeError when nesting qnodes with qjit

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -209,6 +209,12 @@
 
   This reverts a previous breaking change.
 
+* Nesting qnodes now raises an error.
+  [(#1176)](https://github.com/PennyLaneAI/catalyst/pull/1176)
+
+  This is unlikely to affect users since only under certain conditions did
+  nesting qnodes worked successfully.
+
 <h3>Bug fixes</h3>
 
 * Resolve a bug in the `vmap` function when passing shapeless values to the target.

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -52,6 +52,7 @@ from catalyst.logging import debug_logger
 from catalyst.passes import pipeline
 from catalyst.tracing.contexts import EvaluationContext
 from catalyst.tracing.type_signatures import filter_static_args
+from catalyst.utils.exceptions import CompileError
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -99,7 +100,7 @@ class QFunc:
     def __call__(self, *args, **kwargs):
 
         if EvaluationContext.is_quantum_tracing():
-            raise RuntimeError("Can't nest qnodes under qjit")
+            raise CompileError("Can't nest qnodes under qjit")
 
         assert isinstance(self, qml.QNode)
 

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -50,6 +50,7 @@ from catalyst.jax_primitives import func_p
 from catalyst.jax_tracer import trace_quantum_function
 from catalyst.logging import debug_logger
 from catalyst.passes import pipeline
+from catalyst.tracing.contexts import EvaluationContext
 from catalyst.tracing.type_signatures import filter_static_args
 
 logger = logging.getLogger(__name__)
@@ -96,6 +97,10 @@ class QFunc:
     # pylint: disable=self-cls-assignment
     @debug_logger
     def __call__(self, *args, **kwargs):
+
+        if EvaluationContext.is_quantum_tracing():
+            raise RuntimeError("Can't nest qnodes under qjit")
+
         assert isinstance(self, qml.QNode)
 
         # Update the qnode with peephole pipeline

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -277,31 +277,6 @@ class TestIntegration:
         assert check_cache(inner2.func)
         assert fn(np.pi) == -2
 
-    def test_nested_qnode(self):
-        """Test autograph on a QNode called from within another QNode."""
-
-        @qml.qnode(qml.device("lightning.qubit", wires=1))
-        def inner1(x):
-            qml.RX(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
-
-        @qml.qnode(qml.device("lightning.qubit", wires=1))
-        def inner2(x):
-            y = inner1(x) * np.pi
-            qml.RY(y, wires=0)
-            return qml.expval(qml.PauliZ(0))
-
-        @qjit(autograph=True)
-        def fn(x: int):
-            return inner2(x)
-
-        assert hasattr(fn.user_function, "ag_unconverted")
-        assert check_cache(fn.original_function)
-        assert check_cache(inner1.func)
-        assert check_cache(inner2.func)
-        # Unsupported by the runtime:
-        # assert fn(np.pi) == -2
-
     def test_nested_qjit(self):
         """Test autograph on a QJIT function called from within the compilation entry point."""
 

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -514,28 +514,6 @@ class TestCodePrinting:
         assert autograph_source(inner1)
         assert autograph_source(inner2)
 
-    def test_nested_qnode(self):
-        """Test printing on a QNode called from within another QNode."""
-
-        @qml.qnode(qml.device("lightning.qubit", wires=1))
-        def inner1(x):
-            qml.RX(x, wires=0)
-            return qml.expval(qml.PauliZ(0))
-
-        @qml.qnode(qml.device("lightning.qubit", wires=1))
-        def inner2(x):
-            y = inner1(x) * np.pi
-            qml.RY(y, wires=0)
-            return qml.expval(qml.PauliZ(0))
-
-        @qjit(autograph=True)
-        def fn(x: int):
-            return inner2(x)
-
-        assert autograph_source(fn)
-        assert autograph_source(inner1)
-        assert autograph_source(inner2)
-
     def test_nested_qjit(self):
         """Test printing on a QJIT function called from within the compilation entry point."""
 

--- a/frontend/test/pytest/test_gradient_postprocessing.py
+++ b/frontend/test/pytest/test_gradient_postprocessing.py
@@ -298,35 +298,5 @@ def test_no_nested_grad_without_fd():
         outer(9.0)
 
 
-def test_nested_qnode(backend):
-    """Test that Enzyme is able to compile a hybrid program containing nested QNodes"""
-    device = qml.device(backend, wires=2)
-
-    @qml.qnode(device, diff_method="adjoint")
-    def inner(x):
-        qml.RX(x, wires=0)
-        return qml.expval(qml.PauliZ(0))
-
-    @qml.qnode(device, diff_method="parameter-shift")
-    def outer(x):
-        qml.RX(inner(x), wires=0)
-        return qml.expval(qml.PauliY(0))
-
-    def post(x):
-        return outer(x)
-
-    @qjit
-    def _grad_qnode_direct(x: float):
-        return grad(outer, method="auto")(x)
-
-    @qjit
-    def _grad_postprocess(x: float):
-        return grad(post, method="auto")(x)
-
-    # The runtime doesn't support actually executing nested QNodes, so we just make sure they
-    # compile without issues.
-    # assert _grad_qnode_direct(1.0) == pytest.approx(jax.grad(post)(1.0))
-
-
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -995,5 +995,29 @@ class TestParamsAnnotations:
         assert not params_are_annotated(foo)
 
 
+class TestErrorNestedQNode:
+    """Test error is raised with nested qnodes"""
+
+    def test_nested_qnode(self):
+        """Test autograph on a QNode raises error."""
+
+        dev = qml.device("lightning.qubit", wires=1)
+
+        @qml.qnode(dev)
+        def inner():
+            return qml.state()
+
+        @qml.qnode(dev)
+        def outer():
+            inner()
+            return qml.state()
+
+        with pytest.raises(RuntimeError):
+
+            @qjit
+            def fn():
+                return outer()
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -32,6 +32,7 @@ from catalyst.tracing.type_signatures import (
     params_are_annotated,
     typecheck_signatures,
 )
+from catalyst.utils.exceptions import CompileError
 
 
 def f_aot_builder(backend, wires=1, shots=1000):
@@ -1012,7 +1013,7 @@ class TestErrorNestedQNode:
             inner()
             return qml.state()
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(CompileError):
 
             @qjit
             def fn():

--- a/frontend/test/pytest/test_mid_circuit_measurement.py
+++ b/frontend/test/pytest/test_mid_circuit_measurement.py
@@ -570,35 +570,6 @@ class TestDynamicOneShotIntegration:
         assert result.shape == (shots,)
         assert jnp.allclose(result, expected)
 
-    @pytest.mark.parametrize("debug", [False, True])
-    def test_dynamic_one_shot_nested_qnodes(self, backend, debug):
-        """Test that `dynamic_one_shot` handle nested calls correctly."""
-
-        if not debug:
-            pytest.xfail("Error in Catalyst Runtime: Cannot re-initialize an ACTIVE device")
-
-        shots = 10
-        dev = qml.device(backend, wires=2, shots=shots)
-
-        @qml.qnode(dev)
-        def inner():
-            qml.PauliX(0)
-            return qml.sample(wires=0)
-
-        @qjit
-        @qml.qnode(dev, mcm_method="one-shot")
-        def outer():
-            x = inner()
-            if debug:
-                catalyst.debug.print("Value of x = {x}", x=x)
-            qml.RY(jnp.pi * qml.math.sum(x) / shots, wires=0)
-            m0 = measure(0)
-            return qml.sample(m0)
-
-        result = outer()
-        assert result.shape == (shots,)
-        assert jnp.allclose(result, 1.0)
-
     @pytest.mark.xfail(
         reason="Midcircuit measurements with sampling is unseeded and hence this test is flaky"
     )


### PR DESCRIPTION
**Context:** Nesting qnodes is not guaranteed to succeed at runtime. This is because of how the runtime is implemented. The runtime sets some global variables that are reset when each qnode is call. So if one qnode is executing and another qnode executes, then the global variables are overwritten. Nested qnodes only succeed right now if:
- The execution of the nested qnode does not overlap with the execution of the outer qnode.
- The code generated a call to the nested qnode before the `quantum.device_init` instruction in the outer qnode.
 
**Description of the Change:** On the frontend, we disallow nesting qnodes.

**Benefits:** Nice error messages instead of segfaults.

**Possible Drawbacks:** Some possible breaking changes (although unlikely)
