### PR TITLE
Bump CPL RC versions for Catalyst 0.9.0

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -39,7 +39,7 @@ jobs:
         git checkout $(git tag | sort -V | tail -1)
     - if: ${{ inputs.catalyst == 'release-candidate' }}
       run: |
-        git checkout v0.8.2-rc
+        git checkout v0.9.0-rc
 
     - name: Install deps
       run: |
@@ -132,7 +132,7 @@ jobs:
         C_COMPILER=$(which gcc }}) \
         CXX_COMPILER=$(which g++ }}) \
         RT_BUILD_DIR="$(pwd)/runtime-build" \
-        LIGHTNING_GIT_TAG_VALUE=v0.38.0_rc \
+        LIGHTNING_GIT_TAG_VALUE=v0.39.0_rc \
         ENABLE_OPENQASM=ON \
         make runtime
 
@@ -186,8 +186,8 @@ jobs:
     - name: Install PennyLane (release-candidate)
       if: ${{ inputs.pennylane == 'release-candidate' }}
       run: |
-        pip install --upgrade git+https://github.com/PennyLaneAI/pennylane@v0.38.0-rc0
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.38.0-rc0
+        pip install --upgrade git+https://github.com/PennyLaneAI/pennylane@v0.39.0-rc0
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.39.0-rc0
 
     - name: Add Frontend Dependencies to PATH
       run: |


### PR DESCRIPTION
**Context:** In preparation for the Catalyst 0.9.0 release candidate (RC), the GitHub action must point to the corresponding RC branch, `v0.9.0-rc`.

**Description of the Change:** Update the Catalyst RC branch `v0.8.2-rc` -> `v0.9.0-rc`, as well as the corresponding RC branches for Lightning and PennyLane from `v0.38.0` to `v0.39.0`.