### PR TITLE
Add back missing scipy dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ requirements = [
     f"jaxlib=={jax_version}",
     "tomlkit; python_version < '3.11'",
     "numpy!=2.0.0",
+    "scipy",
     "diastatic-malt>=2.15.2",
 ]
 


### PR DESCRIPTION
Accidentally removed it entirely instead of just removing the pin.
