### PR TITLE
Remove qml.(C)Rot from the list of merged rotations in documentation

### DIFF
--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -329,8 +329,6 @@ def merge_rotations(fn=None):
     :class:`qml.CRZ <pennylane.CRZ>`,
     :class:`qml.PhaseShift <pennylane.PhaseShift>`,
     :class:`qml.ControlledPhaseShift <pennylane.ControlledPhaseShift>`,
-    :class:`qml.Rot <pennylane.Rot>`,
-    :class:`qml.CRot <pennylane.CRot>`,
     :class:`qml.MultiRZ <pennylane.MultiRZ>`.
 
 


### PR DESCRIPTION
**Context:**
qml.Rot and qml.CRot are removed from merge rotation patterns #1206 but the frontend documentation for the python decorator still has them.

**Description of the Change:**
Remove qml.(C)Rot from the list of merged rotations in documentation

**Benefits:**
Correct documentation


