### PR TITLE
Apply modifications forced by black version 25.1.0

### DIFF
--- a/benchmark/batchrun.py
+++ b/benchmark/batchrun.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Measurement cycle management entry point """
+"""Measurement cycle management entry point"""
 import sys
 
 from catalyst_benchmark.toplevel import (

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Single measurement entry point """
+"""Single measurement entry point"""
 import sys
 from argparse import ArgumentParser
 from json import dump as json_dump

--- a/benchmark/catalyst_benchmark/measurements.py
+++ b/benchmark/catalyst_benchmark/measurements.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" This file contains a libraru of single value measurement procedures plus the self-checking
+"""This file contains a libraru of single value measurement procedures plus the self-checking
 routine ensuring the numeric equivalence across similar problems."""
 
 # pylint: disable=import-outside-toplevel

--- a/benchmark/catalyst_benchmark/measurements.py
+++ b/benchmark/catalyst_benchmark/measurements.py
@@ -134,7 +134,10 @@ def measure_compile_catalyst(a: ParsedArguments) -> BenchmarkResult:
         from catalyst_benchmark.test_cases.chemvqe_catalyst import (
             ProblemCVQE as Problem,
         )
-        from catalyst_benchmark.test_cases.chemvqe_catalyst import qcompile, workflow
+        from catalyst_benchmark.test_cases.chemvqe_catalyst import (
+            qcompile,
+            workflow,
+        )
 
         p = Problem(
             qml.device("lightning.qubit", wires=a.nqubits),
@@ -215,7 +218,10 @@ def measure_runtime_catalyst(a: ParsedArguments) -> BenchmarkResult:
         from catalyst_benchmark.test_cases.chemvqe_catalyst import (
             ProblemCVQE as Problem,
         )
-        from catalyst_benchmark.test_cases.chemvqe_catalyst import qcompile, workflow
+        from catalyst_benchmark.test_cases.chemvqe_catalyst import (
+            qcompile,
+            workflow,
+        )
 
         p = Problem(qml.device("lightning.qubit", wires=a.nqubits), diff_method=a.vqe_diff_method)
     elif a.problem == "chemvqe-hybrid":
@@ -319,7 +325,9 @@ def measure_compile_pennylanejax(a: ParsedArguments) -> BenchmarkResult:
         from catalyst_benchmark.test_cases.chemvqe_pennylane import (
             qcompile_hybrid as qcompile,
         )
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import size
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
+            size,
+        )
         from catalyst_benchmark.test_cases.chemvqe_pennylane import (
             workflow_hybrid as workflow,
         )
@@ -414,7 +422,9 @@ def measure_runtime_pennylanejax(a: ParsedArguments) -> BenchmarkResult:
         from catalyst_benchmark.test_cases.chemvqe_pennylane import (
             qcompile_hybrid as qcompile,
         )
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import size
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
+            size,
+        )
         from catalyst_benchmark.test_cases.chemvqe_pennylane import (
             workflow_hybrid as workflow,
         )
@@ -504,7 +514,9 @@ def measure_compile_pennylane(a: ParsedArguments) -> BenchmarkResult:
         from catalyst_benchmark.test_cases.chemvqe_pennylane import (
             qcompile_hybrid as qcompile,
         )
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import size
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
+            size,
+        )
         from catalyst_benchmark.test_cases.chemvqe_pennylane import (
             workflow_hybrid as workflow,
         )
@@ -584,7 +596,9 @@ def measure_runtime_pennylane(a: ParsedArguments) -> BenchmarkResult:
         from catalyst_benchmark.test_cases.chemvqe_pennylane import (
             qcompile_hybrid as qcompile,
         )
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import size
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
+            size,
+        )
         from catalyst_benchmark.test_cases.chemvqe_pennylane import (
             workflow_hybrid as workflow,
         )

--- a/benchmark/catalyst_benchmark/test_cases/chemvqe_catalyst.py
+++ b/benchmark/catalyst_benchmark/test_cases/chemvqe_catalyst.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" ChemVQE problem, PennyLane+Catalyst implementation """
+"""ChemVQE problem, PennyLane+Catalyst implementation"""
 
 # pylint: disable=too-many-instance-attributes
 # pylint: disable=no-value-for-parameter; It happens when we use Catalyst control-flow

