### PR TITLE
[Frontend] Sink autograph patches

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -72,6 +72,9 @@
 * `catalyst-cli` and `quantum-opt` are compiled with `default` visibility, which allows for MLIR plugins to work.
   [(#1287)](https://github.com/PennyLaneAI/catalyst/pull/1287)
 
+* Sink patching of autograph's allowlist.
+  [(#1332)](https://github.com/PennyLaneAI/catalyst/pull/1332)
+
 <h3>Documentation 📝</h3>
 
 * A new tutorial going through how to write a new MLIR pass is available. The tutorial writes an


### PR DESCRIPTION
**Context:** `jit.py` is getting a bit overwhelming. 

**Description of the Change:** We had this patching mechanism in three different locations. Instead of having it spread out, I just sinked it to where it will be used.

**Benefits:** Less indentation.

**Possible Drawbacks:** None

**Related GitHub Issues:**
