### PR TITLE
Fix discrepancy between default pipeline in compiler driver and frontend

### DIFF
--- a/mlir/lib/Driver/Pipelines.cpp
+++ b/mlir/lib/Driver/Pipelines.cpp
@@ -30,7 +30,7 @@ namespace driver {
 void createEnforceRuntimeInvariantsPipeline(OpPassManager &pm)
 {
     pm.addPass(catalyst::createSplitMultipleTapesPass());
-    pm.addPass(catalyst::createApplyTransformSequencePass());
+    pm.addNestedPass<ModuleOp>(catalyst::createApplyTransformSequencePass());
     pm.addPass(catalyst::createStaticCustomLoweringPass());
     pm.addPass(catalyst::createInlineNestedModulePass());
 }


### PR DESCRIPTION
**Context:**
There is a small discrepancy between default pipeline in compiler driver and frontend

**Description of the Change:**
Fixed the discrepancy.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
