### PR TITLE
Add [[maybe_unused]] for maybe unused arguments to some runtime baseclass methods

### DIFF
--- a/runtime/include/QuantumDevice.hpp
+++ b/runtime/include/QuantumDevice.hpp
@@ -165,7 +165,8 @@ struct QuantumDevice {
      * @param state A state vector of size 2**len(wires)
      * @param wires The wire(s) the operation acts on
      */
-    virtual void SetState(DataView<std::complex<double>, 1> &state, std::vector<QubitIdType> &wires)
+    virtual void SetState([[maybe_unused]] DataView<std::complex<double>, 1> &state,
+                          [[maybe_unused]] std::vector<QubitIdType> &wires)
     {
         RT_FAIL("Unsupported functionality");
     }
@@ -176,7 +177,8 @@ struct QuantumDevice {
      * @param n Prepares the basis state |n>, where n is an array of integers from the set {0, 1}
      * @param wires The wire(s) the operation acts on
      */
-    virtual void SetBasisState(DataView<int8_t, 1> &n, std::vector<QubitIdType> &wires)
+    virtual void SetBasisState([[maybe_unused]] DataView<int8_t, 1> &n,
+                               [[maybe_unused]] std::vector<QubitIdType> &wires)
     {
         RT_FAIL("Unsupported functionality");
     }


### PR DESCRIPTION
**Context:**
The methods `QuantumDevice::SetState` and `QuantumDevice::SetBasisState` in runtime take in some arguments, but because not all devices support setting quantum states, the base implementation does nothing and does not use the arguments. This causes clang-tidy to warn unused-arguments.

**Description of the Change:**
We add [[maybe-unused]] to these arguments.

**Benefits:**
clang-tidy passes