--- a/benchmark/catalyst_benchmark/test_cases/chemvqe_pennylane.py
+++ b/benchmark/catalyst_benchmark/test_cases/chemvqe_pennylane.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" ChemVQE problem, PennyLane/PennyLane+JAX implementation """
+"""ChemVQE problem, PennyLane/PennyLane+JAX implementation"""
 
 # pylint: disable=import-outside-toplevel
 # pylint: disable=too-many-instance-attributes

--- a/benchmark/catalyst_benchmark/test_cases/grover_catalyst.py
+++ b/benchmark/catalyst_benchmark/test_cases/grover_catalyst.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Grover-like problem, PennyLane+Catalyst implementation """
+"""Grover-like problem, PennyLane+Catalyst implementation"""
 
 # pylint: disable=too-many-instance-attributes
 

--- a/benchmark/catalyst_benchmark/test_cases/grover_pennylane.py
+++ b/benchmark/catalyst_benchmark/test_cases/grover_pennylane.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Grover-like problem, PennyLane/PennyLane+JAX implementation """
+"""Grover-like problem, PennyLane/PennyLane+JAX implementation"""
 
 # pylint: disable=import-outside-toplevel
 # pylint: disable=too-many-instance-attributes

--- a/benchmark/catalyst_benchmark/test_cases/qft_catalyst.py
+++ b/benchmark/catalyst_benchmark/test_cases/qft_catalyst.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" ChemVQE problem, PennyLane+Catalyst implementation """
+"""ChemVQE problem, PennyLane+Catalyst implementation"""
 
 from dataclasses import dataclass
 

--- a/benchmark/catalyst_benchmark/test_cases/qft_pennylane.py
+++ b/benchmark/catalyst_benchmark/test_cases/qft_pennylane.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" ChemVQE problem, PennyLane+Catalyst implementation """
+"""ChemVQE problem, PennyLane+Catalyst implementation"""
 from copy import deepcopy
 from dataclasses import dataclass
 

