### PR TITLE
Fix wheel upload issues

### DIFF
--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -80,3 +80,4 @@ jobs:
       with:
         repository-url: https://test.pypi.org/legacy/
         packages-dir: dist
+        verbose: true

--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -7,52 +7,52 @@ on:
   workflow_dispatch:
 
 jobs:
-  setup:
-    name: Setup the release
-    runs-on: ubuntu-22.04
-    steps:
-    - name: Checkout Catalyst repo
-      uses: actions/checkout@v4
-      with:
-        ssh-key: ${{ secrets.NIGHTLY_VERSION_UPDATE_DEPLOY_KEY }}
+  # setup:
+  #   name: Setup the release
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #   - name: Checkout Catalyst repo
+  #     uses: actions/checkout@v4
+  #     with:
+  #       ssh-key: ${{ secrets.NIGHTLY_VERSION_UPDATE_DEPLOY_KEY }}
 
-    - name: Bump dev version
-      run: |
-        python $GITHUB_WORKSPACE/.github/workflows/set_nightly_version.py
+  #   - name: Bump dev version
+  #     run: |
+  #       python $GITHUB_WORKSPACE/.github/workflows/set_nightly_version.py
 
-    - name: Push new version
-      run: |
-        git config --global user.email '${{ secrets.AUTO_UPDATE_VERSION_RINGO_EMAIL }}'
-        git config --global user.name "ringo-but-quantum"
-        git add $GITHUB_WORKSPACE/frontend/catalyst/_version.py
-        git commit -m "[no ci] bump nightly version"
-        git push
+  #   - name: Push new version
+  #     run: |
+  #       git config --global user.email '${{ secrets.AUTO_UPDATE_VERSION_RINGO_EMAIL }}'
+  #       git config --global user.name "ringo-but-quantum"
+  #       git add $GITHUB_WORKSPACE/frontend/catalyst/_version.py
+  #       git commit -m "[no ci] bump nightly version"
+  #       git push
 
   # Only build the most popular configurations on a nightly schedule to save PyPI storage.
 
   linux-x86:
     name: Build on Linux x86-64
-    needs: [setup]
+    # needs: [setup]
     uses: ./.github/workflows/build-wheel-linux-x86_64.yaml
 
-  # linux-aarch:
-  #   name: Build on Linux aarch64
-  #   needs: [setup]
-  #   uses: ./.github/workflows/build-wheel-linux-arm64.yaml
+  linux-aarch:
+    name: Build on Linux aarch64
+    # needs: [setup]
+    uses: ./.github/workflows/build-wheel-linux-arm64.yaml
 
   macos-arm:
     name: Build on macOS arm64
-    needs: [setup]
+    # needs: [setup]
     uses: ./.github/workflows/build-wheel-macos-arm64.yaml
 
-  # macos-x86:
-  #   name: Build on macOS x86-64
-  #   needs: [setup]
-  #   uses: ./.github/workflows/build-wheel-macos-x86_64.yaml
+  macos-x86:
+    name: Build on macOS x86-64
+    # needs: [setup]
+    uses: ./.github/workflows/build-wheel-macos-x86_64.yaml
 
   upload:
     name: Prepare & Upload wheels to TestPyPI
-    needs: [linux-x86, macos-arm]  # linux-aarch, macos-x86
+    needs: [linux-x86, macos-arm, linux-aarch, macos-x86]
     runs-on: ubuntu-22.04
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ pennylane_catalyst.egg-info
 
 # Packaging directories
 dist
-frontend/catalyst/bin
+frontend/bin
 frontend/catalyst/lib
 frontend/catalyst/_revision.py
 frontend/mlir_quantum

