### PR TITLE
[tests] Use _get_call_jaxpr instead of magic numbers

### DIFF
--- a/frontend/test/pytest/test_from_plxpr.py
+++ b/frontend/test/pytest/test_from_plxpr.py
@@ -25,6 +25,7 @@ jax = pytest.importorskip("jax")
 # needs to be below the importorskip calls
 # pylint: disable=wrong-import-position
 from catalyst.from_plxpr import from_plxpr
+from catalyst.jax_primitives import _get_call_jaxpr
 
 
 def catalyst_execute_jaxpr(jaxpr):
@@ -215,8 +216,8 @@ class TestCatalystCompareJaxpr:
         qjit_obj = qml.qjit(circuit)
         qjit_obj(x)
         catalxpr = qjit_obj.jaxpr
-        call_jaxpr_pl = converted.eqns[0].params["call_jaxpr"]
-        call_jaxpr_c = catalxpr.eqns[1].params["call_jaxpr"]
+        call_jaxpr_pl = _get_call_jaxpr(converted)
+        call_jaxpr_c = _get_call_jaxpr(catalxpr)
         compare_call_jaxprs(call_jaxpr_pl, call_jaxpr_c)
 
     def test_globalphase(self):
@@ -241,8 +242,8 @@ class TestCatalystCompareJaxpr:
         qjit_obj(0.5)
 
         catalxpr = qjit_obj.jaxpr
-        call_jaxpr_pl = converted.eqns[0].params["call_jaxpr"]
-        call_jaxpr_c = catalxpr.eqns[1].params["call_jaxpr"]
+        call_jaxpr_pl = _get_call_jaxpr(converted)
+        call_jaxpr_c = _get_call_jaxpr(catalxpr)
         compare_call_jaxprs(call_jaxpr_pl, call_jaxpr_c)
 
     def test_expval(self):
@@ -269,8 +270,8 @@ class TestCatalystCompareJaxpr:
         qjit_obj = qml.qjit(circuit)
         qjit_obj(0.5)
         catalxpr = qjit_obj.jaxpr
-        call_jaxpr_pl = converted.eqns[0].params["call_jaxpr"]
-        call_jaxpr_c = catalxpr.eqns[1].params["call_jaxpr"]
+        call_jaxpr_pl = _get_call_jaxpr(converted)
+        call_jaxpr_c = _get_call_jaxpr(catalxpr)
 
         compare_call_jaxprs(call_jaxpr_pl, call_jaxpr_c)
 
@@ -301,8 +302,8 @@ class TestCatalystCompareJaxpr:
         qjit_obj = qml.qjit(circuit)
         qjit_obj(0.5)
         catalxpr = qjit_obj.jaxpr
-        call_jaxpr_pl = converted.eqns[0].params["call_jaxpr"]
-        call_jaxpr_c = catalxpr.eqns[1].params["call_jaxpr"]
+        call_jaxpr_pl = _get_call_jaxpr(converted)
+        call_jaxpr_c = _get_call_jaxpr(catalxpr)
 
         compare_call_jaxprs(call_jaxpr_pl, call_jaxpr_c)
 
@@ -340,8 +341,8 @@ class TestCatalystCompareJaxpr:
         qjit_obj = qml.qjit(circuit)
         qjit_obj(phi)
         catalxpr = qjit_obj.jaxpr
-        call_jaxpr_pl = converted.eqns[0].params["call_jaxpr"]
-        call_jaxpr_c = catalxpr.eqns[1].params["call_jaxpr"]
+        call_jaxpr_pl = _get_call_jaxpr(converted)
+        call_jaxpr_c = _get_call_jaxpr(catalxpr)
 
         # confused by the weak_types error here
         compare_call_jaxprs(call_jaxpr_pl, call_jaxpr_c)
@@ -375,8 +376,8 @@ class TestCatalystCompareJaxpr:
         qjit_obj = qml.qjit(circuit)
         qjit_obj(x)
         catalxpr = qjit_obj.jaxpr
-        call_jaxpr_pl = converted.eqns[0].params["call_jaxpr"]
-        call_jaxpr_c = catalxpr.eqns[1].params["call_jaxpr"]
+        call_jaxpr_pl = _get_call_jaxpr(converted)
+        call_jaxpr_c = _get_call_jaxpr(catalxpr)
 
         compare_call_jaxprs(call_jaxpr_pl, call_jaxpr_c)
 
@@ -407,8 +408,8 @@ class TestCatalystCompareJaxpr:
         qjit_obj = qml.qjit(circuit)
         qjit_obj()
         catalxpr = qjit_obj.jaxpr
-        call_jaxpr_pl = converted.eqns[0].params["call_jaxpr"]
-        call_jaxpr_c = catalxpr.eqns[1].params["call_jaxpr"]
+        call_jaxpr_pl = _get_call_jaxpr(converted)
+        call_jaxpr_c = _get_call_jaxpr(catalxpr)
 
         compare_call_jaxprs(call_jaxpr_pl, call_jaxpr_c)
 
@@ -449,8 +450,8 @@ class TestCatalystCompareJaxpr:
         qjit_obj = qml.qjit(circuit)
         qjit_obj(x, y, z)
         catalxpr = qjit_obj.jaxpr
-        call_jaxpr_pl = converted.eqns[0].params["call_jaxpr"]
-        call_jaxpr_c = catalxpr.eqns[1].params["call_jaxpr"]
+        call_jaxpr_pl = _get_call_jaxpr(converted)
+        call_jaxpr_c = _get_call_jaxpr(catalxpr)
 
         compare_call_jaxprs(call_jaxpr_pl, call_jaxpr_c)
 
@@ -494,8 +495,8 @@ class TestHybridPrograms:
         qjit_obj = qml.qjit(workflow)
         qjit_obj(0.5)
 
-        call_jaxpr_pl = converted.eqns[1].params["call_jaxpr"]
-        call_jaxpr_c = qjit_obj.jaxpr.eqns[2].params["call_jaxpr"]
+        call_jaxpr_pl = _get_call_jaxpr(converted)
+        call_jaxpr_c = _get_call_jaxpr(qjit_obj.jaxpr)
 
         # qubit extraction and classical equations in a slightly different order
         # thus cant check specific equations and have to discard comparing counts


### PR DESCRIPTION
**Context:** There were some magic constants in the plxpr tests.

**Description of the Change:** Change magic constants in favour of function to obtain call_jaxpr.

**Benefits:** No magic constants, code reuse.
