### PR TITLE
Restore braket tests

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -492,7 +492,7 @@ jobs:
         python${{ matrix.python_version }} -m pytest frontend/test/pytest -n auto
         python${{ matrix.python_version }} -m pytest frontend/test/pytest --backend="lightning.kokkos" -n auto
         python${{ matrix.python_version }} -m pytest frontend/test/async_tests
-        # python${{ matrix.python_version }} -m pytest frontend/test/pytest --runbraket=LOCAL -n auto
+        python${{ matrix.python_version }} -m pytest frontend/test/pytest --runbraket=LOCAL -n auto
         python${{ matrix.python_version }} -m pytest frontend/test/test_oqc/oqc -n auto
 
     - name: Run Standalone Plugin Tests

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -477,7 +477,7 @@ jobs:
         python${{ matrix.python_version }} -m pytest frontend/test/pytest -n auto
         python${{ matrix.python_version }} -m pytest frontend/test/pytest --backend="lightning.kokkos" -n auto
         python${{ matrix.python_version }} -m pytest frontend/test/async_tests
-        # python${{ matrix.python_version }} -m pytest frontend/test/pytest --runbraket=LOCAL -n auto
+        python${{ matrix.python_version }} -m pytest frontend/test/pytest --runbraket=LOCAL -n auto
         python${{ matrix.python_version }} -m pytest frontend/test/test_oqc/oqc -n auto
 
     - name: Run Standalone Plugin Tests

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -445,7 +445,7 @@ jobs:
         # TODO: Uncomment after fixing https://github.com/PennyLaneAI/pennylane-lightning/issues/552
         # python${{ matrix.python_version }} -m pytest frontend/test/pytest --backend="lightning.kokkos" -n auto
         python${{ matrix.python_version }} -m pytest frontend/test/async_tests
-        # python${{ matrix.python_version }} -m pytest frontend/test/pytest --runbraket=LOCAL -n auto
+        python${{ matrix.python_version }} -m pytest frontend/test/pytest --runbraket=LOCAL -n auto
         python${{ matrix.python_version }} -m pytest frontend/test/test_oqc/oqc -n auto
 
     - name: Run Standalone Plugin Tests

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -565,62 +565,62 @@ jobs:
       run: |
         make pytest TEST_BACKEND="lightning.kokkos" SKIP_OQD="true"
 
