### PR TITLE
Replace Py_DECREF with Py_DecRef, which is part of the Stable ABI

### DIFF
--- a/frontend/catalyst/utils/wrapper.cpp
+++ b/frontend/catalyst/utils/wrapper.cpp
@@ -190,8 +190,8 @@ nb::list move_returns(void *memref_array_ptr, nb::object result_desc, nb::object
         // Decrement reference counts.
         // The final ref count of `new_array` should be 2: one for the `returns` list and one for
         // the `numpy_arrays` dict.
-        Py_DECREF(pyLong);
-        Py_DECREF(new_array);
+        Py_DecRef(pyLong);
+        Py_DecRef(new_array);
     }
     return returns;
 }


### PR DESCRIPTION
**Context:** In order to generate Catalyst wheels with stable Python, we need to change all direct Python API calls with those from the limited API.

**Description of the Change:** Replace Py_DECREF with Py_DecRef, which is part of the Stable ABI.

**Benefits:** Python 3.12 wheels and up will be using the stable API only.

[sc-73088]