### PR TITLE
Bump PennyLane and Lightning minimum versions for Catalyst v0.10.0

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,8 +8,8 @@ enzyme=v0.0.149
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt
-pennylane=0.40.0-dev20
+
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'
-lightning=0.40.0-dev41
+

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -458,6 +458,11 @@ jobs:
 
     - name: Install Catalyst
       run: |
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install pennylane-lightning==0.40.0
+        pip install pennylane-lightning-kokkos==0.40.0
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.40.0-rc0
+        # -------------------------------------------------------------------- #
         python${{ matrix.python_version }} -m pip install dist/*.whl --extra-index-url https://test.pypi.org/simple
 
     - name: Install Standalone Plugin

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -453,6 +453,11 @@ jobs:
 
     - name: Install Catalyst
       run: |
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install pennylane-lightning==0.40.0
+        pip install pennylane-lightning-kokkos==0.40.0
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.40.0-rc0
+        # -------------------------------------------------------------------- #
         python${{ matrix.python_version }} -m pip install dist/*.whl --extra-index-url https://test.pypi.org/simple
 
     - name: Install Standalone Plugin

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -416,6 +416,11 @@ jobs:
 
     - name: Install Catalyst
       run: |
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install pennylane-lightning==0.40.0
+        pip install pennylane-lightning-kokkos==0.40.0
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.40.0-rc0
+        # -------------------------------------------------------------------- #
         python${{ matrix.python_version }} -m pip install dist/*.whl --extra-index-url https://test.pypi.org/simple
 
     - name: Install Standalone Plugin

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -436,6 +436,11 @@ jobs:
         # macOS requirements.txt
         python3 -m pip install cuda-quantum==0.6.0
         python3 -m pip install oqc-qcaas-client
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install pennylane-lightning==0.40.0
+        pip install pennylane-lightning-kokkos==0.40.0
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.40.0-rc0
+        # -------------------------------------------------------------------- #
         make frontend
 
     - name: Get Cached LLVM Build
@@ -524,6 +529,11 @@ jobs:
         sudo apt-get install -y python3 python3-pip libomp-dev libasan6 make ninja-build
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install pennylane-lightning==0.40.0
+        pip install pennylane-lightning-kokkos==0.40.0
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.40.0-rc0
+        # -------------------------------------------------------------------- #
         make frontend
 
     - name: Get Cached LLVM Build
@@ -588,6 +598,11 @@ jobs:
         sudo apt-get install -y python3 python3-pip libomp-dev libasan6 make ninja-build
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install pennylane-lightning==0.40.0
+        pip install pennylane-lightning-kokkos==0.40.0
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.40.0-rc0
+        # -------------------------------------------------------------------- #
         make frontend
 
     - name: Get Cached LLVM Build

--- a/.github/workflows/scripts/linux_arm64/rh8/test_wheels.sh
+++ b/.github/workflows/scripts/linux_arm64/rh8/test_wheels.sh
@@ -34,6 +34,12 @@ export PATH=/catalyst/llvm-build/bin:/opt/_internal/cpython-${PYTHON_MAJOR_MINOR
 /usr/bin/python3 -m pip install pennylane pybind11 PyYAML cmake ninja pytest pytest-xdist pytest-mock autoray PennyLane-Lightning-Kokkos 'amazon-braket-pennylane-plugin>1.27.1'
 /usr/bin/python3 -m pip install oqc-qcaas-client
 
+# TODO: --- remove workaround before merging to main ----------------- #
+pip install pennylane-lightning==0.40.0
+pip install pennylane-lightning-kokkos==0.40.0
+pip install git+https://github.com/PennyLaneAI/pennylane@v0.40.0-rc0
+# -------------------------------------------------------------------- #
+
 # Install Catalyst wheel
 /usr/bin/python3 -m pip install /catalyst/dist/*.whl --extra-index-url https://test.pypi.org/simple
 

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,9 @@ frontend:
 	@echo "install Catalyst Frontend"
 	# Uninstall pennylane before updating Catalyst, since pip will not replace two development
 	# versions of a package with the same version tag (e.g. 0.38-dev0).
-	$(PYTHON) -m pip uninstall -y pennylane
+	# TODO: --- enable the following line before merging to main ------------- #
+	# $(PYTHON) -m pip uninstall -y pennylane
+	# ------------------------------------------------------------------------ #
 	$(PYTHON) -m pip install -e . --extra-index-url https://test.pypi.org/simple $(PIP_VERBOSE_FLAG)
 	rm -r frontend/PennyLane_Catalyst.egg-info
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -30,6 +30,6 @@ lxml_html_clean
 
 # Pre-install PL development wheels
 --extra-index-url https://test.pypi.org/simple/
-pennylane-lightning-kokkos==0.40.0-dev41
-pennylane-lightning==0.40.0-dev41
-pennylane==0.40.0-dev20
+pennylane-lightning-kokkos==0.40.0
+pennylane-lightning==0.40.0
+pennylane @ git+https://github.com/pennylaneAI/pennylane@v0.40.0-rc0

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ with open(".dep-versions", encoding="utf-8") as f:
     pl_version = next((line[10:].strip() for line in lines if "pennylane=" in line), None)
     lq_version = next((line[10:].strip() for line in lines if "lightning=" in line), None)
 
-pl_min_release = 0.39
+pl_min_release = 0.40
 lq_min_release = pl_min_release
 
 if pl_version is not None:


### PR DESCRIPTION
Bump the PennyLane and Lightning minimum versions in preparation for the Catalyst 0.10.0 release. These changes ensure we can build the wheels after the Lightning release and before the core PennyLane release.