### PR TITLE
Fix a missed branch update in rcrcrc action (v0.9.0)

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -156,7 +156,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: PennyLaneAI/pennylane-lightning
-        ref: v0.38.0_rc
+        ref: v0.39.0_rc
         path: lightning_build
         fetch-depth: 0
 

--- a/.github/workflows/rc_sync.yaml
+++ b/.github/workflows/rc_sync.yaml
@@ -82,4 +82,4 @@ jobs:
           pr_body: "Automatic sync from the release candidate to main during a feature freeze."
           pr_allow_empty: false
           pr_draft: false
-          pr_reviewer: "dime10,rauletorresc"
+          pr_reviewer: "dime10,joeycarter"

--- a/doc/dev/release_notes.rst
+++ b/doc/dev/release_notes.rst
@@ -3,6 +3,8 @@ Release notes
 
 This page contains the release notes for Catalyst.
 
+.. mdinclude:: ../releases/changelog-dev.md
+
 .. mdinclude:: ../releases/changelog-0.9.0.md
 
 .. mdinclude:: ../releases/changelog-0.8.0.md

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1,0 +1,19 @@
+:orphan:
+
+# Release 0.10.0-dev (development release)
+
+<h3>New features since last release</h3>
+
+<h3>Improvements 🛠</h3>
+
+<h3>Breaking changes 💔</h3>
+
+<h3>Deprecations 👋</h3>
+
+<h3>Documentation 📝</h3>
+
+<h3>Bug fixes 🐛</h3>
+
+<h3>Contributors ✍️</h3>
+
+This release contains contributions from (in alphabetical order):

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.9.0"
+__version__ = "0.10.0-dev"

--- a/mlir/lib/Gradient/Transforms/GradMethods/PS_QuantumGradient.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/PS_QuantumGradient.cpp
@@ -56,7 +56,7 @@ static std::vector<Value> computePartialDerivative(PatternRewriter &rewriter, Lo
                                                    Value selectorBuffer, func::FuncOp shiftedFn,
                                                    std::vector<Value> callArgs)
 {
-    constexpr double shift = PI / 2;
+    constexpr double shift = llvm::numbers::pi / 2;
     ShapedType shiftVectorType = RankedTensorType::get({numShifts}, rewriter.getF64Type());
     Value selectorVector = rewriter.create<bufferization::ToTensorOp>(loc, selectorBuffer);
 

--- a/mlir/lib/Gradient/Transforms/GradMethods/ParameterShift.hpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/ParameterShift.hpp
@@ -21,8 +21,6 @@
 
 #include "Gradient/IR/GradientOps.h"
 
-constexpr double PI = 3.14159265358979323846;
-
 using namespace mlir;
 
 namespace catalyst {


### PR DESCRIPTION
There was one missed `v0.38.0_rc` in rcrcrc workflow. 
We update it.