### PR TITLE
Update deprecated `gradient_kwargs` usage

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.149
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt
-pennylane=0.41.0-dev14
+pennylane=0.41.0.dev14
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/.dep-versions
+++ b/.dep-versions
@@ -8,8 +8,8 @@ enzyme=v0.0.149
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt
-pennylane=0.41.0.dev14
+pennylane=0.41.0-dev14
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'
-lightning=0.41.0.dev6
+# lightning=0.41.0-dev1

--- a/.dep-versions
+++ b/.dep-versions
@@ -12,4 +12,4 @@ pennylane=0.41.0.dev14
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'
-# lightning=0.41.0-dev1
+lightning=0.41.0.dev6

--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.149
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt
-# pennylane=0.41.0-dev1
+# pennylane=0.41.0-dev14
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.149
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt
-# pennylane=0.41.0-dev14
+pennylane=0.41.0-dev14
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -16,6 +16,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Update deprecated `gradient_kwargs` usage.
+  [(#1480)](https://github.com/PennyLaneAI/catalyst/pull/1480)
+
 * `from_plxpr` now uses the `qml.capture.PlxprInterpreter` class for reduced code duplication.
   [(#1398)](https://github.com/PennyLaneAI/catalyst/pull/1398)
 
@@ -48,4 +51,5 @@ This release contains contributions from (in alphabetical order):
 Sengthai Heng,
 Christina Lee,
 Mehrdad Malekmohammadi,
+Andrija Paurevic,
 Paul Haochen Wang.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -16,9 +16,6 @@
 
 <h3>Internal changes ⚙️</h3>
 
-* Update deprecated `gradient_kwargs` usage.
-  [(#1480)](https://github.com/PennyLaneAI/catalyst/pull/1480)
-
 * `from_plxpr` now uses the `qml.capture.PlxprInterpreter` class for reduced code duplication.
   [(#1398)](https://github.com/PennyLaneAI/catalyst/pull/1398)
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -32,4 +32,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.40.0
 pennylane-lightning==0.40.0
-pennylane==0.40.0
+pennylane==0.41.0-dev14

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -30,6 +30,6 @@ lxml_html_clean
 
 # Pre-install PL development wheels
 --extra-index-url https://test.pypi.org/simple/
-pennylane-lightning-kokkos==0.40.0
-pennylane-lightning==0.40.0
+pennylane-lightning-kokkos==0.41.0.dev6
+pennylane-lightning==0.41.0.dev6
 pennylane==0.41.0.dev14

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -30,6 +30,6 @@ lxml_html_clean
 
 # Pre-install PL development wheels
 --extra-index-url https://test.pypi.org/simple/
-pennylane-lightning-kokkos==0.41.0.dev6
-pennylane-lightning==0.41.0.dev6
-pennylane==0.41.0.dev14
+pennylane-lightning-kokkos==0.40.0
+pennylane-lightning==0.40.0
+pennylane==0.41.0-dev14

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -32,4 +32,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.40.0
 pennylane-lightning==0.40.0
-pennylane==0.41.0-dev14
+pennylane==0.41.0.dev14

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -799,7 +799,7 @@ def test_finite_diff_h(inp, backend):
 
     def interpretted_grad_h(x):
         device = qml.device("default.qubit", wires=1)
-        g = qml.QNode(f, device, diff_method="finite-diff", h=0.1)
+        g = qml.QNode(f, device, diff_method="finite-diff", gradient_kwargs={"h": 0.1})
         h = qml.grad(g, argnum=0)
         return h(x)
 


### PR DESCRIPTION
**Context:**

As of https://github.com/PennyLaneAI/pennylane/pull/6828,  `gradient_kwargs` is now a positional keyword argument for the `QNode`. This means you can not simply express,
```python
qml.QNode(func, dev, h=1)
```
instead, you must deliberately specify,
```python
qml.QNode(func, dev, gradient_kwargs={"h":1})
```

**Description of the Change:**

Updated any deprecated code that was found. 

**Benefits:** Consistency with code-base.

**Possible Drawbacks:** None identified.

[sc-81531]
