### PR TITLE
[MLIR] Mark scatter pass as depending on func dialect

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -290,6 +290,9 @@
 * Fixes taking gradient of nested accelerate callbacks.
   [(#1156)](https://github.com/PennyLaneAI/catalyst/pull/1156)
 
+* Registers the func dialect as a requirement for running the scatter lowering pass.
+  [(#1216)](https://github.com/PennyLaneAI/catalyst/pull/1216)
+
 <h3>Internal changes</h3>
 
 * Remove deprecated pennylane code across the frontend.

--- a/mlir/include/Catalyst/Transforms/Passes.td
+++ b/mlir/include/Catalyst/Transforms/Passes.td
@@ -71,6 +71,7 @@ def ScatterLoweringPass : Pass<"scatter-lowering"> {
     let summary = "Lower scatter op from Stable HLO to loops.";
 
     let dependentDialects = [
+        "mlir::func::FuncDialect",
         "index::IndexDialect",
         "mhlo::MhloDialect",
         "scf::SCFDialect"

--- a/mlir/lib/Catalyst/Transforms/scatter_lowering.cpp
+++ b/mlir/lib/Catalyst/Transforms/scatter_lowering.cpp
@@ -22,6 +22,7 @@
 #include "mhlo/transforms/passes.h"
 
 #include "mlir/Dialect/Index/IR/IndexDialect.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"

--- a/mlir/lib/Catalyst/Transforms/scatter_lowering.cpp
+++ b/mlir/lib/Catalyst/Transforms/scatter_lowering.cpp
@@ -21,8 +21,8 @@
 #include "mhlo/IR/hlo_ops.h"
 #include "mhlo/transforms/passes.h"
 
-#include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Index/IR/IndexDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"


### PR DESCRIPTION
**Context:** All MLIR transformations are required to register dialects if they produce operations or attributes from those dialects. The `--scatter-lowering` pass produces `func.func` ops, but does not register the func dialect as a dependency.

**Description of the Change:** Register the func dialect as a dependency.

**Benefits:** More correct.

**Possible Drawbacks:** None
