### PR TITLE
[Frontend] add fuse-elementwise-ops pass

### DIFF
--- a/frontend/catalyst/pipelines.py
+++ b/frontend/catalyst/pipelines.py
@@ -191,6 +191,7 @@ def get_hlo_lowering_stage(_options: CompileOptions) -> List[str]:
         "func.func(linalg-detensorize{aggressive-mode})",
         "detensorize-scf",
         "canonicalize",
+        "linalg-fuse-elementwise-ops",
     ]
     return hlo_lowering
 


### PR DESCRIPTION
**Context:** stablehlo lowering creates many elementwise operations. It is possible to fuse them and thus reduce code size. For example:

```python
import pennylane as qml
import catalyst
import jax

MATSIZE=128 #scale with me

@catalyst.qjit(keep_intermediate=True)
#@jax.jit
def func(a, b):
    return jax.scipy.linalg.expm(1j*a)

a = jax.numpy.outer(jax.numpy.array([2]*MATSIZE), jax.numpy.array([2]*MATSIZE))
b = jax.numpy.outer(jax.numpy.array([3]*MATSIZE), jax.numpy.array([3]*MATSIZE))

print(func(a,b))

```

Produces a stablehlo of 1176 lines after stablehlo lowering and 14039 lines in LLVM.
After this change that goes down to 759 and 9936 respectively.
I also expect this to possibly reduce execution time, but I haven't benchmarked it yet.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
