### PR TITLE
Add '.cache' to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ doc/code/api
 
 # Development
 venv
+
+# Cache files
+.cache


### PR DESCRIPTION
There are a number of development tools out there, e.g. [`clangd`](https://clangd.llvm.org/), that leave behind a `.cache` directory in the source tree. This change adds `.cache` to the `gitignore` file to stop git from tracking these files.