### PR TITLE
Refactor 'merge_ rotations' and 'cancel_inverses' peephole optimizations tests

### DIFF
--- a/frontend/test/pytest/test_peephole_optimizations.py
+++ b/frontend/test/pytest/test_peephole_optimizations.py
@@ -23,6 +23,7 @@ from catalyst.passes import cancel_inverses, merge_rotations
 
 # pylint: disable=missing-function-docstring
 
+
 #
 # cancel_inverses
 #

--- a/frontend/test/pytest/test_peephole_optimizations.py
+++ b/frontend/test/pytest/test_peephole_optimizations.py
@@ -74,7 +74,7 @@ def test_merge_rotation_functionality(theta, backend):
 
     customized_device = qml.device(backend, wires=1)
     qjitted_workflow = qjit(qml.QNode(circuit, customized_device))
-    optimized_workflow = qjit(cancel_inverses(qml.QNode(circuit, customized_device)))
+    optimized_workflow = qjit(merge_rotations(qml.QNode(circuit, customized_device)))
 
     assert np.allclose(reference_workflow(theta), qjitted_workflow(theta))
     assert np.allclose(reference_workflow(theta), optimized_workflow(theta))


### PR DESCRIPTION
**Context:** The tests for both  'merge_rotations' and 'cancel_inverses' peephole optimizations contained a lot of duplicated code. 

**Description of the Change:** Use one single circuit for each optimization and apply stacked modifiers to create the reference and modified versions.

**Benefits:** Remove boiler-plate, which makes maintenance easier. 

**Possible Drawbacks:** The usage of stacked modifiers instead of stacked decorators might decrease code readability.
