### PR TITLE
Seed non-deterministic TestMeasurementTransforms test

### DIFF
--- a/frontend/test/pytest/test_measurement_transforms.py
+++ b/frontend/test/pytest/test_measurement_transforms.py
@@ -489,7 +489,7 @@ class TestMeasurementTransforms:
 
         dev = qml.device("lightning.qubit", wires=4, shots=shots)
 
-        @qml.qjit
+        @qml.qjit(seed=37)
         @partial(measurements_from_samples, device_wires=dev.wires)
         @qml.qnode(dev)
         def circuit(theta: float):


### PR DESCRIPTION
**Context:** We noticed a non-deterministic failing pytest, `TestMeasurementTransforms.test_measurement_from_samples_single_measurement_analytic`, in #1173. We can fix the non-deterministic failure by seeding the qjit-ed circuit.

**Description of the Change:** Replace `@qjit` decorator with `@qjit(seed=37)`.
