### PR TITLE
[MLIR] Remove scheduling at FunctionOpInterfaces

### DIFF
--- a/mlir/lib/Quantum/Transforms/DisentangleCNOT.cpp
+++ b/mlir/lib/Quantum/Transforms/DisentangleCNOT.cpp
@@ -133,7 +133,11 @@ struct DisentangleCNOTPass : public impl::DisentangleCNOTPassBase<DisentangleCNO
     void runOnOperation() override
     {
         auto op = getOperation();
-        op->walk([&](FunctionOpInterface func) { disentangleCNOTs(func, EmitFSMStateRemark); });
+        for (Operation &nestedOp : op->getRegion(0).front().getOperations()) {
+            if (auto func = dyn_cast<FunctionOpInterface>(nestedOp)) {
+                disentangleCNOTs(func, EmitFSMStateRemark);
+            }
+        }
     }
 };
 

--- a/mlir/lib/Quantum/Transforms/DisentangleCNOT.cpp
+++ b/mlir/lib/Quantum/Transforms/DisentangleCNOT.cpp
@@ -40,13 +40,11 @@ struct DisentangleCNOTPass : public impl::DisentangleCNOTPassBase<DisentangleCNO
 
     void runOnOperation() override
     {
-
         auto op = getOperation();
         SmallVector<Operation *> targets;
         op->walk([&](FunctionOpInterface func) { targets.push_back(func); });
 
         for (auto func : targets) {
-
             mlir::IRRewriter builder(func->getContext());
             Location loc = func->getLoc();
 

--- a/mlir/lib/Quantum/Transforms/DisentangleCNOT.cpp
+++ b/mlir/lib/Quantum/Transforms/DisentangleCNOT.cpp
@@ -63,20 +63,20 @@ void disentangleCNOTs(FunctionOpInterface &func, bool verbose)
 
         // |0> control, always do nothing
         if (pssa.isZero(qubitValues[controlIn])) {
-            controlOut.replaceAllUsesWith(controlIn);
-            targetOut.replaceAllUsesWith(targetIn);
-            op->erase();
+            builder.replaceAllUsesWith(controlOut, controlIn);
+            builder.replaceAllUsesWith(targetOut, targetIn);
+            builder.eraseOp(op);
             return;
         }
 
         // |1> control, insert PauliX gate on target
         if (pssa.isOne(qubitValues[controlIn])) {
-            controlOut.replaceAllUsesWith(controlIn);
+            builder.replaceAllUsesWith(controlOut, controlIn);
 
             // PauliX on |+-> is unnecessary: they are eigenstates!
             if ((pssa.isPlus(qubitValues[targetIn])) || (pssa.isMinus(qubitValues[targetIn]))) {
-                targetOut.replaceAllUsesWith(targetIn);
-                op->erase();
+                builder.replaceAllUsesWith(targetOut, targetIn);
+                builder.eraseOp(op);
                 return;
             }
             else {
@@ -84,28 +84,28 @@ void disentangleCNOTs(FunctionOpInterface &func, bool verbose)
                 quantum::CustomOp xgate =
                     builder.create<quantum::CustomOp>(loc, /*gate_name=*/"PauliX",
                                                       /*in_qubits=*/mlir::ValueRange({targetIn}));
-                targetOut.replaceAllUsesWith(xgate->getResult(0));
-                op->erase();
+                builder.replaceAllUsesWith(targetOut, xgate->getResult(0));
+                builder.eraseOp(op);
                 return;
             }
         }
 
         // |+> target, always do nothing
         if (pssa.isPlus(qubitValues[targetIn])) {
-            controlOut.replaceAllUsesWith(controlIn);
-            targetOut.replaceAllUsesWith(targetIn);
-            op->erase();
+            builder.replaceAllUsesWith(controlOut, controlIn);
+            builder.replaceAllUsesWith(targetOut, targetIn);
+            builder.eraseOp(op);
             return;
         }
 
         // |-> target, insert PauliZ on control
         if (pssa.isMinus(qubitValues[targetIn])) {
-            targetOut.replaceAllUsesWith(targetIn);
+            builder.replaceAllUsesWith(targetOut, targetIn);
 
             // PauliZ on |01> is unnecessary: they are eigenstates!
             if ((pssa.isZero(qubitValues[controlIn])) || (pssa.isOne(qubitValues[controlIn]))) {
-                controlOut.replaceAllUsesWith(controlIn);
-                op->erase();
+                builder.replaceAllUsesWith(controlOut, controlIn);
+                builder.eraseOp(op);
                 return;
             }
             else {
@@ -113,8 +113,8 @@ void disentangleCNOTs(FunctionOpInterface &func, bool verbose)
                 quantum::CustomOp zgate =
                     builder.create<quantum::CustomOp>(loc, /*gate_name=*/"PauliZ",
                                                       /*in_qubits=*/mlir::ValueRange({controlIn}));
-                controlOut.replaceAllUsesWith(zgate->getResult(0));
-                op->erase();
+                builder.replaceAllUsesWith(controlOut, zgate->getResult(0));
+                builder.eraseOp(op);
                 return;
             }
         }

--- a/mlir/lib/Quantum/Transforms/DisentangleSWAP.cpp
+++ b/mlir/lib/Quantum/Transforms/DisentangleSWAP.cpp
@@ -136,7 +136,7 @@ struct DisentangleSWAPPass : public impl::DisentangleSWAPPassBase<DisentangleSWA
         mlir::IRRewriter builder(func->getContext());
         Location loc = func->getLoc();
 
-        PropagateSimpleStatesAnalysis &pssa = getAnalysis<PropagateSimpleStatesAnalysis>();
+        PropagateSimpleStatesAnalysis pssa(func);
         llvm::DenseMap<Value, QubitState> qubitValues = pssa.getQubitValues();
 
         func->walk([&](quantum::CustomOp op) {
@@ -495,7 +495,11 @@ struct DisentangleSWAPPass : public impl::DisentangleSWAPPassBase<DisentangleSWA
     void runOnOperation() override
     {
         auto op = getOperation();
-        op->walk([&](FunctionOpInterface func) { disentangleSWAPs(func); });
+        for (Operation &nestedOp : op->getRegion(0).front().getOperations()) {
+            if (auto func = dyn_cast<FunctionOpInterface>(nestedOp)) {
+                disentangleSWAPs(func);
+             }
+        }
     }
 };
 

--- a/mlir/lib/Quantum/Transforms/DisentangleSWAP.cpp
+++ b/mlir/lib/Quantum/Transforms/DisentangleSWAP.cpp
@@ -154,33 +154,33 @@ struct DisentangleSWAPPass : public impl::DisentangleSWAPPassBase<DisentangleSWA
             if (pssa.isZero(qubitValues[SwapQubit_0_In])) {
                 // second qubit in |0>: SWAP(|0>,|0>)
                 if (pssa.isZero(qubitValues[SwapQubit_1_In])) {
-                    SwapQubit_0_Out.replaceAllUsesWith(SwapQubit_0_In);
-                    SwapQubit_1_Out.replaceAllUsesWith(SwapQubit_1_In);
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, SwapQubit_0_In);
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, SwapQubit_1_In);
+                    builder.eraseOp(op);
                     return;
                 }
                 // second qubit in |1>: SWAP(|0>,|1>)
                 else if (pssa.isOne(qubitValues[SwapQubit_1_In])) {
                     quantum::CustomOp xgate_on_0 = createSimpleOneBitGate(
                         "PauliX", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
-                    SwapQubit_0_Out.replaceAllUsesWith(xgate_on_0->getResult(0));
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, xgate_on_0->getResult(0));
 
                     quantum::CustomOp xgate_on_1 = createSimpleOneBitGate(
                         "PauliX", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, xgate_on_0);
-                    SwapQubit_1_Out.replaceAllUsesWith(xgate_on_1->getResult(0));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, xgate_on_1->getResult(0));
+                    builder.eraseOp(op);
                     return;
                 }
                 // second qubit in |+>: SWAP(|0>,|+>)
                 else if (pssa.isPlus(qubitValues[SwapQubit_1_In])) {
                     quantum::CustomOp hgate_on_0 = createSimpleOneBitGate(
                         "Hadamard", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
-                    SwapQubit_0_Out.replaceAllUsesWith(hgate_on_0->getResult(0));
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, hgate_on_0->getResult(0));
 
                     quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
                         "Hadamard", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, hgate_on_0);
-                    SwapQubit_1_Out.replaceAllUsesWith(hgate_on_1->getResult(0));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, hgate_on_1->getResult(0));
+                    builder.eraseOp(op);
                     return;
                 }
                 // second qubit in |->: SWAP(|0>,|->)
