### PR TITLE
Fix Enzyme pass check and add `replace_ir_from_file` helper

### DIFF
--- a/frontend/catalyst/debug/__init__.py
+++ b/frontend/catalyst/debug/__init__.py
@@ -20,6 +20,7 @@ from catalyst.debug.compiler_functions import (
     get_cmain,
     get_compilation_stage,
     replace_ir,
+    replace_ir_from_file,
 )
 from catalyst.debug.instruments import instrumentation
 from catalyst.debug.printing import (  # pylint: disable=redefined-builtin

--- a/frontend/catalyst/debug/compiler_functions.py
+++ b/frontend/catalyst/debug/compiler_functions.py
@@ -182,6 +182,20 @@ def replace_ir(fn, stage, new_ir):
 
 
 @debug_logger
+def replace_ir_from_file(fn, stage, new_ir_path):
+    r"""Replace the IR at any compilation stage that will be used the next time the function runs.
+    This helper reads ir from file. Please consult replace_ir for all the available compiler stages.
+    Args:
+        fn (QJIT): a qjit-decorated function
+        stage (str): Recompilation picks up after this stage.
+        new_ir_path (str): the path of the replacement IR to use for recompilation.
+    """
+    with open(new_ir_path, "r", encoding="utf-8") as file:
+        file_content = file.read()
+    replace_ir(fn, stage, file_content)
+
+
+@debug_logger
 def compile_executable(fn, *args):
     """Generate an executable binary for the native host architecture from a
     :func:`~.qjit` decorated function with provided arguments.


### PR DESCRIPTION
**Context:**

In the compiler driver, we only check if there is any `GradientOpInterface` for enzyme. However, it only works for early mlir levels with `replace_ir`. This PR moves the check to the llvm level and detects any `__enzyme_*` functions.

The PR also adds an extra helper `replace_ir_from_file` to read the replacement ir from file. 
