### PR TITLE
Remove shots attr from `expval` and `var` operations

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -131,6 +131,9 @@
   6283185307.179586
   ```
 
+* `expval` and `var` operations no longer keep the static shots attribute, as a step towards supporting dynamic shots across catalyst.
+  [(#1360)](https://github.com/PennyLaneAI/catalyst/pull/1360)
+
 <h3>Documentation 📝</h3>
 
 * A new tutorial going through how to write a new MLIR pass is available. The tutorial writes an

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -371,7 +371,7 @@ class QFuncPlxprInterpreter:
                 counts_p, {"shots": device_shots}, obs, shape=shaped_array.shape
             )
         elif primitive in (expval_p, var_p):
-            mval = expval_p.bind(obs, shape=shaped_array.shape)
+            mval = primitive.bind(obs, shape=shaped_array.shape)
         else:
             mval = primitive.bind(
                 obs, shape=shaped_array.shape, shots=self._device.shots.total_shots

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -370,6 +370,8 @@ class QFuncPlxprInterpreter:
             mval = bind_flexible_primitive(
                 counts_p, {"shots": device_shots}, obs, shape=shaped_array.shape
             )
+        elif primitive is expval_p:
+            mval = expval_p.bind(obs, shape=shaped_array.shape)
         else:
             mval = primitive.bind(
                 obs, shape=shaped_array.shape, shots=self._device.shots.total_shots

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -370,7 +370,7 @@ class QFuncPlxprInterpreter:
             mval = bind_flexible_primitive(
                 counts_p, {"shots": device_shots}, obs, shape=shaped_array.shape
             )
-        elif primitive is expval_p:
+        elif primitive in (expval_p, var_p):
             mval = expval_p.bind(obs, shape=shaped_array.shape)
         else:
             mval = primitive.bind(

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1460,17 +1460,17 @@ def _expval_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shape=Non
 # var measurement
 #
 @var_p.def_abstract_eval
-def _var_abstract_eval(obs, shots, shape=None):
+def _var_abstract_eval(obs, shape=None):
     assert isinstance(obs, AbstractObs)
     return core.ShapedArray((), jax.numpy.float64)
 
 
 @var_p.def_impl
-def _var_def_impl(ctx, obs, shots, shape=None):  # pragma: no cover
+def _var_def_impl(ctx, obs, shape=None):  # pragma: no cover
     raise NotImplementedError()
 
 
-def _var_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shots: int, shape=None):
+def _var_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shape=None):
     ctx = jax_ctx.module_context.context
     ctx.allow_unregistered_dialects = True
 
@@ -1478,11 +1478,9 @@ def _var_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shots: int, 
     assert ir.OpaqueType(obs.type).dialect_namespace == "quantum"
     assert ir.OpaqueType(obs.type).data == "obs"
 
-    i64_type = ir.IntegerType.get_signless(64, ctx)
-    shots_attr = ir.IntegerAttr.get(i64_type, shots) if shots is not None else None
     result_type = ir.F64Type.get()
 
-    mres = VarianceOp(result_type, obs, shots=shots_attr).result
+    mres = VarianceOp(result_type, obs).result
     result_from_elements_op = ir.RankedTensorType.get((), result_type)
     from_elements_op = FromElementsOp(result_from_elements_op, mres)
     return from_elements_op.results

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1448,8 +1448,6 @@ def _expval_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shape=Non
     assert ir.OpaqueType(obs.type).dialect_namespace == "quantum"
     assert ir.OpaqueType(obs.type).data == "obs"
 
-    i64_type = ir.IntegerType.get_signless(64, ctx)
-    #shots_attr = ir.IntegerAttr.get(i64_type, shots) if shots is not None else None
     result_type = ir.F64Type.get()
 
     mres = ExpvalOp(result_type, obs).result

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1430,17 +1430,17 @@ def _counts_lowering(
 # expval measurement
 #
 @expval_p.def_abstract_eval
-def _expval_abstract_eval(obs, shots, shape=None):
+def _expval_abstract_eval(obs, shape=None):
     assert isinstance(obs, AbstractObs)
     return core.ShapedArray((), jax.numpy.float64)
 
 
 @expval_p.def_impl
-def _expval_def_impl(ctx, obs, shots, shape=None):  # pragma: no cover
+def _expval_def_impl(ctx, obs, shape=None):  # pragma: no cover
     raise NotImplementedError()
 
 
-def _expval_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shots: int, shape=None):
+def _expval_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shape=None):
     ctx = jax_ctx.module_context.context
     ctx.allow_unregistered_dialects = True
 
@@ -1449,10 +1449,10 @@ def _expval_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shots: in
     assert ir.OpaqueType(obs.type).data == "obs"
 
     i64_type = ir.IntegerType.get_signless(64, ctx)
-    shots_attr = ir.IntegerAttr.get(i64_type, shots) if shots is not None else None
+    #shots_attr = ir.IntegerAttr.get(i64_type, shots) if shots is not None else None
     result_type = ir.F64Type.get()
 
-    mres = ExpvalOp(result_type, obs, shots=shots_attr).result
+    mres = ExpvalOp(result_type, obs).result
     result_from_elements_op = ir.RankedTensorType.get((), result_type)
     from_elements_op = FromElementsOp(result_from_elements_op, mres)
     return from_elements_op.results

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -908,7 +908,6 @@ def trace_quantum_measurements(
                     out_classical_tracers.append(reshaped_result)
 
             elif type(o) is ExpectationMP:
-                #out_classical_tracers.append(expval_p.bind(obs_tracers, shots=shots))
                 out_classical_tracers.append(expval_p.bind(obs_tracers))
             elif type(o) is VarianceMP:
                 out_classical_tracers.append(var_p.bind(obs_tracers, shots=shots))

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -910,7 +910,7 @@ def trace_quantum_measurements(
             elif type(o) is ExpectationMP:
                 out_classical_tracers.append(expval_p.bind(obs_tracers))
             elif type(o) is VarianceMP:
-                out_classical_tracers.append(var_p.bind(obs_tracers, shots=shots))
+                out_classical_tracers.append(var_p.bind(obs_tracers))
             elif type(o) is ProbabilityMP:
                 assert using_compbasis
                 shape = (2**nqubits,)

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -908,7 +908,8 @@ def trace_quantum_measurements(
                     out_classical_tracers.append(reshaped_result)
 
             elif type(o) is ExpectationMP:
-                out_classical_tracers.append(expval_p.bind(obs_tracers, shots=shots))
+                #out_classical_tracers.append(expval_p.bind(obs_tracers, shots=shots))
+                out_classical_tracers.append(expval_p.bind(obs_tracers))
             elif type(o) is VarianceMP:
                 out_classical_tracers.append(var_p.bind(obs_tracers, shots=shots))
             elif type(o) is ProbabilityMP:

--- a/frontend/catalyst/third_party/cuda/catalyst_to_cuda_interpreter.py
+++ b/frontend/catalyst/third_party/cuda/catalyst_to_cuda_interpreter.py
@@ -576,13 +576,8 @@ def change_expval(ctx, eqn):
     invals = _map(ctx.read, eqn.invars)
     obs = invals[0]
 
-    # Params:
-    # * shots: Shots
-    shots = eqn.params["shots"]
-    shots = shots if shots is not None else -1
-
     # To obtain expval, we first obtain an observe object.
-    observe_results = cudaq_observe(ctx.kernel, obs, shots)
+    observe_results = cudaq_observe(ctx.kernel, obs)
     # And then we call expectation on that object.
     result = cudaq_expectation(observe_results)
     outvariables = [ctx.new_variable()]

--- a/frontend/test/pytest/test_measurement_primitives.py
+++ b/frontend/test/pytest/test_measurement_primitives.py
@@ -123,11 +123,11 @@ def test_var():
 
     def f():
         obs = compbasis_p.bind()
-        return var_p.bind(obs, shots=5, shape=(1,))
+        return var_p.bind(obs, shape=(1,))
 
     jaxpr = jax.make_jaxpr(f)()
     assert jaxpr.eqns[1].primitive == var_p
-    assert jaxpr.eqns[1].params == {"shape": (1,), "shots": 5}
+    assert jaxpr.eqns[1].params == {"shape": (1,)}
     assert jaxpr.eqns[1].outvars[0].aval.shape == ()
 
 

--- a/frontend/test/pytest/test_measurement_primitives.py
+++ b/frontend/test/pytest/test_measurement_primitives.py
@@ -110,11 +110,11 @@ def test_expval():
 
     def f():
         obs = compbasis_p.bind()
-        return expval_p.bind(obs, shots=5, shape=(1,))
+        return expval_p.bind(obs, shape=(1,))
 
     jaxpr = jax.make_jaxpr(f)()
     assert jaxpr.eqns[1].primitive == expval_p
-    assert jaxpr.eqns[1].params == {"shape": (1,), "shots": 5}
+    assert jaxpr.eqns[1].params == {"shape": (1,)}
     assert jaxpr.eqns[1].outvars[0].aval.shape == ()
 
 

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -856,9 +856,9 @@ def ExpvalOp : Measurement_Op<"expval"> {
     let description = [{
         The `quantum.expval` operation represents the measurement process of computing the
         expectation value of an observable on the current quantum state. While this quantity can
-        be computed analytically on simulators, an optional attribute specifiying the shot number,
-        i.e. the number of samples to draw, can be specified for hardware execution or shot noise
-        simulation.
+        be computed analytically on simulators, for hardware execution or shot noise
+        simulation, the shots attached to the device
+        in the local scope is used.
         The only SSA argument is an observable that must be defined by an operation in the local
         scope.
 
@@ -892,9 +892,9 @@ def VarianceOp : Measurement_Op<"var"> {
     let summary = "Compute the variance of the given observable for the current state";
     let description = [{
         The `quantum.var` operation represents the measurement process of computing the variance of
-        an observable on the current quantum state. While this quantity can be computed analytically
-        on simulators, an optional attribute specifiying the shot number, i.e. the number of samples
-        to draw, can be specified for hardware execution or shot noise simulation.
+        an observable on the current quantum state. While this quantity can be computed analytically on simulators, for hardware execution or shot noise
+        simulation, the shots attached to the device
+        in the local scope is used.
         The only SSA argument is an observable that must be defined by an operation in the local
         scope.
 
@@ -912,8 +912,7 @@ def VarianceOp : Measurement_Op<"var"> {
     }];
 
     let arguments = (ins
-        ObservableType:$obs,
-        OptionalAttr<I64Attr>:$shots
+        ObservableType:$obs
     );
 
     let results = (outs

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -877,7 +877,6 @@ def ExpvalOp : Measurement_Op<"expval"> {
 
     let arguments = (ins
         ObservableType:$obs
-        //OptionalAttr<I64Attr>:$shots
     );
 
     let results = (outs

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -876,8 +876,8 @@ def ExpvalOp : Measurement_Op<"expval"> {
     }];
 
     let arguments = (ins
-        ObservableType:$obs,
-        OptionalAttr<I64Attr>:$shots
+        ObservableType:$obs
+        //OptionalAttr<I64Attr>:$shots
     );
 
     let results = (outs


### PR DESCRIPTION
**Context:**
As part of the work to support dynamically shaped measurement primitives, shots is now tied to the device through a SSA value, so it can be dynamic. See #1310 .

Correspondingly, the static shots int literal attribute of the `expval` and `var` operations in mlir should be removed. This is more so the case since their shots values are not actually used in their respective runtime CAPIs.

**Description of the Change:**
Remove shots attr from `expval` and `var` operations in mlir, and frontend tracing and jax primitives.

**Benefits:**
Unification of how measurement operations handle shots.

[sc-78845]
