### PR TITLE
Fix topological-sort ordering during tracing

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -17,6 +17,10 @@
 * Fixed `argnums` parameter of `grad` and `value_and_grad` being ignored.
   [(#1478)](https://github.com/PennyLaneAI/catalyst/pull/1478)
 
+* Fixed an issue ([(#1488)](https://github.com/PennyLaneAI/catalyst/pull/1488)) where Catalyst could
+  give incorrect results for circuits containing `qml.StatePrep`.
+  [(#1491)](https://github.com/PennyLaneAI/catalyst/pull/1491)
+
 <h3>Internal changes ⚙️</h3>
 
 * Update deprecated access to `QNode.execute_kwargs["mcm_config"]`.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -59,6 +59,7 @@
 
 This release contains contributions from (in alphabetical order):
 
+Joey Carter,
 Yushao Chen,
 Sengthai Heng,
 Christina Lee,

--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -235,6 +235,7 @@ def stable_toposort(end_nodes: list) -> list:
     while childless_nodes:
         node = childless_nodes.pop()
         sorted_nodes.append(node)
+        # pylint: disable=unnecessary-lambda
         sorted_parents = sorted(node.parents, key=lambda n: end_nodes.index(n))
         for parent in sorted_parents:
             if child_counts[parent.id] == 1:

--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -235,7 +235,8 @@ def stable_toposort(end_nodes: list) -> list:
     while childless_nodes:
         node = childless_nodes.pop()
         sorted_nodes.append(node)
-        for parent in node.parents:
+        sorted_parents = sorted(node.parents, key=lambda n: end_nodes.index(n))
+        for parent in sorted_parents:
             if child_counts[parent.id] == 1:
                 childless_nodes.append(parent)
             else:

--- a/frontend/test/lit/test_decomposition.py
+++ b/frontend/test/lit/test_decomposition.py
@@ -178,11 +178,13 @@ def test_decompose_singleexcitationplus():
         # CHECK-NOT: name = "SingleExcitationPlus"
         # CHECK: [[a_scalar_tensor_float_2:%.+]] = stablehlo.constant dense<2.{{[0]+}}e+00>
         # CHECK-NOT: name = "SingleExcitationPlus"
-        # CHECK: [[s0q1:%.+]] = quantum.custom "PauliX"
+        # CHECK: [[b_theta_div_2:%.+]] = stablehlo.divide %arg0, [[a_scalar_tensor_float_2]]
+        # CHECK-NOT: name = "SingleExcitationPlus"
+        # CHECK: [[a_theta_div_2:%.+]] = stablehlo.divide %arg0, [[a_scalar_tensor_float_2]]
         # CHECK-NOT: name = "SingleExcitationPlus"
         # CHECK: [[s0q0:%.+]] = quantum.custom "PauliX"
         # CHECK-NOT: name = "SingleExcitationPlus"
-        # CHECK: [[a_theta_div_2:%.+]] = stablehlo.divide %arg0, [[a_scalar_tensor_float_2]]
+        # CHECK: [[s0q1:%.+]] = quantum.custom "PauliX"
         # CHECK-NOT: name = "SingleExcitationPlus"
         # CHECK: [[a_theta_div_2_scalar:%.+]] = tensor.extract [[a_theta_div_2]]
         # CHECK-NOT: name = "SingleExcitationPlus"
@@ -191,8 +193,6 @@ def test_decompose_singleexcitationplus():
         # CHECK: [[s2q1:%.+]] = quantum.custom "PauliX"() [[s1]]#1
         # CHECK-NOT: name = "SingleExcitationPlus"
         # CHECK: [[s2q0:%.+]] = quantum.custom "PauliX"() [[s1]]#0
-        # CHECK-NOT: name = "SingleExcitationPlus"
-        # CHECK: [[b_theta_div_2:%.+]] = stablehlo.divide %arg0, [[a_scalar_tensor_float_2]]
         # CHECK-NOT: name = "SingleExcitationPlus"
         # CHECK: [[b_theta_div_2_scalar:%.+]] = tensor.extract [[b_theta_div_2]]
         # CHECK-NOT: name = "SingleExcitationPlus"

--- a/frontend/test/lit/test_split_multiple_tapes.py
+++ b/frontend/test/lit/test_split_multiple_tapes.py
@@ -67,7 +67,7 @@ def test_multiple_tape_transforms():
     # CHECK: qdevice[
     # CHECK: ]
     # CHECK: qdealloc
-    # CHECK-NEXT: qdevice[
+    # CHECK: qdevice[
     # CHECK: ]
     # CHECK: qdealloc
     # CHECK-NEXT: {{.+}}:f64[] = add {{.+}} {{.+}}
@@ -77,7 +77,7 @@ def test_multiple_tape_transforms():
     # CHECK: quantum.device
     # CHECK: quantum.dealloc
     # CHECK-NEXT: quantum.device_release
-    # CHECK-NEXT: quantum.device
+    # CHECK: quantum.device
     # CHECK: quantum.dealloc
     # CHECK-NEXT: quantum.device_release
     # CHECK-NEXT: {{%.+}} = stablehlo.add {{%.+}}, {{%.+}} : tensor<f64>

--- a/frontend/test/lit/test_static_circuit.py
+++ b/frontend/test/lit/test_static_circuit.py
@@ -54,14 +54,14 @@ def test_static_params():
 
 # CHECK-LABEL: public @jit_circuit
 # CHECK: %[[REG:.*]] = quantum.alloc( 4) : !quantum.reg
-# CHECK: %[[BIT1:.*]] = quantum.extract %[[REG]][ 0] : !quantum.reg -> !quantum.bit
+# CHECK: %[[BIT2:.*]] = quantum.extract %[[REG]][ 2]
+# CHECK: %[[RZ:.*]] = quantum.static_custom "RZ"
+# CHECK: %[[BIT0:.*]] = quantum.extract %[[REG]][ 0] : !quantum.reg -> !quantum.bit
 # CHECK: %[[ROT:.*]] = quantum.static_custom "Rot"
 # CHECK: %[[RX:.*]] = quantum.static_custom "RX"
 # CHECK: %[[BIT1:.*]] = quantum.extract %[[REG]][ 1]
 # CHECK: %[[RY1:.*]] = quantum.static_custom "RY"
 # CHECK: %[[XX1:.*]] = quantum.static_custom "IsingXX"
-# CHECK: %[[BIT2:.*]] = quantum.extract %[[REG]][ 2]
-# CHECK: %[[RZ:.*]] = quantum.static_custom "RZ"
 # CHECK: %[[XX2:.*]] = quantum.static_custom "IsingXX"
 # CHECK: %[[ZZ:.*]] = quantum.static_custom "IsingZZ"
 # CHECK: %[[CRX:.*]] = quantum.static_custom "CRX"

--- a/frontend/test/pytest/test_from_plxpr.py
+++ b/frontend/test/pytest/test_from_plxpr.py
@@ -533,12 +533,7 @@ class TestHybridPrograms:
         call_jaxpr_pl = get_call_jaxpr(converted)
         call_jaxpr_c = get_call_jaxpr(qjit_obj.jaxpr)
 
-        # qubit extraction and classical equations in a slightly different order
-        # thus cant check specific equations and have to discard comparing counts
-        compare_call_jaxprs(call_jaxpr_pl, call_jaxpr_c, skip_eqns=(4, 5, 6))
-        compare_eqns(call_jaxpr_pl.eqns[4], call_jaxpr_c.eqns[5])
-        compare_eqns(call_jaxpr_pl.eqns[5], call_jaxpr_c.eqns[6])
-        compare_eqns(call_jaxpr_pl.eqns[6], call_jaxpr_c.eqns[4])
+        compare_call_jaxprs(call_jaxpr_pl, call_jaxpr_c)
 
     def test_multiple_qnodes(self, disable_capture):
         """Test that a workflow with multiple qnodes can be converted."""

--- a/frontend/test/pytest/test_state_prep.py
+++ b/frontend/test/pytest/test_state_prep.py
@@ -26,6 +26,16 @@ from catalyst import qjit
 
 
 def generate_random_state(n=1, seed=None):
+    """Generate a random n-qubit state in state-vector representation.
+
+    Args:
+        n (int, optional): Number of qubits in the state. Defaults to 1.
+        seed (int, optional): Seed to the random-number generator. Defaults to None, in which case
+            a random seed is used.
+
+    Returns:
+        numpy.ndarray: The generated state vector.
+    """
     rng = np.random.default_rng(seed=seed)
     input_state = rng.random(2**n) + 1j * rng.random(2**n)
     return input_state / np.linalg.norm(input_state)
@@ -59,6 +69,7 @@ class Test2QubitStatePrep:
 
     @qjit
     @qml.qnode(dev)
+    @staticmethod
     def circuit_01(input_state):
         """A circuit that applies StatePrep on wire 0 and the Hadamard on wire 1.
 
@@ -74,6 +85,7 @@ class Test2QubitStatePrep:
 
     @qjit
     @qml.qnode(dev)
+    @staticmethod
     def circuit_10(input_state):
         """A circuit that applies StatePrep on wire 1 and the Hadamard on wire 0.
 

--- a/frontend/test/pytest/test_state_prep.py
+++ b/frontend/test/pytest/test_state_prep.py
@@ -1,0 +1,112 @@
+# Copyright 2025 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Integration tests for qml.StatePrep.
+
+This test suite was introduced following https://github.com/PennyLaneAI/catalyst/issues/1488.
+"""
+
+import numpy as np
+import pennylane as qml
+import pytest
+
+from catalyst import qjit
+
+
+def generate_random_state(n=1, seed=None):
+    rng = np.random.default_rng(seed=seed)
+    input_state = rng.random(2**n) + 1j * rng.random(2**n)
+    return input_state / np.linalg.norm(input_state)
+
+
+class Test2QubitStatePrep:
+    """
+    Tests two variations of a simple two-qubit circuit beginning with state preparation on one of
+    the wires followed by a Hadamard gate on the other wire, and finally a CZ gate. The circuit
+    returns the expectation values for each of the Pauli X, Y, Z operations for each wire.
+
+    The results are compared against the analytic solution, which can easily be determined given an
+    arbitrary input state
+
+        |psi> = a|0> + b|1>,
+
+    where a, b are complex numbers with |a|^2 + |b|^2 = 1.
+    """
+
+    input_states = [
+        np.array([1, 0]),  # |0>
+        np.array([0, 1]),  # |1>
+        np.array([1 / np.sqrt(2), 1 / np.sqrt(2)]),  # |+>
+        np.array([1 / np.sqrt(2), -1 / np.sqrt(2)]),  # |->
+        np.array([complex(1 / np.sqrt(2), 0.0), complex(0.0, 1 / np.sqrt(2))]),  # |R>
+        np.array([complex(1 / np.sqrt(2), 0.0), complex(0.0, -1 / np.sqrt(2))]),  # |L>
+        generate_random_state(seed=42),
+    ]
+
+    dev = qml.device("lightning.qubit", wires=2)
+
+    @qjit
+    @qml.qnode(dev)
+    def circuit_01(input_state):
+        """A circuit that applies StatePrep on wire 0 and the Hadamard on wire 1.
+
+        The analytic solution for this circuit, given input state |psi>, is:
+
+            |psi'> = (a|00> + a|01> + b|10> - b|11>) / sqrt(2)
+        """
+        qml.StatePrep(input_state, wires=[0])
+        qml.Hadamard(1)
+        qml.CZ([1, 0])
+
+        return qml.state()
+
+    @qjit
+    @qml.qnode(dev)
+    def circuit_10(input_state):
+        """A circuit that applies StatePrep on wire 1 and the Hadamard on wire 0.
+
+        The analytic solution for this circuit, given input state |psi>, is:
+
+            |psi'> = (a|00> + b|01> + a|10> - b|11>) / sqrt(2)
+        """
+        qml.StatePrep(input_state, wires=[1])
+        qml.Hadamard(0)
+        qml.CZ([1, 0])
+
+        return qml.state()
+
+    @pytest.mark.parametrize("input_state", input_states)
+    def test_2qubit_state_prep_H_CZ_01(self, input_state):
+        """Test circuit_01"""
+        result_obs = self.circuit_01(input_state)
+
+        a, b = input_state
+        result_exp = (1 / np.sqrt(2)) * np.array([a, a, b, -b])
+
+        assert np.allclose(result_obs, result_exp)
+
+    @pytest.mark.parametrize("input_state", input_states)
+    def test_2qubit_state_prep_H_CZ_10(self, input_state):
+        """Test circuit_10"""
+        result_obs = self.circuit_10(input_state)
+
+        a, b = input_state
+        result_exp = (1 / np.sqrt(2)) * np.array([a, b, a, -b])
+
+        assert np.allclose(result_obs, result_exp)
+
+
+if __name__ == "__main__":
+    pytest.main(["-x", __file__])


### PR DESCRIPTION
**Context:** See Issue #1488.

**Description of the Change:** This fixes an issue where the original topological-sort ordering placed a `quantum.set_state` operation (introduced via `qml.StatePrep`) _after_ other quantum ops, resulting in Catalyst giving incorrect results under certain circumstances. This new topological-sort ordering ensures the `quantum.set_state` operation appears in the MLIR in the same relative location as it occurred in the captured PennyLane program.

Introducing this change required that some frontend tests be modified to account for the change in operation ordering. However, this fix should not affect functionality in these test cases as the SSA values remain unchanged.

**Benefits:** Catalyst gives correct results for circuits containing `qml.StatePrep` operations.

**Possible Drawbacks:** Changing the order of operations may introduce unintended side-effects, for which we may not currently have test coverage.

**Related GitHub Issues:** Fixes #1488.

[[sc-83476](https://app.shortcut.com/xanaduai/story/83476/catalyst-can-give-incorrect-results-for-circuits-containing-qml-stateprep)]

-----

**TODO:**

* ~Investigate using the Python stdlib [`TopologicalSorter`](https://docs.python.org/3/library/graphlib.html) instead.~ Won't fix now; will follow up in future PR.

-----

Shout out to @mehrdad2m for proposing this fix! :tada: 
