### PR TITLE
Fix docstring in qjit: Replace `verbosity` with `verbose`

### DIFF
--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -116,7 +116,7 @@ def qjit(
             compilation. If ``True``, intermediate representations are available via the
             :attr:`~.QJIT.mlir`, :attr:`~.QJIT.jaxpr`, and :attr:`~.QJIT.qir`, representing
             different stages in the optimization process.
-        verbosity (bool): If ``True``, the tools and flags used by Catalyst behind the scenes are
+        verbose (bool): If ``True``, the tools and flags used by Catalyst behind the scenes are
             printed out.
         logfile (Optional[TextIOWrapper]): File object to write verbose messages to (default -
             ``sys.stderr``).


### PR DESCRIPTION
**Context:**
Correct a minor error in the qjit docstring. The parameter `verbosity` was mistakenly used instead of verbose.