### PR TITLE
Fix runtime coverage

### DIFF
--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -633,9 +633,6 @@ jobs:
         compiler: ${{ fromJson(needs.constants.outputs.compilers) }}
 
     steps:
-    #   - name: Collect Workflow Telemetry
-    #     uses: catchpoint/workflow-telemetry-action@v2
-
       - name: Checkout the repo
         uses: actions/checkout@v4
 
@@ -658,7 +655,6 @@ jobs:
           path: runtime-build/lib
 
       - name: Build Runtime test suite for OQC device
-
         if: ${{ matrix.backend == 'oqc' }}
         run: |
           C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
@@ -667,34 +663,12 @@ jobs:
           make test-oqc
 
       - name: Build Runtime test suite for OQD device
-
         if: ${{ matrix.backend == 'oqd' }}
         run: |
           C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
           CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
           RT_BUILD_DIR="$(pwd)/runtime-build" \
           make test-oqd
-
-      - name: Build Runtime test suite for Lightning simulator
-        if: ${{ matrix.backend == 'lightning' }}
-        run: |
-          C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
-          CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
-          COMPILER_LAUNCHER="" \
-          ENABLE_OPENQASM=OFF \
-          ENABLE_ASAN=ON \
-          make test-runtime
-
-      - name: Build Runtime test suite with both Lightning and Lightning-Kokkos simulators
-        if: ${{ matrix.backend == 'lightning-kokkos' }}
-        run: |
-          # ASAN fails w/ leaks, odr-violation, and double-free from Kokkos_Profiling.cpp
-          C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
-          CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
-          COMPILER_LAUNCHER="" \
-          ENABLE_OPENQASM=OFF \
-          ENABLE_ASAN=OFF \
-          make test-runtime
 
       - name: Build Runtime test suite for OpenQasm device
         if: ${{ matrix.backend == 'openqasm' }}

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -639,14 +639,8 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get -y -q install cmake ninja-build libomp-dev lcov libasan6
+          sudo apt-get -y -q install cmake ninja-build
           python3 -m pip install nanobind
-
-      - name: Install additional dependencies (OpenQasm device)
-        if: ${{ matrix.backend == 'openqasm' }}
-        run: |
-          pip install numpy amazon-braket-sdk
-          echo "AWS_DEFAULT_REGION=us-east-1" >> $GITHUB_ENV
 
       - name: Download Catalyst-Runtime Artifact
         uses: actions/download-artifact@v4
@@ -670,16 +664,6 @@ jobs:
           RT_BUILD_DIR="$(pwd)/runtime-build" \
           make test-oqd
 
-      - name: Build Runtime test suite for OpenQasm device
-        if: ${{ matrix.backend == 'openqasm' }}
-        run: |
-          # Asan prevents dlopen from working?
-          C_COMPILER=$(which ${{ needs.constants.outputs[format('c_compiler.{0}', matrix.compiler)] }}) \
-          CXX_COMPILER=$(which ${{ needs.constants.outputs[format('cxx_compiler.{0}', matrix.compiler)] }}) \
-          COMPILER_LAUNCHER="" \
-          ENABLE_ASAN=OFF \
-          make test-runtime
-
   runtime-code-cov:
     name: Runtime Code Coverage (Linux)
     needs: [constants, determine_runner]
@@ -694,6 +678,11 @@ jobs:
           sudo apt-get update
           sudo apt-get -y -q install cmake ninja-build libomp-dev lcov
           python3 -m pip install nanobind
+
+      - name: Install additional dependencies for OpenQasm device
+        run: |
+          pip install numpy amazon-braket-sdk
+          echo "AWS_DEFAULT_REGION=us-east-1" >> $GITHUB_ENV
 
       - name: Build Runtime test suite for Lightning simulator
         run: |

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ dialects:
 	$(MAKE) -C mlir dialects
 
 runtime:
-	$(MAKE) -C runtime all
+	$(MAKE) -C runtime runtime
 
 oqc:
 	$(MAKE) -C frontend/catalyst/third_party/oqc/src oqc

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -59,18 +59,16 @@ configure:
 		-Dpybind11_DIR=$(shell $(PYTHON) -c "import pybind11; print(pybind11.get_cmake_dir())") \
 		-DENABLE_ADDRESS_SANITIZER=$(ENABLE_ASAN)
 
