### PR TITLE
Add make option to enable pip install verbose output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,12 @@ endif
 # Export variables so that they can be set here without needing to also set them in sub-make files.
 export ENABLE_ASAN ASAN_COMMAND
 
+# Flag for verbose pip install output
+PIP_VERBOSE_FLAG :=
+ifeq ($(VERBOSE),1)
+PIP_VERBOSE_FLAG := --verbose
+endif
+
 .PHONY: help
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
@@ -87,13 +93,6 @@ help:
 .PHONY: all catalyst
 all: runtime oqc oqd mlir frontend
 catalyst: runtime dialects frontend
-
-# Flag for verbose pip install output
-PIP_VERBOSE_FLAG :=
-
-ifeq ($(VERBOSE),1)
-    PIP_VERBOSE_FLAG := --verbose
-endif
 
 .PHONY: frontend
 frontend:

--- a/Makefile
+++ b/Makefile
@@ -88,13 +88,20 @@ help:
 all: runtime oqc oqd mlir frontend
 catalyst: runtime dialects frontend
 
+# Flag for verbose pip install output
+PIP_VERBOSE_FLAG :=
+
+ifeq ($(VERBOSE),1)
+    PIP_VERBOSE_FLAG := --verbose
+endif
+
 .PHONY: frontend
 frontend:
 	@echo "install Catalyst Frontend"
 	# Uninstall pennylane before updating Catalyst, since pip will not replace two development
 	# versions of a package with the same version tag (e.g. 0.38-dev0).
 	$(PYTHON) -m pip uninstall -y pennylane
-	$(PYTHON) -m pip install -e . --extra-index-url https://test.pypi.org/simple
+	$(PYTHON) -m pip install -e . --extra-index-url https://test.pypi.org/simple $(PIP_VERBOSE_FLAG)
 	rm -r frontend/PennyLane_Catalyst.egg-info
 
 .PHONY: mlir llvm mhlo enzyme dialects runtime oqc oqd

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -144,6 +144,11 @@
   6283185307.179586
   ```
 
+* Installing Catalyst from source via `make frontend` (and similarly for `make all`) now has the
+  option to enable verbose output in the underlying `pip install` command. This option is enabled by
+  appending `VERBOSE=1` to the `make` command.
+  [(#1371)](https://github.com/PennyLaneAI/catalyst/pull/1371)
+
 * A default backend for OQD trapped-ion quantum devices has been added.
   [(#1355)](https://github.com/PennyLaneAI/catalyst/pull/1355)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -144,16 +144,16 @@
   6283185307.179586
   ```
 
