### PR TITLE
[Frontend] Compile IR from docstring.

### DIFF
--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -264,7 +264,7 @@ class Compiler:
         self.options = options if options is not None else CompileOptions()
 
     @debug_logger
-    def get_cli_command(self, tmp_infile_name, output_ir_name, module_name, workspace):
+    def get_cli_command(self, tmp_infile_name, output_ir_name, module_name, workspace, *args):
         """Prepare the command for catalyst-cli to compile the file.
 
         Args:
@@ -290,6 +290,9 @@ class Compiler:
             cmd += ["--verbose"]
         if self.options.checkpoint_stage:
             cmd += ["--checkpoint-stage", self.options.checkpoint_stage]
+        if args:
+            for arg in args:
+                cmd += [str(arg)]
 
         pipeline_str = ""
         for pipeline in self.options.get_pipelines():
@@ -301,7 +304,7 @@ class Compiler:
         return cmd
 
     @debug_logger
-    def run_from_ir(self, ir: str, module_name: str, workspace: Directory):
+    def run_from_ir(self, ir: str, module_name: str, workspace: Directory, *args):
         """Compile a shared object from a textual IR (MLIR or LLVM).
 
         Args:
@@ -335,7 +338,7 @@ class Compiler:
         output_object_name = os.path.join(str(workspace), f"{module_name}.o")
         output_ir_name = os.path.join(str(workspace), f"{module_name}{output_ir_ext}")
 
-        cmd = self.get_cli_command(tmp_infile_name, output_ir_name, module_name, workspace)
+        cmd = self.get_cli_command(tmp_infile_name, output_ir_name, module_name, workspace, *args)
         try:
             if self.options.verbose:
                 print(f"[SYSTEM] {' '.join(cmd)}", file=self.options.logfile)

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -543,6 +543,11 @@ class QJIT(CatalystCallable):
         """Compile Python function on initialization using the type hint signature."""
 
         self.workspace = self._get_workspace()
+        return_annotation = inspect.signature(self.original_function).return_annotation
+        if return_annotation and return_annotation != inspect.Signature.empty:
+            return_annotation = get_abstract_signature(return_annotation)
+        else:
+            return_annotation = None
 
         # TODO: awkward, refactor or redesign the target feature
         if self.compile_options.target in ("jaxpr", "mlir", "binary"):
@@ -553,6 +558,10 @@ class QJIT(CatalystCallable):
                 self.jaxpr, self.out_type, self.out_treedef, self.c_sig = self.capture(
                     self.user_sig or ()
                 )
+
+        if return_annotation:
+            vals, self.out_treedef = tree_flatten(return_annotation)
+            self.out_type = [(True, retty) for retty in vals]
 
         if self.compile_options.target in ("mlir", "binary"):
             self.mlir_module, self.mlir = self.generate_ir()

--- a/frontend/catalyst/pipelines.py
+++ b/frontend/catalyst/pipelines.py
@@ -143,7 +143,7 @@ class CompileOptions:
         """Returns all stages in order for compilation"""
         # Dictionaries in python are ordered
         stages = {}
-        stages["EnforeRuntimeInvariantsPass"] = get_enforce_runtime_invariants_stage(self)
+        stages["EnforceRuntimeInvariantsPass"] = get_enforce_runtime_invariants_stage(self)
         stages["HLOLoweringPass"] = get_hlo_lowering_stage(self)
         stages["QuantumCompilationPass"] = get_quantum_compilation_stage(self)
         stages["BufferizationPass"] = get_bufferization_stage(self)


### PR DESCRIPTION
**Context:**

Adds functionality to compile and execute code specified in a docstring for debugging purposes.

```python
import pennylane as qml

from catalyst.debug.compiler_functions import docstringir


@docstringir
def foo(x: int) -> int:
    """
    module @foo {
      func.func public @jit_foo(%arg0: tensor<i64>) -> tensor<i64> attributes { llvm.emit_c_interface } {
        return %arg0 : tensor<i64>
      }
      module attributes {transform.with_named_sequence} {
        transform.named_sequence @__transform_main(%arg0: !transform.op<"builtin.module">) {
          transform.yield
        }
      }
      func.func @setup() {
        quantum.init
        return
      }
      func.func @teardown() {
        quantum.finalize
        return
      }
    }
    """


print(foo(1))
print(foo.mlir)

```

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
