### PR TITLE
Fixed Z gate name matching in Ion decomposition pass

### DIFF
--- a/mlir/lib/Quantum/Transforms/IonsDecompositionPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/IonsDecompositionPatterns.cpp
@@ -140,7 +140,7 @@ void cnotDecomp(catalyst::quantum::CustomOp op, mlir::PatternRewriter &rewriter)
 }
 
 std::map<std::string, std::function<void(catalyst::quantum::CustomOp, mlir::PatternRewriter &)>>
-    funcMap = {{"T", &tDecomp},        {"S", &sDecomp},   {"Z", &zDecomp},
+    funcMap = {{"T", &tDecomp},        {"S", &sDecomp},   {"PauliZ", &zDecomp},
                {"Hadamard", &hDecomp}, {"RZ", &rzDecomp}, {"PhaseShift", &psDecomp},
                {"CNOT", &cnotDecomp}};
 


### PR DESCRIPTION
**Context:**

In ion decomposition pass, we are matching the name of the gates with "Z" while Z-gate is registered as "PauliZ".

**Description of the Change:**

Corrected the string to match against "PauliZ"

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
