### PR TITLE
Extend the cancel_inverses pass to cancel adjoints of an arbitrary unitary

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -208,6 +208,8 @@
 * Samples on lightning.qubit/kokkos can now be seeded with `qjit(seed=...)`.
   [(#1164)](https://github.com/PennyLaneAI/catalyst/pull/1164)
 
+* The compiler pass `-remove-chained-self-inverse` can now also cancel adjoints of arbitrary unitaries (on top of just the named Hermitian gates).
+  [(#1186)](https://github.com/PennyLaneAI/catalyst/pull/1186)
 
 <h3>Breaking changes</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -209,7 +209,7 @@
 * Samples on lightning.qubit/kokkos can now be seeded with `qjit(seed=...)`.
   [(#1164)](https://github.com/PennyLaneAI/catalyst/pull/1164)
 
-* The compiler pass `-remove-chained-self-inverse` can now also cancel adjoints of arbitrary unitaries (on top of just the named Hermitian gates).
+* The compiler pass `-remove-chained-self-inverse` can now also cancel adjoints of arbitrary unitary operations (in addition to the the named Hermitian gates).
   [(#1186)](https://github.com/PennyLaneAI/catalyst/pull/1186)
 
 <h3>Breaking changes</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -209,7 +209,7 @@
 * Samples on lightning.qubit/kokkos can now be seeded with `qjit(seed=...)`.
   [(#1164)](https://github.com/PennyLaneAI/catalyst/pull/1164)
 
-* The compiler pass `-remove-chained-self-inverse` can now also cancel adjoints of arbitrary unitary operations (in addition to the the named Hermitian gates).
+* The compiler pass `-remove-chained-self-inverse` can now also cancel adjoints of arbitrary unitary operations (in addition to the named Hermitian gates).
   [(#1186)](https://github.com/PennyLaneAI/catalyst/pull/1186)
 
 <h3>Breaking changes</h3>

--- a/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
@@ -139,7 +139,7 @@ struct ChainedUUadjOpRewritePattern : public mlir::OpRewritePattern<OpType> {
     {
         LLVM_DEBUG(dbgs() << "Simplifying the following operation:\n" << op << "\n");
 
-        llvm::errs() << "visiting " << op << "\n";
+        //llvm::errs() << "visiting " << op << "\n";
 
         ValueRange InQubits = op.getInQubits();
         auto parentOp = dyn_cast_or_null<OpType>(InQubits[0].getDefiningOp());
@@ -158,13 +158,11 @@ struct ChainedUUadjOpRewritePattern : public mlir::OpRewritePattern<OpType> {
             return failure();
         }
 
-        llvm::errs() << "matched!\n";
+        //llvm::errs() << "matched!\n";
         ValueRange simplifiedVal = parentOp.getInQubits();
         rewriter.replaceOp(op, simplifiedVal);
         return success();
     }
-
-
 };
 
 } // namespace

--- a/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
@@ -44,13 +44,13 @@ struct ChainedNamedHermitianOpRewritePattern : public mlir::OpRewritePattern<Cus
     {
         LLVM_DEBUG(dbgs() << "Simplifying the following operation:\n" << op << "\n");
 
-        VerifyParentGateAnalysis<CustomOp> vpga(op);
-        if (!vpga.getVerifierResult()) {
+        StringRef OpGateName = op.getGateName();
+        if (!HermitianOps.contains(OpGateName)) {
             return failure();
         }
 
-        StringRef OpGateName = op.getGateName();
-        if (!HermitianOps.contains(OpGateName)) {
+        VerifyParentGateAnalysis<CustomOp> vpga(op);
+        if (!vpga.getVerifierResult()) {
             return failure();
         }
 

--- a/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
@@ -49,9 +49,8 @@ struct ChainedNamedHermitianOpRewritePattern : public mlir::OpRewritePattern<Cus
             return failure();
         }
 
-        // Aggressive verifier checks the parent gate has the same name.
-        AggressiveVerifyParentGateAnalysis<CustomOp> avpga(op);
-        if (!avpga.getVerifierResult()) {
+        VerifyParentGateAndNameAnalysis<CustomOp> vpga(op);
+        if (!vpga.getVerifierResult()) {
             return failure();
         }
 
@@ -105,8 +104,8 @@ struct ChainedUUadjOpRewritePattern : public mlir::OpRewritePattern<OpType> {
     {
         LLVM_DEBUG(dbgs() << "Simplifying the following operation:\n" << op << "\n");
 
-        AggressiveVerifyParentGateAnalysis<OpType> avpga(op);
-        if (!avpga.getVerifierResult()) {
+        VerifyParentGateAndNameAnalysis<OpType> vpga(op);
+        if (!vpga.getVerifierResult()) {
             return failure();
         }
 
@@ -150,7 +149,6 @@ void populateSelfInversePatterns(RewritePatternSet &patterns)
     patterns.add<ChainedUUadjOpRewritePattern<CustomOp>>(patterns.getContext(), 1);
     patterns.add<ChainedUUadjOpRewritePattern<QubitUnitaryOp>>(patterns.getContext(), 1);
     patterns.add<ChainedUUadjOpRewritePattern<MultiRZOp>>(patterns.getContext(), 1);
-    //patterns.add<ChainedUUadjOpRewritePattern<GlobalPhaseOp>>(patterns.getContext(), 1);
 }
 
 } // namespace quantum

--- a/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
@@ -49,7 +49,7 @@ struct ChainedNamedHermitianOpRewritePattern : public mlir::OpRewritePattern<Cus
             return failure();
         }
 
-        VerifyParentGateAndNameAnalysis<CustomOp> vpga(op);
+        VerifyParentGateAndNameAnalysis vpga(op);
         if (!vpga.getVerifierResult()) {
             return failure();
         }
@@ -104,9 +104,17 @@ struct ChainedUUadjOpRewritePattern : public mlir::OpRewritePattern<OpType> {
     {
         LLVM_DEBUG(dbgs() << "Simplifying the following operation:\n" << op << "\n");
 
-        VerifyParentGateAndNameAnalysis<OpType> vpga(op);
-        if (!vpga.getVerifierResult()) {
-            return failure();
+        if (isa<CustomOp>(op)) {
+            VerifyParentGateAndNameAnalysis vpga(cast<CustomOp>(op));
+            if (!vpga.getVerifierResult()) {
+                return failure();
+            }
+        }
+        else {
+            VerifyParentGateAnalysis<OpType> vpga(op);
+            if (!vpga.getVerifierResult()) {
+                return failure();
+            }
         }
 
         ValueRange InQubits = op.getInQubits();

--- a/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
@@ -142,8 +142,15 @@ namespace quantum {
 void populateSelfInversePatterns(RewritePatternSet &patterns)
 {
     patterns.add<ChainedNamedHermitianOpRewritePattern>(patterns.getContext(), 1);
+
+    // TODO: better organize the quantum dialect
+    // There is an interface `QuantumGate` for all the unitary gate operations,
+    // but interfaces cannot be accepted by pattern matchers, since pattern
+    // matchers require the target operations to have concrete names in the IR.
     patterns.add<ChainedUUadjOpRewritePattern<CustomOp>>(patterns.getContext(), 1);
     patterns.add<ChainedUUadjOpRewritePattern<QubitUnitaryOp>>(patterns.getContext(), 1);
+    patterns.add<ChainedUUadjOpRewritePattern<MultiRZOp>>(patterns.getContext(), 1);
+    //patterns.add<ChainedUUadjOpRewritePattern<GlobalPhaseOp>>(patterns.getContext(), 1);
 }
 
 } // namespace quantum

--- a/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
@@ -108,7 +108,7 @@ struct ChainedUUadjOpRewritePattern : public mlir::OpRewritePattern<OpType> {
         }
 
         for (const auto &[idx, qubit] : llvm::enumerate(inNonCtrlQubits)) {
-            if (qubit.getDefiningOp<OpType>() != parentOp || qubit != parentOutNonCtrlQubits[idx]) {
+            if (qubit.getDefiningOp() != parentOp || qubit != parentOutNonCtrlQubits[idx]) {
                 return false;
             }
         }

--- a/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
@@ -49,18 +49,15 @@ struct ChainedNamedHermitianOpRewritePattern : public mlir::OpRewritePattern<Cus
             return failure();
         }
 
+        // Aggressive verifier checks the parent gate has the same name.
         AggressiveVerifyParentGateAnalysis<CustomOp> avpga(op);
         if (!avpga.getVerifierResult()) {
             return failure();
         }
 
+        // Replace uses
         ValueRange InQubits = op.getInQubits();
         auto ParentOp = dyn_cast_or_null<CustomOp>(InQubits[0].getDefiningOp());
-        if (ParentOp.getGateName() != OpGateName) {
-            return failure();
-        }
-
-        // Replace uses
         ValueRange simplifiedVal = ParentOp.getInQubits();
         rewriter.replaceOp(op, simplifiedVal);
         return success();

--- a/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
@@ -29,7 +29,7 @@ static const mlir::StringSet<> HermitianOps = {"Hadamard", "PauliX", "PauliY", "
 
 namespace {
 
-struct ChainedHadamardOpRewritePattern : public mlir::OpRewritePattern<CustomOp> {
+struct ChainedNamedHermitianOpRewritePattern : public mlir::OpRewritePattern<CustomOp> {
     using mlir::OpRewritePattern<CustomOp>::OpRewritePattern;
 
     /// We simplify consecutive Hermitian quantum gates by removing them.
@@ -68,7 +68,7 @@ namespace quantum {
 
 void populateSelfInversePatterns(RewritePatternSet &patterns)
 {
-    patterns.add<ChainedHadamardOpRewritePattern>(patterns.getContext(), 1);
+    patterns.add<ChainedNamedHermitianOpRewritePattern>(patterns.getContext(), 1);
 }
 
 } // namespace quantum

--- a/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
@@ -14,14 +14,14 @@
 
 #define DEBUG_TYPE "chained-self-inverse"
 
-#include "VerifyParentGateAnalysis.hpp"
-
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Errc.h"
 
 #include "Quantum/IR/QuantumOps.h"
 #include "Quantum/Transforms/Patterns.h"
+
+#include "VerifyParentGateAnalysis.hpp"
 
 using llvm::dbgs;
 using namespace mlir;

--- a/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
@@ -49,8 +49,8 @@ struct ChainedNamedHermitianOpRewritePattern : public mlir::OpRewritePattern<Cus
             return failure();
         }
 
-        VerifyParentGateAnalysis<CustomOp> vpga(op);
-        if (!vpga.getVerifierResult()) {
+        AggressiveVerifyParentGateAnalysis<CustomOp> avpga(op);
+        if (!avpga.getVerifierResult()) {
             return failure();
         }
 
@@ -108,8 +108,8 @@ struct ChainedUUadjOpRewritePattern : public mlir::OpRewritePattern<OpType> {
     {
         LLVM_DEBUG(dbgs() << "Simplifying the following operation:\n" << op << "\n");
 
-        VerifyParentGateAnalysis<OpType> vpga(op);
-        if (!vpga.getVerifierResult()) {
+        AggressiveVerifyParentGateAnalysis<OpType> avpga(op);
+        if (!avpga.getVerifierResult()) {
             return failure();
         }
 

--- a/mlir/lib/Quantum/Transforms/VerifyParentGateAnalysis.hpp
+++ b/mlir/lib/Quantum/Transforms/VerifyParentGateAnalysis.hpp
@@ -158,6 +158,7 @@ class AggressiveVerifyParentGateAnalysis : public VerifyParentGateAnalysis<OpTyp
         }
     }
 
+  private:
     bool verifyParentGateName(OpType op, OpType parentOp) const
     {
         // If OpType is quantum.custom, also verify that parent gate has the

--- a/mlir/lib/Quantum/Transforms/VerifyParentGateAnalysis.hpp
+++ b/mlir/lib/Quantum/Transforms/VerifyParentGateAnalysis.hpp
@@ -33,7 +33,7 @@
 //  3. If the gates are controlled, both gates' control wires and values
 //     must be the same. The control wires must be in the same order
 //
-//  On top of the above, we also provide a AggressiveVerifyParentGateAnalysis,
+//  On top of the above, we also provide a VerifyParentGateAndNameAnalysis,
 //  which also checks:
 //  4. If the gates are quantum.custom, then both gates have the same name.
 
@@ -135,9 +135,9 @@ template <typename OpType> class VerifyParentGateAnalysis {
 };
 
 template <typename OpType>
-class AggressiveVerifyParentGateAnalysis : public VerifyParentGateAnalysis<OpType> {
+class VerifyParentGateAndNameAnalysis : public VerifyParentGateAnalysis<OpType> {
   public:
-    AggressiveVerifyParentGateAnalysis(OpType gate) : VerifyParentGateAnalysis<OpType>(gate)
+    VerifyParentGateAndNameAnalysis(OpType gate) : VerifyParentGateAnalysis<OpType>(gate)
     {
         if (!isa<quantum::CustomOp>(gate)) {
             // No extra checks for non quantum.custom ops

--- a/mlir/lib/Quantum/Transforms/VerifyParentGateAnalysis.hpp
+++ b/mlir/lib/Quantum/Transforms/VerifyParentGateAnalysis.hpp
@@ -1,0 +1,133 @@
+// Copyright 2024 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This analysis checks if a gate operation and its parent gate operation
+// are correctly matched for the purposes of peephole optimizations like
+// merge rotations and cancel inverses.
+// Gates passing this analysis are considered valid candidates for merge
+// rotation and cancel inverses.
+
+// Specifically, we check the following conditions:
+//  1. Both gates must be of the same type, i.e. a quantum.custom can
+//     only be cancelled with a quantum.custom, not a quantum.unitary
+//  2. The results of the parent gate must map one-to-one, in order,
+//     to the operands of the second gate
+//     For example, the pair
+//        %0:2 = quantum.custom "CNOT"() %.., %..
+//        %1:2 = quantum.custom "CNOT"() %0#0, %0#1
+//     is considered to be a successful match, but the pair
+//        %0:2 = quantum.custom "CNOT"() %.., %..
+//        %1:2 = quantum.custom "CNOT"() %0#1, %0#0
+//     is not.
+//  3. If the gates are controlled, both gates' control wires and values
+//     must be the same. The control wires must be in the same order
+
+#pragma once
+
+#include "mlir/IR/BuiltinOps.h"
+#include "llvm/Support/Debug.h"
+
+#include "Catalyst/IR/CatalystDialect.h"
+#include "Quantum/IR/QuantumOps.h"
+
+using namespace llvm;
+using namespace mlir;
+using namespace catalyst;
+
+namespace catalyst {
+
+template <typename OpType> class VerifyParentGateAnalysis {
+  public:
+    VerifyParentGateAnalysis(OpType gate)
+    {
+        ValueRange inQubits = gate.getInQubits();
+        auto parentGate = dyn_cast_or_null<OpType>(inQubits[0].getDefiningOp());
+
+        if (!verifyParentGateType(gate, parentGate)) {
+            verified = false;
+            return;
+        }
+
+        if (!verifyAllInQubits(gate, parentGate)) {
+            verified = false;
+            return;
+        }
+    }
+
+    bool getVerifierResult() { return verified; }
+
+  private:
+    bool verified = true;
+
+    bool verifyParentGateType(OpType op, OpType parentOp) const
+    {
+        // Verify that the parent gate is of the same type.
+        // If OpType is quantum.custom, also verify that parent gate has the
+        // same gate name.
+
+        if (!parentOp || !isa<OpType>(parentOp)) {
+            return false;
+        }
+
+        if (isa<quantum::CustomOp>(op)) {
+            StringRef opGateName = cast<quantum::CustomOp>(op).getGateName();
+            StringRef parentGateName = cast<quantum::CustomOp>(parentOp).getGateName();
+            if (opGateName != parentGateName) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    bool verifyAllInQubits(OpType op, OpType parentOp) const
+    {
+        // Verify that parent's results and current gate's inputs are in the same order
+        // If the gates are controlled, both gates' control wires and values
+        // must be the same. The control wires must be in the same order.
+
+        ValueRange inNonCtrlQubits = op.getNonCtrlQubitOperands();
+        ValueRange inCtrlQubits = op.getCtrlQubitOperands();
+        ValueRange parentOutNonCtrlQubits = parentOp.getNonCtrlQubitResults();
+        ValueRange parentOutCtrlQubits = parentOp.getCtrlQubitResults();
+
+        if ((inNonCtrlQubits.size() != parentOutNonCtrlQubits.size()) ||
+            (inCtrlQubits.size() != parentOutCtrlQubits.size())) {
+            return false;
+        }
+
+        for (const auto &[idx, qubit] : llvm::enumerate(inNonCtrlQubits)) {
+            if (qubit.getDefiningOp() != parentOp || qubit != parentOutNonCtrlQubits[idx]) {
+                return false;
+            }
+        }
+
+        ValueRange opCtrlValues = op.getCtrlValueOperands();
+        ValueRange parentCtrlValues = parentOp.getCtrlValueOperands();
+        if (opCtrlValues.size() != parentCtrlValues.size()) {
+            return false;
+        }
+
+        for (const auto &[idx, v] : llvm::enumerate(opCtrlValues)) {
+            // We assume CSE is already run before this analysis.
+            if (v != parentCtrlValues[idx]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+};
+
+} // namespace catalyst

--- a/mlir/lib/Quantum/Transforms/VerifyParentGateAnalysis.hpp
+++ b/mlir/lib/Quantum/Transforms/VerifyParentGateAnalysis.hpp
@@ -18,7 +18,7 @@
 // Gates passing this analysis are considered valid candidates for merge
 // rotation and cancel inverses.
 
-// Specifically, we check the following conditions:
+// Specifically, we check the following conditions in VerifyParentGateAnalysis:
 //  1. Both gates must be of the same type, i.e. a quantum.custom can
 //     only be cancelled with a quantum.custom, not a quantum.unitary
 //  2. The results of the parent gate must map one-to-one, in order,
@@ -32,6 +32,10 @@
 //     is not.
 //  3. If the gates are controlled, both gates' control wires and values
 //     must be the same. The control wires must be in the same order
+//
+//  On top of the above, we also provide a AggressiveVerifyParentGateAnalysis,
+//  which also checks:
+//  4. If the gates are quantum.custom, then both gates have the same name.
 
 #pragma once
 
@@ -55,17 +59,19 @@ template <typename OpType> class VerifyParentGateAnalysis {
         auto parentGate = dyn_cast_or_null<OpType>(inQubits[0].getDefiningOp());
 
         if (!verifyParentGateType(gate, parentGate)) {
-            succeeded = false;
+            setVerifierResult(false);
             return;
         }
 
         if (!verifyAllInQubits(gate, parentGate)) {
-            succeeded = false;
+            setVerifierResult(false);
             return;
         }
     }
 
     bool getVerifierResult() { return succeeded; }
+
+    void setVerifierResult(bool b) { succeeded = b; }
 
   private:
     bool succeeded = true;
@@ -78,14 +84,6 @@ template <typename OpType> class VerifyParentGateAnalysis {
 
         if (!parentOp || !isa<OpType>(parentOp)) {
             return false;
-        }
-
-        if (isa<quantum::CustomOp>(op)) {
-            StringRef opGateName = cast<quantum::CustomOp>(op).getGateName();
-            StringRef parentGateName = cast<quantum::CustomOp>(parentOp).getGateName();
-            if (opGateName != parentGateName) {
-                return false;
-            }
         }
 
         return true;
@@ -136,4 +134,37 @@ template <typename OpType> class VerifyParentGateAnalysis {
     }
 };
 
+template <typename OpType>
+class AggressiveVerifyParentGateAnalysis : public VerifyParentGateAnalysis<OpType> {
+  public:
+    AggressiveVerifyParentGateAnalysis(OpType gate) : VerifyParentGateAnalysis<OpType>(gate)
+    {
+        if (!isa<quantum::CustomOp>(gate)) {
+            // No extra checks for non quantum.custom ops
+            return;
+        }
+
+        ValueRange inQubits = gate.getInQubits();
+        auto parentGate = dyn_cast_or_null<OpType>(inQubits[0].getDefiningOp());
+
+        if (!parentGate) {
+            this->setVerifierResult(false);
+            return;
+        }
+
+        if (!verifyParentGateName(gate, parentGate)) {
+            this->setVerifierResult(false);
+            return;
+        }
+    }
+
+    bool verifyParentGateName(OpType op, OpType parentOp) const
+    {
+        // If OpType is quantum.custom, also verify that parent gate has the
+        // same gate name.
+        StringRef opGateName = cast<quantum::CustomOp>(op).getGateName();
+        StringRef parentGateName = cast<quantum::CustomOp>(parentOp).getGateName();
+        return opGateName == parentGateName;
+    }
+};
 } // namespace catalyst

--- a/mlir/lib/Quantum/Transforms/VerifyParentGateAnalysis.hpp
+++ b/mlir/lib/Quantum/Transforms/VerifyParentGateAnalysis.hpp
@@ -113,6 +113,12 @@ template <typename OpType> class VerifyParentGateAnalysis {
             }
         }
 
+        for (const auto &[idx, qubit] : llvm::enumerate(inCtrlQubits)) {
+            if (qubit.getDefiningOp() != parentOp || qubit != parentOutCtrlQubits[idx]) {
+                return false;
+            }
+        }
+
         ValueRange opCtrlValues = op.getCtrlValueOperands();
         ValueRange parentCtrlValues = parentOp.getCtrlValueOperands();
         if (opCtrlValues.size() != parentCtrlValues.size()) {

--- a/mlir/lib/Quantum/Transforms/VerifyParentGateAnalysis.hpp
+++ b/mlir/lib/Quantum/Transforms/VerifyParentGateAnalysis.hpp
@@ -55,20 +55,20 @@ template <typename OpType> class VerifyParentGateAnalysis {
         auto parentGate = dyn_cast_or_null<OpType>(inQubits[0].getDefiningOp());
 
         if (!verifyParentGateType(gate, parentGate)) {
-            verified = false;
+            succeeded = false;
             return;
         }
 
         if (!verifyAllInQubits(gate, parentGate)) {
-            verified = false;
+            succeeded = false;
             return;
         }
     }
 
-    bool getVerifierResult() { return verified; }
+    bool getVerifierResult() { return succeeded; }
 
   private:
-    bool verified = true;
+    bool succeeded = true;
 
     bool verifyParentGateType(OpType op, OpType parentOp) const
     {

--- a/mlir/lib/Quantum/Transforms/VerifyParentGateAnalysis.hpp
+++ b/mlir/lib/Quantum/Transforms/VerifyParentGateAnalysis.hpp
@@ -134,18 +134,15 @@ template <typename OpType> class VerifyParentGateAnalysis {
     }
 };
 
-template <typename OpType>
-class VerifyParentGateAndNameAnalysis : public VerifyParentGateAnalysis<OpType> {
+class VerifyParentGateAndNameAnalysis : public VerifyParentGateAnalysis<quantum::CustomOp> {
+    // If OpType is quantum.custom, also verify that parent gate has the
+    // same gate name.
   public:
-    VerifyParentGateAndNameAnalysis(OpType gate) : VerifyParentGateAnalysis<OpType>(gate)
+    VerifyParentGateAndNameAnalysis(quantum::CustomOp gate)
+        : VerifyParentGateAnalysis<quantum::CustomOp>(gate)
     {
-        if (!isa<quantum::CustomOp>(gate)) {
-            // No extra checks for non quantum.custom ops
-            return;
-        }
-
         ValueRange inQubits = gate.getInQubits();
-        auto parentGate = dyn_cast_or_null<OpType>(inQubits[0].getDefiningOp());
+        auto parentGate = dyn_cast_or_null<quantum::CustomOp>(inQubits[0].getDefiningOp());
 
         if (!parentGate) {
             this->setVerifierResult(false);
@@ -159,12 +156,10 @@ class VerifyParentGateAndNameAnalysis : public VerifyParentGateAnalysis<OpType> 
     }
 
   private:
-    bool verifyParentGateName(OpType op, OpType parentOp) const
+    bool verifyParentGateName(quantum::CustomOp op, quantum::CustomOp parentOp) const
     {
-        // If OpType is quantum.custom, also verify that parent gate has the
-        // same gate name.
-        StringRef opGateName = cast<quantum::CustomOp>(op).getGateName();
-        StringRef parentGateName = cast<quantum::CustomOp>(parentOp).getGateName();
+        StringRef opGateName = op.getGateName();
+        StringRef parentGateName = parentOp.getGateName();
         return opGateName == parentGateName;
     }
 };

--- a/mlir/lib/Quantum/Transforms/remove_chained_self_inverse.cpp
+++ b/mlir/lib/Quantum/Transforms/remove_chained_self_inverse.cpp
@@ -25,8 +25,8 @@
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
-#include "mlir/Transforms/Passes.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
 
 #include "Catalyst/IR/CatalystDialect.h"
 #include "Quantum/IR/QuantumOps.h"
@@ -58,7 +58,7 @@ struct RemoveChainedSelfInversePass
         MLIRContext *ctx = &getContext();
         auto earlyCSEpm = PassManager::on<ModuleOp>(ctx);
         earlyCSEpm.addPass(mlir::createCSEPass());
-        if (failed(runPipeline(earlyCSEpm, getOperation()))){
+        if (failed(runPipeline(earlyCSEpm, getOperation()))) {
             return signalPassFailure();
         }
 

--- a/mlir/lib/Quantum/Transforms/remove_chained_self_inverse.cpp
+++ b/mlir/lib/Quantum/Transforms/remove_chained_self_inverse.cpp
@@ -24,6 +24,8 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #include "Catalyst/IR/CatalystDialect.h"
@@ -49,6 +51,13 @@ struct RemoveChainedSelfInversePass
     {
         LLVM_DEBUG(dbgs() << "remove chained self inverse pass"
                           << "\n");
+
+        // Run cse pass before running remove-chained-self-inverse,
+        // to aid identifiying equivalent SSA values when verifying
+        // the gates have the same params
+        MLIRContext *ctx = &getContext();
+        auto pm = PassManager::on<ModuleOp>(ctx);
+        pm.addPass(mlir::createCSEPass());
 
         Operation *module = getOperation();
         Operation *targetfunc;

--- a/mlir/lib/Quantum/Transforms/remove_chained_self_inverse.cpp
+++ b/mlir/lib/Quantum/Transforms/remove_chained_self_inverse.cpp
@@ -53,11 +53,14 @@ struct RemoveChainedSelfInversePass
                           << "\n");
 
         // Run cse pass before running remove-chained-self-inverse,
-        // to aid identifiying equivalent SSA values when verifying
+        // to aid identifying equivalent SSA values when verifying
         // the gates have the same params
         MLIRContext *ctx = &getContext();
-        auto pm = PassManager::on<ModuleOp>(ctx);
-        pm.addPass(mlir::createCSEPass());
+        auto earlyCSEpm = PassManager::on<ModuleOp>(ctx);
+        earlyCSEpm.addPass(mlir::createCSEPass());
+        if (failed(runPipeline(earlyCSEpm, getOperation()))){
+            return signalPassFailure();
+        }
 
         Operation *module = getOperation();
         Operation *targetfunc;

--- a/mlir/test/Catalyst/ApplyTransformSequenceTest.mlir
+++ b/mlir/test/Catalyst/ApplyTransformSequenceTest.mlir
@@ -29,25 +29,25 @@ module @workflow {
     }
   }
 
-  func.func private @f(%arg0: tensor<f64>) -> tensor<f64> {
+  func.func private @f(%arg0: tensor<f64>) -> !quantum.bit {
     %c_0 = stablehlo.constant dense<0> : tensor<i64>
     %extracted = tensor.extract %c_0[] : tensor<i64>
     %0 = quantum.alloc( 1) : !quantum.reg
     %1 = quantum.extract %0[%extracted] : !quantum.reg -> !quantum.bit
     %out_qubits = quantum.custom "Hadamard"() %1 : !quantum.bit
     %out_qubits_1 = quantum.custom "Hadamard"() %out_qubits : !quantum.bit
-    return %arg0 : tensor<f64>
+    return %out_qubits_1 : !quantum.bit
   }
 
 
-  func.func private @g(%arg0: tensor<f64>) -> tensor<f64> {
+  func.func private @g(%arg0: tensor<f64>) -> !quantum.bit {
     %c_0 = stablehlo.constant dense<0> : tensor<i64>
     %extracted = tensor.extract %c_0[] : tensor<i64>
     %0 = quantum.alloc( 1) : !quantum.reg
     %1 = quantum.extract %0[%extracted] : !quantum.reg -> !quantum.bit
     %out_qubits = quantum.custom "Hadamard"() %1 : !quantum.bit
     %out_qubits_1 = quantum.custom "Hadamard"() %out_qubits : !quantum.bit
-    return %arg0 : tensor<f64>
+    return %out_qubits_1 : !quantum.bit
   }
 
 }

--- a/mlir/test/Quantum/ChainedSelfInverseTest.mlir
+++ b/mlir/test/Quantum/ChainedSelfInverseTest.mlir
@@ -556,3 +556,51 @@ func.func @test_chained_self_inverse() -> (!quantum.bit, !quantum.bit, !quantum.
 
     return %out_qubits_1#0, %out_qubits_1#1, %out_ctrl_qubits_1#0, %out_ctrl_qubits_1#1 : !quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit
 }
+
+
+// -----
+
+
+// test quantum.multirz labeled with adjoint attribute
+
+// CHECK-LABEL: test_chained_self_inverse
+func.func @test_chained_self_inverse(%arg0: f64) -> (!quantum.bit, !quantum.bit, !quantum.bit) {
+    // CHECK: quantum.alloc
+    // CHECK: [[IN0:%.+]] = quantum.extract
+    // CHECK: [[IN1:%.+]] = quantum.extract
+    // CHECK: [[IN2:%.+]] = quantum.extract
+    %0 = quantum.alloc( 3) : !quantum.reg
+    %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+    %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+    %3 = quantum.extract %0[ 2] : !quantum.reg -> !quantum.bit
+
+    %mrz:3 = quantum.multirz(%arg0) %1, %2, %3 : !quantum.bit, !quantum.bit, !quantum.bit
+    %mrz_out:3 = quantum.multirz(%arg0) %mrz#0, %mrz#1, %mrz#2 {adjoint} : !quantum.bit, !quantum.bit, !quantum.bit
+
+    // CHECK-NOT: quantum.multirz
+    // CHECK: return [[IN0]], [[IN1]], [[IN2]]
+    return %mrz_out#0, %mrz_out#1, %mrz_out#2 : !quantum.bit, !quantum.bit, !quantum.bit
+}
+
+// -----
+
+
+// test quantum.multirz but wrong wire order
+
+// CHECK-LABEL: test_chained_self_inverse
+func.func @test_chained_self_inverse(%arg0: f64) -> (!quantum.bit, !quantum.bit, !quantum.bit) {
+    // CHECK: quantum.alloc
+    // CHECK: [[IN0:%.+]] = quantum.extract
+    // CHECK: [[IN1:%.+]] = quantum.extract
+    // CHECK: [[IN2:%.+]] = quantum.extract
+    %0 = quantum.alloc( 3) : !quantum.reg
+    %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+    %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+    %3 = quantum.extract %0[ 2] : !quantum.reg -> !quantum.bit
+
+    %mrz:3 = quantum.multirz(%arg0) %1, %2, %3 : !quantum.bit, !quantum.bit, !quantum.bit
+    %mrz_out:3 = quantum.multirz(%arg0) %mrz#1, %mrz#2, %mrz#0 {adjoint} : !quantum.bit, !quantum.bit, !quantum.bit
+
+    // CHECK: quantum.multirz
+    return %mrz_out#0, %mrz_out#1, %mrz_out#2 : !quantum.bit, !quantum.bit, !quantum.bit
+}

--- a/mlir/test/Quantum/ChainedSelfInverseTest.mlir
+++ b/mlir/test/Quantum/ChainedSelfInverseTest.mlir
@@ -274,7 +274,7 @@ func.func @test_chained_self_inverse() -> !quantum.bit {
 
 // test parametrized gates labeled with adjoint attribute
 // CHECK-LABEL: test_chained_self_inverse
-func.func @test_chained_self_inverse(%arg0: tensor<2x2xf64>) -> !quantum.bit {
+func.func @test_chained_self_inverse(%arg0: tensor<2x2xf64>, %arg1: tensor<f64>, %arg2: tensor<f64>) -> (!quantum.bit, !quantum.bit) {
     // CHECK: quantum.alloc
     // CHECK: quantum.extract
     %0 = quantum.alloc( 1) : !quantum.reg
@@ -285,5 +285,11 @@ func.func @test_chained_self_inverse(%arg0: tensor<2x2xf64>) -> !quantum.bit {
     %3 = stablehlo.convert %arg0 : (tensor<2x2xf64>) -> tensor<2x2xcomplex<f64>>
     %out_qubits_1 = quantum.unitary(%3 : tensor<2x2xcomplex<f64>>) %out_qubits {adjoint} : !quantum.bit
 
-    return %out_qubits_1 : !quantum.bit
+    %extracted_3 = tensor.extract %arg1[] : tensor<f64>
+    %out_qubits_4 = quantum.custom "RX"(%extracted_3) %out_qubits_1 : !quantum.bit
+    %extracted_5 = tensor.extract %arg1[] : tensor<f64>
+    %out_qubits_6 = quantum.custom "RX"(%extracted_5) %out_qubits_4 {adjoint} : !quantum.bit
+
+
+    return %out_qubits_1, %out_qubits_6 : !quantum.bit, !quantum.bit
 }

--- a/mlir/test/Quantum/ChainedSelfInverseTest.mlir
+++ b/mlir/test/Quantum/ChainedSelfInverseTest.mlir
@@ -523,3 +523,36 @@ func.func @test_chained_self_inverse() -> (!quantum.bit, !quantum.bit, !quantum.
 
     return %out_qubits_1#0, %out_qubits_1#1, %out_ctrl_qubits_1#0, %out_ctrl_qubits_1#1 : !quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit
 }
+
+
+// -----
+
+
+// test with params in the wrong order
+
+// CHECK-LABEL: test_chained_self_inverse
+func.func @test_chained_self_inverse() -> (!quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit) {
+    %true = llvm.mlir.constant (1 : i1) :i1
+    %false = llvm.mlir.constant (0 : i1) :i1
+    %cst = llvm.mlir.constant (6.000000e-01 : f64) : f64
+    %cst_0 = llvm.mlir.constant (9.000000e-01 : f64) : f64
+    %cst_1 = llvm.mlir.constant (3.000000e-01 : f64) : f64
+
+    // CHECK: quantum.alloc
+    // CHECK: [[IN0:%.+]] = quantum.extract {{.+}}[ 0]
+    // CHECK: [[IN1:%.+]] = quantum.extract {{.+}}[ 1]
+    // CHECK: [[IN2:%.+]] = quantum.extract {{.+}}[ 2]
+    // CHECK: [[IN3:%.+]] = quantum.extract {{.+}}[ 3]
+    %reg = quantum.alloc( 4) : !quantum.reg
+    %0 = quantum.extract %reg[ 0] : !quantum.reg -> !quantum.bit
+    %1 = quantum.extract %reg[ 1] : !quantum.reg -> !quantum.bit
+    %2 = quantum.extract %reg[ 2] : !quantum.reg -> !quantum.bit
+    %3 = quantum.extract %reg[ 3] : !quantum.reg -> !quantum.bit
+
+    // CHECK: quantum.custom
+    %out_qubits:2, %out_ctrl_qubits:2 = quantum.custom "Rot"(%cst, %cst_0, %cst_1) %0, %1 ctrls(%2, %3) ctrlvals(%true, %false) : !quantum.bit, !quantum.bit ctrls !quantum.bit, !quantum.bit
+    %out_qubits_1:2, %out_ctrl_qubits_1:2 = quantum.custom "Rot"(%cst_0, %cst, %cst_1) %out_qubits#0, %out_qubits#1 {adjoint} ctrls(%out_ctrl_qubits#0, %out_ctrl_qubits#1) ctrlvals(%true, %false) : !quantum.bit, !quantum.bit ctrls !quantum.bit, !quantum.bit
+
+
+    return %out_qubits_1#0, %out_qubits_1#1, %out_ctrl_qubits_1#0, %out_ctrl_qubits_1#1 : !quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit
+}

--- a/mlir/test/Quantum/ChainedSelfInverseTest.mlir
+++ b/mlir/test/Quantum/ChainedSelfInverseTest.mlir
@@ -312,3 +312,28 @@ func.func @test_chained_self_inverse(%arg0: tensor<f64>) -> !quantum.bit {
     // CHECK: return [[IN]]
     return %out_qubits_1 : !quantum.bit
 }
+
+
+// -----
+
+
+// test with explicit rotation angles
+// CHECK-LABEL: test_chained_self_inverse
+func.func @test_chained_self_inverse() -> !quantum.bit {
+    // CHECK: quantum.alloc
+    // CHECK: [[IN:%.+]] = quantum.extract
+    %0 = quantum.alloc( 1) : !quantum.reg
+    %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+
+    %cst_0 = stablehlo.constant dense<1.234000e+01> : tensor<f64>
+    %extracted_0 = tensor.extract %cst_0[] : tensor<f64>
+    %out_qubits_0 = quantum.custom "RY"(%extracted_0) %1 {adjoint} : !quantum.bit
+
+    %cst_1 = stablehlo.constant dense<1.234000e+01> : tensor<f64>
+    %extracted_1 = tensor.extract %cst_1[] : tensor<f64>
+    %out_qubits_1 = quantum.custom "RY"(%extracted_1) %out_qubits_0 : !quantum.bit
+
+    // CHECK-NOT: quantum.custom
+    // CHECK: return [[IN]]
+    return %out_qubits_1 : !quantum.bit
+}

--- a/mlir/test/Quantum/ChainedSelfInverseTest.mlir
+++ b/mlir/test/Quantum/ChainedSelfInverseTest.mlir
@@ -337,3 +337,27 @@ func.func @test_chained_self_inverse() -> !quantum.bit {
     // CHECK: return [[IN]]
     return %out_qubits_1 : !quantum.bit
 }
+
+
+// -----
+
+
+// test with unmatched explicit rotation angles
+// CHECK-LABEL: test_chained_self_inverse
+func.func @test_chained_self_inverse() -> !quantum.bit {
+    %0 = quantum.alloc( 1) : !quantum.reg
+    %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+
+    %cst_0 = stablehlo.constant dense<1.234000e+01> : tensor<f64>
+    %extracted_0 = tensor.extract %cst_0[] : tensor<f64>
+    %out_qubits_0 = quantum.custom "RY"(%extracted_0) %1 {adjoint} : !quantum.bit
+
+    %cst_1 = stablehlo.constant dense<5.678000e+01> : tensor<f64>
+    %extracted_1 = tensor.extract %cst_1[] : tensor<f64>
+    %out_qubits_1 = quantum.custom "RY"(%extracted_1) %out_qubits_0 : !quantum.bit
+
+    return %out_qubits_1 : !quantum.bit
+}
+
+// CHECK: quantum.custom "RY"{{.+}}{adjoint}
+// CHECK: quantum.custom "RY"

--- a/mlir/test/Quantum/ChainedSelfInverseTest.mlir
+++ b/mlir/test/Quantum/ChainedSelfInverseTest.mlir
@@ -269,3 +269,21 @@ func.func @test_chained_self_inverse() -> !quantum.bit {
     return %4 : !quantum.bit
 }
 
+
+// -----
+
+// test parametrized gates labeled with adjoint attribute
+// CHECK-LABEL: test_chained_self_inverse
+func.func @test_chained_self_inverse(%arg0: tensor<2x2xf64>) -> !quantum.bit {
+    // CHECK: quantum.alloc
+    // CHECK: quantum.extract
+    %0 = quantum.alloc( 1) : !quantum.reg
+    %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+
+    %2 = stablehlo.convert %arg0 : (tensor<2x2xf64>) -> tensor<2x2xcomplex<f64>>
+    %out_qubits = quantum.unitary(%2 : tensor<2x2xcomplex<f64>>) %1 : !quantum.bit
+    %3 = stablehlo.convert %arg0 : (tensor<2x2xf64>) -> tensor<2x2xcomplex<f64>>
+    %out_qubits_1 = quantum.unitary(%3 : tensor<2x2xcomplex<f64>>) %out_qubits {adjoint} : !quantum.bit
+
+    return %out_qubits_1 : !quantum.bit
+}


### PR DESCRIPTION
**Context:**
Extend the cancel_inverses pass to cancel adjoints of an arbitrary unitary.

**Description of the Change:**
- Add an analysis to check whether a quantum gate and its parent gate are well-matched for the purposes of peephole optimizations like cancel_inverse and merge_rotation
- Include a new cancel_inverse pattern "---U---U{adj}---" for arbitrary U.

**Benefits:**
Arbitrary inverses can now be cancelled, in addition to the named Hermitian gates.

**Possible Drawbacks:**
Two potential improvements:
1. Control wires' values don't have to match one-to-one exactly, but only the set of true wires and the set of false wires need to match, and within the set the wires can be of arbitrary order. The exact one-to-one being checked right now is overly conservative.
2. Instead of manually adding the pattern for `customOp`, `unitaryOp` and `multiRZOp` separately, we might want to use the [quantum op interface](https://github.com/PennyLaneAI/catalyst/blob/main/mlir/include/Quantum/IR/QuantumInterfaces.td). However, mlir pattern matcher expects the op being matched to be concrete (so that it can look for a name in the textual IR) instead of being an abstract interface. Some redesign of the interface and its usage might be beneficial. 

**Related GitHub Issues:**
[sc-74518]
