### PR TITLE
Source OpenBLAS from dedicated package

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -16,8 +16,8 @@
   its ability to target Python's [stable ABI interface](https://docs.python.org/3/c-api/stable.html)
   starting with Python 3.12.
 
-* Add a MLIR decomposition for the gate set {"T", "S", "Z", "Hadamard", "RZ", "PhaseShift", "CNOT"} to
-  the gate set {RX, RY, MS}. It is useful for trapped ion devices. It can be used thanks to
+* Add a MLIR decomposition for the gate set {"T", "S", "Z", "Hadamard", "RZ", "PhaseShift", "CNOT"}
+  to the gate set {RX, RY, MS}. It is useful for trapped ion devices. It can be used thanks to
   `quantum-opt --ions-decomposition`.
   [(#1226)](https://github.com/PennyLaneAI/catalyst/pull/1226)
 
@@ -44,6 +44,10 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Catalyst no longer depends on or pins the `scipy` package, instead OpenBLAS is sourced directly
+  from `scipy-openblas32`.
+  [(#1322)](https://github.com/PennyLaneAI/catalyst/pull/1322)
+
 * The `QuantumExtension` module (previously implemented with pybind11) has been removed. This module
   was not included in the distributed wheels and has been deprecated to align with our adoption of
   Python's stable ABI, which pybind11 does not support.
@@ -56,7 +60,9 @@
 
 <h3>Documentation 📝</h3>
 
-* A new tutorial going through how to write a new MLIR pass is available. The tutorial writes an empty pass that prints hello world. The code of the tutorial is at [a separate github branch](https://github.com/PennyLaneAI/catalyst/commit/ba7b3438667963b307c07440acd6d7082f1960f3).
+* A new tutorial going through how to write a new MLIR pass is available. The tutorial writes an
+  empty pass that prints hello world. The code of the tutorial is at
+  [a separate github branch](https://github.com/PennyLaneAI/catalyst/commit/ba7b3438667963b307c07440acd6d7082f1960f3).
   [(#872)](https://github.com/PennyLaneAI/catalyst/pull/872)
 
 <h3>Bug fixes 🐛</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -16,7 +16,7 @@
 * Catalyst now uses the new compiler API to compile quantum code from the python frontend.
   Frontend no longer uses pybind11 to connect to the compiler. Instead, it uses subprocess instead.
   [(#1285)](https://github.com/PennyLaneAI/catalyst/pull/1285)
-  
+ 
 * Add a MLIR decomposition for the gate set {"T", "S", "Z", "Hadamard", "RZ", "PhaseShift", "CNOT"}
   to the gate set {RX, RY, MS}. It is useful for trapped ion devices. It can be used thanks to
   `quantum-opt --ions-decomposition`.
@@ -50,7 +50,7 @@
 <h3>Internal changes ⚙️</h3>
 
 * Catalyst no longer depends on or pins the `scipy` package, instead OpenBLAS is sourced directly
-  from `scipy-openblas32`.
+  from [`scipy-openblas32`](https://pypi.org/project/scipy-openblas32/).
   [(#1322)](https://github.com/PennyLaneAI/catalyst/pull/1322)
 
 * The `QuantumExtension` module (previously implemented with pybind11) has been removed. This module

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -116,29 +116,27 @@ class LinkerDriver:
 
         # Discover the LAPACK library provided by scipy & add link against it.
         # Doing this here ensures we will always have the correct library name.
-
+        lib_name = "openblas"
         package_name = "scipy_openblas32"
-        file_path_within_package = "lib"
+        path_within_package = "lib"
         file_extension = ".so" if platform.system() == "Linux" else ".dylib"
 
-        scipy_package = importlib.util.find_spec(package_name)
-        package_directory = path.dirname(scipy_package.origin)
-        scipy_lib_path = path.join(package_directory, file_path_within_package)
+        package_spec = importlib.util.find_spec(package_name)
+        package_directory = path.dirname(package_spec.origin)
+        lapack_lib_path = path.join(package_directory, path_within_package)
 
-        file_prefix = "openblas"
-        search_pattern = path.join(scipy_lib_path, f"lib*{file_prefix}*{file_extension}")
+        search_pattern = path.join(lapack_lib_path, f"lib*{lib_name}*{file_extension}")
         search_result = glob.glob(search_pattern)
         if not search_result:
             raise CompileError(
                 f'Unable to find OpenBLAS library at "{search_pattern}". '
                 "Please ensure that scipy-openblas32 is installed and available via pip."
             )
-        openblas_so_file = search_result[0]
-        openblas_lib_name = path.basename(openblas_so_file)[3 : -len(file_extension)]
 
+        lapack_lib_name = path.basename(search_result[0])[3 : -len(file_extension)]
         lib_path_flags += [
-            f"-Wl,-rpath,{scipy_lib_path}",
-            f"-L{scipy_lib_path}",
+            f"-Wl,-rpath,{lapack_lib_path}",
+            f"-L{lapack_lib_path}",
         ]
 
         system_flags = []
@@ -166,7 +164,7 @@ class LinkerDriver:
             "-lrt_capi",
             "-lpthread",
             "-lmlir_c_runner_utils",  # required for memref.copy
-            f"-l{openblas_lib_name}",  # required for custom_calls lib
+            f"-l{lapack_lib_name}",  # required for custom_calls lib
             "-lcustom_calls",
             "-lmlir_async_runtime",
         ]

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -117,27 +117,21 @@ class LinkerDriver:
         # Discover the LAPACK library provided by scipy & add link against it.
         # Doing this here ensures we will always have the correct library name.
 
-        if platform.system() == "Linux":
-            file_path_within_package = "../scipy.libs/"
-            file_extension = ".so"
-        else:  # pragma: nocover
-            msg = "Attempting to use catalyst on an unsupported system"
-            assert platform.system() == "Darwin", msg
-            file_path_within_package = ".dylibs/"
-            file_extension = ".dylib"
+        package_name = "scipy_openblas32"
+        file_path_within_package = "lib"
+        file_extension = ".so" if platform.system() == "Linux" else ".dylib"
 
-        package_name = "scipy"
         scipy_package = importlib.util.find_spec(package_name)
         package_directory = path.dirname(scipy_package.origin)
         scipy_lib_path = path.join(package_directory, file_path_within_package)
 
-        file_prefix = "libopenblas"
-        search_pattern = path.join(scipy_lib_path, f"{file_prefix}*{file_extension}")
+        file_prefix = "openblas"
+        search_pattern = path.join(scipy_lib_path, f"lib*{file_prefix}*{file_extension}")
         search_result = glob.glob(search_pattern)
         if not search_result:
             raise CompileError(
                 f'Unable to find OpenBLAS library at "{search_pattern}". '
-                "Please ensure that SciPy is installed and available via pip."
+                "Please ensure that scipy-openblas32 is installed and available via pip."
             )
         openblas_so_file = search_result[0]
         openblas_lib_name = path.basename(openblas_so_file)[3 : -len(file_extension)]

--- a/frontend/catalyst/utils/jax_cpu_lapack_kernels/lapack_kernels_using_lapack.cpp
+++ b/frontend/catalyst/utils/jax_cpu_lapack_kernels/lapack_kernels_using_lapack.cpp
@@ -41,120 +41,120 @@
 
 extern "C" {
 
-jax::RealTrsm<float>::FnType cblas_strsm;
-jax::RealTrsm<double>::FnType cblas_dtrsm;
-jax::ComplexTrsm<std::complex<float>>::FnType cblas_ctrsm;
-jax::ComplexTrsm<std::complex<double>>::FnType cblas_ztrsm;
+jax::RealTrsm<float>::FnType scipy_cblas_strsm;
+jax::RealTrsm<double>::FnType scipy_cblas_dtrsm;
+jax::ComplexTrsm<std::complex<float>>::FnType scipy_cblas_ctrsm;
+jax::ComplexTrsm<std::complex<double>>::FnType scipy_cblas_ztrsm;
 
-jax::Getrf<float>::FnType LAPACKE_sgetrf;
-jax::Getrf<double>::FnType LAPACKE_dgetrf;
-jax::Getrf<std::complex<float>>::FnType LAPACKE_cgetrf;
-jax::Getrf<std::complex<double>>::FnType LAPACKE_zgetrf;
+jax::Getrf<float>::FnType scipy_LAPACKE_sgetrf;
+jax::Getrf<double>::FnType scipy_LAPACKE_dgetrf;
+jax::Getrf<std::complex<float>>::FnType scipy_LAPACKE_cgetrf;
+jax::Getrf<std::complex<double>>::FnType scipy_LAPACKE_zgetrf;
 
-jax::Geqrf<float>::FnType LAPACKE_sgeqrf;
-jax::Geqrf<double>::FnType LAPACKE_dgeqrf;
-jax::Geqrf<std::complex<float>>::FnType LAPACKE_cgeqrf;
-jax::Geqrf<std::complex<double>>::FnType LAPACKE_zgeqrf;
+jax::Geqrf<float>::FnType scipy_LAPACKE_sgeqrf;
+jax::Geqrf<double>::FnType scipy_LAPACKE_dgeqrf;
+jax::Geqrf<std::complex<float>>::FnType scipy_LAPACKE_cgeqrf;
+jax::Geqrf<std::complex<double>>::FnType scipy_LAPACKE_zgeqrf;
 
-jax::Orgqr<float>::FnType LAPACKE_sorgqr;
-jax::Orgqr<double>::FnType LAPACKE_dorgqr;
-jax::Orgqr<std::complex<float>>::FnType LAPACKE_cungqr;
-jax::Orgqr<std::complex<double>>::FnType LAPACKE_zungqr;
+jax::Orgqr<float>::FnType scipy_LAPACKE_sorgqr;
+jax::Orgqr<double>::FnType scipy_LAPACKE_dorgqr;
+jax::Orgqr<std::complex<float>>::FnType scipy_LAPACKE_cungqr;
+jax::Orgqr<std::complex<double>>::FnType scipy_LAPACKE_zungqr;
 
-jax::Potrf<float>::FnType LAPACKE_spotrf;
-jax::Potrf<double>::FnType LAPACKE_dpotrf;
-jax::Potrf<std::complex<float>>::FnType LAPACKE_cpotrf;
-jax::Potrf<std::complex<double>>::FnType LAPACKE_zpotrf;
+jax::Potrf<float>::FnType scipy_LAPACKE_spotrf;
+jax::Potrf<double>::FnType scipy_LAPACKE_dpotrf;
+jax::Potrf<std::complex<float>>::FnType scipy_LAPACKE_cpotrf;
+jax::Potrf<std::complex<double>>::FnType scipy_LAPACKE_zpotrf;
 
-jax::RealGesdd<float>::FnType LAPACKE_sgesdd;
-jax::RealGesdd<double>::FnType LAPACKE_dgesdd;
-jax::ComplexGesdd<std::complex<float>>::FnType LAPACKE_cgesdd;
-jax::ComplexGesdd<std::complex<double>>::FnType LAPACKE_zgesdd;
+jax::RealGesdd<float>::FnType scipy_LAPACKE_sgesdd;
+jax::RealGesdd<double>::FnType scipy_LAPACKE_dgesdd;
+jax::ComplexGesdd<std::complex<float>>::FnType scipy_LAPACKE_cgesdd;
+jax::ComplexGesdd<std::complex<double>>::FnType scipy_LAPACKE_zgesdd;
 
-jax::RealSyevd<float>::FnType LAPACKE_ssyevd;
-jax::RealSyevd<double>::FnType LAPACKE_dsyevd;
-jax::ComplexHeevd<std::complex<float>>::FnType LAPACKE_cheevd;
-jax::ComplexHeevd<std::complex<double>>::FnType LAPACKE_zheevd;
+jax::RealSyevd<float>::FnType scipy_LAPACKE_ssyevd;
+jax::RealSyevd<double>::FnType scipy_LAPACKE_dsyevd;
+jax::ComplexHeevd<std::complex<float>>::FnType scipy_LAPACKE_cheevd;
+jax::ComplexHeevd<std::complex<double>>::FnType scipy_LAPACKE_zheevd;
 
-jax::RealGeev<float>::FnType LAPACKE_sgeev;
-jax::RealGeev<double>::FnType LAPACKE_dgeev;
-jax::ComplexGeev<std::complex<float>>::FnType LAPACKE_cgeev;
-jax::ComplexGeev<std::complex<double>>::FnType LAPACKE_zgeev;
+jax::RealGeev<float>::FnType scipy_LAPACKE_sgeev;
+jax::RealGeev<double>::FnType scipy_LAPACKE_dgeev;
+jax::ComplexGeev<std::complex<float>>::FnType scipy_LAPACKE_cgeev;
+jax::ComplexGeev<std::complex<double>>::FnType scipy_LAPACKE_zgeev;
 
-jax::RealGees<float>::FnType LAPACKE_sgees;
-jax::RealGees<double>::FnType LAPACKE_dgees;
-jax::ComplexGees<std::complex<float>>::FnType LAPACKE_cgees;
-jax::ComplexGees<std::complex<double>>::FnType LAPACKE_zgees;
+jax::RealGees<float>::FnType scipy_LAPACKE_sgees;
+jax::RealGees<double>::FnType scipy_LAPACKE_dgees;
+jax::ComplexGees<std::complex<float>>::FnType scipy_LAPACKE_cgees;
+jax::ComplexGees<std::complex<double>>::FnType scipy_LAPACKE_zgees;
 
-jax::Gehrd<float>::FnType LAPACKE_sgehrd;
-jax::Gehrd<double>::FnType LAPACKE_dgehrd;
-jax::Gehrd<std::complex<float>>::FnType LAPACKE_cgehrd;
-jax::Gehrd<std::complex<double>>::FnType LAPACKE_zgehrd;
+jax::Gehrd<float>::FnType scipy_LAPACKE_sgehrd;
+jax::Gehrd<double>::FnType scipy_LAPACKE_dgehrd;
+jax::Gehrd<std::complex<float>>::FnType scipy_LAPACKE_cgehrd;
+jax::Gehrd<std::complex<double>>::FnType scipy_LAPACKE_zgehrd;
 
-jax::Sytrd<float>::FnType LAPACKE_ssytrd;
-jax::Sytrd<double>::FnType LAPACKE_dsytrd;
-jax::Sytrd<std::complex<float>>::FnType LAPACKE_chetrd;
-jax::Sytrd<std::complex<double>>::FnType LAPACKE_zhetrd;
+jax::Sytrd<float>::FnType scipy_LAPACKE_ssytrd;
+jax::Sytrd<double>::FnType scipy_LAPACKE_dsytrd;
+jax::Sytrd<std::complex<float>>::FnType scipy_LAPACKE_chetrd;
+jax::Sytrd<std::complex<double>>::FnType scipy_LAPACKE_zhetrd;
 
 } // extern "C"
 
 namespace jax {
 
 static auto init = []() -> int {
-    RealTrsm<float>::fn = cblas_strsm;
-    RealTrsm<double>::fn = cblas_dtrsm;
-    ComplexTrsm<std::complex<float>>::fn = cblas_ctrsm;
-    ComplexTrsm<std::complex<double>>::fn = cblas_ztrsm;
+    RealTrsm<float>::fn = scipy_cblas_strsm;
+    RealTrsm<double>::fn = scipy_cblas_dtrsm;
+    ComplexTrsm<std::complex<float>>::fn = scipy_cblas_ctrsm;
+    ComplexTrsm<std::complex<double>>::fn = scipy_cblas_ztrsm;
 
-    Getrf<float>::fn = LAPACKE_sgetrf;
-    Getrf<double>::fn = LAPACKE_dgetrf;
-    Getrf<std::complex<float>>::fn = LAPACKE_cgetrf;
-    Getrf<std::complex<double>>::fn = LAPACKE_zgetrf;
+    Getrf<float>::fn = scipy_LAPACKE_sgetrf;
+    Getrf<double>::fn = scipy_LAPACKE_dgetrf;
+    Getrf<std::complex<float>>::fn = scipy_LAPACKE_cgetrf;
+    Getrf<std::complex<double>>::fn = scipy_LAPACKE_zgetrf;
 
-    Geqrf<float>::fn = LAPACKE_sgeqrf;
-    Geqrf<double>::fn = LAPACKE_dgeqrf;
-    Geqrf<std::complex<float>>::fn = LAPACKE_cgeqrf;
-    Geqrf<std::complex<double>>::fn = LAPACKE_zgeqrf;
+    Geqrf<float>::fn = scipy_LAPACKE_sgeqrf;
+    Geqrf<double>::fn = scipy_LAPACKE_dgeqrf;
+    Geqrf<std::complex<float>>::fn = scipy_LAPACKE_cgeqrf;
+    Geqrf<std::complex<double>>::fn = scipy_LAPACKE_zgeqrf;
 
-    Orgqr<float>::fn = LAPACKE_sorgqr;
-    Orgqr<double>::fn = LAPACKE_dorgqr;
-    Orgqr<std::complex<float>>::fn = LAPACKE_cungqr;
-    Orgqr<std::complex<double>>::fn = LAPACKE_zungqr;
+    Orgqr<float>::fn = scipy_LAPACKE_sorgqr;
+    Orgqr<double>::fn = scipy_LAPACKE_dorgqr;
+    Orgqr<std::complex<float>>::fn = scipy_LAPACKE_cungqr;
+    Orgqr<std::complex<double>>::fn = scipy_LAPACKE_zungqr;
 
-    Potrf<float>::fn = LAPACKE_spotrf;
-    Potrf<double>::fn = LAPACKE_dpotrf;
-    Potrf<std::complex<float>>::fn = LAPACKE_cpotrf;
-    Potrf<std::complex<double>>::fn = LAPACKE_zpotrf;
+    Potrf<float>::fn = scipy_LAPACKE_spotrf;
+    Potrf<double>::fn = scipy_LAPACKE_dpotrf;
+    Potrf<std::complex<float>>::fn = scipy_LAPACKE_cpotrf;
+    Potrf<std::complex<double>>::fn = scipy_LAPACKE_zpotrf;
 
-    RealGesdd<float>::fn = LAPACKE_sgesdd;
-    RealGesdd<double>::fn = LAPACKE_dgesdd;
-    ComplexGesdd<std::complex<float>>::fn = LAPACKE_cgesdd;
-    ComplexGesdd<std::complex<double>>::fn = LAPACKE_zgesdd;
+    RealGesdd<float>::fn = scipy_LAPACKE_sgesdd;
+    RealGesdd<double>::fn = scipy_LAPACKE_dgesdd;
+    ComplexGesdd<std::complex<float>>::fn = scipy_LAPACKE_cgesdd;
+    ComplexGesdd<std::complex<double>>::fn = scipy_LAPACKE_zgesdd;
 
-    RealSyevd<float>::fn = LAPACKE_ssyevd;
-    RealSyevd<double>::fn = LAPACKE_dsyevd;
-    ComplexHeevd<std::complex<float>>::fn = LAPACKE_cheevd;
-    ComplexHeevd<std::complex<double>>::fn = LAPACKE_zheevd;
+    RealSyevd<float>::fn = scipy_LAPACKE_ssyevd;
+    RealSyevd<double>::fn = scipy_LAPACKE_dsyevd;
+    ComplexHeevd<std::complex<float>>::fn = scipy_LAPACKE_cheevd;
+    ComplexHeevd<std::complex<double>>::fn = scipy_LAPACKE_zheevd;
 
-    RealGeev<float>::fn = LAPACKE_sgeev;
-    RealGeev<double>::fn = LAPACKE_dgeev;
-    ComplexGeev<std::complex<float>>::fn = LAPACKE_cgeev;
-    ComplexGeev<std::complex<double>>::fn = LAPACKE_zgeev;
+    RealGeev<float>::fn = scipy_LAPACKE_sgeev;
+    RealGeev<double>::fn = scipy_LAPACKE_dgeev;
+    ComplexGeev<std::complex<float>>::fn = scipy_LAPACKE_cgeev;
+    ComplexGeev<std::complex<double>>::fn = scipy_LAPACKE_zgeev;
 
-    RealGees<float>::fn = LAPACKE_sgees;
-    RealGees<double>::fn = LAPACKE_dgees;
-    ComplexGees<std::complex<float>>::fn = LAPACKE_cgees;
-    ComplexGees<std::complex<double>>::fn = LAPACKE_zgees;
+    RealGees<float>::fn = scipy_LAPACKE_sgees;
+    RealGees<double>::fn = scipy_LAPACKE_dgees;
+    ComplexGees<std::complex<float>>::fn = scipy_LAPACKE_cgees;
+    ComplexGees<std::complex<double>>::fn = scipy_LAPACKE_zgees;
 
-    Gehrd<float>::fn = LAPACKE_sgehrd;
-    Gehrd<double>::fn = LAPACKE_dgehrd;
-    Gehrd<std::complex<float>>::fn = LAPACKE_cgehrd;
-    Gehrd<std::complex<double>>::fn = LAPACKE_zgehrd;
+    Gehrd<float>::fn = scipy_LAPACKE_sgehrd;
+    Gehrd<double>::fn = scipy_LAPACKE_dgehrd;
+    Gehrd<std::complex<float>>::fn = scipy_LAPACKE_cgehrd;
+    Gehrd<std::complex<double>>::fn = scipy_LAPACKE_zgehrd;
 
-    Sytrd<float>::fn = LAPACKE_ssytrd;
-    Sytrd<double>::fn = LAPACKE_dsytrd;
-    Sytrd<std::complex<float>>::fn = LAPACKE_chetrd;
-    Sytrd<std::complex<double>>::fn = LAPACKE_zhetrd;
+    Sytrd<float>::fn = scipy_LAPACKE_ssytrd;
+    Sytrd<double>::fn = scipy_LAPACKE_dsytrd;
+    Sytrd<std::complex<float>>::fn = scipy_LAPACKE_chetrd;
+    Sytrd<std::complex<double>>::fn = scipy_LAPACKE_zhetrd;
 
     return 0;
 }();

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ nanobind
 numpy!=2.0.0
 pybind11>=2.12.0
 PyYAML
-scipy==1.13
 
 # formatting/linting
 black

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,9 @@ requirements = [
     f"jaxlib=={jax_version}",
     "tomlkit; python_version < '3.11'",
     "numpy!=2.0.0",
-    "scipy-openblas32",
+    # rpath linking on macos is only available starting in 0.3.27.63
+    # 0.3.28 suffers from precision issues on macos
+    "scipy-openblas32>=0.3.27.63,<0.3.28",
     "diastatic-malt>=2.15.2",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ requirements = [
     f"jaxlib=={jax_version}",
     "tomlkit; python_version < '3.11'",
     "numpy!=2.0.0",
-    "scipy<1.14",
+    "scipy-openblas32",
     "diastatic-malt>=2.15.2",
 ]
 


### PR DESCRIPTION
SciPy now publishes a standalone OpenBLAS distribution on PyPI `scipy-openblas32`, which will allow us to unpin scipy in `setup.py` (the pin was required since recent versions of scipy, `1.14` and up, no longer distribute OpenBLAS in their wheels on macOS).

Symbols in this library are prefixed with `scipy_` which requires adjusting our symbol names. Library discovery is now made easier since it's uniform for linux and mac. However, some versions of this package need to be excluded due to precision and linking issues. 

[sc-78888]