### PR TITLE
Remove a duplicated author name in changelog

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -104,5 +104,4 @@ Christina Lee,
 Mehrdad Malekmohammadi,
 Andrija Paurevic,
 Paul Haochen Wang,
-Rohan Nolan Lasrado,
 Raul Torres.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -103,5 +103,5 @@ Rohan Nolan Lasrado,
 Christina Lee,
 Mehrdad Malekmohammadi,
 Andrija Paurevic,
-Paul Haochen Wang,
-Raul Torres.
+Raul Torres,
+Paul Haochen Wang.


### PR DESCRIPTION
**Context:**
An external contributor's name was listed twice in changelog.

**Description of the Change:**
Remove a duplicated author name in changelog

