### PR TITLE
Fix lapack symbol discovery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ requirements = [
     f"jaxlib=={jax_version}",
     "tomlkit; python_version < '3.11'",
     "numpy!=2.0.0",
-    "scipy",
+    "scipy<1.14",
     "diastatic-malt>=2.15.2",
 ]
 


### PR DESCRIPTION
On macOS, numpy and scipy have removed the openblas binary from their wheels in recent releases.

Temporary fix for issue introduced in #1313 / #1314 