### PR TITLE
Improve error message for invalid measurement in adjoint() region

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -15,6 +15,9 @@
 * `from_plxpr` now uses the `qml.capture.PlxprInterpreter` class for reduced code duplication.
   [(#1398)](https://github.com/PennyLaneAI/catalyst/pull/1398)
 
+* Improve the error message for invalid measurement in `adjoin()` or `ctrl()` region.
+  [(#1425)](https://github.com/PennyLaneAI/catalyst/pull/1425)
+
 <h3>Documentation 📝</h3>
 
 <h3>Contributors ✍️</h3>
@@ -22,3 +25,4 @@
 This release contains contributions from (in alphabetical order):
 
 Christina Lee
+Sengthai Heng

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -722,4 +722,6 @@ def _check_no_measurements(tape: QuantumTape) -> None:
                 _check_no_measurements(r.quantum_tape)
         else:
             if isinstance(op, MidCircuitMeasure):
-                raise ValueError("Measurements are not invertible and cannot be used within an adjoint() region.")
+                raise ValueError(
+                    "Measurements are not invertible and cannot be used within an adjoint() region."
+                )

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -723,5 +723,5 @@ def _check_no_measurements(tape: QuantumTape) -> None:
         else:
             if isinstance(op, MidCircuitMeasure):
                 raise ValueError(
-                    "Measurements are not invertible and cannot be used within an adjoint() region."
+                    "Measurements cannot be used within an adjoint() or ctrl() region."
                 )

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -713,7 +713,7 @@ def _check_no_measurements(tape: QuantumTape) -> None:
     """Check the nested quantum tape for the absense of quantum measurements of any kind"""
 
     if len(tape.measurements) > 0:
-        raise ValueError("Measurement processes cannot be used within an adjoint() or ctrl() region.")
+        raise ValueError("Measurement process cannot be used within an adjoint() or ctrl() region.")
     for op in tape.operations:
         if has_nested_tapes(op):
             for r in [r for r in op.regions if r.quantum_tape is not None]:
@@ -721,5 +721,6 @@ def _check_no_measurements(tape: QuantumTape) -> None:
         else:
             if isinstance(op, MidCircuitMeasure):
                 raise ValueError(
-                    "Mid-circuit measurements cannot be used within an adjoint() or ctrl() region."
+                    "Mid-circuit measurements cannot be used "
+                    "within an adjoint() or ctrl() region."
                 )

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -712,10 +712,8 @@ def ctrl_distribute(
 def _check_no_measurements(tape: QuantumTape) -> None:
     """Check the nested quantum tape for the absense of quantum measurements of any kind"""
 
-    msg = "Quantum measurements are not allowed"
-
     if len(tape.measurements) > 0:
-        raise ValueError(msg)
+        raise ValueError("Quantum measurements are not allowed")
     for op in tape.operations:
         if has_nested_tapes(op):
             for r in [r for r in op.regions if r.quantum_tape is not None]:

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -721,5 +721,5 @@ def _check_no_measurements(tape: QuantumTape) -> None:
         else:
             if isinstance(op, MidCircuitMeasure):
                 raise ValueError(
-                    "Measurements cannot be used within an adjoint() or ctrl() region."
+                    "Mid-circuit measurements cannot be used within an adjoint() or ctrl() region."
                 )

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -713,7 +713,7 @@ def _check_no_measurements(tape: QuantumTape) -> None:
     """Check the nested quantum tape for the absense of quantum measurements of any kind"""
 
     if len(tape.measurements) > 0:
-        raise ValueError("Quantum measurements are not allowed")
+        raise ValueError("Measurement processes cannot be used within an adjoint() or ctrl() region.")
     for op in tape.operations:
         if has_nested_tapes(op):
             for r in [r for r in op.regions if r.quantum_tape is not None]:

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -722,4 +722,4 @@ def _check_no_measurements(tape: QuantumTape) -> None:
                 _check_no_measurements(r.quantum_tape)
         else:
             if isinstance(op, MidCircuitMeasure):
-                raise ValueError(msg)
+                raise ValueError("Measurements are not invertible and cannot be used within an adjoint() region.")

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -245,7 +245,7 @@ class TestCatalyst:
             qml.RX(np.pi / 2, wires=0)
             qml.sample()
 
-        with pytest.raises(ValueError, match="Quantum measurements are not allowed"):
+        with pytest.raises(ValueError, match="Measurement process cannot be used"):
 
             @qjit
             @qml.qnode(qml.device("lightning.qubit", wires=2))

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -290,7 +290,7 @@ class TestCatalystControlled:
             C_ctrl(_func1, control=[1], control_values=[True])()
             return qml.state()
 
-        with pytest.raises(ValueError, match="measurements are not allowed"):
+        with pytest.raises(ValueError, match="Measurements cannot be used"):
             qjit(circuit)(0.1)
 
     def test_qctrl_no_end_circuit_measurements(self, backend):

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -290,7 +290,7 @@ class TestCatalystControlled:
             C_ctrl(_func1, control=[1], control_values=[True])()
             return qml.state()
 
-        with pytest.raises(ValueError, match="Measurements cannot be used"):
+        with pytest.raises(ValueError, match="Mid-circuit measurements cannot be used"):
             qjit(circuit)(0.1)
 
     def test_qctrl_no_end_circuit_measurements(self, backend):
@@ -305,7 +305,7 @@ class TestCatalystControlled:
             C_ctrl(_func1, control=[1], control_values=[True])()
             return qml.state()
 
-        with pytest.raises(ValueError, match="measurements are not allowed"):
+        with pytest.raises(ValueError, match="Measurement process cannot be used"):
             qjit(circuit)(0.1)
 
     def test_qctrl_wires(self, backend):


### PR DESCRIPTION
**Context:**
Improve the error message when using measure within an `adjoin()` region.

**Example**
```python
import pennylane as qml
from pennylane import qjit
from catalyst import measure

dev = qml.device("lightning.qubit", wires=1)

@qjit
@qml.qnode(dev)
def circuit():
    def foo():
        measure(wires=0)
    qml.adjoint(foo)()
    return qml.expval(qml.PauliZ(0))

print(circuit())
```

**Description of the Change:**
Write and insert an error message `"Measurements are not invertible and cannot be used within an adjoint() region."` 

**Related GitHub Issues:**
#1188 
