### PR TITLE
Remove test randomization on mac

### DIFF
--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -437,10 +437,7 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        # During the 0.10.0 release cycle we discovered that having exactly 2700 test items distributed on 
-        # exactly 3 cores (e.g. GH M1 runner) produces a lot of test failures. Randomizing the test order
-        # (pytest-randomly) fixes the issue for now.
-        python${{ matrix.python_version }} -m pip install pytest pytest-xdist pytest-mock pytest-randomly
+        python${{ matrix.python_version }} -m pip install pytest pytest-xdist pytest-mock
 
     - name: Install PennyLane Plugins
       run: |
@@ -465,7 +462,7 @@ jobs:
       run: |
         python${{ matrix.python_version }} -m pytest frontend/test/pytest -n auto
         python${{ matrix.python_version }} -m pytest frontend/test/pytest --backend="lightning.kokkos" -n auto
-        python${{ matrix.python_version }} -m pytest frontend/test/async_tests -p no:randomly
+        python${{ matrix.python_version }} -m pytest frontend/test/async_tests
         python${{ matrix.python_version }} -m pytest frontend/test/pytest --runbraket=LOCAL -n auto
         python${{ matrix.python_version }} -m pytest frontend/test/test_oqc/oqc -n auto
 


### PR DESCRIPTION
While we originally added the test randomization to avoid one specific test order caused by improper handling of global state in tests (now fixed), it is clear that there are more orderings that will produce test failures due to race conditions or other global state issues (e.g. https://github.com/PennyLaneAI/catalyst/actions/runs/12921842532). Let's remove the randomized testing again although at some point it would be nice to resolve these race conditions in the test suite.