### PR TITLE
Add `**kwargs` to pipeline `_decorator` call signature

### DIFF
--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -131,7 +131,7 @@ def pipeline(pass_pipeline: Optional[dict[str, dict[str, str]]] = None):
     will always take precedence over global pass pipelines.
     """
 
-    def _decorator(fn=None):
+    def _decorator(fn=None, **kwargs):
         if fn is None:
             return functools.partial(pipeline, **kwargs)
 


### PR DESCRIPTION
**Context:** The `main` and `v0.9.0-rc` branches became out of sync: `main` currently has a `**kwargs` argument in the pipeline `_decorator` call signature, but `v0.9.0-rc` does not. The function argument is needed because it's referenced in the function body:

```python
def _decorator(fn=None):  # <- **kwargs should be in the call signature
    if fn is None:
        return functools.partial(pipeline, **kwargs)
    ...
```

Note that we don't have good testing coverage for this particular branch of the code since all tests pass with or without the `**kwargs` argument in the call signature. However, we should add it in for the sake of internal consistency.

**Description of the Change:** Add `**kwargs` to pipeline `_decorator` call signature