### PR TITLE
Update catalyst-cli.rst to fix the title hierarchy

### DIFF
--- a/doc/catalyst-cli/catalyst-cli.rst
+++ b/doc/catalyst-cli/catalyst-cli.rst
@@ -241,7 +241,7 @@ For a list of transformation passes currently available in Catalyst, see the
 ``catalyst-cli --help`` message.
 
 MLIR Plugins
-============
+------------
 
 ``mlir-opt``-like tools are able to take plugins as inputs.
 These plugins are shared objects that include dialects and passes written by third parties.


### PR DESCRIPTION
The MLIR Plugins sections was erroneously appearing as a top level section header

![image](https://github.com/user-attachments/assets/ca6f6e2b-798e-4a8d-b901-cf0ff7c092c4)
