### PR TITLE
Bump CPL RC versions for Catalyst 0.10.0

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -39,7 +39,7 @@ jobs:
         git checkout $(git tag | sort -V | tail -1)
     - if: ${{ inputs.catalyst == 'release-candidate' }}
       run: |
-        git checkout v0.9.0-rc
+        git checkout v0.10.0-rc
 
     - name: Install deps
       run: |
@@ -124,7 +124,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: PennyLaneAI/pennylane-lightning
-        ref: v0.39.0_rc
+        ref: v0.40.0_rc
         path: lightning_build
         fetch-depth: 0
 
@@ -153,7 +153,7 @@ jobs:
     - name: Install PennyLane (release-candidate)
       if: ${{ inputs.pennylane == 'release-candidate' }}
       run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.39.0-rc0
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.40.0-rc0
 
     - name: Add Frontend Dependencies to PATH
       run: |


### PR DESCRIPTION
**Context:** In preparation for the Catalyst 0.10.0 release candidate (RC), the GitHub action must point to the corresponding RC branch, `v0.10.0-rc`.

**Description of the Change:** Update the Catalyst RC branch `v0.9.0-rc` -> `v0.10.0-rc`, as well as the corresponding RC branches for Lightning and PennyLane from `v0.39.0` to `v0.40.0`.