### PR TITLE
Remove reference to examples folder when doing 'make clean'

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -46,18 +46,17 @@
   Python's stable ABI, which pybind11 does not support.
   [(#1187)](https://github.com/PennyLaneAI/catalyst/pull/1187)
 
+* Remove Lightning Qubit Dynamic plugin from Catalyst.
+  [(#1227)](https://github.com/PennyLaneAI/catalyst/pull/1227)
+  [(#1307)](https://github.com/PennyLaneAI/catalyst/pull/1307)
+  [(#1312)](https://github.com/PennyLaneAI/catalyst/pull/1312)
+
 <h3>Documentation 📝</h3>
 
 * A new tutorial going through how to write a new MLIR pass is available. The tutorial writes an empty pass that prints hello world. The code of the tutorial is at [a separate github branch](https://github.com/PennyLaneAI/catalyst/commit/ba7b3438667963b307c07440acd6d7082f1960f3).
   [(#872)](https://github.com/PennyLaneAI/catalyst/pull/872)
 
 <h3>Bug fixes 🐛</h3>
-
-<h3>Internal changes</h3>
-
-* Remove Lightning Qubit Dynamic plugin from Catalyst.
-  [(#1227)](https://github.com/PennyLaneAI/catalyst/pull/1227)
-  [(#1307)](https://github.com/PennyLaneAI/catalyst/pull/1307)
 
 <h3>Contributors ✍️</h3>
 

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -86,7 +86,6 @@ coverage: capi_target $(RT_BUILD_DIR)/tests/runner_tests_all_targets
 clean:
 	@echo "clean build files"
 	rm -rf $(RT_BUILD_DIR) cov coverage.info $(MK_DIR)/BuildTidy
-	$(MAKE) -C examples clean
 
 .PHONY: format
 format:


### PR DESCRIPTION
**Context:** The examples folder was removed together with the LQ plugin but `make clean` still refers to it.

**Description of the Change:** Remove reference.

**NOTE:** It also unifies the duplicated section "Internal changes" in the change log.