### PR TITLE
Fix failing standalone plugin tests

### DIFF
--- a/standalone_plugin_wheel/standalone_plugin/test/test_mlir_plugin.py
+++ b/standalone_plugin_wheel/standalone_plugin/test/test_mlir_plugin.py
@@ -20,7 +20,8 @@ https://github.com/llvm/llvm-project/tree/main/mlir/examples/standalone
 import pennylane as qml
 import pytest
 
-from catalyst.passes import apply_pass, apply_pass_plugin, pipeline
+from catalyst import pipeline
+from catalyst.passes import apply_pass, apply_pass_plugin
 
 have_standalone_plugin = True
 


### PR DESCRIPTION
**Context:** The standalone plugins tests were failing recently because of the import hierarchy of the `pipeline` decorator had changed ([example failing CI workflow](https://github.com/PennyLaneAI/catalyst/actions/runs/12802222887/job/35693280463)). We hadn't noticed this failure before because the standalone plugin tests are only run on Thursday.

**Description of the Change:** Refactor the `pipeline` import from

```python
from catalyst.passes import pipeline
```

to

```python
from catalyst import pipeline
```