### PR TITLE
Fixed some minor typos in default pipeline names

### DIFF
--- a/doc/catalyst-cli/catalyst-cli.rst
+++ b/doc/catalyst-cli/catalyst-cli.rst
@@ -108,10 +108,10 @@ Catalyst's main ``mlir`` stage is split up into a sequence of pass pipelines tha
 individually via this option. In that case, the name of the pipeline is substituted for the pass
 name. Currently, the following pipelines are available:
 ``enforce-runtime-invariants-pipeline``,
-``hlo_lowering-pipeline``,
+``hlo-lowering-pipeline``,
 ``quantum-compilation-pipeline``,
 ``bufferization-pipeline``,
-``llvm-dialect-lowring-pipeline``, and finally 
+``llvm-dialect-lowering-pipeline``, and finally 
 ``default-catalyst-pipeline`` which encompasses all the above as the default pipeline used by the
 Catalyst CLI tool if no pass option is specified.
 

--- a/mlir/lib/Driver/Pipelines.cpp
+++ b/mlir/lib/Driver/Pipelines.cpp
@@ -140,7 +140,7 @@ void registerEnforceRuntimeInvariantsPipeline()
 }
 void registerHloLoweringPipeline()
 {
-    PassPipelineRegistration<>("hlo_lowering-pipeline", "Register HLO lowering pipeline as a pass.",
+    PassPipelineRegistration<>("hlo-lowering-pipeline", "Register HLO lowering pipeline as a pass.",
                                createHloLoweringPipeline);
 }
 void registerQuantumCompilationPipeline()
@@ -157,8 +157,8 @@ void registerBufferizationPipeline()
 }
 void registerLLVMDialectLoweringPipeline()
 {
-    PassPipelineRegistration<>("llvm-dialect-lowring-pipeline",
-                               "Register LLVM dialect lowring pipeline as a pass.",
+    PassPipelineRegistration<>("llvm-dialect-lowering-pipeline",
+                               "Register LLVM dialect lowering pipeline as a pass.",
                                createLLVMDialectLoweringPipeline);
 }
 

--- a/mlir/test/cli/DumpAfterFailure.mlir
+++ b/mlir/test/cli/DumpAfterFailure.mlir
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// RUN: not catalyst-cli --tool=opt %s --catalyst-pipeline="pipeline(llvm-dialect-lowring-pipeline)" --mlir-print-ir-after-failure --verify-diagnostics 2>&1 | FileCheck %s
+// RUN: not catalyst-cli --tool=opt %s --catalyst-pipeline="pipeline(llvm-dialect-lowering-pipeline)" --mlir-print-ir-after-failure --verify-diagnostics 2>&1 | FileCheck %s
 
 func.func @foo(%arg0: tensor<?xf64>) {
     "catalyst.print"(%arg0) : (tensor<?xf64>) -> ()


### PR DESCRIPTION
**Context:**
Found some typos in the name of the default pipelines in c++

**Description of the Change:**

Fixed some minor typos in default pipeline names

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
