### PR TITLE
Update seeding docs to reflect newly supported methods

### DIFF
--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -140,7 +140,9 @@ def qjit(
             ``lightning.gpu``. The default value is None, which means no seeding is performed,
             and all processes are random. A seed is expected to be an unsigned 32-bit integer.
             Currently, the following measurement processes are seeded: :func:`~.measure`,
-            :func:`qml.sample() <pennylane.sample>`, :func:`qml.counts() <pennylane.counts>`.
+            :func:`qml.sample() <pennylane.sample>`, :func:`qml.counts() <pennylane.counts>`,
+            :func:`qml.probs() <pennylane.probs>`, :func:`qml.expval() <pennylane.expval>`,
+            :func:`qml.var() <pennylane.var>`.
         experimental_capture (bool): If set to ``True``, the qjit decorator
             will use PennyLane's experimental program capture capabilities
             to capture the decorated function for compilation.


### PR DESCRIPTION
**Context:**
Recently `qml.probs/var/expval` became seeded #1344, so we update the user-facing documentation.
