### PR TITLE
Version bump to 0.10.0-dev0

### DIFF
--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.10.0-dev"
+__version__ = "0.10.0-dev0"


### PR DESCRIPTION
**Context:** The nightly build script needs an integer after the dev suffix.

**Description of the Change:** Bump 0.10.0-dev to 0.10.0-dev0

**Benefits:** Fixes nightly build script.