### PR TITLE
Add enable-debug-info flag in catalyst

### DIFF
--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -383,7 +383,10 @@ class Compiler:
 
         return self.run_from_ir(
             mlir_module.operation.get_asm(
-                binary=False, print_generic_op_form=False, assume_verified=True
+                binary=False,
+                print_generic_op_form=False,
+                assume_verified=True,
+                enable_debug_info=True,
             ),
             str(mlir_module.operation.attributes["sym_name"]).replace('"', ""),
             *args,

--- a/frontend/catalyst/jax_extras/lowering.py
+++ b/frontend/catalyst/jax_extras/lowering.py
@@ -52,7 +52,7 @@ logger.addHandler(logging.NullHandler())
 
 
 @debug_logger
-def jaxpr_to_mlir(func_name, jaxpr):
+def jaxpr_to_mlir(func_name, jaxpr, func_loc=None):
     """Lower a Jaxpr into an MLIR module.
 
     Args:
@@ -80,6 +80,7 @@ def jaxpr_to_mlir(func_name, jaxpr):
             platform="cpu",
             axis_context=axis_context,
             name_stack=name_stack,
+            func_loc=func_loc,
         )
 
     return module, context
@@ -98,6 +99,7 @@ def custom_lower_jaxpr_to_module(
     replicated_args=None,
     arg_shardings=None,
     result_shardings=None,
+    func_loc=None,
 ):
     """Lowers a top-level jaxpr to an MHLO module.
 
@@ -135,7 +137,7 @@ def custom_lower_jaxpr_to_module(
         lowering_parameters=lowering_params,
     )
     ctx.context.allow_unregistered_dialects = True
-    with ctx.context, ir.Location.unknown(ctx.context):
+    with ctx.context, ir.Location.file(func_loc[0], func_loc[1], func_loc[2], ctx.context):
         # register_dialect()
         # Remove module name characters that XLA would alter. This ensures that
         # XLA computation preserves the module name.

--- a/frontend/catalyst/jax_extras/lowering.py
+++ b/frontend/catalyst/jax_extras/lowering.py
@@ -137,7 +137,13 @@ def custom_lower_jaxpr_to_module(
         lowering_parameters=lowering_params,
     )
     ctx.context.allow_unregistered_dialects = True
-    with ctx.context, ir.Location.file(func_loc[0], func_loc[1], func_loc[2], ctx.context):
+
+    if func_loc and len(func_loc) == 3:
+        loc = ir.Location.file(func_loc[0], func_loc[1], func_loc[2], ctx.context)
+    else:
+        loc = ir.Location.unknown(ctx.context)
+
+    with ctx.context, loc:
         # register_dialect()
         # Remove module name characters that XLA would alter. This ensures that
         # XLA computation preserves the module name.

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -553,7 +553,7 @@ def trace_to_jaxpr(func, static_argnums, abstracted_axes, args, kwargs):
 
 
 @debug_logger
-def lower_jaxpr_to_mlir(jaxpr, func_name):
+def lower_jaxpr_to_mlir(jaxpr, func_name, func_loc=None):
     """Lower a JAXPR to MLIR.
 
     Args:
@@ -568,7 +568,7 @@ def lower_jaxpr_to_mlir(jaxpr, func_name):
     MemrefCallable.clearcache()
 
     with transient_jax_config({"jax_dynamic_shapes": True}):
-        mlir_module, ctx = jaxpr_to_mlir(func_name, jaxpr)
+        mlir_module, ctx = jaxpr_to_mlir(func_name, jaxpr, func_loc)
 
     return mlir_module, ctx
 

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -633,6 +633,24 @@ class QJIT(CatalystCallable):
 
         return processed_fn
 
+    @instrument
+    @debug_logger
+    def get_func_loc(self):
+        """Find the location of the user function."""
+        func = self.original_function
+        while isinstance(func, qml.QNode) and hasattr(func, "func"):
+            func = func.func
+        source_file = getsourcefile(func)
+        source_code = getsourcelines(func)[0]
+        source_line = getsourcelines(func)[1]
+        func_loc = None
+        for i, s in enumerate(source_code):
+            if self.__name__ in s:
+                position = s.find(self.__name__)
+                func_loc = (source_file, source_line + i, position)
+                break
+        return func_loc
+
     @instrument(size_from=0)
     @debug_logger
     def capture(self, args, **kwargs):
@@ -709,17 +727,7 @@ class QJIT(CatalystCallable):
             Tuple[ir.Module, str]: the in-memory MLIR module and its string representation
         """
 
-        source_file = getsourcefile(self.user_function.func)
-        source_code = getsourcelines(self.user_function.func)[0]
-        source_line = getsourcelines(self.user_function.func)[1]
-        func_loc = None
-        for i, s in enumerate(source_code):
-            if self.__name__ in s:
-                position = s.find(self.__name__)
-                func_loc = (source_file, source_line + i, position)
-                break
-
-        mlir_module, ctx = lower_jaxpr_to_mlir(self.jaxpr, self.__name__, func_loc)
+        mlir_module, ctx = lower_jaxpr_to_mlir(self.jaxpr, self.__name__, self.get_func_loc())
 
         # Inject Runtime Library-specific functions (e.g. setup/teardown).
         inject_functions(mlir_module, ctx, self.compile_options.seed)

--- a/frontend/catalyst/pipelines.py
+++ b/frontend/catalyst/pipelines.py
@@ -298,7 +298,7 @@ def get_convert_to_llvm_stage(options: CompileOptions) -> List[str]:
         "register-inactive-callback",
     ]
     if options.enable_debug_info:
-        convert_to_llvm.append("ensure-debug-info-on-llvm-func")
+        convert_to_llvm.append("ensure-debug-info-scope-on-llvm-func")
     return list(filter(partial(is_not, None), convert_to_llvm))
 
 

--- a/frontend/catalyst/pipelines.py
+++ b/frontend/catalyst/pipelines.py
@@ -48,6 +48,8 @@ class CompileOptions:
             Default is ``sys.stderr``
         keep_intermediate (Optional[bool]): flag indicating whether to keep intermediate results.
             Default is ``False``
+        enable_debug_info (Optional[bool]): flag indicating whether to enable debug info.
+            Default is ``False``
         pipelines (Optional[List[Tuple[str,List[str]]]]): A list of tuples. The first entry of the
             tuple corresponds to the name of a pipeline. The second entry of the tuple corresponds
             to a list of MLIR passes.
@@ -80,6 +82,7 @@ class CompileOptions:
     logfile: Optional[TextIOWrapper] = sys.stderr
     target: Optional[str] = "binary"
     keep_intermediate: Optional[bool] = False
+    enable_debug_info: Optional[bool] = False
     pipelines: Optional[List[Any]] = None
     autograph: Optional[bool] = False
     autograph_include: Optional[Iterable[str]] = ()
@@ -294,6 +297,8 @@ def get_convert_to_llvm_stage(options: CompileOptions) -> List[str]:
         "gep-inbounds",
         "register-inactive-callback",
     ]
+    if options.enable_debug_info:
+        convert_to_llvm.append("ensure-debug-info-on-llvm-func")
     return list(filter(partial(is_not, None), convert_to_llvm))
 
 


### PR DESCRIPTION
**Context:**
Currently debug info is not propagated from JAX to LLVM making it. 

**Description of the Change:**
This PR adds a qjit option "enable_debug_info" that adds the debug info to the intermediate IRs. 

**Benefits:**
IR will now include IR with debug info. 

**Possible Drawbacks:**
the large number of MLIR passed that modify the IR may distort the debug info, so it may lose accuracy.

**Related GitHub Issues:**
[sc-73579]
