### PR TITLE
[Documentation][Frontend] Documentation for plugins and small improvement

### DIFF
--- a/doc/dev/plugins.rst
+++ b/doc/dev/plugins.rst
@@ -334,7 +334,7 @@ From here, you can change the name of the pass, change the name of the shared ob
 Now that you have your ``StandalonePlugin.so``, you can ship it in a python wheel.
 To allow users to run your pass, we have provided a class called :class:`~.passes.Pass` and :class:`~.passes.PassPlugin`.
 You can extend these classes and allow the user to import your derived classes and run passes as a decorator.
-We provide the `~passes.apply_pass_plugin` decorator to allow pass plugins to be loaded and executed.
+We provide the :func:`~passes.apply_pass_plugin` decorator to allow pass plugins to be loaded and executed.
 See for example:
 
 .. code-block:: python

--- a/doc/dev/plugins.rst
+++ b/doc/dev/plugins.rst
@@ -338,6 +338,7 @@ We provide the :func:`~.passes.apply_pass_plugin` decorator to allow pass plugin
 See for example:
 
 .. code-block:: python
+
     from standalone import getStandalonePluginAbsolutePath
 
     @apply_pass_plugin("standalone-switch-bar-foo", getStandalonePluginAbsolutePath())
@@ -362,6 +363,7 @@ To do this, you only need to define a function named ``name2pass``—it must be 
 For the `standalone plugin python <https://github.com/PennyLaneAI/catalyst/tree/main/standalone_plugin_wheel/standalone_plugin>`_ package we defined:
 
 .. code-block:: python
+
     def name2pass(_name):
         """Example entry point for standalone plugin"""
 
@@ -406,6 +408,7 @@ E.g.,:
 
 
 .. code-block:: python
+
     from standalone import SwitchBarToFoo
 
     @SwitchBarToFoo

--- a/doc/dev/plugins.rst
+++ b/doc/dev/plugins.rst
@@ -334,7 +334,7 @@ From here, you can change the name of the pass, change the name of the shared ob
 Now that you have your ``StandalonePlugin.so``, you can ship it in a python wheel.
 To allow users to run your pass, we have provided a class called :class:`~.passes.Pass` and :class:`~.passes.PassPlugin`.
 You can extend these classes and allow the user to import your derived classes and run passes as a decorator.
-We provide the :func:`~passes.apply_pass_plugin` decorator to allow pass plugins to be loaded and executed.
+We provide the :func:`~.passes.apply_pass_plugin` decorator to allow pass plugins to be loaded and executed.
 See for example:
 
 .. code-block:: python
@@ -385,7 +385,7 @@ See our ``setup.py`` `file in the standalone plugin python package <https://gith
         # ... snip ...
     )
 
-After this, the user will be able to use your pass with the :func:`~passes.apply_pass` function.
+After this, the user will be able to use your pass with the :func:`~.passes.apply_pass` function.
 
 .. code-block:: python
 
@@ -400,7 +400,7 @@ After this, the user will be able to use your pass with the :func:`~passes.apply
 
     print(module.mlir)
 
-You can of course, also define your own decorators similar to :func:`~passes.apply_pass` to check parameters, do some other validation or perhaps just to improve the user interface.
+You can of course, also define your own decorators similar to :func:`~.passes.apply_pass` to check parameters, do some other validation or perhaps just to improve the user interface.
 E.g.,:
 
 

--- a/doc/dev/plugins.rst
+++ b/doc/dev/plugins.rst
@@ -355,7 +355,7 @@ See for example:
 
 If you have followed all the steps in this tutorial and inspect the MLIR sources, you'll find that the number of qubits allocated will be 42.
 Take a look into the ``standalone_plugin_wheel`` make rule to see how we test shipping a plugin.
