### PR TITLE
delete BasisStatePrepartion in test_template

### DIFF
--- a/frontend/test/pytest/test_template.py
+++ b/frontend/test/pytest/test_template.py
@@ -162,7 +162,7 @@ def test_basis_state_preparation(backend):
     """Test basis state preparation."""
 
     def basis_state_preparation(basis_state):
-        qml.BasisStatePreparation(basis_state, wires=range(4))
+        qml.BasisState(basis_state, wires=range(4))
         return [qml.expval(qml.PauliZ(wires=i)) for i in range(4)]
 
     device = qml.device(backend, wires=4)

--- a/frontend/test/pytest/test_template.py
+++ b/frontend/test/pytest/test_template.py
@@ -157,21 +157,6 @@ def test_basic_entangler_layers(backend):
     assert np.allclose(interpreted_fn(params), jitted_fn(params))
 
 
-@pytest.mark.filterwarnings("ignore::pennylane.PennyLaneDeprecationWarning")
-def test_basis_state_preparation(backend):
-    """Test basis state preparation."""
-
-    def basis_state_preparation(basis_state):
-        qml.BasisState(basis_state, wires=range(4))
-        return [qml.expval(qml.PauliZ(wires=i)) for i in range(4)]
-
-    device = qml.device(backend, wires=4)
-    params = jnp.array([0, 1, 1, 0.0])
-    interpreted_fn = qml.QNode(basis_state_preparation, device)
-    jitted_fn = qjit(interpreted_fn)
-    assert np.allclose(interpreted_fn(params), jitted_fn(params))
-
-
 def test_mottonen_state_preparation(backend):
     """Test mottonen state preparation."""
 


### PR DESCRIPTION
**Context:**
In PL0.40 removals, the `qml.BasisStatePreparation` will be removed and instead we should use `qml.BasisState`
**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-77480]