### PR TITLE
Add control qubits to chained named Hermitian gate cancel_inverse patterns

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -249,6 +249,7 @@
 
 * The compiler pass `-remove-chained-self-inverse` can now also cancel adjoints of arbitrary unitary operations (in addition to the named Hermitian gates).
   [(#1186)](https://github.com/PennyLaneAI/catalyst/pull/1186)
+  [(#1211)](https://github.com/PennyLaneAI/catalyst/pull/1211)
 
 <h3>Breaking changes</h3>
 

--- a/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
@@ -56,6 +56,21 @@ struct ChainedNamedHermitianOpRewritePattern : public mlir::OpRewritePattern<Cus
 
         // Replace uses
         ValueRange InQubits = op.getInQubits();
+
+        /*
+        llvm::errs() << "self: " << op << "\n";
+        auto parentOp = cast<CustomOp>(InQubits[0].getDefiningOp());
+        llvm::errs() << "parent: " << parentOp << "\n";
+        ValueRange qubitOperands = parentOp.getQubitOperands();
+        //llvm::errs() << "first parent operand: " << qubitOperands[0] << "\n";
+        for (const auto &[idx, qubitResult] : llvm::enumerate(op.getQubitResults())) {
+            llvm::errs() << qubitResult << "\n";
+            llvm::errs() << qubitOperands[idx] << "\n";
+            qubitResult.replaceAllUsesWith(qubitOperands[idx]);
+        }
+        return success();
+        */
+
         auto parentOp = cast<CustomOp>(InQubits[0].getDefiningOp());
         ValueRange originalNonCtrlQubits = parentOp.getNonCtrlQubitOperands();
         ValueRange originalCtrlQubits = parentOp.getCtrlQubitOperands();

--- a/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
@@ -56,30 +56,13 @@ struct ChainedNamedHermitianOpRewritePattern : public mlir::OpRewritePattern<Cus
 
         // Replace uses
         ValueRange InQubits = op.getInQubits();
-
-        /*
-        llvm::errs() << "self: " << op << "\n";
         auto parentOp = cast<CustomOp>(InQubits[0].getDefiningOp());
-        llvm::errs() << "parent: " << parentOp << "\n";
-        ValueRange qubitOperands = parentOp.getQubitOperands();
-        //llvm::errs() << "first parent operand: " << qubitOperands[0] << "\n";
-        for (const auto &[idx, qubitResult] : llvm::enumerate(op.getQubitResults())) {
-            llvm::errs() << qubitResult << "\n";
-            llvm::errs() << qubitOperands[idx] << "\n";
-            qubitResult.replaceAllUsesWith(qubitOperands[idx]);
-        }
-        return success();
-        */
 
-        auto parentOp = cast<CustomOp>(InQubits[0].getDefiningOp());
-        ValueRange originalNonCtrlQubits = parentOp.getNonCtrlQubitOperands();
-        ValueRange originalCtrlQubits = parentOp.getCtrlQubitOperands();
-        for (const auto &[idx, nonCtrlQubitResult] : llvm::enumerate(op.getNonCtrlQubitResults())) {
-            nonCtrlQubitResult.replaceAllUsesWith(originalNonCtrlQubits[idx]);
-        }
-        for (const auto &[idx, ctrlQubitResult] : llvm::enumerate(op.getCtrlQubitResults())) {
-            ctrlQubitResult.replaceAllUsesWith(originalCtrlQubits[idx]);
-        }
+        // TODO: it would make more sense for getQubitOperands()
+        // to return ValueRange, like the other getters
+        std::vector<mlir::Value> originalQubits = parentOp.getQubitOperands();
+
+        rewriter.replaceOp(op, originalQubits);
         return success();
     }
 };

--- a/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
@@ -56,7 +56,7 @@ struct ChainedNamedHermitianOpRewritePattern : public mlir::OpRewritePattern<Cus
 
         // Replace uses
         ValueRange InQubits = op.getInQubits();
-        auto parentOp = dyn_cast_or_null<CustomOp>(InQubits[0].getDefiningOp());
+        auto parentOp = cast<CustomOp>(InQubits[0].getDefiningOp());
         ValueRange originalNonCtrlQubits = parentOp.getNonCtrlQubitOperands();
         ValueRange originalCtrlQubits = parentOp.getCtrlQubitOperands();
         for (const auto &[idx, nonCtrlQubitResult] : llvm::enumerate(op.getNonCtrlQubitResults())) {

--- a/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ChainedSelfInversePatterns.cpp
@@ -56,9 +56,15 @@ struct ChainedNamedHermitianOpRewritePattern : public mlir::OpRewritePattern<Cus
 
         // Replace uses
         ValueRange InQubits = op.getInQubits();
-        auto ParentOp = dyn_cast_or_null<CustomOp>(InQubits[0].getDefiningOp());
-        ValueRange simplifiedVal = ParentOp.getInQubits();
-        rewriter.replaceOp(op, simplifiedVal);
+        auto parentOp = dyn_cast_or_null<CustomOp>(InQubits[0].getDefiningOp());
+        ValueRange originalNonCtrlQubits = parentOp.getNonCtrlQubitOperands();
+        ValueRange originalCtrlQubits = parentOp.getCtrlQubitOperands();
+        for (const auto &[idx, nonCtrlQubitResult] : llvm::enumerate(op.getNonCtrlQubitResults())) {
+            nonCtrlQubitResult.replaceAllUsesWith(originalNonCtrlQubits[idx]);
+        }
+        for (const auto &[idx, ctrlQubitResult] : llvm::enumerate(op.getCtrlQubitResults())) {
+            ctrlQubitResult.replaceAllUsesWith(originalCtrlQubits[idx]);
+        }
         return success();
     }
 };

--- a/mlir/test/Quantum/ChainedSelfInverseTest.mlir
+++ b/mlir/test/Quantum/ChainedSelfInverseTest.mlir
@@ -631,3 +631,29 @@ func.func @test_chained_self_inverse() -> (!quantum.bit, !quantum.bit, !quantum.
     // CHECK: return [[IN0]], [[IN1]], [[IN2]]
     return %out_qubits_1, %out_ctrl_qubits_1#0, %out_ctrl_qubits_1#1 : !quantum.bit, !quantum.bit, !quantum.bit
 }
+
+// -----
+
+
+// test with unmatched control wires on named Hermitian gate
+
+// CHECK-LABEL: test_chained_self_inverse
+func.func @test_chained_self_inverse() -> (!quantum.bit, !quantum.bit, !quantum.bit) {
+    %true = llvm.mlir.constant (1 : i1) :i1
+    %false = llvm.mlir.constant (0 : i1) :i1
+
+    // CHECK: quantum.alloc
+    // CHECK: [[IN0:%.+]] = quantum.extract {{.+}}[ 0]
+    // CHECK: [[IN1:%.+]] = quantum.extract {{.+}}[ 1]
+    // CHECK: [[IN2:%.+]] = quantum.extract {{.+}}[ 2]
+    %reg = quantum.alloc( 3) : !quantum.reg
+    %0 = quantum.extract %reg[ 0] : !quantum.reg -> !quantum.bit
+    %1 = quantum.extract %reg[ 1] : !quantum.reg -> !quantum.bit
+    %2 = quantum.extract %reg[ 2] : !quantum.reg -> !quantum.bit
+
+    %out_qubits, %out_ctrl_qubits:2 = quantum.custom "Hadamard"() %0 ctrls(%1, %2) ctrlvals(%true, %false) : !quantum.bit ctrls !quantum.bit, !quantum.bit
+    %out_qubits_1, %out_ctrl_qubits_1:2 = quantum.custom "Hadamard"() %out_qubits ctrls(%out_ctrl_qubits#1, %out_ctrl_qubits#0) ctrlvals(%true, %false) : !quantum.bit ctrls !quantum.bit, !quantum.bit
+
+    // CHECK: quantum.custom "Hadamard"
+    return %out_qubits_1, %out_ctrl_qubits_1#0, %out_ctrl_qubits_1#1 : !quantum.bit, !quantum.bit, !quantum.bit
+}

--- a/mlir/test/Quantum/ChainedSelfInverseTest.mlir
+++ b/mlir/test/Quantum/ChainedSelfInverseTest.mlir
@@ -604,3 +604,30 @@ func.func @test_chained_self_inverse(%arg0: f64) -> (!quantum.bit, !quantum.bit,
     // CHECK: quantum.multirz
     return %mrz_out#0, %mrz_out#1, %mrz_out#2 : !quantum.bit, !quantum.bit, !quantum.bit
 }
+
+// -----
+
+
+// test with matched control wires on named Hermitian gate
+
+// CHECK-LABEL: test_chained_self_inverse
+func.func @test_chained_self_inverse() -> (!quantum.bit, !quantum.bit, !quantum.bit) {
+    %true = llvm.mlir.constant (1 : i1) :i1
+    %false = llvm.mlir.constant (0 : i1) :i1
+
+    // CHECK: quantum.alloc
+    // CHECK: [[IN0:%.+]] = quantum.extract {{.+}}[ 0]
+    // CHECK: [[IN1:%.+]] = quantum.extract {{.+}}[ 1]
+    // CHECK: [[IN2:%.+]] = quantum.extract {{.+}}[ 2]
+    %reg = quantum.alloc( 3) : !quantum.reg
+    %0 = quantum.extract %reg[ 0] : !quantum.reg -> !quantum.bit
+    %1 = quantum.extract %reg[ 1] : !quantum.reg -> !quantum.bit
+    %2 = quantum.extract %reg[ 2] : !quantum.reg -> !quantum.bit
+
+    %out_qubits, %out_ctrl_qubits:2 = quantum.custom "Hadamard"() %0 ctrls(%1, %2) ctrlvals(%true, %false) : !quantum.bit ctrls !quantum.bit, !quantum.bit
+    %out_qubits_1, %out_ctrl_qubits_1:2 = quantum.custom "Hadamard"() %out_qubits ctrls(%out_ctrl_qubits#0, %out_ctrl_qubits#1) ctrlvals(%true, %false) : !quantum.bit ctrls !quantum.bit, !quantum.bit
+
+    // CHECK-NOT: quantum.custom
+    // CHECK: return [[IN0]], [[IN1]], [[IN2]]
+    return %out_qubits_1, %out_ctrl_qubits_1#0, %out_ctrl_qubits_1#1 : !quantum.bit, !quantum.bit, !quantum.bit
+}


### PR DESCRIPTION
**Context:**
We realized the named Hermitian gates in cancel_inverses patterns do not include control qubits. We add it.