-capi_target: configure
-	cmake --build $(RT_BUILD_DIR) --target rt_capi -j$(NPROC)
-
-.PHONY: all
-all: configure
+.PHONY: runtime
+runtime: configure
 	cmake --build $(RT_BUILD_DIR) --target $(BUILD_TARGETS) -j$(NPROC)
 
-$(RT_BUILD_DIR)/tests/runner_tests_all_targets: configure
+.PHONY: test_runner
+test_runner: configure
 	cmake --build $(RT_BUILD_DIR) --target $(TEST_TARGETS) -j$(NPROC)
 
 .PHONY: test
-test: $(RT_BUILD_DIR)/tests/runner_tests_all_targets
+test: test_runner
 	@echo "Catalyst runtime test suite - NullQubit"
 	$(ASAN_COMMAND) $(RT_BUILD_DIR)/tests/runner_tests_qir_runtime
 ifeq ($(ENABLE_OPENQASM), ON)
@@ -79,7 +77,7 @@ ifeq ($(ENABLE_OPENQASM), ON)
 endif
 
 .PHONY: coverage
-coverage: capi_target $(RT_BUILD_DIR)/tests/runner_tests_all_targets
+coverage: test_runner
 	@echo "check C++ code coverage"
 	$(RT_BUILD_DIR)/tests/runner_tests_qir_runtime
 ifeq ($(ENABLE_OPENQASM), ON)

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -81,6 +81,7 @@ endif
 .PHONY: coverage
 coverage: capi_target $(RT_BUILD_DIR)/tests/runner_tests_all_targets
 	@echo "check C++ code coverage"
+	$(RT_BUILD_DIR)/tests/runner_tests_qir_runtime
 
 	lcov --directory $(RT_BUILD_DIR) -b $(MK_DIR)/lib --capture --output-file $(RT_BUILD_DIR)/coverage.info
 	lcov --remove $(RT_BUILD_DIR)/coverage.info '/usr/*' '*/_deps/*' '*/envs/*' '*/mlir/*' --output-file $(RT_BUILD_DIR)/coverage.info

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -82,7 +82,9 @@ endif
 coverage: capi_target $(RT_BUILD_DIR)/tests/runner_tests_all_targets
 	@echo "check C++ code coverage"
 	$(RT_BUILD_DIR)/tests/runner_tests_qir_runtime
-
+ifeq ($(ENABLE_OPENQASM), ON)
+	$(RT_BUILD_DIR)/tests/runner_tests_openqasm
+endif
 	lcov --directory $(RT_BUILD_DIR) -b $(MK_DIR)/lib --capture --output-file $(RT_BUILD_DIR)/coverage.info
 	lcov --remove $(RT_BUILD_DIR)/coverage.info '/usr/*' '*/_deps/*' '*/envs/*' '*/mlir/*' --output-file $(RT_BUILD_DIR)/coverage.info
 	genhtml $(RT_BUILD_DIR)/coverage.info --output-directory $(RT_BUILD_DIR)/cov -t "Catalyst Runtime C++ Coverage" --num-spaces 4

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -57,6 +57,7 @@ configure:
 		-DPython_ROOT_DIR=$(PYTHON_PREFIX) \
 		-DPYTHON_VERSION_TO_FIND=$(PYTHON_VERSION) \
 		-Dpybind11_DIR=$(shell $(PYTHON) -c "import pybind11; print(pybind11.get_cmake_dir())") \
+		-Dnanobind_DIR=$(shell $(PYTHON) -c "import nanobind; print(nanobind.cmake_dir())") \
 		-DENABLE_ADDRESS_SANITIZER=$(ENABLE_ASAN)
 
 .PHONY: runtime


### PR DESCRIPTION
Fixes bug from #1227 that stopped actually running the tests in the coverage target (instead only building them).

OpenQASM runtime tests are now included in the coverage.

Some CI cleanup.

[sc-80437]