### PR TITLE
Remove "experimental" when referring to Catalyst

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <img src="./doc/_static/catalyst-dark.png#gh-dark-mode-only" width="700px" onerror="this.style.display='none'" alt=""/>
 </p>
 
-Catalyst is an experimental package that enables just-in-time (JIT) compilation of hybrid
+Catalyst is a package that enables just-in-time (JIT) compilation of hybrid
 quantum-classical programs.
 
 **Catalyst is currently under heavy development — if you have suggestions on the API or use-cases

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,4 +1,4 @@
-:og:description: Catalyst is an experimental package that enables just-in-time (JIT) compilation of PennyLane programs. Compile the entire quantum-classical workflow.
+:og:description: Catalyst is a package that enables just-in-time (JIT) compilation of PennyLane programs. Compile the entire quantum-classical workflow.
 
 Catalyst
 ########
@@ -25,7 +25,7 @@ Catalyst
 
     <div class="container mt-2 mb-2">
         <p class="lead grey-text">
-            Catalyst is an experimental package that enables just-in-time (JIT)
+            Catalyst is a package that enables just-in-time (JIT)
             compilation of PennyLane programs. Compile the entire quantum-classical workflow.
         </p>
         <img src="_static/catalyst.png" style="max-width: 700px; width: 100%;">


### PR DESCRIPTION
**Context:** Catalyst is no longer "experimental"!

**Description of the Change:** Remove applicable occurrences of "experimental" 

**Benefits:** clarity

**Possible Drawbacks:** zilch 

**Related GitHub Issues:** --
