### PR TITLE
Changed ValueRange to ResultRange and Value to OpResult in Gate_Op

### DIFF
--- a/mlir/include/Quantum/IR/QuantumInterfaces.td
+++ b/mlir/include/Quantum/IR/QuantumInterfaces.td
@@ -73,7 +73,7 @@ def QuantumOperation : OpInterface<"QuantumOperation"> {
         >,
         InterfaceMethod<
             "Return all results which are considered output qubit values (including controls).",
-            "std::vector<mlir::Value>", "getQubitResults"
+            "std::vector<mlir::OpResult>", "getQubitResults"
         >
     ];
 
@@ -129,7 +129,7 @@ def QuantumGate : OpInterface<"QuantumGate", [QuantumOperation]> {
         >,
         InterfaceMethod<
             "Return all operands which are considered controlling output qubit values.",
-            "mlir::ValueRange", "getCtrlQubitResults"
+            "mlir::ResultRange", "getCtrlQubitResults"
         >,
         InterfaceMethod<
             "Return adjoint flag.",

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -211,8 +211,8 @@ class Gate_Op<string mnemonic, list<Trait> traits = []> :
             qubits.assign(replacements);
         }
 
-        std::vector<mlir::Value> getQubitResults() {
-            std::vector<mlir::Value> values;
+        std::vector<mlir::OpResult> getQubitResults() {
+            std::vector<mlir::OpResult> values;
             values.insert(values.end(), getOutQubits().begin(), getOutQubits().end());
             return values;
         }
@@ -242,8 +242,8 @@ class UnitaryGate_Op<string mnemonic, list<Trait> traits = []> :
             ctrls.assign(replacements.take_back(ctrls.size()));
         }
 
-        std::vector<mlir::Value> getQubitResults() {
-            std::vector<mlir::Value> values;
+        std::vector<mlir::OpResult> getQubitResults() {
+            std::vector<mlir::OpResult> values;
             values.insert(values.end(), getOutQubits().begin(), getOutQubits().end());
             values.insert(values.end(), getOutCtrlQubits().begin(), getOutCtrlQubits().end());
             return values;
@@ -283,10 +283,10 @@ class UnitaryGate_Op<string mnemonic, list<Trait> traits = []> :
                    "must provide values for all control qubit values");
             ctrls.assign(replacements);
         }
-        mlir::ValueRange getNonCtrlQubitResults() {
+        mlir::ResultRange getNonCtrlQubitResults() {
             return getOutQubits();
         }
-        mlir::ValueRange getCtrlQubitResults() {
+        mlir::ResultRange getCtrlQubitResults() {
             return getOutCtrlQubits();
         }
     }];


### PR DESCRIPTION
**Context:**
This PR updates `gate_op` by replacing `ValueRange` with `ResultRange` and `Value` with `OpResult` to better align with the semantics of `**QubitResult()` functions like `getNonCtrlQubitResults()`. This change ensures clearer intent and usage.

**Related GitHub Issues:**
#1192 