-#  frontend-tests-openqasm-device:
-#    name: Frontend Tests (backend="openqasm3")
-#    needs: [constants, llvm, runtime, quantum, determine_runner]
-#    runs-on: ${{ needs.determine_runner.outputs.runner_group }}
-#    strategy:
-#      matrix:
-#        compiler: ${{ fromJson(needs.constants.outputs.compilers) }}
-#
-#    steps:
-#    - name: Checkout Catalyst repo
-#      uses: actions/checkout@v4
-#
-#    - name: Install device dependencies (OpenQasm device)
-#      run: |
-#        pip install amazon-braket-pennylane-plugin
-#        echo "AWS_DEFAULT_REGION=us-east-1" >> $GITHUB_ENV
-#
-#    - name: Install Deps
-#      run: |
-#        sudo apt-get update
-#        sudo apt-get install -y python3 python3-pip libomp-dev libasan6 make ninja-build
-#        python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
-#        python3 -m pip install -r requirements.txt
-#        make frontend
-#
-#    - name: Get Cached LLVM Build
-#      id: cache-llvm-build
-#      uses: actions/cache@v4
-#      with:
-#        path: llvm-build
-#        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-${{ matrix.compiler }}
-#        fail-on-cache-miss: true
-#
-#    - name: Download Quantum Build Artifact
-#      uses: actions/download-artifact@v4
-#      with:
-#        name: quantum-build-${{ matrix.compiler }}
-#        path: quantum-build
-#
-#    - name: Download Catalyst-Runtime Artifact
-#      uses: actions/download-artifact@v4
-#      with:
-#        name: runtime-build-${{ matrix.compiler }}
-#        path: runtime-build/lib
-#
-#    - name: Add Frontend Dependencies to PATH
-#      run: |
-#        echo "PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum" >> $GITHUB_ENV
-#        echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
-#        echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
-#        echo "CATALYST_BIN_DIR=$(pwd)/quantum-build/bin" >> $GITHUB_ENV
-#        chmod +x $(pwd)/quantum-build/bin/catalyst-cli  # artifact upload does not preserve permissions
-#
-#    - name: Run Python Pytest Tests
-#      run: |
-#        make pytest TEST_BRAKET=LOCAL
+  frontend-tests-openqasm-device:
+    name: Frontend Tests (backend="openqasm3")
+    needs: [constants, llvm, runtime, quantum, determine_runner]
+    runs-on: ${{ needs.determine_runner.outputs.runner_group }}
+    strategy:
+      matrix:
+        compiler: ${{ fromJson(needs.constants.outputs.compilers) }}
+
+    steps:
+    - name: Checkout Catalyst repo
+      uses: actions/checkout@v4
+
+    - name: Install device dependencies (OpenQasm device)
+      run: |
+        pip install amazon-braket-pennylane-plugin
+        echo "AWS_DEFAULT_REGION=us-east-1" >> $GITHUB_ENV
+
+    - name: Install Deps
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y python3 python3-pip libomp-dev libasan6 make ninja-build
+        python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
+        python3 -m pip install -r requirements.txt
+        make frontend
+
+    - name: Get Cached LLVM Build
+      id: cache-llvm-build
+      uses: actions/cache@v4
+      with:
+        path: llvm-build
+        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-default-build-${{ matrix.compiler }}
+        fail-on-cache-miss: true
+
+    - name: Download Quantum Build Artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: quantum-build-${{ matrix.compiler }}
+        path: quantum-build
+
+    - name: Download Catalyst-Runtime Artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: runtime-build-${{ matrix.compiler }}
+        path: runtime-build/lib
+
+    - name: Add Frontend Dependencies to PATH
+      run: |
+        echo "PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum" >> $GITHUB_ENV
+        echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
+        echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
+        echo "CATALYST_BIN_DIR=$(pwd)/quantum-build/bin" >> $GITHUB_ENV
+        chmod +x $(pwd)/quantum-build/bin/catalyst-cli  # artifact upload does not preserve permissions
+
+    - name: Run Python Pytest Tests
+      run: |
+        make pytest TEST_BRAKET=LOCAL
 
   runtime-device-tests:
     name: Runtime Tests (Linux)

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -171,9 +171,9 @@ jobs:
       run: |
         make pytest TEST_BACKEND="lightning.kokkos"
 
-    # - name: Run Frontend Tests (Braket)
-    #   run: |
-    #     make pytest TEST_BRAKET=LOCAL
+    - name: Run Frontend Tests (Braket)
+      run: |
+        make pytest TEST_BRAKET=LOCAL
 
     - name: Run Demos
       run: | # Do not run demos in parallel, seems to cause package issues with numpy.

