### PR TITLE
Are runtime tests actually required in CI?

### DIFF
--- a/runtime/tests/Test_NullQubit.cpp
+++ b/runtime/tests/Test_NullQubit.cpp
@@ -28,6 +28,7 @@ TEST_CASE("Test success of loading a device", "[NullQubit]")
 {
     std::unique_ptr<ExecutionContext> driver = std::make_unique<ExecutionContext>();
     CHECK(loadDevice("NullQubit", "librtd_null_qubit" + get_dylib_ext()));
+    CHECK(1 == 0);
 }
 
 TEST_CASE("Test __catalyst__rt__device_init registering device=null.qubit", "[NullQubit]")


### PR DESCRIPTION
**Context:**
There are a couple different items that seem to be running runtime tests in CI. however it seems like the only entry that runs the full runtime test suite, `Runtime Code Coverage`, is not actually a required CI item.

Moreover, it seems like the "lightning", "lightning-kokkos" and "openqasm" entries are not actually doing any testing at all. 

We slip in a expected failed test to see which CI entries can pick it up.