-For more information, please consult our `dialect guide <../dev/dialects.html>`_, our `compiler passes guide <../dev/transforms.html>`_, and the `MLIR documentation <https://mlir.llvm.org/>`_.
+For more information, please consult our :doc:`dialect guide </dev/dialects.html>`_, our `compiler passes guide :doc:</dev/transforms.html>`_, and the `MLIR documentation <https://mlir.llvm.org/>`_.
 
 You can also register your pass with Catalyst via Python's `entry_points <https://packaging.python.org/en/latest/specifications/entry-points/>`_ (for reference, we have an `example in the Catalyst Github repository <https://github.com/PennyLaneAI/catalyst/tree/main/standalone_plugin_wheel/standalone_plugin>`_ 
 that implements the standalone plugin as a Python package).

--- a/doc/dev/plugins.rst
+++ b/doc/dev/plugins.rst
@@ -341,7 +341,7 @@ See for example:
 
     from standalone import getStandalonePluginAbsolutePath
 
-    @apply_pass_plugin("standalone-switch-bar-foo", getStandalonePluginAbsolutePath())
+    @apply_pass_plugin(getStandalonePluginAbsolutePath(), "standalone-switch-bar-foo")
     @qml.qnode(qml.device("lightning.qubit", wires=1))
     def qnode():
         return qml.state()

--- a/doc/dev/plugins.rst
+++ b/doc/dev/plugins.rst
@@ -385,7 +385,7 @@ See our ``setup.py`` `file in the standalone plugin python package <https://gith
         # ... snip ...
     )
 
-After this, the user will be able to use your pass with the `~passes.apply_pass` function.
+After this, the user will be able to use your pass with the :func:`~passes.apply_pass` function.
 
 .. code-block:: python
 
@@ -400,7 +400,7 @@ After this, the user will be able to use your pass with the `~passes.apply_pass`
 
     print(module.mlir)
 
-You can of course, also define your own decorators similar to `~passes.apply_pass` to check parameters, do some other validation or perhaps just to improve the user interface.
+You can of course, also define your own decorators similar to :func:`~passes.apply_pass` to check parameters, do some other validation or perhaps just to improve the user interface.
 E.g.,:
 
 

--- a/doc/dev/plugins.rst
+++ b/doc/dev/plugins.rst
@@ -357,7 +357,7 @@ If you have followed all the steps in this tutorial and inspect the MLIR sources
 Take a look into the ``standalone_plugin_wheel`` make rule to see how we test shipping a plugin.
 For more information, please consult our `dialect guide <../dev/dialects.html>`_, our `compiler passes guide <../dev/transforms.html>`_, and the `MLIR documentation <https://mlir.llvm.org/>`_.
 
-You can also register your pass with Catalyst via Python's `entry_ponts <https://packaging.python.org/en/latest/specifications/entry-points/>`_ (for reference, we have an `example in the Catalyst Github repository <https://github.com/PennyLaneAI/catalyst/tree/main/standalone_plugin_wheel/standalone_plugin>`_ 
+You can also register your pass with Catalyst via Python's `entry_points <https://packaging.python.org/en/latest/specifications/entry-points/>`_ (for reference, we have an `example in the Catalyst Github repository <https://github.com/PennyLaneAI/catalyst/tree/main/standalone_plugin_wheel/standalone_plugin>`_ 
 that implements the standalone plugin as a Python package).
 To do this, you only need to define a function named ``name2pass``—it must be named ``name2pass``—that takes a string with the name of the pass (from the user perspective) and returns the absolute path to the plugin stored in your package and the name of the MLIR pass.
 For the `standalone plugin python <https://github.com/PennyLaneAI/catalyst/tree/main/standalone_plugin_wheel/standalone_plugin>`_ package we defined:
