### PR TITLE
[Makefile] Add standalone-plugin to Makefile and fix path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ TEST_BACKEND ?= "lightning.qubit"
 TEST_BRAKET ?= NONE
 ENABLE_ASAN ?= OFF
 TOML_SPECS ?= $(shell find ./runtime ./frontend -name '*.toml' -not -name 'pyproject.toml')
-MLIR_DIR ?= $(shell pwd)/mlir/llvm-project/build/lib/cmake/mlir
 
 PLATFORM := $(shell uname -s)
 ifeq ($(PLATFORM),Linux)
@@ -117,7 +116,7 @@ oqc:
 	$(MAKE) -C frontend/catalyst/third_party/oqc/src oqc
 
 .PHONY: test test-runtime test-frontend lit pytest test-demos test-oqc test-toml-spec
-test: test-runtime test-frontend test-demos
+test: test-runtime standalone-plugin test-frontend test-demos
 
 test-toml-spec:
 	$(PYTHON) ./bin/toml-check.py $(TOML_SPECS)

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ test-frontend: lit pytest
 test-oqc:
 	$(MAKE) -C frontend/catalyst/third_party/oqc/src test
 
-lit:
+lit: standalone-plugin
 ifeq ($(ENABLE_ASAN),ON)
 ifneq ($(findstring clang,$(C_COMPILER)),clang)
 	@echo "Build and Test with Address Sanitizer are only supported by Clang, but provided $(C_COMPILER)"

--- a/mlir/Makefile
+++ b/mlir/Makefile
@@ -15,6 +15,7 @@ BUILD_TYPE?=Release
 TARGET_FILE=$(MK_DIR)/mlir-hlo/mhlo/transforms/CMakeLists.txt
 PATCH_FILE=$(MK_DIR)/patches/mhlo-Add-PassesIncGen-in-transforms-CMakeList.patch
 LLVM_EXTERNAL_LIT ?= $(LLVM_BUILD_DIR)/bin/llvm-lit
+MLIR_DIR ?= $(shell pwd)/llvm-project/build/lib/cmake/mlir
 
 ifeq ($(shell uname), Darwin)
 DEFAULT_ENABLE_LLD := OFF

--- a/mlir/Makefile
+++ b/mlir/Makefile
@@ -51,7 +51,7 @@ help:
 	@echo "  format [version=?] to apply C++ formatter; use with 'version={version}' to run clang-format-{version} instead of clang-format"
 
 .PHONY: all
-all: llvm mhlo enzyme dialects
+all: llvm mhlo enzyme dialects standalone-plugin
 
 .PHONY: llvm
 llvm:


### PR DESCRIPTION
**Context:** Adds standalone-plugin to the rule for testing. This makes sure that the standalone-plugin gets build before the frontend tests are run.

**Description of the Change:** Adds standalone-plugin to the Makefile fix the MLIR_DIR path.

**Benefits:** Developers don't need to build the standalone plugin manually.

**Possible Drawbacks:** More compilation time for developers (when compiling the project, not quantum programs)
