### PR TITLE
Insert TBAA pointer tag for AlignedPointer and dealloc_helper Indices

### DIFF
--- a/mlir/lib/Catalyst/Transforms/TBAAPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/TBAAPatterns.cpp
@@ -30,6 +30,7 @@ void setTag(mlir::Type baseType, catalyst::TBAATree *tree, mlir::MLIRContext *ct
             mlir::LLVM::AliasAnalysisOpInterface newOp)
 {
     mlir::LLVM::TBAATagAttr tag;
+    // Index can be used as a pointer.
     if ((isa<IndexType>(baseType) && !isa<LLVM::StoreOp>(newOp) && !isa<LLVM::LoadOp>(newOp)) ||
         isa<IntegerType>(baseType)) {
         tag = tree->getTag("int");

--- a/mlir/lib/Catalyst/Transforms/TBAAPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/TBAAPatterns.cpp
@@ -66,7 +66,6 @@ void setTag(mlir::Type baseType, catalyst::TBAATree *tree, Operation *currentOp,
             tag = tree->getTag("any pointer");
         }
         else {
-            isInsideDeallocHelper(currentOp);
             tag = tree->getTag("int");
         }
         newOp.setTBAATags(ArrayAttr::get(ctx, tag));

--- a/mlir/lib/Catalyst/Transforms/TBAAPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/TBAAPatterns.cpp
@@ -30,7 +30,8 @@ void setTag(mlir::Type baseType, catalyst::TBAATree *tree, mlir::MLIRContext *ct
             mlir::LLVM::AliasAnalysisOpInterface newOp)
 {
     mlir::LLVM::TBAATagAttr tag;
-    if (isa<IndexType>(baseType) || isa<IntegerType>(baseType)) {
+    if ((isa<IndexType>(baseType) && !isa<LLVM::StoreOp>(newOp) && !isa<LLVM::LoadOp>(newOp)) ||
+        isa<IntegerType>(baseType)) {
         tag = tree->getTag("int");
         newOp.setTBAATags(ArrayAttr::get(ctx, tag));
     }

--- a/mlir/lib/Catalyst/Transforms/TBAAPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/TBAAPatterns.cpp
@@ -54,20 +54,13 @@ bool isInsideDeallocHelper(Operation *op)
     return false;
 }
 
-void setTag(mlir::Type baseType, catalyst::TBAATree *tree, Operation *currentOp,
+void setTag(mlir::Type baseType, catalyst::TBAATree *tree, mlir::MLIRContext *ctx,
             mlir::LLVM::AliasAnalysisOpInterface newOp)
 {
-    mlir::MLIRContext *ctx = currentOp->getContext();
     mlir::LLVM::TBAATagAttr tag;
     if (isa<IndexType>(baseType) || isa<IntegerType>(baseType)) {
         // Index can be used as a pointer.
-        if (isa<IndexType>(baseType) &&
-            (isFromExtractAlignedPointerAsIndexOp(currentOp) || isInsideDeallocHelper(currentOp))) {
-            tag = tree->getTag("any pointer");
-        }
-        else {
-            tag = tree->getTag("int");
-        }
+        tag = tree->getTag("int");
         newOp.setTBAATags(ArrayAttr::get(ctx, tag));
     }
     else if (isa<FloatType>(baseType)) {
@@ -107,8 +100,14 @@ struct MemrefLoadTBAARewritePattern : public ConvertOpToLLVMPattern<memref::Load
             loadOp, typeConverter->convertType(type.getElementType()), dataPtr, 0, false,
             loadOp.getNontemporal());
 
-        if (isAnyOf<IndexType, IntegerType, FloatType, MemRefType>(baseType)) {
-            setTag(baseType, tree, loadOp, op);
+        // Index can be used as a pointer.
+        if (isa<IndexType>(baseType) &&
+            (isFromExtractAlignedPointerAsIndexOp(loadOp) || isInsideDeallocHelper(loadOp))) {
+            mlir::LLVM::TBAATagAttr tag = tree->getTag("any pointer");
+            op.setTBAATags(ArrayAttr::get(loadOp.getContext(), tag));
+        }
+        else if (isAnyOf<IndexType, IntegerType, FloatType, MemRefType>(baseType)) {
+            setTag(baseType, tree, loadOp.getContext(), op);
         }
         else {
             return failure();
@@ -138,8 +137,14 @@ struct MemrefStoreTBAARewritePattern : public ConvertOpToLLVMPattern<memref::Sto
         auto op = rewriter.replaceOpWithNewOp<LLVM::StoreOp>(storeOp, adaptor.getValue(), dataPtr,
                                                              0, false, storeOp.getNontemporal());
 
-        if (isAnyOf<IndexType, IntegerType, FloatType, MemRefType>(baseType)) {
-            setTag(baseType, tree, storeOp, op);
+        // Index can be used as a pointer.
+        if (isa<IndexType>(baseType) &&
+            (isFromExtractAlignedPointerAsIndexOp(storeOp) || isInsideDeallocHelper(storeOp))) {
+            mlir::LLVM::TBAATagAttr tag = tree->getTag("any pointer");
+            op.setTBAATags(ArrayAttr::get(storeOp.getContext(), tag));
+        }
+        else if (isAnyOf<IndexType, IntegerType, FloatType, MemRefType>(baseType)) {
+            setTag(baseType, tree, storeOp.getContext(), op);
         }
         else {
             return failure();

--- a/mlir/lib/Catalyst/Transforms/TBAAPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/TBAAPatterns.cpp
@@ -32,7 +32,7 @@ void setTag(mlir::Type baseType, catalyst::TBAATree *tree, mlir::MLIRContext *ct
     mlir::LLVM::TBAATagAttr tag;
     if (isa<IndexType>(baseType) || isa<IntegerType>(baseType)) {
         // Index can be used as a pointer.
-        if(isa<IndexType>(baseType) && (isa<LLVM::StoreOp>(newOp) || isa<LLVM::LoadOp>(newOp))) {
+        if (isa<IndexType>(baseType) && (isa<LLVM::StoreOp>(newOp) || isa<LLVM::LoadOp>(newOp))) {
             tag = tree->getTag("any pointer");
         }
         else {

--- a/mlir/lib/Catalyst/Transforms/TBAAPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/TBAAPatterns.cpp
@@ -30,10 +30,14 @@ void setTag(mlir::Type baseType, catalyst::TBAATree *tree, mlir::MLIRContext *ct
             mlir::LLVM::AliasAnalysisOpInterface newOp)
 {
     mlir::LLVM::TBAATagAttr tag;
-    // Index can be used as a pointer.
-    if ((isa<IndexType>(baseType) && !isa<LLVM::StoreOp>(newOp) && !isa<LLVM::LoadOp>(newOp)) ||
-        isa<IntegerType>(baseType)) {
-        tag = tree->getTag("int");
+    if (isa<IndexType>(baseType) || isa<IntegerType>(baseType)) {
+        // Index can be used as a pointer.
+        if(isa<IndexType>(baseType) && (isa<LLVM::StoreOp>(newOp) || isa<LLVM::LoadOp>(newOp))) {
+            tag = tree->getTag("any pointer");
+        }
+        else {
+            tag = tree->getTag("int");
+        }
         newOp.setTBAATags(ArrayAttr::get(ctx, tag));
     }
     else if (isa<FloatType>(baseType)) {

--- a/mlir/test/Catalyst/MemrefLoadStoreLoweringTBAA.mlir
+++ b/mlir/test/Catalyst/MemrefLoadStoreLoweringTBAA.mlir
@@ -103,9 +103,9 @@ module @my_model {
 
 // CHECK: [[root:#.+]] = #llvm.tbaa_root<id = "Catalyst TBAA">
 // CHECK: [[typedescdouble:#.+]] = #llvm.tbaa_type_desc<id = "double", members = {<[[root]], 0>}>
-// CHECK: [[typedescptr:#.+]] = #llvm.tbaa_type_desc<id = "any pointer", members = {<[[root]], 0>}>
+// CHECK: [[typedescint:#.+]] = #llvm.tbaa_type_desc<id = "int", members = {<[[root]], 0>}>
 // CHECK: [[tagdouble:#.+]] = #llvm.tbaa_tag<base_type = [[typedescdouble]], access_type = [[typedescdouble]], offset = 0>
-// CHECK: [[tagptr:#.+]] = #llvm.tbaa_tag<base_type = [[typedescptr]], access_type = [[typedescptr]], offset = 0>
+// CHECK: [[tagint:#.+]] = #llvm.tbaa_tag<base_type = [[typedescint]], access_type = [[typedescint]], offset = 0>
 module @my_model {
     llvm.func @__enzyme_autodiff2(...)
     func.func @func_mix_f64_index(%arg0: memref<f64>, %arg1: memref<4xf64>, %arg2: memref<index>, %arg3: memref<3xindex>) -> (memref<4xf64>, memref<3xindex>) {
@@ -121,12 +121,12 @@ module @my_model {
         // CHECK: [[getPtr:%.+]] = llvm.getelementptr [[extract1]][[[idxCast]]] : (!llvm.ptr, i64) -> !llvm.ptr, f64
         // CHECK: llvm.store [[load0]], [[getPtr]] {tbaa = [[[tagdouble]]]} : f64, !llvm.ptr
         // CHECK: [[extract2:%.+]] = llvm.extractvalue [[castArg2]][1] : !llvm.struct<(ptr, ptr, i64)>
-        // CHECK: [[load1:%.+]] = llvm.load [[extract2]] {tbaa = [[[tagptr]]]} : !llvm.ptr -> i64
+        // CHECK: [[load1:%.+]] = llvm.load [[extract2]] {tbaa = [[[tagint]]]} : !llvm.ptr -> i64
         // CHECK: [[idx1:%.+]] = index.constant 1
         // CHECK: [[idxCast1:%.+]] = builtin.unrealized_conversion_cast [[idx1]] : index to i64
         // CHECK: [[extract2:%.+]] = llvm.extractvalue [[castArg3]][1] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
         // CHECK: [[getPtr1:%.+]] = llvm.getelementptr [[extract2]][[[idxCast1]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
-        // CHECK: llvm.store [[load1]], [[getPtr1]] {tbaa = [[[tagptr]]]} : i64, !llvm.ptr
+        // CHECK: llvm.store [[load1]], [[getPtr1]] {tbaa = [[[tagint]]]} : i64, !llvm.ptr
         %0 = memref.load %arg0[] : memref<f64>
         %idx0 = index.constant 0
         memref.store %0, %arg1[%idx0] : memref<4xf64>

--- a/mlir/test/Catalyst/MemrefLoadStoreLoweringTBAA.mlir
+++ b/mlir/test/Catalyst/MemrefLoadStoreLoweringTBAA.mlir
@@ -103,9 +103,7 @@ module @my_model {
 
 // CHECK: [[root:#.+]] = #llvm.tbaa_root<id = "Catalyst TBAA">
 // CHECK: [[typedescdouble:#.+]] = #llvm.tbaa_type_desc<id = "double", members = {<[[root]], 0>}>
-// CHECK: [[typedescint:#.+]] = #llvm.tbaa_type_desc<id = "int", members = {<[[root]], 0>}>
 // CHECK: [[tagdouble:#.+]] = #llvm.tbaa_tag<base_type = [[typedescdouble]], access_type = [[typedescdouble]], offset = 0>
-// CHECK: [[tagint:#.+]] = #llvm.tbaa_tag<base_type = [[typedescint]], access_type = [[typedescint]], offset = 0>
 module @my_model {
     llvm.func @__enzyme_autodiff2(...)
     func.func @func_mix_f64_index(%arg0: memref<f64>, %arg1: memref<4xf64>, %arg2: memref<index>, %arg3: memref<3xindex>) -> (memref<4xf64>, memref<3xindex>) {
@@ -121,12 +119,12 @@ module @my_model {
         // CHECK: [[getPtr:%.+]] = llvm.getelementptr [[extract1]][[[idxCast]]] : (!llvm.ptr, i64) -> !llvm.ptr, f64
         // CHECK: llvm.store [[load0]], [[getPtr]] {tbaa = [[[tagdouble]]]} : f64, !llvm.ptr
         // CHECK: [[extract2:%.+]] = llvm.extractvalue [[castArg2]][1] : !llvm.struct<(ptr, ptr, i64)>
-        // CHECK: [[load1:%.+]] = llvm.load [[extract2]] {tbaa = [[[tagint]]]} : !llvm.ptr -> i64
+        // CHECK: [[load1:%.+]] = llvm.load [[extract2]] : !llvm.ptr -> i64
         // CHECK: [[idx1:%.+]] = index.constant 1
         // CHECK: [[idxCast1:%.+]] = builtin.unrealized_conversion_cast [[idx1]] : index to i64
         // CHECK: [[extract2:%.+]] = llvm.extractvalue [[castArg3]][1] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
         // CHECK: [[getPtr1:%.+]] = llvm.getelementptr [[extract2]][[[idxCast1]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
-        // CHECK: llvm.store [[load1]], [[getPtr1]] {tbaa = [[[tagint]]]} : i64, !llvm.ptr
+        // CHECK: llvm.store [[load1]], [[getPtr1]] : i64, !llvm.ptr
         %0 = memref.load %arg0[] : memref<f64>
         %idx0 = index.constant 0
         memref.store %0, %arg1[%idx0] : memref<4xf64>

--- a/mlir/test/Catalyst/MemrefLoadStoreLoweringTBAA.mlir
+++ b/mlir/test/Catalyst/MemrefLoadStoreLoweringTBAA.mlir
@@ -103,7 +103,9 @@ module @my_model {
 
 // CHECK: [[root:#.+]] = #llvm.tbaa_root<id = "Catalyst TBAA">
 // CHECK: [[typedescdouble:#.+]] = #llvm.tbaa_type_desc<id = "double", members = {<[[root]], 0>}>
+// CHECK: [[typedescptr:#.+]] = #llvm.tbaa_type_desc<id = "any pointer", members = {<[[root]], 0>}>
 // CHECK: [[tagdouble:#.+]] = #llvm.tbaa_tag<base_type = [[typedescdouble]], access_type = [[typedescdouble]], offset = 0>
+// CHECK: [[tagptr:#.+]] = #llvm.tbaa_tag<base_type = [[typedescptr]], access_type = [[typedescptr]], offset = 0>
 module @my_model {
     llvm.func @__enzyme_autodiff2(...)
     func.func @func_mix_f64_index(%arg0: memref<f64>, %arg1: memref<4xf64>, %arg2: memref<index>, %arg3: memref<3xindex>) -> (memref<4xf64>, memref<3xindex>) {
@@ -119,12 +121,12 @@ module @my_model {
         // CHECK: [[getPtr:%.+]] = llvm.getelementptr [[extract1]][[[idxCast]]] : (!llvm.ptr, i64) -> !llvm.ptr, f64
         // CHECK: llvm.store [[load0]], [[getPtr]] {tbaa = [[[tagdouble]]]} : f64, !llvm.ptr
         // CHECK: [[extract2:%.+]] = llvm.extractvalue [[castArg2]][1] : !llvm.struct<(ptr, ptr, i64)>
-        // CHECK: [[load1:%.+]] = llvm.load [[extract2]] : !llvm.ptr -> i64
+        // CHECK: [[load1:%.+]] = llvm.load [[extract2]] {tbaa = [[[tagptr]]]} : !llvm.ptr -> i64
         // CHECK: [[idx1:%.+]] = index.constant 1
         // CHECK: [[idxCast1:%.+]] = builtin.unrealized_conversion_cast [[idx1]] : index to i64
         // CHECK: [[extract2:%.+]] = llvm.extractvalue [[castArg3]][1] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
         // CHECK: [[getPtr1:%.+]] = llvm.getelementptr [[extract2]][[[idxCast1]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
-        // CHECK: llvm.store [[load1]], [[getPtr1]] : i64, !llvm.ptr
+        // CHECK: llvm.store [[load1]], [[getPtr1]] {tbaa = [[[tagptr]]]} : i64, !llvm.ptr
         %0 = memref.load %arg0[] : memref<f64>
         %idx0 = index.constant 0
         memref.store %0, %arg1[%idx0] : memref<4xf64>


### PR DESCRIPTION
**Context:**

Update the if-condition in TBAAPatterns so that it can insert pointer tag to `Index`.  (`Index` can be treated as Pointer.)
We check if the index comes from `ExtractAlignedPointerAsIndexOp` or is located in `dealloc_helper` created by the deallocation pass. However, even with this fix, we still get `double free` error related Enzyme (https://github.com/PennyLaneAI/catalyst/pull/1167#issuecomment-2405927491).

**Trace:**
The following example has a integer tag (!tbaa !4) for Index. It should be changed to the pointer tag (!tbaa !6).
```llvm
define internal void @loss.cloned(ptr %0, ptr %1, i64 %2, i64 %3, i64 %4, ptr nocapture readnone %5, ptr nocapture writeonly %6, i64 %7) {
  %9 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 0)
  %10 = call ptr @_mlir_memref_to_llvm_alloc(i64 24)
  %11 = ptrtoint ptr %9 to i64
  store i64 %11, ptr %10, align 4, !tbaa !4
  ret void
}
``` 
Otherwise, this error will be thrown.
```shell
error: <unknown>:0:0: in function loss.cloned void (ptr, ptr, i64, i64, i64, ptr, ptr, i64): Enzyme: <analysis>
ptr %0: {[-1]:Pointer}, intvals: {}
ptr %1: {[-1]:Pointer}, intvals: {}
i64 %2: {[-1]:Integer}, intvals: {}
i64 %3: {[-1]:Integer}, intvals: {}
i64 %4: {[-1]:Integer}, intvals: {}
ptr %5: {[-1]:Pointer}, intvals: {}
ptr %6: {[-1]:Pointer}, intvals: {}
i64 %7: {[-1]:Integer}, intvals: {}
  %10 = call ptr @_mlir_memref_to_llvm_alloc(i64 24): {[-1]:Pointer, [-1,0]:Integer, [-1,1]:Integer, [-1,2]:Integer, [-1,3]:Integer, [-1,4]:Integer, [-1,5]:Integer, [-1,6]:Integer, [-1,7]:Integer}, intvals: {}
  %11 = ptrtoint ptr %9 to i64: {[-1]:Integer}, intvals: {}
  %9 = tail call ptr @_mlir_memref_to_llvm_alloc(i64 0): {[-1]:Pointer}, intvals: {}
</analysis>
Illegal updateAnalysis prev:{[-1]:Integer} new: {[-1]:Pointer}
val:   %11 = ptrtoint ptr %9 to i64 origin=  %11 = ptrtoint ptr %9 to i64
