### PR TITLE
[Frontend] Corrected output of PyTree when using qml.counts()

### DIFF
--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -934,19 +934,20 @@ def trace_quantum_measurements(
 
     return out_classical_tracers, out_tree
 
+
 def replace_child_tree(tree: PyTreeDef, index: int, subtree: PyTreeDef) -> PyTreeDef:
     """
     Replace the index-th leaf node in a PyTreeDef with a given subtree.
-    
+
     Args:
         tree (PyTreeDef): The original PyTree.
         index (int): The index of the leaf node to replace.
         subtree (PyTreeDef): The new subtree to replace the original leaf node with.
-    
+
     Returns:
-        PyTreeDef: The modified PyTree with the replaced leaf node. 
+        PyTreeDef: The modified PyTree with the replaced leaf node.
     """
-    
+
     def replace_node(node, idx):
         if not node.children():
             # Leaf node => update leaf node counter
@@ -955,11 +956,10 @@ def replace_child_tree(tree: PyTreeDef, index: int, subtree: PyTreeDef) -> PyTre
                 return subtree
             return node
 
-        
         return node.make_from_node_data_and_children(
             PyTreeRegistry(),
             node.node_data(),
-            [replace_node(child, idx) for child in node.children()]
+            [replace_node(child, idx) for child in node.children()],
         )
 
     return replace_node(tree, [0])

--- a/frontend/test/pytest/test_jax_integration.py
+++ b/frontend/test/pytest/test_jax_integration.py
@@ -491,11 +491,12 @@ class TestJAXRecompilation:
 
     def test_pytree_qml_counts_simple(self):
         dev = qml.device("lightning.qubit", wires=1, shots=20)
+
         @qjit
         @qml.qnode(dev)
         def circuit(x):
             qml.RX(x, wires=0)
-            return {"1":  qml.counts()}
+            return {"1": qml.counts()}
 
         result = circuit(0.5)
         _, result_tree = jax.tree.flatten(result)
@@ -503,6 +504,7 @@ class TestJAXRecompilation:
 
     def test_pytree_qml_counts_nested(self):
         dev = qml.device("lightning.qubit", wires=1, shots=20)
+
         @qjit
         @qml.qnode(dev)
         def circuit(x):
@@ -513,12 +515,12 @@ class TestJAXRecompilation:
         _, result_tree = jax.tree.flatten(result)
         assert "PyTreeDef(({'1': (*, *)}, {'2': *}))" == str(result_tree)
 
-
         @qjit
         @qml.qnode(dev)
         def circuit(x):
             qml.RX(x, wires=0)
             return [{"1": qml.expval(qml.Z(0))}, {"2": qml.counts()}], {"3": qml.expval(qml.Z(0))}
+
         result = circuit(0.5)
         _, result_tree = jax.tree.flatten(result)
 
@@ -526,40 +528,58 @@ class TestJAXRecompilation:
 
     def test_pytree_qml_counts_2_nested(self):
         dev = qml.device("lightning.qubit", wires=1, shots=20)
-        @qjit
-        @qml.qnode(dev)
-        def circuit(x):
-            qml.RX(x, wires=0)
-            return [{"1": qml.expval(qml.Z(0))}, {"2": qml.counts()}], [{"3": qml.expval(qml.Z(0))}, {'4': qml.counts()}]
-
-        result = circuit(0.5)
-        _, result_tree = jax.tree.flatten(result)
-        assert "PyTreeDef(([{'1': *}, {'2': (*, *)}], [{'3': *}, {'4': (*, *)}]))" == str(result_tree)
-
 
         @qjit
         @qml.qnode(dev)
         def circuit(x):
             qml.RX(x, wires=0)
-            return [{"1": qml.expval(qml.Z(0))}, {"2": qml.counts()}], [{"3": qml.counts()}, {'4': qml.expval(qml.Z(0))}]
+            return [{"1": qml.expval(qml.Z(0))}, {"2": qml.counts()}], [
+                {"3": qml.expval(qml.Z(0))},
+                {"4": qml.counts()},
+            ]
+
+        result = circuit(0.5)
+        _, result_tree = jax.tree.flatten(result)
+        assert "PyTreeDef(([{'1': *}, {'2': (*, *)}], [{'3': *}, {'4': (*, *)}]))" == str(
+            result_tree
+        )
+
+        @qjit
+        @qml.qnode(dev)
+        def circuit(x):
+            qml.RX(x, wires=0)
+            return [{"1": qml.expval(qml.Z(0))}, {"2": qml.counts()}], [
+                {"3": qml.counts()},
+                {"4": qml.expval(qml.Z(0))},
+            ]
+
         result = circuit(0.5)
         _, result_tree = jax.tree.flatten(result)
 
-        assert "PyTreeDef(([{'1': *}, {'2': (*, *)}], [{'3': (*, *)}, {'4': *}]))" == str(result_tree)
-
+        assert "PyTreeDef(([{'1': *}, {'2': (*, *)}], [{'3': (*, *)}, {'4': *}]))" == str(
+            result_tree
+        )
 
     def test_pytree_qml_counts_longer(self):
         dev = qml.device("lightning.qubit", wires=1, shots=20)
+
         @qjit
         @qml.qnode(dev)
         def circuit(x):
             qml.RX(x, wires=0)
-            return [[{"1": qml.expval(qml.Z(0))}, {"2": qml.counts()}], [{"3": qml.expval(qml.Z(0))}, {'4': qml.counts()}], {"5": qml.expval(qml.Z(0))}, {'6': qml.counts()}]
+            return [
+                [{"1": qml.expval(qml.Z(0))}, {"2": qml.counts()}],
+                [{"3": qml.expval(qml.Z(0))}, {"4": qml.counts()}],
+                {"5": qml.expval(qml.Z(0))},
+                {"6": qml.counts()},
+            ]
 
         result = circuit(0.5)
         _, result_tree = jax.tree.flatten(result)
-        assert "PyTreeDef([[{'1': *}, {'2': (*, *)}], [{'3': *}, {'4': (*, *)}], {'5': *}, {'6': (*, *)}])" == str(result_tree)
-
+        assert (
+            "PyTreeDef([[{'1': *}, {'2': (*, *)}], [{'3': *}, {'4': (*, *)}], {'5': *}, {'6': (*, *)}])"
+            == str(result_tree)
+        )
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_jax_integration.py
+++ b/frontend/test/pytest/test_jax_integration.py
@@ -489,6 +489,78 @@ class TestJAXRecompilation:
         params = jnp.array([0.54, 0.3154, 0.654, 0.123, 0.1, 0.2])
         jax.grad(circuit, argnums=0)(params, 3)
 
+    def test_pytree_qml_counts_simple(self):
+        dev = qml.device("lightning.qubit", wires=1, shots=20)
+        @qjit
+        @qml.qnode(dev)
+        def circuit(x):
+            qml.RX(x, wires=0)
+            return {"1":  qml.counts()}
+
+        result = circuit(0.5)
+        _, result_tree = jax.tree.flatten(result)
+        assert "PyTreeDef({'1': (*, *)})" == str(result_tree)
+
+    def test_pytree_qml_counts_nested(self):
+        dev = qml.device("lightning.qubit", wires=1, shots=20)
+        @qjit
+        @qml.qnode(dev)
+        def circuit(x):
+            qml.RX(x, wires=0)
+            return {"1": qml.counts()}, {"2": qml.expval(qml.Z(0))}
+
+        result = circuit(0.5)
+        _, result_tree = jax.tree.flatten(result)
+        assert "PyTreeDef(({'1': (*, *)}, {'2': *}))" == str(result_tree)
+
+
+        @qjit
+        @qml.qnode(dev)
+        def circuit(x):
+            qml.RX(x, wires=0)
+            return [{"1": qml.expval(qml.Z(0))}, {"2": qml.counts()}], {"3": qml.expval(qml.Z(0))}
+        result = circuit(0.5)
+        _, result_tree = jax.tree.flatten(result)
+
+        assert "PyTreeDef(([{'1': *}, {'2': (*, *)}], {'3': *}))" == str(result_tree)
+
+    def test_pytree_qml_counts_2_nested(self):
+        dev = qml.device("lightning.qubit", wires=1, shots=20)
+        @qjit
+        @qml.qnode(dev)
+        def circuit(x):
+            qml.RX(x, wires=0)
+            return [{"1": qml.expval(qml.Z(0))}, {"2": qml.counts()}], [{"3": qml.expval(qml.Z(0))}, {'4': qml.counts()}]
+
+        result = circuit(0.5)
+        _, result_tree = jax.tree.flatten(result)
+        assert "PyTreeDef(([{'1': *}, {'2': (*, *)}], [{'3': *}, {'4': (*, *)}]))" == str(result_tree)
+
+
+        @qjit
+        @qml.qnode(dev)
+        def circuit(x):
+            qml.RX(x, wires=0)
+            return [{"1": qml.expval(qml.Z(0))}, {"2": qml.counts()}], [{"3": qml.counts()}, {'4': qml.expval(qml.Z(0))}]
+        result = circuit(0.5)
+        _, result_tree = jax.tree.flatten(result)
+
+        assert "PyTreeDef(([{'1': *}, {'2': (*, *)}], [{'3': (*, *)}, {'4': *}]))" == str(result_tree)
+
+
+    def test_pytree_qml_counts_longer(self):
+        dev = qml.device("lightning.qubit", wires=1, shots=20)
+        @qjit
+        @qml.qnode(dev)
+        def circuit(x):
+            qml.RX(x, wires=0)
+            return [[{"1": qml.expval(qml.Z(0))}, {"2": qml.counts()}], [{"3": qml.expval(qml.Z(0))}, {'4': qml.counts()}], {"5": qml.expval(qml.Z(0))}, {'6': qml.counts()}]
+
+        result = circuit(0.5)
+        _, result_tree = jax.tree.flatten(result)
+        assert "PyTreeDef([[{'1': *}, {'2': (*, *)}], [{'3': *}, {'4': (*, *)}], {'5': *}, {'6': (*, *)}])" == str(result_tree)
+
+
 
 if __name__ == "__main__":
     pytest.main(["-x", __file__])


### PR DESCRIPTION
**Context:** When using `qml.counts()` in the output of a quantum circuit with qjit, the output pytree is modified to replace the output pytree element related to `qml.counts` with `tree_structure(("keys", "counts"))`. Previously, this operation was buggy and didn't work well with nested return statements, more complex patterns, etc. This PR aims to fix this problem.

**Description of the Change:** We add a `replace_child_tree(tree, index, subtree)` method as suggested [here](https://github.com/PennyLaneAI/catalyst/issues/1016#issuecomment-2297347906), which recursively traverses the `PyTreeDef`s and correctly updates based on this traversal and a `num_counts` variable which stores the number of `qml.counts()` calls within a potentially complex return expression. 

**Benefits:** This function should handle more complex, nested cases robustly.

**Possible Drawbacks:** More computationally intensive than the prior version.

**Related GitHub Issues:** This closes #1016.