### PR TITLE
Update macos-12 runners to macos-13

### DIFF
--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -71,7 +71,7 @@ jobs:
     - name: Prepare wheels
       run: |
         rename "s/linux/manylinux_2_28/" dist/PennyLane_Catalyst-*
-        rename "s/macosx_12_0_universal2/macosx_12_0_x86_64/" dist/PennyLane_Catalyst-*
+        rename "s/macosx_13_0_universal2/macosx_13_0_x86_64/" dist/PennyLane_Catalyst-*
         rename "s/macosx_14_0_universal2/macosx_13_0_arm64/" dist/PennyLane_Catalyst-*
         rename "s/macosx_14/macosx_13/" dist/PennyLane_Catalyst-*
 

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -14,7 +14,7 @@ on:
   workflow_call:
 
 env:
-  MACOSX_DEPLOYMENT_TARGET: 12
+  MACOSX_DEPLOYMENT_TARGET: 13
 
 concurrency:
   group: Build Catalyst Wheel on macOS (x86_64)-${{ github.ref }}
@@ -40,7 +40,7 @@ jobs:
         python_version: ["3.10"]
 
     name: Build Dependencies (Python ${{ matrix.python_version }})
-    runs-on: macos-12
+    runs-on: macos-13
 
     if: needs.check_if_wheel_build_required.outputs.build-wheels == 'true'
 
@@ -217,7 +217,7 @@ jobs:
         python_version: ${{ fromJson(needs.constants.outputs.python_versions) }}
 
     name: Build Wheels (Python ${{ matrix.python_version }})
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
     - name: Checkout Catalyst repo
@@ -368,7 +368,7 @@ jobs:
 
     # To check all wheels for supported python3 versions
     name: Test Wheels (Python ${{ matrix.python_version }}) on Mac x86
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
     - name: Checkout Catalyst repo


### PR DESCRIPTION
**Context:** GitHub is deprecating macos-12 runners: https://github.com/actions/runner-images/issues/10721. They are initiating "brownouts" where certain actions on macos-12 runners will fail. We therefore need to update the runners to use macos-13.