### PR TITLE
Notify failed nightly releases

### DIFF
--- a/.github/workflows/notify-failed-jobs.yaml
+++ b/.github/workflows/notify-failed-jobs.yaml
@@ -10,6 +10,7 @@ on:
       - Build Catalyst Wheel on Linux (x86_64)
       - Build Catalyst Wheel on macOS (arm64)
       - Build Catalyst Wheel on macOS (x86_64)
+      - Build nightly Catalyst releases for TestPyPI
 
 jobs:
   on-failure:


### PR DESCRIPTION
Seems like TestPyPI wheels have been failing for a week during upload. Couldn't determine the cause (400 error), but I cleared some space just in case. Let's get notifications if the nightly release fails.