### PR TITLE
[NFC] Fix doc: 'make plugin' instead of 'make standalone-plugin'

### DIFF
--- a/doc/catalyst-cli/catalyst-cli.rst
+++ b/doc/catalyst-cli/catalyst-cli.rst
@@ -245,7 +245,7 @@ These plugins are shared objects that include dialects and passes written by thi
 This means that you can write dialects and passes that can be used with ``catalyst-cli`` and ``quantum-opt``.
 
 As an example, the `LLVM repository includes a very simple plugin <https://github.com/llvm/llvm-project/tree/main/mlir/examples/standalone/standalone-plugin>`_.
-To build it, simply run ``make standalone-plugin`` and the standalone plugin
+To build it, simply run ``make plugin`` and the standalone plugin
 will be built in the root directory of the Catalyst project.
 
 With this, you can now run your own passes by using the following flags:


### PR DESCRIPTION
**Context:** Updates related to the standalone plugin rule on the `Makefile `did not made it to the docs.

**Description of the Change:** Instruct to use `make plugin` instead of `make standalone-plugin`