### PR TITLE
[Build System] Remove visibility preset from MLIR

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -69,12 +69,6 @@ include_directories(${LLVM_INCLUDE_DIRS}
 link_directories(${LLVM_BUILD_LIBRARY_DIR})
 add_definitions(${LLVM_DEFINITIONS})
 
-if(APPLE)
-  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-else()
-  set(CMAKE_CXX_VISIBILITY_PRESET protected)
-endif()
-
 add_subdirectory(include)
 add_subdirectory(lib)
 add_subdirectory(tools)


### PR DESCRIPTION
**Context:** While most visibility presets had already been changed, there was one that was missing.

**Description of the Change:** Change visibility presets in CMake.

**Benefits:** MLIR Plugin can load the Quantum dialect and cast operations to Quantum operations.

**Possible Drawbacks:** None

**Related GitHub Issues:**
