### PR TITLE
[Frontend] Only read from disk if necessary

### DIFF
--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -453,9 +453,7 @@ class Compiler:
         if self.options.verbose:
             print(f"[LIB] Running compiler driver in {workspace}", file=self.options.logfile)
 
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".mlir", dir=str(workspace), delete=False
-        ) as tmp_infile:
+        with open(str(workspace) + "/input.test", "w") as tmp_infile:
             tmp_infile_name = tmp_infile.name
             tmp_infile.write(ir)
 
@@ -477,9 +475,6 @@ class Compiler:
                 f"catalyst-cli failed with error code {e.returncode}: {e.stderr}"
             ) from e
 
-        with open(output_ir_name, "r", encoding="utf-8") as f:
-            out_IR = f.read()
-
         if lower_to_llvm:
             output = LinkerDriver.run(output_object_name, options=self.options)
             output_object_name = str(pathlib.Path(output).absolute())
@@ -487,10 +482,8 @@ class Compiler:
         # Clean up temporary files
         if os.path.exists(tmp_infile_name):
             os.remove(tmp_infile_name)
-        if os.path.exists(output_ir_name):
-            os.remove(output_ir_name)
 
-        return output_object_name, out_IR
+        return output_object_name, output_ir_name
 
     @debug_logger
     def run(self, mlir_module, *args, **kwargs):

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -270,6 +270,7 @@ class TestCompilerState:
             qml.PauliX(wires=0)
             return qml.state()
 
+        workflow.mlir
         directory = os.path.join(os.getcwd(), workflow.__name__)
         files = os.listdir(directory)
         # The directory is non-empty. Should at least contain the original .mlir file

--- a/frontend/test/pytest/test_debug.py
+++ b/frontend/test/pytest/test_debug.py
@@ -423,12 +423,7 @@ class TestCProgramGeneration:
 
         f(2.0)
 
-        with pytest.raises(
-            CompileError,
-            match="Attempting to get output for pipeline: mlir, "
-            "but no file was found.\nAre you sure the file exists?",
-        ):
-            get_compilation_stage(f, "mlir")
+        get_compilation_stage(f, "mlir")
 
     @pytest.mark.parametrize(
         "arg",


### PR DESCRIPTION
**Context:** The QIR and MLIR fields in the QJIT object are purely used for either debugging or cosmetic features. As such, their implementation should really be optional and not affect compile time.

**Description of the Change:** This commit introduces the change that the fields QIR and MLIR are computed lazily to avoid reading their contents from disk. Instead of unconditionally reading them from disk, just read them from disk if the user really wants them.

**Benefits:** Not yet benchmarked, but ideally it should reduce compilation time.

**Possible Drawbacks:** The size of LLVM-IR is not measured through instrumentation in the current state of this PR. 

**Related GitHub Issues:**

[sc-78851]