### PR TITLE
[frontend] Add entry_points support for MLIR plugins

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -2,8 +2,9 @@
 
 <h3>New features since last release</h3>
 
-* Catalyst can now load local MLIR plugins from python.
+* Catalyst can now load local MLIR plugins from python. Including support for `entry_points`.
   [(#1317)](https://github.com/PennyLaneAI/catalyst/pull/1317)
+  [(#1361)](https://github.com/PennyLaneAI/catalyst/pull/1361)
 
 <h3>Improvements 🛠</h3>
 

--- a/frontend/catalyst/example_entry_point/__init__.py
+++ b/frontend/catalyst/example_entry_point/__init__.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from catalyst.utils.runtime_environment import get_bin_path
 
 
-def name2pass(name):
+def name2pass(_name):
     """Example entry point for standalone plugin"""
     plugin_path = get_bin_path("cli", "CATALYST_BIN_DIR") + "/../lib/StandalonePlugin.so"
     plugin = Path(plugin_path)

--- a/frontend/catalyst/example_entry_point/__init__.py
+++ b/frontend/catalyst/example_entry_point/__init__.py
@@ -1,0 +1,26 @@
+# Copyright 2024 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Example module with entry points"""
+
+from pathlib import Path
+
+from catalyst.utils.runtime_environment import get_bin_path
+
+
+def name2pass(name):
+    """Example entry point for standalone plugin"""
+    plugin_path = get_bin_path("cli", "CATALYST_BIN_DIR") + "/../lib/StandalonePlugin.so"
+    plugin = Path(plugin_path)
+    return plugin, "standalone-switch-bar-foo"

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -51,7 +51,7 @@ class Pass:
     def __init__(self, name, *options, **valued_options):
         self.options = options
         self.valued_options = valued_options
-        try:
+        if "." in name:
             resolution_functions = entry_points(group="catalyst.passes_resolution")
             key, passname = name.split(".")
             resolution_function = resolution_functions[key + ".passes"]
@@ -59,8 +59,6 @@ class Pass:
             path, name = module.name2pass(passname)
             assert EvaluationContext.is_tracing()
             EvaluationContext.add_plugin(path)
-        except:
-            pass
 
         self.name = name
 
@@ -93,11 +91,8 @@ def dictionary_to_tuple_of_passes(pass_pipeline: PipelineDict):
     passes = tuple()
     pass_names = _API_name_to_pass_name()
     for API_name, pass_options in pass_pipeline.items():
-        try:
-            passes += (Pass(API_name, **pass_options),)
-        except:
-            name = pass_names[API_name]
-            passes += (Pass(name, **pass_options),)
+        name = pass_names.get(API_name, API_name)
+        passes += (Pass(name, **pass_options),)
     return passes
 
 

--- a/frontend/test/pytest/test_mlir_plugin.py
+++ b/frontend/test/pytest/test_mlir_plugin.py
@@ -80,4 +80,3 @@ def test_standalone_entry_point():
     # It would be nice if we were able to combine lit tests with
     # pytest
     assert "standalone-switch-bar-foo" in module.mlir
-    print(module.mlir)

--- a/frontend/test/pytest/test_mlir_plugin.py
+++ b/frontend/test/pytest/test_mlir_plugin.py
@@ -64,3 +64,20 @@ def test_standalone_plugin_no_preregistration():
     # It would be nice if we were able to combine lit tests with
     # pytest
     assert "standalone-switch-bar-foo" in module.mlir
+
+def test_standalone_entry_point():
+    """Generate MLIR for the standalone plugin via entry-point"""
+
+    @apply_pass("standalone.standalone-switch-bar-foo")
+    @qml.qnode(qml.device("lightning.qubit", wires=0))
+    def qnode():
+        return qml.state()
+
+    @qml.qjit(target="mlir")
+    def module():
+        return qnode()
+
+    # It would be nice if we were able to combine lit tests with
+    # pytest
+    assert "standalone-switch-bar-foo" in module.mlir
+    print(module.mlir)

--- a/frontend/test/pytest/test_mlir_plugin.py
+++ b/frontend/test/pytest/test_mlir_plugin.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import pennylane as qml
 
-from catalyst.passes import apply_pass, apply_pass_plugin
+from catalyst.passes import apply_pass, apply_pass_plugin, pipeline
 from catalyst.utils.runtime_environment import get_bin_path
 
 ext = "so" if platform.system() == "Linux" else "dylib"
@@ -65,10 +65,28 @@ def test_standalone_plugin_no_preregistration():
     # pytest
     assert "standalone-switch-bar-foo" in module.mlir
 
+
 def test_standalone_entry_point():
     """Generate MLIR for the standalone plugin via entry-point"""
 
     @apply_pass("standalone.standalone-switch-bar-foo")
+    @qml.qnode(qml.device("lightning.qubit", wires=0))
+    def qnode():
+        return qml.state()
+
+    @qml.qjit(target="mlir")
+    def module():
+        return qnode()
+
+    # It would be nice if we were able to combine lit tests with
+    # pytest
+    assert "standalone-switch-bar-foo" in module.mlir
+
+
+def test_standalone_dictionary():
+    """Generate MLIR for the standalone plugin via entry-point"""
+
+    @pipeline({"standalone.standalone-switch-bar-foo": {}})
     @qml.qnode(qml.device("lightning.qubit", wires=0))
     def qnode():
         return qml.state()

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ entry_points = {
         "cuda_quantum.qjit = catalyst.third_party.cuda:cudaqjit",
     ],
     "catalyst.passes_resolution": [
-        "standalone.passes = catalyst.passes.example_entry_point",
+        "standalone.passes = catalyst.example_entry_point",
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,9 @@ entry_points = {
         "cuda_quantum.ops = catalyst.api_extensions",
         "cuda_quantum.qjit = catalyst.third_party.cuda:cudaqjit",
     ],
+    "catalyst.passes_resolution": [
+        "standalone.passes = catalyst.passes.example_entry_point",
+    ],
 }
 
 classifiers = [


### PR DESCRIPTION
**Context:** Add support for adding passes via entry_points.

**Description of the Change:** Adds support for the following syntax:

```python
def test_standalone_entry_point():
    """Generate MLIR for the standalone plugin via entry-point"""

    @apply_pass("standalone.standalone-switch-bar-foo") # notice that this is namespace.pass-name
    @qml.qnode(qml.device("lightning.qubit", wires=0))
    def qnode():
        return qml.state()

    @qml.qjit(target="mlir")
    def module():
        return qnode()

    assert "standalone-switch-bar-foo" in module.mlir
    print(module.mlir)
```

Also tests for support for the dictionary interface:

```python
def test_standalone_dictionary():
    """Generate MLIR for the standalone plugin via entry-point"""

    @pipeline({"standalone.standalone-switch-bar-foo": {}})
    @qml.qnode(qml.device("lightning.qubit", wires=0))
    def qnode():
        return qml.state()

    @qml.qjit(target="mlir")
    def module():
        return qnode()

    assert "standalone-switch-bar-foo" in module.mlir
```

**Benefits:** Entry Points!

**Possible Drawbacks:** Having entry points is essentially adding dynamism, which means it may impact compile time.

**Related GitHub Issues:**

[sc-73572]
