### PR TITLE
[build system] Ship with catalyst lock for the python interpreter

### DIFF
--- a/.github/workflows/scripts/linux_arm64/rh8/build_catalyst.sh
+++ b/.github/workflows/scripts/linux_arm64/rh8/build_catalyst.sh
@@ -79,7 +79,7 @@ cmake --build quantum-build --target check-dialects compiler_driver catalyst-cli
 
 # Copy files needed for the wheel where they are expected
 cp /catalyst/runtime-build/lib/*/*/*/*/librtd* /catalyst/runtime-build/lib
-find . -name 'libcatalyst_python_interpreter.*' -exec cp /catalyst/runtime-build/lib {} \;
+find . -name 'libcatalyst_python_interpreter.*' -exec cp {} /catalyst/runtime-build/lib \;
 cp /catalyst/runtime-build/lib/registry/runtime-build/lib/catalyst_callback_registry.cpython-${PYTHON_ALTERNATIVE_VERSION}-aarch64-linux-gnu.so /catalyst/runtime-build/lib
 cp /catalyst/runtime-build/lib/capi/runtime-build/lib/librt_capi.so /catalyst/runtime-build/lib/
 

--- a/.github/workflows/scripts/linux_arm64/rh8/build_catalyst.sh
+++ b/.github/workflows/scripts/linux_arm64/rh8/build_catalyst.sh
@@ -51,7 +51,7 @@ cmake -S runtime -B runtime-build -G Ninja \
     -DENABLE_OPENQASM=ON \
     -DENABLE_OPENMP=OFF \
     -DLQ_ENABLE_KERNEL_OMP=OFF
-cmake --build runtime-build --target rt_capi rtd_lightning rtd_openqasm rtd_null_qubit
+cmake --build runtime-build --target rt_capi rtd_lightning rtd_openqasm rtd_null_qubit catalyst_python_interpreter
 
 # Build OQC
 export OQC_BUILD_DIR="/catalyst/oqc-build"
@@ -79,7 +79,7 @@ cmake --build quantum-build --target check-dialects compiler_driver catalyst-cli
 
 # Copy files needed for the wheel where they are expected
 cp /catalyst/runtime-build/lib/*/*/*/*/librtd* /catalyst/runtime-build/lib
-cp /catalyst/runtime-build/lib/libcatalyst_python_interpreter.* /catalyst/runtime-build/lib
+find . -name libcatalyst_python_interpreter.* -exec cp /catalyst/runtime-build/lib {} \;
 cp /catalyst/runtime-build/lib/registry/runtime-build/lib/catalyst_callback_registry.cpython-${PYTHON_ALTERNATIVE_VERSION}-aarch64-linux-gnu.so /catalyst/runtime-build/lib
 cp /catalyst/runtime-build/lib/capi/runtime-build/lib/librt_capi.so /catalyst/runtime-build/lib/
 

--- a/.github/workflows/scripts/linux_arm64/rh8/build_catalyst.sh
+++ b/.github/workflows/scripts/linux_arm64/rh8/build_catalyst.sh
@@ -79,7 +79,7 @@ cmake --build quantum-build --target check-dialects compiler_driver catalyst-cli
 
 # Copy files needed for the wheel where they are expected
 cp /catalyst/runtime-build/lib/*/*/*/*/librtd* /catalyst/runtime-build/lib
-find . -name libcatalyst_python_interpreter.* -exec cp /catalyst/runtime-build/lib {} \;
+find . -name 'libcatalyst_python_interpreter.*' -exec cp /catalyst/runtime-build/lib {} \;
 cp /catalyst/runtime-build/lib/registry/runtime-build/lib/catalyst_callback_registry.cpython-${PYTHON_ALTERNATIVE_VERSION}-aarch64-linux-gnu.so /catalyst/runtime-build/lib
 cp /catalyst/runtime-build/lib/capi/runtime-build/lib/librt_capi.so /catalyst/runtime-build/lib/
 

--- a/.github/workflows/scripts/linux_arm64/rh8/build_catalyst.sh
+++ b/.github/workflows/scripts/linux_arm64/rh8/build_catalyst.sh
@@ -79,6 +79,7 @@ cmake --build quantum-build --target check-dialects compiler_driver catalyst-cli
 
 # Copy files needed for the wheel where they are expected
 cp /catalyst/runtime-build/lib/*/*/*/*/librtd* /catalyst/runtime-build/lib
+cp /catalyst/runtime-build/lib/libcatalyst_python_interpreter.* /catalyst/runtime-build/lib
 cp /catalyst/runtime-build/lib/registry/runtime-build/lib/catalyst_callback_registry.cpython-${PYTHON_ALTERNATIVE_VERSION}-aarch64-linux-gnu.so /catalyst/runtime-build/lib
 cp /catalyst/runtime-build/lib/capi/runtime-build/lib/librt_capi.so /catalyst/runtime-build/lib/
 

--- a/Makefile
+++ b/Makefile
@@ -170,6 +170,7 @@ wheel:
 	# Copy libs to frontend/catalyst/lib
 	mkdir -p $(MK_DIR)/frontend/catalyst/lib/backend
 	cp $(RT_BUILD_DIR)/lib/librtd* $(MK_DIR)/frontend/catalyst/lib
