### PR TITLE
Minor fixes to standalone plugin and makefile

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -393,7 +393,7 @@ jobs:
         CCACHE_DIR="$(pwd)/.ccache" \
         MLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir" \
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \
-        make standalone-plugin
+        make plugin
         mkdir -p quantum-build/lib
         mv mlir/standalone/build/lib/StandalonePlugin.so quantum-build/lib/
 

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -366,7 +366,7 @@ jobs:
       run: |
         MLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir" \
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \
-        make standalone-plugin
+        make plugin
         mkdir -p quantum-build/lib
         mv mlir/standalone/build/lib/StandalonePlugin.* quantum-build/lib
 

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -345,7 +345,7 @@ jobs:
         CCACHE_DIR="$(pwd)/.ccache" \
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \
         MLIR_DIR="$(pwd)/llvm-build/lib/cmake/mlir" \
-        make standalone-plugin
+        make plugin
         mkdir -p quantum-build/lib
         mv mlir/standalone/build/lib/StandalonePlugin.* quantum-build/lib
 

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -391,7 +391,7 @@ jobs:
         CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
         LLVM_BUILD_DIR="$(pwd)/llvm-build" \
         MLIR_DIR="$(pwd)/llvm-build/lib/cmake/mlir" \
-        make standalone-plugin
+        make plugin
         mkdir -p $(pwd)/quantum-build/lib
         mv mlir/standalone/build/lib/StandalonePlugin.so "$(pwd)/quantum-build/lib"
 
@@ -457,7 +457,7 @@ jobs:
       with:
         name: runtime-build-${{ matrix.compiler }}
         path: runtime-build/lib
-    
+
     - name: Download OQC-Runtime Artifact
       uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/scripts/linux_arm64/rh8/build_catalyst.sh
+++ b/.github/workflows/scripts/linux_arm64/rh8/build_catalyst.sh
@@ -92,7 +92,7 @@ export OQC_BUILD_DIR=/catalyst/oqc-build
 export OQD_BUILD_DIR=/catalyst/oqd-build
 export ENZYME_BUILD_DIR=/catalyst/enzyme-build
 export PYTHON=/usr/bin/python3
-make standalone-plugin
+make plugin
 make wheel
 
 # Exclude libopenblas as we rely on the openblas/lapack library shipped by scipy

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ help:
 
 .PHONY: all catalyst
 all: runtime oqc oqd mlir frontend
-catalyst: runtime dialects frontend
+catalyst: runtime dialects plugin frontend
 
 .PHONY: frontend
 frontend:
@@ -123,7 +123,7 @@ oqd:
 	$(MAKE) -C frontend/catalyst/third_party/oqd/src oqd
 
 .PHONY: test test-runtime test-frontend lit pytest test-demos test-oqc test-oqd test-toml-spec
-test: test-runtime standalone-plugin test-frontend test-demos
+test: test-runtime test-frontend test-demos
 
 test-toml-spec:
 	$(PYTHON) ./bin/toml-check.py $(TOML_SPECS)
@@ -142,7 +142,7 @@ test-oqc:
 test-oqd:
 	$(MAKE) -C frontend/catalyst/third_party/oqd/src test
 
-lit: standalone-plugin
+lit:
 ifeq ($(ENABLE_ASAN),ON)
 ifneq ($(findstring clang,$(C_COMPILER)),clang)
 	@echo "Build and Test with Address Sanitizer are only supported by Clang, but provided $(C_COMPILER)"
@@ -209,36 +209,31 @@ wheel:
 	$(PYTHON) -m pip wheel --no-deps . -w dist
 
 	rm -r $(MK_DIR)/build
+	rm -r frontend/PennyLane_Catalyst.egg-info
 
 .PHONY: clean clean-all
 clean:
 	@echo "uninstall catalyst and delete all temporary and cache files"
 	$(PYTHON) -m pip uninstall -y pennylane-catalyst
-	rm -rf $(MK_DIR)/frontend/mlir_quantum $(MK_DIR)/frontend/catalyst/lib
+	find frontend/catalyst -name "*.so" -exec rm -v {} +
+	git restore frontend/catalyst/_configuration.py
+	rm -rf $(MK_DIR)/frontend/catalyst/_revision.py
+	rm -rf $(MK_DIR)/frontend/mlir_quantum $(MK_DIR)/frontend/catalyst/lib $(MK_DIR)/frontend/catalyst/bin
 	rm -rf dist __pycache__
 	rm -rf .coverage coverage_html_report
+	rm -rf .benchmarks
 
