### PR TITLE
Increase minimum plugin version for building linux wheels

### DIFF
--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -471,7 +471,7 @@ jobs:
     - name: Install PennyLane Plugins
       run: |
         python${{ matrix.python_version }} -m pip install PennyLane-Lightning-Kokkos
-        python${{ matrix.python_version }} -m pip install 'amazon-braket-pennylane-plugin>=1.31.0' "boto3==1.26"
+        python${{ matrix.python_version }} -m pip install 'amazon-braket-pennylane-plugin>=1.31.0'
 
     - name: Install OQC client
       run: |

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -471,7 +471,7 @@ jobs:
     - name: Install PennyLane Plugins
       run: |
         python${{ matrix.python_version }} -m pip install PennyLane-Lightning-Kokkos
-        python${{ matrix.python_version }} -m pip install 'amazon-braket-pennylane-plugin>1.27.1' "boto3==1.26"
+        python${{ matrix.python_version }} -m pip install 'amazon-braket-pennylane-plugin>=1.31.0' "boto3==1.26"
 
     - name: Install OQC client
       run: |


### PR DESCRIPTION
**Context:**
The [wheels are failing](https://github.com/PennyLaneAI/catalyst/actions/runs/12563739994/job/35026196938) after we put the Braket tests stuff back

Looking at the wheels, it's ending up installing version 1.28 (we set the minimum to 1.27). We need a more recent version because `QubitDevice` isn't accessible at top level and legacy opmath has been removed.

**Description of the Change:**

Install with `>=0.31.0` instead. We also remove the `boto3` pin, because it was creating version conflicts and seems to no longer be needed.
