### PR TITLE
Plugins from passes need to use the pass pipeline

### DIFF
--- a/doc/dev/plugins.rst
+++ b/doc/dev/plugins.rst
@@ -50,7 +50,7 @@ And you can schedule this pass as any other pass
 
 .. code-block::
 
-    quantum-opt --load-pass-plugin=/path/to/StandalonePlugin.so --standalone-switch-bar-to-foo example.mlir'
+    quantum-opt --load-pass-plugin=/path/to/StandalonePlugin.so --pass-pipeline='builtin.module(standalone-switch-bar-foo)' example.mlir'
 
 And you have your transformed program
 
@@ -90,7 +90,7 @@ But if we try to run it, using the same command as shown earlier
 
 .. code-block::
 
-      quantum-opt --load-pass-plugin=/path/to/StandalonePlugin.so --standalone-switch-bar-to-foo example.mlir'
+      quantum-opt --load-pass-plugin=/path/to/StandalonePlugin.so --pass-pipeline='builtin.module(standalone-switch-bar-foo)' example.mlir'
 
 the compilation will fail with the following message:
 
@@ -105,9 +105,9 @@ To be able to parse this dialect, we need to load the dialect which is stored in
 
 .. code-block::
 
-    quantum-opt --load-pass-plugin=/path/to/StandalonePlugin.so --load-dialect-plugin-/path/to/StandalonePlugin.so --standalone-switch-bar-to-foo example.mlir'
+    quantum-opt --load-pass-plugin=/path/to/StandalonePlugin.so --load-dialect-plugin-/path/to/StandalonePlugin.so --pass-pipeline='builtin.module(standalone-switch-bar-foo)' example.mlir'
 
-Now, you can parse the program without the error and run the ``standalone-switch-bar-to-foo`` pass.
+Now, you can parse the program without the error and run the ``standalone-switch-bar-foo`` pass.
 
 Creating your own Pass Plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
**Context:** Pass plugins cannot be scheduled directly from the command line. I.e., they need to go through the pass-pipeline. E.g., This is a bad command: `quantum-opt --standalone-switch-bar-foo`. This is a good command `quantum-opt --pass-pipeline=builtin.module(standalone-switch-bar-foo)`

**Description of the Change:** Changes the documentation to reflect this fact. Changes the name of the pass in the example from `standalone-switch-bar-to-foo` to `standalone-switch-bar-foo`, which is the correct name.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:** Fixes #1449 
