### PR TITLE
Catalyst accepts device specific pipelines (OQD device)

### DIFF
--- a/doc/dev/custom_devices.rst
+++ b/doc/dev/custom_devices.rst
@@ -154,7 +154,11 @@ There are two things that are needed in order to integrate with PennyLane device
 
 * Adding a ``get_c_interface`` method to your ``qml.devices.Device`` class.
 * Adding a ``config_filepath`` class variable pointing to your configuration file. This file should be a `toml file <https://toml.io/en/>`_ with fields that describe what gates and features are supported by your device.
-* Optionally, adding a ``device_kwargs`` dictionary for runtime parameters to pass from the PennyLane device to the ``QuantumDevice`` upon initialization.
+
+Optionally, on top of the above two requirements, you can also add the following:
+
+* A ``device_kwargs`` dictionary for runtime parameters to pass from the PennyLane device to the ``QuantumDevice`` upon initialization.
+* A ``get_compilation_pipelines`` function that returns a list of catalyst compilation pipelines that the device requires for compilation.
 
 If you already have a custom PennyLane device defined in Python and have added a shared object that corresponds to your implementation of the ``QuantumDevice`` class, then all you need to do is to add a ``get_c_interface`` method to your PennyLane device.
 The ``get_c_interface`` method should be a static method that takes no parameters and returns the complete path to your shared library with the ``QuantumDevice`` implementation.
@@ -334,3 +338,30 @@ of the ``QuantumDevice`` constructor to variables. For example:
 
 In the above example, a dictionary will be constructed at runtime and passed to the constructor of
 the ``QuantumDevice`` implementation.
+
+Finally, if the device requires compilation pipelines, a ``get_compilation_pipelines`` method
+should be added to the device class. This method should return a list of Catalyst compilation
+pipelines that the device requires for compilation. For example:
+
+.. code-block:: python
+
+    class CustomDevice(qml.devices.Device):
+        """Custom Device"""
+
+        config_filepath = pathlib.Path("absolute/path/to/configuration/file.toml")
+
+        ...
+
+        def get_compilation_pipelines(self):
+            return [
+            (
+                "pipeline_A",
+                [
+                    "pass_1",
+                    "pass_2",
+                ],
+            ),]
+
+In the above example, the device requires a compilation pipeline named "pipeline_A" which include
+the passes "pass_1", and "pass_2". The pass names should match the names of the registerd passes in 
+Catalyst. Note that this pipeline would override the default pipeline in Catalyst.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -36,6 +36,10 @@
       return qml.expval(qml.Z(0))
   ```
 
+  * Custom deivces can optionally define a default pass pipeline using `get_compilation_pipelines` 
+    that overrides the catalyst default pass pipeline.
+    [(#1500)](https://github.com/PennyLaneAI/catalyst/pull/1500)
+
 <h3>Breaking changes 💔</h3>
 
 <h3>Deprecations 👋</h3>

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -122,8 +122,9 @@ def qjit(
             ``sys.stderr``).
         pipelines (Optional(List[Tuple[str,List[str]]])): A list of pipelines to be executed. The
             elements of this list are named sequences of MLIR passes to be executed. A ``None``
-            value (the default) results in the execution of the default pipeline. This option is
-            considered to be used by advanced users for low-level debugging purposes.
+            value (the default) results in the execution of the default pipeline (specified by the device). 
+            If ``pipelines != None``, the default behaviour is overrided. This option is considered 
+            to be used by advanced users for low-level debugging purposes.
         static_argnums(int or Seqence[Int]): an index or a sequence of indices that specifies the
             positions of static arguments.
         static_argnames(str or Seqence[str]): a string or a sequence of strings that specifies the

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -521,7 +521,11 @@ class QJIT(CatalystCallable):
 
         # pylint: disable=no-member
         if isQNode and hasattr(self.device, "get_compilation_pipelines"):
-            self.compile_options.pipelines = self.device.get_compilation_pipelines()
+            # TODO: This line is not currently covered by tests. This will be resolved as soon as
+            # the OQD runtime is implemented and integration tests are added.
+            self.compile_options.pipelines = (
+                self.device.get_compilation_pipelines()
+            )  # pragma: nocover
 
         requires_promotion = self.jit_compile(args, **kwargs)
 

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -519,6 +519,7 @@ class QJIT(CatalystCallable):
 
             return self.user_function(*args, **kwargs)
 
+        # pylint: disable=no-member
         if isQNode and hasattr(self.device, "get_compilation_pipelines"):
             self.compile_options.pipelines = self.device.get_compilation_pipelines()
 


### PR DESCRIPTION
**Context:**
In the current design, the pass pipeline is attached to the compiler. With this, adding device-specific pipelines for a custom device is challenging as we would have to redefine the whole pipeline and modify the parts that need to change for that specific device. 

TODO:

- [x] Add Changelog

- [x] Update custom devices documentation (Maybe not necessary considering that defining `get_compilation_pipelines` is optional?)

**Description of the Change:**
Check if a device have a `get_compilation_pipelines` method and if so, replace the default pipeline with that.

**Benefits:**
Custom devices now can define their own default pipeline.

**Possible Drawbacks:**


**Related GitHub Issues:**