+	cp $(RT_BUILD_DIR)/lib/libcatalyst_python_interpreter.* $(MK_DIR)/frontend/catalyst/lib
 	cp $(RT_BUILD_DIR)/lib/catalyst_callback_registry*.* $(MK_DIR)/frontend/catalyst/lib
 	cp $(RT_BUILD_DIR)/lib/librt_capi.* $(MK_DIR)/frontend/catalyst/lib
 	cp $(RT_BUILD_DIR)/lib/backend/*.toml $(MK_DIR)/frontend/catalyst/lib/backend

--- a/frontend/catalyst/third_party/oqc/src/CMakeLists.txt
+++ b/frontend/catalyst/third_party/oqc/src/CMakeLists.txt
@@ -55,9 +55,18 @@ set(OQC_LIBRARIES
     catalyst_python_interpreter
 )
 
-set_target_properties(rtd_oqc PROPERTIES BUILD_RPATH "$ORIGIN/../utils")
 target_link_directories(rtd_oqc PRIVATE ${runtime_lib})
 target_link_libraries(rtd_oqc PRIVATE pybind11::module catalyst_python_interpreter)
+set_target_properties(rtd_oqc PROPERTIES BUILD_RPATH "$ORIGIN/../utils")
+
+# TODO: learn more cmake for this
+#add_dependencies(rtd_oqc catalyst_python_interpreter)
+#set_property(TARGET rtd_oqc APPEND PROPERTY BUILD_RPATH "$<TARGET_FILE_DIR:catalyst_python_interpreter>")
+if(NOT APPLE)
+    set_property(TARGET rtd_oqc APPEND PROPERTY BUILD_RPATH $ORIGIN)
+else()
+    set_property(TARGET rtd_oqc APPEND PROPERTY BUILD_RPATH @loader_path)
+endif()
 
 if(USE_ALTERNATIVE_CATALYST_PYTHON_INTERPRETER_PATH)
  target_link_directories(rtd_oqc PRIVATE  ${catalyst_python_interpreter_path})

--- a/runtime/lib/backend/openqasm/CMakeLists.txt
+++ b/runtime/lib/backend/openqasm/CMakeLists.txt
@@ -26,5 +26,11 @@ target_include_directories(rtd_openqasm PRIVATE .
     )
 
 target_link_libraries(rtd_openqasm pybind11::module catalyst_python_interpreter)
+set_property(TARGET rt_openqasm APPEND PROPERTY BUILD_RPATH "$<TARGET_FILE_DIR:catalyst_python_interpreter>")
+if(NOT APPLE)
+    set_property(TARGET rt_openqasm APPEND PROPERTY BUILD_RPATH $ORIGIN)
+else()
+    set_property(TARGET rt_openqasm APPEND PROPERTY BUILD_RPATH @loader_path)
+endif()
 
 set_property(TARGET rtd_openqasm PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/runtime/lib/backend/openqasm/CMakeLists.txt
+++ b/runtime/lib/backend/openqasm/CMakeLists.txt
@@ -26,11 +26,11 @@ target_include_directories(rtd_openqasm PRIVATE .
     )
 
 target_link_libraries(rtd_openqasm pybind11::module catalyst_python_interpreter)
-set_property(TARGET rt_openqasm APPEND PROPERTY BUILD_RPATH "$<TARGET_FILE_DIR:catalyst_python_interpreter>")
+set_property(TARGET rtd_openqasm APPEND PROPERTY BUILD_RPATH "$<TARGET_FILE_DIR:catalyst_python_interpreter>")
 if(NOT APPLE)
-    set_property(TARGET rt_openqasm APPEND PROPERTY BUILD_RPATH $ORIGIN)
+    set_property(TARGET rtd_openqasm APPEND PROPERTY BUILD_RPATH $ORIGIN)
 else()
-    set_property(TARGET rt_openqasm APPEND PROPERTY BUILD_RPATH @loader_path)
+    set_property(TARGET rtd_openqasm APPEND PROPERTY BUILD_RPATH @loader_path)
 endif()
 
 set_property(TARGET rtd_openqasm PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/runtime/lib/capi/CMakeLists.txt
+++ b/runtime/lib/capi/CMakeLists.txt
@@ -45,7 +45,13 @@ set_property(TARGET catalyst_qir_qis_obj PROPERTY POSITION_INDEPENDENT_CODE ON)
 add_library(rt_capi SHARED)
 
 target_link_libraries(rt_capi ${CMAKE_DL_LIBS} catalyst_qir_qis_obj)
-add_dependencies(rt_capi catalyst_callback_registry)
+add_dependencies(rt_capi catalyst_callback_registry catalyst_python_interpreter)
+set_property(TARGET rt_capi APPEND PROPERTY BUILD_RPATH "$<TARGET_FILE_DIR:catalyst_python_interpreter>")
+if(NOT APPLE)
+    set_property(TARGET rt_capi APPEND PROPERTY BUILD_RPATH $ORIGIN)
+else()
+    set_property(TARGET rt_capi APPEND PROPERTY BUILD_RPATH @loader_path)
+endif()
 
 
 target_include_directories(rt_capi PUBLIC .


### PR DESCRIPTION
**Context:** The library `libcatalyst_python_interpreter.py`'s only purpose is to have a mutex for threads to share the python interpreter. This library is not explicitly shipped by Catalyst but it is implicitly included in Catalyst by `auditwheel repair` and `delocate wheel` in Linux and macOS respectively.

**Description of the Change:** This change fixes the rpath and includes the library explicitly to avoid relying on these processes.

**Benefits:** The build script is more explicit.

Note that this does not yet fixes the makefile to have something like `make wheel && python -m pip install dist/PennyLane_Catalyst-0.10.0.dev0-cp311-cp311-linux_x86_64.whl`

[sc-77254]
