### PR TITLE
Revert openblas linking changes from #451

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -12,4 +12,4 @@ pennylane=0.40.0-dev20
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'
-lightning=0.40.0-dev30
+lightning=0.40.0-dev41

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -51,6 +51,7 @@ jobs:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v4
 
+    # Python 3.10 was dropped from the GH images on macOS arm
     - name: Install Python 3.10
       uses: actions/setup-python@v5
       with:
@@ -235,8 +236,10 @@ jobs:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v4
 
+    # Python 3.10 was dropped from the GH images on macOS arm
     - name: Install Python 3.10
       uses: actions/setup-python@v5
+      if: ${{ matrix.python_version }} == '3.10'
       with:
         python-version: '3.10'
 
@@ -418,10 +421,12 @@ jobs:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v4
 
-    - name: Install Python ${{ matrix.python_version }}
+    # Python 3.10 was dropped from the GH images on macOS arm
+    - name: Install Python 3.10
       uses: actions/setup-python@v5
+      if: ${{ matrix.python_version }} == '3.10'
       with:
-        python-version: ${{ matrix.python_version }}
+        python-version: '3.10'
 
     - name: Download Wheel Artifact
       uses: actions/download-artifact@v4
@@ -452,7 +457,6 @@ jobs:
       run: |
         python${{ matrix.python_version }} -m pip install PennyLane-Lightning-Kokkos
         python${{ matrix.python_version }} -m pip install 'amazon-braket-pennylane-plugin>1.27.1'
-
 
     - name: Install OQC client
       run: |

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -30,6 +30,6 @@ lxml_html_clean
 
 # Pre-install PL development wheels
 --extra-index-url https://test.pypi.org/simple/
-pennylane-lightning-kokkos==0.40.0-dev30
-pennylane-lightning==0.40.0-dev30
+pennylane-lightning-kokkos==0.40.0-dev41
+pennylane-lightning==0.40.0-dev41
 pennylane==0.40.0-dev20

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -121,25 +121,24 @@ class LinkerDriver:
         path_within_package = "lib"
         file_extension = ".so" if platform.system() == "Linux" else ".dylib"  # pragma: no branch
 
-        package_spec = importlib.util.find_spec(package_name)
-        package_directory = path.dirname(package_spec.origin)
-        lapack_lib_path = path.join(package_directory, path_within_package)
-
-        search_pattern = path.join(lapack_lib_path, f"lib*{lib_name}*{file_extension}")
-        search_result = glob.glob(search_pattern)
-        if not search_result:  # pragma: nocover
-            raise CompileError(
-                f'Unable to find OpenBLAS library at "{search_pattern}". '
-                "Please ensure that scipy is installed and available via pip."
-            )
-
-        lib_path_flags += [f"-Wl,-rpath,{lapack_lib_path}", f"-L{lapack_lib_path}"]
-        lapack_lib_name = path.basename(search_result[0])[3 : -len(file_extension)]
-
-        lapack_libs = [lapack_lib_name]
         if platform.system() == "Darwin" and platform.machine() == "arm64":  # pragma: nocover
             # use our own build of LAPACKe to interface with Accelerate
-            lapack_libs += ["lapacke.3"]
+            lapack_lib_name = "lapacke.3"
+        else:
+            package_spec = importlib.util.find_spec(package_name)
+            package_directory = path.dirname(package_spec.origin)
+            lapack_lib_path = path.join(package_directory, path_within_package)
+
+            search_pattern = path.join(lapack_lib_path, f"lib*{lib_name}*{file_extension}")
+            search_result = glob.glob(search_pattern)
+            if not search_result:  # pragma: nocover
+                raise CompileError(
+                    f'Unable to find OpenBLAS library at "{search_pattern}". '
+                    "Please ensure that scipy is installed and available via pip."
+                )
+
+            lib_path_flags += [f"-Wl,-rpath,{lapack_lib_path}", f"-L{lapack_lib_path}"]
+            lapack_lib_name = path.basename(search_result[0])[3 : -len(file_extension)]
 
         system_flags = []
         if platform.system() == "Linux":
@@ -159,8 +158,6 @@ class LinkerDriver:
         elif options.async_qnodes and platform.system() == "Darwin":  # pragma: nocover
             system_flags += ["-lc++"]
 
-        lapack_libs = [f"-l{name}" for name in lapack_libs]
-
         default_flags = [
             "-shared",
             "-rdynamic",
@@ -169,7 +166,7 @@ class LinkerDriver:
             "-lrt_capi",
             "-lpthread",
             "-lmlir_c_runner_utils",  # required for memref.copy
-            *lapack_libs,
+            f"-l{lapack_lib_name}",  # required for custom_calls lib
             "-lcustom_calls",
             "-lmlir_async_runtime",
         ]


### PR DESCRIPTION
PR #451 introduced linking against both OpenBLAS and LAPACKE+Accelerate on arm macOS, which breaks re-compilation of certain user programs (like Shor's). The cause of the shared library conflict is unknown. 

For now, we revert these linking changes, which were originally introduced due to Lightning not finding its OpenBLAS dependency when invoked through Catalyst:
```
FAILED frontend/test/pytest/test_measurements_shots_results.py::TestExpval::test_hermitian[lightning.qubit]

RuntimeError: [pennylane_lightning/core/src/utils/SharedLibLoader.hpp][Line:60][Method:SharedLibLoader]: Error in PennyLane Lightning: dlopen(libscipy_openblas.dylib, 0x0001): tried: 'libscipy_openblas.dylib' (no such file), '$ORIGIN/../scipy_openblas32/lib/libscipy_openblas.dylib' (no such file)
```

The above test will fail as a result of this, which we plan to fix with a PR on the lightning side.

[sc-80803]