@@ -190,15 +190,15 @@ struct DisentangleSWAPPass : public impl::DisentangleSWAPPassBase<DisentangleSWA
 
                     quantum::CustomOp hgate_on_0 = createSimpleOneBitGate(
                         "Hadamard", xgate_on_0->getResult(0), builder, loc, xgate_on_0);
-                    SwapQubit_0_Out.replaceAllUsesWith(hgate_on_0->getResult(0));
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, hgate_on_0->getResult(0));
 
                     quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
                         "Hadamard", SwapQubit_1_In, builder, loc, hgate_on_0);
 
                     quantum::CustomOp xgate_on_1 = createSimpleOneBitGate(
                         "PauliX", hgate_on_1->getResult(0), builder, loc, hgate_on_1);
-                    SwapQubit_1_Out.replaceAllUsesWith(xgate_on_1->getResult(0));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, xgate_on_1->getResult(0));
+                    builder.eraseOp(op);
                     return;
                 }
                 // second qubit in NON_BASIS: SWAP(|0>,|NON_BASIS>)
@@ -210,9 +210,9 @@ struct DisentangleSWAPPass : public impl::DisentangleSWAPPassBase<DisentangleSWA
                         "CNOT", cnot_on_1_0->getResult(1), cnot_on_1_0->getResult(0), builder, loc,
                         cnot_on_1_0);
 
-                    SwapQubit_0_Out.replaceAllUsesWith(cnot_on_0_1->getResult(0));
-                    SwapQubit_1_Out.replaceAllUsesWith(cnot_on_0_1->getResult(1));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, cnot_on_0_1->getResult(0));
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, cnot_on_0_1->getResult(1));
+                    builder.eraseOp(op);
                     return;
                 }
             }
@@ -223,19 +223,19 @@ struct DisentangleSWAPPass : public impl::DisentangleSWAPPassBase<DisentangleSWA
                 if (pssa.isZero(qubitValues[SwapQubit_1_In])) {
                     quantum::CustomOp xgate_on_0 = createSimpleOneBitGate(
                         "PauliX", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
-                    SwapQubit_0_Out.replaceAllUsesWith(xgate_on_0->getResult(0));
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, xgate_on_0->getResult(0));
 
                     quantum::CustomOp xgate_on_1 = createSimpleOneBitGate(
                         "PauliX", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, xgate_on_0);
-                    SwapQubit_1_Out.replaceAllUsesWith(xgate_on_1->getResult(0));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, xgate_on_1->getResult(0));
+                    builder.eraseOp(op);
                     return;
                 }
                 // second qubit in |1>: SWAP(|1>,|1>)
                 else if (pssa.isOne(qubitValues[SwapQubit_1_In])) {
-                    SwapQubit_0_Out.replaceAllUsesWith(SwapQubit_0_In);
-                    SwapQubit_1_Out.replaceAllUsesWith(SwapQubit_1_In);
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, SwapQubit_0_In);
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, SwapQubit_1_In);
+                    builder.eraseOp(op);
                     return;
                 }
                 // second qubit in |+>: SWAP(|1>,|+>)
@@ -245,27 +245,27 @@ struct DisentangleSWAPPass : public impl::DisentangleSWAPPassBase<DisentangleSWA
 
                     quantum::CustomOp hgate_on_0 = createSimpleOneBitGate(
                         "Hadamard", xgate_on_0->getResult(0), builder, loc, xgate_on_0);
-                    SwapQubit_0_Out.replaceAllUsesWith(hgate_on_0->getResult(0));
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, hgate_on_0->getResult(0));
 
                     quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
                         "Hadamard", SwapQubit_1_In, builder, loc, hgate_on_0);
 
                     quantum::CustomOp xgate_on_1 = createSimpleOneBitGate(
                         "PauliX", hgate_on_1->getResult(0), builder, loc, hgate_on_1);
-                    SwapQubit_1_Out.replaceAllUsesWith(xgate_on_1->getResult(0));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, xgate_on_1->getResult(0));
+                    builder.eraseOp(op);
                     return;
                 }
                 // second qubit in |->: SWAP(|1>,|->)
                 else if (pssa.isMinus(qubitValues[SwapQubit_1_In])) {
                     quantum::CustomOp hgate_on_0 = createSimpleOneBitGate(
                         "Hadamard", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
-                    SwapQubit_0_Out.replaceAllUsesWith(hgate_on_0->getResult(0));
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, hgate_on_0->getResult(0));
 
                     quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
                         "Hadamard", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, hgate_on_0);
-                    SwapQubit_1_Out.replaceAllUsesWith(hgate_on_1->getResult(0));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, hgate_on_1->getResult(0));
+                    builder.eraseOp(op);
                     return;
                 }
                 // second qubit in |NON_BASIS>: SWAP(|1>,|NON_BASIS>)
@@ -280,9 +280,9 @@ struct DisentangleSWAPPass : public impl::DisentangleSWAPPassBase<DisentangleSWA
                         "CNOT", cnot_on_1_0->getResult(1), cnot_on_1_0->getResult(0), builder, loc,
                         cnot_on_1_0);
 
-                    SwapQubit_0_Out.replaceAllUsesWith(cnot_on_0_1->getResult(0));
-                    SwapQubit_1_Out.replaceAllUsesWith(cnot_on_0_1->getResult(1));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, cnot_on_0_1->getResult(0));
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, cnot_on_0_1->getResult(1));
+                    builder.eraseOp(op);
                     return;
                 }
             }
@@ -293,12 +293,12 @@ struct DisentangleSWAPPass : public impl::DisentangleSWAPPassBase<DisentangleSWA
                 if (pssa.isZero(qubitValues[SwapQubit_1_In])) {
                     quantum::CustomOp hgate_on_0 = createSimpleOneBitGate(
                         "Hadamard", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
-                    SwapQubit_0_Out.replaceAllUsesWith(hgate_on_0->getResult(0));
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, hgate_on_0->getResult(0));
 
                     quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
                         "Hadamard", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, hgate_on_0);
-                    SwapQubit_1_Out.replaceAllUsesWith(hgate_on_1->getResult(0));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, hgate_on_1->getResult(0));
+                    builder.eraseOp(op);
                     return;
                 }
                 // second qubit in |01>: SWAP(|+>,|1>)
@@ -308,34 +308,34 @@ struct DisentangleSWAPPass : public impl::DisentangleSWAPPassBase<DisentangleSWA
 
                     quantum::CustomOp xgate_on_0 = createSimpleOneBitGate(
                         "PauliX", hgate_on_0->getResult(0), builder, loc, hgate_on_0);
-                    SwapQubit_0_Out.replaceAllUsesWith(xgate_on_0->getResult(0));
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, xgate_on_0->getResult(0));
 
                     quantum::CustomOp xgate_on_1 =
                         createSimpleOneBitGate("PauliX", SwapQubit_1_In, builder, loc, xgate_on_0);
 
                     quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
                         "Hadamard", xgate_on_1->getResult(0), builder, loc, xgate_on_1);
