### PR TITLE
Add ComplexType to the list of supported types for the MemrefToLLVMWithTBAA pass

### DIFF
--- a/doc/releases/changelog-0.10.0.md
+++ b/doc/releases/changelog-0.10.0.md
@@ -171,6 +171,10 @@
   to not work properly.
   [(#1405)](https://github.com/PennyLaneAI/catalyst/pull/1405)
 
+* Fixed a bug that made `catalyst.grad` break when using a computed decomposition or a unitary to 
+rotation transform inside a QNode.
+  [(#1417)](https://github.com/PennyLaneAI/catalyst/pull/1417)
+
 <h3>Internal changes ⚙️</h3>
 
 * Catalyst no longer depends on or pins the `scipy` package. Instead, OpenBLAS is sourced directly

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1790,7 +1790,7 @@ class TestDecompositionGradient:
 
         @qml.qnode(dev)
         def circuit(x):
-            U = jnp.array([[1, 0], [0, x]])
+            U = jnp.array([[1, 0], [0, jnp.exp(1j * x)]])
             decomp = qml.QubitUnitary.compute_decomposition(U, wires=0)
             for op in decomp:
                 qml.apply(op)
@@ -1800,7 +1800,7 @@ class TestDecompositionGradient:
             probs = circuit(x)
             return probs[0] + probs[1]
 
-        assert np.isnan(grad(qjit(f), argnums=0)(0.0)) == True
+        assert np.isnan(grad(qjit(f), argnums=0)(1.0)) == True
 
     def test_unitary_to_rot(self):
         """Test usage with unitary to rot transform."""
@@ -1810,7 +1810,7 @@ class TestDecompositionGradient:
         @qml.transforms.unitary_to_rot
         @qml.qnode(dev)
         def circuit(x):
-            U = jnp.array([[1, 0], [0, x]])
+            U = jnp.array([[1, 0], [0, jnp.exp(1j * x)]])
             qml.QubitUnitary(U, wires=0)
             return qml.probs()
 
@@ -1818,7 +1818,7 @@ class TestDecompositionGradient:
             probs = circuit(x)
             return probs[0] + probs[1]
 
-        assert np.isnan(grad(qjit(f), argnums=0)(0.0)) == True
+        assert np.isnan(grad(qjit(f), argnums=0)(1.0)) == True
 
 
 if __name__ == "__main__":

--- a/mlir/lib/Catalyst/Transforms/TBAAPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/TBAAPatterns.cpp
@@ -71,7 +71,7 @@ struct MemrefLoadTBAARewritePattern : public ConvertOpToLLVMPattern<memref::Load
             loadOp, typeConverter->convertType(type.getElementType()), dataPtr, 0, false,
             loadOp.getNontemporal());
 
-        if (isAnyOf<IndexType, IntegerType, FloatType, MemRefType>(baseType)) {
+        if (isAnyOf<IndexType, IntegerType, FloatType, MemRefType, ComplexType>(baseType)) {
             setTag(baseType, tree, loadOp.getContext(), op);
         }
         else {
@@ -102,7 +102,7 @@ struct MemrefStoreTBAARewritePattern : public ConvertOpToLLVMPattern<memref::Sto
         auto op = rewriter.replaceOpWithNewOp<LLVM::StoreOp>(storeOp, adaptor.getValue(), dataPtr,
                                                              0, false, storeOp.getNontemporal());
 
-        if (isAnyOf<IndexType, IntegerType, FloatType, MemRefType>(baseType)) {
+        if (isAnyOf<IndexType, IntegerType, FloatType, MemRefType, ComplexType>(baseType)) {
             setTag(baseType, tree, storeOp.getContext(), op);
         }
         else {


### PR DESCRIPTION
**Context:** According to https://github.com/PennyLaneAI/catalyst/issues/1393 , processing the 
 'MemrefToLLVMWithTBAAPass' pass failed to lower the MLIR module. Further investigation showed  the generated code contained memrefs of complex type, which are not covered by the mentioned pass:

```
%alloc_5 = memref.alloc() {alignment = 64 : i64} : memref<1x2x2xcomplex<f64>> 
```

**Description of the Change:** Add ComplexType to the list of supported types 

**Benefits:** Extended type support

**Related GitHub Issues:** https://github.com/PennyLaneAI/catalyst/issues/1393

**TODO:**

- [x] Add tests
- [x] Update changelog
- [x] Investigate why the test program outputs `nan`
