### PR TITLE
`catalyst.pipeline` fixes

### DIFF
--- a/doc/releases/changelog-0.9.0.md
+++ b/doc/releases/changelog-0.9.0.md
@@ -53,9 +53,10 @@
   Array([[1], [0], [1], [1], [0], [1],[0]], dtype=int64))
   ```
 
-* A new function `catalyst.passes.pipeline` allows the quantum circuit transformation pass pipeline
+* A new function `catalyst.pipeline` allows the quantum circuit transformation pass pipeline
   for QNodes within a qjit-compiled workflow to be configured.
   [(#1131)](https://github.com/PennyLaneAI/catalyst/pull/1131)
+  [(#1240)](https://github.com/PennyLaneAI/catalyst/pull/1240)
 
   ```python
     my_passes = {
@@ -116,6 +117,8 @@
 
   Available MLIR passes are now documented and available within the
   [catalyst.passes module documentation](https://docs.pennylane.ai/projects/catalyst/en/stable/code/__init__.html#module-catalyst.passes).
+
+  The `pipeline` function is available as `catalyst.pipeline` and `catalyst.passes.pipeline`.
 
 * A peephole merge rotations pass is now available in MLIR. It can be added to `catalyst.passes.pipeline`, or the
   Python function `catalyst.passes.merge_rotations` can be directly called on a `QNode`.

--- a/frontend/catalyst/__init__.py
+++ b/frontend/catalyst/__init__.py
@@ -89,6 +89,7 @@ from catalyst.autograph import __all__ as _autograph_functions
 from catalyst.compiler import CompileOptions
 from catalyst.debug.assertion import debug_assert
 from catalyst.jit import QJIT, qjit
+from catalyst.passes import pipeline
 from catalyst.utils.exceptions import (
     AutoGraphError,
     CompileError,
@@ -186,6 +187,7 @@ __all__ = (
     "debug_assert",
     "CompileOptions",
     "debug",
+    "pipeline",
     *_api_extension_list,
     *_autograph_functions,
 )

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -44,7 +44,7 @@ from catalyst.tracing.contexts import EvaluationContext
 
 ## API ##
 # pylint: disable=line-too-long
-def pipeline(fn=None, *, pass_pipeline: Optional[dict[str, dict[str, str]]] = None):
+def pipeline(pass_pipeline: Optional[dict[str, dict[str, str]]] = None):
     """Configures the Catalyst MLIR pass pipeline for quantum circuit transformations for a QNode within a qjit-compiled program.
 
     Args:
@@ -131,55 +131,55 @@ def pipeline(fn=None, *, pass_pipeline: Optional[dict[str, dict[str, str]]] = No
     will always take precedence over global pass pipelines.
     """
 
-    kwargs = copy.copy(locals())
-    kwargs.pop("fn")
+    def _decorator(fn=None):
+        if fn is None:
+            return functools.partial(pipeline, **kwargs)
 
-    if fn is None:
-        return functools.partial(pipeline, **kwargs)
+        if not isinstance(fn, qml.QNode):
+            raise TypeError(f"A QNode is expected, got the classical function {fn}")
 
-    if not isinstance(fn, qml.QNode):
-        raise TypeError(f"A QNode is expected, got the classical function {fn}")
+        if pass_pipeline is None:
+            # TODO: design a default peephole pipeline
+            return fn
 
-    if pass_pipeline is None:
-        # TODO: design a default peephole pipeline
-        return fn
+        fn_original_name = fn.__name__
+        wrapped_qnode_function = fn.func
+        fn_clone = copy.copy(fn)
+        uniquer = str(_rename_to_unique())
+        fn_clone.__name__ = fn_original_name + "_transformed" + uniquer
 
-    fn_original_name = fn.__name__
-    wrapped_qnode_function = fn.func
-    fn_clone = copy.copy(fn)
-    uniquer = str(_rename_to_unique())
-    fn_clone.__name__ = fn_original_name + "_transformed" + uniquer
+        pass_names = _API_name_to_pass_name()
 
-    pass_names = _API_name_to_pass_name()
+        def wrapper(*args, **kwrags):
+            # TODO: we should not match pass targets by function name.
+            # The quantum scope work will likely put each qnode into a module
+            # instead of a `func.func ... attributes {qnode}`.
+            # When that is in place, the qnode's module can have a proper attribute
+            # (as opposed to discardable) that records its transform schedule, i.e.
+            #    module_with_transform @name_of_module {
+            #      // transform schedule
+            #    } {
+            #      // contents of the module
+            #    }
+            # This eliminates the need for matching target functions by name.
 
-    def wrapper(*args, **kwrags):
-        # TODO: we should not match pass targets by function name.
-        # The quantum scope work will likely put each qnode into a module
-        # instead of a `func.func ... attributes {qnode}`.
-        # When that is in place, the qnode's module can have a proper attribute
-        # (as opposed to discardable) that records its transform schedule, i.e.
-        #    module_with_transform @name_of_module {
-        #      // transform schedule
-        #    } {
-        #      // contents of the module
-        #    }
-        # This eliminates the need for matching target functions by name.
+            if EvaluationContext.is_tracing():
+                for API_name, pass_options in pass_pipeline.items():
+                    opt = ""
+                    for option, option_value in pass_options.items():
+                        opt += " " + str(option) + "=" + str(option_value)
+                    apply_registered_pass_p.bind(
+                        pass_name=pass_names[API_name],
+                        options=f"func-name={fn_original_name}" + "_transformed" + uniquer + opt,
+                    )
+            return wrapped_qnode_function(*args, **kwrags)
 
-        if EvaluationContext.is_tracing():
-            for API_name, pass_options in pass_pipeline.items():
-                opt = ""
-                for option, option_value in pass_options.items():
-                    opt += " " + str(option) + "=" + str(option_value)
-                apply_registered_pass_p.bind(
-                    pass_name=pass_names[API_name],
-                    options=f"func-name={fn_original_name}" + "_transformed" + uniquer + opt,
-                )
-        return wrapped_qnode_function(*args, **kwrags)
+        fn_clone.func = wrapper
+        fn_clone._peephole_transformed = True  # pylint: disable=protected-access
 
-    fn_clone.func = wrapper
-    fn_clone._peephole_transformed = True  # pylint: disable=protected-access
+        return fn_clone
 
-    return fn_clone
+    return _decorator
 
 
 def cancel_inverses(fn=None):

--- a/frontend/test/lit/test_peephole_optimizations.py
+++ b/frontend/test/lit/test_peephole_optimizations.py
@@ -29,9 +29,9 @@ import shutil
 import pennylane as qml
 from lit_util_printers import print_jaxpr, print_mlir
 
-from catalyst import qjit
+from catalyst import qjit, pipeline
 from catalyst.debug import get_compilation_stage
-from catalyst.passes import cancel_inverses, merge_rotations, pipeline
+from catalyst.passes import cancel_inverses, merge_rotations
 
 
 def flush_peephole_opted_mlir_to_iostream(QJIT):

--- a/frontend/test/lit/test_peephole_optimizations.py
+++ b/frontend/test/lit/test_peephole_optimizations.py
@@ -90,7 +90,7 @@ def test_pipeline_lowering():
     }
 
     @qjit(keep_intermediate=True)
-    @pipeline(pass_pipeline=my_pipeline)
+    @pipeline(my_pipeline)
     @qml.qnode(qml.device("lightning.qubit", wires=2))
     def test_pipeline_lowering_workflow(x):
         qml.RX(x, wires=[0])

--- a/frontend/test/pytest/test_peephole_optimizations.py
+++ b/frontend/test/pytest/test_peephole_optimizations.py
@@ -18,8 +18,8 @@ import numpy as np
 import pennylane as qml
 import pytest
 
-from catalyst import qjit
-from catalyst.passes import cancel_inverses, merge_rotations, pipeline
+from catalyst import qjit, pipeline
+from catalyst.passes import cancel_inverses, merge_rotations
 
 # pylint: disable=missing-function-docstring
 

--- a/frontend/test/pytest/test_peephole_optimizations.py
+++ b/frontend/test/pytest/test_peephole_optimizations.py
@@ -189,7 +189,7 @@ def test_cancel_inverses_bad_usages():
             TypeError,
             match="A QNode is expected, got the classical function",
         ):
-            pipeline({})(classical_func)
+            pipeline()(classical_func)
 
         with pytest.raises(
             TypeError,

--- a/frontend/test/pytest/test_peephole_optimizations.py
+++ b/frontend/test/pytest/test_peephole_optimizations.py
@@ -167,7 +167,7 @@ def test_pipeline_functionality(theta, backend):
             return qml.expval(qml.PauliY(wires=0))
 
         no_pipeline_result = f(theta)
-        pipeline_result = pipeline(pass_pipeline=my_pipeline)(f)(theta)
+        pipeline_result = pipeline(my_pipeline)(f)(theta)
 
         return no_pipeline_result, pipeline_result
 
@@ -189,7 +189,7 @@ def test_cancel_inverses_bad_usages():
             TypeError,
             match="A QNode is expected, got the classical function",
         ):
-            pipeline(classical_func)
+            pipeline({})(classical_func)
 
         with pytest.raises(
             TypeError,


### PR DESCRIPTION
**Context:**
Two fixes on `catalyst.passes.pipeline`:

1. Moved to top level, so now also available as `catalyst.pipeline`
2. No need to specify the argument name, i.e. `catalyst.pipeline({...})(qnode_func)` now works (as opposed to `catalyst.pipeline(pass_pipeline={...})(qnode_func)` )