### PR TITLE
Test MLIR conversion correctness of peephole optimizations

### DIFF
--- a/frontend/test/pytest/test_peephole_optimizations.py
+++ b/frontend/test/pytest/test_peephole_optimizations.py
@@ -23,6 +23,7 @@ from catalyst.passes import cancel_inverses, merge_rotations
 
 # pylint: disable=missing-function-docstring
 
+
 #
 # cancel_inverses
 #

--- a/frontend/test/pytest/test_peephole_optimizations.py
+++ b/frontend/test/pytest/test_peephole_optimizations.py
@@ -74,7 +74,7 @@ def test_merge_rotation_functionality(theta, backend):
 
     customized_device = qml.device(backend, wires=1)
     qjitted_workflow = qjit(qml.QNode(circuit, customized_device))
-    optimized_workflow = qjit(cancel_inverses(qml.QNode(circuit, customized_device)))
+    optimized_workflow = qjit(merge_rotations(qml.QNode(circuit, customized_device)))
 
     assert np.allclose(reference_workflow(theta), qjitted_workflow(theta))
     assert np.allclose(reference_workflow(theta), optimized_workflow(theta))


### PR DESCRIPTION
**Context:** Peephole optimizations tests are not compared against their  manually optimized counterparts.

**Description of the Change:** Add the manual optimized version of the code and compare its results against the ones applying optimizations. Also, count the number of gates in the MLIR and compare among the different versions.

**Benefits:** Make sure the optimizations are really happening.