--- a/Makefile
+++ b/Makefile
@@ -204,8 +204,8 @@ wheel:
 	for file in gradient quantum _ods_common catalyst mitigation _transform; do \
 		cp $(COPY_FLAGS) $(DIALECTS_BUILD_DIR)/python_packages/quantum/mlir_quantum/dialects/*$${file}* $(MK_DIR)/frontend/mlir_quantum/dialects ; \
 	done
-	mkdir -p $(MK_DIR)/frontend/catalyst/bin
-	cp $(COPY_FLAGS) $(DIALECTS_BUILD_DIR)/bin/catalyst $(MK_DIR)/frontend/catalyst/bin
+	mkdir -p $(MK_DIR)/frontend/bin
+	cp $(COPY_FLAGS) $(DIALECTS_BUILD_DIR)/bin/catalyst $(MK_DIR)/frontend/bin/
 	find $(MK_DIR)/frontend -type d -name __pycache__ -exec rm -rf {} +
 
 	$(PYTHON) -m pip wheel --no-deps . -w dist

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -32,7 +32,7 @@ from catalyst.logging import debug_logger, debug_logger_init
 from catalyst.pipelines import CompileOptions
 from catalyst.utils.exceptions import CompileError
 from catalyst.utils.filesystem import Directory
-from catalyst.utils.runtime_environment import get_bin_path, get_lib_path
+from catalyst.utils.runtime_environment import get_cli_path, get_lib_path
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
@@ -62,7 +62,7 @@ class LinkerDriver:
     this class defines a compiler resolution order where multiple known compilers are attempted.
     The order is defined as follows:
     1. A user specified compiler via the environment variable CATALYST_CC. It is expected that the
-        user provided compiler is flag compatilble with GCC/Clang.
+        user provided compiler is flag compatible with GCC/Clang.
     2. clang: Priority is given to clang to maintain an LLVM toolchain through most of the process.
     3. gcc: Usually configured to link with LD.
     4. c99: Usually defaults to gcc, but no linker interface is specified.
@@ -275,7 +275,7 @@ class Compiler:
         Returns:
             cmd (str): The command to be executed.
         """
-        cli_build_path = get_bin_path("cli", "CATALYST_BIN_DIR") + "/catalyst"
+        cli_build_path = get_cli_path()
         if not path.isfile(cli_build_path):
             raise FileNotFoundError("catalyst executable was not found.")  # pragma: nocover
         cmd = [cli_build_path]

--- a/frontend/catalyst/utils/runtime_environment.py
+++ b/frontend/catalyst/utils/runtime_environment.py
@@ -17,6 +17,8 @@ Utility code for keeping paths
 """
 import os
 import os.path
+import sys
+import sysconfig
 
 from catalyst._configuration import INSTALLED
 
@@ -35,14 +37,46 @@ DEFAULT_BIN_PATHS = {
     "cli": os.path.join(package_root, "../../../mlir/build/bin"),
 }
 
+
 def get_lib_path(project, env_var):
     """Get the library path."""
     if INSTALLED:
         return os.path.join(package_root, "..", "lib")  # pragma: no cover
     return os.getenv(env_var, DEFAULT_LIB_PATHS.get(project, ""))
 
+
 def get_bin_path(project, env_var):
     """Get the library path."""
     if INSTALLED:
         return os.path.join(package_root, "..", "bin")  # pragma: no cover
     return os.getenv(env_var, DEFAULT_BIN_PATHS.get(project, ""))
+
+
+def get_cli_path() -> str:  # pragma: nocover
+    """Method to obtain the Catalyst CLI path packaged via the data_files mechanism."""
+    catalyst_cli = "catalyst"
+
+    if not INSTALLED:
+        return os.path.join(
+            os.getenv("CATALYST_BIN_DIR", DEFAULT_BIN_PATHS.get("cli", "")), catalyst_cli
+        )
+
+    # Default path
+    path = os.path.join(sysconfig.get_path("scripts"), catalyst_cli)
+    if os.path.isfile(path):
+        return path
+
+    # User path
+    user_scheme = sysconfig.get_preferred_scheme("user")
+    path = os.path.join(sysconfig.get_path("scripts", scheme=user_scheme), catalyst_cli)
+    if os.path.isfile(path):
+        return path
+
+    # Fallback to python location
+    path = os.path.join(os.path.dirname(sys.executable), catalyst_cli)
+    if os.path.isfile(path):
+        return path
+
+    raise RuntimeError(
+        "Could not locate the Catalyst executable, please report this issue on GitHub."
+    )

--- a/setup.py
+++ b/setup.py
@@ -331,7 +331,6 @@ else:
 setup(
     classifiers=classifiers,
     name="PennyLane-Catalyst",
-    provides=["catalyst"],
     version=version,
     python_requires=">=3.10",
     entry_points=entry_points,

--- a/setup.py
+++ b/setup.py
@@ -321,8 +321,8 @@ options = {"bdist_wheel": {"py_limited_api": "cp312"}} if sys.hexversion >= 0x03
 
 # Install the `catalyst` binary into the user's Python environment so it is accessible on the PATH.
 # Does not work with editable installs. Requires the Catalyst mlir module to be built.
-if os.path.exists("frontend/catalyst/bin/catalyst"):
-    catalyst_cli = ["frontend/catalyst/bin/catalyst"]
+if os.path.exists("frontend/bin/catalyst"):
+    catalyst_cli = ["frontend/bin/catalyst"]
 elif os.path.exists("mlir/build/bin/catalyst"):
     catalyst_cli = ["mlir/build/bin/catalyst"]
 else:


### PR DESCRIPTION
This PR fixes two issues preventing wheel upload to PyPI:
- removes the deprecated `provides` kwarg in setup.py
- reduces the file size of the wheel due to duplicate packaging of the catalyst cli

Here is the successful build & upload of all wheels based on this branch:
https://github.com/PennyLaneAI/catalyst/actions/runs/12754030162