@@ -404,7 +404,7 @@ After this, the user will be able to use your pass with the :func:`~.passes.appl
     print(module.mlir)
 
 Of course, you can also define your own decorators similar to :func:`~.passes.apply_pass` to check parameters, do some other validation or perhaps just to improve the user interface.
-E.g.,:
+For example:
 
 
 .. code-block:: python

--- a/doc/dev/plugins.rst
+++ b/doc/dev/plugins.rst
@@ -356,8 +356,9 @@ If you have followed all the steps in this tutorial and inspect the MLIR sources
 Take a look into the ``standalone_plugin_wheel`` make rule to see how we test shipping a plugin.
 For more information, please consult our `dialect guide <../dev/dialects.html>`_, our `compiler passes guide <../dev/transforms.html>`_, and the `MLIR documentation <https://mlir.llvm.org/>`_.
 
-You can also register your pass with Catalyst via Python's `entry_ponts <https://packaging.python.org/en/latest/specifications/entry-points/>`_.
-To do this, you only need to define a function named ``name2pass`` that takes a string with the name of the pass (from the user perspective) and returns the absolute path to the plugin stored in your package and the name of the MLIR pass.
+You can also register your pass with Catalyst via Python's `entry_ponts <https://packaging.python.org/en/latest/specifications/entry-points/>`_ (for reference, we have an `example in the Catalyst Github repository <https://github.com/PennyLaneAI/catalyst/tree/main/standalone_plugin_wheel/standalone_plugin>`_ 
+that implements the standalone plugin as a Python package).
+To do this, you only need to define a function named ``name2pass``—it must be named ``name2pass``—that takes a string with the name of the pass (from the user perspective) and returns the absolute path to the plugin stored in your package and the name of the MLIR pass.
 For the `standalone plugin python <https://github.com/PennyLaneAI/catalyst/tree/main/standalone_plugin_wheel/standalone_plugin>`_ package we defined:
 
 .. code-block:: python
@@ -380,9 +381,9 @@ See our ``setup.py`` `file in the standalone plugin python package <https://gith
     setup(
         name="standalone_plugin",
         version="0.1.0",
-        # ... snip ...
+        # ... 
         entry_points=entry_points,
-        # ... snip ...
+        # ... 
     )
 
 After this, the user will be able to use your pass with the :func:`~.passes.apply_pass` function.
@@ -400,7 +401,7 @@ After this, the user will be able to use your pass with the :func:`~.passes.appl
 
     print(module.mlir)
 
-You can of course, also define your own decorators similar to :func:`~.passes.apply_pass` to check parameters, do some other validation or perhaps just to improve the user interface.
+Of course, you can also define your own decorators similar to :func:`~.passes.apply_pass` to check parameters, do some other validation or perhaps just to improve the user interface.
 E.g.,:
 
 

--- a/doc/dev/plugins.rst
+++ b/doc/dev/plugins.rst
@@ -334,20 +334,86 @@ From here, you can change the name of the pass, change the name of the shared ob
 Now that you have your ``StandalonePlugin.so``, you can ship it in a python wheel.
 To allow users to run your pass, we have provided a class called :class:`~.passes.Pass` and :class:`~.passes.PassPlugin`.
 You can extend these classes and allow the user to import your derived classes and run passes as a decorator.
-For example:
+We provide the `~passes.apply_pass_plugin` decorator to allow pass plugins to be loaded and executed.
+See for example:
 
 .. code-block:: python
