### PR TITLE
Clean the Standalone Plugin when needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ endif
 	MDD_BENCHMARK_PRECISION=1 \
 	$(ASAN_COMMAND) $(PYTHON) -m pytest demos --nbmake $(PARALLELIZE)
 
-wheel:
+wheel: standalone-plugin
 	echo "INSTALLED = True" > $(MK_DIR)/frontend/catalyst/_configuration.py
 
 	# Copy libs to frontend/catalyst/lib
@@ -205,6 +205,10 @@ clean:
 	rm -rf $(MK_DIR)/frontend/mlir_quantum $(MK_DIR)/frontend/catalyst/lib
 	rm -rf dist __pycache__
 	rm -rf .coverage coverage_html_report
+
+	# Remove the standalone plugin 
+	rm -rf  $(MK_DIR)/mlir/build/lib/StandalonePlugin.*
+	rm -rf  $(MK_DIR)/mlir/standalone/build/lib/StandalonePlugin.*
 
 clean-all: clean-frontend clean-mlir clean-runtime clean-oqc
 	@echo "uninstall catalyst and delete all temporary, cache, and build files"

--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ endif
 	MDD_BENCHMARK_PRECISION=1 \
 	$(ASAN_COMMAND) $(PYTHON) -m pytest demos --nbmake $(PARALLELIZE)
 
-wheel: standalone-plugin
+wheel:
 	echo "INSTALLED = True" > $(MK_DIR)/frontend/catalyst/_configuration.py
 
 	# Copy libs to frontend/catalyst/lib
@@ -206,15 +206,16 @@ clean:
 	rm -rf dist __pycache__
 	rm -rf .coverage coverage_html_report
 
-	# Remove the standalone plugin 
-	rm -rf  $(MK_DIR)/mlir/build/lib/StandalonePlugin.*
-	rm -rf  $(MK_DIR)/mlir/standalone/build/lib/StandalonePlugin.*
-
-clean-all: clean-frontend clean-mlir clean-runtime clean-oqc
+clean-all: clean-frontend clean-mlir clean-runtime clean-oqc clean-standalone-plugin
 	@echo "uninstall catalyst and delete all temporary, cache, and build files"
 	$(PYTHON) -m pip uninstall -y pennylane-catalyst
 	rm -rf dist __pycache__
 	rm -rf .coverage coverage_html_report/
+
+.PHONY: clean-standalone-plugin
+clean-standalone-plugin:
+	rm -rf  $(MK_DIR)/mlir/build/lib/StandalonePlugin.*
+	rm -rf  $(MK_DIR)/mlir/standalone/build/lib/StandalonePlugin.*
 
 .PHONY: clean-frontend
 clean-frontend:


### PR DESCRIPTION
**Context:** `make clean-all` is not deleting the standalone-plugin files.

**Description of the Change:** Remove the standalone-plugin files when doing `make clean-all` by calling the `clean-standalone-plugin` rule.

**Benefits:** A clean build.