-                    SwapQubit_1_Out.replaceAllUsesWith(hgate_on_1->getResult(0));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, hgate_on_1->getResult(0));
+                    builder.eraseOp(op);
                     return;
                 }
                 // second qubit in |+>: SWAP(|+>,|+>)
                 else if (pssa.isPlus(qubitValues[SwapQubit_1_In])) {
-                    SwapQubit_0_Out.replaceAllUsesWith(SwapQubit_0_In);
-                    SwapQubit_1_Out.replaceAllUsesWith(SwapQubit_1_In);
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, SwapQubit_0_In);
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, SwapQubit_1_In);
+                    builder.eraseOp(op);
                     return;
                 }
                 // second qubit in |->: SWAP(|+>,|->)
                 else if (pssa.isMinus(qubitValues[SwapQubit_1_In])) {
                     quantum::CustomOp zgate_on_0 = createSimpleOneBitGate(
                         "PauliZ", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
-                    SwapQubit_0_Out.replaceAllUsesWith(zgate_on_0->getResult(0));
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, zgate_on_0->getResult(0));
 
                     quantum::CustomOp zgate_on_1 = createSimpleOneBitGate(
                         "PauliZ", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, zgate_on_0);
-                    SwapQubit_1_Out.replaceAllUsesWith(zgate_on_1->getResult(0));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, zgate_on_1->getResult(0));
+                    builder.eraseOp(op);
                     return;
                 }
                 // second qubit in |NON_BASIS>: SWAP(|+>,|NON_BASIS>)
@@ -347,9 +347,9 @@ struct DisentangleSWAPPass : public impl::DisentangleSWAPPassBase<DisentangleSWA
                         "CNOT", cnot_on_0_1->getResult(1), cnot_on_0_1->getResult(0), builder, loc,
                         cnot_on_0_1);
 
-                    SwapQubit_0_Out.replaceAllUsesWith(cnot_on_1_0->getResult(1));
-                    SwapQubit_1_Out.replaceAllUsesWith(cnot_on_1_0->getResult(0));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, cnot_on_1_0->getResult(1));
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, cnot_on_1_0->getResult(0));
+                    builder.eraseOp(op);
                     return;
                 }
             }
@@ -363,46 +363,46 @@ struct DisentangleSWAPPass : public impl::DisentangleSWAPPassBase<DisentangleSWA
 
                     quantum::CustomOp xgate_on_0 = createSimpleOneBitGate(
                         "PauliX", hgate_on_0->getResult(0), builder, loc, hgate_on_0);
-                    SwapQubit_0_Out.replaceAllUsesWith(xgate_on_0->getResult(0));
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, xgate_on_0->getResult(0));
 
                     quantum::CustomOp xgate_on_1 =
                         createSimpleOneBitGate("PauliX", SwapQubit_1_In, builder, loc, xgate_on_0);
 
                     quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
                         "Hadamard", xgate_on_1->getResult(0), builder, loc, xgate_on_1);
-                    SwapQubit_1_Out.replaceAllUsesWith(hgate_on_1->getResult(0));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, hgate_on_1->getResult(0));
+                    builder.eraseOp(op);
                     return;
                 }
                 // second qubit in |1>: SWAP(|->,|1>)
                 else if (pssa.isOne(qubitValues[SwapQubit_1_In])) {
                     quantum::CustomOp hgate_on_0 = createSimpleOneBitGate(
                         "Hadamard", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
-                    SwapQubit_0_Out.replaceAllUsesWith(hgate_on_0->getResult(0));
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, hgate_on_0->getResult(0));
 
                     quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
                         "Hadamard", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, hgate_on_0);
-                    SwapQubit_1_Out.replaceAllUsesWith(hgate_on_1->getResult(0));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, hgate_on_1->getResult(0));
+                    builder.eraseOp(op);
                     return;
                 }
                 // second qubit in |+>: SWAP(|->,|+>)
                 else if (pssa.isPlus(qubitValues[SwapQubit_1_In])) {
                     quantum::CustomOp zgate_on_0 = createSimpleOneBitGate(
                         "PauliZ", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
-                    SwapQubit_0_Out.replaceAllUsesWith(zgate_on_0->getResult(0));
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, zgate_on_0->getResult(0));
 
                     quantum::CustomOp zgate_on_1 = createSimpleOneBitGate(
                         "PauliZ", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, zgate_on_0);
-                    SwapQubit_1_Out.replaceAllUsesWith(zgate_on_1->getResult(0));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, zgate_on_1->getResult(0));
+                    builder.eraseOp(op);
                     return;
                 }
                 // second qubit in |->: SWAP(|->,|->)
                 else if (pssa.isMinus(qubitValues[SwapQubit_1_In])) {
-                    SwapQubit_0_Out.replaceAllUsesWith(SwapQubit_0_In);
-                    SwapQubit_1_Out.replaceAllUsesWith(SwapQubit_1_In);
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, SwapQubit_0_In);
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, SwapQubit_1_In);
+                    builder.eraseOp(op);
                     return;
                 }
                 // second qubit in |NON_BASIS>: SWAP(|->,|NON_BASIS>)
@@ -417,9 +417,9 @@ struct DisentangleSWAPPass : public impl::DisentangleSWAPPassBase<DisentangleSWA
                         "CNOT", cnot_on_0_1->getResult(1), cnot_on_0_1->getResult(0), builder, loc,
                         cnot_on_0_1);
 
-                    SwapQubit_0_Out.replaceAllUsesWith(cnot_on_1_0->getResult(1));
-                    SwapQubit_1_Out.replaceAllUsesWith(cnot_on_1_0->getResult(0));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, cnot_on_1_0->getResult(1));
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, cnot_on_1_0->getResult(0));
+                    builder.eraseOp(op);
                     return;
                 }
             }
@@ -435,9 +435,9 @@ struct DisentangleSWAPPass : public impl::DisentangleSWAPPassBase<DisentangleSWA
                         "CNOT", cnot_on_0_1->getResult(1), cnot_on_0_1->getResult(0), builder, loc,
                         cnot_on_0_1);
 
-                    SwapQubit_0_Out.replaceAllUsesWith(cnot_on_1_0->getResult(1));
-                    SwapQubit_1_Out.replaceAllUsesWith(cnot_on_1_0->getResult(0));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, cnot_on_1_0->getResult(1));
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, cnot_on_1_0->getResult(0));
+                    builder.eraseOp(op);
                     return;
                 }
                 // second qubit in |1>: SWAP(|NON_BASIS>,|1>)
@@ -452,9 +452,9 @@ struct DisentangleSWAPPass : public impl::DisentangleSWAPPassBase<DisentangleSWA
                         "CNOT", cnot_on_0_1->getResult(1), cnot_on_0_1->getResult(0), builder, loc,
                         cnot_on_0_1);
 
-                    SwapQubit_0_Out.replaceAllUsesWith(cnot_on_1_0->getResult(1));
-                    SwapQubit_1_Out.replaceAllUsesWith(cnot_on_1_0->getResult(0));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, cnot_on_1_0->getResult(1));
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, cnot_on_1_0->getResult(0));
+                    builder.eraseOp(op);
                     return;
                 }
                 // second qubit in |+>: SWAP(|NON_BASIS>,|+>)
@@ -466,9 +466,9 @@ struct DisentangleSWAPPass : public impl::DisentangleSWAPPassBase<DisentangleSWA
                         "CNOT", cnot_on_1_0->getResult(1), cnot_on_1_0->getResult(0), builder, loc,
                         cnot_on_1_0);
 
-                    SwapQubit_0_Out.replaceAllUsesWith(cnot_on_0_1->getResult(0));
-                    SwapQubit_1_Out.replaceAllUsesWith(cnot_on_0_1->getResult(1));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, cnot_on_0_1->getResult(0));
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, cnot_on_0_1->getResult(1));
+                    builder.eraseOp(op);
                     return;
                 }
                 // second qubit in |->: SWAP(|NON_BASIS>,|->)
@@ -483,9 +483,9 @@ struct DisentangleSWAPPass : public impl::DisentangleSWAPPassBase<DisentangleSWA
                         "CNOT", cnot_on_1_0->getResult(1), cnot_on_1_0->getResult(0), builder, loc,
                         cnot_on_1_0);
 
-                    SwapQubit_0_Out.replaceAllUsesWith(cnot_on_0_1->getResult(0));
-                    SwapQubit_1_Out.replaceAllUsesWith(cnot_on_0_1->getResult(1));
-                    op->erase();
+                    builder.replaceAllUsesWith(SwapQubit_0_Out, cnot_on_0_1->getResult(0));
+                    builder.replaceAllUsesWith(SwapQubit_1_Out, cnot_on_0_1->getResult(1));
+                    builder.eraseOp(op);
                     return;
                 }
             }

