### PR TITLE
Remove the function `add_mlir_quantum_decomposition` in passes.py from documentation

### DIFF
--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -96,7 +96,7 @@ from catalyst.jax_primitives import (
     var_p,
 )
 from catalyst.logging import debug_logger, debug_logger_init
-from catalyst.passes import add_mlir_quantum_decomposition
+from catalyst.passes import _add_mlir_quantum_decomposition
 from catalyst.tracing.contexts import (
     EvaluationContext,
     EvaluationMode,
@@ -1141,7 +1141,7 @@ def trace_quantum_function(
         out_tree: PyTree shapen of the result
     """
     # Add the decomposition passes with the transform dialect
-    add_mlir_quantum_decomposition(f, device)
+    _add_mlir_quantum_decomposition(f, device)
 
     with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
         # (1) - Classical tracing

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -434,7 +434,7 @@ def _inject_transform_named_sequence():
     transform_named_sequence_p.bind()
 
 
-def add_mlir_quantum_decomposition(f, device):
+def _add_mlir_quantum_decomposition(f, device):
     """When called it adds the MLIR decomposition pass thanks to the transform dialect."""
     # TODO: make this non related to the name of the device
     if device.original_device.name == "oqd.cloud":


### PR DESCRIPTION
**Context:**
An internal helper function, `frontend/catalyst/passes.py/add_mlir_quantum_decomposition`, incorrectly appeared on user facing documentation.

**Description of the Change:**
Remove the function from documentation by marking it private in sphinx (by prepending an underscore).
