### PR TITLE
[Tests] Improve stack-trace pattern-matching

### DIFF
--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -304,16 +304,18 @@ class TestCompilerState:
             )
             compiled.compile()
 
+        stack_trace_pattern = "diagnostic emitted with trace"
+
         assert "Failed to lower MLIR module" in e.value.args[0]
         assert "While processing 'TestPass' pass " in e.value.args[0]
-        assert "Trace" not in e.value.args[0]
+        assert stack_trace_pattern not in e.value.args[0]
         assert isfile(os.path.join(str(compiled.workspace), "2_TestPass_FAILED.mlir"))
         compiled.workspace.cleanup()
 
         with pytest.raises(CompileError) as e:
             qjit(circuit, pipelines=test_pipelines, verbose=True)()
 
-        assert "Trace" in e.value.args[0]
+        assert stack_trace_pattern in e.value.args[0]
 
 
 class TestCustomCall:


### PR DESCRIPTION
**Context:** I had observed when working on the pybind11 -> nanobind conversions in the MLIR python binding (#1187) that the `test_pipeline_error` test fails on some platforms because it asserts that the string `"Trace"` (with a capital "T") is in the error message, but it is not, even though the stack trace was printed. Normally, it would match the string `"Trace"` in the first line of the stack trace, which contains `"llvm::sys::PrintStackTrace"`. For whatever reason, this line is not always printed out. We can make this test more robust by matching a string not contained within the stack trace itself, but one immediately preceding it, which should always be part of the error message. I've chosen `"diagnostic emitted with trace"` for this purpose (but I'm happy to take other suggestions).

**Description of the Change:** Change test from

```python
assert "Trace" in e.value.args[0]
```

to

```python
assert "diagnostic emitted with trace" in e.value.args[0]
```

and similarly when asserting that there is **no** stack trace in the error message.

**Benefits:** More robust test; unblocks #1187.