### PR TITLE
Solves Issue #1316: Implement an option to print out instructions in the null device 

### DIFF
--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -307,7 +307,7 @@ class QJITDevice(qml.devices.Device):
         self.backend_name = backend.c_interface_name
         self.backend_lib = backend.lpath
         self.backend_kwargs = backend.kwargs
-        self.backend_kwargs["print_instructions"] = print_instructions # this includes 'print_instructions' as a keyword argument for the device constructor.
+        self.backend_kwargs["print_instructions"] = print_instructions # include 'print_instructions' as a keyword argument for the device constructor.
 
         self.capabilities = get_qjit_device_capabilities(original_device_capabilities)
 

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -307,7 +307,9 @@ class QJITDevice(qml.devices.Device):
         self.backend_name = backend.c_interface_name
         self.backend_lib = backend.lpath
         self.backend_kwargs = backend.kwargs
-        self.backend_kwargs["print_instructions"] = print_instructions # include 'print_instructions' as a keyword argument for the device constructor.
+        self.backend_kwargs["print_instructions"] = (
+            print_instructions  # include 'print_instructions' as a keyword argument for the device constructor.
+        )
 
         self.capabilities = get_qjit_device_capabilities(original_device_capabilities)
 

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -290,7 +290,7 @@ class QJITDevice(qml.devices.Device):
         return extract_backend_info(device, capabilities)
 
     @debug_logger_init
-    def __init__(self, original_device):
+    def __init__(self, original_device, print_instructions=False):
         self.original_device = original_device
 
         for key, value in original_device.__dict__.items():
@@ -307,6 +307,7 @@ class QJITDevice(qml.devices.Device):
         self.backend_name = backend.c_interface_name
         self.backend_lib = backend.lpath
         self.backend_kwargs = backend.kwargs
