### PR TITLE
Fix a missed branch update in rcrcrc action (v0.9.0) (rc)

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -156,7 +156,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: PennyLaneAI/pennylane-lightning
-        ref: v0.38.0_rc
+        ref: v0.39.0_rc
         path: lightning_build
         fetch-depth: 0
 


### PR DESCRIPTION
There was one missed v0.38.0_rc in rcrcrc workflow.
We update it.