### PR TITLE
_probs_def_impl was wrongly decorated with @var_p.def_impl

### DIFF
--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1795,7 +1795,7 @@ def _probs_abstract_eval(obs, shape, shots=None):
     return core.ShapedArray(shape, jax.numpy.float64)
 
 
-@var_p.def_impl
+@probs_p.def_impl
 def _probs_def_impl(ctx, obs, shape, shots=None):  # pragma: no cover
     raise NotImplementedError()
 


### PR DESCRIPTION
**Context:** There seems to be a wrongly decorated function which is not affecting the functionality

**Description of the Change:** _probs_def_impl is now decorated with @probs_p.def_impl

**Benefits:** Consistency
