### PR TITLE
Fix python formatting

### DIFF
--- a/frontend/test/pytest/test_mlir_plugin_interface.py
+++ b/frontend/test/pytest/test_mlir_plugin_interface.py
@@ -17,7 +17,9 @@
 from pathlib import Path
 
 import pytest
+
 import catalyst
+
 
 def test_path_does_not_exists():
     """Test what happens when a pass_plugin is given an path that does not exist"""


### PR DESCRIPTION
**Context:** Some invalid Python code formatting slipped into the codebase. The offending file is `frontend/test/pytest/test_mlir_plugin_interface.py`.

**Description of the Change:** Run `make format` to fix formatting warnings.