### PR TITLE
Fix macos failure due to test schedule

### DIFF
--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -465,7 +465,7 @@ jobs:
       run: |
         python${{ matrix.python_version }} -m pytest frontend/test/pytest -n auto
         python${{ matrix.python_version }} -m pytest frontend/test/pytest --backend="lightning.kokkos" -n auto
-        python${{ matrix.python_version }} -m pytest frontend/test/async_tests
+        python${{ matrix.python_version }} -m pytest frontend/test/async_tests -p no:randomly
         python${{ matrix.python_version }} -m pytest frontend/test/pytest --runbraket=LOCAL -n auto
         python${{ matrix.python_version }} -m pytest frontend/test/test_oqc/oqc -n auto
 

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -437,7 +437,10 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        python${{ matrix.python_version }} -m pip install pytest pytest-xdist pytest-mock
+        # During the 0.10.0 release cycle we discovered that having exactly 2700 test items distributed on 
+        # exactly 3 cores (e.g. GH M1 runner) produces a lot of test failures. Randomizing the test order
+        # (pytest-randomly) fixes the issue for now.
+        python${{ matrix.python_version }} -m pip install pytest pytest-xdist pytest-mock pytest-randomly
 
     - name: Install PennyLane Plugins
       run: |


### PR DESCRIPTION
During the current release cycle we discovered that having exactly 2700 test items distributed on 
exactly 3 cores (e.g. GH M1 runner) produces a lot of test failures. Randomizing the test order
(pytest-randomly) fixes the issue for now.