### PR TITLE
Update `make format-frontend` rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,11 +262,11 @@ endif
 .PHONY: format-frontend
 format-frontend:
 ifdef check
-	$(PYTHON) ./bin/format.py --check $(if $(version:-=),--cfversion $(version)) ./frontend/catalyst/utils
+	$(PYTHON) ./bin/format.py --check $(if $(version:-=),--cfversion $(version)) ./frontend
 	black --check --verbose .
 	isort --check --diff .
 else
-	$(PYTHON) ./bin/format.py $(if $(version:-=),--cfversion $(version)) ./frontend/catalyst/utils
+	$(PYTHON) ./bin/format.py $(if $(version:-=),--cfversion $(version)) ./frontend
 	black .
 	isort .
 endif


### PR DESCRIPTION
**Context:** The formatting command for C++ code under this rule is currently only applied to files in the `frontend/catalyst/utils/` directory. However, there are several other C++ files under `frontend/` that could use this formatting rule, such as those under `frontend/catalyst/third_party/oqc/src/`. Indeed, our CI action "Check Code Formatting" [checks all C++ files under the project root directory](https://github.com/PennyLaneAI/catalyst/blob/main/.github/workflows/check-formatting.yaml#L46), which could result in a failure of this CI action if files modified in a PR contain incorrect code formatting, even if `make format` had been run locally before committing. 

**Description of the Change:** This change updates the `make format-frontend` rule to check/apply C++ code formatting to all files under the `frontend/` directory.

**Benefits:** Formatting of all C++ files under `frontend/` modified in a PR can be checked and fixed locally, avoiding a failure of the "Check Code Formatting" CI action.