+    from standalone import getStandalonePluginAbsolutePath
+
+    @apply_pass_plugin("standalone-switch-bar-foo", getStandalonePluginAbsolutePath())
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    def qnode():
+        return qml.state()
+
+    @qml.qjit(target="mlir")
+    def module():
+        return qnode()
+
+    print(module.mlir)
+
+
+If you have followed all the steps in this tutorial and inspect the MLIR sources, you'll find that the number of qubits allocated will be 42.
+Take a look into the ``standalone_plugin_wheel`` make rule to see how we test shipping a plugin.
+For more information, please consult our `dialect guide <../dev/dialects.html>`_, our `compiler passes guide <../dev/transforms.html>`_, and the `MLIR documentation <https://mlir.llvm.org/>`_.
+
+You can also register your pass with Catalyst via Python's `entry_ponts <https://packaging.python.org/en/latest/specifications/entry-points/>`_.
+To do this, you only need to define a function named ``name2pass`` that takes a string with the name of the pass (from the user perspective) and returns the absolute path to the plugin stored in your package and the name of the MLIR pass.
+For the `standalone plugin python <https://github.com/PennyLaneAI/catalyst/tree/main/standalone_plugin_wheel/standalone_plugin>`_ package we defined:
+
+.. code-block:: python
+    def name2pass(_name):
+        """Example entry point for standalone plugin"""
+
+        return getStandalonePluginAbsolutePath(), "standalone-switch-bar-foo"
+
+You will also need to modify your setup to include the ``entry_points``.
+See our ``setup.py`` `file in the standalone plugin python package <https://github.com/PennyLaneAI/catalyst/blob/main/standalone_plugin_wheel/setup.py>`_.
+
+.. code-block:: python
+
+    entry_points = {
+        "catalyst.passes_resolution": [
+            "standalone.passes = standalone_plugin",
+        ],
+    }
+
+    setup(
+        name="standalone_plugin",
+        version="0.1.0",
+        # ... snip ...
+        entry_points=entry_points,
+        # ... snip ...
+    )
+
+After this, the user will be able to use your pass with the `~passes.apply_pass` function.
+
+.. code-block:: python
+
+    @apply_pass("standalone.standalone-switch-bar-foo")
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    def qnode():
+        return qml.state()
+
+    @qml.qjit(target="mlir")
+    def module():
+        return qnode()
+
+    print(module.mlir)
+
+You can of course, also define your own decorators similar to `~passes.apply_pass` to check parameters, do some other validation or perhaps just to improve the user interface.
+E.g.,:
+
+
+.. code-block:: python
+    from standalone import SwitchBarToFoo
 
     @SwitchBarToFoo
     @qml.qnode(qml.device("lightning.qubit", wires=1))
     def qnode():
         return qml.state()
 
-    @qml.qjit
+    @qml.qjit(target="mlir")
     def module():
         return qnode()
 
-If you inspect the MLIR sources, you'll find that the number of qubits allocated will be 42.
-Take a look into the ``standalone_plugin_wheel`` make rule to see how we test shipping a plugin.
-For more information, please consult our `dialect guide <../dev/dialects.html>`_, our `compiler passes guide <../dev/transforms.html>`_, and the `MLIR documentation <https://mlir.llvm.org/>`_.
-
+    print(module.mlir)

--- a/doc/dev/plugins.rst
+++ b/doc/dev/plugins.rst
@@ -33,7 +33,7 @@ For example using ``quantum-opt --help`` while loading your pass plugin will ena
 
 .. code-block::
 
-    --standalone-switch-bar-foo                            -   Switches the name of a FuncOp named `bar` to `foo` and folds.
+    --standalone-switch-bar-foo		-   Switches the name of a FuncOp named `bar` to `foo` and folds.
 
 Taking into account the description of the pass ``standalone-switch-bar-foo``, let's write the most minimal program that would be transformed by this transformation.
 

--- a/frontend/catalyst/__init__.py
+++ b/frontend/catalyst/__init__.py
@@ -89,7 +89,7 @@ from catalyst.autograph import __all__ as _autograph_functions
 from catalyst.compiler import CompileOptions
 from catalyst.debug.assertion import debug_assert
 from catalyst.jit import QJIT, qjit
