### PR TITLE
Update seeding documentation to indicate what circuit readout processes are seeded

### DIFF
--- a/doc/releases/changelog-0.9.0.md
+++ b/doc/releases/changelog-0.9.0.md
@@ -302,7 +302,7 @@
 * Calling gradients twice (with same GradParams) will now only lower to a single MLIR function.
   [(#1172)](https://github.com/PennyLaneAI/catalyst/pull/1172)
 
-* Samples on lightning.qubit/kokkos can now be seeded with `qjit(seed=...)`.
+* `qml.sample()` and `qml.counts()` on lightning.qubit/kokkos can now be seeded with `qjit(seed=...)`.
   [(#1164)](https://github.com/PennyLaneAI/catalyst/pull/1164)
 
 * The compiler pass `-remove-chained-self-inverse` can now also cancel adjoints of arbitrary unitary operations (in addition to the named Hermitian gates).

--- a/doc/releases/changelog-0.9.0.md
+++ b/doc/releases/changelog-0.9.0.md
@@ -304,6 +304,7 @@
 
 * `qml.sample()` and `qml.counts()` on lightning.qubit/kokkos can now be seeded with `qjit(seed=...)`.
   [(#1164)](https://github.com/PennyLaneAI/catalyst/pull/1164)
+  [(#1248)](https://github.com/PennyLaneAI/catalyst/pull/1248)
 
 * The compiler pass `-remove-chained-self-inverse` can now also cancel adjoints of arbitrary unitary operations (in addition to the named Hermitian gates).
   [(#1186)](https://github.com/PennyLaneAI/catalyst/pull/1186)

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -141,7 +141,8 @@ def qjit(
             on simulator devices including ``lightning.qubit`` and ``lightning.kokkos``.
             The default value is None, which means no seeding is performed, and all processes
             are random. A seed is expected to be an unsigned 32-bit integer.
-            Currently, the following measurement processes are seeded: `catalyst.measure`, `qml.sample`, `qml.counts`.
+            Currently, the following measurement processes are seeded: :func:`~.measure`,
+            :func:`qml.sample <pennylane.sample>`, :func:`qml.counts <pennylane.counts>`.
         experimental_capture (bool): If set to ``True``, the qjit decorator
             will use PennyLane's experimental program capture capabilities
             to capture the decorated function for compilation.

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -142,7 +142,7 @@ def qjit(
             The default value is None, which means no seeding is performed, and all processes
             are random. A seed is expected to be an unsigned 32-bit integer.
             Currently, the following measurement processes are seeded: :func:`~.measure`,
-            :func:`qml.sample <pennylane.sample>`, :func:`qml.counts <pennylane.counts>`.
+            :func:`qml.sample() <pennylane.sample>`, :func:`qml.counts() <pennylane.counts>`.
         experimental_capture (bool): If set to ``True``, the qjit decorator
             will use PennyLane's experimental program capture capabilities
             to capture the decorated function for compilation.

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -137,10 +137,11 @@ def qjit(
         disable_assertions (bool): If set to ``True``, runtime assertions included in
             ``fn`` via :func:`~.debug_assert` will be disabled during compilation.
         seed (Optional[Int]):
-            The seed for mid-circuit measurement results when the qjit-compiled function is executed
+            The seed for circuit readout results when the qjit-compiled function is executed
             on simulator devices including ``lightning.qubit`` and ``lightning.kokkos``.
             The default value is None, which means no seeding is performed, and all processes
             are random. A seed is expected to be an unsigned 32-bit integer.
+            Currently, the following measurement processes are seeded: `catalyst.measure`, `qml.sample`, `qml.counts`.
         experimental_capture (bool): If set to ``True``, the qjit decorator
             will use PennyLane's experimental program capture capabilities
             to capture the decorated function for compilation.

--- a/frontend/test/lit/test_peephole_optimizations.py
+++ b/frontend/test/lit/test_peephole_optimizations.py
@@ -29,7 +29,7 @@ import shutil
 import pennylane as qml
 from lit_util_printers import print_jaxpr, print_mlir
 
-from catalyst import qjit, pipeline
+from catalyst import pipeline, qjit
 from catalyst.debug import get_compilation_stage
 from catalyst.passes import cancel_inverses, merge_rotations
 

--- a/frontend/test/pytest/test_peephole_optimizations.py
+++ b/frontend/test/pytest/test_peephole_optimizations.py
@@ -18,7 +18,7 @@ import numpy as np
 import pennylane as qml
 import pytest
 
-from catalyst import qjit, pipeline
+from catalyst import pipeline, qjit
 from catalyst.passes import cancel_inverses, merge_rotations
 
 # pylint: disable=missing-function-docstring

--- a/frontend/test/pytest/test_seeded_qjit.py
+++ b/frontend/test/pytest/test_seeded_qjit.py
@@ -110,7 +110,8 @@ def test_seeded_measurement(seed, backend):
     ],
 )
 @pytest.mark.parametrize("shots", [10])
-def test_seeded_sample(seed, shots, backend):
+@pytest.mark.parametrize("readout", [qml.sample, qml.counts])
+def test_seeded_sample(seed, shots, readout, backend):
     """Test that different calls to qjits with the same seed produce the same sample results"""
 
     if backend not in ["lightning.qubit", "lightning.kokkos"]:
@@ -124,7 +125,7 @@ def test_seeded_sample(seed, shots, backend):
         def circuit():
             qml.Hadamard(wires=[0])
             qml.RX(12.34, wires=[1])
-            return qml.sample()
+            return readout()
 
         return circuit(), circuit(), circuit(), circuit()
 
@@ -134,7 +135,7 @@ def test_seeded_sample(seed, shots, backend):
         def circuit():
             qml.Hadamard(wires=[0])
             qml.RX(12.34, wires=[1])
-            return qml.sample()
+            return readout()
 
         return circuit(), circuit(), circuit(), circuit()
 


### PR DESCRIPTION
**Context:**
Add a list of seeding-supported circuit readout methods to the documentation. 

**Benefits:**
Avoid potential user misunderstanding when unseeded readout methods are used with a seed.