-* Installing Catalyst from source via `make frontend` (and similarly for `make all`) now has the
-  option to enable verbose output in the underlying `pip install` command. This option is enabled by
-  appending `VERBOSE=1` to the `make` command.
-  [(#1371)](https://github.com/PennyLaneAI/catalyst/pull/1371)
-
 * A default backend for OQD trapped-ion quantum devices has been added.
   [(#1355)](https://github.com/PennyLaneAI/catalyst/pull/1355)
 
 * `expval` and `var` operations no longer keep the static shots attribute, as a step towards supporting dynamic shots across catalyst.
   [(#1360)](https://github.com/PennyLaneAI/catalyst/pull/1360)
+
+* Installing Catalyst from source via `make frontend` (and similarly for `make all`) now has the
+  option to enable verbose output in the underlying `pip install` command. This option is enabled by
+  appending `VERBOSE=1` to the `make` command.
+  [(#1371)](https://github.com/PennyLaneAI/catalyst/pull/1371)
 
 <h3>Documentation 📝</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -150,11 +150,6 @@
 * `expval` and `var` operations no longer keep the static shots attribute, as a step towards supporting dynamic shots across catalyst.
   [(#1360)](https://github.com/PennyLaneAI/catalyst/pull/1360)
 
-* Installing Catalyst from source via `make frontend` (and similarly for `make all`) now has the
-  option to enable verbose output in the underlying `pip install` command. This option is enabled by
-  appending `VERBOSE=1` to the `make` command.
-  [(#1371)](https://github.com/PennyLaneAI/catalyst/pull/1371)
-
 <h3>Documentation 📝</h3>
 
 * A new tutorial going through how to write a new MLIR pass is available. The tutorial writes an


### PR DESCRIPTION
**Context:** Running `make frontend` calls `pip install -e . --extra-index-url https://test.pypi.org/simple`. The pip install command builds a number of C++ modules under the hood via the `setuptools.Extension` utility. However, the output of these builds is hidden by default, unless the `--verbose` flag is passed to the pip install command. This can make debugging the build process of these frontend C++ extensions difficult.

**Description of the Change:** Adds the `--verbose` flag to the pip install command when the `VERBOSE` Makefile variable is set to 1. For example:

Normal build process:

```console
$ make frontend
install Catalyst Frontend
...
Successfully built PennyLane-Catalyst
Installing collected packages: pennylane, PennyLane-Catalyst
  Attempting uninstall: PennyLane-Catalyst
    Found existing installation: PennyLane-Catalyst 0.10.0.dev22
    Uninstalling PennyLane-Catalyst-0.10.0.dev22:
      Successfully uninstalled PennyLane-Catalyst-0.10.0.dev22
Successfully installed PennyLane-Catalyst-0.10.0.dev22 pennylane-0.40.0.dev20
rm -r frontend/PennyLane_Catalyst.egg-info
```

With verbose output:

```console
$ make frontend VERBOSE=1
install Catalyst Frontend
...
building 'catalyst.utils.libcustom_calls' extension
  creating /tmp/tmp9wh98swt.build-temp/frontend/catalyst/utils/jax_cpu_lapack_kernels
  x86_64-linux-gnu-g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O2 -Wall -fPIC -I/home/joseph.carter/work/pennylane/pyenv-catalyst-dev/include -I/usr/include/python3.12 -c frontend/catalyst/utils/jax_cpu_lapack_kernels/lapack_kernels.cpp -o /tmp/tmp9wh98swt.build-temp/frontend/catalyst/utils/jax_cpu_lapack_kernels/lapack_kernels.o -std=c++17
...
  x86_64-linux-gnu-g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O2 -Wall -fPIC -I/home/joseph.carter/work/pennylane/pyenv-catalyst-dev/include -I/usr/include/python3.12 -c frontend/catalyst/utils/jax_cpu_lapack_kernels/lapack_kernels_using_lapack.cpp -o /tmp/tmp9wh98swt.build-temp/frontend/catalyst/utils/jax_cpu_lapack_kernels/lapack_kernels_using_lapack.o -std=c++17
  x86_64-linux-gnu-g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O2 -Wall -fPIC -I/home/joseph.carter/work/pennylane/pyenv-catalyst-dev/include -I/usr/include/python3.12 -c frontend/catalyst/utils/libcustom_calls.cpp -o /tmp/tmp9wh98swt.build-temp/frontend/catalyst/utils/libcustom_calls.o -std=c++17
  creating /tmp/tmpn514cs4j.build-lib/catalyst/utils
  x86_64-linux-gnu-g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O2 -Wall -shared -Wl,-O1 -Wl,-Bsymbolic-functions /tmp/tmp9wh98swt.build-temp/frontend/catalyst/utils/jax_cpu_lapack_kernels/lapack_kernels.o /tmp/tmp9wh98swt.build-temp/frontend/catalyst/utils/jax_cpu_lapack_kernels/lapack_kernels_using_lapack.o /tmp/tmp9wh98swt.build-temp/frontend/catalyst/utils/libcustom_calls.o -L/usr/lib/x86_64-linux-gnu -o /tmp/tmpn514cs4j.build-lib/catalyst/utils/libcustom_calls.so
  Re-run cmake no build system arguments
  -- The CXX compiler identification is GNU 13.2.0
  -- Detecting CXX compiler ABI info
  -- Detecting CXX compiler ABI info - done
  -- Check for working CXX compiler: /usr/bin/c++ - skipped
  -- Detecting CXX compile features
  -- Detecting CXX compile features - done
  -- Found Python: /home/joseph.carter/work/pennylane/pyenv-catalyst-dev/bin/python3.12 (found suitable version "3.12.3", minimum required is "3") found components: Interpreter Development.Module Development.SABIModule
  -- Configuring done (0.4s)
  -- Generating done (0.0s)
  -- Build files have been written to: /tmp/tmp9wh98swt.build-temp
...
Successfully built PennyLane-Catalyst
Installing collected packages: pennylane, PennyLane-Catalyst
  changing mode of /home/joseph.carter/work/pennylane/pyenv-catalyst-dev/bin/pl-device-test to 775
  Attempting uninstall: PennyLane-Catalyst
    Found existing installation: PennyLane-Catalyst 0.10.0.dev22
    Uninstalling PennyLane-Catalyst-0.10.0.dev22:
      Removing file or directory /home/joseph.carter/work/pennylane/pyenv-catalyst-dev/lib/python3.12/site-packages/PennyLane_Catalyst-0.10.0.dev22.dist-info/
      Removing file or directory /home/joseph.carter/work/pennylane/pyenv-catalyst-dev/lib/python3.12/site-packages/__editable__.PennyLane_Catalyst-0.10.0.dev22.pth
      Successfully uninstalled PennyLane-Catalyst-0.10.0.dev22
Successfully installed PennyLane-Catalyst-0.10.0.dev22 pennylane-0.40.0.dev20
```

**Benefits:** Easier debugging, no change to the normal build process.