### PR TITLE
Fix latest/latest/latest failure

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -119,7 +119,7 @@ jobs:
         path: lightning_build
         fetch-depth: 0
 
-    - name: Download PennyLane-Lightning (latest)
+    - name: Download PennyLane-Lightning (release-candidate)
       if: ${{ inputs.lightning == 'release-candidate' }}
       uses: actions/checkout@v4
       with:

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ help:
 
 .PHONY: all catalyst
 all: runtime oqc oqd mlir frontend
-catalyst: runtime dialects plugin frontend
+catalyst: runtime dialects plugin oqd frontend
 
 .PHONY: frontend
 frontend:


### PR DESCRIPTION
**Context:** Check CPL latest/latest/latest is failing because the device toml file is not found when instantiating an OQD device. This happened because Check CPL installs catalyst using `make catalyst`, not `make all`, and the oqd build target was not added as a dependency of `make catalyst`.

**Description of the Change:** Add `oqd` to dependencies of `make catalyst`. Also, I've made an opportunistic fix to an incorrect GitHub action title: "Download PennyLane-Lightning (**latest**)" where it should be "Download PennyLane-Lightning (**release-candidate**)"