### PR TITLE
[MLIR] Emit error instead of segfault in current scatter lowering

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -290,8 +290,12 @@
 * Fixes taking gradient of nested accelerate callbacks.
   [(#1156)](https://github.com/PennyLaneAI/catalyst/pull/1156)
 
-* Registers the func dialect as a requirement for running the scatter lowering pass.
+* Some small fixes for scatter lowering:
   [(#1216)](https://github.com/PennyLaneAI/catalyst/pull/1216)
+  [(#1217)](https://github.com/PennyLaneAI/catalyst/pull/1217)
+
+  - Registers the func dialect as a requirement for running the scatter lowering pass.
+  - Emits error if `%input`, `%update` and `%result` are not of length 1 instead of segfaulting.
 
 <h3>Internal changes</h3>
 

--- a/mlir/lib/Catalyst/Transforms/ScatterPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/ScatterPatterns.cpp
@@ -53,7 +53,6 @@ struct ScatterOpRewritePattern : public mlir::OpRewritePattern<mhlo::ScatterOp> 
     mlir::LogicalResult matchAndRewrite(mhlo::ScatterOp op,
                                         mlir::PatternRewriter &rewriter) const override
     {
-
         if (failed(onlyOneInputUpdateAndResult(op))) {
             // Otherwise it will segfault.
             op.emitError() << "Only one input, update, and result";

--- a/mlir/test/Catalyst/ScatterTest.mlir
+++ b/mlir/test/Catalyst/ScatterTest.mlir
@@ -247,3 +247,25 @@ func.func public @example_no_update_dim(%arg0: tensor<4xf64>) -> tensor<4xf64> {
 //   CHECK:      scf.yield [[INSERTED]] : tensor<4xf64>
 //   CHECK:    }
 //   CHECK:    return [[FORRES]] : tensor<4xf64>
+
+// -----
+
+module @test_multiple_inputs {
+      %inputs = "test.op"() : () -> (tensor<7x131072xf64>)
+      %scatter_indices = "test.op"() : () -> (tensor<1xi32>)
+      %updates = "test.op"() : () -> (tensor<131072xf64>)
+      // expected-error@+1 {{Only one input, update, and result}}
+      %results:2 = "mhlo.scatter"(%inputs, %inputs, %scatter_indices, %updates, %updates) <{
+          indices_are_sorted = true,
+          unique_indices = true,
+          scatter_dimension_numbers = #mhlo.scatter<
+              update_window_dims = [0],
+              inserted_window_dims = [0],
+              scatter_dims_to_operand_dims = [0]
+          >
+      }> ({
+      ^bb0(%arg3: tensor<f64>, %arg4: tensor<f64>, %arg5: tensor<f64>, %arg6: tensor<f64>):
+        mhlo.return %arg4, %arg6 : tensor<f64>, tensor<f64>
+      }) : (tensor<7x131072xf64>, tensor<7x131072xf64>, tensor<1xi32>, tensor<131072xf64>, tensor<131072xf64>) -> (tensor<7x131072xf64>, tensor<7x131072xf64>)
+      "test.op"(%results#0, %results#1) : (tensor<7x131072xf64>, tensor<7x131072xf64>) -> ()
+}


### PR DESCRIPTION
**Context:** The current scatter lowering makes some assumptions and only handles a subset of the inputs. However, it is too optimistic and will attempt to convert inputs that it can't handle. In particular if there are more than one input update and result tensors, it will segfault. This condition may never happen but it is valid IR. It may never happen if another pass runs before that canonicalizes mhlo.scatter. However, it is good to emit an error in case the canonicalization was not run before.

**Description of the Change:** Emit error instead of segfaulting

**Benefits:** No segfaults

**Possible Drawbacks:** None

**Related GitHub Issues:**

Depends on #1216
