### PR TITLE
Do not mandate order of outlined tape functions in split tape lit test

### DIFF
--- a/mlir/test/Quantum/SplitMultipleTapesTest.mlir
+++ b/mlir/test/Quantum/SplitMultipleTapesTest.mlir
@@ -102,40 +102,40 @@ module @circuit_twotapes_module {
 // CHECK: func.call @circuit_twotapes_tape_1(%arg1, %arg0, %cst)
 // CHECK: {{%.+}} = stablehlo.subtract {{%.+}}, {{%.+}} : tensor<f64>
 
-// CHECK: func.func private @circuit_twotapes_tape_0(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode}
-// CHECK: quantum.device
-// CHECK: {{%.+}} = stablehlo.add %arg0, %arg1 : tensor<f64>
-// CHECK: quantum.device_release
-// CHECK: return {{%.+}} : tensor<f64>
-// CHECK-NEXT: }
+// CHECK-DAG: func.func private @circuit_twotapes_tape_0(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode}
+// CHECK-DAG: quantum.device
+// CHECK-DAG: [[retAdd:%.+]] = stablehlo.add %arg0, %arg1 : tensor<f64>
+// CHECK-DAG: quantum.device_release
+// CHECK-DAG: return [[retAdd]] : tensor<f64>
+// CHECK-DAG: }
 
-// CHECK: func.func private @circuit_twotapes_tape_1(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode}
-// CHECK: quantum.device
-// CHECK: tensor.extract %arg0[]
-// CHECK: {{%.+}} = stablehlo.multiply %arg1, %arg2 : tensor<f64>
-// CHECK: quantum.device_release
-// CHECK: return {{%.+}} : tensor<f64>
-// CHECK-NEXT: }
+// CHECK-DAG: func.func private @circuit_twotapes_tape_1(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode}
+// CHECK-DAG: quantum.device
+// CHECK-DAG: tensor.extract %arg0[]
+// CHECK-DAG: [[retMult:%.+]] = stablehlo.multiply %arg1, %arg2 : tensor<f64>
+// CHECK-DAG: quantum.device_release
+// CHECK-DAG: return [[retMult]] : tensor<f64>
+// CHECK-DAG: }
 
 // CHECK: func.func private @circuit_twotapes_doppleganger
 // CHECK: func.call @circuit_twotapes_doppleganger_tape_0(%arg1, %cst_0)
 // CHECK: func.call @circuit_twotapes_doppleganger_tape_1(%arg1, %arg0, %cst)
 // CHECK: {{%.+}} = stablehlo.subtract {{%.+}}, {{%.+}} : tensor<f64>
 
-// CHECK: func.func private @circuit_twotapes_doppleganger_tape_0(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode}
-// CHECK: quantum.device
-// CHECK: {{%.+}} = stablehlo.add %arg0, %arg1 : tensor<f64>
-// CHECK: quantum.device_release
-// CHECK: return {{%.+}} : tensor<f64>
-// CHECK-NEXT: }
+// CHECK-DAG: func.func private @circuit_twotapes_doppleganger_tape_0(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode}
+// CHECK-DAG: quantum.device
+// CHECK-DAG: [[retAddDop:%.+]] = stablehlo.add %arg0, %arg1 : tensor<f64>
+// CHECK-DAG: quantum.device_release
+// CHECK-DAG: return [[retAddDop]] : tensor<f64>
+// CHECK-DAG: }
 
-// CHECK: func.func private @circuit_twotapes_doppleganger_tape_1(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode}
-// CHECK: quantum.device
-// CHECK: tensor.extract %arg0[]
-// CHECK: {{%.+}} = stablehlo.multiply %arg1, %arg2 : tensor<f64>
-// CHECK: quantum.device_release
-// CHECK: return {{%.+}} : tensor<f64>
-// CHECK-NEXT: }
+// CHECK-DAG: func.func private @circuit_twotapes_doppleganger_tape_1(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode}
+// CHECK-DAG: quantum.device
+// CHECK-DAG: tensor.extract %arg0[]
+// CHECK-DAG: [[retMultDop:%.+]] = stablehlo.multiply %arg1, %arg2 : tensor<f64>
+// CHECK-DAG: quantum.device_release
+// CHECK-DAG: return [[retMultDop]] : tensor<f64>
+// CHECK-DAG: }
 
 // CHECK: }
 


### PR DESCRIPTION
There is a [test](https://github.com/PennyLaneAI/catalyst/blob/main/mlir/test/Quantum/SplitMultipleTapesTest.mlir#L67) in the split tape lit tests where there are two multi-tape functions in a module, and we split both of them.

It is unclear why, but on CI the outlined single-tape functions are, very occasionally (about 4 times in 3 months), processed in the reversed order.

#1130 was an attempt to fix this, which did reduce the flaky frequency by a lot; however there is a small remaining mysterious flakiness.

Recognizing that the outlined single-tape functions' order does not actually matter, we change the `CHECK`s to `CHECK-DAG`s, which do not mandate the order of the checked string during filecheck.