### PR TITLE
Support static parameters for GlobalPhase and multiRZ gates.

### DIFF
--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -41,7 +41,6 @@ from catalyst.jax_primitives import (
     compbasis_p,
     counts_p,
     expval_p,
-    gphase_p,
     namedobs_p,
     probs_p,
     qalloc_p,
@@ -298,8 +297,6 @@ class QFuncPlxprInterpreter:
 
         if eqn.primitive.name == "QubitUnitary":
             outvals = qunitary_p.bind(*invals, *wires, **kwargs)
-        elif eqn.primitive.name == "GlobalPhase":
-            outvals = gphase_p.bind(*invals, ctrl_len=0, adjoint=False)
         else:
             outvals = qinst_p.bind(
                 *wires,

--- a/frontend/test/lit/test_quantum_control.py
+++ b/frontend/test/lit/test_quantum_control.py
@@ -148,7 +148,7 @@ def test_native_controlled_multirz():
     @qml.qnode(dev)
     # CHECK-LABEL: public @jit_native_controlled_multirz
     def native_controlled_multirz():
-        # CHECK: [[out:%.+]]:2, [[out_ctrl:%.+]] = quantum.multirz
+        # CHECK: [[out:%.+]]:2, [[out_ctrl:%.+]] = quantum.static_custom "MultiRZ"
         # CHECK-SAME: ctrls
         # CHECK-SAME: ctrlvals(%true)
         qml.ctrl(qml.MultiRZ(0.6, wires=[0, 2]), control=[1])

--- a/frontend/test/lit/test_static_circuit.py
+++ b/frontend/test/lit/test_static_circuit.py
@@ -45,6 +45,8 @@ def test_static_params():
         qml.CRY(x, wires=[0, 1])
         qml.CRZ(x, wires=[0, 1])
 
+        qml.MultiRZ(x, wires=[0, 1, 2, 3])
+
         return qml.state()
 
     print(circuit.mlir)
@@ -65,4 +67,6 @@ def test_static_params():
 # CHECK: %[[CRX:.*]] = quantum.static_custom "CRX"
 # CHECK: %[[CRY:.*]] = quantum.static_custom "CRY"
 # CHECK: %[[CRZ:.*]] = quantum.static_custom "CRZ"
+# CHECK: %[[BIT3:.*]] = quantum.extract %[[REG]][ 3]
+# CHECK: %[[MRZ:.*]] = quantum.static_custom "MultiRZ"
 test_static_params()

--- a/mlir/lib/Quantum/Transforms/StaticCustomPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/StaticCustomPatterns.cpp
@@ -40,7 +40,26 @@ struct LowerStaticCustomOp : public OpConversionPattern<StaticCustomOp> {
                                                                rewriter.getF64FloatAttr(param));
             paramValues.push_back(constant);
         }
-
+        if (op.getGateName() == "MultiRZ") {
+            if (paramValues.size() != 1) {
+                op.emitError() << "MultiRZ gate expects exactly one parameter";
+                return failure();
+            }
+            rewriter.replaceOpWithNewOp<MultiRZOp>(
+                op, op.getOutQubits().getTypes(), op.getOutCtrlQubits().getTypes(), paramValues[0],
+                op.getInQubits(), op.getAdjointAttr(), op.getInCtrlQubits(), op.getInCtrlValues());
+            return success();
+        }
+        if (op.getGateName() == "GlobalPhase") {
+            if (paramValues.size() != 1) {
+                op.emitError() << "GlobalPhase gate expects exactly one parameter";
+                return failure();
+            }
+            rewriter.replaceOpWithNewOp<GlobalPhaseOp>(op, op.getOutCtrlQubits().getTypes(),
+                                                       paramValues[0], op.getAdjointAttr(),
+                                                       op.getInCtrlQubits(), op.getInCtrlValues());
+            return success();
+        }
         rewriter.replaceOpWithNewOp<CustomOp>(op, op.getGateName(), op.getInQubits(),
                                               op.getInCtrlQubits(), op.getInCtrlValues(),
                                               paramValues, op.getAdjointFlag());

--- a/mlir/lib/Quantum/Transforms/static_custom_lowering.cpp
+++ b/mlir/lib/Quantum/Transforms/static_custom_lowering.cpp
@@ -48,6 +48,8 @@ struct StaticCustomLoweringPass : impl::StaticCustomLoweringPassBase<StaticCusto
 
         target.addLegalOp<CustomOp>();
         target.addLegalOp<mlir::arith::ConstantOp>();
+        target.addLegalOp<GlobalPhaseOp>();
+        target.addLegalOp<MultiRZOp>();
         target.addIllegalOp<StaticCustomOp>();
 
         populateStaticCustomPatterns(patterns);


### PR DESCRIPTION
**Context:** 
PR #1387, adds support for static parameters in customOp. However support for GlobalPhase and MultiRZ gates are missing. 

**Description of the Change:**
This PR adds support for the missing two gates. We unified the way `GlobalPhase` and `MultiRZ` are treated in the frontend. right now, GlobalPase has its own primitive (`qphase_p`) however `MultiRZ` is binded through the `qinst_p` primitive. `qphase_p` is now removed from frontend and binded through `qints_p` similar to MultiRZ. 
If a `MultiRZ` or `GlobalPhase` gate has static parameters parameters, a `staticCustomOp` is created which will be lowered to the respective gate in static_custom_lowering pass.

**Benefits:**
removed inconsistency in the definition of odd custom gates (MultiRZ and GlobalPhase)
static circuit IR now supports more parameterized gates.

**Possible Drawbacks:**

**Related GitHub Issues:**
