### PR TITLE
Fix typo in changelog for development release

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1,4 +1,4 @@
-# Release 0.10.0 (development release)
+# Release 0.11.0 (development release)
 
 <h3>New features since last release</h3>
 


### PR DESCRIPTION
**Context:** The new development release is v0.11.0, not v0.10.0. :confounded: 

**Description of the Change:** Fix typo in title of changelog for development release. 
