### PR TITLE
[CI] Remove pinned version of Lightning-Kokkos

### DIFF
--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -514,10 +514,6 @@ jobs:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v4
 
-    - name: Install lightning.kokkos used in Python tests
-      run: |
-        pip install PennyLane-Lightning-Kokkos==0.40.0 --extra-index-url https://test.pypi.org/simple
-
     - name: Install Deps
       run: |
         sudo apt-get update


### PR DESCRIPTION
**Context:** Currently, it is not strictly necessary to manually pip install a pinned version of `PennyLane-Lightning-Kokkos` when running the frontend tests with the `lightning-kokkos` backend in the Check Catalyst CI workflow, since `PennyLane-Lightning-Kokkos` is already a dependency listed in requirements.txt. We run `pip install -r requirements.txt` before running this test suite, therefore this manual pip install is redundant.

**Description of the Change:** Removes the `Install lightning.kokkos used in Python tests` step in the CI action script.

**Benefits:** Remove redundancy, manage dependencies in one place.

**Possible Drawbacks:** Having a separate step in the CI action could be convenient if we ever need to install a development version of `lightning-kokkos` from TestPyPI.