### PR TITLE
Change the pattern rewrite infrastructure in quantum-to-ion lowering pass to use dialect conversion

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,6 +4,10 @@
 
 <h3>Improvements 🛠</h3>
 
+* Changed pattern rewritting in `quantum-to-ion` lowering pass to use MLIR's dialect conversion
+  infrastracture.
+  [(#1442)](https://github.com/PennyLaneAI/catalyst/pull/1442)
+
 <h3>Breaking changes 💔</h3>
 
 <h3>Deprecations 👋</h3>

--- a/mlir/test/Ion/QuantumToIon.mlir
+++ b/mlir/test/Ion/QuantumToIon.mlir
@@ -21,8 +21,6 @@
 // CHECK-LABEL: example_ion_two_qubit
 func.func @example_ion_two_qubit(%arg0: f64) -> !quantum.bit {
 
-    // CHECK-DAG: [[rabi1:%.+]] = arith.constant 1.100000e+00 : f64
-    // CHECK-DAG: [[rabi2:%.+]] = arith.constant 1.230000e+00 : f64
 
     // COM: attr-dict in op's assembly format sorts fields alphabetically
     // COM: so we have to CHECK-SAME in alphabetical order as well
@@ -147,6 +145,7 @@ func.func @example_ion_two_qubit(%arg0: f64) -> !quantum.bit {
 
     // CHECK: [[rx1out:%.+]] = ion.parallelprotocol([[qubit0]]) : !quantum.bit {
     // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit):
+    // CHECK-NEXT: [[rabi1:%.+]] = arith.constant 1.100000e+00 : f64
     // CHECK-NEXT: [[timerx1:%.+]] = arith.divf %arg0, [[rabi1]] : f64
     // CHECK-NEXT: ion.pulse([[timerx1]] : f64) %arg1 {
     // CHECK-SAME:     beam = #ion.beam<
@@ -169,6 +168,7 @@ func.func @example_ion_two_qubit(%arg0: f64) -> !quantum.bit {
 
     // CHECK: [[ry1out:%.+]] = ion.parallelprotocol([[rx1out]]) : !quantum.bit {
     // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit):
+    // CHECK-NEXT: [[rabi1:%.+]] = arith.constant 1.100000e+00 : f64
     // CHECK-NEXT: [[timery1:%.+]] = arith.divf %arg0, [[rabi1]] : f64
     // CHECK-NEXT: ion.pulse([[timery1]] : f64) %arg1 {
     // CHECK-SAME:     beam = #ion.beam<
@@ -191,6 +191,7 @@ func.func @example_ion_two_qubit(%arg0: f64) -> !quantum.bit {
 
     // CHECK: [[rx2out:%.+]] = ion.parallelprotocol([[ry1out]]) : !quantum.bit {
     // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit):
+    // CHECK-NEXT: [[rabi1:%.+]] = arith.constant 1.100000e+00 : f64
     // CHECK-NEXT: [[timerx2:%.+]] = arith.divf %arg0, [[rabi1]] : f64
     // CHECK-NEXT: ion.pulse([[timerx2]] : f64) %arg1 {
     // CHECK-SAME:     beam = #ion.beam<
@@ -213,6 +214,7 @@ func.func @example_ion_two_qubit(%arg0: f64) -> !quantum.bit {
 
     // CHECK: [[msout:%.+]] = ion.parallelprotocol([[rx2out]], [[qubit1]]) : !quantum.bit, !quantum.bit {
     // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit, %arg2: !quantum.bit):
+    // CHECK-NEXT: [[rabi2:%.+]] = arith.constant 1.230000e+00 : f64
     // CHECK-NEXT: [[timems:%.+]] = arith.divf %arg0, [[rabi2]] : f64
     // CHECK-NEXT: ion.pulse([[timems]] : f64) %arg1 {
     // CHECK-SAME:     beam = #ion.beam<
@@ -274,10 +276,6 @@ func.func @example_ion_two_qubit(%arg0: f64) -> !quantum.bit {
 // CHECK-LABEL: example_ion_three_qubit
 func.func @example_ion_three_qubit(%arg0: f64) -> (!quantum.bit, !quantum.bit, !quantum.bit) {
 
-    // CHECK-DAG: [[rabi1:%.+]] = arith.constant 1.230000e+00 : f64
-    // CHECK-DAG: [[rabi2:%.+]] = arith.constant 4.560000e+00 : f64
-    // CHECK-DAG: [[rabi3:%.+]] = arith.constant 99.989999999999994 : f64
-
     // CHECK: {{%.+}} = ion.ion
 
     %1 = quantum.alloc( 3) : !quantum.reg
@@ -292,6 +290,7 @@ func.func @example_ion_three_qubit(%arg0: f64) -> (!quantum.bit, !quantum.bit, !
     // CHECK: [[ms1out:%.+]]:2 = ion.parallelprotocol([[qubit0]], [[qubit1]]) : !quantum.bit, !quantum.bit {
 
     // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit, %arg2: !quantum.bit):
+    // CHECK-NEXT: [[rabi1:%.+]] = arith.constant 1.230000e+00 : f64
     // CHECK-NEXT: [[timems1:%.+]] = arith.divf %arg0, [[rabi1]] : f64
     // CHECK-NEXT: ion.pulse([[timems1]] : f64) %arg1 {
     // CHECK-SAME:     beam = #ion.beam<
@@ -346,6 +345,7 @@ func.func @example_ion_three_qubit(%arg0: f64) -> (!quantum.bit, !quantum.bit, !
 
     // CHECK: [[ms2out:%.+]]:2 = ion.parallelprotocol([[ms1out]]#0, [[qubit2]]) : !quantum.bit, !quantum.bit {
     // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit, %arg2: !quantum.bit):
+    // CHECK-NEXT: [[rabi2:%.+]] = arith.constant 4.560000e+00 : f64
     // CHECK-NEXT: [[timems2:%.+]] = arith.divf %arg0, [[rabi2]] : f64
     // CHECK-NEXT: ion.pulse([[timems2]] : f64) %arg1 {
     // CHECK-SAME:     beam = #ion.beam<
@@ -400,6 +400,7 @@ func.func @example_ion_three_qubit(%arg0: f64) -> (!quantum.bit, !quantum.bit, !
 
     // CHECK: [[ms3out:%.+]]:2 = ion.parallelprotocol([[ms1out]]#1, [[ms2out]]#1) : !quantum.bit, !quantum.bit {
     // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit, %arg2: !quantum.bit):
+    // CHECK-NEXT: [[rabi3:%.+]] = arith.constant 99.989999999999994 : f64
     // CHECK-NEXT: [[timems3:%.+]] = arith.divf %arg0, [[rabi3]] : f64
     // CHECK-NEXT: ion.pulse([[timems3]] : f64) %arg1 {
     // CHECK-SAME:     beam = #ion.beam<


### PR DESCRIPTION
**Context:**

In this issue #1431, we found that crash messages that happen in `quantum-to-ion` lowering pass are not preserved correctly in the output. currently, some of the error messages are raised by an assertion, however, we like to be able to gracefully exit in a way that diagnostic messages are printed in a nice way. 

One possible solution is to return a failure in the form of `LogicalResult` and let the catalyst compiler driver handle the diagnostic messages. However, with the current greedy pattern rewriting infrastructure used, we do not have roll back procedure and a failure would not stop the pass from continuing which causes trouble in the subsequent pattern matchings in the case of a previous failure.

**Description of the Change:**

Instead of greedy pattern rewriting system, we now use a dialect conversion system which supports roll backs and allow us to exit when a failure is encountered. This then enables the compiler driver to print the diagnostic messages nicely. 

**Benefits:**

We exit gracefully with nice output error messages.
We use an infrastructure that is more suitable for a dialect converting pass.

**Possible Drawbacks:**
Dialect converting infrastructure is generally slower that a greedy rewrite due to the roll back housekeeping.

**Related GitHub Issues:**
#1431 