### PR TITLE
Reduce max-parallel to 1 for Linux Arm 64 workflow

### DIFF
--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -204,7 +204,7 @@ jobs:
     needs: [constants, build-dependencies]
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 1
       matrix:
         python_version: [{major_minor: "3.10", patch: "14", package: "python3.10", alternative: "310"},
                          {major_minor: "3.11", patch: "9",  package: "python3.11", alternative: "311"},
@@ -299,7 +299,7 @@ jobs:
     needs: [constants, catalyst-linux-wheels-arm64]
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 1
       matrix:
         python_version: [{major_minor: "3.10", patch: "14", package: "python3.10"},
                          {major_minor: "3.11", patch: "9",  package: "python3.11"},


### PR DESCRIPTION
**Context:** The Linux Arm 64 runner seems to fail frequently due to resource contention issues. 

**Description of the Change:** Reduce `max-parallel` to 1 for Linux Arm 64.

**Benefits:** Less chances for resource contention issues.

**Possible Drawbacks:** Sequential execution of jobs.