--- a/mlir/lib/Quantum/Transforms/DisentangleSWAP.cpp
+++ b/mlir/lib/Quantum/Transforms/DisentangleSWAP.cpp
@@ -131,375 +131,371 @@ struct DisentangleSWAPPass : public impl::DisentangleSWAPPassBase<DisentangleSWA
         return newGate;
     }
 
+    void disentangleSWAPs(FunctionOpInterface &func)
+    {
+        mlir::IRRewriter builder(func->getContext());
+        Location loc = func->getLoc();
+
+        PropagateSimpleStatesAnalysis &pssa = getAnalysis<PropagateSimpleStatesAnalysis>();
+        llvm::DenseMap<Value, QubitState> qubitValues = pssa.getQubitValues();
+
+        func->walk([&](quantum::CustomOp op) {
+            StringRef gate = op.getGateName();
+            if (gate != "SWAP") {
+                return;
+            }
+
+            Value SwapQubit_0_In = op->getOperand(0);
+            Value SwapQubit_1_In = op->getOperand(1);
+            Value SwapQubit_0_Out = op->getResult(0);
+            Value SwapQubit_1_Out = op->getResult(1);
+
+            // first qubit in |0>
+            if (pssa.isZero(qubitValues[SwapQubit_0_In])) {
+                // second qubit in |0>: SWAP(|0>,|0>)
+                if (pssa.isZero(qubitValues[SwapQubit_1_In])) {
+                    SwapQubit_0_Out.replaceAllUsesWith(SwapQubit_0_In);
+                    SwapQubit_1_Out.replaceAllUsesWith(SwapQubit_1_In);
+                    op->erase();
+                    return;
+                }
+                // second qubit in |1>: SWAP(|0>,|1>)
+                else if (pssa.isOne(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp xgate_on_0 = createSimpleOneBitGate(
+                        "PauliX", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
+                    SwapQubit_0_Out.replaceAllUsesWith(xgate_on_0->getResult(0));
+
+                    quantum::CustomOp xgate_on_1 = createSimpleOneBitGate(
+                        "PauliX", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, xgate_on_0);
+                    SwapQubit_1_Out.replaceAllUsesWith(xgate_on_1->getResult(0));
+                    op->erase();
+                    return;
+                }
+                // second qubit in |+>: SWAP(|0>,|+>)
+                else if (pssa.isPlus(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp hgate_on_0 = createSimpleOneBitGate(
+                        "Hadamard", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
+                    SwapQubit_0_Out.replaceAllUsesWith(hgate_on_0->getResult(0));
+
+                    quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
+                        "Hadamard", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, hgate_on_0);
+                    SwapQubit_1_Out.replaceAllUsesWith(hgate_on_1->getResult(0));
+                    op->erase();
+                    return;
+                }
+                // second qubit in |->: SWAP(|0>,|->)
+                else if (pssa.isMinus(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp xgate_on_0 =
+                        createSimpleOneBitGate("PauliX", SwapQubit_0_In, builder, loc, op);
+
+                    quantum::CustomOp hgate_on_0 = createSimpleOneBitGate(
+                        "Hadamard", xgate_on_0->getResult(0), builder, loc, xgate_on_0);
+                    SwapQubit_0_Out.replaceAllUsesWith(hgate_on_0->getResult(0));
+
+                    quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
+                        "Hadamard", SwapQubit_1_In, builder, loc, hgate_on_0);
+
+                    quantum::CustomOp xgate_on_1 = createSimpleOneBitGate(
+                        "PauliX", hgate_on_1->getResult(0), builder, loc, hgate_on_1);
+                    SwapQubit_1_Out.replaceAllUsesWith(xgate_on_1->getResult(0));
+                    op->erase();
+                    return;
+                }
+                // second qubit in NON_BASIS: SWAP(|0>,|NON_BASIS>)
+                else if (pssa.isOther(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp cnot_on_1_0 = createSimpleTwoBitGate(
+                        "CNOT", SwapQubit_1_In, SwapQubit_0_In, builder, loc, op);
+
+                    quantum::CustomOp cnot_on_0_1 = createSimpleTwoBitGate(
+                        "CNOT", cnot_on_1_0->getResult(1), cnot_on_1_0->getResult(0), builder, loc,
+                        cnot_on_1_0);
+
+                    SwapQubit_0_Out.replaceAllUsesWith(cnot_on_0_1->getResult(0));
+                    SwapQubit_1_Out.replaceAllUsesWith(cnot_on_0_1->getResult(1));
+                    op->erase();
+                    return;
+                }
+            }
+
+            // first qubit in |1>
+            else if (pssa.isOne(qubitValues[SwapQubit_0_In])) {
+                // second qubit in |0>: SWAP(|1>,|0>)
+                if (pssa.isZero(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp xgate_on_0 = createSimpleOneBitGate(
+                        "PauliX", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
+                    SwapQubit_0_Out.replaceAllUsesWith(xgate_on_0->getResult(0));
+
+                    quantum::CustomOp xgate_on_1 = createSimpleOneBitGate(
+                        "PauliX", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, xgate_on_0);
+                    SwapQubit_1_Out.replaceAllUsesWith(xgate_on_1->getResult(0));
+                    op->erase();
+                    return;
+                }
+                // second qubit in |1>: SWAP(|1>,|1>)
+                else if (pssa.isOne(qubitValues[SwapQubit_1_In])) {
+                    SwapQubit_0_Out.replaceAllUsesWith(SwapQubit_0_In);
+                    SwapQubit_1_Out.replaceAllUsesWith(SwapQubit_1_In);
+                    op->erase();
+                    return;
+                }
+                // second qubit in |+>: SWAP(|1>,|+>)
+                else if (pssa.isPlus(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp xgate_on_0 =
+                        createSimpleOneBitGate("PauliX", SwapQubit_0_In, builder, loc, op);
+
+                    quantum::CustomOp hgate_on_0 = createSimpleOneBitGate(
+                        "Hadamard", xgate_on_0->getResult(0), builder, loc, xgate_on_0);
+                    SwapQubit_0_Out.replaceAllUsesWith(hgate_on_0->getResult(0));
+
+                    quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
+                        "Hadamard", SwapQubit_1_In, builder, loc, hgate_on_0);
+
+                    quantum::CustomOp xgate_on_1 = createSimpleOneBitGate(
+                        "PauliX", hgate_on_1->getResult(0), builder, loc, hgate_on_1);
+                    SwapQubit_1_Out.replaceAllUsesWith(xgate_on_1->getResult(0));
+                    op->erase();
+                    return;
+                }
+                // second qubit in |->: SWAP(|1>,|->)
+                else if (pssa.isMinus(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp hgate_on_0 = createSimpleOneBitGate(
+                        "Hadamard", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
+                    SwapQubit_0_Out.replaceAllUsesWith(hgate_on_0->getResult(0));
+
+                    quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
+                        "Hadamard", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, hgate_on_0);
+                    SwapQubit_1_Out.replaceAllUsesWith(hgate_on_1->getResult(0));
+                    op->erase();
+                    return;
+                }
+                // second qubit in |NON_BASIS>: SWAP(|1>,|NON_BASIS>)
+                else if (pssa.isOther(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp xgate_on_1 =
+                        createSimpleOneBitGate("PauliX", SwapQubit_1_In, builder, loc, op);
+
+                    quantum::CustomOp cnot_on_1_0 = createSimpleTwoBitGate(
+                        "CNOT", xgate_on_1->getResult(0), SwapQubit_0_In, builder, loc, xgate_on_1);
+
+                    quantum::CustomOp cnot_on_0_1 = createSimpleTwoBitGate(
+                        "CNOT", cnot_on_1_0->getResult(1), cnot_on_1_0->getResult(0), builder, loc,
+                        cnot_on_1_0);
+
+                    SwapQubit_0_Out.replaceAllUsesWith(cnot_on_0_1->getResult(0));
+                    SwapQubit_1_Out.replaceAllUsesWith(cnot_on_0_1->getResult(1));
+                    op->erase();
+                    return;
+                }
+            }
+
+            // first qubit in |+>
+            else if (pssa.isPlus(qubitValues[SwapQubit_0_In])) {
+                // second qubit in |0>: SWAP(|+>,|0>)
+                if (pssa.isZero(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp hgate_on_0 = createSimpleOneBitGate(
+                        "Hadamard", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
+                    SwapQubit_0_Out.replaceAllUsesWith(hgate_on_0->getResult(0));
+
+                    quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
+                        "Hadamard", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, hgate_on_0);
+                    SwapQubit_1_Out.replaceAllUsesWith(hgate_on_1->getResult(0));
+                    op->erase();
+                    return;
+                }
+                // second qubit in |01>: SWAP(|+>,|1>)
+                else if (pssa.isOne(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp hgate_on_0 =
+                        createSimpleOneBitGate("Hadamard", SwapQubit_0_In, builder, loc, op);
+
+                    quantum::CustomOp xgate_on_0 = createSimpleOneBitGate(
+                        "PauliX", hgate_on_0->getResult(0), builder, loc, hgate_on_0);
+                    SwapQubit_0_Out.replaceAllUsesWith(xgate_on_0->getResult(0));
+
+                    quantum::CustomOp xgate_on_1 =
+                        createSimpleOneBitGate("PauliX", SwapQubit_1_In, builder, loc, xgate_on_0);
+
+                    quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
+                        "Hadamard", xgate_on_1->getResult(0), builder, loc, xgate_on_1);
+                    SwapQubit_1_Out.replaceAllUsesWith(hgate_on_1->getResult(0));
+                    op->erase();
+                    return;
+                }
+                // second qubit in |+>: SWAP(|+>,|+>)
+                else if (pssa.isPlus(qubitValues[SwapQubit_1_In])) {
+                    SwapQubit_0_Out.replaceAllUsesWith(SwapQubit_0_In);
+                    SwapQubit_1_Out.replaceAllUsesWith(SwapQubit_1_In);
+                    op->erase();
+                    return;
+                }
+                // second qubit in |->: SWAP(|+>,|->)
+                else if (pssa.isMinus(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp zgate_on_0 = createSimpleOneBitGate(
+                        "PauliZ", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
+                    SwapQubit_0_Out.replaceAllUsesWith(zgate_on_0->getResult(0));
+
+                    quantum::CustomOp zgate_on_1 = createSimpleOneBitGate(
+                        "PauliZ", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, zgate_on_0);
+                    SwapQubit_1_Out.replaceAllUsesWith(zgate_on_1->getResult(0));
+                    op->erase();
+                    return;
+                }
+                // second qubit in |NON_BASIS>: SWAP(|+>,|NON_BASIS>)
+                else if (pssa.isOther(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp cnot_on_0_1 = createSimpleTwoBitGate(
+                        "CNOT", SwapQubit_0_In, SwapQubit_1_In, builder, loc, op);
+
+                    quantum::CustomOp cnot_on_1_0 = createSimpleTwoBitGate(
+                        "CNOT", cnot_on_0_1->getResult(1), cnot_on_0_1->getResult(0), builder, loc,
+                        cnot_on_0_1);
+
+                    SwapQubit_0_Out.replaceAllUsesWith(cnot_on_1_0->getResult(1));
+                    SwapQubit_1_Out.replaceAllUsesWith(cnot_on_1_0->getResult(0));
+                    op->erase();
+                    return;
+                }
+            }
+
+            // first qubit in |->
+            else if (pssa.isMinus(qubitValues[SwapQubit_0_In])) {
+                // second qubit in |0>: SWAP(|->,|0>)
+                if (pssa.isZero(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp hgate_on_0 =
+                        createSimpleOneBitGate("Hadamard", SwapQubit_0_In, builder, loc, op);
+
+                    quantum::CustomOp xgate_on_0 = createSimpleOneBitGate(
+                        "PauliX", hgate_on_0->getResult(0), builder, loc, hgate_on_0);
+                    SwapQubit_0_Out.replaceAllUsesWith(xgate_on_0->getResult(0));
+
+                    quantum::CustomOp xgate_on_1 =
+                        createSimpleOneBitGate("PauliX", SwapQubit_1_In, builder, loc, xgate_on_0);
+
+                    quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
+                        "Hadamard", xgate_on_1->getResult(0), builder, loc, xgate_on_1);
+                    SwapQubit_1_Out.replaceAllUsesWith(hgate_on_1->getResult(0));
+                    op->erase();
+                    return;
+                }
+                // second qubit in |1>: SWAP(|->,|1>)
+                else if (pssa.isOne(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp hgate_on_0 = createSimpleOneBitGate(
+                        "Hadamard", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
+                    SwapQubit_0_Out.replaceAllUsesWith(hgate_on_0->getResult(0));
+
+                    quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
+                        "Hadamard", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, hgate_on_0);
+                    SwapQubit_1_Out.replaceAllUsesWith(hgate_on_1->getResult(0));
+                    op->erase();
+                    return;
+                }
+                // second qubit in |+>: SWAP(|->,|+>)
+                else if (pssa.isPlus(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp zgate_on_0 = createSimpleOneBitGate(
+                        "PauliZ", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
+                    SwapQubit_0_Out.replaceAllUsesWith(zgate_on_0->getResult(0));
+
+                    quantum::CustomOp zgate_on_1 = createSimpleOneBitGate(
+                        "PauliZ", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, zgate_on_0);
+                    SwapQubit_1_Out.replaceAllUsesWith(zgate_on_1->getResult(0));
+                    op->erase();
+                    return;
+                }
+                // second qubit in |->: SWAP(|->,|->)
+                else if (pssa.isMinus(qubitValues[SwapQubit_1_In])) {
+                    SwapQubit_0_Out.replaceAllUsesWith(SwapQubit_0_In);
+                    SwapQubit_1_Out.replaceAllUsesWith(SwapQubit_1_In);
+                    op->erase();
+                    return;
+                }
+                // second qubit in |NON_BASIS>: SWAP(|->,|NON_BASIS>)
+                else if (pssa.isOther(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp zgate_on_1 =
+                        createSimpleOneBitGate("PauliZ", SwapQubit_1_In, builder, loc, op);
+
+                    quantum::CustomOp cnot_on_0_1 = createSimpleTwoBitGate(
+                        "CNOT", SwapQubit_0_In, zgate_on_1->getResult(0), builder, loc, zgate_on_1);
+
+                    quantum::CustomOp cnot_on_1_0 = createSimpleTwoBitGate(
+                        "CNOT", cnot_on_0_1->getResult(1), cnot_on_0_1->getResult(0), builder, loc,
+                        cnot_on_0_1);
+
+                    SwapQubit_0_Out.replaceAllUsesWith(cnot_on_1_0->getResult(1));
+                    SwapQubit_1_Out.replaceAllUsesWith(cnot_on_1_0->getResult(0));
+                    op->erase();
+                    return;
+                }
+            }
+
+            // first qubit in |NON_BASIS>
+            else if (pssa.isOther(qubitValues[SwapQubit_0_In])) {
+                // second qubit in |0>: SWAP(|NON_BASIS>,|0>)
+                if (pssa.isZero(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp cnot_on_0_1 = createSimpleTwoBitGate(
+                        "CNOT", SwapQubit_0_In, SwapQubit_1_In, builder, loc, op);
+
+                    quantum::CustomOp cnot_on_1_0 = createSimpleTwoBitGate(
+                        "CNOT", cnot_on_0_1->getResult(1), cnot_on_0_1->getResult(0), builder, loc,
+                        cnot_on_0_1);
+
+                    SwapQubit_0_Out.replaceAllUsesWith(cnot_on_1_0->getResult(1));
+                    SwapQubit_1_Out.replaceAllUsesWith(cnot_on_1_0->getResult(0));
+                    op->erase();
+                    return;
+                }
+                // second qubit in |1>: SWAP(|NON_BASIS>,|1>)
+                else if (pssa.isOne(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp xgate_on_0 =
+                        createSimpleOneBitGate("PauliX", SwapQubit_0_In, builder, loc, op);
+
+                    quantum::CustomOp cnot_on_0_1 = createSimpleTwoBitGate(
+                        "CNOT", xgate_on_0->getResult(0), SwapQubit_1_In, builder, loc, xgate_on_0);
+
+                    quantum::CustomOp cnot_on_1_0 = createSimpleTwoBitGate(
+                        "CNOT", cnot_on_0_1->getResult(1), cnot_on_0_1->getResult(0), builder, loc,
+                        cnot_on_0_1);
+
+                    SwapQubit_0_Out.replaceAllUsesWith(cnot_on_1_0->getResult(1));
+                    SwapQubit_1_Out.replaceAllUsesWith(cnot_on_1_0->getResult(0));
+                    op->erase();
+                    return;
+                }
+                // second qubit in |+>: SWAP(|NON_BASIS>,|+>)
+                else if (pssa.isPlus(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp cnot_on_1_0 = createSimpleTwoBitGate(
+                        "CNOT", SwapQubit_1_In, SwapQubit_0_In, builder, loc, op);
+
+                    quantum::CustomOp cnot_on_0_1 = createSimpleTwoBitGate(
+                        "CNOT", cnot_on_1_0->getResult(1), cnot_on_1_0->getResult(0), builder, loc,
+                        cnot_on_1_0);
+
+                    SwapQubit_0_Out.replaceAllUsesWith(cnot_on_0_1->getResult(0));
+                    SwapQubit_1_Out.replaceAllUsesWith(cnot_on_0_1->getResult(1));
+                    op->erase();
+                    return;
+                }
+                // second qubit in |->: SWAP(|NON_BASIS>,|->)
+                else if (pssa.isMinus(qubitValues[SwapQubit_1_In])) {
+                    quantum::CustomOp zgate_on_0 =
+                        createSimpleOneBitGate("PauliZ", SwapQubit_0_In, builder, loc, op);
+
+                    quantum::CustomOp cnot_on_1_0 = createSimpleTwoBitGate(
+                        "CNOT", SwapQubit_1_In, zgate_on_0->getResult(0), builder, loc, zgate_on_0);
+
+                    quantum::CustomOp cnot_on_0_1 = createSimpleTwoBitGate(
+                        "CNOT", cnot_on_1_0->getResult(1), cnot_on_1_0->getResult(0), builder, loc,
+                        cnot_on_1_0);
+
+                    SwapQubit_0_Out.replaceAllUsesWith(cnot_on_0_1->getResult(0));
+                    SwapQubit_1_Out.replaceAllUsesWith(cnot_on_0_1->getResult(1));
+                    op->erase();
+                    return;
+                }
+            }
+        });
+    }
+
     void runOnOperation() override
     {
         auto op = getOperation();
-        SmallVector<Operation *> targets;
-        op->walk([&](FunctionOpInterface func) { targets.push_back(func); });
-
-        for (auto func : targets) {
-            mlir::IRRewriter builder(func->getContext());
-            Location loc = func->getLoc();
-
-            PropagateSimpleStatesAnalysis &pssa = getAnalysis<PropagateSimpleStatesAnalysis>();
-            llvm::DenseMap<Value, QubitState> qubitValues = pssa.getQubitValues();
-
-            func->walk([&](quantum::CustomOp op) {
-                StringRef gate = op.getGateName();
-                if (gate != "SWAP") {
-                    return;
-                }
-
-                Value SwapQubit_0_In = op->getOperand(0);
-                Value SwapQubit_1_In = op->getOperand(1);
-                Value SwapQubit_0_Out = op->getResult(0);
-                Value SwapQubit_1_Out = op->getResult(1);
-
-                // first qubit in |0>
-                if (pssa.isZero(qubitValues[SwapQubit_0_In])) {
-                    // second qubit in |0>: SWAP(|0>,|0>)
-                    if (pssa.isZero(qubitValues[SwapQubit_1_In])) {
-                        SwapQubit_0_Out.replaceAllUsesWith(SwapQubit_0_In);
-                        SwapQubit_1_Out.replaceAllUsesWith(SwapQubit_1_In);
-                        op->erase();
-                        return;
-                    }
-                    // second qubit in |1>: SWAP(|0>,|1>)
-                    else if (pssa.isOne(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp xgate_on_0 = createSimpleOneBitGate(
-                            "PauliX", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
-                        SwapQubit_0_Out.replaceAllUsesWith(xgate_on_0->getResult(0));
-
-                        quantum::CustomOp xgate_on_1 = createSimpleOneBitGate(
-                            "PauliX", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, xgate_on_0);
-                        SwapQubit_1_Out.replaceAllUsesWith(xgate_on_1->getResult(0));
-                        op->erase();
-                        return;
-                    }
-                    // second qubit in |+>: SWAP(|0>,|+>)
-                    else if (pssa.isPlus(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp hgate_on_0 = createSimpleOneBitGate(
-                            "Hadamard", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
-                        SwapQubit_0_Out.replaceAllUsesWith(hgate_on_0->getResult(0));
-
-                        quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
-                            "Hadamard", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, hgate_on_0);
-                        SwapQubit_1_Out.replaceAllUsesWith(hgate_on_1->getResult(0));
-                        op->erase();
-                        return;
-                    }
-                    // second qubit in |->: SWAP(|0>,|->)
-                    else if (pssa.isMinus(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp xgate_on_0 =
-                            createSimpleOneBitGate("PauliX", SwapQubit_0_In, builder, loc, op);
-
-                        quantum::CustomOp hgate_on_0 = createSimpleOneBitGate(
-                            "Hadamard", xgate_on_0->getResult(0), builder, loc, xgate_on_0);
-                        SwapQubit_0_Out.replaceAllUsesWith(hgate_on_0->getResult(0));
-
-                        quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
-                            "Hadamard", SwapQubit_1_In, builder, loc, hgate_on_0);
-
-                        quantum::CustomOp xgate_on_1 = createSimpleOneBitGate(
-                            "PauliX", hgate_on_1->getResult(0), builder, loc, hgate_on_1);
-                        SwapQubit_1_Out.replaceAllUsesWith(xgate_on_1->getResult(0));
-                        op->erase();
-                        return;
-                    }
-                    // second qubit in NON_BASIS: SWAP(|0>,|NON_BASIS>)
-                    else if (pssa.isOther(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp cnot_on_1_0 = createSimpleTwoBitGate(
-                            "CNOT", SwapQubit_1_In, SwapQubit_0_In, builder, loc, op);
-
-                        quantum::CustomOp cnot_on_0_1 = createSimpleTwoBitGate(
-                            "CNOT", cnot_on_1_0->getResult(1), cnot_on_1_0->getResult(0), builder,
-                            loc, cnot_on_1_0);
-
-                        SwapQubit_0_Out.replaceAllUsesWith(cnot_on_0_1->getResult(0));
-                        SwapQubit_1_Out.replaceAllUsesWith(cnot_on_0_1->getResult(1));
-                        op->erase();
-                        return;
-                    }
-                }
-
-                // first qubit in |1>
-                else if (pssa.isOne(qubitValues[SwapQubit_0_In])) {
-                    // second qubit in |0>: SWAP(|1>,|0>)
-                    if (pssa.isZero(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp xgate_on_0 = createSimpleOneBitGate(
-                            "PauliX", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
-                        SwapQubit_0_Out.replaceAllUsesWith(xgate_on_0->getResult(0));
-
-                        quantum::CustomOp xgate_on_1 = createSimpleOneBitGate(
-                            "PauliX", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, xgate_on_0);
-                        SwapQubit_1_Out.replaceAllUsesWith(xgate_on_1->getResult(0));
-                        op->erase();
-                        return;
-                    }
-                    // second qubit in |1>: SWAP(|1>,|1>)
-                    else if (pssa.isOne(qubitValues[SwapQubit_1_In])) {
-                        SwapQubit_0_Out.replaceAllUsesWith(SwapQubit_0_In);
-                        SwapQubit_1_Out.replaceAllUsesWith(SwapQubit_1_In);
-                        op->erase();
-                        return;
-                    }
-                    // second qubit in |+>: SWAP(|1>,|+>)
-                    else if (pssa.isPlus(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp xgate_on_0 =
-                            createSimpleOneBitGate("PauliX", SwapQubit_0_In, builder, loc, op);
-
-                        quantum::CustomOp hgate_on_0 = createSimpleOneBitGate(
-                            "Hadamard", xgate_on_0->getResult(0), builder, loc, xgate_on_0);
-                        SwapQubit_0_Out.replaceAllUsesWith(hgate_on_0->getResult(0));
-
-                        quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
-                            "Hadamard", SwapQubit_1_In, builder, loc, hgate_on_0);
-
-                        quantum::CustomOp xgate_on_1 = createSimpleOneBitGate(
-                            "PauliX", hgate_on_1->getResult(0), builder, loc, hgate_on_1);
-                        SwapQubit_1_Out.replaceAllUsesWith(xgate_on_1->getResult(0));
-                        op->erase();
-                        return;
-                    }
-                    // second qubit in |->: SWAP(|1>,|->)
-                    else if (pssa.isMinus(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp hgate_on_0 = createSimpleOneBitGate(
-                            "Hadamard", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
-                        SwapQubit_0_Out.replaceAllUsesWith(hgate_on_0->getResult(0));
-
-                        quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
-                            "Hadamard", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, hgate_on_0);
-                        SwapQubit_1_Out.replaceAllUsesWith(hgate_on_1->getResult(0));
-                        op->erase();
-                        return;
-                    }
-                    // second qubit in |NON_BASIS>: SWAP(|1>,|NON_BASIS>)
-                    else if (pssa.isOther(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp xgate_on_1 =
-                            createSimpleOneBitGate("PauliX", SwapQubit_1_In, builder, loc, op);
-
-                        quantum::CustomOp cnot_on_1_0 =
-                            createSimpleTwoBitGate("CNOT", xgate_on_1->getResult(0), SwapQubit_0_In,
-                                                   builder, loc, xgate_on_1);
-
-                        quantum::CustomOp cnot_on_0_1 = createSimpleTwoBitGate(
-                            "CNOT", cnot_on_1_0->getResult(1), cnot_on_1_0->getResult(0), builder,
-                            loc, cnot_on_1_0);
-
-                        SwapQubit_0_Out.replaceAllUsesWith(cnot_on_0_1->getResult(0));
-                        SwapQubit_1_Out.replaceAllUsesWith(cnot_on_0_1->getResult(1));
-                        op->erase();
-                        return;
-                    }
-                }
-
-                // first qubit in |+>
-                else if (pssa.isPlus(qubitValues[SwapQubit_0_In])) {
-                    // second qubit in |0>: SWAP(|+>,|0>)
-                    if (pssa.isZero(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp hgate_on_0 = createSimpleOneBitGate(
-                            "Hadamard", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
-                        SwapQubit_0_Out.replaceAllUsesWith(hgate_on_0->getResult(0));
-
-                        quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
-                            "Hadamard", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, hgate_on_0);
-                        SwapQubit_1_Out.replaceAllUsesWith(hgate_on_1->getResult(0));
-                        op->erase();
-                        return;
-                    }
-                    // second qubit in |01>: SWAP(|+>,|1>)
-                    else if (pssa.isOne(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp hgate_on_0 =
-                            createSimpleOneBitGate("Hadamard", SwapQubit_0_In, builder, loc, op);
-
-                        quantum::CustomOp xgate_on_0 = createSimpleOneBitGate(
-                            "PauliX", hgate_on_0->getResult(0), builder, loc, hgate_on_0);
-                        SwapQubit_0_Out.replaceAllUsesWith(xgate_on_0->getResult(0));
-
-                        quantum::CustomOp xgate_on_1 = createSimpleOneBitGate(
-                            "PauliX", SwapQubit_1_In, builder, loc, xgate_on_0);
-
-                        quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
-                            "Hadamard", xgate_on_1->getResult(0), builder, loc, xgate_on_1);
-                        SwapQubit_1_Out.replaceAllUsesWith(hgate_on_1->getResult(0));
-                        op->erase();
-                        return;
-                    }
-                    // second qubit in |+>: SWAP(|+>,|+>)
-                    else if (pssa.isPlus(qubitValues[SwapQubit_1_In])) {
-                        SwapQubit_0_Out.replaceAllUsesWith(SwapQubit_0_In);
-                        SwapQubit_1_Out.replaceAllUsesWith(SwapQubit_1_In);
-                        op->erase();
-                        return;
-                    }
-                    // second qubit in |->: SWAP(|+>,|->)
-                    else if (pssa.isMinus(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp zgate_on_0 = createSimpleOneBitGate(
-                            "PauliZ", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
-                        SwapQubit_0_Out.replaceAllUsesWith(zgate_on_0->getResult(0));
-
-                        quantum::CustomOp zgate_on_1 = createSimpleOneBitGate(
-                            "PauliZ", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, zgate_on_0);
-                        SwapQubit_1_Out.replaceAllUsesWith(zgate_on_1->getResult(0));
-                        op->erase();
-                        return;
-                    }
-                    // second qubit in |NON_BASIS>: SWAP(|+>,|NON_BASIS>)
-                    else if (pssa.isOther(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp cnot_on_0_1 = createSimpleTwoBitGate(
-                            "CNOT", SwapQubit_0_In, SwapQubit_1_In, builder, loc, op);
-
-                        quantum::CustomOp cnot_on_1_0 = createSimpleTwoBitGate(
-                            "CNOT", cnot_on_0_1->getResult(1), cnot_on_0_1->getResult(0), builder,
-                            loc, cnot_on_0_1);
-
-                        SwapQubit_0_Out.replaceAllUsesWith(cnot_on_1_0->getResult(1));
-                        SwapQubit_1_Out.replaceAllUsesWith(cnot_on_1_0->getResult(0));
-                        op->erase();
-                        return;
-                    }
-                }
-
-                // first qubit in |->
-                else if (pssa.isMinus(qubitValues[SwapQubit_0_In])) {
-                    // second qubit in |0>: SWAP(|->,|0>)
-                    if (pssa.isZero(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp hgate_on_0 =
-                            createSimpleOneBitGate("Hadamard", SwapQubit_0_In, builder, loc, op);
-
-                        quantum::CustomOp xgate_on_0 = createSimpleOneBitGate(
-                            "PauliX", hgate_on_0->getResult(0), builder, loc, hgate_on_0);
-                        SwapQubit_0_Out.replaceAllUsesWith(xgate_on_0->getResult(0));
-
-                        quantum::CustomOp xgate_on_1 = createSimpleOneBitGate(
-                            "PauliX", SwapQubit_1_In, builder, loc, xgate_on_0);
-
-                        quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
-                            "Hadamard", xgate_on_1->getResult(0), builder, loc, xgate_on_1);
-                        SwapQubit_1_Out.replaceAllUsesWith(hgate_on_1->getResult(0));
-                        op->erase();
-                        return;
-                    }
-                    // second qubit in |1>: SWAP(|->,|1>)
-                    else if (pssa.isOne(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp hgate_on_0 = createSimpleOneBitGate(
-                            "Hadamard", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
-                        SwapQubit_0_Out.replaceAllUsesWith(hgate_on_0->getResult(0));
-
-                        quantum::CustomOp hgate_on_1 = createSimpleOneBitGate(
-                            "Hadamard", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, hgate_on_0);
-                        SwapQubit_1_Out.replaceAllUsesWith(hgate_on_1->getResult(0));
-                        op->erase();
-                        return;
-                    }
-                    // second qubit in |+>: SWAP(|->,|+>)
-                    else if (pssa.isPlus(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp zgate_on_0 = createSimpleOneBitGate(
-                            "PauliZ", SwapQubit_0_In, SwapQubit_0_Out, builder, loc, op);
-                        SwapQubit_0_Out.replaceAllUsesWith(zgate_on_0->getResult(0));
-
-                        quantum::CustomOp zgate_on_1 = createSimpleOneBitGate(
-                            "PauliZ", SwapQubit_1_In, SwapQubit_1_Out, builder, loc, zgate_on_0);
-                        SwapQubit_1_Out.replaceAllUsesWith(zgate_on_1->getResult(0));
-                        op->erase();
-                        return;
-                    }
-                    // second qubit in |->: SWAP(|->,|->)
-                    else if (pssa.isMinus(qubitValues[SwapQubit_1_In])) {
-                        SwapQubit_0_Out.replaceAllUsesWith(SwapQubit_0_In);
-                        SwapQubit_1_Out.replaceAllUsesWith(SwapQubit_1_In);
-                        op->erase();
-                        return;
-                    }
-                    // second qubit in |NON_BASIS>: SWAP(|->,|NON_BASIS>)
-                    else if (pssa.isOther(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp zgate_on_1 =
-                            createSimpleOneBitGate("PauliZ", SwapQubit_1_In, builder, loc, op);
-
-                        quantum::CustomOp cnot_on_0_1 =
-                            createSimpleTwoBitGate("CNOT", SwapQubit_0_In, zgate_on_1->getResult(0),
-                                                   builder, loc, zgate_on_1);
-
-                        quantum::CustomOp cnot_on_1_0 = createSimpleTwoBitGate(
-                            "CNOT", cnot_on_0_1->getResult(1), cnot_on_0_1->getResult(0), builder,
-                            loc, cnot_on_0_1);
-
-                        SwapQubit_0_Out.replaceAllUsesWith(cnot_on_1_0->getResult(1));
-                        SwapQubit_1_Out.replaceAllUsesWith(cnot_on_1_0->getResult(0));
-                        op->erase();
-                        return;
-                    }
-                }
-
-                // first qubit in |NON_BASIS>
-                else if (pssa.isOther(qubitValues[SwapQubit_0_In])) {
-                    // second qubit in |0>: SWAP(|NON_BASIS>,|0>)
-                    if (pssa.isZero(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp cnot_on_0_1 = createSimpleTwoBitGate(
-                            "CNOT", SwapQubit_0_In, SwapQubit_1_In, builder, loc, op);
-
-                        quantum::CustomOp cnot_on_1_0 = createSimpleTwoBitGate(
-                            "CNOT", cnot_on_0_1->getResult(1), cnot_on_0_1->getResult(0), builder,
-                            loc, cnot_on_0_1);
-
-                        SwapQubit_0_Out.replaceAllUsesWith(cnot_on_1_0->getResult(1));
-                        SwapQubit_1_Out.replaceAllUsesWith(cnot_on_1_0->getResult(0));
-                        op->erase();
-                        return;
-                    }
-                    // second qubit in |1>: SWAP(|NON_BASIS>,|1>)
-                    else if (pssa.isOne(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp xgate_on_0 =
-                            createSimpleOneBitGate("PauliX", SwapQubit_0_In, builder, loc, op);
-
-                        quantum::CustomOp cnot_on_0_1 =
-                            createSimpleTwoBitGate("CNOT", xgate_on_0->getResult(0), SwapQubit_1_In,
-                                                   builder, loc, xgate_on_0);
-
-                        quantum::CustomOp cnot_on_1_0 = createSimpleTwoBitGate(
-                            "CNOT", cnot_on_0_1->getResult(1), cnot_on_0_1->getResult(0), builder,
-                            loc, cnot_on_0_1);
-
-                        SwapQubit_0_Out.replaceAllUsesWith(cnot_on_1_0->getResult(1));
-                        SwapQubit_1_Out.replaceAllUsesWith(cnot_on_1_0->getResult(0));
-                        op->erase();
-                        return;
-                    }
-                    // second qubit in |+>: SWAP(|NON_BASIS>,|+>)
-                    else if (pssa.isPlus(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp cnot_on_1_0 = createSimpleTwoBitGate(
-                            "CNOT", SwapQubit_1_In, SwapQubit_0_In, builder, loc, op);
-
-                        quantum::CustomOp cnot_on_0_1 = createSimpleTwoBitGate(
-                            "CNOT", cnot_on_1_0->getResult(1), cnot_on_1_0->getResult(0), builder,
-                            loc, cnot_on_1_0);
-
-                        SwapQubit_0_Out.replaceAllUsesWith(cnot_on_0_1->getResult(0));
-                        SwapQubit_1_Out.replaceAllUsesWith(cnot_on_0_1->getResult(1));
-                        op->erase();
-                        return;
-                    }
-                    // second qubit in |->: SWAP(|NON_BASIS>,|->)
-                    else if (pssa.isMinus(qubitValues[SwapQubit_1_In])) {
-                        quantum::CustomOp zgate_on_0 =
-                            createSimpleOneBitGate("PauliZ", SwapQubit_0_In, builder, loc, op);
-
-                        quantum::CustomOp cnot_on_1_0 =
-                            createSimpleTwoBitGate("CNOT", SwapQubit_1_In, zgate_on_0->getResult(0),
-                                                   builder, loc, zgate_on_0);
-
-                        quantum::CustomOp cnot_on_0_1 = createSimpleTwoBitGate(
-                            "CNOT", cnot_on_1_0->getResult(1), cnot_on_1_0->getResult(0), builder,
-                            loc, cnot_on_1_0);
-
-                        SwapQubit_0_Out.replaceAllUsesWith(cnot_on_0_1->getResult(0));
-                        SwapQubit_1_Out.replaceAllUsesWith(cnot_on_0_1->getResult(1));
-                        op->erase();
-                        return;
-                    }
-                }
-            });
-        }
+        op->walk([&](FunctionOpInterface func) { disentangleSWAPs(func); });
     }
 };
 

--- a/mlir/test/Quantum/DisentangleCNOTTest.mlir
+++ b/mlir/test/Quantum/DisentangleCNOTTest.mlir
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// RUN: quantum-opt %s --pass-pipeline="builtin.module(func.func(disentangle-CNOT))" --split-input-file --verify-diagnostics | FileCheck %s
+// RUN: quantum-opt %s --pass-pipeline="builtin.module(disentangle-CNOT)" --split-input-file --verify-diagnostics | FileCheck %s
 
 
 // Explicit unit tests for all CNOT disentangling table entries

--- a/mlir/test/Quantum/DisentangleSWAPTest.mlir
+++ b/mlir/test/Quantum/DisentangleSWAPTest.mlir
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// RUN: quantum-opt %s --pass-pipeline="builtin.module(func.func(disentangle-SWAP))" --split-input-file --verify-diagnostics | FileCheck %s
+// RUN: quantum-opt %s --pass-pipeline="builtin.module(disentangle-SWAP)" --split-input-file --verify-diagnostics | FileCheck %s
 
 
 // Explicit unit tests for all SWAP disentangling table entries

--- a/mlir/test/Quantum/PropagateSimpleStatesTest.mlir
+++ b/mlir/test/Quantum/PropagateSimpleStatesTest.mlir
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// RUN: quantum-opt %s --pass-pipeline="builtin.module(func.func(disentangle-CNOT{emit-FSM-state-remark=true}))" --split-input-file --verify-diagnostics | FileCheck %s
+// RUN: quantum-opt %s --pass-pipeline="builtin.module(disentangle-CNOT{emit-FSM-state-remark=true})" --split-input-file --verify-diagnostics | FileCheck %s
 
 
 // Basic test with an actual circuit that has every state in the standard FSM.


### PR DESCRIPTION
**Context:** The `apply_pass` function from the frontend is capable of scheduling any MLIR pass from the frontend for a specific qnode. However, in order for the pass to succeed in its compilation, it must allow itself to be scheduled to transform a module.

**Description of the Change:** There is another branch that I worked on where I moved the bulk of the transformation to Patterns; however, the pattern applicators that are upstream in MLIR do not support running a single iteration of the worklist. I would like at some point to add a custom pattern applicator that doesn't fold and only does a single pass through the worklist (or take a variable). The passes as written represent a single iteration through the worklist. Running a single iteration through the worklist may not yield all full optimizations, but that's how it is currently coded. I think this is acceptable as we don't yet do a cost benefit analysis for any transformation.

**Benefits:** Can write the following:

```python
import jax
import pennylane as qml

import catalyst


@qml.qjit(keep_intermediate=True)
@catalyst.passes.apply_pass("disentangle-CNOT")
@qml.qnode(qml.device("lightning.qubit", wires=2))
def foo():
    qml.Hadamard(0)
    qml.Hadamard(0)
    qml.Hadamard(1)
    qml.Hadamard(1)
    qml.CNOT(wires=[0, 1])
    return qml.state()


foo()
print(foo.mlir)
```
