### PR TITLE
[Frontend][Driver] Remove `compile_from_mlir`.

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -218,6 +218,13 @@
   This is unlikely to affect users since only under certain conditions did
   nesting qnodes worked successfully.
 
+* Changes in the `debug.compile_from_mlir`'s API.
+  [(#1181)](https://github.com/PennyLaneAI/catalyst/pull/1181)
+
+  Now instead of automatically inferring the entry function's name
+  and return types from the IR, the user must add them as inputs.
+  This function is only useful for debugging, so it is unlikely to affect users.
+
 <h3>Bug fixes</h3>
 
 * Resolve a bug in the `vmap` function when passing shapeless values to the target.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -218,12 +218,10 @@
   This is unlikely to affect users since only under certain conditions did
   nesting qnodes worked successfully.
 
-* Changes in the `debug.compile_from_mlir`'s API.
+* Removes `debug.compile_from_mlir`.
   [(#1181)](https://github.com/PennyLaneAI/catalyst/pull/1181)
 
-  Now instead of automatically inferring the entry function's name
-  and return types from the IR, the user must add them as inputs.
-  This function is only useful for debugging, so it is unlikely to affect users.
+  Please use `debug.replace_ir`.
 
 <h3>Bug fixes</h3>
 

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -553,9 +553,6 @@ class Compiler:
                                    shard object library path.
             out_IR (str): Output IR in textual form. For the default pipeline this would be the
                           LLVM IR.
-            A list of:
-               func_name (str) Inferred name of the main function
-               ret_type_name (str) Inferred main function result type name
         """
         assert isinstance(
             workspace, Directory
@@ -590,8 +587,6 @@ class Compiler:
 
         filename = compiler_output.get_object_filename()
         out_IR = compiler_output.get_output_ir()
-        func_name = compiler_output.get_function_attributes().get_function_name()
-        ret_type_name = compiler_output.get_function_attributes().get_return_type()
 
         if lower_to_llvm:
             output = LinkerDriver.run(filename, options=self.options)
@@ -600,7 +595,7 @@ class Compiler:
             output_filename = filename
 
         self.last_compiler_output = compiler_output
-        return output_filename, out_IR, [func_name, ret_type_name]
+        return output_filename, out_IR
 
     @debug_logger
     def run(self, mlir_module, *args, **kwargs):

--- a/frontend/catalyst/debug/__init__.py
+++ b/frontend/catalyst/debug/__init__.py
@@ -17,7 +17,6 @@
 from catalyst.debug.callback import callback
 from catalyst.debug.compiler_functions import (
     compile_executable,
-    compile_from_mlir,
     get_cmain,
     get_compilation_stage,
     replace_ir,
@@ -34,7 +33,6 @@ __all__ = (
     "print_memref",
     "get_compilation_stage",
     "get_cmain",
-    "compile_from_mlir",
     "instrumentation",
     "replace_ir",
     "compile_executable",

--- a/frontend/catalyst/debug/compiler_functions.py
+++ b/frontend/catalyst/debug/compiler_functions.py
@@ -69,7 +69,7 @@ def get_compilation_stage(fn, stage):
     Returns:
         str: output ir from the target compiler stage
 
-    .. seealso:: :doc:`/dev/debugging`, :func:`~.replace_ir`, :func:`~.compile_from_mlir`.
+    .. seealso:: :doc:`/dev/debugging`, :func:`~.replace_ir`.
 
     **Example**
 
@@ -130,63 +130,6 @@ def get_cmain(fn, *args):
     return fn.compiled_function.get_cmain(*args)
 
 
-# pylint: disable=line-too-long
-@debug_logger
-def compile_from_mlir(ir, entry_point, result_types, compiler=None, compile_options=None):
-    r"""Compile a Catalyst function to binary code from the provided MLIR.
-
-    Args:
-        ir (str): the MLIR to compile in string form
-        entry_point (str): Name of MLIR function which is the entry point
-        result_types List[mlir.Type]: Return types
-        compile_options: options to use during compilation
-
-    Returns:
-        CompiledFunction: A callable that manages the compiled shared library and its invocation.
-
-    .. seealso:: :doc:`/dev/debugging`, :func:`~.get_compilation_stage`, :func:`~.replace_ir`.
-
-    **Example**
-
-    The program is required to contain ``setup`` and ``teardown`` functions.
-
-    .. code-block:: python
-
-        ir = r\"""
-            module @workflow {
-                func.func public @catalyst.entry_point(%arg0: tensor<f64>) -> tensor<f64> attributes {llvm.emit_c_interface} {
-                    return %arg0 : tensor<f64>
-                }
-                func.func @setup() {
-                    quantum.init
-                    return
-                }
-                func.func @teardown() {
-                    quantum.finalize
-                    return
-                }
-            }
-        \"""
-
-        with mlir.ir.Context():
-            result_types = [mlir.ir.RankedTensorType.parse("tensor<f64>")]
-        compiled_function = debug.compile_from_mlir(ir, "catalyst.entry_point", result_types)
-
-    >>> compiled_function(0.1)
-    [0.1]
-    """
-    EvaluationContext.check_is_not_tracing("Cannot compile from IR in tracing context.")
-
-    if compiler is None:
-        compiler = Compiler(compile_options)
-
-    module_name = "debug_module"
-    workspace_dir = os.getcwd() if compiler.options.keep_intermediate else None
-    workspace = WorkspaceManager.get_or_create_workspace("debug_workspace", workspace_dir)
-    shared_object, _llvm_ir = compiler.run_from_ir(ir, module_name, workspace)
-    return CompiledFunction(shared_object, entry_point, result_types, None, compiler.options)
-
-
 @debug_logger
 def replace_ir(fn, stage, new_ir):
     r"""Replace the IR at any compilation stage that will be used the next time the function runs.
@@ -210,7 +153,7 @@ def replace_ir(fn, stage, new_ir):
         stage (str): Recompilation picks up after this stage.
         new_ir (str): The replacement IR to use for recompilation.
 
-    .. seealso:: :doc:`/dev/debugging`, :func:`~.get_compilation_stage`, :func:`~.compile_from_mlir`.
+    .. seealso:: :doc:`/dev/debugging`, :func:`~.get_compilation_stage`.
 
     **Example**
 

--- a/frontend/catalyst/debug/compiler_functions.py
+++ b/frontend/catalyst/debug/compiler_functions.py
@@ -26,13 +26,11 @@ import sysconfig
 from itertools import product
 
 import catalyst
-from catalyst.compiled_functions import CompiledFunction
-from catalyst.compiler import Compiler, LinkerDriver
+from catalyst.compiler import LinkerDriver
 from catalyst.logging import debug_logger
 from catalyst.tracing.contexts import EvaluationContext
 from catalyst.tracing.type_signatures import filter_static_args, promote_arguments
 from catalyst.utils.exceptions import CompileError
-from catalyst.utils.filesystem import WorkspaceManager
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -703,7 +703,7 @@ class QJIT:
         canonicalizer = Compiler(options)
 
         # TODO: the in-memory and textual form are different after this, consider unification
-        _, mlir_string, _ = canonicalizer.run(mlir_module, self.workspace)
+        _, mlir_string = canonicalizer.run(mlir_module, self.workspace)
 
         return mlir_module, mlir_string
 
@@ -732,13 +732,13 @@ class QJIT:
         # `replace` method, so we need to get a regular Python string out of it.
         func_name = str(self.mlir_module.body.operations[0].name).replace('"', "")
         if self.overwrite_ir:
-            shared_object, llvm_ir, _ = self.compiler.run_from_ir(
+            shared_object, llvm_ir = self.compiler.run_from_ir(
                 self.overwrite_ir,
                 str(self.mlir_module.operation.attributes["sym_name"]).replace('"', ""),
                 self.workspace,
             )
         else:
-            shared_object, llvm_ir, _ = self.compiler.run(self.mlir_module, self.workspace)
+            shared_object, llvm_ir = self.compiler.run(self.mlir_module, self.workspace)
 
         compiled_fn = CompiledFunction(
             shared_object, func_name, restype, self.out_type, self.compile_options

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -158,7 +158,10 @@ void _catalyst_pyface_jit_cpp_exception_test(void*, void*) {
                     )
                     output = LinkerDriver.run(object_file, options=self.options)
                     filename = str(pathlib.Path(output).absolute())
-                    return filename, "<FAKE_IR>", ["<FAKE_FN>", "<FAKE_TYPE>"]
+                    return (
+                        filename,
+                        "<FAKE_IR>",
+                    )
 
         @qjit(target="mlir")
         @qml.qnode(qml.device(backend, wires=1))

--- a/frontend/test/pytest/test_debug.py
+++ b/frontend/test/pytest/test_debug.py
@@ -26,7 +26,6 @@ from catalyst import debug, for_loop, qjit, value_and_grad
 from catalyst.compiler import CompileOptions, Compiler
 from catalyst.debug import (
     compile_executable,
-    compile_from_mlir,
     get_cmain,
     get_compilation_stage,
     replace_ir,
@@ -257,123 +256,6 @@ class TestPrintStage:
 
         with pytest.raises(TypeError, match="needs to be a 'QJIT' object"):
             print(get_compilation_stage(func, "HLOLoweringPass"))
-
-
-class TestCompileFromIR:
-    """Test the debug feature that compiles from a string representation of the IR."""
-
-    def test_compiler_from_textual_ir(self):
-        """Test the textual IR compilation."""
-        full_path = get_lib_path("runtime", "RUNTIME_LIB_DIR")
-        extension = ".so" if platform.system() == "Linux" else ".dylib"
-
-        # pylint: disable=line-too-long
-        ir = (
-            r"""
-module @workflow {
-  func.func public @catalyst.entry_point(%arg0: tensor<f64>) -> tensor<f64> attributes {llvm.emit_c_interface} {
-    %0 = call @workflow(%arg0) : (tensor<f64>) -> tensor<f64>
-    return %0 : tensor<f64>
-  }
-  func.func private @workflow(%arg0: tensor<f64>) -> tensor<f64> attributes {diff_method = "finite-diff", llvm.linkage = #llvm.linkage<internal>, qnode} {
-    quantum.device ["""
-            + r'"'
-            + full_path
-            + r"""/librtd_lightning"""
-            + extension
-            + """", "LightningSimulator", "{'shots': 0}"]
-    %0 = stablehlo.constant dense<4> : tensor<i64>
-    %1 = quantum.alloc( 4) : !quantum.reg
-    %2 = stablehlo.constant dense<0> : tensor<i64>
-    %extracted = tensor.extract %2[] : tensor<i64>
-    %3 = quantum.extract %1[%extracted] : !quantum.reg -> !quantum.bit
-    %4 = quantum.custom "PauliX"() %3 : !quantum.bit
-    %5 = stablehlo.constant dense<1> : tensor<i64>
-    %extracted_0 = tensor.extract %5[] : tensor<i64>
-    %6 = quantum.extract %1[%extracted_0] : !quantum.reg -> !quantum.bit
-    %extracted_1 = tensor.extract %arg0[] : tensor<f64>
-    %7 = quantum.custom "RX"(%extracted_1) %6 : !quantum.bit
-    %8 = quantum.namedobs %4[ PauliZ] : !quantum.obs
-    %9 = quantum.expval %8 : f64
-    %from_elements = tensor.from_elements %9 : tensor<f64>
-    quantum.dealloc %1 : !quantum.reg
-    quantum.device_release
-    return %from_elements : tensor<f64>
-  }
-  func.func @setup() {
-    quantum.init
-    return
-  }
-  func.func @teardown() {
-    quantum.finalize
-    return
-  }
-  module attributes {transform.with_named_sequence} {
-    transform.named_sequence @__transform_main(%arg0: !transform.op<"builtin.module">){
-      transform.yield
-    }
-  }
-}
-"""
-        )
-        with mlir.ir.Context():
-            result_types = [mlir.ir.RankedTensorType.parse("tensor<f64>")]
-
-        compiled_function = compile_from_mlir(ir, "catalyst.entry_point", result_types)
-        assert compiled_function(0.1) == [-1]
-
-    def test_compile_from_ir_with_compiler(self):
-        """Supply a custom compiler instance to the textual compilation function."""
-
-        options = CompileOptions(static_argnums=[1])
-        compiler = Compiler(options)
-
-        ir = r"""
-module @workflow {
-  func.func public @catalyst.entry_point(%arg0: tensor<f64>) -> tensor<f64> attributes {llvm.emit_c_interface} {
-    return %arg0 : tensor<f64>
-  }
-  func.func @setup() {
-    quantum.init
-    return
-  }
-  func.func @teardown() {
-    quantum.finalize
-    return
-  }
-  module attributes {transform.with_named_sequence} {
-    transform.named_sequence @__transform_main(%arg0: !transform.op<"builtin.module">){
-      transform.yield
-    }
-  }
-}
-"""
-        with mlir.ir.Context():
-            result_types = [mlir.ir.RankedTensorType.parse("tensor<f64>")]
-        compiled_function = compile_from_mlir(
-            ir, "catalyst.entry_point", result_types, compiler=compiler
-        )
-        assert compiled_function(0.1, 0.2) == [0.1]  # allow call with one extra argument
-
-    def test_parsing_errors(self):
-        """Test parsing error handling."""
-
-        ir = r"""
-module @workflow {
-  func.func public @catalyst.entry_point(%arg0: tensor<f64>) -> tensor<f64> attributes {llvm.emit_c_interface} {
-    %c = stablehlo.constant dense<4.0> : tensor<i64>
-    return %c : tensor<f64> // Invalid type
-  }
-}
-"""
-        with mlir.ir.Context():
-            result_types = [mlir.ir.RankedTensorType.parse("tensor<f64>")]
-
-        with pytest.raises(CompileError) as e:
-            compile_from_mlir(ir, "catalyst.entry_point", result_types)(0.1)
-
-        assert "Failed to parse module as MLIR source" in e.value.args[0]
-        assert "Failed to parse module as LLVM source" in e.value.args[0]
 
 
 class TestCProgramGeneration:

--- a/frontend/test/pytest/test_debug.py
+++ b/frontend/test/pytest/test_debug.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 
 import os
-import platform
 import re
 import shutil
 import subprocess
@@ -19,11 +18,9 @@ import jax.numpy as jnp
 import numpy as np
 import pennylane as qml
 import pytest
-from jax.interpreters import mlir
 from jax.tree_util import register_pytree_node_class
 
 from catalyst import debug, for_loop, qjit, value_and_grad
-from catalyst.compiler import CompileOptions, Compiler
 from catalyst.debug import (
     compile_executable,
     get_cmain,
@@ -31,7 +28,6 @@ from catalyst.debug import (
     replace_ir,
 )
 from catalyst.utils.exceptions import CompileError
-from catalyst.utils.runtime_environment import get_lib_path
 
 
 class TestDebugPrint:

--- a/mlir/include/Driver/CompilerDriver.h
+++ b/mlir/include/Driver/CompilerDriver.h
@@ -27,17 +27,6 @@
 namespace catalyst {
 namespace driver {
 
-/// Data about the JIT function that is optionally inferred and returned to the caller.
-///
-/// This is important for calling a function when invoking the compiler on an MLIR or LLVM textual
-/// representation intead of from Python.
-struct FunctionAttributes {
-    /// The name of the primary JIT entry point function.
-    std::string functionName;
-    /// The return type of the JIT entry point function.
-    std::string returnType;
-};
-
 /// Verbosity level
 // TODO: Adjust the number of levels according to our needs. MLIR seems to print few really
 // low-level messages, we might want to hide these.
@@ -96,7 +85,6 @@ struct CompilerOutput {
     std::string objectFilename;
     std::string outIR;
     std::string diagnosticMessages;
-    FunctionAttributes inferredAttributes;
     PipelineOutputs pipelineOutputs;
     size_t pipelineCounter = 0;
     /// if the compiler reach the pass specified by startAfterPass.

--- a/mlir/python/PyCompilerDriver.cpp
+++ b/mlir/python/PyCompilerDriver.cpp
@@ -51,13 +51,6 @@ PYBIND11_MODULE(compiler_driver, m)
     //===--------------------------------------------------------------------===//
     // Catalyst Compiler Driver
     //===--------------------------------------------------------------------===//
-    py::class_<FunctionAttributes> funcattrs_class(m, "FunctionAttributes");
-    funcattrs_class.def(py::init<>())
-        .def("get_function_name",
-             [](const FunctionAttributes &fa) -> std::string { return fa.functionName; })
-        .def("get_return_type",
-             [](const FunctionAttributes &fa) -> std::string { return fa.returnType; });
-
     py::class_<CompilerOutput> compout_class(m, "CompilerOutput");
     compout_class.def(py::init<>())
         .def("get_pipeline_output",
@@ -69,8 +62,6 @@ PYBIND11_MODULE(compiler_driver, m)
         .def("get_output_ir", [](const CompilerOutput &co) -> std::string { return co.outIR; })
         .def("get_object_filename",
              [](const CompilerOutput &co) -> std::string { return co.objectFilename; })
-        .def("get_function_attributes",
-             [](const CompilerOutput &co) -> FunctionAttributes { return co.inferredAttributes; })
         .def("get_diagnostic_messages",
              [](const CompilerOutput &co) -> std::string { return co.diagnosticMessages; })
         .def("get_is_checkpoint_found",


### PR DESCRIPTION
**Context:** In order to make the compiler driver a standalone executable, we would to simplify the compiler driver interface. I.e., the compiler driver executable should just produce a shared object. The `struct FunctionAttributes` which contained two string fields (one for the name of the entry point of the function and the other for the return values of the entry point) was only used when lowering MLIR from the textual representation, which has been useful for debugging. 

**Description of the Change:** Remove `compile_from_mlir`.

**Benefits:** The benefit is that the compiler driver can just focus on compiling without having to return extra metadata which simplifies the interface between the compiler driver and the python process running it.

**Possible Drawbacks:** None, use `replace_ir` instead.

**Related GitHub Issues:**

EDIT: I do believe I can keep it being pythonic by using the following syntactic sugar of the docstring. We can use the python's function signature to derive the signature of the MLIR function (just like we do right now for the normal lowering) and we use the same name for the QJIT-ed function in python as the entry_point (similar to what we do in QJIT). During compilation, we can see the bytecode and find out that the function only contains a docstring and returns None, which would then allow us to decide to compile the docstring.

```python
@qjit
def identity(x: float) -> float:
  """
  func.func identity(tensor<f64> %arg) -> tensor<f64> {
    return %arg: tensor<f64>
  }
  """
```
