### PR TITLE
[Frontend] Refactor registering passes and caching primitive mechanisms

### DIFF
--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -15,7 +15,6 @@
 of quantum operations, measurements, and observables to JAXPR.
 """
 
-import copy
 import sys
 from dataclasses import dataclass
 from enum import Enum
@@ -42,7 +41,6 @@ from jaxlib.mlir.dialects.arith import (
     MulIOp,
     SubIOp,
 )
-from jaxlib.mlir.dialects.builtin import ModuleOp
 from jaxlib.mlir.dialects.func import FunctionType
 from jaxlib.mlir.dialects.scf import ConditionOp, ForOp, IfOp, WhileOp, YieldOp
 from jaxlib.mlir.dialects.stablehlo import ConstantOp as StableHLOConstantOp

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -627,8 +627,7 @@ def _grad_lowering(ctx, *args, jaxpr, fn, grad_params):
     argnum_numpy = np.array(new_argnums)
     diffArgIndices = ir.DenseIntElementsAttr.get(argnum_numpy)
     func_call_jaxpr = _get_call_jaxpr(jaxpr)
-    lower_callable(ctx, fn, func_call_jaxpr)
-    func_op = get_cached(ctx, fn)
+    func_op = lower_callable(ctx, fn, func_call_jaxpr)
 
     symbol_ref = get_symbolref(ctx, func_op)
     output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
@@ -703,9 +702,8 @@ def _value_and_grad_lowering(ctx, *args, jaxpr, fn, grad_params):
     val_result_types = flat_output_types[: len(flat_output_types) - len(argnums)]
     gradient_result_types = flat_output_types[len(flat_output_types) - len(argnums) :]
 
-    lower_callable(ctx, fn, func_call_jaxpr)
+    func_op = lower_callable(ctx, fn, func_call_jaxpr)
 
-    func_op = get_cached(ctx, fn)
     symbol_ref = get_symbolref(ctx, func_op)
     return ValueAndGradOp(
         val_result_types,
@@ -754,12 +752,11 @@ def _jvp_lowering(ctx, *args, jaxpr, fn, grad_params):
     func_args = consts_and_args[: len(func_call_jaxpr.invars)]
     tang_args = consts_and_args[len(func_call_jaxpr.invars) :]
 
-    lower_callable(ctx, fn, func_call_jaxpr)
+    func_op = lower_callable(ctx, fn, func_call_jaxpr)
 
     assert (
         len(flat_output_types) % 2 == 0
     ), f"The total number of result tensors is expected to be even, not {len(flat_output_types)}"
-    func_op = get_cached(ctx, fn)
     symbol_ref = get_symbolref(ctx, func_op)
     return JVPOp(
         flat_output_types[: len(flat_output_types) // 2],
@@ -808,9 +805,8 @@ def _vjp_lowering(ctx, *args, jaxpr, fn, grad_params):
     func_result_types = flat_output_types[: len(flat_output_types) - len(argnums)]
     vjp_result_types = flat_output_types[len(flat_output_types) - len(argnums) :]
 
-    lower_callable(ctx, fn, func_call_jaxpr)
+    func_op = lower_callable(ctx, fn, func_call_jaxpr)
 
-    func_op = get_cached(ctx, fn)
     symbol_ref = get_symbolref(ctx, func_op)
     return VJPOp(
         func_result_types,
@@ -862,8 +858,7 @@ def _zne_lowering(ctx, *args, folding, jaxpr, fn):
     """
     func_call_jaxpr = _get_call_jaxpr(jaxpr)
 
