### PR TITLE
Fixes extension on macOS

### DIFF
--- a/frontend/catalyst/example_entry_point/__init__.py
+++ b/frontend/catalyst/example_entry_point/__init__.py
@@ -14,13 +14,16 @@
 
 """Example module with entry points"""
 
+import platform
 from pathlib import Path
 
 from catalyst.utils.runtime_environment import get_bin_path
 
+ext = "so" if platform.system() == "Linux" else "dylib"
+plugin_path = get_bin_path("cli", "CATALYST_BIN_DIR") + f"/../lib/StandalonePlugin.{ext}"
+plugin = Path(plugin_path)
+
 
 def name2pass(_name):
     """Example entry point for standalone plugin"""
-    plugin_path = get_bin_path("cli", "CATALYST_BIN_DIR") + "/../lib/StandalonePlugin.so"
-    plugin = Path(plugin_path)
     return plugin, "standalone-switch-bar-foo"


### PR DESCRIPTION
**Context:** #1361 hard coded the MLIR plugin name with ".so", however it is ".dylib" on macOS.

**Description of the Change:** determine the name of the plugin by looking at which platform we are running on.

**Benefits:** Wheels's tests pass again.