-from catalyst.passes import pipeline
+from catalyst.passes import Pass, PassPlugin, pipeline
 from catalyst.utils.exceptions import (
     AutoGraphError,
     CompileError,
@@ -188,6 +188,8 @@ __all__ = (
     "CompileOptions",
     "debug",
     "pipeline",
+    "Pass",
+    "PassPlugin",
     *_api_extension_list,
     *_autograph_functions,
 )

--- a/frontend/catalyst/__init__.py
+++ b/frontend/catalyst/__init__.py
@@ -89,7 +89,7 @@ from catalyst.autograph import __all__ as _autograph_functions
 from catalyst.compiler import CompileOptions
 from catalyst.debug.assertion import debug_assert
 from catalyst.jit import QJIT, qjit
-from catalyst.passes import Pass, PassPlugin, pipeline
+from catalyst.passes import Pass, PassPlugin, apply_pass, apply_pass_plugin, pipeline
 from catalyst.utils.exceptions import (
     AutoGraphError,
     CompileError,
@@ -187,6 +187,8 @@ __all__ = (
     "debug_assert",
     "CompileOptions",
     "debug",
+    "apply_pass",
+    "apply_pass_plugin",
     "pipeline",
     "Pass",
     "PassPlugin",

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -337,7 +337,7 @@ def cancel_inverses(qnode=None):
 def apply_pass(pass_name: str, *flags, **valued_options):
     """
     Applies a single pass to the QNode, where the pass is from Catalyst or a third-party
-    if `entry_points` has been implemented. See :doc:`doc/plugins`
+    if `entry_points` has been implemented. See :doc:`the compiler plugin documentation <dev/plugins>`
     for more details.
 
     Args:
@@ -382,7 +382,7 @@ def apply_pass(pass_name: str, *flags, **valued_options):
 
 def apply_pass_plugin(path_to_plugin: str | Path, pass_name: str, *flags, **valued_options):
     """
-    Applies a pass plugin to the QNode. See :doc:`dev/plugins`
+    Applies a pass plugin to the QNode. See :doc:`the compiler plugin documentation <dev/plugins>`
     for more details.
 
     Args:

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -345,7 +345,7 @@ def apply_pass(pass_name: str, *flags, **valued_options):
         **valued_options: options with values
 
     Returns:
-        function that can be used as a decorator to a qnode.
+        Function that can be used as a decorator to a QNode.
     """
 
     def decorator(qnode):
@@ -378,7 +378,7 @@ def apply_pass_plugin(path_to_plugin: Path, pass_name: str, *flags, **valued_opt
         **valued_options: options with values
 
     Returns:
-        function that can be used as a decorator to a qnode.
+        Function that can be used as a decorator to a QNode.
     """
 
     def decorator(qnode):

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -350,7 +350,7 @@ def apply_pass(pass_name: str, *flags, **valued_options):
         E.g.,
 
         .. code-block:: python
-        
+
             @apply_pass("merge-rotations")
             @qml.qnode(qml.device("lightning.qubit", wires=1))
             def qnode():
@@ -394,9 +394,9 @@ def apply_pass_plugin(path_to_plugin: Path, pass_name: str, *flags, **valued_opt
     Returns:
         Function that can be used as a decorator to a QNode.
         E.g.,
-        
+
         .. code-block:: python
-        
+
             from standalone import getStandalonePluginAbsolutePath
 
             @apply_pass_plugin(getStandalonePluginAbsolutePath(), "standalone-switch-bar-foo")

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -334,8 +334,19 @@ def cancel_inverses(qnode=None):
     return wrapper
 
 
-def apply_pass(pass_name, *flags, **valued_options):
-    """Applies a single pass to the qnode"""
+def apply_pass(pass_name: str, *flags, **valued_options):
+    """Applies a single pass to the QNode, where the pass is from Catalyst or a third-party
+    if `entry_points` has been implemented. See :doc:`the compiler plugin documentation <dev/plugins>`
+    for more details.
+
+    Args:
+        pass_name (str): Name of the pass
+        *flags: Pass options
+        **valued_options: options with values
+
+    Returns:
+        function that can be used as a decorator to a qnode.
+    """
 
     def decorator(qnode):
 
@@ -356,8 +367,19 @@ def apply_pass(pass_name, *flags, **valued_options):
     return decorator
 
 
-def apply_pass_plugin(plugin_name, pass_name, *flags, **valued_options):
-    """Applies a pass plugin"""
+def apply_pass_plugin(path_to_plugin: Path, pass_name: str, *flags, **valued_options):
+    """Applies a pass plugin to the QNode. See :doc:`the compiler plugin documentation <dev/plugins>`
+    for more details.
+
+    Args:
+        path_to_plugin (Path): full path to plugin
+        pass_name (str): Name of the pass
+        *flags: Pass options
+        **valued_options: options with values
+
+    Returns:
+        function that can be used as a decorator to a qnode.
+    """
 
     def decorator(qnode):
         if not isinstance(qnode, qml.QNode):
@@ -368,7 +390,7 @@ def apply_pass_plugin(plugin_name, pass_name, *flags, **valued_options):
 
         def qnode_call(*args, **kwargs):
             pass_pipeline = kwargs.get("pass_pipeline", [])
-            pass_pipeline.append(PassPlugin(plugin_name, pass_name, *flags, **valued_options))
+            pass_pipeline.append(PassPlugin(path_to_plugin, pass_name, *flags, **valued_options))
             kwargs["pass_pipeline"] = pass_pipeline
             return qnode(*args, **kwargs)
 

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -335,8 +335,9 @@ def cancel_inverses(qnode=None):
 
 
 def apply_pass(pass_name: str, *flags, **valued_options):
-    """Applies a single pass to the QNode, where the pass is from Catalyst or a third-party
-    if `entry_points` has been implemented. See :doc:`the compiler plugin documentation <dev/plugins>`
+    """
+    Applies a single pass to the QNode, where the pass is from Catalyst or a third-party
+    if `entry_points` has been implemented. See :doc:`doc/plugins`
     for more details.
 
     Args:
@@ -368,7 +369,8 @@ def apply_pass(pass_name: str, *flags, **valued_options):
 
 
 def apply_pass_plugin(path_to_plugin: Path, pass_name: str, *flags, **valued_options):
-    """Applies a pass plugin to the QNode. See :doc:`the compiler plugin documentation <dev/plugins>`
+    """
+    Applies a pass plugin to the QNode. See :doc:`dev/plugins`
     for more details.
 
     Args:

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -82,17 +82,20 @@ class PassPlugin(Pass):
         super().__init__(name, *options, **valued_options)
 
 
-def dictionary_to_tuple_of_passes(pass_pipeline: PipelineDict):
-    """Convert dictionary of passes into tuple of passes"""
+def dictionary_to_list_of_passes(pass_pipeline: PipelineDict):
+    """Convert dictionary of passes into list of passes"""
+
+    if pass_pipeline == None:
+        return []
 
     if type(pass_pipeline) != dict:
         return pass_pipeline
 
-    passes = tuple()
+    passes = []
     pass_names = _API_name_to_pass_name()
     for API_name, pass_options in pass_pipeline.items():
         name = pass_names.get(API_name, API_name)
-        passes += (Pass(name, **pass_options),)
+        passes.append(Pass(name, **pass_options))
     return passes
 
 
@@ -195,8 +198,8 @@ def pipeline(pass_pipeline: PipelineDict):
         @functools.wraps(clone)
         def wrapper(*args, **kwargs):
             if EvaluationContext.is_tracing():
-                passes = kwargs.pop("pass_pipeline", tuple())
-                passes += dictionary_to_tuple_of_passes(pass_pipeline)
+                passes = kwargs.pop("pass_pipeline", [])
+                passes += dictionary_to_list_of_passes(pass_pipeline)
                 kwargs["pass_pipeline"] = passes
             return clone(*args, **kwargs)
 
@@ -323,8 +326,8 @@ def cancel_inverses(qnode=None):
 
     @functools.wraps(clone)
     def wrapper(*args, **kwargs):
-        pass_pipeline = kwargs.pop("pass_pipeline", tuple())
-        pass_pipeline += (Pass("remove-chained-self-inverse"),)
+        pass_pipeline = kwargs.pop("pass_pipeline", [])
+        pass_pipeline.append(Pass("remove-chained-self-inverse"))
         kwargs["pass_pipeline"] = pass_pipeline
         return clone(*args, **kwargs)
 
@@ -443,8 +446,8 @@ def merge_rotations(qnode=None):
 
     @functools.wraps(clone)
     def wrapper(*args, **kwargs):
-        pass_pipeline = kwargs.pop("pass_pipeline", tuple())
-        pass_pipeline += (Pass("merge-rotations"),)
+        pass_pipeline = kwargs.pop("pass_pipeline", [])
+        pass_pipeline.append(Pass("merge-rotations"))
         kwargs["pass_pipeline"] = pass_pipeline
         return clone(*args, **kwargs)
 
@@ -467,8 +470,8 @@ def ions_decomposition(qnode=None):  # pragma: nocover
 
     @functools.wraps(qnode)
     def wrapper(*args, **kwargs):
-        pass_pipeline = kwargs.pop("pass_pipeline", tuple())
-        pass_pipeline += (Pass("ions-decomposition"),)
+        pass_pipeline = kwargs.pop("pass_pipeline", [])
+        pass_pipeline.append(Pass("ions-decomposition"))
         kwargs["pass_pipeline"] = pass_pipeline
         return qnode(*args, **kwargs)
 

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -381,6 +381,20 @@ def apply_pass_plugin(path_to_plugin: Path, pass_name: str, *flags, **valued_opt
 
     Returns:
         Function that can be used as a decorator to a QNode.
+        E.g.,
+        
+        .. code-block:: python
+        
+            from standalone import getStandalonePluginAbsolutePath
+
+           @apply_pass_plugin("standalone-switch-bar-foo", getStandalonePluginAbsolutePath())
+           @qml.qnode(qml.device("lightning.qubit", wires=1))
+           def qnode():
+               return qml.state()
+
+           @qml.qjit(target="mlir")
+           def module():
+               return qnode()
     """
 
     def decorator(qnode):

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -380,13 +380,13 @@ def apply_pass(pass_name: str, *flags, **valued_options):
     return decorator
 
 
-def apply_pass_plugin(path_to_plugin: Path, pass_name: str, *flags, **valued_options):
+def apply_pass_plugin(path_to_plugin: str | Path, pass_name: str, *flags, **valued_options):
     """
     Applies a pass plugin to the QNode. See :doc:`dev/plugins`
     for more details.
 
     Args:
-        path_to_plugin (Path): full path to plugin
+        path_to_plugin (str | Path): full path to plugin
         pass_name (str): Name of the pass
         *flags: Pass options
         **valued_options: options with values
@@ -408,6 +408,12 @@ def apply_pass_plugin(path_to_plugin: Path, pass_name: str, *flags, **valued_opt
             def module():
                 return qnode()
     """
+
+    if not isinstance(path_to_plugin, Path):
+        path_to_plugin = Path(path_to_plugin)
+
+    if not path_to_plugin.exists():
+        raise FileNotFoundError(f"File '{path_to_plugin}' does not exist.")
 
     def decorator(qnode):
         if not isinstance(qnode, qml.QNode):

--- a/frontend/catalyst/passes.py
+++ b/frontend/catalyst/passes.py
@@ -347,6 +347,18 @@ def apply_pass(pass_name: str, *flags, **valued_options):
 
     Returns:
         Function that can be used as a decorator to a QNode.
+        E.g.,
+
+        .. code-block:: python
+        
+            @apply_pass("merge-rotations")
+            @qml.qnode(qml.device("lightning.qubit", wires=1))
+            def qnode():
+                return qml.state()
+
+            @qml.qjit(target="mlir")
+            def module():
+                return qnode()
     """
 
     def decorator(qnode):
@@ -387,14 +399,14 @@ def apply_pass_plugin(path_to_plugin: Path, pass_name: str, *flags, **valued_opt
         
             from standalone import getStandalonePluginAbsolutePath
 
-           @apply_pass_plugin("standalone-switch-bar-foo", getStandalonePluginAbsolutePath())
-           @qml.qnode(qml.device("lightning.qubit", wires=1))
-           def qnode():
-               return qml.state()
+            @apply_pass_plugin(getStandalonePluginAbsolutePath(), "standalone-switch-bar-foo")
+            @qml.qnode(qml.device("lightning.qubit", wires=1))
+            def qnode():
+                return qml.state()
 
-           @qml.qjit(target="mlir")
-           def module():
-               return qnode()
+            @qml.qjit(target="mlir")
+            def module():
+                return qnode()
     """
 
     def decorator(qnode):

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -49,7 +49,7 @@ from catalyst.jax_extras import (
 from catalyst.jax_primitives import quantum_kernel_p
 from catalyst.jax_tracer import Function, trace_quantum_function
 from catalyst.logging import debug_logger
-from catalyst.passes import dictionary_to_tuple_of_passes
+from catalyst.passes import dictionary_to_list_of_passes
 from catalyst.tracing.contexts import EvaluationContext
 from catalyst.tracing.type_signatures import filter_static_args
 from catalyst.utils.exceptions import CompileError
@@ -105,8 +105,8 @@ class QFunc:
         assert isinstance(self, qml.QNode)
 
         # Update the qnode with peephole pipeline
-        pass_pipeline = kwargs.pop("pass_pipeline", tuple())
-        pass_pipeline = dictionary_to_tuple_of_passes(pass_pipeline)
+        pass_pipeline = kwargs.pop("pass_pipeline", [])
+        pass_pipeline = dictionary_to_list_of_passes(pass_pipeline)
 
         # Mid-circuit measurement configuration/execution
         dynamic_one_shot_called = getattr(self, "_dynamic_one_shot_called", False)
@@ -148,7 +148,7 @@ class QFunc:
         dynamic_args = filter_static_args(args, static_argnums)
         args_flat = tree_flatten((dynamic_args, kwargs))[0]
         res_flat = quantum_kernel_p.bind(
-            flattened_fun, *args_flat, qnode=self, pipeline=pass_pipeline
+            flattened_fun, *args_flat, qnode=self, pipeline=tuple(pass_pipeline)
         )
         return tree_unflatten(out_tree_promise(), res_flat)[0]
 

--- a/frontend/test/pytest/test_mlir_plugin_interface.py
+++ b/frontend/test/pytest/test_mlir_plugin_interface.py
@@ -1,0 +1,29 @@
+# Copyright 2025 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Testing interface around main plugin functionality"""
+
+from pathlib import Path
+
+import pytest
+import catalyst
+
+def test_path_does_not_exists():
+    """Test what happens when a pass_plugin is given an path that does not exist"""
+
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        catalyst.apply_pass_plugin("this-path-does-not-exist", "this-pass-also-doesnt-exists")
+
+    with pytest.raises(FileNotFoundError, match="does not exist"):
+        catalyst.apply_pass_plugin(Path("this-path-does-not-exist"), "this-pass-also-doesnt-exists")


### PR DESCRIPTION
**Context:** The documentation for MLIR plugins did not state anything about `entry_points` nor relevant functions when loading MLIR plugins from python. Also changed the type of the `pass_pipeline` kwarg. Instead of it being a tuple of Passes, it is now a list of Passes. This is nicer for developers.

**Description of the Change:** The `pass_pipeline` keyword argument is now a list instead of a tuple. This list is converted into a tuple at the moment the qnode primitive is bound.

Added documentation for MLIR plugins.