-    lower_callable(ctx, fn, func_call_jaxpr)
-    func_op = get_cached(ctx, fn)
+    func_op = lower_callable(ctx, fn, func_call_jaxpr)
     symbol_ref = get_symbolref(ctx, func_op)
     output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
     flat_output_types = util.flatten(output_types)

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -519,11 +519,11 @@ def _apply_registered_pass_lowering(
 
 
 @quantum_kernel_p.def_impl
-def _quantum_kernel_def_impl(*args, call_jaxpr, qnode):  # pragma: no cover
+def _quantum_kernel_def_impl(*args, call_jaxpr, qnode, pipeline=None):  # pragma: no cover
     raise NotImplementedError()
 
 
-def _quantum_kernel_lowering(ctx, *args, call_jaxpr, qnode):
+def _quantum_kernel_lowering(ctx, *args, call_jaxpr, qnode, pipeline=None):
     """Lower's qnodes to moduleOp
 
     Args:
@@ -534,9 +534,11 @@ def _quantum_kernel_lowering(ctx, *args, call_jaxpr, qnode):
     Returns:
       List[mlir.Value] corresponding
     """
-
     assert isinstance(qnode, qml.QNode), "This function expects qnodes"
-    func_op = lower_callable(ctx, qnode, call_jaxpr)
+    if pipeline is None:
+        pipeline = tuple()
+
+    func_op = lower_callable(ctx, qnode, call_jaxpr, pipeline)
     call_op = create_call_op(ctx, func_op, *args)
     return call_op.results
 

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -106,8 +106,6 @@ from catalyst.jax_primitives_utils import (
     cache,
     create_call_op,
     get_cached,
-    get_or_create_funcop,
-    get_or_create_qnode_funcop,
     get_symbolref,
     lower_callable,
 )
@@ -362,8 +360,8 @@ def _python_callback_lowering(
     rev = custom_grad._bwd
     fwd_jaxpr = custom_grad._fwd_jaxpr
     rev_jaxpr = custom_grad._bwd_jaxpr
-    mlir_fwd = get_or_create_funcop(jax_ctx, fwd, fwd_jaxpr)
-    mlir_rev = get_or_create_funcop(jax_ctx, rev, rev_jaxpr)
+    mlir_fwd = lower_callable(jax_ctx, fwd, fwd_jaxpr)
+    mlir_rev = lower_callable(jax_ctx, rev, rev_jaxpr)
     sym_fwd = mlir_fwd.sym_name.value + ".fwd"
 
     argc = len(args)
@@ -536,7 +534,7 @@ def _quantum_kernel_lowering(ctx, *args, call_jaxpr, qnode):
     """
 
     assert isinstance(qnode, qml.QNode), "This function expects qnodes"
-    func_op = get_or_create_qnode_funcop(ctx, qnode, call_jaxpr)
+    func_op = lower_callable(ctx, qnode, call_jaxpr)
     call_op = create_call_op(ctx, func_op, *args)
     return call_op.results
 
@@ -558,7 +556,7 @@ def _func_lowering(ctx, *args, call_jaxpr, fn):
       call_jaxpr: the jaxpr representation of the fn
       fn: the function being compiled
     """
-    func_op = get_or_create_funcop(ctx, fn, call_jaxpr)
+    func_op = lower_callable(ctx, fn, call_jaxpr)
     call_op = create_call_op(ctx, func_op, *args)
     return call_op.results
 

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -43,20 +43,15 @@ from jaxlib.mlir.dialects.arith import (
     SubIOp,
 )
 from jaxlib.mlir.dialects.builtin import ModuleOp
-from jaxlib.mlir.dialects.func import CallOp, FunctionType
+from jaxlib.mlir.dialects.func import FunctionType
 from jaxlib.mlir.dialects.scf import ConditionOp, ForOp, IfOp, WhileOp, YieldOp
 from jaxlib.mlir.dialects.stablehlo import ConstantOp as StableHLOConstantOp
 from jaxlib.mlir.dialects.stablehlo import ConvertOp as StableHLOConvertOp
-from mlir_quantum.dialects._transform_ops_gen import (
-    ApplyRegisteredPassOp,
-    NamedSequenceOp,
-)
-from mlir_quantum.dialects._transform_ops_gen import YieldOp as TransformYieldOp
+from mlir_quantum.dialects._transform_ops_gen import ApplyRegisteredPassOp
 from mlir_quantum.dialects.catalyst import (
     AssertionOp,
     CallbackCallOp,
     CallbackOp,
-    LaunchKernelOp,
     PrintOp,
 )
 from mlir_quantum.dialects.gradient import (
@@ -106,6 +101,13 @@ from catalyst.jax_extras import (
     for_loop_expansion_strategy,
     infer_output_type_jaxpr,
     while_loop_expansion_strategy,
+)
+from catalyst.jax_primitives_utils import (
+    create_call_op,
+    get_or_create_funcop,
+    get_or_create_qnode_funcop,
+    get_symbolref,
+    lower_callable,
 )
 from catalyst.utils.calculate_grad_shape import Signature, calculate_grad_shape
 from catalyst.utils.extra_bindings import FromElementsOp, TensorExtractOp
@@ -422,48 +424,6 @@ def get_named_sequence_in_module(mod):
     return None
 
 
-def _transform_named_sequence_lowering(jax_ctx: mlir.LoweringRuleContext):
-    transform_mod_type = ir.OpaqueType.get("transform", 'op<"builtin.module">')
-    module = jax_ctx.module_context.module
-
-    # We wish to generate the transformer module, and place it in the top-level module
-    # The transformer module must be marked with the "transform.with_named_sequence" attribute
-    # The transformer module has a single block, and the block contains the
-    # "transform.named_sequence @__transform_main" operation
-
-    with ir.InsertionPoint(module.body):
-        transformer_module = ModuleOp()
-        with_named_sequence_attr = ir.UnitAttr.get(jax_ctx.module_context.context)
-        transformer_module.operation.attributes["transform.with_named_sequence"] = (
-            with_named_sequence_attr
-        )
-        bb_transformer = transformer_module.body
-
-    functype = ir.FunctionType.get(inputs=[transform_mod_type], results=[])
-    functype_attr = ir.TypeAttr.get(functype)
-
-    # Insert the transform.named_sequence op into the transformer module
-    # Note that InsertionPoint(Block) inserts after the last operation but still inside the block.
-    with ir.InsertionPoint(bb_transformer):
-        named_sequence_op = NamedSequenceOp(
-            sym_name="__transform_main",
-            function_type=functype_attr,
-        )
-
-        # transform.named_sequence op is the "main function" of the transform dialect
-        # and thus needs an entry block (which also should be its only block)
-        # The argument of the block is the payload module
-        bb_named_sequence = ir.Block.create_at_start(
-            named_sequence_op.body, arg_types=[transform_mod_type]
-        )
-
-        # The transform.named_sequence needs a terminator called "transform.yield"
-        with ir.InsertionPoint(bb_named_sequence):
-            transform_yield_op = TransformYieldOp(operands_=[])  # pylint: disable=unused-variable
-
-    return named_sequence_op.results
-
-
 #
 # apply_registered_pass
 #
@@ -554,164 +514,11 @@ def _apply_registered_pass_lowering(
 #
 # module
 #
-def lower_callable_to_funcop(ctx, callable_, call_jaxpr):
-    """Lower callable to either a FuncOp"""
-    if isinstance(call_jaxpr, core.Jaxpr):
-        call_jaxpr = core.ClosedJaxpr(call_jaxpr, ())
-
-    kwargs = {}
-    kwargs["ctx"] = ctx.module_context
-    kwargs["name"] = callable_.__name__
-    kwargs["jaxpr"] = call_jaxpr
-    kwargs["effects"] = []
-    kwargs["name_stack"] = ctx.name_stack
-    func_op = mlir.lower_jaxpr_to_fun(**kwargs)
-
-    if isinstance(callable_, qml.QNode):
-        func_op.attributes["qnode"] = ir.UnitAttr.get()
-        # "best", the default option in PennyLane, chooses backprop on the device
-        # if supported and parameter-shift otherwise. Emulating the same behaviour
-        # would require generating code to query the device.
-        # For simplicity, Catalyst instead defaults to parameter-shift.
-        diff_method = (
-            "parameter-shift" if callable_.diff_method == "best" else str(callable_.diff_method)
-        )
-        func_op.attributes["diff_method"] = ir.StringAttr.get(diff_method)
-
-    return func_op
-
-
-def get_or_create_funcop(ctx, callable_, call_jaxpr):
-    """Get funcOp from cache, or create it from scratch"""
-    if func_op := ctx.module_context.cached_primitive_lowerings.get(callable_):
-        return func_op
-    func_op = lower_callable_to_funcop(ctx, callable_, call_jaxpr)
-    ctx.module_context.cached_primitive_lowerings[callable_] = func_op
-    return func_op
-
-
-def get_symbolref(ctx, func_op):
-    """Get symbolref by deciding whether to constructo a symbolref or flatsymbolref"""
-    is_call_same_module = ctx.module_context.module.operation == func_op.parent
-    if is_call_same_module:
-        return ir.FlatSymbolRefAttr.get(func_op.name.value)
-    parent = func_op.parent
-    parent_name = parent.operation.attributes["sym_name"].value
-    child_name = func_op.name.value
-    return ir.SymbolRefAttr.get([parent_name, child_name])
-
-
-def create_call_op(ctx, func_op, *args):
-    """Create a func::CallOp from JAXPR."""
-    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
-    flat_output_types = util.flatten(output_types)
-    mlir_args = mlir.flatten_lowering_ir_args(args)
-    symbol_ref = get_symbolref(ctx, func_op)
-    is_call_same_module = ctx.module_context.module.operation == func_op.parent
-    constructor = CallOp if is_call_same_module else LaunchKernelOp
-    return constructor(flat_output_types, symbol_ref, mlir_args)
-
-
-def create_module_op(ctx, name):
-    """Create a module with name name"""
-
-    symbol_table = ctx.module_context.symbol_table
-    parent = ctx.module_context.module
-    with ir.InsertionPoint(parent.body):
-        module = ModuleOp()
-        symbol_attr = ir._symbolNameAttr(name, ctx.module_context.context)
-        module.operation.attributes["sym_name"] = symbol_attr
-        symbol_table.insert(module)
-
-    return module
-
-
-class NestedModule:
-    """Context manager for the nested module"""
-
-    def __init__(self, ctx, name):
-        self.ctx = ctx
-        self.moduleOp = create_module_op(ctx, name)
-        self.old_module_context = ctx.module_context
-
-    def __enter__(self):
-        self.ctx.module_context = copy.copy(self.ctx.module_context)
-        self.ctx.module_context.module = self.moduleOp
-        self.ctx.module_context.cached_primitive_lowerings = {}
-        return self.moduleOp
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.ctx.module_context = self.old_module_context
 
 
 @quantum_kernel_p.def_impl
 def _quantum_kernel_def_impl(*args, call_jaxpr, qnode):  # pragma: no cover
     raise NotImplementedError()
-
-
-def lower_callable(ctx, callable_, call_jaxpr):
-    """Lowers _callable to MLIR.
-
-    If callable_ is a qnode, then we will first create a module, then
-    create a FuncOp corresponding to call_jaxpr. Otherwise, a FuncOp
-    will be created in the current module. This function might
-    add more than one FuncOps. This depends on the contents of call_jaxpr.
-
-    Args:
-      ctx: LoweringRuleContext
-      callable_: python function
-      call_jaxpr: jaxpr representing callable_
-    Returns:
-      FuncOp
-    """
-    if not isinstance(callable_, qml.QNode):
-        return get_or_create_funcop(ctx, callable_, call_jaxpr)
-
-    return get_or_create_qnode_funcop(ctx, callable_, call_jaxpr)
-
-
-def lower_qnode_to_funcop(ctx, callable_, call_jaxpr):
-    """Lowers callable_ to MLIR.
-
-    Will create ModuleOp and then lower the callable_ to a
-    FuncOp inside the ModuleOp. The ModuleOp may have more
-    than one FuncOp. This depends on the contents of call_jaxpr.
-
-    Args:
-      ctx: LoweringRuleContext
-      callable_: qml.Qnode
-      call_jaxpr: jaxpr representing callable_
-    Returns:
-      FuncOp
-    """
-    assert isinstance(callable_, qml.QNode), "This function expects qnodes"
-
-    name = "module_" + callable_.__name__
-    # pylint: disable-next=no-member
-    with NestedModule(ctx, name) as module, ir.InsertionPoint(module.regions[0].blocks[0]) as ip:
-        _transform_named_sequence_lowering(ctx)
-        ctx.module_context.ip = ip
-        func_op = get_or_create_funcop(ctx, callable_, call_jaxpr)
-        func_op.sym_visibility = ir.StringAttr.get("public")
-
-    return func_op
-
-
-def get_or_create_qnode_funcop(ctx, callable_, call_jaxpr):
-    """A wrapper around lower_qnode_to_funcop that will cache the FuncOp.
-
-    Args:
-      ctx: LoweringRuleContext
-      callable_: qml.Qnode
-      call_jaxpr: jaxpr representing callable_
-    Returns:
-      FuncOp
-    """
-    if func_op := ctx.module_context.cached_primitive_lowerings.get(callable_):
-        return func_op
-    func_op = lower_qnode_to_funcop(ctx, callable_, call_jaxpr)
-    ctx.module_context.cached_primitive_lowerings[callable_] = func_op
-    return func_op
 
 
 def _quantum_kernel_lowering(ctx, *args, call_jaxpr, qnode):

--- a/frontend/catalyst/jax_primitives_utils.py
+++ b/frontend/catalyst/jax_primitives_utils.py
@@ -1,4 +1,4 @@
-# Copyright 2022-2023 Xanadu Quantum Technologies Inc.
+# Copyright 2024 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/frontend/catalyst/jax_primitives_utils.py
+++ b/frontend/catalyst/jax_primitives_utils.py
@@ -40,6 +40,7 @@ def get_call_jaxpr(jaxpr):
 
 
 def get_call_equation(jaxpr):
+    """Extracts the equation which has a call_jaxpr."""
     for eqn in jaxpr.eqns:
         if eqn.params.get("call_jaxpr"):
             return eqn
@@ -47,6 +48,7 @@ def get_call_equation(jaxpr):
 
 
 def lower_jaxpr(ctx, jaxpr):
+    """Lowers a call primitive jaxpr, may be either func_p or quantum_kernel_p"""
     equation = get_call_equation(jaxpr)
     call_jaxpr = equation.params["call_jaxpr"]
     callable_ = equation.params.get("fn")
@@ -231,6 +233,9 @@ class NestedModule:
 
 
 def transform_named_sequence_lowering(jax_ctx: mlir.LoweringRuleContext, pipeline):
+    """Generate a transform module embedded in the current module and schedule
+    the transformations in pipeline"""
+
     transform_mod_type = ir.OpaqueType.get("transform", 'op<"builtin.module">')
     module = jax_ctx.module_context.module
 

--- a/frontend/catalyst/jax_primitives_utils.py
+++ b/frontend/catalyst/jax_primitives_utils.py
@@ -26,12 +26,22 @@ from mlir_quantum.dialects._transform_ops_gen import NamedSequenceOp, YieldOp
 from mlir_quantum.dialects.catalyst import LaunchKernelOp
 
 
+def get_cached(ctx, key):
+    """Looks for key in the cache"""
+    return ctx.module_context.cached_primitive_lowerings.get(key)
+
+
+def cache(ctx, key, val):
+    """Caches value in cache with key"""
+    ctx.module_context.cached_primitive_lowerings[key] = val
+
+
 def get_or_create_funcop(ctx, callable_, call_jaxpr):
     """Get funcOp from cache, or create it from scratch"""
-    if func_op := ctx.module_context.cached_primitive_lowerings.get(callable_):
+    if func_op := get_cached(ctx, callable_):
         return func_op
     func_op = lower_callable_to_funcop(ctx, callable_, call_jaxpr)
-    ctx.module_context.cached_primitive_lowerings[callable_] = func_op
+    cache(ctx, callable_, func_op)
     return func_op
 
 
@@ -45,10 +55,10 @@ def get_or_create_qnode_funcop(ctx, callable_, call_jaxpr):
     Returns:
       FuncOp
     """
-    if func_op := ctx.module_context.cached_primitive_lowerings.get(callable_):
+    if func_op := get_cached(ctx, callable_):
         return func_op
     func_op = lower_qnode_to_funcop(ctx, callable_, call_jaxpr)
-    ctx.module_context.cached_primitive_lowerings[callable_] = func_op
+    cache(ctx, callable_, func_op)
     return func_op
 
 

--- a/frontend/catalyst/jax_primitives_utils.py
+++ b/frontend/catalyst/jax_primitives_utils.py
@@ -26,6 +26,14 @@ from mlir_quantum.dialects._transform_ops_gen import NamedSequenceOp, YieldOp
 from mlir_quantum.dialects.catalyst import LaunchKernelOp
 
 
+def get_call_jaxpr(jaxpr):
+    """Extracts the `call_jaxpr` from a JAXPR if it exists.""" ""
+    for eqn in jaxpr.eqns:
+        if eqn.params.get("call_jaxpr"):
+            return eqn.params["call_jaxpr"]
+    raise AssertionError("No call_jaxpr found in the JAXPR.")
+
+
 def lower_callable(ctx, callable_, call_jaxpr):
     """Lowers _callable to MLIR.
 

--- a/frontend/catalyst/jax_primitives_utils.py
+++ b/frontend/catalyst/jax_primitives_utils.py
@@ -1,0 +1,223 @@
+# Copyright 2022-2023 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module contains some helper functions for translating JAX
+primitives to MLIR"""
+
+import copy
+
+import pennylane as qml
+from jax._src import core, util
+from jax._src.lib.mlir import ir
+from jax.interpreters import mlir
+from jaxlib.mlir.dialects.builtin import ModuleOp
+from jaxlib.mlir.dialects.func import CallOp
+from mlir_quantum.dialects._transform_ops_gen import NamedSequenceOp, YieldOp
+from mlir_quantum.dialects.catalyst import LaunchKernelOp
+
+
+def get_or_create_funcop(ctx, callable_, call_jaxpr):
+    """Get funcOp from cache, or create it from scratch"""
+    if func_op := ctx.module_context.cached_primitive_lowerings.get(callable_):
+        return func_op
+    func_op = lower_callable_to_funcop(ctx, callable_, call_jaxpr)
+    ctx.module_context.cached_primitive_lowerings[callable_] = func_op
+    return func_op
+
+
+def get_or_create_qnode_funcop(ctx, callable_, call_jaxpr):
+    """A wrapper around lower_qnode_to_funcop that will cache the FuncOp.
+
+    Args:
+      ctx: LoweringRuleContext
+      callable_: qml.Qnode
+      call_jaxpr: jaxpr representing callable_
+    Returns:
+      FuncOp
+    """
+    if func_op := ctx.module_context.cached_primitive_lowerings.get(callable_):
+        return func_op
+    func_op = lower_qnode_to_funcop(ctx, callable_, call_jaxpr)
+    ctx.module_context.cached_primitive_lowerings[callable_] = func_op
+    return func_op
+
+
+def get_symbolref(ctx, func_op):
+    """Get symbolref by deciding whether to constructo a symbolref or flatsymbolref"""
+    is_call_same_module = ctx.module_context.module.operation == func_op.parent
+    if is_call_same_module:
+        return ir.FlatSymbolRefAttr.get(func_op.name.value)
+    parent = func_op.parent
+    parent_name = parent.operation.attributes["sym_name"].value
+    child_name = func_op.name.value
+    return ir.SymbolRefAttr.get([parent_name, child_name])
+
+
+def create_call_op(ctx, func_op, *args):
+    """Create a func::CallOp from JAXPR."""
+    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
+    flat_output_types = util.flatten(output_types)
+    mlir_args = mlir.flatten_lowering_ir_args(args)
+    symbol_ref = get_symbolref(ctx, func_op)
+    is_call_same_module = ctx.module_context.module.operation == func_op.parent
+    constructor = CallOp if is_call_same_module else LaunchKernelOp
+    return constructor(flat_output_types, symbol_ref, mlir_args)
+
+
+def create_module_op(ctx, name):
+    """Create a module with name name"""
+
+    symbol_table = ctx.module_context.symbol_table
+    parent = ctx.module_context.module
+    with ir.InsertionPoint(parent.body):
+        module = ModuleOp()
+        symbol_attr = ir._symbolNameAttr(name, ctx.module_context.context)
+        module.operation.attributes["sym_name"] = symbol_attr
+        symbol_table.insert(module)
+
+    return module
+
+
+def lower_callable(ctx, callable_, call_jaxpr):
+    """Lowers _callable to MLIR.
+
+    If callable_ is a qnode, then we will first create a module, then
+    create a FuncOp corresponding to call_jaxpr. Otherwise, a FuncOp
+    will be created in the current module. This function might
+    add more than one FuncOps. This depends on the contents of call_jaxpr.
+
+    Args:
+      ctx: LoweringRuleContext
+      callable_: python function
+      call_jaxpr: jaxpr representing callable_
+    Returns:
+      FuncOp
+    """
+    if not isinstance(callable_, qml.QNode):
+        return get_or_create_funcop(ctx, callable_, call_jaxpr)
+
+    return get_or_create_qnode_funcop(ctx, callable_, call_jaxpr)
+
+
+def lower_callable_to_funcop(ctx, callable_, call_jaxpr):
+    """Lower callable to either a FuncOp"""
+    if isinstance(call_jaxpr, core.Jaxpr):
+        call_jaxpr = core.ClosedJaxpr(call_jaxpr, ())
+
+    kwargs = {}
+    kwargs["ctx"] = ctx.module_context
+    kwargs["name"] = callable_.__name__
+    kwargs["jaxpr"] = call_jaxpr
+    kwargs["effects"] = []
+    kwargs["name_stack"] = ctx.name_stack
+    func_op = mlir.lower_jaxpr_to_fun(**kwargs)
+
+    if isinstance(callable_, qml.QNode):
+        func_op.attributes["qnode"] = ir.UnitAttr.get()
+        # "best", the default option in PennyLane, chooses backprop on the device
+        # if supported and parameter-shift otherwise. Emulating the same behaviour
+        # would require generating code to query the device.
+        # For simplicity, Catalyst instead defaults to parameter-shift.
+        diff_method = (
+            "parameter-shift" if callable_.diff_method == "best" else str(callable_.diff_method)
+        )
+        func_op.attributes["diff_method"] = ir.StringAttr.get(diff_method)
+
+    return func_op
+
+
+class NestedModule:
+    """Context manager for the nested module"""
+
+    def __init__(self, ctx, name):
+        self.ctx = ctx
+        self.moduleOp = create_module_op(ctx, name)
+        self.old_module_context = ctx.module_context
+
+    def __enter__(self):
+        self.ctx.module_context = copy.copy(self.ctx.module_context)
+        self.ctx.module_context.module = self.moduleOp
+        self.ctx.module_context.cached_primitive_lowerings = {}
+        return self.moduleOp
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.ctx.module_context = self.old_module_context
+
+
+def lower_qnode_to_funcop(ctx, callable_, call_jaxpr):
+    """Lowers callable_ to MLIR.
+
+    Will create ModuleOp and then lower the callable_ to a
+    FuncOp inside the ModuleOp. The ModuleOp may have more
+    than one FuncOp. This depends on the contents of call_jaxpr.
+
+    Args:
+      ctx: LoweringRuleContext
+      callable_: qml.Qnode
+      call_jaxpr: jaxpr representing callable_
+    Returns:
+      FuncOp
+    """
+    assert isinstance(callable_, qml.QNode), "This function expects qnodes"
+
+    name = "module_" + callable_.__name__
+    # pylint: disable-next=no-member
+    with NestedModule(ctx, name) as module, ir.InsertionPoint(module.regions[0].blocks[0]) as ip:
+        transform_named_sequence_lowering(ctx)
+        ctx.module_context.ip = ip
+        func_op = get_or_create_funcop(ctx, callable_, call_jaxpr)
+        func_op.sym_visibility = ir.StringAttr.get("public")
+
+    return func_op
+
+
+def transform_named_sequence_lowering(jax_ctx: mlir.LoweringRuleContext):
+    transform_mod_type = ir.OpaqueType.get("transform", 'op<"builtin.module">')
+    module = jax_ctx.module_context.module
+
+    # We wish to generate the transformer module, and place it in the top-level module
+    # The transformer module must be marked with the "transform.with_named_sequence" attribute
+    # The transformer module has a single block, and the block contains the
+    # "transform.named_sequence @__transform_main" operation
+
+    with ir.InsertionPoint(module.body):
+        transformer_module = ModuleOp()
+        with_named_sequence_attr = ir.UnitAttr.get(jax_ctx.module_context.context)
+        transformer_module.operation.attributes["transform.with_named_sequence"] = (
+            with_named_sequence_attr
+        )
+        bb_transformer = transformer_module.body
+
+    functype = ir.FunctionType.get(inputs=[transform_mod_type], results=[])
+    functype_attr = ir.TypeAttr.get(functype)
+
+    # Insert the transform.named_sequence op into the transformer module
+    # Note that InsertionPoint(Block) inserts after the last operation but still inside the block.
+    with ir.InsertionPoint(bb_transformer):
+        named_sequence_op = NamedSequenceOp(
+            sym_name="__transform_main",
+            function_type=functype_attr,
+        )
+
+        # transform.named_sequence op is the "main function" of the transform dialect
+        # and thus needs an entry block (which also should be its only block)
+        # The argument of the block is the payload module
+        bb_named_sequence = ir.Block.create_at_start(
+            named_sequence_op.body, arg_types=[transform_mod_type]
+        )
+
+        # The transform.named_sequence needs a terminator called "transform.yield"
+        with ir.InsertionPoint(bb_named_sequence):
+            transform_yield_op = YieldOp(operands_=[])  # pylint: disable=unused-variable
+
+    return named_sequence_op.results

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -96,7 +96,6 @@ from catalyst.jax_primitives import (
     var_p,
 )
 from catalyst.logging import debug_logger, debug_logger_init
-from catalyst.passes import _add_mlir_quantum_decomposition
 from catalyst.tracing.contexts import (
     EvaluationContext,
     EvaluationMode,
@@ -1140,9 +1139,6 @@ def trace_quantum_function(
         out_type: JAXPR output type (list of abstract values with explicitness flags).
         out_tree: PyTree shapen of the result
     """
-
-    # Add the decomposition passes with the transform dialect
-    _add_mlir_quantum_decomposition(device)
 
     with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
         # (1) - Classical tracing

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -637,9 +637,11 @@ class QJIT(CatalystCallable):
             params = {}
             params["static_argnums"] = kwargs.pop("static_argnums", static_argnums)
             params["_out_tree_expected"] = []
+            default_pass_pipeline = self.compile_options.circuit_transform_pipeline
+            pass_pipeline = params.get("pass_pipeline", default_pass_pipeline)
+            params["pass_pipeline"] = pass_pipeline
             return QFunc.__call__(
                 qnode,
-                pass_pipeline=self.compile_options.circuit_transform_pipeline,
                 *args,
                 **dict(params, **kwargs),
             )

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -382,7 +382,11 @@ def merge_rotations(qnode=None):
 
 
 def _API_name_to_pass_name():
-    return {"cancel_inverses": "remove-chained-self-inverse", "merge_rotations": "merge-rotations"}
+    return {
+        "cancel_inverses": "remove-chained-self-inverse",
+        "merge_rotations": "merge-rotations",
+        "ions_decomposition": "ions-decomposition",
+    }
 
 
 def ions_decomposition(qnode=None):

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -41,9 +41,10 @@ import pennylane as qml
 from catalyst.jax_primitives import apply_registered_pass_p
 from catalyst.tracing.contexts import EvaluationContext
 
+
 ## API ##
 # pylint: disable=line-too-long
-def pipeline(pass_pipeline: Optional[dict[str, dict[str, str]]] = None):
+def pipeline(pass_pipeline: dict[str, dict[str, str]]):
     """Configures the Catalyst MLIR pass pipeline for quantum circuit transformations for a QNode within a qjit-compiled program.
 
     Args:

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -34,7 +34,7 @@ individual Catalyst MLIR compiler passes.
 
 import copy
 import functools
-from typing import Optional, TypeAlias
+from typing import TypeAlias
 
 import pennylane as qml
 
@@ -56,13 +56,15 @@ class Pass:
 
 
 def dictionary_to_tuple_of_passes(pass_pipeline: PipelineDict):
+    """Convert dictionary of passes into tuple of passes"""
+
     if type(pass_pipeline) != dict:
         return pass_pipeline
 
     passes = tuple()
     pass_names = _API_name_to_pass_name()
     for API_name, pass_options in pass_pipeline.items():
-        name = pass_name = pass_names[API_name]
+        name = pass_names[API_name]
         passes += (Pass(name, **pass_options),)
     return passes
 

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -389,7 +389,7 @@ def _API_name_to_pass_name():
     }
 
 
-def ions_decomposition(qnode=None):
+def ions_decomposition(qnode=None):  # pragma: nocover
     """Apply decomposition pass at the MLIR level"""
 
     if not isinstance(qnode, qml.QNode):

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -387,10 +387,15 @@ def _API_name_to_pass_name():
     return {"cancel_inverses": "remove-chained-self-inverse", "merge_rotations": "merge-rotations"}
 
 
-def _add_mlir_quantum_decomposition(device):
-    """When called it adds the MLIR decomposition pass thanks to the transform dialect."""
-    # TODO: make this non related to the name of the device
-    if device.original_device.name == "oqd.cloud":
+def ions_decomposition(qnode=None):
+    if not isinstance(qnode, qml.QNode):
+        raise TypeError(f"A QNode is expected, got the classical function {qnode}")
+
+    @functools.wraps(qnode)
+    def wrapper(*args, **kwrags):
         pass_pipeline = kwrags.pop("pass_pipeline", tuple())
         pass_pipeline += (Pass("ions-decomposition"),)
         kwrags["pass_pipeline"] = pass_pipeline
+        return qnode(*args, **kwrags)
+
+    return wrapper

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -41,14 +41,12 @@ import pennylane as qml
 from catalyst.jax_primitives import apply_registered_pass_p
 from catalyst.tracing.contexts import EvaluationContext
 
-
 ## API ##
 # pylint: disable=line-too-long
 def pipeline(pass_pipeline: Optional[dict[str, dict[str, str]]] = None):
     """Configures the Catalyst MLIR pass pipeline for quantum circuit transformations for a QNode within a qjit-compiled program.
 
     Args:
-        fn (QNode): The QNode to run the pass pipeline on.
         pass_pipeline (dict[str, dict[str, str]]): A dictionary that specifies the pass pipeline order, and optionally
             arguments for each pass in the pipeline. Keys of this dictionary should correspond to names of passes
             found in the `catalyst.passes <https://docs.pennylane.ai/projects/catalyst/en/stable/code
@@ -58,7 +56,7 @@ def pipeline(pass_pipeline: Optional[dict[str, dict[str, str]]] = None):
             If not specified, the default pass pipeline will be applied.
 
     Returns:
-        ~.QNode:
+        callable : A decorator that can be applied to a qnode.
 
     For a list of available passes, please see the :doc:`catalyst.passes module <code/passes>`.
 
@@ -150,18 +148,6 @@ def pipeline(pass_pipeline: Optional[dict[str, dict[str, str]]] = None):
         pass_names = _API_name_to_pass_name()
 
         def wrapper(*args, **kwrags):
-            # TODO: we should not match pass targets by function name.
-            # The quantum scope work will likely put each qnode into a module
-            # instead of a `func.func ... attributes {qnode}`.
-            # When that is in place, the qnode's module can have a proper attribute
-            # (as opposed to discardable) that records its transform schedule, i.e.
-            #    module_with_transform @name_of_module {
-            #      // transform schedule
-            #    } {
-            #      // contents of the module
-            #    }
-            # This eliminates the need for matching target functions by name.
-
             if EvaluationContext.is_tracing():
                 for API_name, pass_options in pass_pipeline.items():
                     opt = ""

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -38,7 +38,6 @@ from typing import Optional, TypeAlias
 
 import pennylane as qml
 
-from catalyst.jax_primitives import apply_registered_pass_p
 from catalyst.tracing.contexts import EvaluationContext
 
 PipelineDict: TypeAlias = dict[str, dict[str, str]]

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -166,10 +166,6 @@ def pipeline(pass_pipeline: PipelineDict):
     return _decorator
 
 
-@pipeline.register
-def pipeline_list(pass_pipeline: list): ...
-
-
 def cancel_inverses(fn=None):
     """
     Specify that the ``-removed-chained-self-inverse`` MLIR compiler pass

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -49,7 +49,7 @@ from catalyst.jax_extras import (
 from catalyst.jax_primitives import quantum_kernel_p
 from catalyst.jax_tracer import Function, trace_quantum_function
 from catalyst.logging import debug_logger
-from catalyst.passes import pipeline
+from catalyst.passes import dictionary_to_tuple_of_passes, pipeline
 from catalyst.tracing.contexts import EvaluationContext
 from catalyst.tracing.type_signatures import filter_static_args
 from catalyst.utils.exceptions import CompileError
@@ -105,10 +105,8 @@ class QFunc:
         assert isinstance(self, qml.QNode)
 
         # Update the qnode with peephole pipeline
-        pass_pipeline = kwargs.pop("pass_pipeline", None)
-
-        if pass_pipeline and not hasattr(self, "_peephole_transformed"):
-            self = pipeline(pass_pipeline)(self)
+        pass_pipeline = kwargs.pop("pass_pipeline", tuple())
+        pass_pipeline = dictionary_to_tuple_of_passes(pass_pipeline)
 
         # Mid-circuit measurement configuration/execution
         dynamic_one_shot_called = getattr(self, "_dynamic_one_shot_called", False)
@@ -149,7 +147,9 @@ class QFunc:
         )
         dynamic_args = filter_static_args(args, static_argnums)
         args_flat = tree_flatten((dynamic_args, kwargs))[0]
-        res_flat = quantum_kernel_p.bind(flattened_fun, *args_flat, qnode=self)
+        res_flat = quantum_kernel_p.bind(
+            flattened_fun, *args_flat, qnode=self, pipeline=pass_pipeline
+        )
         return tree_unflatten(out_tree_promise(), res_flat)[0]
 
 

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -49,7 +49,7 @@ from catalyst.jax_extras import (
 from catalyst.jax_primitives import quantum_kernel_p
 from catalyst.jax_tracer import Function, trace_quantum_function
 from catalyst.logging import debug_logger
-from catalyst.passes import dictionary_to_tuple_of_passes, pipeline
+from catalyst.passes import dictionary_to_tuple_of_passes
 from catalyst.tracing.contexts import EvaluationContext
 from catalyst.tracing.type_signatures import filter_static_args
 from catalyst.utils.exceptions import CompileError

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -105,11 +105,10 @@ class QFunc:
         assert isinstance(self, qml.QNode)
 
         # Update the qnode with peephole pipeline
-        if "pass_pipeline" in kwargs.keys():
-            pass_pipeline = kwargs["pass_pipeline"]
-            if not hasattr(self, "_peephole_transformed"):
-                self = pipeline(pass_pipeline=pass_pipeline)(self)
-            kwargs.pop("pass_pipeline")
+        pass_pipeline = kwargs.pop("pass_pipeline", None)
+
+        if pass_pipeline and not hasattr(self, "_peephole_transformed"):
+            self = pipeline(pass_pipeline)(self)
 
         # Mid-circuit measurement configuration/execution
         dynamic_one_shot_called = getattr(self, "_dynamic_one_shot_called", False)

--- a/frontend/test/lit/test_mlir_decomposition.py
+++ b/frontend/test/lit/test_mlir_decomposition.py
@@ -85,9 +85,6 @@ def test_decomposition_lowering():
         qml.Hadamard(wires=[1])
         return qml.expval(qml.PauliY(wires=0))
 
-    # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK:   pass_name=ions-decomposition
-    # CHECK: ]
     print_jaxpr(test_decomposition_lowering_workflow, 1.2)
     # CHECK: quantum.custom "RX"
     # CHECK-NOT: quantum.custom "Hadamard"

--- a/frontend/test/lit/test_mlir_decomposition.py
+++ b/frontend/test/lit/test_mlir_decomposition.py
@@ -33,6 +33,7 @@ import pennylane as qml
 from lit_util_printers import print_jaxpr
 from pennylane.devices import NullQubit
 
+import catalyst
 from catalyst import qjit
 from catalyst.debug import get_compilation_stage
 from catalyst.utils.runtime_environment import get_lib_path
@@ -78,6 +79,7 @@ def test_decomposition_lowering():
     """
 
     @qjit(keep_intermediate=True)
+    @catalyst.passes.ions_decomposition
     @qml.qnode(CustomDevice(2))
     def test_decomposition_lowering_workflow(x):
         qml.RX(x, wires=[0])

--- a/frontend/test/lit/test_peephole_optimizations.py
+++ b/frontend/test/lit/test_peephole_optimizations.py
@@ -112,7 +112,7 @@ def test_pipeline_lowering_keep_original():
         qml.Hadamard(wires=[1])
         return qml.expval(qml.PauliY(wires=0))
 
-    f_pipeline = pipeline(pass_pipeline=my_pipeline)(f)
+    f_pipeline = pipeline(my_pipeline)(f)
 
     @qjit(keep_intermediate=True)
     def test_pipeline_lowering_keep_original_workflow(x):
@@ -246,7 +246,7 @@ def test_pipeline_lowering_globloc_override():
             qml.Hadamard(wires=[1])
             return qml.expval(qml.PauliY(wires=0))
 
-        @pipeline(pass_pipeline=local_pipeline)
+        @pipeline(local_pipeline)
         @qml.qnode(qml.device("lightning.qubit", wires=2))
         def h(x):
             qml.RX(x, wires=[0])

--- a/frontend/test/lit/test_peephole_optimizations.py
+++ b/frontend/test/lit/test_peephole_optimizations.py
@@ -69,12 +69,7 @@ def test_pipeline_lowering():
         qml.Hadamard(wires=[1])
         return qml.expval(qml.PauliY(wires=0))
 
-    # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK:   pass_name=remove-chained-self-inverse
-    # CHECK: ]
-    # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK:   pass_name=merge-rotations
-    # CHECK: ]
+    # CHECK: pipeline=(remove-chained-self-inverse, merge-rotations)
     print_jaxpr(test_pipeline_lowering_workflow, 1.2)
 
     # CHECK: transform.named_sequence @__transform_main
@@ -118,13 +113,12 @@ def test_pipeline_lowering_keep_original():
     def test_pipeline_lowering_keep_original_workflow(x):
         return f(x), f_pipeline(x)
 
-    # CHECK: call_jaxpr=
-    # CHECK: call_jaxpr=
-    # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK:   pass_name=remove-chained-self-inverse
-    # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK:   pass_name=merge-rotations
-    # CHECK: ]
+    # COM: this if for f(x)
+    # CHECK: quantum_kernel
+    # COM: this if for f_pipeline(x)
+    # COM: Unfortunately, we don't have a nice repr for qnode
+    # CHECK: quantum_kernel
+    # CHECK: pipeline=(remove-chained-self-inverse, merge-rotations)
     print_jaxpr(test_pipeline_lowering_keep_original_workflow, 1.2)
 
     # COM: This is the one that is unchanged
@@ -182,18 +176,10 @@ def test_pipeline_lowering_global():
 
         return g(1.2), h(1.2)
 
-    # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK:   pass_name=remove-chained-self-inverse
-    # CHECK: ]
-    # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK:   pass_name=merge-rotations
-    # CHECK: ]
-    # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK:   pass_name=remove-chained-self-inverse
-    # CHECK: ]
-    # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK:   pass_name=merge-rotations
-    # CHECK: ]
+    # CHECK: quantum_kernel
+    # CHECK: pipeline=(remove-chained-self-inverse, merge-rotations)
+    # CHECK: quantum_kernel
+    # CHECK: pipeline=(remove-chained-self-inverse, merge-rotations)
     print_jaxpr(global_wf)
 
     # CHECK: transform.named_sequence @__transform_main
@@ -206,13 +192,13 @@ def test_pipeline_lowering_global():
     print_mlir(global_wf)
 
     # CHECK: func.func public @jit_global_wf()
-    # CHECK {{%.+}} = call @g_transformed(
-    # CHECK {{%.+}} = call @h_transformed(
-    # CHECK: func.func public @g_transformed
+    # CHECK {{%.+}} = call @g_0(
+    # CHECK {{%.+}} = call @h_0(
+    # CHECK: func.func public @g_0(
     # CHECK: {{%.+}} = quantum.custom "RX"({{%.+}}) {{%.+}} : !quantum.bit
     # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
     # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
-    # CHECK: func.func public @h_transformed
+    # CHECK: func.func public @h_0(
     # CHECK: {{%.+}} = quantum.custom "RX"({{%.+}}) {{%.+}} : !quantum.bit
     # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
     # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
@@ -256,16 +242,10 @@ def test_pipeline_lowering_globloc_override():
 
         return g(1.2), h(1.2)
 
-    # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK:   pass_name=remove-chained-self-inverse
-    # CHECK: ]
-    # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK:   pass_name=merge-rotations
-    # CHECK: ]
-    # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK-NOT:   pass_name=remove-chained-self-inverse
-    # CHECK:   pass_name=merge-rotations
-    # CHECK: ]
+    # CHECK: quantum_kernel
+    # CHECK: pipeline=(remove-chained-self-inverse, merge-rotations)
+    # CHECK: quantum_kernel
+    # CHECK: pipeline=(merge-rotations,)
     print_jaxpr(global_wf)
 
     # CHECK: transform.named_sequence @__transform_main
@@ -278,13 +258,13 @@ def test_pipeline_lowering_globloc_override():
     print_mlir(global_wf)
 
     # CHECK: func.func public @jit_global_wf()
-    # CHECK {{%.+}} = call @g_transformed(
+    # CHECK {{%.+}} = call @g(
     # CHECK {{%.+}} = call @h_transformed(
-    # CHECK: func.func public @g_transformed
+    # CHECK: func.func public @g_0
     # CHECK: {{%.+}} = quantum.custom "RX"({{%.+}}) {{%.+}} : !quantum.bit
     # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
     # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
-    # CHECK: func.func public @h_transformed
+    # CHECK: func.func public @h_transformed_0
     # CHECK: {{%.+}} = quantum.custom "RX"({{%.+}}) {{%.+}} : !quantum.bit
     # CHECK: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
     # CHECK: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
@@ -336,14 +316,10 @@ def test_cancel_inverses_tracing_and_lowering():
         _h = h(xx)
         return _f, _g, _h
 
-    # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK:   pass_name=remove-chained-self-inverse
-    # CHECK: ]
-    # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK:   pass_name=remove-chained-self-inverse
-    # CHECK: ]
-    # CHECK-NOT: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK-NOT:   pass_name=remove-chained-self-inverse
+    # CHECK: quantum_kernel
+    # CHECK: pipeline=(remove-chained-self-inverse,)
+    # CHECK: quantum_kernel
+    # CHECK: pipeline=(remove-chained-self-inverse,)
     print_jaxpr(test_cancel_inverses_tracing_and_lowering_workflow, 1.1)
 
     # CHECK: module @test_cancel_inverses_tracing_and_lowering_workflow
@@ -378,9 +354,8 @@ def test_cancel_inverses_tracing_and_lowering_outside_qjit():
         _f = f(xx)
         return _f
 
-    # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK:   pass_name=remove-chained-self-inverse
-    # CHECK: ]
+    # CHECK: quantum_kernel
+    # CHECK: pipeline=(remove-chained-self-inverse,)
     print_jaxpr(test_cancel_inverses_tracing_and_lowering_outside_qjit_workflow, 1.1)
 
     # CHECK: module @test_cancel_inverses_tracing_and_lowering_outside_qjit_workflow
@@ -561,14 +536,11 @@ def test_merge_rotations_tracing_and_lowering():
         _h = h(xx)
         return _f, _g, _h
 
-    # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK:   pass_name=merge-rotations
-    # CHECK: ]
-    # CHECK: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK:   pass_name=merge-rotations
-    # CHECK: ]
-    # CHECK-NOT: _:AbstractTransformMod() = apply_registered_pass[
-    # CHECK-NOT:   pass_name=merge-rotations
+    # CHECK: quantum_kernel
+    # CHECK: pipeline=(merge-rotations,)
+    # CHECK: quantum_kernel
+    # CHECK: pipeline=(merge-rotations,)
+    # CHECK: quantum_kernel
     print_jaxpr(test_merge_rotations_tracing_and_lowering_workflow, 1.1)
 
     # CHECK: module @test_merge_rotations_tracing_and_lowering_workflow

--- a/frontend/test/pytest/test_from_plxpr.py
+++ b/frontend/test/pytest/test_from_plxpr.py
@@ -25,7 +25,7 @@ jax = pytest.importorskip("jax")
 # needs to be below the importorskip calls
 # pylint: disable=wrong-import-position
 from catalyst.from_plxpr import from_plxpr
-from catalyst.jax_primitives import _get_call_jaxpr
+from catalyst.jax_primitives import get_call_jaxpr
 
 
 def catalyst_execute_jaxpr(jaxpr):
@@ -216,8 +216,8 @@ class TestCatalystCompareJaxpr:
         qjit_obj = qml.qjit(circuit)
         qjit_obj(x)
         catalxpr = qjit_obj.jaxpr
-        call_jaxpr_pl = _get_call_jaxpr(converted)
-        call_jaxpr_c = _get_call_jaxpr(catalxpr)
+        call_jaxpr_pl = get_call_jaxpr(converted)
+        call_jaxpr_c = get_call_jaxpr(catalxpr)
         compare_call_jaxprs(call_jaxpr_pl, call_jaxpr_c)
 
     def test_globalphase(self):
@@ -242,8 +242,8 @@ class TestCatalystCompareJaxpr:
         qjit_obj(0.5)
 
         catalxpr = qjit_obj.jaxpr
-        call_jaxpr_pl = _get_call_jaxpr(converted)
-        call_jaxpr_c = _get_call_jaxpr(catalxpr)
+        call_jaxpr_pl = get_call_jaxpr(converted)
+        call_jaxpr_c = get_call_jaxpr(catalxpr)
         compare_call_jaxprs(call_jaxpr_pl, call_jaxpr_c)
 
     def test_expval(self):
@@ -270,8 +270,8 @@ class TestCatalystCompareJaxpr:
         qjit_obj = qml.qjit(circuit)
         qjit_obj(0.5)
         catalxpr = qjit_obj.jaxpr
-        call_jaxpr_pl = _get_call_jaxpr(converted)
-        call_jaxpr_c = _get_call_jaxpr(catalxpr)
+        call_jaxpr_pl = get_call_jaxpr(converted)
+        call_jaxpr_c = get_call_jaxpr(catalxpr)
 
         compare_call_jaxprs(call_jaxpr_pl, call_jaxpr_c)
 
@@ -302,8 +302,8 @@ class TestCatalystCompareJaxpr:
         qjit_obj = qml.qjit(circuit)
         qjit_obj(0.5)
         catalxpr = qjit_obj.jaxpr
-        call_jaxpr_pl = _get_call_jaxpr(converted)
-        call_jaxpr_c = _get_call_jaxpr(catalxpr)
+        call_jaxpr_pl = get_call_jaxpr(converted)
+        call_jaxpr_c = get_call_jaxpr(catalxpr)
 
         compare_call_jaxprs(call_jaxpr_pl, call_jaxpr_c)
 
@@ -341,8 +341,8 @@ class TestCatalystCompareJaxpr:
         qjit_obj = qml.qjit(circuit)
         qjit_obj(phi)
         catalxpr = qjit_obj.jaxpr
-        call_jaxpr_pl = _get_call_jaxpr(converted)
-        call_jaxpr_c = _get_call_jaxpr(catalxpr)
+        call_jaxpr_pl = get_call_jaxpr(converted)
+        call_jaxpr_c = get_call_jaxpr(catalxpr)
 
         # confused by the weak_types error here
         compare_call_jaxprs(call_jaxpr_pl, call_jaxpr_c)
@@ -376,8 +376,8 @@ class TestCatalystCompareJaxpr:
         qjit_obj = qml.qjit(circuit)
         qjit_obj(x)
         catalxpr = qjit_obj.jaxpr
-        call_jaxpr_pl = _get_call_jaxpr(converted)
-        call_jaxpr_c = _get_call_jaxpr(catalxpr)
+        call_jaxpr_pl = get_call_jaxpr(converted)
+        call_jaxpr_c = get_call_jaxpr(catalxpr)
 
         compare_call_jaxprs(call_jaxpr_pl, call_jaxpr_c)
 
@@ -408,8 +408,8 @@ class TestCatalystCompareJaxpr:
         qjit_obj = qml.qjit(circuit)
         qjit_obj()
         catalxpr = qjit_obj.jaxpr
-        call_jaxpr_pl = _get_call_jaxpr(converted)
-        call_jaxpr_c = _get_call_jaxpr(catalxpr)
+        call_jaxpr_pl = get_call_jaxpr(converted)
+        call_jaxpr_c = get_call_jaxpr(catalxpr)
 
         compare_call_jaxprs(call_jaxpr_pl, call_jaxpr_c)
 
@@ -450,8 +450,8 @@ class TestCatalystCompareJaxpr:
         qjit_obj = qml.qjit(circuit)
         qjit_obj(x, y, z)
         catalxpr = qjit_obj.jaxpr
-        call_jaxpr_pl = _get_call_jaxpr(converted)
-        call_jaxpr_c = _get_call_jaxpr(catalxpr)
+        call_jaxpr_pl = get_call_jaxpr(converted)
+        call_jaxpr_c = get_call_jaxpr(catalxpr)
 
         compare_call_jaxprs(call_jaxpr_pl, call_jaxpr_c)
 
@@ -495,8 +495,8 @@ class TestHybridPrograms:
         qjit_obj = qml.qjit(workflow)
         qjit_obj(0.5)
 
-        call_jaxpr_pl = _get_call_jaxpr(converted)
-        call_jaxpr_c = _get_call_jaxpr(qjit_obj.jaxpr)
+        call_jaxpr_pl = get_call_jaxpr(converted)
+        call_jaxpr_c = get_call_jaxpr(qjit_obj.jaxpr)
 
         # qubit extraction and classical equations in a slightly different order
         # thus cant check specific equations and have to discard comparing counts

--- a/frontend/test/pytest/test_jax_primitives.py
+++ b/frontend/test/pytest/test_jax_primitives.py
@@ -26,10 +26,10 @@ from jax._src.lib.mlir import ir
 from jax.interpreters.mlir import ir_constant, make_ir_context
 
 from catalyst.jax_primitives import (
-    get_call_jaxpr,
     _qextract_lowering,
     _qinsert_lowering,
     extract_scalar,
+    get_call_jaxpr,
     safe_cast_to_f64,
 )
 

--- a/frontend/test/pytest/test_jax_primitives.py
+++ b/frontend/test/pytest/test_jax_primitives.py
@@ -26,7 +26,7 @@ from jax._src.lib.mlir import ir
 from jax.interpreters.mlir import ir_constant, make_ir_context
 
 from catalyst.jax_primitives import (
-    _get_call_jaxpr,
+    get_call_jaxpr,
     _qextract_lowering,
     _qinsert_lowering,
     extract_scalar,
@@ -136,14 +136,14 @@ class TestHelpers:
 
 
 def test_get_call_jaxpr():
-    """Test _get_call_jaxpr raises AsserionError if no function primitive exists."""
+    """Test get_call_jaxpr raises AsserionError if no function primitive exists."""
 
     def f(x):
         return x * x
 
     jaxpr = make_jaxpr(f)(2.0)
     with pytest.raises(AssertionError, match="No call_jaxpr found in the JAXPR"):
-        _ = _get_call_jaxpr(jaxpr)
+        _ = get_call_jaxpr(jaxpr)
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_peephole_optimizations.py
+++ b/frontend/test/pytest/test_peephole_optimizations.py
@@ -189,12 +189,6 @@ def test_cancel_inverses_bad_usages():
             TypeError,
             match="A QNode is expected, got the classical function",
         ):
-            pipeline()(classical_func)
-
-        with pytest.raises(
-            TypeError,
-            match="A QNode is expected, got the classical function",
-        ):
             cancel_inverses(classical_func)
 
         with pytest.raises(

--- a/frontend/test/pytest/test_peephole_optimizations.py
+++ b/frontend/test/pytest/test_peephole_optimizations.py
@@ -189,6 +189,12 @@ def test_cancel_inverses_bad_usages():
             TypeError,
             match="A QNode is expected, got the classical function",
         ):
+            pipeline({})(classical_func)
+
+        with pytest.raises(
+            TypeError,
+            match="A QNode is expected, got the classical function",
+        ):
             cancel_inverses(classical_func)
 
         with pytest.raises(


### PR DESCRIPTION
**Context:** Registering a pass to run in MLIR was a bit messy. This code simplifies that process.

**Description of the Change:**

* Removes the `apply_registered_pass_p` primitive and instead denotes the pass as an object. This object is used as a JAX static parameter and its properties are used to lower the proper transform schedule.
* Simplify the process of adding a pass to the pipeline by just appending it to a kwargs sequence.
* Simplify the process of mlir_quantum_decomposition for the ion pass (@joeycarter). Ideally we should have a field in the device that corresponds to the default passes to be applied. This is instead of detecting the device during the lowering and adding a pass specific for that device.
* Refactors the caching mechanism for primitives.

**Benefits:** Less complexity, more maintainable code. We can still improve upon this. This change makes it easier to implement loading pass plugins from python.

**Possible Drawbacks:** Changes some of the original formulation of the pipeline (instead of having a dictionary, users can now just pass a list of Pass objects)

**Related GitHub Issues:**