--- a/benchmark/catalyst_benchmark/toplevel.py
+++ b/benchmark/catalyst_benchmark/toplevel.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" This file defines certain high-level routines, such as the data collection cycle, data loading
-and the plotting. Measurement ranges and scales are all defined here as global dictionaries. """
+"""This file defines certain high-level routines, such as the data collection cycle, data loading
+and the plotting. Measurement ranges and scales are all defined here as global dictionaries."""
 
 import sys
 from argparse import ArgumentParser

--- a/benchmark/catalyst_benchmark/types.py
+++ b/benchmark/catalyst_benchmark/types.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Benchmarking data type definitions """
+"""Benchmarking data type definitions"""
 
 from argparse import SUPPRESS, Action
 from dataclasses import dataclass

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -46,6 +46,9 @@
   - The region of a `ParallelProtocolOp` is now always terminated with a `ion::YieldOp` with explicitly yielded SSA values. This ensures the op is well-formed, and improves readability.
     [(#1475)](https://github.com/PennyLaneAI/catalyst/pull/1475)
 
+* Update source code to comply with changes requested by black v25.1.0
+  [(#1490)](https://github.com/PennyLaneAI/catalyst/pull/1490)
+
 <h3>Documentation 📝</h3>
 
 <h3>Contributors ✍️</h3>

--- a/frontend/catalyst/_configuration.py
+++ b/frontend/catalyst/_configuration.py
@@ -1,6 +1,6 @@
-""" When catalyst is packaged into a python wheel
-    the contents of this file will be overridden with:
-    INSTALLED = True
+"""When catalyst is packaged into a python wheel
+the contents of this file will be overridden with:
+INSTALLED = True
 """
 
 INSTALLED = False

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Version information.
-   Version number (major.minor.patch[-label])
+Version number (major.minor.patch[-label])
 """
 
 __version__ = "0.11.0-dev21"

--- a/frontend/catalyst/jax_extras/__init__.py
+++ b/frontend/catalyst/jax_extras/__init__.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Catalyst additions to the Jax library """
+"""Catalyst additions to the Jax library"""
 
 from catalyst.jax_extras.lowering import custom_lower_jaxpr_to_module, jaxpr_to_mlir
 from catalyst.jax_extras.patches import (

--- a/frontend/catalyst/jax_extras/lowering.py
+++ b/frontend/catalyst/jax_extras/lowering.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Jax extras module containing functions related to the StableHLO lowering """
+"""Jax extras module containing functions related to the StableHLO lowering"""
 
 from __future__ import annotations
 

--- a/frontend/catalyst/jax_extras/patches.py
+++ b/frontend/catalyst/jax_extras/patches.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Jax extras module containing Jax patches  """
+"""Jax extras module containing Jax patches"""
 
 # pylint: disable=too-many-arguments
 

--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Jax extras module containing functions related to the Python program tracing  """
+"""Jax extras module containing functions related to the Python program tracing"""
 
 # pylint: disable=line-too-long
 

--- a/frontend/catalyst/logging/__init__.py
+++ b/frontend/catalyst/logging/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-Wrapper for PennyLane logging module. 
+Wrapper for PennyLane logging module.
 """
 from pennylane.logging import debug_logger, debug_logger_init
 

--- a/frontend/catalyst/third_party/cuda/primitives/__init__.py
+++ b/frontend/catalyst/third_party/cuda/primitives/__init__.py
@@ -29,6 +29,7 @@ from jax import numpy as jnp
 
 class AbsCudaQState(jax.core.AbstractValue):
     "Abstract CUDA-quantum State."
+
     hash_value = hash("AbsCudaQState")
 
     def __eq__(self, other):
@@ -40,11 +41,13 @@ class AbsCudaQState(jax.core.AbstractValue):
 
 class CudaQState(cudaq.State):
     "Concrete CUDA-quantum state."
+
     aval = AbsCudaQState
 
 
 class AbsCudaQbit(jax.core.AbstractValue):
     "Abstract CUDA-quantum qbit."
+
     hash_value = hash("AbsCudaQbit")
 
     def __eq__(self, other):
@@ -56,11 +59,13 @@ class AbsCudaQbit(jax.core.AbstractValue):
 
 class CudaQbit(cudaq._pycudaq.QuakeValue):
     "Concrete CUDA-quantum qbit."
+
     aval = AbsCudaQbit
 
 
 class AbsCudaQReg(jax.core.AbstractValue):
     "Abstract CUDA-quantum quantum register."
+
     hash_value = hash("AbsCudaQReg")
 
     def __eq__(self, other):
@@ -72,11 +77,13 @@ class AbsCudaQReg(jax.core.AbstractValue):
 
 class CudaQReg(cudaq._pycudaq.QuakeValue):
     "Concrete CUDA-quantum quantum register."
+
     aval = AbsCudaQReg
 
 
 class AbsCudaValue(jax.core.AbstractValue):
     "Abstract CUDA-quantum value."
+
     hash_value = hash("AbsCudaValue")
 
     def __eq__(self, other):
@@ -88,11 +95,13 @@ class AbsCudaValue(jax.core.AbstractValue):
 
 class CudaValue(cudaq._pycudaq.QuakeValue):
     "Concrete CUDA-quantum value."
+
     aval = AbsCudaValue
 
 
 class AbsCudaKernel(jax.core.AbstractValue):
     "Abstract CUDA-quantum kernel."
+
     hash_value = hash("AbsCudaKernel")
 
     def __eq__(self, other):
@@ -104,11 +113,13 @@ class AbsCudaKernel(jax.core.AbstractValue):
 
 class CudaKernel(cudaq._pycudaq.QuakeValue):
     "Concrete CUDA-quantum kernel."
+
     aval = AbsCudaKernel
 
 
 class AbsCudaSampleResult(jax.core.AbstractValue):
     "Abstract CUDA-quantum kernel."
+
     hash_value = hash("AbsCudaSampleResult")
 
     def __eq__(self, other):
@@ -120,6 +131,7 @@ class AbsCudaSampleResult(jax.core.AbstractValue):
 
 class CudaSampleResult(cudaq.SampleResult):
     "Concrete CUDA-quantum kernel."
+
     aval = AbsCudaSampleResult
 
 
@@ -137,6 +149,7 @@ class AbsCudaSpinOperator(jax.core.AbstractValue):
 
 class CudaSpinOperator(cudaq.SpinOperator):
     "Concrete CUDA-quantum spin operator."
+
     aval = AbsCudaSpinOperator
 
 
@@ -154,6 +167,7 @@ class AbsCudaQObserveResult(jax.core.AbstractValue):
 
 class CudaQObserveResult(cudaq.ObserveResult):
     "Concrete CUDA-quantum observe result."
+
     aval = AbsCudaQObserveResult
 
 

--- a/frontend/catalyst/utils/jnp_to_memref.py
+++ b/frontend/catalyst/utils/jnp_to_memref.py
@@ -13,7 +13,9 @@ to be converted to and from memrefs.
 
 import jax
 import numpy as np
-from mlir_quantum.runtime import as_ctype
+from mlir_quantum.runtime import (
+    as_ctype,
+)
 from mlir_quantum.runtime import (
     get_ranked_memref_descriptor as mlir_get_ranked_memref_descriptor,
 )

--- a/frontend/test/async_tests/test_async.py
+++ b/frontend/test/async_tests/test_async.py
@@ -322,7 +322,7 @@ def test_qnode_exception_dependency(order, backend):
 # TODO: add the following diff_methods once issue #419 is fixed:
 # ("parameter-shift", "auto"), ("adjoint", "auto")]
 @pytest.mark.parametrize("diff_methods", [("finite-diff", "fd")])
-@pytest.mark.parametrize("inp", [(1.0)])
+@pytest.mark.parametrize("inp", [1.0])
 def test_gradient_exception(inp, diff_methods, backend):
     """Parameter shift and finite diff generate multiple QNode that are run async."""
 

--- a/frontend/test/lit/test_device_api.py
+++ b/frontend/test/lit/test_device_api.py
@@ -16,8 +16,7 @@
 
 # pylint: disable=line-too-long
 
-"""Test for the device API.
-"""
+"""Test for the device API."""
 import os
 import pathlib
 import platform

--- a/frontend/test/lit/test_mlir_decomposition.py
+++ b/frontend/test/lit/test_mlir_decomposition.py
@@ -17,7 +17,7 @@ This file performs the frontend lit tests that the peephole transformations are 
 
 We check the transform jax primitives for each pass is correctly injected
 during tracing, and these transform primitives are correctly lowered to the mlir before
-running -apply-transform-sequence. 
+running -apply-transform-sequence.
 """
 
 # RUN: %PYTHON %s | FileCheck %s

--- a/frontend/test/lit/test_peephole_optimizations.py
+++ b/frontend/test/lit/test_peephole_optimizations.py
@@ -17,7 +17,7 @@ This file performs the frontend lit tests that the peephole transformations are 
 
 We check the transform jax primitives for each pass is correctly injected
 during tracing, and these transform primitives are correctly lowered to the mlir before
-running -apply-transform-sequence. 
+running -apply-transform-sequence.
 """
 
 # RUN: %PYTHON %s | FileCheck %s

--- a/frontend/test/lit/test_quantum_control.py
+++ b/frontend/test/lit/test_quantum_control.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # RUN: %PYTHON %s | FileCheck %s
-""" Test the lowering cases involving quantum control """
+"""Test the lowering cases involving quantum control"""
 
 import os
 import pathlib

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit tests for the Catalyst adjoint function.
-"""
+"""Unit tests for the Catalyst adjoint function."""
 
 from functools import partial
 

--- a/frontend/test/pytest/test_braket_local_devices.py
+++ b/frontend/test/pytest/test_braket_local_devices.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for `OpenQasmDevice` on "local" Amazon Braket devices
-"""
+"""Unit tests for `OpenQasmDevice` on "local" Amazon Braket devices"""
 import numpy as np
 import pennylane as qml
 import pytest

--- a/frontend/test/pytest/test_braket_remote_devices.py
+++ b/frontend/test/pytest/test_braket_remote_devices.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for `OpenQasmDevice` on "remote" Amazon Braket devices
-"""
+"""Unit tests for `OpenQasmDevice` on "remote" Amazon Braket devices"""
 import numpy as np
 import pennylane as qml
 import pytest

--- a/frontend/test/pytest/test_buffer_args.py
+++ b/frontend/test/pytest/test_buffer_args.py
@@ -116,7 +116,7 @@ class TestReturnValues:
 
         assert isinstance(identity(1.0), jax.Array)
 
-    @pytest.mark.parametrize("dtype", [(jnp.float16)])
+    @pytest.mark.parametrize("dtype", [jnp.float16])
     def test_types_which_are_unhandled(self, dtype):
         """Test that there's a nice error message when a function returns an f16."""
 

--- a/frontend/test/pytest/test_c_template.py
+++ b/frontend/test/pytest/test_c_template.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for contents of c_template
-"""
+"""Unit tests for contents of c_template"""
 import numpy as np
 
 from catalyst.utils.c_template import CType, CVariable

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Integration tests for the the PL capture in Catalyst.
-"""
+"""Integration tests for the the PL capture in Catalyst."""
 import jax.numpy as jnp
 import pennylane as qml
 import pytest

--- a/frontend/test/pytest/test_custom_devices.py
+++ b/frontend/test/pytest/test_custom_devices.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Unit test for custom device integration with Catalyst.
-"""
+"""Unit test for custom device integration with Catalyst."""
 import platform
 
 import pennylane as qml

--- a/frontend/test/pytest/test_device_api.py
+++ b/frontend/test/pytest/test_device_api.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test for the device API.
-"""
+"""Test for the device API."""
 import platform
 
 import pennylane as qml

--- a/frontend/test/pytest/test_jvpvjp.py
+++ b/frontend/test/pytest/test_jvpvjp.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Test JVP/VJP operation lowering """
+"""Test JVP/VJP operation lowering"""
 
 from typing import TypeVar
 

--- a/frontend/test/pytest/test_measurement_transforms.py
+++ b/frontend/test/pytest/test_measurement_transforms.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test for the device preprocessing.
-"""
+"""Test for the device preprocessing."""
 # pylint: disable=unused-argument
 import os
 

--- a/frontend/test/pytest/test_np_to_memref.py
+++ b/frontend/test/pytest/test_np_to_memref.py
@@ -19,7 +19,11 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 from jax.core import ShapedArray
-from mlir_quantum.runtime import C64, C128, as_ctype
+from mlir_quantum.runtime import (
+    C64,
+    C128,
+    as_ctype,
+)
 from mlir_quantum.runtime import (
     get_unranked_memref_descriptor as mlir_get_unranked_memref_descriptor,
 )

--- a/frontend/test/pytest/test_preprocess.py
+++ b/frontend/test/pytest/test_preprocess.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test for the device preprocessing.
-"""
+"""Test for the device preprocessing."""
 import platform
 from dataclasses import replace
 

--- a/frontend/test/pytest/test_split_multiple_tapes.py
+++ b/frontend/test/pytest/test_split_multiple_tapes.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """
-This file performs the frontend pytest checking that multi-tape transforms retain 
+This file performs the frontend pytest checking that multi-tape transforms retain
 correct funcitonality after splitting each tape into a separate function in mlir.
 """
 

--- a/frontend/test/pytest/test_verification.py
+++ b/frontend/test/pytest/test_verification.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Test program verification routines """
+"""Test program verification routines"""
 
 import platform
 from copy import deepcopy

--- a/frontend/test/test_oqc/oqc/test_oqc_device.py
+++ b/frontend/test/test_oqc/oqc/test_oqc_device.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Test for the OQC device.
-"""
+"""Test for the OQC device."""
 # pylint: disable=unused-argument,import-outside-toplevel,unused-import
 
 import pennylane as qml

--- a/frontend/test/test_oqd/oqd/test_oqd_device.py
+++ b/frontend/test/test_oqd/oqd/test_oqd_device.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the OQD device.
-"""
+"""Tests for the OQD device."""
 
 import pennylane as qml
 import pytest


### PR DESCRIPTION
**Context:**
The updated black version (25.1.0) will break CI due to formatting.

**Description of the Change:**
updated the changed required by black.

**Benefits:**
no more CI failure.

**Possible Drawbacks:**
Note that we are not pinning the version of our formatting tools (black, isort, pylint) in Catalyst.
So the developer should always update these tools to the latest version in order to achieve the same result as CI when formatting (make format)

**Related GitHub Issues:**
