### PR TITLE
Fix MLIR default pipeline

### DIFF
--- a/doc/releases/changelog-0.9.0.md
+++ b/doc/releases/changelog-0.9.0.md
@@ -192,6 +192,7 @@
 * Catalyst now has a standalone compiler tool called `catalyst-cli` which quantum
   compiles MLIR input files into an object file without any dependancy to the python frontend.
   [(#1208)](https://github.com/PennyLaneAI/catalyst/pull/1208)
+  [(#1255)](https://github.com/PennyLaneAI/catalyst/pull/1255)
 
   This compiler tool combines three stages of compilation which are:
 

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -557,7 +557,7 @@ LogicalResult runLowering(const CompilerOptions &options, MLIRContext *ctx, Modu
     bool clHasIndividulaPass = pm.size() > 0;
     bool clHasManualPipeline = !options.pipelinesCfg.empty();
     if (clHasIndividulaPass && clHasManualPipeline) {
-        llvm::errs() << "--catalyst-pipline option can't be used with individual pass options "
+        llvm::errs() << "--catalyst-pipeline option can't be used with individual pass options "
                         "or -pass-pipeline.\n";
         return failure();
     }

--- a/mlir/lib/Driver/Pipelines.cpp
+++ b/mlir/lib/Driver/Pipelines.cpp
@@ -190,8 +190,7 @@ std::vector<Pipeline> getDefaultPipeline()
         "enforce-runtime-invariants-pipeline", "hlo-lowering-pipeline",
         "quantum-compilation-pipeline", "bufferization-pipeline", "llvm-dialect-lowering-pipeline"};
 
-    std::vector<Pipeline> defaultPipelines;
-    defaultPipelines.reserve(defaultPipelineNames.size());
+    std::vector<Pipeline> defaultPipelines(defaultPipelineNames.size());
     for (size_t i = 0; i < defaultPipelineNames.size(); ++i) {
         defaultPipelines[i].setRegisterFunc(pipelineFuncs[i]);
         defaultPipelines[i].setName(defaultPipelineNames[i]);

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -16,6 +16,7 @@ set(TEST_SUITES
     Gradient
     Mitigation
     Catalyst
+    cli
     )
 
 

--- a/mlir/test/cli/DumpPipeline.mlir
+++ b/mlir/test/cli/DumpPipeline.mlir
@@ -32,5 +32,5 @@ func.func @foo() {
 // CHECK-ONE-PASS: Pass Manager with 1 passes
 // CHECK-ONE-PASS: builtin.module(cse)
 
-// CHECK-FAIL: --catalyst-pipline option can't be used with individual pass options or -pass-pipeline.
+// CHECK-FAIL: --catalyst-pipeline option can't be used with individual pass options or -pass-pipeline.
 // CHECK-FAIL: Compilation failed


### PR DESCRIPTION
**Context:** There was a bug when running the new `catalyst-cli` tool without supplying a `--catalyst-pipeline` argument. In such cases, the tool gets a default pipeline using the `getDefaultPipeline()` function, which contained an incorrect std::vector initialization resulting in an index-out-of-bounds assertion error. Furthermore, the bug was never picked up because the `cli` test suite was never registered in the CMake config.

**Description of the Change:** This change correctly initializes a vector in `getDefaultPipeline()` to avoid the index-out-of-bounds assert and registers the `cli` test suite in the CMake config. It also makes an opportunistic typo fix ("pipline" -> "pipeline")