### PR TITLE
Remove references to `QubitStateVector` class

### DIFF
--- a/doc/dev/custom_devices.rst
+++ b/doc/dev/custom_devices.rst
@@ -258,7 +258,6 @@ headers and fields are generally required, unless stated otherwise.
         SQISW = {}
         CPhase = {}
         BasisState = {}
-        QubitStateVector = {}
         StatePrep = {}
         ControlledQubitUnitary = {}
         MultiControlledX = {}

--- a/frontend/test/pytest/test_custom_devices.py
+++ b/frontend/test/pytest/test_custom_devices.py
@@ -60,7 +60,6 @@ OPERATIONS = [
     "SISWAP",
     "SQISW",
     "BasisState",
-    "QubitStateVector",
     "StatePrep",
     "ControlledQubitUnitary",
     "DiagonalQubitUnitary",

--- a/runtime/lib/backend/dummy/dummy_device.toml
+++ b/runtime/lib/backend/dummy/dummy_device.toml
@@ -53,7 +53,6 @@ PSWAP = {}
 SISWAP = {}
 SQISW = {}
 BasisState = {}
-QubitStateVector = {}
 StatePrep = {}
 ControlledQubitUnitary = {}
 MultiControlledX = {}


### PR DESCRIPTION
**Context:**

Completing the deprecation cycle of `QubitStateVector` in Pennylane.

**Description of the Change:**

Removed all references to `QubitStateVector`.

[sc-77482]