### PR TITLE
Capture "cond" workflow

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -8,6 +8,34 @@
   infrastracture.
   [(#1442)](https://github.com/PennyLaneAI/catalyst/pull/1442)
 
+* Catalyst now supports experimental capture of `cond` control flow.
+  [(#1468)](https://github.com/PennyLaneAI/catalyst/pull/1468)
+  
+  To trigger the PennyLane pipeline for capturing the program as a Jaxpr, simply set
+  `experimental_capture=True` in the qjit decorator.
+
+  ```python
+  import pennylane as qml
+  from catalyst import qjit
+
+  dev = qml.device("lightning.qubit", wires=1)
+
+  @qjit(experimental_capture=True)
+  @qml.qnode(dev)
+  def circuit(x: float):
+
+    def ansatz_true():
+        qml.RX(x, wires=0)
+        qml.Hadamard(wires=0)
+
+    def ansatz_false():
+        qml.RY(x, wires=0)
+
+    qml.cond(x > 1.4, ansatz_true, ansatz_false)()
+
+    return qml.expval(qml.Z(0))
+  ```
+
 <h3>Breaking changes 💔</h3>
 
 <h3>Deprecations 👋</h3>
@@ -71,4 +99,5 @@ Christina Lee,
 Mehrdad Malekmohammadi,
 Andrija Paurevic,
 Paul Haochen Wang,
-Rohan Nolan Lasrado.
+Rohan Nolan Lasrado,
+Raul Torres.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -24,16 +24,16 @@
   @qml.qnode(dev)
   def circuit(x: float):
 
-    def ansatz_true():
-        qml.RX(x, wires=0)
-        qml.Hadamard(wires=0)
+      def ansatz_true():
+          qml.RX(x, wires=0)
+          qml.Hadamard(wires=0)
 
-    def ansatz_false():
-        qml.RY(x, wires=0)
+      def ansatz_false():
+          qml.RY(x, wires=0)
 
-    qml.cond(x > 1.4, ansatz_true, ansatz_false)()
+      qml.cond(x > 1.4, ansatz_true, ansatz_false)()
 
-    return qml.expval(qml.Z(0))
+      return qml.expval(qml.Z(0))
   ```
 
 <h3>Breaking changes 💔</h3>

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -308,11 +308,6 @@ def _(self, phase, *wires, n_wires):
 # pylint: disable=unused-argument, too-many-arguments
 @QFuncPlxprInterpreter.register_primitive(cond_prim)
 def _(self, *invals, jaxpr_branches, consts_slices, args_slice):
-    new_invals = []
-    for inval in invals:
-        if isinstance(inval, jax.core.Tracer):
-            new_invals.append(inval)
-
     args = invals[args_slice]
 
     new_branch_jaxprs = []
@@ -326,7 +321,7 @@ def _(self, *invals, jaxpr_branches, consts_slices, args_slice):
             new_branch_jaxprs.append(branch_jaxpr)
 
     return cond_p.bind(
-        *new_invals, branch_jaxprs=jaxpr_pad_consts(new_branch_jaxprs), nimplicit_outputs=None
+        *invals, branch_jaxprs=jaxpr_pad_consts(new_branch_jaxprs), nimplicit_outputs=None
     )
 
 

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -376,6 +376,7 @@ class BranchPlxprInterpreter(QFuncPlxprInterpreter):
         shots (qml.measurements.Shots)
     """
 
+    # pylint: disable=too-many-branches
     def eval(self, jaxpr: "jax.core.Jaxpr", consts: Sequence, *args) -> list:
         """Evaluate a jaxpr.
 

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -359,6 +359,7 @@ class BranchPlxprInterpreter(QFuncPlxprInterpreter):
         return outvals
 
 
+@BranchPlxprInterpreter.register_primitive(qml.QubitUnitary._primitive)
 @QFuncPlxprInterpreter.register_primitive(qml.QubitUnitary._primitive)
 def _(self, *invals, n_wires):
     wires = [self.get_wire(w) for w in invals[1:]]
@@ -368,12 +369,14 @@ def _(self, *invals, n_wires):
 
 
 # pylint: disable=unused-argument
+@BranchPlxprInterpreter.register_primitive(qml.GlobalPhase._primitive)
 @QFuncPlxprInterpreter.register_primitive(qml.GlobalPhase._primitive)
 def _(self, phase, *wires, n_wires):
     gphase_p.bind(phase, ctrl_len=0, adjoint=False)
 
 
 # pylint: disable=unused-argument, too-many-arguments
+@BranchPlxprInterpreter.register_primitive(cond_prim)
 @QFuncPlxprInterpreter.register_primitive(cond_prim)
 def _(self, *plxpr_invals, jaxpr_branches, consts_slices, args_slice):
     args = plxpr_invals[args_slice]

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -314,6 +314,7 @@ class BranchPlxprInterpreter(QFuncPlxprInterpreter):
             list[TensorLike]: the results of the execution.
 
         """
+        # pylint: disable=attribute-defined-outside-init
         self._env = {}
 
         # We assume the last argument is the qreg
@@ -345,12 +346,14 @@ class BranchPlxprInterpreter(QFuncPlxprInterpreter):
 
         # Reinsert extracted qubits
         for orig_wire, wire in self.wire_map.items():
+            # pylint: disable=attribute-defined-outside-init
             self.qreg = qinsert_p.bind(self.qreg, orig_wire, wire)
 
         outvals = [self.qreg]
 
         self.stateref = None
 
+        # pylint: disable=attribute-defined-outside-init
         self._env = {}
 
         return outvals

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -26,8 +26,8 @@ from pennylane.capture import PlxprInterpreter, disable, enable, enabled, qnode_
 from pennylane.capture.primitives import (
     AbstractMeasurement,
     AbstractOperator,
-    cond_prim,
 )
+from pennylane.capture.primitives import cond_prim as plxpr_cond_prim
 
 from catalyst.device import (
     extract_backend_info,
@@ -311,7 +311,7 @@ def _(self, phase, *wires, n_wires):
 
 
 # pylint: disable=unused-argument, too-many-arguments
-@QFuncPlxprInterpreter.register_primitive(cond_prim)
+@QFuncPlxprInterpreter.register_primitive(plxpr_cond_prim)
 def _(self, *plxpr_invals, jaxpr_branches, consts_slices, args_slice):
     args = plxpr_invals[args_slice]
     args_plus_qreg = [*args, self.qreg]  # Add the qreg to the args

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -344,6 +344,11 @@ def _(self, *invals, jaxpr_branches, consts_slices, args_slice):
         else:
             f = partial(BranchPlxprInterpreter(self).eval, branch_plxpr, consts)
             branch_jaxpr = jax.make_jaxpr(f)(*args).jaxpr
+            invars = []
+            invars.append(branch_jaxpr.constvars[0])
+            branch_jaxpr = branch_jaxpr.replace(invars=invars)
+            constvars = branch_jaxpr.constvars[1:]
+            branch_jaxpr = branch_jaxpr.replace(constvars=constvars)
             new_branch_jaxprs.append(branch_jaxpr)
 
     return cond_p.bind(

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -331,6 +331,7 @@ class QFuncPlxprInterpreter(PlxprInterpreter):
                 if not eqn.primitive.multiple_results:
                     outvals = [outvals]
                 for outvar, outval in zip(outvars, outvals, strict=True):
+                    self.qreg = outval
                     self._env[outvar] = outval
             else:
                 custom_handler = self._primitive_registrations.get(eqn.primitive, None)
@@ -423,13 +424,12 @@ def handle_cond(
             jaxpr_branches.append(None)
         else:
             func = partial(
-                BranchPlxprInterpreter(self._device, self._shots, self.qreg).eval,
+                BranchPlxprInterpreter(self._device, self._shots, qreg).eval,
                 plxpr_branch,
                 branch_consts,
             )
             jaxpr_branch = jax.make_jaxpr(func)(*args).jaxpr
-            if qreg_var is None:
-                qreg_var = jaxpr_branch.constvars[0]
+            qreg_var = jaxpr_branch.constvars[0]
             invars = []
             invars.append(jaxpr_branch.constvars[0])
             jaxpr_branch = jaxpr_branch.replace(invars=invars)

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -15,6 +15,7 @@
 This submodule defines a utility for converting plxpr into Catalyst jaxpr.
 """
 # pylint: disable=protected-access
+from copy import copy
 from functools import partial
 from typing import Callable
 
@@ -347,8 +348,14 @@ def _(self, *invals, jaxpr_branches, consts_slices, args_slice):
             invars = []
             invars.append(branch_jaxpr.constvars[0])
             branch_jaxpr = branch_jaxpr.replace(invars=invars)
+            outvars = []
+            outvars.append(copy(branch_jaxpr.constvars[0]))
+            branch_jaxpr = branch_jaxpr.replace(outvars=outvars)
             constvars = branch_jaxpr.constvars[1:]
             branch_jaxpr = branch_jaxpr.replace(constvars=constvars)
+            branch_jaxpr.eqns[len(branch_jaxpr.eqns) - 1] = branch_jaxpr.eqns[
+                len(branch_jaxpr.eqns) - 1
+            ].replace(outvars=outvars)
             new_branch_jaxprs.append(branch_jaxpr)
 
     return cond_p.bind(

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -339,8 +339,8 @@ def _(self, *plxpr_invals, jaxpr_branches, consts_slices, args_slice):
 
         converted_jaxpr_branches.append(converted_jaxpr_branch)
 
-    # The slice (0,1) of the plxpr input values contains the true predicate of the plxpr cond,
-    # whereas the slice (1,2) refers to the false predicate, which is always True.
+    # The slice [0,1) of the plxpr input values contains the true predicate of the plxpr cond,
+    # whereas the slice [1,2) refers to the false predicate, which is always True.
     # We extract the true predicate and discard the false one.
     predicate_slice = slice(0, 1)
     predicate = plxpr_invals[predicate_slice]

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -35,6 +35,7 @@ from catalyst.jax_extras import jaxpr_pad_consts, make_jaxpr2, transient_jax_con
 from catalyst.jax_extras.tracing import bind_flexible_primitive
 from catalyst.jax_primitives import (
     AbstractQbit,
+    AbstractQreg,
     compbasis_p,
     cond_p,
     counts_p,
@@ -345,27 +346,7 @@ def _(self, *plxpr_invals, jaxpr_branches, consts_slices, args_slice):
     for branch_consts, plxpr_branch in zip(branches_consts, jaxpr_branches):
 
         if plxpr_branch is None:
-            converted_jaxpr_branch = jax.make_jaxpr(lambda: self.qreg)().jaxpr
-
-            # Unfortunately the obtained jaxpr does not comply with the Catalyst
-            # spec. We need to move some vars around as follows:
-
-            # Get the qreg var
-            qreg_var = converted_jaxpr_branch.constvars[0]
-
-            # Insert the qreg var to the input vars
-            invars = []
-            invars.append(converted_jaxpr_branch.constvars[0])
-            converted_jaxpr_branch = converted_jaxpr_branch.replace(invars=invars)
-
-            # Insert the qreg var to the output vars
-            outvars = []
-            outvars.append(converted_jaxpr_branch.constvars[0])
-            converted_jaxpr_branch = converted_jaxpr_branch.replace(outvars=outvars)
-
-            # Remove the qreg var from the constants
-            constvars = converted_jaxpr_branch.constvars[1:]
-            converted_jaxpr_branch = converted_jaxpr_branch.replace(constvars=constvars)
+            converted_jaxpr_branch = jax.make_jaxpr(lambda x: x)(AbstractQreg()).jaxpr
             converted_jaxpr_branches.append(converted_jaxpr_branch)
         else:
             # convert plxpr to Catalyst jaxpr

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -327,11 +327,10 @@ class QFuncPlxprInterpreter(PlxprInterpreter):
                 invals = [self.read(invar) for invar in eqn.invars]
                 outvals = eqn.primitive.bind(*invals, **eqn.params)
 
-            if eqn.primitive.name != "cond":
-                if not eqn.primitive.multiple_results:
-                    outvals = [outvals]
-                for outvar, outval in zip(eqn.outvars, outvals, strict=True):
-                    self._env[outvar] = outval
+            if not eqn.primitive.multiple_results:
+                outvals = [outvals]
+            for outvar, outval in zip(eqn.outvars, outvals, strict=True):
+                self._env[outvar] = outval
 
         # Read the final result of the Jaxpr from the environment
         outvals = []
@@ -442,7 +441,7 @@ def _(self, *plxpr_invals, jaxpr_branches, consts_slices, args_slice):
         self.qreg = outval
         self._env[outvar] = outval
 
-    return outvals
+    return ()
 
 
 def trace_from_pennylane(fn, static_argnums, abstracted_axes, sig, kwargs):

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -293,7 +293,8 @@ class QFuncPlxprInterpreter(PlxprInterpreter):
 
 
 @QFuncPlxprInterpreter.register_primitive(qml.QubitUnitary._primitive)
-def _(self, *invals, n_wires):
+def handle_qubit_unitary(self, *invals, n_wires):
+    """Handle the conversion from plxpr to Catalyst jaxpr for the QubitUnitary primitive"""
     wires = [self.get_wire(w) for w in invals[1:]]
     outvals = qunitary_p.bind(invals[0], *wires, qubits_len=n_wires, ctrl_len=0, adjoint=False)
     for wire_values, new_wire in zip(invals[1:], outvals):
@@ -302,13 +303,15 @@ def _(self, *invals, n_wires):
 
 # pylint: disable=unused-argument
 @QFuncPlxprInterpreter.register_primitive(qml.GlobalPhase._primitive)
-def _(self, phase, *wires, n_wires):
+def handle_global_phase(self, phase, *wires, n_wires):
+    """Handle the conversion from plxpr to Catalyst jaxpr for the GlobalPhase primitive"""
     gphase_p.bind(phase, ctrl_len=0, adjoint=False)
 
 
 # pylint: disable=unused-argument, too-many-arguments
 @QFuncPlxprInterpreter.register_primitive(plxpr_cond_prim)
-def _(self, *plxpr_invals, jaxpr_branches, consts_slices, args_slice):
+def handle_cond(self, *plxpr_invals, jaxpr_branches, consts_slices, args_slice):
+    """Handle the conversion from plxpr to Catalyst jaxpr for the cond primitive"""
     args = plxpr_invals[args_slice]
     args_plus_qreg = [*args, self.qreg]  # Add the qreg to the args
     converted_jaxpr_branches = []

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -15,7 +15,6 @@
 This submodule defines a utility for converting plxpr into Catalyst jaxpr.
 """
 # pylint: disable=protected-access
-from copy import copy
 from functools import partial
 from typing import Callable
 
@@ -24,7 +23,6 @@ import jax.core
 import pennylane as qml
 from jax.extend.linear_util import wrap_init
 from pennylane.capture import PlxprInterpreter, disable, enable, enabled, qnode_prim
-from pennylane.capture.base_interpreter import jaxpr_to_jaxpr
 from pennylane.capture.primitives import cond_prim
 
 from catalyst.device import (

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -199,3 +199,23 @@ class TestCapture:
         actual = catalyst_capture_circuit(theta)
         desired = pl_circuit(theta)
         assert jnp.allclose(actual, desired)
+
+    def test_cond_workflow(self, backend):
+        """Test the integration for a circuit with a cond primitive."""
+
+        @qml.qjit(experimental_capture=True)
+        @qml.qnode(qml.device(backend, wires=1))
+        def circuit(x: float):
+
+            def ansatz_true():
+                qml.RX(x, wires=0)
+                qml.Hadamard(wires=0)
+
+            def ansatz_false():
+                qml.RY(x, wires=0)
+
+            qml.cond(x > 1.4, ansatz_true, ansatz_false)()
+
+            return qml.expval(qml.Z(0))
+
+        assert circuit(0.1) == 0.9950041652780258

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -259,6 +259,5 @@ class TestCapture:
             return qml.expval(qml.Z(0))
 
         default_capture_result = qml.qjit(circuit)(0.1)
-        print(default_capture_result)
         experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(0.1)
         assert default_capture_result == experimental_capture_result

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -296,10 +296,12 @@ class TestCapture:
             def ansatz_true():
                 qml.RX(x, wires=0)
                 qml.Hadamard(wires=0)
+                # pylint: disable=pointless-statement
                 x + 1  # simple primitive
 
             def ansatz_false():
                 qml.RY(x, wires=0)
+                # pylint: disable=pointless-statement
                 x + 1  # simple primitive
 
             qml.cond(x > 1.4, ansatz_true, ansatz_false)()

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -261,3 +261,27 @@ class TestCapture:
         default_capture_result = qml.qjit(circuit)(0.1)
         experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(0.1)
         assert default_capture_result == experimental_capture_result
+
+    def test_cond_workflow_with_abstract_measurement(self, backend):
+        """Test the integration for a circuit with a cond primitive containing an
+        abstract measurement."""
+
+        @qml.qnode(qml.device(backend, wires=1))
+        def circuit(x: float):
+
+            def ansatz_true():
+                qml.RX(x, wires=0)
+                qml.Hadamard(wires=0)
+                qml.state()  # Abstract measurement
+
+            def ansatz_false():
+                qml.RY(x, wires=0)
+                qml.state()  # Abstract measurement
+
+            qml.cond(x > 1.4, ansatz_true, ansatz_false)()
+
+            return qml.expval(qml.Z(0))
+
+        default_capture_result = qml.qjit(circuit)(0.1)
+        experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(0.1)
+        assert default_capture_result == experimental_capture_result

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -237,3 +237,27 @@ class TestCapture:
         default_capture_result = qml.qjit(circuit)(1.5)
         experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(1.5)
         assert default_capture_result == experimental_capture_result
+
+    def test_cond_workflow_with_custom_primitive(self, backend):
+        """Test the integration for a circuit with a cond primitive containing a custom primitive."""
+
+        @qml.qnode(qml.device(backend, wires=1))
+        def circuit(x: float):
+
+            def ansatz_true():
+                qml.RX(x, wires=0)
+                qml.Hadamard(wires=0)
+                qml.GlobalPhase(jnp.pi / 4)  # Custom primitive
+
+            def ansatz_false():
+                qml.RY(x, wires=0)
+                qml.GlobalPhase(jnp.pi / 2)  # Custom primitive
+
+            qml.cond(x > 1.4, ansatz_true, ansatz_false)()
+
+            return qml.expval(qml.Z(0))
+
+        default_capture_result = qml.qjit(circuit)(0.1)
+        print(default_capture_result)
+        experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(0.1)
+        assert default_capture_result == experimental_capture_result

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -239,7 +239,8 @@ class TestCapture:
         assert default_capture_result == experimental_capture_result
 
     def test_cond_workflow_with_custom_primitive(self, backend):
-        """Test the integration for a circuit with a cond primitive containing a custom primitive."""
+        """Test the integration for a circuit with a cond primitive containing a custom
+        primitive."""
 
         @qml.qnode(qml.device(backend, wires=1))
         def circuit(x: float):

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -337,3 +337,18 @@ class TestCapture:
         default_capture_result = qml.qjit(circuit)(0.1, 1.5)
         experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(0.1, 1.5)
         assert default_capture_result == experimental_capture_result
+
+    def test_cond_workflow_operator(self, backend):
+        """Test the integration for a circuit with a cond primitive returning
+        an Operator."""
+
+        @qml.qnode(qml.device(backend, wires=1))
+        def circuit(x: float):
+
+            qml.cond(x > 1.4, qml.RX, qml.RY)(x, wires=0)
+
+            return qml.expval(qml.Z(0))
+
+        default_capture_result = qml.qjit(circuit)(0.1)
+        experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(0.1)
+        assert default_capture_result == experimental_capture_result

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -285,3 +285,27 @@ class TestCapture:
         default_capture_result = qml.qjit(circuit)(0.1)
         experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(0.1)
         assert default_capture_result == experimental_capture_result
+
+    def test_cond_workflow_with_simple_primitive(self, backend):
+        """Test the integration for a circuit with a cond primitive containing an
+        simple primitive."""
+
+        @qml.qnode(qml.device(backend, wires=1))
+        def circuit(x: float):
+
+            def ansatz_true():
+                qml.RX(x, wires=0)
+                qml.Hadamard(wires=0)
+                x + 1  # simple primitive
+
+            def ansatz_false():
+                qml.RY(x, wires=0)
+                x + 1  # simple primitive
+
+            qml.cond(x > 1.4, ansatz_true, ansatz_false)()
+
+            return qml.expval(qml.Z(0))
+
+        default_capture_result = qml.qjit(circuit)(0.1)
+        experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(0.1)
+        assert default_capture_result == experimental_capture_result

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -296,13 +296,11 @@ class TestCapture:
             def ansatz_true():
                 qml.RX(x, wires=0)
                 qml.Hadamard(wires=0)
-                # pylint: disable=pointless-statement
-                x + 1  # simple primitive
+                return x + 1  # simple primitive
 
             def ansatz_false():
                 qml.RY(x, wires=0)
-                # pylint: disable=pointless-statement
-                x + 1  # simple primitive
+                return x + 1  # simple primitive
 
             qml.cond(x > 1.4, ansatz_true, ansatz_false)()
 
@@ -310,4 +308,32 @@ class TestCapture:
 
         default_capture_result = qml.qjit(circuit)(0.1)
         experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(0.1)
+        assert default_capture_result == experimental_capture_result
+
+    def test_cond_workflow_nested(self, backend):
+        """Test the integration for a circuit with a nested cond primitive."""
+
+        @qml.qnode(qml.device(backend, wires=1))
+        def circuit(x: float, y: float):
+
+            def ansatz_true():
+                qml.RX(x, wires=0)
+                qml.Hadamard(wires=0)
+
+            def ansatz_false():
+
+                def branch_true():
+                    qml.RY(y, wires=0)
+
+                def branch_false():
+                    qml.RZ(y, wires=0)
+
+                qml.cond(y > 1.4, branch_true, branch_false)()
+
+            qml.cond(x > 1.4, ansatz_true, ansatz_false)()
+
+            return qml.expval(qml.Z(0))
+
+        default_capture_result = qml.qjit(circuit)(0.1, 1.5)
+        experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(0.1, 1.5)
         assert default_capture_result == experimental_capture_result


### PR DESCRIPTION
**Context:** Currently, Catalyst cannot compile and execute captured workflows with `cond` control flow. E.g.:
```
dev = qml.device("lightning.qubit", wires=1)

@qml.qjit(experimental_capture=True)
@qml.qnode(dev)
def circuit(x):

    def ansatz_true():
            qml.RX(x, wires=0)
            qml.Hadamard(wires=0)

    def ansatz_false():
            qml.RY(x, wires=0)

    qml.cond(x > 1.4, ansatz_true, ansatz_false)()

    return qml.expval(qml.Z(0))

circuit(0.1) # 0.9950041652780258
```

**Description of the Change:** Create a Branch interpreter that accepts an `AbstractQreg()` as input and returns it as well.

**Benefits:** Extended support for plxpr capture.

[sc-81879]