### PR TITLE
[MLIR] Add fast path for lowering scatter

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -286,6 +286,10 @@
 * Registers the func dialect as a requirement for running the scatter lowering pass.
   [(#1216)](https://github.com/PennyLaneAI/catalyst/pull/1216)
 
+* Fixes #1153 : a performance issue with vmap with its root cause in the
+  lowering of the scatter operation.
+  [(#1214)](https://github.com/PennyLaneAI/catalyst/pull/1214)
+
 <h3>Internal changes</h3>
 
 * Remove deprecated pennylane code across the frontend.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -326,7 +326,7 @@
   - Registers the func dialect as a requirement for running the scatter lowering pass.
   - Emits error if `%input`, `%update` and `%result` are not of length 1 instead of segfaulting.
 
-* Fixes #1153 : a performance issue with vmap with its root cause in the
+* Fixes a performance issue with vmap with its root cause in the
   lowering of the scatter operation.
   [(#1214)](https://github.com/PennyLaneAI/catalyst/pull/1214)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -283,6 +283,9 @@
 * Fixes taking gradient of nested accelerate callbacks.
   [(#1156)](https://github.com/PennyLaneAI/catalyst/pull/1156)
 
+* Registers the func dialect as a requirement for running the scatter lowering pass.
+  [(#1216)](https://github.com/PennyLaneAI/catalyst/pull/1216)
+
 <h3>Internal changes</h3>
 
 * Remove deprecated pennylane code across the frontend.

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.9.0-dev36"
+__version__ = "0.9.0-dev37"

--- a/frontend/catalyst/api_extensions/function_maps.py
+++ b/frontend/catalyst/api_extensions/function_maps.py
@@ -256,13 +256,8 @@ class VmapCallable(CatalystCallable):
         # in the flatten format with respect to the 'init_result' shape
         batched_result_list = []
         for j in range(num_axes_out):
-            out_shape = (
-                (batch_size,)
-                if not init_result_flat[j].shape
-                else (batch_size, *init_result_flat[j].shape)
-            )
+            out_shape = (batch_size, *init_result_flat[j].shape)
             batched_result_list.append(jnp.zeros(shape=out_shape, dtype=init_result_flat[j].dtype))
-            batched_result_list[j] = batched_result_list[j].at[0].set(init_result_flat[j])
 
         # Apply mapping batched_args[1:] ---> fn(args)
         @for_loop(0, batch_size, 1)

--- a/frontend/catalyst/api_extensions/function_maps.py
+++ b/frontend/catalyst/api_extensions/function_maps.py
@@ -226,7 +226,10 @@ class VmapCallable(CatalystCallable):
         fn_args = tree_unflatten(args_tree, fn_args_flat)
 
         # Run 'fn' one time to get output-shape
-        init_result = self.fn(*fn_args, **kwargs)
+        _, shape = jax.make_jaxpr(self.fn, return_shape=True)(*fn_args, **kwargs)
+        shapes, init_result_tree = tree_flatten(shape)
+        init_result_flat = [jnp.zeros(shape=shape.shape, dtype=shape.dtype) for shape in shapes]
+        init_result = tree_unflatten(init_result_tree, init_result_flat)
 
         # Check the validity of the output w.r.t. out_axes
         out_axes_deep_struct = tree_structure(self.out_axes, is_leaf=lambda x: x is None)
@@ -237,8 +240,6 @@ class VmapCallable(CatalystCallable):
                 "the number of function results, but got "
                 f"{out_axes_deep_struct} axis specifiers and {init_result_deep_struct} results."
             )
-
-        init_result_flat, init_result_tree = tree_flatten(init_result)
 
         num_axes_out = len(init_result_flat)
 
@@ -264,7 +265,7 @@ class VmapCallable(CatalystCallable):
             batched_result_list[j] = batched_result_list[j].at[0].set(init_result_flat[j])
 
         # Apply mapping batched_args[1:] ---> fn(args)
-        @for_loop(1, batch_size, 1)
+        @for_loop(0, batch_size, 1)
         def loop_fn(i, batched_result_list):
             fn_args_flat = args_flat
             for loc in batch_loc:

--- a/frontend/test/lit/test_mitigation.py
+++ b/frontend/test/lit/test_mitigation.py
@@ -40,7 +40,6 @@ def mcm_method_with_zne():
 # CHECK: mitigation.zne @one_shot_wrapper(%c_0) folding( global) numFolds(%6 : tensor<2xi64>) : (tensor<5xi1>) -> tensor<2xf64>
 
 # CHECK: func.func private @one_shot_wrapper(%arg0: tensor<5xi1>) -> tensor<f64>
-# CHECK: catalyst.launch_kernel @module_circuit::@circuit() : () -> tensor<f64>
 # CHECK: scf.for
 # CHECK: catalyst.launch_kernel @module_circuit::@circuit() : () -> tensor<f64>
 print(mcm_method_with_zne.mlir)

--- a/mlir/include/Catalyst/Transforms/Passes.td
+++ b/mlir/include/Catalyst/Transforms/Passes.td
@@ -71,6 +71,7 @@ def ScatterLoweringPass : Pass<"scatter-lowering"> {
     let summary = "Lower scatter op from Stable HLO to loops.";
 
     let dependentDialects = [
+        "mlir::func::FuncDialect",
         "index::IndexDialect",
         "mhlo::MhloDialect",
         "tensor::TensorDialect",

--- a/mlir/include/Catalyst/Transforms/Passes.td
+++ b/mlir/include/Catalyst/Transforms/Passes.td
@@ -73,6 +73,7 @@ def ScatterLoweringPass : Pass<"scatter-lowering"> {
     let dependentDialects = [
         "index::IndexDialect",
         "mhlo::MhloDialect",
+        "tensor::TensorDialect",
         "scf::SCFDialect"
     ];
 

--- a/mlir/lib/Catalyst/Transforms/ScatterPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/ScatterPatterns.cpp
@@ -262,7 +262,8 @@ struct ScatterOpRewritePattern : public mlir::OpRewritePattern<mhlo::ScatterOp> 
                 staticOffsets.push_back(ShapedType::kDynamic);
                 staticSizes.push_back(updateShape[updateDim]);
                 updateDim++;
-            } else {
+            }
+            else {
                 staticOffsets.push_back(0);
                 staticSizes.push_back(updateShape[updateDim]);
                 updateDim++;

--- a/mlir/lib/Catalyst/Transforms/ScatterPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/ScatterPatterns.cpp
@@ -279,6 +279,13 @@ struct ScatterOpRewritePattern : public mlir::OpRewritePattern<mhlo::ScatterOp> 
             return success();
         }
 
+
+        if (failed(onlyOneInputUpdateAndResult(op))) {
+            // Otherwise it will segfault.
+            op.emitError() << "Only one input, update, and result";
+            return failure();
+        }
+
         // Compute operation hash in case they are more than one scatter and they have different
         // update function
         auto opHash = OperationEquivalence::computeHash(op);

--- a/mlir/lib/Catalyst/Transforms/ScatterPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/ScatterPatterns.cpp
@@ -227,48 +227,10 @@ struct ScatterOpRewritePattern : public mlir::OpRewritePattern<mhlo::ScatterOp> 
         // rank(%scatter_indices) == 1
         // => indexVectorDim = 0
 
-        // But we still have a couple of more attributes that we need to understand.
-        // Somehow I need to use update_window_dims to correctly set this line:
-        // %input[%scatter_indices]
-        // * scatter_dims_to_operand_dims
-        // * index_vector_dim
-        // * inserted_window_dim
-        // Out of these three
-        // %result = tensor.insert_slice %update into
-        // %input[%scatter_indices],[size(%update)...],[1*rank(%update)] Annotated description of
-        // scatter semantics: https://github.com/openxla/stablehlo/blob/main/docs/spec.md#scatter
-        //
-        //   More formally, for all update_index in index_space(updates[0]):
-        //   // In our case len(updates) = 1
-        //   // so change this to index_space(update)
-        //   // index_space is defined here:
-        //   https://github.com/openxla/stablehlo/blob/main/docs/spec.md#shape-computations
-        //
-        //   update_scatter_dims = [d for d in axes(updates[0]) and d not in update_window_dims]
-        //   // rank(%update) == size(update_window_dims)
-        //   // => update_scatter_dims = []
-        //
-        //   update_scatter_index = update_index[update_scatter_dims...]
-        //   // update_scatter_index = update_index
-        //
-        //   update_window_index = update_index[update_window_dims...]
-        //   // rank(%update) == size(update_window_dims)
-        //   // => update_window_index = update_index
-        //
-        //   full_window_index = [wi0, ..., 0, ..., wiN] where wi are individual elements in
-        //   update_window_index, and 0 is inserted at indices from inserted_window_dims and
-        //   input_batching_dims
-        //   // rank(inputs[0]) = size(update_window_dims) + size(inserted_window_dims) +
-        //   size(input_batching_dims)
-
-        // the offset relates to inserted_window_dims
-        //
-        // rewriter.create<tensor::InsertSliceOp>(loc, update, input, dyn_off, dyn_siz, dyn_str,
-        // static_off, static_siz, static_str);
         SmallVector<Value> dynOffsets, dynSizes, dynStrides;
         SmallVector<int64_t> staticOffsets, staticSizes, staticStrides;
 
-        // TODO: Close, but not 100% sure. Verify for correctness...
+        // TODO: upstream to mlir-hlo and stablehlo
         for (int i = 0, inputDim = 0, updateDim = 0; i < inputShape.size(); i++) {
             if (llvm::is_contained(insertedWindowDims, i)) {
                 int scatterDimIndex = scatterDimsToOperandDims[inputDim];

--- a/mlir/lib/Catalyst/Transforms/ScatterPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/ScatterPatterns.cpp
@@ -198,10 +198,7 @@ struct ScatterOpRewritePattern : public mlir::OpRewritePattern<mhlo::ScatterOp> 
         auto inputShape = inputTy.getShape();
         auto updateShape = updateTy.getShape();
         auto scatterIndicesTy = cast<RankedTensorType>(scatterIndices.getType());
-        // shape(%result) == shape(%input)
-        if (resultShape != inputShape) {
-            return failure();
-        }
+        // (C24) shape(%result) == shape(%input)
 
         auto scatterDimNumbers = op.getScatterDimensionNumbers();
         auto updateWindowDims = scatterDimNumbers.getUpdateWindowDims();

--- a/mlir/lib/Catalyst/Transforms/scatter_lowering.cpp
+++ b/mlir/lib/Catalyst/Transforms/scatter_lowering.cpp
@@ -21,6 +21,7 @@
 #include "mhlo/IR/hlo_ops.h"
 #include "mhlo/transforms/passes.h"
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"

--- a/mlir/lib/Catalyst/Transforms/scatter_lowering.cpp
+++ b/mlir/lib/Catalyst/Transforms/scatter_lowering.cpp
@@ -23,6 +23,7 @@
 
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 

--- a/mlir/test/Catalyst/ScatterTest.mlir
+++ b/mlir/test/Catalyst/ScatterTest.mlir
@@ -431,3 +431,15 @@ module @two_dyn_indices_reverted {
       // And changes the order of dimensions here.
       // CHECK: tensor.insert_slice [[updates]] into [[inputs]][[[idx__1]], [[idx__0]], 0] [1, 1, [[dim0]]] [1, 1, 1] : tensor<[[dim0]]xf64> into tensor<9x7x5xf64>
 }
+
+// -----
+
+  func.func public @jit_expand_by_two(%arg0: tensor<3xi64>) -> tensor<6xi64> attributes {llvm.emit_c_interface} {
+    %cst = arith.constant dense<0> : tensor<6xi64>
+    %cst_0 = arith.constant dense<3> : tensor<1xi32>
+    %0 = "mhlo.scatter"(%cst, %cst_0, %arg0) <{indices_are_sorted = true, scatter_dimension_numbers = #mhlo.scatter<update_window_dims = [0], scatter_dims_to_operand_dims = [0]>, unique_indices = true}> ({
+    ^bb0(%arg1: tensor<i64>, %arg2: tensor<i64>):
+      mhlo.return %arg2 : tensor<i64>
+    }) : (tensor<6xi64>, tensor<1xi32>, tensor<3xi64>) -> tensor<6xi64>
+    return %0 : tensor<6xi64>
+  }

--- a/mlir/test/Catalyst/ScatterTest.mlir
+++ b/mlir/test/Catalyst/ScatterTest.mlir
@@ -360,3 +360,38 @@ module @insert_tensor_rank_2 {
       "test.op"(%results) : (tensor<9x7x5xf64>) -> ()
 }
 
+// -----
+
+// CHECK-LABEL: @two_dyn_indices
+module @two_dyn_indices {
+
+      %inputs = "test.op"() : () -> (tensor<9x7x5xf64>)
+      %scatter_indices = "test.op"() : () -> (tensor<2xi32>)
+      %updates = "test.op"() : () -> (tensor<5xf64>)
+
+      // CHECK-DAG: [[idx_0:%.+]] = index.constant 0
+      // CHECK-DAG: [[idx_1:%.+]] = index.constant 1
+      // CHECK-DAG: [[inputs:%.+]] = "test.op"() : () -> tensor<9x[[dim1:.*]]x[[dim0:.*]]xf64>
+      // CHECK-DAG: [[scatter_indices:%.+]] = "test.op"() : () -> tensor<2xi32>
+      // CHECK-DAG: [[updates:%.+]] = "test.op"() : () -> tensor<[[dim0]]xf64>
+      // CHECK-DAG: [[scatter_idx_0:%.+]] = tensor.extract [[scatter_indices]][[[idx_0]]] : tensor<2xi32>
+      // CHECK-DAG: [[scatter_idx_1:%.+]] = tensor.extract [[scatter_indices]][[[idx_1]]] : tensor<2xi32>
+      // CHECK-DAG: [[idx__0:%.+]] = arith.index_cast [[scatter_idx_0]] : i32 to index
+      // CHECK-DAG: [[idx__1:%.+]] = arith.index_cast [[scatter_idx_1]] : i32 to index
+      // CHECK: tensor.insert_slice [[updates]] into [[inputs]][[[idx__0]], [[idx__1]], 0] [1, 1, [[dim0]]] [1, 1, 1] : tensor<[[dim0]]xf64> into tensor<9x7x5xf64>
+
+      %results = "mhlo.scatter"(%inputs, %scatter_indices, %updates) <{
+          indices_are_sorted = true,
+          unique_indices = true,
+          scatter_dimension_numbers = #mhlo.scatter<
+              update_window_dims = [0],
+              inserted_window_dims = [0, 1],
+              scatter_dims_to_operand_dims = [0, 1]
+          >
+      }> ({
+      ^bb0(%arg3: tensor<f64>, %arg4: tensor<f64>):
+        mhlo.return %arg4 : tensor<f64>
+      }) : (tensor<9x7x5xf64>, tensor<2xi32>, tensor<5xf64>) -> tensor<9x7x5xf64>
+      "test.op"(%results) : (tensor<9x7x5xf64>) -> ()
+}
+

--- a/mlir/test/Catalyst/ScatterTest.mlir
+++ b/mlir/test/Catalyst/ScatterTest.mlir
@@ -432,14 +432,3 @@ module @two_dyn_indices_reverted {
       // CHECK: tensor.insert_slice [[updates]] into [[inputs]][[[idx__1]], [[idx__0]], 0] [1, 1, [[dim0]]] [1, 1, 1] : tensor<[[dim0]]xf64> into tensor<9x7x5xf64>
 }
 
-// -----
-
-  func.func public @jit_expand_by_two(%arg0: tensor<3xi64>) -> tensor<6xi64> attributes {llvm.emit_c_interface} {
-    %cst = arith.constant dense<0> : tensor<6xi64>
-    %cst_0 = arith.constant dense<3> : tensor<1xi32>
-    %0 = "mhlo.scatter"(%cst, %cst_0, %arg0) <{indices_are_sorted = true, scatter_dimension_numbers = #mhlo.scatter<update_window_dims = [0], scatter_dims_to_operand_dims = [0]>, unique_indices = true}> ({
-    ^bb0(%arg1: tensor<i64>, %arg2: tensor<i64>):
-      mhlo.return %arg2 : tensor<i64>
-    }) : (tensor<6xi64>, tensor<1xi32>, tensor<3xi64>) -> tensor<6xi64>
-    return %0 : tensor<6xi64>
-  }

--- a/mlir/test/Catalyst/ScatterTest.mlir
+++ b/mlir/test/Catalyst/ScatterTest.mlir
@@ -260,9 +260,9 @@ module @test_happy_path {
       // CHECK: [[index_i32:%.+]] = tensor.extract [[scatter_indices]][[[cst0]]] : tensor<1xi32>
       // CHECK: [[index:%.+]] = arith.index_cast [[index_i32]] : i32 to index
       // CHECK: tensor.insert_slice [[updates]] into [[inputs]][[[index]], 0] [1, [[dim0]]] [1, 1] : tensor<[[dim0]]xf64> into tensor<[[dim1]]x[[dim0]]xf64>
-      %inputs = "test.op"() : () -> (tensor<7x131072xf64>)
+      %inputs = "test.op"() : () -> (tensor<7x5xf64>)
       %scatter_indices = "test.op"() : () -> (tensor<1xi32>)
-      %updates = "test.op"() : () -> (tensor<131072xf64>)
+      %updates = "test.op"() : () -> (tensor<5xf64>)
       %results = "mhlo.scatter"(%inputs, %scatter_indices, %updates) <{
           indices_are_sorted = true,
           unique_indices = true,
@@ -274,17 +274,17 @@ module @test_happy_path {
       }> ({
       ^bb0(%arg3: tensor<f64>, %arg4: tensor<f64>):
         mhlo.return %arg4 : tensor<f64>
-      }) : (tensor<7x131072xf64>, tensor<1xi32>, tensor<131072xf64>) -> tensor<7x131072xf64>
-      "test.op"(%results) : (tensor<7x131072xf64>) -> ()
+      }) : (tensor<7x5xf64>, tensor<1xi32>, tensor<5xf64>) -> tensor<7x5xf64>
+      "test.op"(%results) : (tensor<7x5xf64>) -> ()
 
 }
 
 // -----
 
 module @test_multiple_inputs {
-      %inputs = "test.op"() : () -> (tensor<7x131072xf64>)
+      %inputs = "test.op"() : () -> (tensor<7x5xf64>)
       %scatter_indices = "test.op"() : () -> (tensor<1xi32>)
-      %updates = "test.op"() : () -> (tensor<131072xf64>)
+      %updates = "test.op"() : () -> (tensor<5xf64>)
       // expected-error@+1 {{Only one input, update, and result}}
       %results:2 = "mhlo.scatter"(%inputs, %inputs, %scatter_indices, %updates, %updates) <{
           indices_are_sorted = true,
@@ -297,6 +297,66 @@ module @test_multiple_inputs {
       }> ({
       ^bb0(%arg3: tensor<f64>, %arg4: tensor<f64>, %arg5: tensor<f64>, %arg6: tensor<f64>):
         mhlo.return %arg4, %arg6 : tensor<f64>, tensor<f64>
-      }) : (tensor<7x131072xf64>, tensor<7x131072xf64>, tensor<1xi32>, tensor<131072xf64>, tensor<131072xf64>) -> (tensor<7x131072xf64>, tensor<7x131072xf64>)
-      "test.op"(%results#0, %results#1) : (tensor<7x131072xf64>, tensor<7x131072xf64>) -> ()
+      }) : (tensor<7x5xf64>, tensor<7x5xf64>, tensor<1xi32>, tensor<5xf64>, tensor<5xf64>) -> (tensor<7x5xf64>, tensor<7x5xf64>)
+      "test.op"(%results#0, %results#1) : (tensor<7x5xf64>, tensor<7x5xf64>) -> ()
 }
+
+// -----
+
+// This tests that we use the same lowering as before and not the fast path
+// CHECK-LABEL: @test_is_not_assignment
+module @test_is_not_assignment {
+      %inputs = "test.op"() : () -> (tensor<7x5xf64>)
+      %scatter_indices = "test.op"() : () -> (tensor<1xi32>)
+      %updates = "test.op"() : () -> (tensor<5xf64>)
+
+      // CHECK-NOT: tensor.insert_slice
+
+      %results = "mhlo.scatter"(%inputs, %scatter_indices, %updates) <{
+          indices_are_sorted = true,
+          unique_indices = true,
+          scatter_dimension_numbers = #mhlo.scatter<
+              update_window_dims = [0],
+              inserted_window_dims = [0],
+              scatter_dims_to_operand_dims = [0]
+          >
+      }> ({
+      ^bb0(%arg3: tensor<f64>, %arg4: tensor<f64>):
+        %add = stablehlo.add %arg3, %arg4 : tensor<f64>
+        mhlo.return %add : tensor<f64>
+      }) : (tensor<7x5xf64>, tensor<1xi32>, tensor<5xf64>) -> tensor<7x5xf64>
+      "test.op"(%results) : (tensor<7x5xf64>) -> ()
+}
+
+// -----
+
+// CHECK-LABEL: @insert_tensor_rank_2
+module @insert_tensor_rank_2 {
+
+      %inputs = "test.op"() : () -> (tensor<9x7x5xf64>)
+      %scatter_indices = "test.op"() : () -> (tensor<1xi32>)
+      %updates = "test.op"() : () -> (tensor<7x5xf64>)
+
+      // CHECK-DAG: [[idx_0:%.+]] = index.constant 0
+      // CHECK-DAG: [[inputs:%.+]] = "test.op"() : () -> tensor<9x[[dim1:.*]]x[[dim0:.*]]xf64>
+      // CHECK-DAG: [[scatter_indices:%.+]] = "test.op"() : () -> tensor<1xi32>
+      // CHECK-DAG: [[updates:%.+]] = "test.op"() : () -> tensor<[[dim1]]x[[dim0]]xf64>
+      // CHECK: [[scatter_idx:%.+]] = tensor.extract [[scatter_indices]][[[idx_0]]] : tensor<1xi32>
+      // CHECK: [[idx:%.+]] = arith.index_cast [[scatter_idx]] : i32 to index
+      // CHECK: tensor.insert_slice [[updates]] into [[inputs]][[[idx]], 0, 0] [1, [[dim1]], [[dim0]]] [1, 1, 1] : tensor<7x5xf64> into tensor<9x7x5xf64>
+
+      %results = "mhlo.scatter"(%inputs, %scatter_indices, %updates) <{
+          indices_are_sorted = true,
+          unique_indices = true,
+          scatter_dimension_numbers = #mhlo.scatter<
+              update_window_dims = [0, 1],
+              inserted_window_dims = [0],
+              scatter_dims_to_operand_dims = [0]
+          >
+      }> ({
+      ^bb0(%arg3: tensor<f64>, %arg4: tensor<f64>):
+        mhlo.return %arg4 : tensor<f64>
+      }) : (tensor<9x7x5xf64>, tensor<1xi32>, tensor<7x5xf64>) -> tensor<9x7x5xf64>
+      "test.op"(%results) : (tensor<9x7x5xf64>) -> ()
+}
+


### PR DESCRIPTION
**Context:** The semantics of [`mhlo.scatter`](https://www.tensorflow.org/mlir/hlo_ops#mhloscatter_mhloscatterop) and [`stablehlo.scatter`](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#scatter) are the same. Currently we have a lowering from `mhlo.scatter` to upstream MLIR dialects (a mixture of func and scf dialects). The current implementation will lower the `mhlo.scatter` operation into a loop and move element by element values into the result tensor using `tensor.insert`. 

There are some special cases where it is possible to use [`tensor.insert_slice`](https://mlir.llvm.org/docs/Dialects/TensorOps/#tensorinsert_slice-tensorinsertsliceop) instead of [`tensor.insert`. ](https://mlir.llvm.org/docs/Dialects/TensorOps/#tensorinsert-tensorinsertop)The difference between `tensor.insert` and `tensor.insert_slice` is that `tensor.insert` inserts scalar elements into tensors while `tensor.insert_slice` may insert a tensor into a larger tensor.

This has implications on performance. While both lowerings of scatter should be equivalent, `tensor.insert_slice` will be lowered to `memref.subview` and `memref.copy` which lowers to a single `memcpy`. This is the root cause of the performance issues described in #1153. 

**Description of the Change:** This PR adds an optimized lowering to `mhlo.scatter` to `tensor.insert_slice` in cases we can detect this lowering preserves the same semantics. 

This detection can be generalized in the future. It currently makes the following checks:

1. **`unique_indices` and `indices_are_sorted` are both true**: [The semantics state the following:](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#scatter)

> If indices_are_sorted is true then the implementation can assume that scatter_indices are sorted with respect to scatter_dims_to_operand_dims, otherwise the behavior is undefined. More formally, for all i1 < i2 from indices(result), full_start_index(i1) <= full_start_index(i2).
>
> If unique_indices is true then the implementation can assume that all result_index indices being scattered to are unique. If unique_indices is true but the indices being scattered to are not unique then the behavior is undefined.

I believe these are undefined to keep the possibility of implementing `stablehlo.scatter` in parallel.

2. **Only one `%input` , `%result` and `%update` tensor**: The operands `%input` and `%update` are of variable length. To generalize the lowering to `tensor.insert_slice` one could run a pass earlier that will canonicalize the `scatter` operation into a series of `scatter` operations with a single `%input` , `%result` and `%update` tensor specified in the operation.
3. **Restricting `update_computation` to assignment of `%update_tensor`**. The `stablehlo.scatter` operation is more general than a simple assignment. It allows for the `%input` tensor to be updated with `%update` tensor values by running the function `update_computation` on the corresponding elements. We restrict `update_computation` to be the assignment to the `%update` values: I.e.,
```
({
      ^bb0(%input_element: tensor<T>, %update_element: tensor<T>):
        mhlo.return %update_element : tensor<T>
      })
```
This restriction may be relaxed by first computing a temporary tensor that will hold the result of the `update_computation` and replacing the uses of `update` with this new tensor and using the assignment function above.
4. **No batching**: Our current version of MLIR does not support the batching attributes in the operation. To generalize this more investigation is required.
5. **Single full slice**: This means that we are going to assign the whole `update` tensor to the `input` tensor and not just a subset. We could generalize this by using dynamic sizes when generating the `tensor.insert_slice` operation.
6. **rank(%scatter_indices) == 1** and **indexVectorDim == scatterIndicesTy.getRank() - 1**: This implies that the scatter indices are valid coordinates and do not need to be treated as tensors. To generalize this would imply looping over the number of valid indices depending on the shape of the scatter indices and generating a single `tensor.insert_slice` operation for each iteration.

**Benefits:** Performance

**Possible Drawbacks:** I would feel more comfortable having more time and upstreaming this to stableHLO. That way, we can get a review from the StableHLO team to make sure the semantics are correct since this is a somewhat complex operation.

**Related GitHub Issues:** Fixes #1153

[sc-76025]
