### PR TITLE
Fix version regex in formatter script

### DIFF
--- a/bin/format.py
+++ b/bin/format.py
@@ -33,7 +33,7 @@ BASE_ARGS = f"-assume-filename={CLANG_FMT_CNFG_PATH}"
 
 
 def parse_version(version_string):
-    version_rgx = "version (\d+)"
+    version_rgx = r"version (\d+)"
 
     m = re.search(version_rgx, version_string)
     return int(m.group(1))


### PR DESCRIPTION
**Context:** Currently when I run `make format` I get a `SyntaxWarning` in the `format.py` script, e.g.:

```
make -C mlir format
make[1]: Entering directory '.../catalyst/mlir'
.../venv/bin/python3 ../bin/format.py  .
.../catalyst/mlir/../bin/format.py:36: SyntaxWarning: invalid escape sequence '\d'
  version_rgx = "version (\d+)"
```

**Description of the Change:** Make this string a raw string: `r"version (\d+)"`. This fixes the warning.

**Benefits:** Fewer warnings :rocket: