### PR TITLE
Update merge rotation pass `--help` message

### DIFF
--- a/mlir/include/Quantum/Transforms/Passes.td
+++ b/mlir/include/Quantum/Transforms/Passes.td
@@ -111,7 +111,7 @@ def RemoveChainedSelfInversePass : Pass<"remove-chained-self-inverse"> {
 }
 
 def MergeRotationsPass : Pass<"merge-rotations"> {
-    let summary = "merge rotation boilerplate words";
+    let summary = "Perform merging of chained rotation gates about the same axis.";
 
     let constructor = "catalyst::createMergeRotationsPass()";
     let options = QuantumCircuitTransformationPass.options;


### PR DESCRIPTION
**Context:**
The merge rotation pass's `--help` message was left at its boilerplate state.

**Description of the Change:**
Update merge rotation pass `--help` message.

**Benefits:**
Sensible message in `--help`.