### PR TITLE
Fix failing string `repr` tests

### DIFF
--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -999,11 +999,11 @@ class TestMiscMethods:
 
     def test_repr(self):
         """Test __repr__ method."""
-        assert repr(adjoint(qml.S(0))) == "Adjoint(S(wires=[0]))"
+        assert repr(adjoint(qml.S(0))) == "Adjoint(S(0))"
 
         base = qml.S(0) + qml.T(0)
         op = adjoint(base)
-        assert repr(op) == "Adjoint(S(wires=[0]) + T(wires=[0]))"
+        assert repr(op) == "Adjoint(S(0) + T(0))"
 
     def test_label(self):
         """Test that the label method for the adjoint class adds a † to the end."""

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -840,16 +840,16 @@ class TestControlledMiscMethods:
 
     def test_repr(self):
         """Test __repr__ method."""
-        assert repr(C_ctrl(qml.S(0), [1])) == "Controlled(S(wires=[0]), control_wires=[1])"
+        assert repr(C_ctrl(qml.S(0), [1])) == "Controlled(S(0), control_wires=[1])"
 
         base = qml.S(0) + qml.T(1)
         op = C_ctrl(base, [2])
-        assert repr(op) == "Controlled(S(wires=[0]) + T(wires=[1]), control_wires=[2])"
+        assert repr(op) == "Controlled(S(0) + T(1), control_wires=[2])"
 
         op = C_ctrl(base, [2, 3], control_values=[True, False], work_wires=[4])
         assert (
             repr(op)
-            == "Controlled(S(wires=[0]) + T(wires=[1]), control_wires=[2, 3], work_wires=[4],"
+            == "Controlled(S(0) + T(1), control_wires=[2, 3], work_wires=[4],"
             " control_values=[True, False])"
         )
 


### PR DESCRIPTION
**Context:** Core PennyLane changed the string representation for some operators: https://github.com/PennyLaneAI/pennylane/pull/6493. For example `"Adjoint(S(wires=[0]) + T(wires=[0]))"` -> `"Adjoint(S(0) + T(0))"`. Catalyst contains a few tests that check these string representations, so these tests need to be updated.

**Description of the Change:** Update string representations for all failing tests.