### PR TITLE
Fix tracing of nested Adjoint/Controlled instances

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -61,11 +61,15 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fix bug introduced in 0.8 that breaks nested invocations of `qml.adjoint` and `qml.ctrl`.
+  [(#1301)](https://github.com/PennyLaneAI/catalyst/issues/1301)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
 
 Joey Carter,
+David Ittah,
 Erick Ochoa Lopez,
 Mehrdad Malekmohammadi,
 William Maxwell

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -644,9 +644,17 @@ def trace_quantum_operations(
         # For named-controlled operations (e.g. CNOT, CY, CZ) - bind directly by name. For
         # Controlled(OP) bind OP with native quantum control syntax, and similarly for Adjoint(OP).
         if type(op) in (Controlled, ControlledOp):
-            return bind_native_operation(qrp, op.base, op.control_wires, op.control_values, adjoint)
+            return bind_native_operation(
+                qrp,
+                op.base,
+                controlled_wires + op.control_wires,
+                controlled_values + op.control_values,
+                adjoint,
+            )
         elif isinstance(op, Adjoint):
-            return bind_native_operation(qrp, op.base, controlled_wires, controlled_values, True)
+            return bind_native_operation(
+                qrp, op.base, controlled_wires, controlled_values, not adjoint
+            )
         elif isinstance(op, QubitUnitary):
             qubits = qrp.extract(op.wires)
             controlled_qubits = qrp.extract(controlled_wires)

--- a/frontend/test/lit/test_meta_ops.py
+++ b/frontend/test/lit/test_meta_ops.py
@@ -1,0 +1,46 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# RUN: %PYTHON %s | FileCheck %s
+
+import pennylane as qml
+
+from catalyst import qjit
+
+
+# CHECK-LABEL: @adjoint_adjoint
+@qjit(target="mlir")
+@qml.qnode(qml.device("lightning.qubit", wires=1))
+def adjoint_adjoint():
+    qml.adjoint(qml.adjoint(qml.S(0)))
+    return qml.probs()
+
+
+# CHECK:   quantum.custom "S"() %{{[^\s]+}} : !quantum.bit
+print(adjoint_adjoint.mlir)
+
+
+# -----
+
+
+# CHECK-LABEL: @adjoint_ctrl_adjoint
+@qjit(target="mlir")
+@qml.qnode(qml.device("lightning.qubit", wires=2))
+def adjoint_ctrl_adjoint():
+    qml.adjoint(qml.ctrl(qml.adjoint(qml.S(0)), control=1))
+    return qml.probs()
+
+
+# CHECK:   quantum.custom "S"() %{{[^\s]+}} ctrls(%{{[^\s]+}}) ctrlvals(%{{[^\s]+}}) : !quantum.bit
+print(adjoint_ctrl_adjoint.mlir)


### PR DESCRIPTION
Currently, Catalyst is not capturing the following correctly:
```py
>>> qml.adjoint(qml.adjoint(qml.Gate(0)))
Adjoint(Adjoint(Gate(0)))
```
although the following does work:
```py
>>> qml.adjoint(qml.adjoint(qml.Gate))(0)
HybridAdjoint(tapes=[[Adjoint(Gate(0))]])
```

The conversion from PennyLane operators to JAX primitives was not build with nesting in mind for `Adjoint`/`Controlled`, and instead relied on decomposing `Adjoint(Adjoint(Gate))`. In version 0.9, the acceptance criteria for decomposition was changed without accounting for the above.

The second example works because `HybridAdjoint` operators (used for generic callables that are not operators or operator constructors) are lowered as-is and can thus be arbitrarily nested.

Fixes #1301
[sc-78276]