### PR TITLE
Bump PennyLane dep version from 20 to 51

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.149
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt
-pennylane=0.40.0-dev20
+pennylane=0.40.0-dev51
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'


### PR DESCRIPTION
**Context:** Investigating failed frontend tests on macOS (arm64)

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
