### PR TITLE
Print MLIR with debug info

### DIFF
--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -622,7 +622,7 @@ class Compiler:
 
         return self.run_from_ir(
             mlir_module.operation.get_asm(
-                binary=False, print_generic_op_form=False, assume_verified=True
+                binary=False, print_generic_op_form=False, assume_verified=True, enable_debug_info=True
             ),
             str(mlir_module.operation.attributes["sym_name"]).replace('"', ""),
             *args,

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -476,7 +476,8 @@ LogicalResult runLowering(const CompilerOptions &options, MLIRContext *ctx, Modu
 
     if (options.keepIntermediate && options.checkpointStage == "") {
         llvm::raw_string_ostream s{outputs["mlir"]};
-        s << moduleOp;
+        AsmState state(moduleOp, OpPrintingFlags().enableDebugInfo(true, true).printValueUsers());
+        moduleOp->print(s, state);
         dumpToFile(options, output.nextPipelineDumpFilename(options.moduleName.str(), ".mlir"),
                    outputs["mlir"]);
     }
@@ -501,7 +502,8 @@ LogicalResult runLowering(const CompilerOptions &options, MLIRContext *ctx, Modu
         if (options.keepIntermediate && res != pipelineTailMarkers.end()) {
             auto pipelineName = res->second;
             llvm::raw_string_ostream s{outputs[pipelineName]};
-            s << *op;
+            AsmState state(op, OpPrintingFlags().enableDebugInfo(true, true).printValueUsers());
+            op->print(s, state);
             dumpToFile(options, output.nextPipelineDumpFilename(pipelineName),
                        outputs[pipelineName]);
         }


### PR DESCRIPTION
**Context:** Gets location information from JAX to MLIR, but not yet to LLVM.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
