### PR TITLE
Change NumPy requirement to `numpy!=2.0.0`

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.149
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt
-pennylane=0.39.0.dev26
+pennylane=0.39.0.dev30
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'. Also, update the 'LIGHTNING_GIT_TAG' at

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -192,6 +192,7 @@
 
 * Catalyst now supports numpy 2.0
   [(#1119)](https://github.com/PennyLaneAI/catalyst/pull/1119)
+  [(#1182)](https://github.com/PennyLaneAI/catalyst/pull/1182)
 
 * Importing Catalyst will now pollute less of JAX's global variables by using `LoweringParameters`.
   [(#1152)](https://github.com/PennyLaneAI/catalyst/pull/1152)
@@ -268,11 +269,6 @@
   In particular, the signatures of `get_device_capability`, `catalyst_decompose`,
  `catalyst_acceptance`, and `QJITDevice.__init__` have changed, and the `pennylane_operation_set`
   function has been removed entirely.
-
-* Update NumPy dependency to `numpy<2.1,!=2.0.0` to keep Catalyst in line with the NumPy dependency
-  currently employed in PennyLane (`numpy<2.1`) and to ensure that NumPy version 2.0.0 is not used,
-  as it contains a bug preventing the use of the Python Stable ABI.
-  [(#1182)](https://github.com/PennyLaneAI/catalyst/pull/1182)
 
 <h3>Contributors</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -269,6 +269,11 @@
  `catalyst_acceptance`, and `QJITDevice.__init__` have changed, and the `pennylane_operation_set`
   function has been removed entirely.
 
+* Update NumPy dependency to `numpy<2.1,!=2.0.0` to keep Catalyst in line with the NumPy dependency
+  currently employed in PennyLane (`numpy<2.1`) and to ensure that NumPy version 2.0.0 is not used,
+  as it contains a bug preventing the use of the Python Stable ABI.
+  [(#1182)](https://github.com/PennyLaneAI/catalyst/pull/1182)
+
 <h3>Contributors</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -32,4 +32,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.39.0-dev38
 pennylane-lightning==0.39.0-dev38
-pennylane==0.39.0.dev26
+pennylane==0.39.0.dev30

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ known_third_party = ["diastatic-malt", "jax", "jaxlib", "numpy", "pennylane"]
 skips = ["B607"]
 
 [build-system]
-requires = ["setuptools>=62", "wheel", "pybind11>=2.12.0", "numpy==2.0"]
+requires = ["setuptools>=62", "wheel", "pybind11>=2.12.0", "numpy<2.1,!=2.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ known_third_party = ["diastatic-malt", "jax", "jaxlib", "numpy", "pennylane"]
 skips = ["B607"]
 
 [build-system]
-requires = ["setuptools>=62", "wheel", "pybind11>=2.12.0", "numpy<2.1,!=2.0.0"]
+requires = ["setuptools>=62", "wheel", "pybind11>=2.12.0", "numpy!=2.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 pip>=22.3
 
 # Build dependencies for non-Python components
-numpy==2.0
+numpy<2.1,!=2.0.0
 pybind11>=2.12.0
 PyYAML
 scipy==1.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,9 @@
 pip>=22.3
 
 # Build dependencies for non-Python components
-numpy<2.1,!=2.0.0
+# Do not allow NumPy 2.0.0 due to a bug with their C API that blocks the usage of the Stable ABI;
+# this bug was fixed in 2.0.1 (https://github.com/numpy/numpy/pull/26995)
+numpy!=2.0.0
 pybind11>=2.12.0
 PyYAML
 scipy==1.13

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ requirements = [
     f"jaxlib=={jax_version}",
     "tomlkit; python_version < '3.11'",
     "scipy<=1.13",
-    "numpy<2.1,!=2.0.0",
+    "numpy!=2.0.0",
     "diastatic-malt>=2.15.2",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ requirements = [
     f"jaxlib=={jax_version}",
     "tomlkit; python_version < '3.11'",
     "scipy<=1.13",
-    "numpy<=2.0",
+    "numpy<2.1,!=2.0.0",
     "diastatic-malt>=2.15.2",
 ]
 


### PR DESCRIPTION
**Context:** Catalyst currently contains the NumPy requirement `numpy==2.0` in several places (e.g. `requirements.txt`) and `numpy<=2.0` in `setup.py`. If a version of NumPy more recent than 2.0.0 is already installed by `pip`, these requirements force Catalyst to use NumPy 2.0.0. However, NumPy 2.0.0 contains a bug that's blocking the use of the numpy C API with the Stable ABI in Catalyst. This bug was fixed in NumPy 2.0.1: https://github.com/numpy/numpy/pull/26995 (the original issue was written up here: https://github.com/numpy/numpy/issues/26756). Changing the NumPy requirement to `numpy!=2.0.0` ensures that we avoid the problematic NumPy version, which is necessary as we replace pybind11 with nanobind in Catalyst to use the Stable ABI. Moreover, it also explicitly allows Catalyst to be installed with more recent versions of NumPy. Note that other packages on which Catalyst depends may impose implicit requirements on the version of NumPy used, e.g. PennyLane currently requires `numpy<2.1`.

**Description of the Change:** Changes NumPy requirement to `numpy!=2.0.0`. Also updates the PennyLane dependency to `pennylane==0.39.0.dev30` to capture https://github.com/PennyLaneAI/pennylane/pull/6342, which resolves related NumPy-dependency conflicts.