### PR TITLE
Exclude OQD packages, modules and data from wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,3 @@ recursive-include frontend/catalyst/lib *
 recursive-include frontend/catalyst/enzyme *
 recursive-include frontend/mlir_quantum *
 recursive-include frontend/catalyst/third_party/cuda/ *.toml
-recursive-include frontend/catalyst/third_party/oqd/ *.toml

--- a/Makefile
+++ b/Makefile
@@ -194,8 +194,6 @@ wheel:
 	cp $(OQC_BUILD_DIR)/librtd_oqc* $(MK_DIR)/frontend/catalyst/lib
 	cp $(OQC_BUILD_DIR)/oqc_python_module.so $(MK_DIR)/frontend/catalyst/lib
 	cp $(OQC_BUILD_DIR)/backend/*.toml $(MK_DIR)/frontend/catalyst/lib/backend
-	cp $(OQD_BUILD_DIR)/librtd_oqd* $(MK_DIR)/frontend/catalyst/lib
-	cp $(OQD_BUILD_DIR)/backend/*.toml $(MK_DIR)/frontend/catalyst/lib/backend
 	cp $(COPY_FLAGS) $(LLVM_BUILD_DIR)/lib/libmlir_float16_utils.* $(MK_DIR)/frontend/catalyst/lib
 	cp $(COPY_FLAGS) $(LLVM_BUILD_DIR)/lib/libmlir_c_runner_utils.* $(MK_DIR)/frontend/catalyst/lib
 	cp $(COPY_FLAGS) $(LLVM_BUILD_DIR)/lib/libmlir_async_runtime.* $(MK_DIR)/frontend/catalyst/lib

--- a/doc/dev/devices.rst
+++ b/doc/dev/devices.rst
@@ -95,16 +95,3 @@ Supported backend devices include:
 
       See the `Catalyst configuration file <https://github.com/PennyLaneAI/catalyst/blob/main/frontend/catalyst/third_party/oqc/src/oqc.toml>`__
       for natively supported instructions.
-
-  * - ``oqd.default``
-
-    - Experimental support for execution on `Open Quantum Design (OQD) <https://openquantumdesign.org/>`__
-      trapped-ion hardware. To use OQD with Catalyst, use the ``backend`` argument to specify the
-      OQD backend to use when initializing the device:
-
-      .. code-block:: python
-
-          dev = qml.device("oqd", backend="default", shots=1024, wires=2)
-
-      See the `Catalyst configuration file <https://github.com/PennyLaneAI/catalyst/blob/main/frontend/catalyst/third_party/oqd/src/oqd.toml>`__
-      for natively supported instructions.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -168,6 +168,10 @@
 
 * A default backend for OQD trapped-ion quantum devices has been added.
   [(#1355)](https://github.com/PennyLaneAI/catalyst/pull/1355)
+  [(#1403)](https://github.com/PennyLaneAI/catalyst/pull/1355)
+
+  Support for OQD devices is still under development, therefore the OQD modules are currently not
+  included in the distributed wheels.
 
 * `expval` and `var` operations no longer keep the static shots attribute, as a step towards supporting dynamic shots across catalyst.
   [(#1360)](https://github.com/PennyLaneAI/catalyst/pull/1360)

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,6 @@ requirements = [
 entry_points = {
     "pennylane.plugins": [
         "oqc.cloud = catalyst.third_party.oqc:OQCDevice",
-        "oqd = catalyst.third_party.oqd:OQDDevice",
         "softwareq.qpp = catalyst.third_party.cuda:SoftwareQQPP",
         "nvidia.custatevec = catalyst.third_party.cuda:NvidiaCuStateVec",
         "nvidia.cutensornet = catalyst.third_party.cuda:NvidiaCuTensorNet",
@@ -331,7 +330,11 @@ setup(
     packages=find_namespace_packages(
         where="frontend",
         include=["catalyst", "catalyst.*", "mlir_quantum"],
-        exclude=["catalyst.third_party.oqc.*"],
+        exclude=[
+            "catalyst.third_party.oqc.*",
+            "catalyst.third_party.oqd.*",  # Exclude OQD packages and modules from wheels
+            "catalyst.third_party.oqd",    # as they are still under development
+        ],
     ),
     package_dir={"": "frontend"},
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -332,8 +332,8 @@ setup(
         include=["catalyst", "catalyst.*", "mlir_quantum"],
         exclude=[
             "catalyst.third_party.oqc.*",
-            "catalyst.third_party.oqd.*",  # Exclude OQD packages and modules from wheels
-            "catalyst.third_party.oqd",    # as they are still under development
+            "catalyst.third_party.oqd.*",
+            "catalyst.third_party.oqd",  # Exclude OQD from wheels as it is still under development
         ],
     ),
     package_dir={"": "frontend"},


### PR DESCRIPTION
**Context:** A number of OQD packages, modules and data files had been added recently (e.g. #1348 and #1355). However, as support for OQD devices is still under development, these files should not be included in the wheels.

**Description of the Change:** Excludes _all_ OQD packages, modules and data files (such as toml config files) from the wheels. Furthermore, the OQD device entry in the [Supported devices documentation](https://docs.pennylane.ai/projects/catalyst/en/stable/dev/devices.html) has also been removed.