### PR TITLE
Create stable ABI wheels for Python 3.12 and up

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -42,6 +42,9 @@
 * Cleans up the output of compiler instrumentation.
   [(#1343)](https://github.com/PennyLaneAI/catalyst/pull/1343)
 
+* Generate stable ABI wheels for Python 3.12 and up.
+  [(#1357)](https://github.com/PennyLaneAI/catalyst/pull/1357)
+
 <h3>Breaking changes 💔</h3>
 
 * The `sample` and `counts` measurement primitives now support dynamic shot values across catalyst, although at the PennyLane side, the device shots still is constrained to a static integer literal.

--- a/setup.py
+++ b/setup.py
@@ -308,6 +308,7 @@ ext_modules = [
     CMakeExtension("catalyst.utils.wrapper", sourcedir=frontend_dir),
 ]
 
+options = {"bdist_wheel": {"py_limited_api": "cp312"}} if sys.hexversion >= 0x030C0000 else {}
 # For any compiler packages seeking to be registered in PennyLane, it is imperative that they
 # expose the entry_points metadata under the designated group name `pennylane.compilers`, with
 # the following entry points:
@@ -333,4 +334,5 @@ setup(
     ext_modules=ext_modules,
     cmdclass=cmdclass,
     **description,
+    options=options,
 )


### PR DESCRIPTION
**Context:** We need to ensure we generate and correctly name our stable Python wheels starting with Python 3.12 and up.

**Description of the Change:** Use the `bdist_wheel` option.

**Benefits:** Only one wheel for Python 3.12 and up.

[sc-73093]