### PR TITLE
remove func-name option form catalyst-cli documentation

### DIFF
--- a/doc/catalyst-cli/catalyst-cli.rst
+++ b/doc/catalyst-cli/catalyst-cli.rst
@@ -175,14 +175,11 @@ two quantum-optimization passes:
    this case the two RX gates the become adjacent after the two Hadamard gates have been removed by
    the ``remove-chained-self-inverse`` pass.
 
-To define the pass pipeline, we must supply the name of the function to which each pass applies
-using the ``func-name`` argument. The ``func-name`` argument is specific to the two passes we are
-applying and is not a general requirement. To apply these two passes to our ``my_circuit`` function,
-we can do so as follows:
+To apply these two passes to our ``my_circuit`` function, we can do so as follows:
 
 .. code-block::
 
-    pipe(remove-chained-self-inverse{func-name=my_circuit};merge-rotations{func-name=my_circuit})
+    pipe(remove-chained-self-inverse;merge-rotations)
 
 Finally, we'll use the option ``--mlir-print-ir-after-all`` to print the resulting MLIR after each
 pass that is applied, and the ``-o`` option to set the name of the output IR file:
@@ -191,7 +188,7 @@ pass that is applied, and the ``-o`` option to set the name of the output IR fil
 
     catalyst-cli my_circuit.mlir \
         --tool=opt \
-        --catalyst-pipeline="pipe(remove-chained-self-inverse{func-name=my_circuit};merge-rotations{func-name=my_circuit})" \
+        --catalyst-pipeline="pipe(remove-chained-self-inverse;merge-rotations)" \
         --mlir-print-ir-after-all \
         -o my_circuit-llvm.mlir
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -117,6 +117,9 @@
   [a separate github branch](https://github.com/PennyLaneAI/catalyst/commit/ba7b3438667963b307c07440acd6d7082f1960f3).
   [(#872)](https://github.com/PennyLaneAI/catalyst/pull/872)
 
+* Updated catalyst-cli documentation to reflect the removal of func-name option for trasnformation passes.
+  [(#1368)](https://github.com/PennyLaneAI/catalyst/pull/1368)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):


### PR DESCRIPTION
**Context:**
This [PR](https://github.com/PennyLaneAI/catalyst/pull/1323/files#diff-8c2db8800c5f294c7533f503cfb1deb8ee72212b8ba0fedf1692db93e3043cde) removes the func-name option from QuantumCircuitTransformationPass. However the change is not reflected in catalyst-cli documentations.

**Description of the Change:**
Updates the catalyst-cli documentations

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
