### PR TITLE
Prepare for Catalyst v0.10.0-dev (development release)

### DIFF
--- a/.github/workflows/rc_sync.yaml
+++ b/.github/workflows/rc_sync.yaml
@@ -82,4 +82,4 @@ jobs:
           pr_body: "Automatic sync from the release candidate to main during a feature freeze."
           pr_allow_empty: false
           pr_draft: false
-          pr_reviewer: "dime10,rauletorresc"
+          pr_reviewer: "dime10,joeycarter"

--- a/doc/dev/release_notes.rst
+++ b/doc/dev/release_notes.rst
@@ -3,6 +3,8 @@ Release notes
 
 This page contains the release notes for Catalyst.
 
+.. mdinclude:: ../releases/changelog-dev.md
+
 .. mdinclude:: ../releases/changelog-0.9.0.md
 
 .. mdinclude:: ../releases/changelog-0.8.0.md

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1,6 +1,6 @@
 :orphan:
 
-# Release 0.9.0-dev (development release)
+# Release 0.10.0-dev (development release)
 
 <h3>New features since last release</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1,0 +1,19 @@
+:orphan:
+
+# Release 0.9.0-dev (development release)
+
+<h3>New features since last release</h3>
+
+<h3>Improvements 🛠</h3>
+
+<h3>Breaking changes 💔</h3>
+
+<h3>Deprecations 👋</h3>
+
+<h3>Documentation 📝</h3>
+
+<h3>Bug fixes 🐛</h3>
+
+<h3>Contributors ✍️</h3>
+
+This release contains contributions from (in alphabetical order):

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.9.0"
+__version__ = "0.10.0-dev"


### PR DESCRIPTION
**Context:** Preparing the main branch for Catalyst v0.10.0-dev (development release).

**Description of the Change:** Bump version to "0.10.0-dev", add new changelog, and update PR reviewer.