### PR TITLE
Add a device config opaque pointer to runtime device init

### DIFF
--- a/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
@@ -210,6 +210,7 @@ struct DeviceInitOpPattern : public OpConversionPattern<DeviceInitOp> {
                                                         {/* rtd_lib = */ charPtrType,
                                                          /* rtd_name = */ charPtrType,
                                                          /* rtd_kwargs = */ charPtrType,
+                                                         /* device_config = */ charPtrType,
                                                          /* shots = */ int64Type});
         LLVM::LLVMFuncOp fnDecl = ensureFunctionDeclaration(rewriter, op, qirName, qirSignature);
 
@@ -224,7 +225,12 @@ struct DeviceInitOpPattern : public OpConversionPattern<DeviceInitOp> {
         auto rtd_kwargs_gs = getGlobalString(
             loc, rewriter, rtd_kwargs, StringRef(rtd_kwargs.c_str(), rtd_kwargs.length() + 1), mod);
 
-        SmallVector<Value> operands = {rtd_lib_gs, rtd_name_gs, rtd_kwargs_gs};
+        // Create nullptr for device config
+        // Specific devices should fill these configs downstream, in the
+        // `--quantum-to-<specific_device_dialect>` lowerings
+        Value null_device_config = rewriter.create<LLVM::ZeroOp>(loc, charPtrType);
+
+        SmallVector<Value> operands = {rtd_lib_gs, rtd_name_gs, rtd_kwargs_gs, null_device_config};
 
         Value shots = op.getShots();
         if (!shots) {

--- a/mlir/test/Quantum/ConversionTest.mlir
+++ b/mlir/test/Quantum/ConversionTest.mlir
@@ -44,7 +44,7 @@ func.func @finalize() {
 
 // -----
 
-// CHECK: llvm.func @__catalyst__rt__device_init(!llvm.ptr, !llvm.ptr, !llvm.ptr, i64)
+// CHECK: llvm.func @__catalyst__rt__device_init(!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64)
 
 // CHECK-LABEL: @device
 func.func @device() {
@@ -61,7 +61,8 @@ func.func @device() {
     // CHECK: [[b1:%.+]] = llvm.getelementptr inbounds [[bo]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<16 x i8>
     // CHECK: [[d3:%.+]] = llvm.mlir.addressof @"{my_attr: my_attr_value}" : !llvm.ptr
     // CHECK: [[d4:%.+]] = llvm.getelementptr inbounds [[d3]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<25 x i8>
-    // CHECK: llvm.call @__catalyst__rt__device_init([[d1]], [[b1]], [[d4]], [[shots]]) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> ()
+    // CHECK: [[null0:%.+]] = llvm.mlir.zero : !llvm.ptr
+    // CHECK: llvm.call @__catalyst__rt__device_init([[d1]], [[b1]], [[d4]], [[null0]], [[shots]]) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> ()
     %shots = llvm.mlir.constant(1000 : i64) : i64
     quantum.device shots(%shots) ["rtd_lightning.so", "lightning.qubit", "{my_attr: my_attr_value}"]
 
@@ -71,7 +72,8 @@ func.func @device() {
     // CHECK: [[e3:%.+]] = llvm.getelementptr inbounds [[e2]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<17 x i8>
     // CHECK: [[e4:%.+]] = llvm.mlir.addressof @"{my_other_attr: my_other_attr_value}" : !llvm.ptr
     // CHECK: [[e5:%.+]] = llvm.getelementptr inbounds [[e4]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<37 x i8>
-    // CHECK: llvm.call @__catalyst__rt__device_init([[e1]], [[e3]], [[e5]], [[shots]]) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> ()
+    // CHECK: [[null1:%.+]] = llvm.mlir.zero : !llvm.ptr
+    // CHECK: llvm.call @__catalyst__rt__device_init([[e1]], [[e3]], [[e5]], [[null1]], [[shots]]) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> ()
 
     quantum.device shots(%shots) ["rtd_lightning.so", "lightning.kokkos", "{my_other_attr: my_other_attr_value}"]
 
@@ -81,8 +83,9 @@ func.func @device() {
     // CHECK: [[b1:%.+]] = llvm.getelementptr inbounds [[bo]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<16 x i8>
     // CHECK: [[d3:%.+]] = llvm.mlir.addressof @"{my_noshots_attr: my_noshots_attr_value}" : !llvm.ptr
     // CHECK: [[d4:%.+]] = llvm.getelementptr inbounds [[d3]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<41 x i8>
+    // CHECK: [[null2:%.+]] = llvm.mlir.zero : !llvm.ptr
     // CHECK: [[zero_shots:%.+]] = llvm.mlir.constant(0 : i64) : i64
-    // CHECK: llvm.call @__catalyst__rt__device_init([[d1]], [[b1]], [[d4]], [[zero_shots]]) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> ()
+    // CHECK: llvm.call @__catalyst__rt__device_init([[d1]], [[b1]], [[d4]], [[null2]], [[zero_shots]]) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i64) -> ()
     quantum.device ["rtd_lightning.so", "lightning.qubit", "{my_noshots_attr: my_noshots_attr_value}"]
 
     return

--- a/runtime/include/QuantumDevice.hpp
+++ b/runtime/include/QuantumDevice.hpp
@@ -125,21 +125,6 @@ struct QuantumDevice {
     virtual void SetDevicePRNG([[maybe_unused]] std::mt19937 *gen){};
 
     /**
-     * @brief Set the device-dependent configurations of the device.
-     *
-     * Certain devices might want to record extra information specific
-     * to the device, for example the ion species and energy levels on
-     * an ion-based quantum computer hardware device.
-     *
-     * Such information should be recorded in a struct, and the struct's
-     * pointer is recorded here by the device.
-     *
-     * @param device_config The pointer to a struct recording the
-     * device-specific configurations.
-     */
-    virtual void SetDeviceConfig([[maybe_unused]] DeviceConfig device_config){};
-
-    /**
      * @brief Start recording a quantum tape if provided.
      *
      * @note This is backed by the `Catalyst::Runtime::CacheManager<ComplexT>` property in
@@ -375,5 +360,20 @@ struct QuantumDevice {
      */
     virtual void Gradient(std::vector<DataView<double, 1>> &gradients,
                           const std::vector<size_t> &trainParams) = 0;
+
+    /**
+     * @brief Set the device-dependent configurations of the device.
+     *
+     * Certain devices might want to record extra information specific
+     * to the device, for example the ion species and energy levels on
+     * an ion-based quantum computer hardware device.
+     *
+     * Such information should be recorded in a struct, and the struct's
+     * pointer is recorded here by the device.
+     *
+     * @param device_config The pointer to a struct recording the
+     * device-specific configurations.
+     */
+    virtual void SetDeviceConfig([[maybe_unused]] DeviceConfig device_config){};
 };
 } // namespace Catalyst::Runtime

--- a/runtime/include/QuantumDevice.hpp
+++ b/runtime/include/QuantumDevice.hpp
@@ -125,6 +125,21 @@ struct QuantumDevice {
     virtual void SetDevicePRNG([[maybe_unused]] std::mt19937 *gen){};
 
     /**
+     * @brief Set the device-dependent configurations of the device.
+     *
+     * Certain devices might want to record extra information specific
+     * to the device, for example the ion species and energy levels on
+     * an ion-based quantum computer hardware device.
+     *
+     * Such information should be recorded in a struct, and the struct's
+     * pointer is recorded here by the device.
+     *
+     * @param device_config The pointer to a struct recording the
+     * device-specific configurations.
+     */
+    virtual void SetDeviceConfig([[maybe_unused]] DeviceConfig device_config){};
+
+    /**
      * @brief Start recording a quantum tape if provided.
      *
      * @note This is backed by the `Catalyst::Runtime::CacheManager<ComplexT>` property in

--- a/runtime/include/RuntimeCAPI.h
+++ b/runtime/include/RuntimeCAPI.h
@@ -25,7 +25,7 @@ extern "C" {
 // Quantum Runtime Instructions
 void __catalyst__rt__fail_cstr(const char *);
 void __catalyst__rt__initialize(uint32_t *seed);
-void __catalyst__rt__device_init(int8_t *, int8_t *, int8_t *, int64_t shots);
+void __catalyst__rt__device_init(int8_t *, int8_t *, int8_t *, DeviceConfig, int64_t shots);
 void __catalyst__rt__device_release();
 void __catalyst__rt__finalize();
 void __catalyst__rt__toggle_recorder(bool);

--- a/runtime/include/Types.h
+++ b/runtime/include/Types.h
@@ -32,6 +32,8 @@ using RESULT = bool;
 using Result = RESULT *;
 using QirArray = void *;
 
+using DeviceConfig = void *;
+
 using ObsIdType = intptr_t;
 
 enum ObsId : int8_t {

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -240,7 +240,7 @@ void __catalyst__rt__finalize()
 }
 
 static int __catalyst__rt__device_init__impl(int8_t *rtd_lib, int8_t *rtd_name, int8_t *rtd_kwargs,
-                                             int64_t shots)
+                                             DeviceConfig device_config, int64_t shots)
 {
     // Device library cannot be a nullptr
     RT_FAIL_IF(!rtd_lib, "Invalid device library");
@@ -254,6 +254,7 @@ static int __catalyst__rt__device_init__impl(int8_t *rtd_lib, int8_t *rtd_name, 
     RT_FAIL_IF(!initRTDevicePtr(args[0], args[1], args[2]),
                "Failed initialization of the backend device");
     getQuantumDevicePtr()->SetDeviceShots(shots);
+    getQuantumDevicePtr()->SetDeviceConfig(device_config);
     if (CTX->getDeviceRecorderStatus()) {
         getQuantumDevicePtr()->StartTapeRecording();
     }
@@ -261,10 +262,10 @@ static int __catalyst__rt__device_init__impl(int8_t *rtd_lib, int8_t *rtd_name, 
 }
 
 void __catalyst__rt__device_init(int8_t *rtd_lib, int8_t *rtd_name, int8_t *rtd_kwargs,
-                                 int64_t shots)
+                                 DeviceConfig device_config, int64_t shots)
 {
     timer::timer(__catalyst__rt__device_init__impl, "device_init", /* add_endl */ true, rtd_lib,
-                 rtd_name, rtd_kwargs, shots);
+                 rtd_name, rtd_kwargs, device_config, shots);
 }
 
 static int __catalyst__rt__device_release__impl()

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -254,7 +254,9 @@ static int __catalyst__rt__device_init__impl(int8_t *rtd_lib, int8_t *rtd_name, 
     RT_FAIL_IF(!initRTDevicePtr(args[0], args[1], args[2]),
                "Failed initialization of the backend device");
     getQuantumDevicePtr()->SetDeviceShots(shots);
-    getQuantumDevicePtr()->SetDeviceConfig(device_config);
+    if (device_config != nullptr) {
+        getQuantumDevicePtr()->SetDeviceConfig(device_config);
+    }
     if (CTX->getDeviceRecorderStatus()) {
         getQuantumDevicePtr()->StartTapeRecording();
     }

--- a/runtime/tests/Test_NullQubit.cpp
+++ b/runtime/tests/Test_NullQubit.cpp
@@ -35,7 +35,7 @@ TEST_CASE("Test __catalyst__rt__device_init registering device=null.qubit", "[Nu
     __catalyst__rt__initialize(nullptr);
 
     char rtd_name[11] = "null.qubit";
-    __catalyst__rt__device_init((int8_t *)rtd_name, nullptr, nullptr, 0);
+    __catalyst__rt__device_init((int8_t *)rtd_name, nullptr, nullptr, nullptr, 0);
 
     __catalyst__rt__device_release();
 
@@ -145,7 +145,7 @@ TEST_CASE("Test __catalyst__qis__Sample with num_qubits=2 and PartialSample call
         std::array<std::string, 3>{"null.qubit", "null_qubit", ""};
     __catalyst__rt__initialize(nullptr);
     __catalyst__rt__device_init((int8_t *)rtd_lib.c_str(), (int8_t *)rtd_name.c_str(),
-                                (int8_t *)rtd_kwargs.c_str(), 1000);
+                                (int8_t *)rtd_kwargs.c_str(), nullptr, 1000);
 
     QirArray *qs = __catalyst__rt__qubit_allocate_array(2);
 
@@ -279,7 +279,7 @@ TEST_CASE("Test __catalyst__qis__Gradient_params Op=[Hadamard,RZ,RY,RZ,S,T,Param
         std::array<std::string, 3>{"null.qubit", "null_qubit", ""};
 
     __catalyst__rt__device_init((int8_t *)rtd_lib.c_str(), (int8_t *)rtd_name.c_str(),
-                                (int8_t *)rtd_kwargs.c_str(), 0);
+                                (int8_t *)rtd_kwargs.c_str(), nullptr, 0);
 
     QUBIT *q0 = __catalyst__rt__qubit_allocate();
     QUBIT *q1 = __catalyst__rt__qubit_allocate();

--- a/runtime/tests/Test_NullQubit.cpp
+++ b/runtime/tests/Test_NullQubit.cpp
@@ -48,6 +48,18 @@ TEST_CASE("Test NullQubit qubit allocation is successful.", "[NullQubit]")
     sim->AllocateQubit();
 }
 
+TEST_CASE("Test NullQubit qubit device config setting is successful.", "[NullQubit]")
+{
+    std::unique_ptr<NullQubit> sim = std::make_unique<NullQubit>();
+    struct Config {
+        std::string name;
+        size_t a_number;
+        std::array<double, 2> a_list;
+    };
+    Config config{"null", 42, {3.14, 2.718}};
+    sim->SetDeviceConfig(&config);
+}
+
 TEST_CASE("Test a NullQubit circuit with num_qubits=2 ", "[NullQubit]")
 {
     std::unique_ptr<NullQubit> sim = std::make_unique<NullQubit>();

--- a/runtime/tests/Test_OpenQasmDevice.cpp
+++ b/runtime/tests/Test_OpenQasmDevice.cpp
@@ -660,8 +660,9 @@ TEST_CASE("Test __catalyst__rt__device_init registering the OpenQasm device", "[
 #if __has_include("OpenQasmDevice.hpp")
     __catalyst__rt__device_init((int8_t *)device_aws, nullptr, nullptr, nullptr, 0);
 #else
-    REQUIRE_THROWS_WITH(__catalyst__rt__device_init((int8_t *)device_aws, nullptr, nullptr, nullptr, 0),
-                        Catch::Contains("cannot open shared object file"));
+    REQUIRE_THROWS_WITH(
+        __catalyst__rt__device_init((int8_t *)device_aws, nullptr, nullptr, nullptr, 0),
+        Catch::Contains("cannot open shared object file"));
 #endif
 
     __catalyst__rt__finalize();
@@ -673,8 +674,9 @@ TEST_CASE("Test __catalyst__rt__device_init registering the OpenQasm device", "[
 #if __has_include("OpenQasmDevice.hpp")
     __catalyst__rt__device_init((int8_t *)device_local, nullptr, nullptr, nullptr, 0);
 #else
-    REQUIRE_THROWS_WITH(__catalyst__rt__device_init((int8_t *)(int8_t *), nullptr, nullptr, nullptr, 0),
-                        Catch::Contains("cannot open shared object file"));
+    REQUIRE_THROWS_WITH(
+        __catalyst__rt__device_init((int8_t *)(int8_t *), nullptr, nullptr, nullptr, 0),
+        Catch::Contains("cannot open shared object file"));
 #endif
 
     __catalyst__rt__finalize();

--- a/runtime/tests/Test_OpenQasmDevice.cpp
+++ b/runtime/tests/Test_OpenQasmDevice.cpp
@@ -658,9 +658,9 @@ TEST_CASE("Test __catalyst__rt__device_init registering the OpenQasm device", "[
     char device_aws[30] = "braket.aws.qubit";
 
 #if __has_include("OpenQasmDevice.hpp")
-    __catalyst__rt__device_init((int8_t *)device_aws, nullptr, nullptr, 0);
+    __catalyst__rt__device_init((int8_t *)device_aws, nullptr, nullptr, nullptr, 0);
 #else
-    REQUIRE_THROWS_WITH(__catalyst__rt__device_init((int8_t *)device_aws, nullptr, nullptr, 0),
+    REQUIRE_THROWS_WITH(__catalyst__rt__device_init((int8_t *)device_aws, nullptr, nullptr, nullptr, 0),
                         Catch::Contains("cannot open shared object file"));
 #endif
 
@@ -671,9 +671,9 @@ TEST_CASE("Test __catalyst__rt__device_init registering the OpenQasm device", "[
     char device_local[30] = "braket.local.qubit";
 
 #if __has_include("OpenQasmDevice.hpp")
-    __catalyst__rt__device_init((int8_t *)device_local, nullptr, nullptr, 0);
+    __catalyst__rt__device_init((int8_t *)device_local, nullptr, nullptr, nullptr, 0);
 #else
-    REQUIRE_THROWS_WITH(__catalyst__rt__device_init((int8_t *)(int8_t *), nullptr, nullptr, 0),
+    REQUIRE_THROWS_WITH(__catalyst__rt__device_init((int8_t *)(int8_t *), nullptr, nullptr, nullptr, 0),
                         Catch::Contains("cannot open shared object file"));
 #endif
 


### PR DESCRIPTION
**Context:**
Certain devices might want to record extra compile-time information specific to the device, for example the ion species and energy levels (which are unchanging) on an ion-based quantum computer hardware device.

These information will not be available in the PennyLane frontend, as they are device-specific and are not hardware-agnostic. Hence, such information will not be in the quantum dialect. They should be injected into the IR at compile time, but during the lowering from quantum dialect to the device's specific dialect.

Such information should be recorded in a llvm struct in the LLVM dialect, during the `--quantum-to-<specific_device_dialect>`, then `--convert-<specific_device_dialect>-to-llvm` lowering, and the struct's pointer should be recorded by the device by being passed into `__catalyst__rt__device__init()`.

**Description of the Change:**
Change `__catalyst__rt__device__init()` to take in an extra opaque pointer, for the device specific configurations that are not suited to be recorded in the base `QuantumDevice` class.

**Benefits:**
More abstraction, and more support for catalyst being hardware-agnostic.  

