### PR TITLE
Bump Lightning Kokkos to v0.40.0 in Check Catalyst

### DIFF
--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -516,7 +516,7 @@ jobs:
 
     - name: Install lightning.kokkos used in Python tests
       run: |
-        pip install PennyLane-Lightning-Kokkos==0.39.0 --extra-index-url https://test.pypi.org/simple
+        pip install PennyLane-Lightning-Kokkos==0.40.0 --extra-index-url https://test.pypi.org/simple
 
     - name: Install Deps
       run: |


### PR DESCRIPTION
Bumps the Lightning Kokkos version from v0.39.0 to v0.40.0 in the Check Catalyst CI action script.