+        self.backend_kwargs["print_instructions"] = print_instructions # this includes 'print_instructions' as a keyword argument for the device constructor.
 
         self.capabilities = get_qjit_device_capabilities(original_device_capabilities)
 

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -439,7 +439,7 @@ def qjit(
     if fn is None:
         return functools.partial(qjit, **kwargs)
 
-    return QJIT(fn, CompileOptions(**kwargs), print_instructions)
+    return QJIT(fn, CompileOptions(**kwargs), print_instructions=print_instructions)
 
 
 ## IMPL ##
@@ -469,6 +469,9 @@ class QJIT(CatalystCallable):
 
     @debug_logger_init
     def __init__(self, fn, compile_options, print_instructions=False):
+        # flag for printing instructions in the null device
+        self.print_instructions = print_instructions
+        
         functools.update_wrapper(self, fn)
         self.original_function = fn
         self.compile_options = compile_options
@@ -516,8 +519,6 @@ class QJIT(CatalystCallable):
         if self.user_sig is not None and not self.compile_options.static_argnums:
             self.aot_compile()
 
-        # flag for printing instructions in the null device
-        self.print_instructions = print_instructions
         super().__init__("user_function")
 
     @debug_logger

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -471,7 +471,7 @@ class QJIT(CatalystCallable):
     def __init__(self, fn, compile_options, print_instructions=False):
         # flag for printing instructions in the null device
         self.print_instructions = print_instructions
-        
+
         functools.update_wrapper(self, fn)
         self.original_function = fn
         self.compile_options = compile_options

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -121,7 +121,7 @@ class QFunc:
             if mcm_config.mcm_method == "one-shot":
                 mcm_config.postselect_mode = mcm_config.postselect_mode or "hw-like"
                 return Function(dynamic_one_shot(self, mcm_config=mcm_config))(*args, **kwargs)
-        
+
         # retrieve flag of whether or not to print instructions (in case we execute the pre-compiled program in the null device)
         print_instructions = kwargs.pop("print_instructions", False)
         qjit_device = QJITDevice(self.device, print_instructions)

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -121,8 +121,10 @@ class QFunc:
             if mcm_config.mcm_method == "one-shot":
                 mcm_config.postselect_mode = mcm_config.postselect_mode or "hw-like"
                 return Function(dynamic_one_shot(self, mcm_config=mcm_config))(*args, **kwargs)
-
-        qjit_device = QJITDevice(self.device)
+        
+        # retrieve flag of whether or not to print instructions (in case we execute the pre-compiled program in the null device)
+        print_instructions = kwargs.pop("print_instructions", False)
+        qjit_device = QJITDevice(self.device, print_instructions)
 
         static_argnums = kwargs.pop("static_argnums", ())
         out_tree_expected = kwargs.pop("_out_tree_expected", [])

--- a/runtime/lib/backend/null_qubit/InstructionStrBuilder.hpp
+++ b/runtime/lib/backend/null_qubit/InstructionStrBuilder.hpp
@@ -130,10 +130,11 @@ class InstructionStrBuilder {
      * PartialProbs()
      */
     template <typename T, size_t R>
-    string get_simple_op_str(const string &name, DataView<T, R> &dataview, const std::vector<QubitIdType> &wires={})
+    string get_simple_op_str(const string &name, DataView<T, R> &dataview,
+                             const std::vector<QubitIdType> &wires = {})
     {
         ostringstream oss;
-        oss << name << "(" << get_dataview_str(dataview); 
+        oss << name << "(" << get_dataview_str(dataview);
         if (wires.size() > 0) {
             oss << ", wires=" << vector_to_string(wires);
         }
@@ -195,7 +196,7 @@ class InstructionStrBuilder {
      * @brief This method is used to get the string representation of MatrixOperation()
      */
     string get_matrix_op_str(const std::vector<std::complex<double>> &matrix,
-                             const std::vector<QubitIdType> &wires, bool inverse=false,
+                             const std::vector<QubitIdType> &wires, bool inverse = false,
                              const std::vector<QubitIdType> &controlled_wires = {},
                              const std::vector<bool> &controlled_values = {},
                              const string &name = "MatrixOperation")
@@ -304,7 +305,7 @@ class InstructionStrBuilder {
             if (coeffs[i] != 0) {
                 oss << coeffs[i] << "*" << obs_id_type_to_str[obs_keys[i]];
                 is_first = false;
-            }   
+            }
         }
 
         ObsIdType new_id = obs_id_type_to_str.size();

--- a/runtime/lib/backend/null_qubit/InstructionStrBuilder.hpp
+++ b/runtime/lib/backend/null_qubit/InstructionStrBuilder.hpp
@@ -93,7 +93,7 @@ namespace Catalyst::Runtime {
             oss << "]";
             return oss.str();
         }
-        
+
         public:
             InstructionStrBuilder() = default;
             ~InstructionStrBuilder() = default;
@@ -246,9 +246,16 @@ namespace Catalyst::Runtime {
 
                 for (auto i = 0; i < coeffs.size(); i++) {
                     if (i > 0) {
-                        oss << " + ";
+                        if (coeffs[i] > 0) {
+                            oss << " + ";
+                        }else if(coeffs[i] < 0) {
+                            oss << " ";
+                        }
+                        
                     }
-                    oss << coeffs[i] << "*" << obs_id_type_to_str[obs_keys[i]];
+
+                    if (coeffs[i] != 0)
+                        oss << coeffs[i] << "*" << obs_id_type_to_str[obs_keys[i]];
                 }
 
                 ObsIdType new_id = obs_id_type_to_str.size();

--- a/runtime/lib/backend/null_qubit/InstructionStrBuilder.hpp
+++ b/runtime/lib/backend/null_qubit/InstructionStrBuilder.hpp
@@ -1,0 +1,316 @@
+
+#pragma once
+
+#include <complex>
+#include <iostream>
+#include <vector>
+#include <sstream>
+#include <unordered_map>
+
+#include "DataView.hpp"
+#include "Types.h"
+
+namespace Catalyst::Runtime {
+    using namespace std;
+
+    // string representation of observables
+    static const unordered_map<ObsId, string> obs_id_to_str = {
+                {ObsId::Identity, "Identity"},
+                {ObsId::PauliX, "PauliX"},
+                {ObsId::PauliY, "PauliY"},
+                {ObsId::PauliZ, "PauliZ"},
+                {ObsId::Hadamard, "Hadamard"},
+                {ObsId::Hermitian, "Hermitian"},
+    };
+
+    /**
+     * InstructionStrBuilder
+     *
+     * @brief This class is used by the null device (NullQubit.hpp) whenever the flag to print instructions (print_instructions) is set to true. It is in charge of building string repretations the operations invoked in the aformentioned device interface.
+     */
+
+    class InstructionStrBuilder {
+        private:
+            unordered_map<ObsIdType, string> obs_id_type_to_str{}; // whenever a new observable is created we store the corresponding string representation in this hashmap
+
+            /**
+             * @brief Template function that returns the string representation of some object.
+             */
+            template <typename T> string element_to_str(const T &e) {
+                return to_string(e);
+            }
+
+            /**
+             * @brief Template specialized to return the string representation of complex numbers.
+             */
+            template <typename T> string element_to_str(const complex<T> &c) {
+                ostringstream oss;
+                oss << c.real();
+
+                if (c.imag() != 0) {
+                    // to keep printing output as short as possible, we only print the imaginary part whenever is different from zero;
+                    oss << " + " << c.imag()<<"i";
+                }
+                return oss.str();
+            }
+
+        public:
+            InstructionStrBuilder() = default;
+            ~InstructionStrBuilder() = default;
+
+            /**
+             * @brief This method is used to build a string representation of AllocateQubit(), AllocateQubits(), ReleaseQubit(), ReleaseAllQubits(), Measure()
+             */
+            template <typename T> string get_simple_op_str(const string &name, const T &param) {
+                ostringstream oss;
+                oss << name << "(" << param << ")";
+                return oss.str();
+            }
+
+            /**
+             * @brief This method is used to build a string representation of Expval() and Var()
+             */
+            string get_simple_op_str(const string &name, const ObsIdType &o) {
+                ostringstream oss;
+                oss << name << "(" << get_obs_str(o) << ")";
+                return oss.str();
+            }
+
+            /**
+             * @brief This method is used to build a string representation of State(), Probs(), PartialProbs()
+             */
+            template <typename T, size_t R>
+            string get_simple_op_str(const string &name, DataView<T, R> &dataview) {
+                ostringstream oss;
+                oss << name << "(" << get_dataview_str(dataview) << ")";
+                return oss.str();
+            }
+
+            /**
+             * @brief Takes as input a vector and returns its string representation. If with_brackets=True, the square brackets will be included to enclose the vector. E.g. 
+             * - vector_to_string([0,1,2], false) returns "0, 1, 2"
+             * - vector_to_string([0,1,2], true) returns "[0, 1, 2]"
+             */
+            template <typename T> string vector_to_string(const vector<T>& v, const bool &with_brackets = true) {
+                ostringstream oss;
+                if (with_brackets) oss << "[";
+
+                for (size_t i = 0; i < v.size(); i++) {
+                    if (i > 0) {
+                        oss << ", ";
+                    }
+                    oss << element_to_str(v[i]);
+                }
+                if (with_brackets) oss << "]";
+
+                return oss.str();
+            }
+
+            /**
+             * @brief This method is used to get the string representation of NamedOperation()
+             */
+            string get_named_op_str(const std::string &name, const std::vector<double> &params,
+                            const std::vector<QubitIdType> &wires, bool inverse = false,
+                            const std::vector<QubitIdType> &controlled_wires = {},
+                            const std::vector<bool> &controlled_values = {}) {
+                ostringstream oss;
+                vector<string> values_to_print; // Store the string representation of the parameters passed NamedOperation(). We only consider non-empty vectors to preserve printing-output simplicity.
+
+                for (auto p : params) values_to_print.push_back(std::to_string(p));
+                                                            
+                if (wires.size() > 0){
+                    if (params.size()) {
+                        // when an operation corresponds to a parametric gate, explicity specify the wires as a single vector. E.g Rx(3.14, wires=[0])
+                        values_to_print.push_back("wires=" + vector_to_string(wires, true));
+                    } else {
+                        // Otherwise, we do not represent it as a vector but rather as a list separated with commas. E.g. CX(0,1)
+                        values_to_print.push_back(vector_to_string(wires, false));
+                    }
+                }
+
+                // if inverse is false, we will not print its value
+                if (inverse) values_to_print.push_back("inverse=True");
+
+                if (controlled_wires.size() > 0) values_to_print.push_back("control=" + vector_to_string(controlled_wires));
+
+                if (controlled_values.size() > 0) values_to_print.push_back("control_value=" + vector_to_string(controlled_values));
+
+                oss << name << "(";
+                for (auto i = 0; i < values_to_print.size(); i++) {
+                    if (i > 0) {
+                        oss << ", ";
+                    }
+                    oss << values_to_print[i];
+                }
+                oss << ")";
+                return oss.str();
+            }
+
+            /**
+             * @brief This method is used to get the string representation of MatrixOperation()
+             */
+            string get_matrix_op_str(const std::vector<std::complex<double>> &matrix,
+                            const std::vector<QubitIdType> &wires, bool inverse,
+                            const std::vector<QubitIdType> &controlled_wires = {},
+                            const std::vector<bool> &controlled_values = {}, const string &name="MatrixOperation") {
+                ostringstream oss;
+                vector<string> values_to_print; // Store the string representation of the parameters passed NamedOperation(). We only consider non-empty vectors to preserve printing-output simplicity.
+
+                values_to_print.emplace_back(vector_to_string(matrix));
+
+                values_to_print.emplace_back("wires=" + vector_to_string(wires));                                                        
+                
+                if (inverse) values_to_print.push_back("inverse=True");
+
+                if (controlled_wires.size() > 0) values_to_print.push_back("control=" + vector_to_string(controlled_wires));
+
+                if (controlled_values.size() > 0) values_to_print.push_back("control_value=" + vector_to_string(controlled_values));
+
+                oss << name << "(";
+                for (auto i = 0; i < values_to_print.size(); i++) {
+                    if (i > 0) {
+                        oss << ", ";
+                    }
+                    oss << values_to_print[i];
+                }
+
+                oss << ")";
+                return oss.str();
+            }
+            
+            /**
+             * @brief Every time Observable() is invoked in the null device interface, we invoke this function to create a new ObsIdType and its corresponding string representation.
+             */
+            ObsIdType create_obs_str(ObsId obs_id, const std::vector<std::complex<double>> &matrix,
+                        const std::vector<QubitIdType> &wires) {
+                ObsIdType new_id = obs_id_type_to_str.size();
+
+                if (obs_id == ObsId::Hermitian) {
+                    obs_id_type_to_str.emplace(new_id, 
+                        get_matrix_op_str(matrix, wires, false, {}, {}, "Hermitian"));
+                } else {
+                    auto it = obs_id_to_str.find(obs_id);
+                    if (it != obs_id_to_str.end()) {
+                        obs_id_type_to_str.emplace(new_id, get_named_op_str(it->second, {}, wires));
+                    } else {
+                        RT_FAIL(("please check obs_id_to_str in file InstructionPrinter. Observation with ID" + to_string(obs_id)  + "is not recognized.").c_str());
+                    }
+                }
+                
+                return new_id;
+            }
+
+            /**
+             * @brief Every time TensorObservable() is invoked in the null device interface, we invoke this function to create a new ObsIdType and its corresponding string representation.
+             */
+            ObsIdType create_tensor_obs_str(const std::vector<ObsIdType> &obs_keys) {
+                ostringstream oss;
+                for (auto i = 0 ; i < obs_keys.size(); i++) {
+                    if (i > 0) {
+                        oss << " ⊗ ";
+                    }
+                    oss << obs_id_type_to_str[obs_keys[i]];
+                }
+                ObsIdType new_id = obs_id_type_to_str.size();
+                obs_id_type_to_str[new_id] = oss.str();
+                return new_id;
+            }
+
+            /**
+             * @brief Every time HamiltonianObservable() is invoked in the null device interface, we invoke this function to create a new ObsIdType and its corresponding string representation.
+             */
+            ObsIdType create_hamiltonian_obs_str(const std::vector<double> &coeffs, const std::vector<ObsIdType> &obs_keys) {
+                RT_FAIL_IF(coeffs.size() != obs_keys.size(), "number of coefficients should match the number of observables");
+
+                ostringstream oss;
+
+                for (auto i = 0; i < coeffs.size(); i++) {
+                    if (i > 0) {
+                        oss << " + ";
+                    }
+                    oss << coeffs[i] << "*" << obs_id_type_to_str[obs_keys[i]];
+                }
+
+                ObsIdType new_id = obs_id_type_to_str.size();
+                obs_id_type_to_str[new_id] = oss.str();
+                return new_id;
+            }
+
+            /**
+             * @brief Getter function to retrieve the string representation of the observables we created.
+             */
+            string get_obs_str(const ObsIdType &o) {
+                return obs_id_type_to_str.at(o);
+            }
+
+            /**
+             * @brief Builds the string representation of DataView
+             */
+            template <typename T, size_t R>
+            string get_dataview_str(DataView<T, R> &dataview) {
+                ostringstream oss;
+                bool is_first = true; // boolean to help determine where to put commas
+
+                oss << "[";
+                for (auto it = dataview.begin();  it != dataview.end(); it++) {
+                    if (!is_first) {
+                        oss << ", "; // if is not the first element then we add a comma to separate the elements
+                    }
+                    oss << element_to_str(*it);
+                    is_first = false;
+                }
+                oss << "]";
+                return oss.str();
+            }
+
+            /**
+             * @brief This method is used to get the string representation of Sample() and PartialSample()
+             */
+            string get_samples_str(const string &name, DataView<double, 2> &samples, const size_t &shots, const vector<QubitIdType> &wires={}) {
+                ostringstream oss;
+                bool is_first = true;
+                oss << name << "(" << get_dataview_str(samples);
+
+                if (wires.size() > 0) {
+                    oss << ", wires=" << vector_to_string(wires);
+                }
+                
+                oss << ", shots=" << shots << ")";
+
+                return oss.str();
+            }
+
+            /**
+             * @brief This method is used to get the string representation of Counts() and PartialCounts().
+             */
+            string get_counts_str(const string &name, DataView<double, 1> &vals, DataView<int64_t, 1> &counts, const size_t &shots, const vector<QubitIdType> &wires={}) {
+                RT_FAIL_IF(vals.size() != counts.size(), "number of eigenvalues does not matches counts");
+
+                ostringstream oss;
+                bool is_first = true;
+                oss << name << "(";
+                oss << "[";
+                auto it1 = vals.begin();
+                auto it2 = counts.begin();
+                for ( ; it1 != vals.end(); it1++, it2++) {
+                    if (!is_first) {
+                        oss << ", ";
+                    }
+                    // here we build a substring that represents a pair (eigenval, count)
+                    oss << "(" << element_to_str(*it1) << ", " << element_to_str(*it2) << ")";
+                    is_first = false;
+                }
+                oss << "]"; //
+
+                if (wires.size() > 0) {
+                    oss << ", wires=" << vector_to_string(wires);
+                }
+
+                oss << ", shots=" << shots;
+
+                oss << ")";
+
+                return oss.str();
+            }
+    };
+}

--- a/runtime/lib/backend/null_qubit/InstructionStrBuilder.hpp
+++ b/runtime/lib/backend/null_qubit/InstructionStrBuilder.hpp
@@ -3,321 +3,365 @@
 
 #include <complex>
 #include <iostream>
-#include <vector>
 #include <sstream>
 #include <unordered_map>
+#include <vector>
 
 #include "DataView.hpp"
 #include "Types.h"
 
 namespace Catalyst::Runtime {
-    using namespace std;
+using namespace std;
 
-    // string representation of observables
-    static const unordered_map<ObsId, string> obs_id_to_str = {
-                {ObsId::Identity, "Identity"},
-                {ObsId::PauliX, "PauliX"},
-                {ObsId::PauliY, "PauliY"},
-                {ObsId::PauliZ, "PauliZ"},
-                {ObsId::Hadamard, "Hadamard"},
-                {ObsId::Hermitian, "Hermitian"},
-    };
+// string representation of observables
+static const unordered_map<ObsId, string> obs_id_to_str = {
+    {ObsId::Identity, "Identity"}, {ObsId::PauliX, "PauliX"},     {ObsId::PauliY, "PauliY"},
+    {ObsId::PauliZ, "PauliZ"},     {ObsId::Hadamard, "Hadamard"}, {ObsId::Hermitian, "Hermitian"},
+};
+
+/**
+ * InstructionStrBuilder
+ *
+ * @brief This class is used by the null device (NullQubit.hpp) whenever the flag to print
+ * instructions (print_instructions) is set to true. It is in charge of building string repretations
+ * the operations invoked in the aformentioned device interface.
+ */
+
+class InstructionStrBuilder {
+  private:
+    unordered_map<ObsIdType, string>
+        obs_id_type_to_str{}; // whenever a new observable is created we store the corresponding
+                              // string representation in this hashmap
 
     /**
-     * InstructionStrBuilder
-     *
-     * @brief This class is used by the null device (NullQubit.hpp) whenever the flag to print instructions (print_instructions) is set to true. It is in charge of building string repretations the operations invoked in the aformentioned device interface.
+     * @brief Template function that returns the string representation of some object.
      */
+    template <typename T> string element_to_str(const T &e) { return to_string(e); }
 
-    class InstructionStrBuilder {
-        private:
-            unordered_map<ObsIdType, string> obs_id_type_to_str{}; // whenever a new observable is created we store the corresponding string representation in this hashmap
+    /**
+     * @brief Template specialized to return the string representation of complex numbers.
+     */
+    template <typename T> string element_to_str(const complex<T> &c)
+    {
+        ostringstream oss;
+        oss << c.real();
 
-            /**
-             * @brief Template function that returns the string representation of some object.
-             */
-            template <typename T> string element_to_str(const T &e) {
-                return to_string(e);
-            }
-
-            /**
-             * @brief Template specialized to return the string representation of complex numbers.
-             */
-            template <typename T> string element_to_str(const complex<T> &c) {
-                ostringstream oss;
-                oss << c.real();
-
-                if (c.imag() != 0) {
-                    // to keep printing output as short as possible, we only print the imaginary part whenever is different from zero;
-                    oss << " + " << c.imag()<<"i";
-                }
-                return oss.str();
-            }
-
-            /**
-             * @brief Takes as input a vector and returns its string representation. If with_brackets=True, the square brackets will be included to enclose the vector. E.g. 
-             * - vector_to_string([0,1,2], false) returns "0, 1, 2"
-             * - vector_to_string([0,1,2], true) returns "[0, 1, 2]"
-             */
-            template <typename T> string vector_to_string(const vector<T>& v, const bool &with_brackets = true) {
-                ostringstream oss;
-                if (with_brackets) oss << "[";
-
-                for (size_t i = 0; i < v.size(); i++) {
-                    if (i > 0) {
-                        oss << ", ";
-                    }
-                    oss << element_to_str(v[i]);
-                }
-                if (with_brackets) oss << "]";
-
-                return oss.str();
-            }
-
-        /**
-         * @brief Builds the string representation of DataView
-         */
-        template <typename T, size_t R>
-        string get_dataview_str(DataView<T, R> &dataview) {
-            ostringstream oss;
-            bool is_first = true; // boolean to help determine where to put commas
-
-            oss << "[";
-            for (auto it = dataview.begin();  it != dataview.end(); it++) {
-                if (!is_first) {
-                    oss << ", "; // if is not the first element then we add a comma to separate the elements
-                }
-                oss << element_to_str(*it);
-                is_first = false;
-            }
-            oss << "]";
-            return oss.str();
+        if (c.imag() != 0) {
+            // to keep printing output as short as possible, we only print the imaginary part
+            // whenever is different from zero;
+            oss << " + " << c.imag() << "i";
         }
+        return oss.str();
+    }
 
-        public:
-            InstructionStrBuilder() = default;
-            ~InstructionStrBuilder() = default;
+    /**
+     * @brief Takes as input a vector and returns its string representation. If with_brackets=True,
+     * the square brackets will be included to enclose the vector. E.g.
+     * - vector_to_string([0,1,2], false) returns "0, 1, 2"
+     * - vector_to_string([0,1,2], true) returns "[0, 1, 2]"
+     */
+    template <typename T>
+    string vector_to_string(const vector<T> &v, const bool &with_brackets = true)
+    {
+        ostringstream oss;
+        if (with_brackets)
+            oss << "[";
 
-            /**
-             * @brief This method is used to build a string representation of AllocateQubit(), AllocateQubits(), ReleaseQubit(), ReleaseAllQubits(), Measure()
-             */
-            template <typename T> string get_simple_op_str(const string &name, const T &param) {
-                ostringstream oss;
-                oss << name << "(" << param << ")";
-                return oss.str();
+        for (size_t i = 0; i < v.size(); i++) {
+            if (i > 0) {
+                oss << ", ";
             }
+            oss << element_to_str(v[i]);
+        }
+        if (with_brackets)
+            oss << "]";
 
-            /**
-             * @brief This method is used to build a string representation of Expval() and Var()
-             */
-            string get_simple_op_str(const string &name, const ObsIdType &o) {
-                ostringstream oss;
-                oss << name << "(" << get_obs_str(o) << ")";
-                return oss.str();
+        return oss.str();
+    }
+
+    /**
+     * @brief Builds the string representation of DataView
+     */
+    template <typename T, size_t R> string get_dataview_str(DataView<T, R> &dataview)
+    {
+        ostringstream oss;
+        bool is_first = true; // boolean to help determine where to put commas
+
+        oss << "[";
+        for (auto it = dataview.begin(); it != dataview.end(); it++) {
+            if (!is_first) {
+                oss << ", "; // if is not the first element then we add a comma to separate the
+                             // elements
             }
+            oss << element_to_str(*it);
+            is_first = false;
+        }
+        oss << "]";
+        return oss.str();
+    }
 
-            /**
-             * @brief This method is used to build a string representation of State(), Probs(), PartialProbs()
-             */
-            template <typename T, size_t R>
-            string get_simple_op_str(const string &name, DataView<T, R> &dataview) {
-                ostringstream oss;
-                oss << name << "(" << get_dataview_str(dataview) << ")";
-                return oss.str();
-            }
+  public:
+    InstructionStrBuilder() = default;
+    ~InstructionStrBuilder() = default;
 
-            /**
-             * @brief This method is used to get the string representation of NamedOperation()
-             */
-            string get_named_op_str(const std::string &name, const std::vector<double> &params,
+    /**
+     * @brief This method is used to build a string representation of AllocateQubit(),
+     * AllocateQubits(), ReleaseQubit(), ReleaseAllQubits(), Measure()
+     */
+    template <typename T> string get_simple_op_str(const string &name, const T &param)
+    {
+        ostringstream oss;
+        oss << name << "(" << param << ")";
+        return oss.str();
+    }
+
+    /**
+     * @brief This method is used to build a string representation of Expval() and Var()
+     */
+    string get_simple_op_str(const string &name, const ObsIdType &o)
+    {
+        ostringstream oss;
+        oss << name << "(" << get_obs_str(o) << ")";
+        return oss.str();
+    }
+
+    /**
+     * @brief This method is used to build a string representation of State(), Probs(),
+     * PartialProbs()
+     */
+    template <typename T, size_t R>
+    string get_simple_op_str(const string &name, DataView<T, R> &dataview)
+    {
+        ostringstream oss;
+        oss << name << "(" << get_dataview_str(dataview) << ")";
+        return oss.str();
+    }
+
+    /**
+     * @brief This method is used to get the string representation of NamedOperation()
+     */
+    string get_named_op_str(const std::string &name, const std::vector<double> &params,
                             const std::vector<QubitIdType> &wires, bool inverse = false,
                             const std::vector<QubitIdType> &controlled_wires = {},
-                            const std::vector<bool> &controlled_values = {}) {
-                ostringstream oss;
-                vector<string> values_to_print; // Store the string representation of the parameters passed NamedOperation(). We only consider non-empty vectors to preserve printing-output simplicity.
+                            const std::vector<bool> &controlled_values = {})
+    {
+        ostringstream oss;
+        vector<string> values_to_print; // Store the string representation of the parameters passed
+                                        // NamedOperation(). We only consider non-empty vectors to
+                                        // preserve printing-output simplicity.
 
-                for (auto p : params) values_to_print.push_back(std::to_string(p));
-                                                            
-                if (wires.size() > 0){
-                    if (params.size()) {
-                        // when an operation corresponds to a parametric gate, explicity specify the wires as a single vector. E.g Rx(3.14, wires=[0])
-                        values_to_print.push_back("wires=" + vector_to_string(wires, true));
-                    } else {
-                        // Otherwise, we do not represent it as a vector but rather as a list separated with commas. E.g. CX(0,1)
-                        values_to_print.push_back(vector_to_string(wires, false));
-                    }
+        for (auto p : params)
+            values_to_print.push_back(std::to_string(p));
+
+        if (wires.size() > 0) {
+            if (params.size()) {
+                // when an operation corresponds to a parametric gate, explicity specify the wires
+                // as a single vector. E.g Rx(3.14, wires=[0])
+                values_to_print.push_back("wires=" + vector_to_string(wires, true));
+            }
+            else {
+                // Otherwise, we do not represent it as a vector but rather as a list separated with
+                // commas. E.g. CX(0,1)
+                values_to_print.push_back(vector_to_string(wires, false));
+            }
+        }
+
+        // if inverse is false, we will not print its value
+        if (inverse)
+            values_to_print.push_back("inverse=True");
+
+        if (controlled_wires.size() > 0)
+            values_to_print.push_back("control=" + vector_to_string(controlled_wires));
+
+        if (controlled_values.size() > 0)
+            values_to_print.push_back("control_value=" + vector_to_string(controlled_values));
+
+        oss << name << "(";
+        for (auto i = 0; i < values_to_print.size(); i++) {
+            if (i > 0) {
+                oss << ", ";
+            }
+            oss << values_to_print[i];
+        }
+        oss << ")";
+        return oss.str();
+    }
+
+    /**
+     * @brief This method is used to get the string representation of MatrixOperation()
+     */
+    string get_matrix_op_str(const std::vector<std::complex<double>> &matrix,
+                             const std::vector<QubitIdType> &wires, bool inverse,
+                             const std::vector<QubitIdType> &controlled_wires = {},
+                             const std::vector<bool> &controlled_values = {},
+                             const string &name = "MatrixOperation")
+    {
+        ostringstream oss;
+        vector<string> values_to_print; // Store the string representation of the parameters passed
+                                        // NamedOperation(). We only consider non-empty vectors to
+                                        // preserve printing-output simplicity.
+
+        values_to_print.emplace_back(vector_to_string(matrix));
+
+        values_to_print.emplace_back("wires=" + vector_to_string(wires));
+
+        if (inverse)
+            values_to_print.push_back("inverse=True");
+
+        if (controlled_wires.size() > 0)
+            values_to_print.push_back("control=" + vector_to_string(controlled_wires));
+
+        if (controlled_values.size() > 0)
+            values_to_print.push_back("control_value=" + vector_to_string(controlled_values));
+
+        oss << name << "(";
+        for (auto i = 0; i < values_to_print.size(); i++) {
+            if (i > 0) {
+                oss << ", ";
+            }
+            oss << values_to_print[i];
+        }
+
+        oss << ")";
+        return oss.str();
+    }
+
+    /**
+     * @brief Every time Observable() is invoked in the null device interface, we invoke this
+     * function to create a new ObsIdType and its corresponding string representation.
+     */
+    ObsIdType create_obs_str(ObsId obs_id, const std::vector<std::complex<double>> &matrix,
+                             const std::vector<QubitIdType> &wires)
+    {
+        ObsIdType new_id = obs_id_type_to_str.size();
+
+        if (obs_id == ObsId::Hermitian) {
+            obs_id_type_to_str.emplace(
+                new_id, get_matrix_op_str(matrix, wires, false, {}, {}, "Hermitian"));
+        }
+        else {
+            auto it = obs_id_to_str.find(obs_id);
+            if (it != obs_id_to_str.end()) {
+                obs_id_type_to_str.emplace(new_id, get_named_op_str(it->second, {}, wires));
+            }
+            else {
+                RT_FAIL(
+                    ("please check obs_id_to_str in file InstructionPrinter. Observation with ID" +
+                     to_string(obs_id) + "is not recognized.")
+                        .c_str());
+            }
+        }
+
+        return new_id;
+    }
+
+    /**
+     * @brief Every time TensorObservable() is invoked in the null device interface, we invoke this
+     * function to create a new ObsIdType and its corresponding string representation.
+     */
+    ObsIdType create_tensor_obs_str(const std::vector<ObsIdType> &obs_keys)
+    {
+        ostringstream oss;
+        for (auto i = 0; i < obs_keys.size(); i++) {
+            if (i > 0) {
+                oss << " ⊗ ";
+            }
+            oss << obs_id_type_to_str[obs_keys[i]];
+        }
+        ObsIdType new_id = obs_id_type_to_str.size();
+        obs_id_type_to_str[new_id] = oss.str();
+        return new_id;
+    }
+
+    /**
+     * @brief Every time HamiltonianObservable() is invoked in the null device interface, we invoke
+     * this function to create a new ObsIdType and its corresponding string representation.
+     */
+    ObsIdType create_hamiltonian_obs_str(const std::vector<double> &coeffs,
+                                         const std::vector<ObsIdType> &obs_keys)
+    {
+        RT_FAIL_IF(coeffs.size() != obs_keys.size(),
+                   "number of coefficients should match the number of observables");
+
+        ostringstream oss;
+
+        for (auto i = 0; i < coeffs.size(); i++) {
+            if (i > 0) {
+                if (coeffs[i] > 0) {
+                    oss << " + ";
                 }
-
-                // if inverse is false, we will not print its value
-                if (inverse) values_to_print.push_back("inverse=True");
-
-                if (controlled_wires.size() > 0) values_to_print.push_back("control=" + vector_to_string(controlled_wires));
-
-                if (controlled_values.size() > 0) values_to_print.push_back("control_value=" + vector_to_string(controlled_values));
-
-                oss << name << "(";
-                for (auto i = 0; i < values_to_print.size(); i++) {
-                    if (i > 0) {
-                        oss << ", ";
-                    }
-                    oss << values_to_print[i];
+                else if (coeffs[i] < 0) {
+                    oss << " ";
                 }
-                oss << ")";
-                return oss.str();
             }
 
-            /**
-             * @brief This method is used to get the string representation of MatrixOperation()
-             */
-            string get_matrix_op_str(const std::vector<std::complex<double>> &matrix,
-                            const std::vector<QubitIdType> &wires, bool inverse,
-                            const std::vector<QubitIdType> &controlled_wires = {},
-                            const std::vector<bool> &controlled_values = {}, const string &name="MatrixOperation") {
-                ostringstream oss;
-                vector<string> values_to_print; // Store the string representation of the parameters passed NamedOperation(). We only consider non-empty vectors to preserve printing-output simplicity.
+            if (coeffs[i] != 0)
+                oss << coeffs[i] << "*" << obs_id_type_to_str[obs_keys[i]];
+        }
 
-                values_to_print.emplace_back(vector_to_string(matrix));
+        ObsIdType new_id = obs_id_type_to_str.size();
+        obs_id_type_to_str[new_id] = oss.str();
+        return new_id;
+    }
 
-                values_to_print.emplace_back("wires=" + vector_to_string(wires));                                                        
-                
-                if (inverse) values_to_print.push_back("inverse=True");
+    /**
+     * @brief Getter function to retrieve the string representation of the observables we created.
+     */
+    string get_obs_str(const ObsIdType &o) { return obs_id_type_to_str.at(o); }
 
-                if (controlled_wires.size() > 0) values_to_print.push_back("control=" + vector_to_string(controlled_wires));
+    /**
+     * @brief This method is used to get the string representation of Sample() and PartialSample()
+     */
+    string get_samples_str(const string &name, DataView<double, 2> &samples, const size_t &shots,
+                           const vector<QubitIdType> &wires = {})
+    {
+        ostringstream oss;
+        bool is_first = true;
+        oss << name << "(" << get_dataview_str(samples);
 
-                if (controlled_values.size() > 0) values_to_print.push_back("control_value=" + vector_to_string(controlled_values));
+        if (wires.size() > 0) {
+            oss << ", wires=" << vector_to_string(wires);
+        }
 
-                oss << name << "(";
-                for (auto i = 0; i < values_to_print.size(); i++) {
-                    if (i > 0) {
-                        oss << ", ";
-                    }
-                    oss << values_to_print[i];
-                }
+        oss << ", shots=" << shots << ")";
 
-                oss << ")";
-                return oss.str();
+        return oss.str();
+    }
+
+    /**
+     * @brief This method is used to get the string representation of Counts() and PartialCounts().
+     */
+    string get_counts_str(const string &name, DataView<double, 1> &vals,
+                          DataView<int64_t, 1> &counts, const size_t &shots,
+                          const vector<QubitIdType> &wires = {})
+    {
+        RT_FAIL_IF(vals.size() != counts.size(), "number of eigenvalues does not matches counts");
+
+        ostringstream oss;
+        bool is_first = true;
+        oss << name << "(";
+        oss << "[";
+        auto it1 = vals.begin();
+        auto it2 = counts.begin();
+        for (; it1 != vals.end(); it1++, it2++) {
+            if (!is_first) {
+                oss << ", ";
             }
-            
-            /**
-             * @brief Every time Observable() is invoked in the null device interface, we invoke this function to create a new ObsIdType and its corresponding string representation.
-             */
-            ObsIdType create_obs_str(ObsId obs_id, const std::vector<std::complex<double>> &matrix,
-                        const std::vector<QubitIdType> &wires) {
-                ObsIdType new_id = obs_id_type_to_str.size();
+            // here we build a substring that represents a pair (eigenval, count)
+            oss << "(" << element_to_str(*it1) << ", " << element_to_str(*it2) << ")";
+            is_first = false;
+        }
+        oss << "]"; //
 
-                if (obs_id == ObsId::Hermitian) {
-                    obs_id_type_to_str.emplace(new_id, 
-                        get_matrix_op_str(matrix, wires, false, {}, {}, "Hermitian"));
-                } else {
-                    auto it = obs_id_to_str.find(obs_id);
-                    if (it != obs_id_to_str.end()) {
-                        obs_id_type_to_str.emplace(new_id, get_named_op_str(it->second, {}, wires));
-                    } else {
-                        RT_FAIL(("please check obs_id_to_str in file InstructionPrinter. Observation with ID" + to_string(obs_id)  + "is not recognized.").c_str());
-                    }
-                }
-                
-                return new_id;
-            }
+        if (wires.size() > 0) {
+            oss << ", wires=" << vector_to_string(wires);
+        }
 
-            /**
-             * @brief Every time TensorObservable() is invoked in the null device interface, we invoke this function to create a new ObsIdType and its corresponding string representation.
-             */
-            ObsIdType create_tensor_obs_str(const std::vector<ObsIdType> &obs_keys) {
-                ostringstream oss;
-                for (auto i = 0 ; i < obs_keys.size(); i++) {
-                    if (i > 0) {
-                        oss << " ⊗ ";
-                    }
-                    oss << obs_id_type_to_str[obs_keys[i]];
-                }
-                ObsIdType new_id = obs_id_type_to_str.size();
-                obs_id_type_to_str[new_id] = oss.str();
-                return new_id;
-            }
+        oss << ", shots=" << shots;
 
-            /**
-             * @brief Every time HamiltonianObservable() is invoked in the null device interface, we invoke this function to create a new ObsIdType and its corresponding string representation.
-             */
-            ObsIdType create_hamiltonian_obs_str(const std::vector<double> &coeffs, const std::vector<ObsIdType> &obs_keys) {
-                RT_FAIL_IF(coeffs.size() != obs_keys.size(), "number of coefficients should match the number of observables");
+        oss << ")";
 
-                ostringstream oss;
-
-                for (auto i = 0; i < coeffs.size(); i++) {
-                    if (i > 0) {
-                        if (coeffs[i] > 0) {
-                            oss << " + ";
-                        }else if(coeffs[i] < 0) {
-                            oss << " ";
-                        }
-                        
-                    }
-
-                    if (coeffs[i] != 0)
-                        oss << coeffs[i] << "*" << obs_id_type_to_str[obs_keys[i]];
-                }
-
-                ObsIdType new_id = obs_id_type_to_str.size();
-                obs_id_type_to_str[new_id] = oss.str();
-                return new_id;
-            }
-
-            /**
-             * @brief Getter function to retrieve the string representation of the observables we created.
-             */
-            string get_obs_str(const ObsIdType &o) {
-                return obs_id_type_to_str.at(o);
-            }
-
-            /**
-             * @brief This method is used to get the string representation of Sample() and PartialSample()
-             */
-            string get_samples_str(const string &name, DataView<double, 2> &samples, const size_t &shots, const vector<QubitIdType> &wires={}) {
-                ostringstream oss;
-                bool is_first = true;
-                oss << name << "(" << get_dataview_str(samples);
-
-                if (wires.size() > 0) {
-                    oss << ", wires=" << vector_to_string(wires);
-                }
-                
-                oss << ", shots=" << shots << ")";
-
-                return oss.str();
-            }
-
-            /**
-             * @brief This method is used to get the string representation of Counts() and PartialCounts().
-             */
-            string get_counts_str(const string &name, DataView<double, 1> &vals, DataView<int64_t, 1> &counts, const size_t &shots, const vector<QubitIdType> &wires={}) {
-                RT_FAIL_IF(vals.size() != counts.size(), "number of eigenvalues does not matches counts");
-
-                ostringstream oss;
-                bool is_first = true;
-                oss << name << "(";
-                oss << "[";
-                auto it1 = vals.begin();
-                auto it2 = counts.begin();
-                for ( ; it1 != vals.end(); it1++, it2++) {
-                    if (!is_first) {
-                        oss << ", ";
-                    }
-                    // here we build a substring that represents a pair (eigenval, count)
-                    oss << "(" << element_to_str(*it1) << ", " << element_to_str(*it2) << ")";
-                    is_first = false;
-                }
-                oss << "]"; //
-
-                if (wires.size() > 0) {
-                    oss << ", wires=" << vector_to_string(wires);
-                }
-
-                oss << ", shots=" << shots;
-
-                oss << ")";
-
-                return oss.str();
-            }
-    };
-}
+        return oss.str();
+    }
+};
+} // namespace Catalyst::Runtime

--- a/runtime/lib/backend/null_qubit/InstructionStrBuilder.hpp
+++ b/runtime/lib/backend/null_qubit/InstructionStrBuilder.hpp
@@ -130,10 +130,14 @@ class InstructionStrBuilder {
      * PartialProbs()
      */
     template <typename T, size_t R>
-    string get_simple_op_str(const string &name, DataView<T, R> &dataview)
+    string get_simple_op_str(const string &name, DataView<T, R> &dataview, const std::vector<QubitIdType> &wires={})
     {
         ostringstream oss;
-        oss << name << "(" << get_dataview_str(dataview) << ")";
+        oss << name << "(" << get_dataview_str(dataview); 
+        if (wires.size() > 0) {
+            oss << ", wires=" << vector_to_string(wires);
+        }
+        oss << ")";
         return oss.str();
     }
 
@@ -168,7 +172,7 @@ class InstructionStrBuilder {
 
         // if inverse is false, we will not print its value
         if (inverse)
-            values_to_print.push_back("inverse=True");
+            values_to_print.push_back("inverse=true");
 
         if (controlled_wires.size() > 0)
             values_to_print.push_back("control=" + vector_to_string(controlled_wires));
@@ -191,7 +195,7 @@ class InstructionStrBuilder {
      * @brief This method is used to get the string representation of MatrixOperation()
      */
     string get_matrix_op_str(const std::vector<std::complex<double>> &matrix,
-                             const std::vector<QubitIdType> &wires, bool inverse,
+                             const std::vector<QubitIdType> &wires, bool inverse=false,
                              const std::vector<QubitIdType> &controlled_wires = {},
                              const std::vector<bool> &controlled_values = {},
                              const string &name = "MatrixOperation")
@@ -203,10 +207,11 @@ class InstructionStrBuilder {
 
         values_to_print.emplace_back(vector_to_string(matrix));
 
-        values_to_print.emplace_back("wires=" + vector_to_string(wires));
+        if (wires.size() > 0)
+            values_to_print.emplace_back("wires=" + vector_to_string(wires));
 
         if (inverse)
-            values_to_print.push_back("inverse=True");
+            values_to_print.push_back("inverse=true");
 
         if (controlled_wires.size() > 0)
             values_to_print.push_back("control=" + vector_to_string(controlled_wires));
@@ -285,8 +290,9 @@ class InstructionStrBuilder {
 
         ostringstream oss;
 
+        bool is_first = true;
         for (auto i = 0; i < coeffs.size(); i++) {
-            if (i > 0) {
+            if (!is_first) {
                 if (coeffs[i] > 0) {
                     oss << " + ";
                 }
@@ -295,8 +301,10 @@ class InstructionStrBuilder {
                 }
             }
 
-            if (coeffs[i] != 0)
+            if (coeffs[i] != 0) {
                 oss << coeffs[i] << "*" << obs_id_type_to_str[obs_keys[i]];
+                is_first = false;
+            }   
         }
 
         ObsIdType new_id = obs_id_type_to_str.size();

--- a/runtime/lib/backend/null_qubit/InstructionStrBuilder.hpp
+++ b/runtime/lib/backend/null_qubit/InstructionStrBuilder.hpp
@@ -54,6 +54,46 @@ namespace Catalyst::Runtime {
                 return oss.str();
             }
 
+            /**
+             * @brief Takes as input a vector and returns its string representation. If with_brackets=True, the square brackets will be included to enclose the vector. E.g. 
+             * - vector_to_string([0,1,2], false) returns "0, 1, 2"
+             * - vector_to_string([0,1,2], true) returns "[0, 1, 2]"
+             */
+            template <typename T> string vector_to_string(const vector<T>& v, const bool &with_brackets = true) {
+                ostringstream oss;
+                if (with_brackets) oss << "[";
+
+                for (size_t i = 0; i < v.size(); i++) {
+                    if (i > 0) {
+                        oss << ", ";
+                    }
+                    oss << element_to_str(v[i]);
+                }
+                if (with_brackets) oss << "]";
+
+                return oss.str();
+            }
+
+        /**
+         * @brief Builds the string representation of DataView
+         */
+        template <typename T, size_t R>
+        string get_dataview_str(DataView<T, R> &dataview) {
+            ostringstream oss;
+            bool is_first = true; // boolean to help determine where to put commas
+
+            oss << "[";
+            for (auto it = dataview.begin();  it != dataview.end(); it++) {
+                if (!is_first) {
+                    oss << ", "; // if is not the first element then we add a comma to separate the elements
+                }
+                oss << element_to_str(*it);
+                is_first = false;
+            }
+            oss << "]";
+            return oss.str();
+        }
+        
         public:
             InstructionStrBuilder() = default;
             ~InstructionStrBuilder() = default;
@@ -83,26 +123,6 @@ namespace Catalyst::Runtime {
             string get_simple_op_str(const string &name, DataView<T, R> &dataview) {
                 ostringstream oss;
                 oss << name << "(" << get_dataview_str(dataview) << ")";
-                return oss.str();
-            }
-
-            /**
-             * @brief Takes as input a vector and returns its string representation. If with_brackets=True, the square brackets will be included to enclose the vector. E.g. 
-             * - vector_to_string([0,1,2], false) returns "0, 1, 2"
-             * - vector_to_string([0,1,2], true) returns "[0, 1, 2]"
-             */
-            template <typename T> string vector_to_string(const vector<T>& v, const bool &with_brackets = true) {
-                ostringstream oss;
-                if (with_brackets) oss << "[";
-
-                for (size_t i = 0; i < v.size(); i++) {
-                    if (i > 0) {
-                        oss << ", ";
-                    }
-                    oss << element_to_str(v[i]);
-                }
-                if (with_brackets) oss << "]";
-
                 return oss.str();
             }
 
@@ -241,26 +261,6 @@ namespace Catalyst::Runtime {
              */
             string get_obs_str(const ObsIdType &o) {
                 return obs_id_type_to_str.at(o);
-            }
-
-            /**
-             * @brief Builds the string representation of DataView
-             */
-            template <typename T, size_t R>
-            string get_dataview_str(DataView<T, R> &dataview) {
-                ostringstream oss;
-                bool is_first = true; // boolean to help determine where to put commas
-
-                oss << "[";
-                for (auto it = dataview.begin();  it != dataview.end(); it++) {
-                    if (!is_first) {
-                        oss << ", "; // if is not the first element then we add a comma to separate the elements
-                    }
-                    oss << element_to_str(*it);
-                    is_first = false;
-                }
-                oss << "]";
-                return oss.str();
             }
 
             /**

--- a/runtime/lib/backend/null_qubit/NullQubit.hpp
+++ b/runtime/lib/backend/null_qubit/NullQubit.hpp
@@ -16,11 +16,11 @@
 
 #include <algorithm> // generate_n
 #include <complex>
+#include <iostream>
 #include <memory>
 #include <optional>
 #include <random>
 #include <vector>
-#include <iostream>
 
 #include "DataView.hpp"
 #include "InstructionStrBuilder.hpp"
@@ -42,8 +42,10 @@ namespace Catalyst::Runtime::Devices {
  *   of the device; these are used to implement Quantum Instruction Set (QIS) instructions.
  */
 struct NullQubit final : public Catalyst::Runtime::QuantumDevice {
-    NullQubit(const std::string &kwargs = "{}") { 
-        std::unordered_map<std::string, std::string> device_kwargs = Catalyst::Runtime::parse_kwargs(kwargs);
+    NullQubit(const std::string &kwargs = "{}")
+    {
+        std::unordered_map<std::string, std::string> device_kwargs =
+            Catalyst::Runtime::parse_kwargs(kwargs);
         print_instructions = device_kwargs["print_instructions"] == "True" ? 1 : 0;
     }
     ~NullQubit() = default; // LCOV_EXCL_LINE
@@ -61,7 +63,8 @@ struct NullQubit final : public Catalyst::Runtime::QuantumDevice {
     auto AllocateQubit() -> QubitIdType
     {
         if (print_instructions) {
-            std::cout << instruction_str_builder.get_simple_op_str("AllocateQubit", "") << std::endl;
+            std::cout << instruction_str_builder.get_simple_op_str("AllocateQubit", "")
+                      << std::endl;
         }
 
         num_qubits_++; // next_id
@@ -76,12 +79,14 @@ struct NullQubit final : public Catalyst::Runtime::QuantumDevice {
      * @return `std::vector<QubitIdType>`
      */
     auto AllocateQubits(size_t num_qubits) -> std::vector<QubitIdType>
-    {   
+    {
         bool prev_print_instructions = print_instructions;
         if (print_instructions) {
-            std::cout << instruction_str_builder.get_simple_op_str("AllocateQubits", num_qubits) << std::endl;
+            std::cout << instruction_str_builder.get_simple_op_str("AllocateQubits", num_qubits)
+                      << std::endl;
         }
-        print_instructions = false; // set to false so we do not print instructions for each call to AllocateQubit() below.
+        print_instructions = false; // set to false so we do not print instructions for each call to
+                                    // AllocateQubit() below.
 
         if (!num_qubits) {
             return {};
@@ -114,7 +119,8 @@ struct NullQubit final : public Catalyst::Runtime::QuantumDevice {
     void ReleaseAllQubits()
     {
         if (print_instructions) {
-            std::cout << instruction_str_builder.get_simple_op_str("ReleaseAllQubits", "") << std::endl;
+            std::cout << instruction_str_builder.get_simple_op_str("ReleaseAllQubits", "")
+                      << std::endl;
         }
 
         num_qubits_ = 0;
@@ -215,7 +221,9 @@ struct NullQubit final : public Catalyst::Runtime::QuantumDevice {
                         const std::vector<bool> &controlled_values = {})
     {
         if (print_instructions) {
-            std::cout << instruction_str_builder.get_named_op_str(name, params, wires, inverse, controlled_wires, controlled_values) << std::endl;
+            std::cout << instruction_str_builder.get_named_op_str(
+                             name, params, wires, inverse, controlled_wires, controlled_values)
+                      << std::endl;
         }
     }
 
@@ -229,7 +237,9 @@ struct NullQubit final : public Catalyst::Runtime::QuantumDevice {
                          const std::vector<bool> &controlled_values = {})
     {
         if (print_instructions) {
-            std::cout << instruction_str_builder.get_matrix_op_str(matrix, wires, inverse, controlled_wires, controlled_values) << std::endl;
+            std::cout << instruction_str_builder.get_matrix_op_str(
+                             matrix, wires, inverse, controlled_wires, controlled_values)
+                      << std::endl;
         }
     }
 
@@ -242,7 +252,7 @@ struct NullQubit final : public Catalyst::Runtime::QuantumDevice {
     auto Observable(ObsId obs_id, const std::vector<std::complex<double>> &matrix,
                     const std::vector<QubitIdType> &wires) -> ObsIdType
     {
-        return instruction_str_builder.create_obs_str(obs_id, matrix, wires); 
+        return instruction_str_builder.create_obs_str(obs_id, matrix, wires);
     }
 
     /**
@@ -250,7 +260,8 @@ struct NullQubit final : public Catalyst::Runtime::QuantumDevice {
      *
      * @return `ObsIdType` Index of the constructed observable
      */
-    auto TensorObservable(const std::vector<ObsIdType> &obs_keys) -> ObsIdType {
+    auto TensorObservable(const std::vector<ObsIdType> &obs_keys) -> ObsIdType
+    {
         return instruction_str_builder.create_tensor_obs_str(obs_keys);
     }
 
@@ -259,8 +270,8 @@ struct NullQubit final : public Catalyst::Runtime::QuantumDevice {
      *
      * @return `ObsIdType` Index of the constructed observable
      */
-    auto HamiltonianObservable(const std::vector<double> &matrix, const std::vector<ObsIdType> &obs_keys)
-        -> ObsIdType
+    auto HamiltonianObservable(const std::vector<double> &matrix,
+                               const std::vector<ObsIdType> &obs_keys) -> ObsIdType
     {
         return instruction_str_builder.create_hamiltonian_obs_str(matrix, obs_keys);
     }
@@ -270,11 +281,12 @@ struct NullQubit final : public Catalyst::Runtime::QuantumDevice {
      *
      * @return `double` The expected value
      */
-    auto Expval(ObsIdType o) -> double {
+    auto Expval(ObsIdType o) -> double
+    {
         if (print_instructions) {
             std::cout << instruction_str_builder.get_simple_op_str("Expval", o) << std::endl;
         }
-        return 0.0; 
+        return 0.0;
     }
 
     /**
@@ -282,17 +294,19 @@ struct NullQubit final : public Catalyst::Runtime::QuantumDevice {
      *
      * @return `double` The variance
      */
-    auto Var(ObsIdType o) -> double { 
+    auto Var(ObsIdType o) -> double
+    {
         if (print_instructions) {
             std::cout << instruction_str_builder.get_simple_op_str("Var", o) << std::endl;
         }
-        return 0.0; 
+        return 0.0;
     }
 
     /**
      * @brief Doesn't Get the state-vector of a device.
      */
-    void State(DataView<std::complex<double>, 1> &state) {
+    void State(DataView<std::complex<double>, 1> &state)
+    {
         if (print_instructions) {
             std::cout << instruction_str_builder.get_simple_op_str("State", state) << std::endl;
         }
@@ -301,7 +315,8 @@ struct NullQubit final : public Catalyst::Runtime::QuantumDevice {
     /**
      * @brief Doesn't Compute the probabilities of each computational basis state.
      */
-    void Probs(DataView<double, 1> &probs) {
+    void Probs(DataView<double, 1> &probs)
+    {
         if (print_instructions) {
             std::cout << instruction_str_builder.get_simple_op_str("Probs", probs) << std::endl;
         }
@@ -310,9 +325,11 @@ struct NullQubit final : public Catalyst::Runtime::QuantumDevice {
     /**
      * @brief Doesn't Compute the probabilities for a subset of the full system.
      */
-    void PartialProbs(DataView<double, 1> &probs, const std::vector<QubitIdType> &wires) {
+    void PartialProbs(DataView<double, 1> &probs, const std::vector<QubitIdType> &wires)
+    {
         if (print_instructions) {
-            std::cout << instruction_str_builder.get_simple_op_str("PartialProbs", probs) << std::endl;
+            std::cout << instruction_str_builder.get_simple_op_str("PartialProbs", probs)
+                      << std::endl;
         }
     }
 
@@ -320,9 +337,11 @@ struct NullQubit final : public Catalyst::Runtime::QuantumDevice {
      * @brief Doesn't Compute samples with the number of shots on the entire wires,
      * returing raw samples.
      */
-    void Sample(DataView<double, 2> &samples, size_t shots) {
+    void Sample(DataView<double, 2> &samples, size_t shots)
+    {
         if (print_instructions) {
-            std::cout << instruction_str_builder.get_samples_str("Sample", samples, shots) << std::endl;
+            std::cout << instruction_str_builder.get_samples_str("Sample", samples, shots)
+                      << std::endl;
         }
     }
 
@@ -334,20 +353,25 @@ struct NullQubit final : public Catalyst::Runtime::QuantumDevice {
      * shape `shots * numWires`. The built-in iterator in `DataView<double, 2>`
      * iterates over all elements of `samples` row-wise.
      */
-    void PartialSample(DataView<double, 2> &samples, const std::vector<QubitIdType> &wires, size_t shots) {
+    void PartialSample(DataView<double, 2> &samples, const std::vector<QubitIdType> &wires,
+                       size_t shots)
+    {
         if (print_instructions) {
-            std::cout << instruction_str_builder.get_samples_str("PartialSample", samples, shots, wires) << std::endl;
+            std::cout << instruction_str_builder.get_samples_str("PartialSample", samples, shots,
+                                                                 wires)
+                      << std::endl;
         }
-
     }
 
     /**
      * @brief Doesn't Sample with the number of shots on the entire wires, returning the
      * number of counts for each sample.
      */
-    void Counts(DataView<double, 1> &eigen_vals, DataView<int64_t, 1> &counts, size_t shots) {
+    void Counts(DataView<double, 1> &eigen_vals, DataView<int64_t, 1> &counts, size_t shots)
+    {
         if (print_instructions) {
-            std::cout << instruction_str_builder.get_counts_str("Counts", eigen_vals, counts, shots) << std::endl;
+            std::cout << instruction_str_builder.get_counts_str("Counts", eigen_vals, counts, shots)
+                      << std::endl;
         }
     }
 
@@ -359,7 +383,9 @@ struct NullQubit final : public Catalyst::Runtime::QuantumDevice {
                        const std::vector<QubitIdType> &wires, size_t shots)
     {
         if (print_instructions) {
-            std::cout << instruction_str_builder.get_counts_str("PartialCounts", eigen_vals, counts, shots, wires) << std::endl;
+            std::cout << instruction_str_builder.get_counts_str("PartialCounts", eigen_vals, counts,
+                                                                shots, wires)
+                      << std::endl;
         }
     }
 

--- a/runtime/lib/backend/null_qubit/NullQubit.hpp
+++ b/runtime/lib/backend/null_qubit/NullQubit.hpp
@@ -328,7 +328,7 @@ struct NullQubit final : public Catalyst::Runtime::QuantumDevice {
     void PartialProbs(DataView<double, 1> &probs, const std::vector<QubitIdType> &wires)
     {
         if (print_instructions) {
-            std::cout << instruction_str_builder.get_simple_op_str("PartialProbs", probs)
+            std::cout << instruction_str_builder.get_simple_op_str("PartialProbs", probs, wires)
                       << std::endl;
         }
     }

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ target_link_libraries(runner_tests_qir_runtime PRIVATE
 
 target_sources(runner_tests_qir_runtime PRIVATE
     Test_NullQubit.cpp
+    Test_InstructionStrBuilder.cpp
     )
 
 catch_discover_tests(runner_tests_qir_runtime)

--- a/runtime/tests/Test_InstructionStrBuilder.cpp
+++ b/runtime/tests/Test_InstructionStrBuilder.cpp
@@ -1,0 +1,98 @@
+#include "InstructionStrBuilder.hpp"
+#include "TestUtils.hpp"
+
+TEST_CASE("string building is correct for instructions that require one parameter", "[InstructionStrBuilder]") {
+    InstructionStrBuilder str_builder;
+    CHECK(str_builder.get_simple_op_str("AllocateQubit", "") == "AllocateQubit()");
+    CHECK(str_builder.get_simple_op_str("AllocateQubits", 5) == "AllocateQubits(5)");
+    CHECK(str_builder.get_simple_op_str("ReleaseQubit", "") == "ReleaseQubit()");
+    CHECK(str_builder.get_simple_op_str("ReleaseAllQubits", "") == "ReleaseAllQubits()");
+    CHECK(str_builder.get_simple_op_str("Measure", 0) == "Measure(0)");
+}
+
+TEST_CASE("string building is correct for instructions that require a parameter of type ObsIdType", "[InstructionStrBuilder]") {
+    InstructionStrBuilder str_builder;
+    auto id = str_builder.create_obs_str(ObsId::PauliX, {}, {0});
+
+    CHECK(str_builder.get_simple_op_str("Expval", id) == "Expval(PauliX(0))");
+    CHECK(str_builder.get_simple_op_str("Var", id) == "Var(PauliX(0))");
+}
+
+TEST_CASE("string building is correct for instructions that require a parameter of type DataView", "[InstructionStrBuilder]") {
+    InstructionStrBuilder str_builder;
+    std::vector<std::complex<double>> state(2);
+    DataView<std::complex<double>, 1> view(state);
+
+    CHECK(str_builder.get_simple_op_str("State", view) == "State([0, 0])");
+    CHECK(str_builder.get_simple_op_str("Probs", view) == "Probs([0, 0])");
+    CHECK(str_builder.get_simple_op_str("PartialProbs", view, {0}) == "PartialProbs([0, 0], wires=[0])");
+}
+
+TEST_CASE("string building is correct for NamedOperation", "[InstructionStrBuilder]") {
+    InstructionStrBuilder str_builder;
+
+    CHECK(str_builder.get_named_op_str("NamedOperation", {3.14, 0.705}, {}) == "NamedOperation(3.140000, 0.705000)");
+    CHECK(str_builder.get_named_op_str("NamedOperation", {3.14, 0.705}, {0}) == "NamedOperation(3.140000, 0.705000, wires=[0])");
+    CHECK(str_builder.get_named_op_str("NamedOperation", {}, {0}) == "NamedOperation(0)");
+    CHECK(str_builder.get_named_op_str("NamedOperation", {}, {0}, true) == "NamedOperation(0, inverse=true)");
+    CHECK(str_builder.get_named_op_str("NamedOperation", {}, {1}, false, {0}) == "NamedOperation(1, control=[0])");
+    CHECK(str_builder.get_named_op_str("NamedOperation", {}, {1}, false, {0}, {true}) == "NamedOperation(1, control=[0], control_value=[1])");
+}
+
+TEST_CASE("string building is correct for MatrixOperation", "[InstructionStrBuilder]") {
+    InstructionStrBuilder str_builder;
+    std::vector<std::complex<double>> v = {std::complex<double>(1.0), std::complex<double>(0.0), std::complex<double>(0.0), std::complex<double>(1.0)};
+
+    CHECK(str_builder.get_matrix_op_str(v, {}) == "MatrixOperation([1, 0, 0, 1])");
+    CHECK(str_builder.get_matrix_op_str(v, {0}) == "MatrixOperation([1, 0, 0, 1], wires=[0])");
+    CHECK(str_builder.get_matrix_op_str(v, {0}, true) == "MatrixOperation([1, 0, 0, 1], wires=[0], inverse=true)");
+    CHECK(str_builder.get_matrix_op_str(v, {1}, false, {0}) == "MatrixOperation([1, 0, 0, 1], wires=[1], control=[0])");
+    CHECK(str_builder.get_matrix_op_str(v, {1}, false, {0}, {true}) == "MatrixOperation([1, 0, 0, 1], wires=[1], control=[0], control_value=[1])");
+}
+
+TEST_CASE("registers correctly a new observable", "[InstructionStrBuilder]") {
+    InstructionStrBuilder str_builder;
+
+    ObsId obs_id1 = ObsId::PauliX;
+    ObsId obs_id2 = ObsId::Hermitian;
+
+    CHECK(str_builder.create_obs_str(obs_id1, {}, {0}) == 0);
+    CHECK(str_builder.create_obs_str(obs_id2, {1, 0, 0, 1}, {0}) == 1);
+    CHECK(str_builder.get_obs_str(0) == "PauliX(0)");
+    CHECK(str_builder.get_obs_str(1) == "Hermitian([1, 0, 0, 1], wires=[0])");
+
+    // test tensor product observable
+    CHECK(str_builder.create_tensor_obs_str({0, 1}) == 2);
+    CHECK(str_builder.get_obs_str(2) == "PauliX(0) ⊗ Hermitian([1, 0, 0, 1], wires=[0])");
+
+    // test hamiltonian observable
+    CHECK(str_builder.create_hamiltonian_obs_str({0.1, 0.2}, {0, 1}) == 3);
+    CHECK(str_builder.get_obs_str(3) == "0.1*PauliX(0) + 0.2*Hermitian([1, 0, 0, 1], wires=[0])");
+
+    CHECK(str_builder.create_hamiltonian_obs_str({0.0, 0.2}, {0, 1}) == 4);
+    CHECK(str_builder.get_obs_str(4) == "0.2*Hermitian([1, 0, 0, 1], wires=[0])");
+
+    CHECK(str_builder.create_hamiltonian_obs_str({0.1, -0.2}, {0, 1}) == 5);
+    CHECK(str_builder.get_obs_str(5) == "0.1*PauliX(0) -0.2*Hermitian([1, 0, 0, 1], wires=[0])");
+}
+
+// TEST_CASE("string building for Sample() and PartialSample()", "[InstructionStrBuilder]") {
+//     InstructionStrBuilder str_builder;
+//     std::vector<std::complex<double>> v(2);
+//     DataView<std::vector<std::complex<double>>, 2> view({v, v}, 0, {2, 2}, {1,1});
+
+//     CHECK(str_builder.get_samples_str("Sample", view, 100) == "Sample([0, 0], shots=100)");
+//     CHECK(str_builder.get_samples_str("PartialSample", view, 100, {0}) == "PartialSample([0, 0], wires=[0], shots=100)");
+// }
+
+TEST_CASE("string building for Counts() and PartialCounts()", "[InstructionStrBuilder]") {
+    InstructionStrBuilder str_builder;
+    std::vector<double> state(2);
+    DataView<double, 1> state_view(state);
+
+    std::vector<int64_t> counts(2);
+    DataView<int64_t, 1> counts_view(counts);
+
+    CHECK(str_builder.get_counts_str("Counts", state_view, counts_view, 100) == "Counts([(0.000000, 0), (0.000000, 0)], shots=100)");
+    CHECK(str_builder.get_counts_str("PartialCounts", state_view, counts_view, 100, {0}) == "PartialCounts([(0.000000, 0), (0.000000, 0)], wires=[0], shots=100)");
+}

--- a/runtime/tests/Test_InstructionStrBuilder.cpp
+++ b/runtime/tests/Test_InstructionStrBuilder.cpp
@@ -95,16 +95,6 @@ TEST_CASE("registers correctly a new observable", "[InstructionStrBuilder]")
     CHECK(str_builder.get_obs_str(5) == "0.1*PauliX(0) -0.2*Hermitian([1, 0, 0, 1], wires=[0])");
 }
 
-// TEST_CASE("string building for Sample() and PartialSample()", "[InstructionStrBuilder]") {
-//     InstructionStrBuilder str_builder;
-//     std::vector<std::complex<double>> v(2);
-//     DataView<std::vector<std::complex<double>>, 2> view({v, v}, 0, {2, 2}, {1,1});
-
-//     CHECK(str_builder.get_samples_str("Sample", view, 100) == "Sample([0, 0], shots=100)");
-//     CHECK(str_builder.get_samples_str("PartialSample", view, 100, {0}) == "PartialSample([0, 0],
-//     wires=[0], shots=100)");
-// }
-
 TEST_CASE("string building for Counts() and PartialCounts()", "[InstructionStrBuilder]")
 {
     InstructionStrBuilder str_builder;

--- a/runtime/tests/Test_InstructionStrBuilder.cpp
+++ b/runtime/tests/Test_InstructionStrBuilder.cpp
@@ -1,7 +1,9 @@
 #include "InstructionStrBuilder.hpp"
 #include "TestUtils.hpp"
 
-TEST_CASE("string building is correct for instructions that require one parameter", "[InstructionStrBuilder]") {
+TEST_CASE("string building is correct for instructions that require one parameter",
+          "[InstructionStrBuilder]")
+{
     InstructionStrBuilder str_builder;
     CHECK(str_builder.get_simple_op_str("AllocateQubit", "") == "AllocateQubit()");
     CHECK(str_builder.get_simple_op_str("AllocateQubits", 5) == "AllocateQubits(5)");
@@ -10,7 +12,9 @@ TEST_CASE("string building is correct for instructions that require one paramete
     CHECK(str_builder.get_simple_op_str("Measure", 0) == "Measure(0)");
 }
 
-TEST_CASE("string building is correct for instructions that require a parameter of type ObsIdType", "[InstructionStrBuilder]") {
+TEST_CASE("string building is correct for instructions that require a parameter of type ObsIdType",
+          "[InstructionStrBuilder]")
+{
     InstructionStrBuilder str_builder;
     auto id = str_builder.create_obs_str(ObsId::PauliX, {}, {0});
 
@@ -18,39 +22,54 @@ TEST_CASE("string building is correct for instructions that require a parameter 
     CHECK(str_builder.get_simple_op_str("Var", id) == "Var(PauliX(0))");
 }
 
-TEST_CASE("string building is correct for instructions that require a parameter of type DataView", "[InstructionStrBuilder]") {
+TEST_CASE("string building is correct for instructions that require a parameter of type DataView",
+          "[InstructionStrBuilder]")
+{
     InstructionStrBuilder str_builder;
     std::vector<std::complex<double>> state(2);
     DataView<std::complex<double>, 1> view(state);
 
     CHECK(str_builder.get_simple_op_str("State", view) == "State([0, 0])");
     CHECK(str_builder.get_simple_op_str("Probs", view) == "Probs([0, 0])");
-    CHECK(str_builder.get_simple_op_str("PartialProbs", view, {0}) == "PartialProbs([0, 0], wires=[0])");
+    CHECK(str_builder.get_simple_op_str("PartialProbs", view, {0}) ==
+          "PartialProbs([0, 0], wires=[0])");
 }
 
-TEST_CASE("string building is correct for NamedOperation", "[InstructionStrBuilder]") {
+TEST_CASE("string building is correct for NamedOperation", "[InstructionStrBuilder]")
+{
     InstructionStrBuilder str_builder;
 
-    CHECK(str_builder.get_named_op_str("NamedOperation", {3.14, 0.705}, {}) == "NamedOperation(3.140000, 0.705000)");
-    CHECK(str_builder.get_named_op_str("NamedOperation", {3.14, 0.705}, {0}) == "NamedOperation(3.140000, 0.705000, wires=[0])");
+    CHECK(str_builder.get_named_op_str("NamedOperation", {3.14, 0.705}, {}) ==
+          "NamedOperation(3.140000, 0.705000)");
+    CHECK(str_builder.get_named_op_str("NamedOperation", {3.14, 0.705}, {0}) ==
+          "NamedOperation(3.140000, 0.705000, wires=[0])");
     CHECK(str_builder.get_named_op_str("NamedOperation", {}, {0}) == "NamedOperation(0)");
-    CHECK(str_builder.get_named_op_str("NamedOperation", {}, {0}, true) == "NamedOperation(0, inverse=true)");
-    CHECK(str_builder.get_named_op_str("NamedOperation", {}, {1}, false, {0}) == "NamedOperation(1, control=[0])");
-    CHECK(str_builder.get_named_op_str("NamedOperation", {}, {1}, false, {0}, {true}) == "NamedOperation(1, control=[0], control_value=[1])");
+    CHECK(str_builder.get_named_op_str("NamedOperation", {}, {0}, true) ==
+          "NamedOperation(0, inverse=true)");
+    CHECK(str_builder.get_named_op_str("NamedOperation", {}, {1}, false, {0}) ==
+          "NamedOperation(1, control=[0])");
+    CHECK(str_builder.get_named_op_str("NamedOperation", {}, {1}, false, {0}, {true}) ==
+          "NamedOperation(1, control=[0], control_value=[1])");
 }
 
-TEST_CASE("string building is correct for MatrixOperation", "[InstructionStrBuilder]") {
+TEST_CASE("string building is correct for MatrixOperation", "[InstructionStrBuilder]")
+{
     InstructionStrBuilder str_builder;
-    std::vector<std::complex<double>> v = {std::complex<double>(1.0), std::complex<double>(0.0), std::complex<double>(0.0), std::complex<double>(1.0)};
+    std::vector<std::complex<double>> v = {std::complex<double>(1.0), std::complex<double>(0.0),
+                                           std::complex<double>(0.0), std::complex<double>(1.0)};
 
     CHECK(str_builder.get_matrix_op_str(v, {}) == "MatrixOperation([1, 0, 0, 1])");
     CHECK(str_builder.get_matrix_op_str(v, {0}) == "MatrixOperation([1, 0, 0, 1], wires=[0])");
-    CHECK(str_builder.get_matrix_op_str(v, {0}, true) == "MatrixOperation([1, 0, 0, 1], wires=[0], inverse=true)");
-    CHECK(str_builder.get_matrix_op_str(v, {1}, false, {0}) == "MatrixOperation([1, 0, 0, 1], wires=[1], control=[0])");
-    CHECK(str_builder.get_matrix_op_str(v, {1}, false, {0}, {true}) == "MatrixOperation([1, 0, 0, 1], wires=[1], control=[0], control_value=[1])");
+    CHECK(str_builder.get_matrix_op_str(v, {0}, true) ==
+          "MatrixOperation([1, 0, 0, 1], wires=[0], inverse=true)");
+    CHECK(str_builder.get_matrix_op_str(v, {1}, false, {0}) ==
+          "MatrixOperation([1, 0, 0, 1], wires=[1], control=[0])");
+    CHECK(str_builder.get_matrix_op_str(v, {1}, false, {0}, {true}) ==
+          "MatrixOperation([1, 0, 0, 1], wires=[1], control=[0], control_value=[1])");
 }
 
-TEST_CASE("registers correctly a new observable", "[InstructionStrBuilder]") {
+TEST_CASE("registers correctly a new observable", "[InstructionStrBuilder]")
+{
     InstructionStrBuilder str_builder;
 
     ObsId obs_id1 = ObsId::PauliX;
@@ -82,10 +101,12 @@ TEST_CASE("registers correctly a new observable", "[InstructionStrBuilder]") {
 //     DataView<std::vector<std::complex<double>>, 2> view({v, v}, 0, {2, 2}, {1,1});
 
 //     CHECK(str_builder.get_samples_str("Sample", view, 100) == "Sample([0, 0], shots=100)");
-//     CHECK(str_builder.get_samples_str("PartialSample", view, 100, {0}) == "PartialSample([0, 0], wires=[0], shots=100)");
+//     CHECK(str_builder.get_samples_str("PartialSample", view, 100, {0}) == "PartialSample([0, 0],
+//     wires=[0], shots=100)");
 // }
 
-TEST_CASE("string building for Counts() and PartialCounts()", "[InstructionStrBuilder]") {
+TEST_CASE("string building for Counts() and PartialCounts()", "[InstructionStrBuilder]")
+{
     InstructionStrBuilder str_builder;
     std::vector<double> state(2);
     DataView<double, 1> state_view(state);
@@ -93,6 +114,8 @@ TEST_CASE("string building for Counts() and PartialCounts()", "[InstructionStrBu
     std::vector<int64_t> counts(2);
     DataView<int64_t, 1> counts_view(counts);
 
-    CHECK(str_builder.get_counts_str("Counts", state_view, counts_view, 100) == "Counts([(0.000000, 0), (0.000000, 0)], shots=100)");
-    CHECK(str_builder.get_counts_str("PartialCounts", state_view, counts_view, 100, {0}) == "PartialCounts([(0.000000, 0), (0.000000, 0)], wires=[0], shots=100)");
+    CHECK(str_builder.get_counts_str("Counts", state_view, counts_view, 100) ==
+          "Counts([(0.000000, 0), (0.000000, 0)], shots=100)");
+    CHECK(str_builder.get_counts_str("PartialCounts", state_view, counts_view, 100, {0}) ==
+          "PartialCounts([(0.000000, 0), (0.000000, 0)], wires=[0], shots=100)");
 }


### PR DESCRIPTION
**Context:**  The PennyLane plugin should have an Boolean option `print_instructions` (other names can also be proposed) with a default `False` value. This option must forwarded to the C++ device constructor. In the runtime plugin, the QuantumDevice should be able to print out the instructions when the option is set to `True`:

**Description of the Change:** The PennyLane plugin now has a boolean option `print_instructions` with a default value `False`. 
If this option is set to `True` and we have generated the intermediate code using a null device, then executing the circuit prints out the instructions mentioned in Issue #1316 .

**Benefits:** allows to visualize and confirm the instructions we have called in a circuit that uses the null device. We can now print instructions by simply compiling the circuit and by passing the flag set set to `True` (E.g. `jitted_circ = qjit(circ_circuit, print_instructions=False)`).

**Possible Drawbacks:** Printing some matrices can take a lot of space.

**Related GitHub Issues:** #1316
