### PR TITLE
pin to ubuntu-22.04

### DIFF
--- a/.github/workflows/build-enzyme-v0.0.130.yaml
+++ b/.github/workflows/build-enzyme-v0.0.130.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Determine runner type to use
     uses: ./.github/workflows/determine-workflow-runner.yml
     with:
-      default_runner: ubuntu-latest
+      default_runner: ubuntu-22.04
 
   constants:
     name: "Set build matrix"

--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   setup:
     name: Setup the release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
   upload:
     name: Prepare & Upload wheels to TestPyPI
     needs: [linux-x86, macos-arm]  # linux-aarch, macos-x86
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Determine runner type to use
     uses: ./.github/workflows/determine-workflow-runner.yml
     with:
-      default_runner: ubuntu-latest
+      default_runner: ubuntu-22.04
 
   check_if_wheel_build_required:
     if: github.event.pull_request.draft == false

--- a/.github/workflows/changelog-reminder.yaml
+++ b/.github/workflows/changelog-reminder.yaml
@@ -9,7 +9,7 @@ name: Changelog Reminder
 jobs:
   remind:
     name: Changelog Reminder
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@master
     - name: Changelog Reminder

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -21,7 +21,7 @@ jobs:
     name: Determine runner type to use
     uses: ./.github/workflows/determine-workflow-runner.yml
     with:
-      default_runner: ubuntu-latest
+      default_runner: ubuntu-22.04
 
   constants:
     name: "Set build matrix"

--- a/.github/workflows/check-for-wheel-build.yml
+++ b/.github/workflows/check-for-wheel-build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   check_if_required:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Build is triggered from Pull Request

--- a/.github/workflows/check-formatting.yaml
+++ b/.github/workflows/check-formatting.yaml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   format-python:
     name: Python Formatting & Linting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Install dependencies
@@ -31,7 +31,7 @@ jobs:
 
   format-cpp:
     name: C++ Formatting
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Install dependencies

--- a/.github/workflows/check-jax-release.yaml
+++ b/.github/workflows/check-jax-release.yaml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   check-jax:
     name: Build/Test Catalyst against JAX
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -27,7 +27,7 @@ jobs:
   check-config:
     name: Build Configuration
     needs: [constants]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout Catalyst repo

--- a/.github/workflows/determine-workflow-runner.yml
+++ b/.github/workflows/determine-workflow-runner.yml
@@ -22,7 +22,7 @@ jobs:
         (
           github.event_name == 'pull_request'
           && contains(github.event.pull_request.labels.*.name, 'urgent')
-        ) && 'pl-4-core-large-runner' || 'ubuntu-latest'
+        ) && 'pl-4-core-large-runner' || 'ubuntu-22.04'
       }}
 
     outputs:

--- a/.github/workflows/notify-failed-jobs.yaml
+++ b/.github/workflows/notify-failed-jobs.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   on-failure:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event.workflow_run.conclusion == 'failure' || github.event.workflow_run.conclusion == 'timed_out'
     steps:
       - uses: ravsamhq/notify-slack-action@v2

--- a/.github/workflows/rc_sync.yaml
+++ b/.github/workflows/rc_sync.yaml
@@ -19,7 +19,7 @@ jobs:
   # This workflow contains a single job to sync the main branch with changes from the rc
   sync:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
**Context:**
The github action tag `ubuntu-latest` now hits ubuntu-24.04, causing many failures: https://github.com/actions/runner-images/issues/10636

We pin to ubuntu-22.04.

