### PR TITLE
Update lightning version for dynamic device shots

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -12,4 +12,4 @@ pennylane=0.40.0-dev20
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'
-lightning=0.40.0-dev24
+lightning=0.40.0-dev30

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -30,6 +30,6 @@ lxml_html_clean
 
 # Pre-install PL development wheels
 --extra-index-url https://test.pypi.org/simple/
-pennylane-lightning-kokkos==0.40.0-dev24
-pennylane-lightning==0.40.0-dev24
+pennylane-lightning-kokkos==0.40.0-dev30
+pennylane-lightning==0.40.0-dev30
 pennylane==0.40.0-dev20


### PR DESCRIPTION
**Context:**
As part of the work to support dynamic shapes across catalyst, in #1310 the `DeviceInitOp` was changed to take in a proper SSA argument for shots, instead of having shots as just another entry in the `DeviceInitOp`'s attribute dictionary.

Correspondingly, the backend devices' catalyst interfaces need to stop parsing the `DeviceInitOp`'s attribute dictionary for shots. For the lightning devices, this was done in lightning repo at https://github.com/PennyLaneAI/pennylane-lightning/pull/1017

We now update catalyst to track the lightning with that update.

**Description of the Change:**
Update lightning version to `0.40.0-dev30`, which is the version of https://github.com/PennyLaneAI/pennylane-lightning/pull/1017