--- a/.github/workflows/scripts/linux_arm64/rh8/test_wheels.sh
+++ b/.github/workflows/scripts/linux_arm64/rh8/test_wheels.sh
@@ -45,5 +45,5 @@ export PATH=/catalyst/llvm-build/bin:/opt/_internal/cpython-${PYTHON_MAJOR_MINOR
 /usr/bin/python3 -m pytest -v /catalyst/frontend/test/pytest -n auto
 /usr/bin/python3 -m pytest -v /catalyst/frontend/test/pytest --backend="lightning.kokkos" -n auto
 /usr/bin/python3 -m pytest /catalyst/frontend/test/async_tests
-# /usr/bin/python3 -m pytest -v /catalyst/frontend/test/pytest --runbraket=LOCAL -n auto
+/usr/bin/python3 -m pytest -v /catalyst/frontend/test/pytest --runbraket=LOCAL -n auto
 /usr/bin/python3 -m pytest /catalyst/frontend/test/test_oqc/oqc -n auto

--- a/frontend/test/lit/test_multi_qubit_gates.py
+++ b/frontend/test/lit/test_multi_qubit_gates.py
@@ -71,6 +71,7 @@ print(circuit.mlir)
 # would be decomposed.
 """
 
+
 # CHECK-LABEL: public @jit_circuit
 @qjit(target="mlir")
 @qml.qnode(qml.device("braket.local.qubit", wires=2, shots=100))
@@ -83,7 +84,6 @@ def circuit(x: float):
 
 
 print(circuit.mlir)
-
 
 
 # CHECK-LABEL: public @jit_isingZZ_circuit

--- a/frontend/test/lit/test_multi_qubit_gates.py
+++ b/frontend/test/lit/test_multi_qubit_gates.py
@@ -69,19 +69,21 @@ print(circuit.mlir)
 # We should replace instead create a custom device that has support for ISWAP
 # and PSWAP (which I think are unsupported in lightning.qubit and hence why they
 # would be decomposed.
-# COM: CHECK-LABEL: public @jit_circuit
+"""
+
+# CHECK-LABEL: public @jit_circuit
 @qjit(target="mlir")
 @qml.qnode(qml.device("braket.local.qubit", wires=2, shots=100))
 def circuit(x: float):
-    # COM: CHECK: {{%.+}} = quantum.custom "ISWAP"() {{.+}} : !quantum.bit, !quantum.bit
+    # CHECK: {{%.+}} = quantum.custom "ISWAP"() {{.+}} : !quantum.bit, !quantum.bit
     qml.ISWAP(wires=[0, 1])
-    # COM: CHECK: {{%.+}} = quantum.custom "PSWAP"({{%.+}}) {{.+}} : !quantum.bit, !quantum.bit
+    # CHECK: {{%.+}} = quantum.custom "PSWAP"({{%.+}}) {{.+}} : !quantum.bit, !quantum.bit
     qml.PSWAP(x, wires=[0, 1])
     return qml.probs()
 
 
 print(circuit.mlir)
-"""
+
 
 
 # CHECK-LABEL: public @jit_isingZZ_circuit

--- a/frontend/test/pytest/test_braket_local_devices.py
+++ b/frontend/test/pytest/test_braket_local_devices.py
@@ -23,7 +23,7 @@ from catalyst import grad, qjit
 
 try:
     qml.device("braket.local.qubit", backend="default", wires=1)
-except (qml.DeviceError):
+except qml.DeviceError:
     pytest.skip(
         "skipping Braket local tests because ``amazon-braket-pennylane-plugin`` is not installed",
         allow_module_level=True,

--- a/frontend/test/pytest/test_braket_local_devices.py
+++ b/frontend/test/pytest/test_braket_local_devices.py
@@ -23,9 +23,9 @@ from catalyst import grad, qjit
 
 try:
     qml.device("braket.local.qubit", backend="default", wires=1)
-except (qml.DeviceError, ImportError):
+except (qml.DeviceError):
     pytest.skip(
-        "skipping Braket local tests because ``amazon-braket-pennylane-plugin`` is not installed or could not be imported",
+        "skipping Braket local tests because ``amazon-braket-pennylane-plugin`` is not installed",
         allow_module_level=True,
     )
 


### PR DESCRIPTION
**Context:**
Braket tests were removed temporarily because the dev version of PennyLane needed for Catalyst tests was incompatible with the Braket plugin in the interim between removing legacy operator arithmetic from PennyLane and releasing a version of the Braket plugin with no references to legacy opmath.

Braket has released, so we expect things to work again now. 

**Description of the Change:**
This PR reverses the changes disabling Braket tests in #1308 and #1321.

[sc-78774]