### PR TITLE
Allow standard `qml.cond` usage of `qml.cond(pred, qml.some_gate)(*args, **kwargs)` in qjit

### DIFF
--- a/doc/releases/changelog-0.9.0.md
+++ b/doc/releases/changelog-0.9.0.md
@@ -363,6 +363,10 @@
   lowering of the scatter operation.
   [(#1214)](https://github.com/PennyLaneAI/catalyst/pull/1214)
 
+* Fixes a bug where conditional-ed single gates cannot be used in qjit,
+  i.e. `qml.cond(x > 1, qml.Hadamard)(wires=0)`.
+  [(#1213)](https://github.com/PennyLaneAI/catalyst/pull/1232)
+
 <h3>Internal changes</h3>
 
 * Remove deprecated pennylane code across the frontend.

--- a/doc/releases/changelog-0.9.0.md
+++ b/doc/releases/changelog-0.9.0.md
@@ -364,7 +364,7 @@
   [(#1214)](https://github.com/PennyLaneAI/catalyst/pull/1214)
 
 * Fixes a bug where conditional-ed single gates cannot be used in qjit,
-  i.e. `qml.cond(x > 1, qml.Hadamard)(wires=0)`.
+  e.g. `qml.cond(x > 1, qml.Hadamard)(wires=0)`.
   [(#1232)](https://github.com/PennyLaneAI/catalyst/pull/1232)
 
 <h3>Internal changes</h3>

--- a/doc/releases/changelog-0.9.0.md
+++ b/doc/releases/changelog-0.9.0.md
@@ -365,7 +365,7 @@
 
 * Fixes a bug where conditional-ed single gates cannot be used in qjit,
   i.e. `qml.cond(x > 1, qml.Hadamard)(wires=0)`.
-  [(#1213)](https://github.com/PennyLaneAI/catalyst/pull/1232)
+  [(#1232)](https://github.com/PennyLaneAI/catalyst/pull/1232)
 
 <h3>Internal changes</h3>
 

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -620,7 +620,7 @@ class CondCallable:
 
         if isinstance(pred, jax.Array) and pred.shape not in ((), (1,)):
             raise TypeError("Array with multiple elements is not a valid predicate")
-        # breakpoint()
+
         if not self._is_any_boolean(pred):
             try:
                 pred = jnp.astype(pred, bool, copy=False)
@@ -629,7 +629,6 @@ class CondCallable:
                     "Conditional predicates are required to be of bool, integer or float type"
                 ) from e
 
-        # breakpoint()
         return pred
 
     def _is_any_boolean(self, pred):

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -792,7 +792,12 @@ class CondCallableSingleGateHandler(CondCallable):
 
     def otherwise(self, otherwise_fn):
         # Override the "can't have arguments" check in the original CondCallable's `otherwise`
-        self.sgh_otherwise_fn = otherwise_fn
+        if isinstance(otherwise_fn, type) and issubclass(otherwise_fn, qml.operation.Operation):
+            self.sgh_otherwise_fn = otherwise_fn
+        else:
+            raise TypeError(
+                "Conditional 'False' function is allowed to have arguments only if it is a PennyLane gate."
+            )
 
 
 class ForLoopCallable:

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -567,7 +567,7 @@ class CondCallable:
         self._operation = None
         self.expansion_strategy = cond_expansion_strategy()
 
-    def set_otherwise_fn(self, otherwise_fn):
+    def set_otherwise_fn(self, otherwise_fn):  # pylint:disable=missing-function-docstring
         self.otherwise_fn = otherwise_fn
 
     @property
@@ -796,7 +796,7 @@ class CondCallableSingleGateHandler(CondCallable):
             self.sgh_otherwise_fn = otherwise_fn
         else:
             raise TypeError(
-                "Conditional 'False' function is allowed to have arguments only if it is a PennyLane gate."
+                "Conditional 'False' function can have arguments only if it is a PennyLane gate."
             )
 
 

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -767,7 +767,7 @@ class CondCallableSingleGateHandler(CondCallable):
     This allows us to perform the conditional branch gate function with arguments.
     """
 
-    def __init__(self, pred, true_fn):
+    def __init__(self, pred, true_fn):  # pylint:disable=super-init-not-called
         self.pred = pred
         self.true_fn = true_fn
 

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -775,16 +775,16 @@ class CondCallableSingleGateHandler(CondCallable):
         self._true_fn = true_fn
         self._otherwise_fn = None
 
-    def __call__(self, *my_args, **my_kwargs):
+    def __call__(self, *args, **kwargs):
         def new_true_fn():
-            self._true_fn(*my_args, **my_kwargs)
+            self._true_fn(*args, **kwargs)
 
         super().__init__(self._pred, new_true_fn)
 
         if self._otherwise_fn is not None:
 
             def new_otherwise_fn():
-                self._otherwise_fn(*my_args, **my_kwargs)
+                self._otherwise_fn(*args, **kwargs)
 
             super().set_otherwise_fn(new_otherwise_fn)
 

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -771,20 +771,20 @@ class CondCallableSingleGateHandler(CondCallable):
     """
 
     def __init__(self, pred, true_fn):  # pylint:disable=super-init-not-called
-        self._pred = pred
-        self._true_fn = true_fn
-        self._otherwise_fn = None
+        self.sgh_pred = pred
+        self.sgh_true_fn = true_fn
+        self.sgh_otherwise_fn = None
 
     def __call__(self, *args, **kwargs):
         def new_true_fn():
-            self._true_fn(*args, **kwargs)
+            self.sgh_true_fn(*args, **kwargs)
 
-        super().__init__(self._pred, new_true_fn)
+        super().__init__(self.sgh_pred, new_true_fn)
 
-        if self._otherwise_fn is not None:
+        if self.sgh_otherwise_fn is not None:
 
             def new_otherwise_fn():
-                self._otherwise_fn(*args, **kwargs)
+                self.sgh_otherwise_fn(*args, **kwargs)
 
             super().set_otherwise_fn(new_otherwise_fn)
 
@@ -792,7 +792,7 @@ class CondCallableSingleGateHandler(CondCallable):
 
     def otherwise(self, otherwise_fn):
         # Override the "can't have arguments" check in the original CondCallable's `otherwise`
-        self._otherwise_fn = otherwise_fn
+        self.sgh_otherwise_fn = otherwise_fn
 
 
 class ForLoopCallable:

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -776,17 +776,17 @@ class CondCallableSingleGateHandler(CondCallable):
         self.sgh_otherwise_fn = None
 
     def __call__(self, *args, **kwargs):
-        def new_true_fn():
+        def argless_true_fn():
             self.sgh_true_fn(*args, **kwargs)
 
-        super().__init__(self.sgh_pred, new_true_fn)
+        super().__init__(self.sgh_pred, argless_true_fn)
 
         if self.sgh_otherwise_fn is not None:
 
-            def new_otherwise_fn():
+            def argless_otherwise_fn():
                 self.sgh_otherwise_fn(*args, **kwargs)
 
-            super().set_otherwise_fn(new_otherwise_fn)
+            super().set_otherwise_fn(argless_otherwise_fn)
 
         return super().__call__()
 

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -67,11 +67,6 @@ from catalyst.tracing.contexts import (
 )
 
 
-def is_pennylane_gate(callable):
-    # TODO
-    return True
-
-
 ## API ##
 def cond(pred: DynamicJaxprTracer):
     """A :func:`~.qjit` compatible decorator for if-else conditionals in PennyLane/Catalyst.
@@ -244,12 +239,13 @@ def cond(pred: DynamicJaxprTracer):
 
     def _decorator(true_fn: Callable):
 
-        # if len(inspect.signature(true_fn).parameters):
-        #    raise TypeError("Conditional 'True' function is not allowed to have any arguments")
+        if len(inspect.signature(true_fn).parameters):
+            if isinstance(true_fn, type) and issubclass(true_fn, qml.operation.Operation):
+                return CondCallableSingleGateHandler(pred, true_fn)
+            else:
+                raise TypeError("Conditional 'True' function is not allowed to have any arguments")
 
-        # return CondCallable(pred, true_fn)
-        # if true_fn is a plain gate:
-        return CondCallableSingleGateHandler(pred, true_fn)
+        return CondCallable(pred, true_fn)
 
     return _decorator
 

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -763,7 +763,7 @@ class CondCallableSingleGateHandler(CondCallable):
     the usual CondCallable class, which expects the conditional body function to have no arguments,
     cannot be used.
     This class inherits from base CondCallable, but wraps the gate in a function with no arguments,
-    and send that function to CondCallable.
+    and sends that function to CondCallable.
     This allows us to perform the conditional branch gate function with arguments.
     """
 

--- a/frontend/test/lit/test_if_else.py
+++ b/frontend/test/lit/test_if_else.py
@@ -62,24 +62,29 @@ print(circuit.mlir)
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=1))
 def circuit_single_gate(n: int):
+    # pylint: disable=line-too-long
     # CHECK-DAG:   [[c5:%[a-zA-Z0-9_]+]] = stablehlo.constant dense<5> : tensor<i64>
     # CHECK-DAG:   [[c6:%[a-zA-Z0-9_]+]] = stablehlo.constant dense<6> : tensor<i64>
+    # CHECK-DAG:   [[c7:%[a-zA-Z0-9_]+]] = stablehlo.constant dense<7> : tensor<i64>
+    # CHECK-DAG:   [[c8:%[a-zA-Z0-9_]+]] = stablehlo.constant dense<8> : tensor<i64>
+    # CHECK-DAG:   [[c9:%[a-zA-Z0-9_]+]] = stablehlo.constant dense<9> : tensor<i64>
     # CHECK-DAG:       [[b_t5:%[a-zA-Z0-9_]+]] = stablehlo.compare  LE, %arg0, [[c5]], SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
     # CHECK-DAG:       [[b_t6:%[a-zA-Z0-9_]+]] = stablehlo.compare  LE, %arg0, [[c6]], SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    # CHECK-DAG:       [[b_t7:%[a-zA-Z0-9_]+]] = stablehlo.compare  LE, %arg0, [[c7]], SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    # CHECK-DAG:       [[b_t8:%[a-zA-Z0-9_]+]] = stablehlo.compare  LE, %arg0, [[c8]], SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    # CHECK-DAG:       [[b_t9:%[a-zA-Z0-9_]+]] = stablehlo.compare  LE, %arg0, [[c9]], SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
     # CHECK-DAG:   [[qreg_0:%[a-zA-Z0-9_]+]] = quantum.alloc
-    # CHECK:       [[b5:%[a-zA-Z0-9_]+]] = tensor.extract [[b_t5]]
 
+    # CHECK:       [[b5:%[a-zA-Z0-9_]+]] = tensor.extract [[b_t5]]
     # CHECK:       [[qreg_out:%.+]] = scf.if [[b5]]
     # CHECK-DAG:   [[q0:%[a-zA-Z0-9_]+]] = quantum.extract [[qreg_0]]
     # CHECK-DAG:   [[q1:%[a-zA-Z0-9_]+]] = quantum.custom "PauliX"() [[q0]]
-    # pylint: disable=line-too-long
     # CHECK-DAG:   [[qreg_1:%[a-zA-Z0-9_]+]] = quantum.insert [[qreg_0]][ {{[%a-zA-Z0-9_]+}}], [[q1]]
     # CHECK:       scf.yield [[qreg_1]]
 
     # CHECK:       else
     # CHECK-DAG:   [[q2:%[a-zA-Z0-9_]+]] = quantum.extract [[qreg_0]]
     # CHECK-DAG:   [[q3:%[a-zA-Z0-9_]+]] = quantum.custom "Hadamard"() [[q2]]
-    # pylint: disable=line-too-long
     # CHECK-DAG:   [[qreg_2:%[a-zA-Z0-9_]+]] = quantum.insert [[qreg_0]][ {{[%a-zA-Z0-9_]+}}], [[q3]]
     # CHECK:       scf.yield [[qreg_2]]
     qml.cond(n <= 5, qml.PauliX, qml.Hadamard)(wires=0)
@@ -88,16 +93,53 @@ def circuit_single_gate(n: int):
     # CHECK:       [[qreg_out1:%.+]] = scf.if [[b6]]
     # CHECK-DAG:   [[q4:%[a-zA-Z0-9_]+]] = quantum.extract [[qreg_out]]
     # CHECK-DAG:   [[q5:%[a-zA-Z0-9_]+]] = quantum.custom "RX"({{%.+}}) [[q4]]
-    # pylint: disable=line-too-long
-    # CHECK-DAG:   [[qreg_3:%[a-zA-Z0-9_]+]] = quantum.insert [[qreg_out]][ {{[%a-zA-Z0-9_]+}}], [[q1]]
+    # CHECK-DAG:   [[qreg_3:%[a-zA-Z0-9_]+]] = quantum.insert [[qreg_out]][ {{[%a-zA-Z0-9_]+}}], [[q5]]
     # CHECK:       scf.yield [[qreg_3]]
     # CHECK:       else
     # CHECK:       scf.yield [[qreg_out]]
 
     qml.cond(n <= 6, qml.RX)(3.14, wires=0)
 
-    # CHECK:       [[qreg_3:%.+]] = quantum.extract [[qreg_out1]][ 0]
-    # CHECK:       [[qobs:%.+]] = quantum.compbasis [[qreg_3]] : !quantum.obs
+    # CHECK:       [[b7:%[a-zA-Z0-9_]+]] = tensor.extract [[b_t7]]
+    # CHECK:       [[qreg_out2:%.+]] = scf.if [[b7]]
+    # CHECK-DAG:      [[q7:%[a-zA-Z0-9_]+]] = quantum.extract [[qreg_out1]]
+    # CHECK-DAG:      [[q8:%[a-zA-Z0-9_]+]] = quantum.custom "Hadamard"() [[q7]]
+    # pylint: disable=line-too-long
+    # CHECK-DAG:      [[qreg_4:%[a-zA-Z0-9_]+]] = quantum.insert [[qreg_out1]][ {{[%a-zA-Z0-9_]+}}], [[q8]]
+    # CHECK:          scf.yield [[qreg_4]]
+    # CHECK:       else {
+    # CHECK:          [[b8:%[a-zA-Z0-9_]+]] = tensor.extract [[b_t8]]
+    # CHECK:          [[qreg_out3:%.+]] = scf.if [[b8]]
+    # CHECK-DAG:         [[q9:%[a-zA-Z0-9_]+]] = quantum.extract [[qreg_out1]]
+    # CHECK-DAG:         [[q10:%[a-zA-Z0-9_]+]] = quantum.custom "PauliY"() [[q9]]
+    # CHECK-DAG:         [[qreg_5:%[a-zA-Z0-9_]+]] = quantum.insert [[qreg_out1]][ {{[%a-zA-Z0-9_]+}}], [[q10]]
+    # CHECK:             scf.yield [[qreg_5]]
+    # CHECK:          else {
+    # CHECK:             [[b9:%[a-zA-Z0-9_]+]] = tensor.extract [[b_t9]]
+    # CHECK:             [[qreg_out4:%.+]] = scf.if [[b9]]
+    # CHECK-DAG:            [[q11:%[a-zA-Z0-9_]+]] = quantum.extract [[qreg_out1]]
+    # CHECK-DAG:            [[q12:%[a-zA-Z0-9_]+]] = quantum.custom "PauliZ"() [[q11]]
+    # CHECK-DAG:            [[qreg_6:%[a-zA-Z0-9_]+]] = quantum.insert [[qreg_out1]][ {{[%a-zA-Z0-9_]+}}], [[q12]]
+    # CHECK:                scf.yield [[qreg_6]]
+    # CHECK:                else {
+    # CHECK-DAG:            [[q13:%[a-zA-Z0-9_]+]] = quantum.extract [[qreg_out1]]
+    # CHECK-DAG:            [[q14:%[a-zA-Z0-9_]+]] = quantum.custom "PauliX"() [[q13]]
+    # CHECK-DAG:            [[qreg_7:%[a-zA-Z0-9_]+]] = quantum.insert [[qreg_out1]][ {{[%a-zA-Z0-9_]+}}], [[q14]]
+    # CHECK:                scf.yield [[qreg_7]]
+    # CHECK:             scf.yield [[qreg_out4]]
+    # CHECK:          scf.yield [[qreg_out3]]
+    qml.cond(
+        n <= 7,
+        qml.Hadamard,
+        qml.PauliX,
+        (
+            (n <= 8, qml.PauliY),
+            (n <= 9, qml.PauliZ),
+        ),
+    )(wires=0)
+
+    # CHECK:       [[qreg_ret:%.+]] = quantum.extract [[qreg_out2]][ 0]
+    # CHECK:       [[qobs:%.+]] = quantum.compbasis [[qreg_ret]] : !quantum.obs
     # CHECK:       [[ret:%.+]] = quantum.probs [[qobs]]
     # CHECK:       return [[ret]]
     return qml.probs()

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -427,6 +427,18 @@ class TestCond:
         with pytest.raises(TypeError, match="not allowed to have any arguments"):
             qjit(f)
 
+        def f(x: int):
+
+            res = qml.cond(x < 5, qml.Hadamard, lambda z: z + 1)(0)
+
+            return res
+
+        with pytest.raises(
+            TypeError,
+            match="Conditional 'False' function is allowed to have arguments only if it is a PennyLane gate.",
+        ):
+            qjit(f)
+
 
 class TestInterpretationConditional:
     """Test that the conditional operation's execution is semantically equivalent

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -435,7 +435,7 @@ class TestCond:
 
         with pytest.raises(
             TypeError,
-            match="Conditional 'False' function is allowed to have arguments only if it is a PennyLane gate.",
+            match="Conditional 'False' function can have arguments only if it is a PennyLane gate.",
         ):
             qjit(f)
 

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -676,8 +676,10 @@ class TestCondOperatorAccess:
         assert func(False) == 0
 
     def test_cond_single_gate(self, backend):
-        """Test standard pennylane qml.cond usage on single quantum gates."""
-        """Fixes https://github.com/PennyLaneAI/catalyst/issues/449"""
+        """
+        Test standard pennylane qml.cond usage on single quantum gates.
+        Fixes https://github.com/PennyLaneAI/catalyst/issues/449
+        """
 
         @qml.qnode(qml.device(backend, wires=2))
         def func(x, y):

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -676,6 +676,20 @@ class TestCondOperatorAccess:
         assert func(True) == 1
         assert func(False) == 0
 
+    def test_cond_single_gate(self, backend):
+        """Test standard pennylane qml.cond usage on single quantum gates."""
+        """Fixes https://github.com/PennyLaneAI/catalyst/issues/449"""
+
+        @qjit
+        @qml.qnode(qml.device(backend, wires=1))
+        def func(x, y):
+            qml.cond(x == 42, qml.Hadamard)(wires=0)
+            qml.cond(y == 37, qml.Hadamard)(wires=0)
+            return qml.probs()
+
+        assert np.allclose(func(42, 37), [1, 0])
+        assert np.allclose(func(0, 37), [0.5, 0.5])
+
 
 class TestCondPredicateConversion:
     """Test suite for checking predicate conversion to bool."""

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -683,8 +683,8 @@ class TestCondOperatorAccess:
 
         @qml.qnode(qml.device(backend, wires=2))
         def func(x, y):
-            qml.cond(x == 42, qml.Hadamard)(wires=0)
-            qml.cond(x == 42, qml.RY)(1.5, wires=0)
+            qml.cond(x == 42, qml.Hadamard, qml.PauliX)(wires=0)
+            qml.cond(x == 42, qml.RY, qml.RZ)(1.5, wires=0)
             qml.cond(x == 42, qml.CNOT)(wires=[1, 0])
             qml.cond(y == 37, qml.PauliX)(wires=1)
             qml.cond(y == 37, qml.RZ)(5.1, wires=0)

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -418,12 +418,11 @@ class TestCond:
     def test_argument_error_with_callables(self):
         """Test for the error when arguments are supplied and the target is not a function."""
 
-        @qml.qnode(qml.device("lightning.qubit", wires=1))
         def f(x: int):
 
-            qml.cond(x < 5, qml.Hadamard)(0)
+            res = qml.cond(x < 5, lambda z: z + 1)(0)
 
-            return qml.probs()
+            return res
 
         with pytest.raises(TypeError, match="not allowed to have any arguments"):
             qjit(f)


### PR DESCRIPTION
**Context:**
The standard `qml.cond` usage for single gates fails with qjit:
```python
@qjit
@qml.qnode(dev)
def func(x, y):
    qml.cond(x == 42, qml.Hadamard)(wires=0)
    qml.cond(y == 37, qml.Hadamard)(wires=0)
    return qml.probs()

print(func(42, 37), func(42, 2))
```

```
TypeError: Conditional 'True' function is not allowed to have any arguments
```

While users can work around this by using [`catalyst.cond` syntax](https://docs.pennylane.ai/projects/catalyst/en/stable/code/api/catalyst.cond.html), it is a bit incovenient. 

Moreover, the fewer code changes required to qjit a pennylane circuit, the better. Since [`qml.cond` just aliases to `catalyst.cond` within qjit](https://github.com/PennyLaneAI/catalyst/blob/175cf8c3fc04691f74e089506b29cdbc7caa6c14/doc/releases/changelog-0.4.0.md?plain=1#L41), we should make sure qjit does not reject any valid plain pennylane use patterns.


**Description of the Change:**
The error arises because the conditional branch functions are not allowed to have arguments. This is because the `CondCallable` class's `__call__()` method does not take any arguments.

While we do not want to change the overarching design of `CondCallable`, we can make a new class that inherits from it, which specifically deals with the case where the conditional branch function is a pennylane gate (like `qml.Hadamard`, ...).

This new class, named `CondCallableSingleGateHandler`, has a `__call__()` method that can take in arbitrary args and kwargs. The class creates a wrapper conditional function taking in no arguments and sends the wrapper to the usual `CondCallable`, but the body of the wrapper calls the actual conditional branch function that is passed in. This allows us to perform the conditional branch function with arguments.


**Benefits:**
The standard usage `qml.cond(predicate, qml.some_gate)(*args, **kwargs)` works within qjit.

**Related GitHub Issues:** closes #449 

[sc-55079]