-clean-all: clean-frontend clean-mlir clean-runtime clean-oqc clean-oqd clean-standalone-plugin
-	@echo "uninstall catalyst and delete all temporary, cache, and build files"
-	$(PYTHON) -m pip uninstall -y pennylane-catalyst
-	rm -rf dist __pycache__
-	rm -rf .coverage coverage_html_report/
+clean-all: clean clean-mlir clean-runtime clean-oqc clean-oqd
 
-.PHONY: clean-standalone-plugin
-clean-standalone-plugin:
-	rm -rf  $(MK_DIR)/mlir/build/lib/StandalonePlugin.*
-	rm -rf  $(MK_DIR)/mlir/standalone/build/lib/StandalonePlugin.*
-
-.PHONY: clean-frontend
-clean-frontend:
-	find frontend/catalyst -name "*.so" -exec rm -v {} +
-
-.PHONY: clean-mlir clean-dialects clean-llvm clean-mhlo clean-enzyme
+.PHONY: clean-mlir clean-dialects clean-plugin clean-llvm clean-mhlo clean-enzyme
 clean-mlir:
 	$(MAKE) -C mlir clean
 
 clean-dialects:
 	$(MAKE) -C mlir clean-dialects
+
+clean-plugin:
+	$(MAKE) -C mlir clean-plugin
 
 clean-llvm:
 	$(MAKE) -C mlir clean-llvm
@@ -274,9 +269,9 @@ endif
 coverage-runtime:
 	$(MAKE) -C runtime coverage
 
-.PHONY: standalone-plugin
-standalone-plugin:
-	$(MAKE) -C mlir standalone-plugin
+.PHONY: plugin
+plugin:
+	$(MAKE) -C mlir plugin
 
 .PHONY: format
 format:

--- a/frontend/catalyst/example_entry_point/__init__.py
+++ b/frontend/catalyst/example_entry_point/__init__.py
@@ -14,6 +14,7 @@
 
 """Example module with entry points"""
 
+import platform
 from pathlib import Path
 
 from catalyst.utils.runtime_environment import get_bin_path
@@ -21,6 +22,7 @@ from catalyst.utils.runtime_environment import get_bin_path
 
 def name2pass(_name):
     """Example entry point for standalone plugin"""
-    plugin_path = get_bin_path("cli", "CATALYST_BIN_DIR") + "/../lib/StandalonePlugin.so"
+    ext = "so" if platform.system() == "Linux" else "dylib"
+    plugin_path = get_bin_path("cli", "CATALYST_BIN_DIR") + f"/../lib/StandalonePlugin.{ext}"
     plugin = Path(plugin_path)
     return plugin, "standalone-switch-bar-foo"

--- a/frontend/test/pytest/test_mlir_plugin.py
+++ b/frontend/test/pytest/test_mlir_plugin.py
@@ -21,6 +21,7 @@ import platform
 from pathlib import Path
 
 import pennylane as qml
+import pytest
 
 from catalyst.passes import apply_pass, apply_pass_plugin, pipeline
 from catalyst.utils.runtime_environment import get_bin_path
@@ -98,3 +99,7 @@ def test_standalone_dictionary():
     # It would be nice if we were able to combine lit tests with
     # pytest
     assert "standalone-switch-bar-foo" in module.mlir
+
+
+if __name__ == "__main__":
+    pytest.main(["-x", __file__])

--- a/mlir/Makefile
+++ b/mlir/Makefile
@@ -50,7 +50,7 @@ help:
 	@echo "  format [version=?] to apply C++ formatter; use with 'version={version}' to run clang-format-{version} instead of clang-format"
 
 .PHONY: all
-all: llvm mhlo enzyme dialects standalone-plugin
+all: llvm mhlo enzyme dialects plugin
 
 .PHONY: llvm
 llvm:
@@ -121,8 +121,8 @@ enzyme:
 
 	cmake --build $(ENZYME_BUILD_DIR) --target EnzymeStatic-19
 
-.PHONY: standalone-plugin
-standalone-plugin:
+.PHONY: plugin
+plugin:
 	[ -f $(MK_DIR)/standalone ] || cp -r $(MK_DIR)/llvm-project/mlir/examples/standalone .
 	@if patch -p0 --dry-run -N < $(MK_DIR)/patches/test-plugin-with-catalyst.patch > /dev/null 2>&1; then \
 		patch -p0 < $(MK_DIR)/patches/test-plugin-with-catalyst.patch; \
@@ -193,6 +193,7 @@ clean-enzyme:
 clean-plugin:
 	@echo "clean plugin"
 	rm -rf standalone/build
+	rm -rf $(DIALECTS_BUILD_DIR)/lib/StandalonePlugin.*
 
 .PHONY: format
 format:


### PR DESCRIPTION
Cleans up some duplication in the make targets and updates the clean command with all the latest artifacts that may be generated during development.

Also fixes a bug on macOS introduced in #1361 