### PR TITLE
Ensure an `ion.yield` operation is returning a region output to all parallal protocol ops

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -16,11 +16,6 @@
 
 <h3>Internal changes ⚙️</h3>
 
-* The `get_c_interface` method has been added to the OQD device, which enables retrieval of the C++
-  implementation of the device from Python. This allows `qjit` to accept an instance of the device
-  and connect to its runtime.
-  [(#1420)](https://github.com/PennyLaneAI/catalyst/pull/1420)
-
 * `from_plxpr` now uses the `qml.capture.PlxprInterpreter` class for reduced code duplication.
   [(#1398)](https://github.com/PennyLaneAI/catalyst/pull/1398)
 
@@ -30,10 +25,19 @@
 * Replace `ValueRange` with `ResultRange` and `Value` with `OpResult` to better align with the semantics of `**QubitResult()` functions like `getNonCtrlQubitResults()`. This change ensures clearer intent and usage. Improve the `matchAndRewrite` function by using `replaceAllUsesWith` instead of for loop.
   [(#1426)](https://github.com/PennyLaneAI/catalyst/pull/1426)
 
-* Improved ion dialect to reduce redundant code generated. Added a string attribute `label` to Level.
-  Also changed the levels of a transition from `LevelAttr` to `string`
-  [(#1471)](https://github.com/PennyLaneAI/catalyst/pull/1471)
+* Several changes for experimental support of trapped-ion OQD devices have been made, including:
 
+  - The `get_c_interface` method has been added to the OQD device, which enables retrieval of the C++
+    implementation of the device from Python. This allows `qjit` to accept an instance of the device
+    and connect to its runtime.
+    [(#1420)](https://github.com/PennyLaneAI/catalyst/pull/1420)
+
+  - Improved ion dialect to reduce redundant code generated. Added a string attribute `label` to Level.
+    Also changed the levels of a transition from `LevelAttr` to `string`
+    [(#1471)](https://github.com/PennyLaneAI/catalyst/pull/1471)
+
+  - The region of a `ParallelProtocolOp` is now always terminated with a `ion::YieldOp` with explicitly yielded SSA values. This ensures the op is well-formed, and improves readability.
+    [(#1475)](https://github.com/PennyLaneAI/catalyst/pull/1475)
 
 <h3>Documentation 📝</h3>
 
@@ -41,6 +45,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Christina Lee
-Mehrdad Malekmohammadi
-Sengthai Heng
+Sengthai Heng,
+Christina Lee,
+Mehrdad Malekmohammadi,
+Paul Haochen Wang.

--- a/mlir/lib/Ion/IR/IonOps.cpp
+++ b/mlir/lib/Ion/IR/IonOps.cpp
@@ -42,6 +42,7 @@ void ParallelProtocolOp::build(OpBuilder &builder, OperationState &result, Value
                                BodyBuilderFn bodyBuilder)
 {
     OpBuilder::InsertionGuard guard(builder);
+    Location loc = result.location;
 
     result.addOperands(inQubits);
     for (Value v : inQubits)
@@ -49,11 +50,15 @@ void ParallelProtocolOp::build(OpBuilder &builder, OperationState &result, Value
 
     Region *bodyRegion = result.addRegion();
     Block *bodyBlock = builder.createBlock(bodyRegion);
-    for (Value v : inQubits)
+    for (Value v : inQubits) {
         bodyBlock->addArgument(v.getType(), v.getLoc());
+    }
 
     builder.setInsertionPointToStart(bodyBlock);
-    bodyBuilder(builder, result.location, bodyBlock->getArguments());
+    bodyBuilder(builder, loc, bodyBlock->getArguments());
+
+    builder.setInsertionPointToEnd(bodyBlock);
+    builder.create<ion::YieldOp>(loc, bodyBlock->getArguments());
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Ion/Transforms/QuantumToIonPatterns.cpp
+++ b/mlir/lib/Ion/Transforms/QuantumToIonPatterns.cpp
@@ -190,7 +190,6 @@ mlir::LogicalResult oneQubitGateToPulse(CustomOp op, mlir::PatternRewriter &rewr
                 auto qubit = qubits.front();
                 builder.create<ion::PulseOp>(loc, time, qubit, beam0toEAttr, phase1Attr);
                 builder.create<ion::PulseOp>(loc, time, qubit, beam1toEAttr, phase2Attr);
-                builder.create<ion::YieldOp>(loc);
             });
         rewriter.replaceOp(op, ppOp);
         return success();
@@ -408,8 +407,6 @@ mlir::LogicalResult MSGateToPulse(CustomOp op, mlir::PatternRewriter &rewriter,
                         rewriter.getI64VectorAttr(beam.polarization),
                         rewriter.getI64VectorAttr(flipSign(beam.wavevector)));
                     builder.create<ion::PulseOp>(loc, time, qubit1, beam6Attr, phase0Attr);
-
-                    builder.create<ion::YieldOp>(loc);
                 });
             rewriter.replaceOp(op, ppOp);
             return success();

--- a/mlir/test/Ion/QuantumToIon.mlir
+++ b/mlir/test/Ion/QuantumToIon.mlir
@@ -163,6 +163,7 @@ func.func @example_ion_two_qubit(%arg0: f64) -> !quantum.bit {
     // CHECK-SAME:         polarization = dense<[0, 1]> : vector<2xi64>,
     // CHECK-SAME:         wavevector = dense<[-2, 3]> : vector<2xi64>>,
     // CHECK-SAME:     phase = 0.000000e+00 : f64}
+    // CHECK-NEXT:   ion.yield %arg1 : !quantum.bit
     // CHECK-NEXT: }
     %4 = quantum.custom "RX"(%arg0) %2 : !quantum.bit
 
@@ -186,6 +187,7 @@ func.func @example_ion_two_qubit(%arg0: f64) -> !quantum.bit {
     // CHECK-SAME:         polarization = dense<[0, 1]> : vector<2xi64>,
     // CHECK-SAME:         wavevector = dense<[-2, 3]> : vector<2xi64>>,
     // CHECK-SAME:     phase = 3.1415926535{{[0-9]*}} : f64}
+    // CHECK-NEXT:   ion.yield %arg1 : !quantum.bit
     // CHECK-NEXT: }
     %5 = quantum.custom "RY"(%arg0) %4 : !quantum.bit
 
@@ -209,6 +211,7 @@ func.func @example_ion_two_qubit(%arg0: f64) -> !quantum.bit {
     // CHECK-SAME:         polarization = dense<[0, 1]> : vector<2xi64>,
     // CHECK-SAME:         wavevector = dense<[-2, 3]> : vector<2xi64>>,
     // CHECK-SAME:     phase = 0.000000e+00 : f64}
+    // CHECK-NEXT:   ion.yield %arg1 : !quantum.bit
     // CHECK-NEXT: }
     %6 = quantum.custom "RX"(%arg0) %5 : !quantum.bit
 
@@ -264,6 +267,7 @@ func.func @example_ion_two_qubit(%arg0: f64) -> !quantum.bit {
     // CHECK-SAME:         polarization = dense<[7, 8]> : vector<2xi64>,
     // CHECK-SAME:         wavevector = dense<[-9, -10]> : vector<2xi64>>,
     // CHECK-SAME:     phase = 0.000000e+00 : f64}
+    // CHECK-NEXT:   ion.yield %arg1, %arg2 : !quantum.bit, !quantum.bit
     // CHECK-NEXT: }
     %7:2 = quantum.custom "MS"(%arg0) %6, %3 : !quantum.bit, !quantum.bit
     return %7#0: !quantum.bit
@@ -340,6 +344,7 @@ func.func @example_ion_three_qubit(%arg0: f64) -> (!quantum.bit, !quantum.bit, !
     // CHECK-SAME:         polarization = dense<[7, 8]> : vector<2xi64>,
     // CHECK-SAME:         wavevector = dense<[-9, -10]> : vector<2xi64>>,
     // CHECK-SAME:     phase = 0.000000e+00 : f64}
+    // CHECK-NEXT:   ion.yield %arg1, %arg2 : !quantum.bit, !quantum.bit
     // CHECK-NEXT: }
     %5:2 = quantum.custom "MS"(%arg0) %2, %3 : !quantum.bit, !quantum.bit
 
@@ -395,6 +400,7 @@ func.func @example_ion_three_qubit(%arg0: f64) -> (!quantum.bit, !quantum.bit, !
     // CHECK-SAME:         polarization = dense<[1, 2]> : vector<2xi64>,
     // CHECK-SAME:         wavevector = dense<[3, -4]> : vector<2xi64>>,
     // CHECK-SAME:     phase = 0.000000e+00 : f64}
+    // CHECK-NEXT:   ion.yield %arg1, %arg2 : !quantum.bit, !quantum.bit
     // CHECK-NEXT: }
     %6:2 = quantum.custom "MS"(%arg0) %5#0, %4 : !quantum.bit, !quantum.bit
 
@@ -450,6 +456,7 @@ func.func @example_ion_three_qubit(%arg0: f64) -> (!quantum.bit, !quantum.bit, !
     // CHECK-SAME:         polarization = dense<[37, 42]> : vector<2xi64>,
     // CHECK-SAME:         wavevector = dense<[42, 37]> : vector<2xi64>>,
     // CHECK-SAME:     phase = 0.000000e+00 : f64}
+    // CHECK-NEXT:   ion.yield %arg1, %arg2 : !quantum.bit, !quantum.bit
     // CHECK-NEXT: }
     %7:2 = quantum.custom "MS"(%arg0) %5#1, %6#1 : !quantum.bit, !quantum.bit
     return %6#0, %7#0, %7#1: !quantum.bit, !quantum.bit, !quantum.bit


### PR DESCRIPTION
**Context:** During `quantum-to-ion` pass, when decomposing RX, RY and MS gates to pulses in a `ParallelProtocolOp`'s region, the region was terminated with yield ops without any operands. This means no SSA values were actually yielded from the region. At the same time, `ParallelProtocolOp` returns (variadic-length) values of type `!quantum.bit`. This means the IR is ill-formed. 

**Description of the Change:**
Ensure that all `ParallelProtocolOp`s will yield the input-ed qubit SSA values by doing so in the builder, when building the region of the `ParallelProtocolOp`.

**Benefits:** mlir is no longer ill-formed; increased readability

