### PR TITLE
Capture "for_loop" workflow

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -11,8 +11,9 @@
 * Extend `merge-rotations` peephole optimization pass to also merge compatible rotation gates (either both controlled, or both uncontrolled) where rotation angles are any combination of static constants or dynamic values.
   [(#1489)](https://github.com/PennyLaneAI/catalyst/pull/1489)
 
-* Catalyst now supports experimental capture of `cond` control flow.
+* Catalyst now supports experimental capture of `cond` and `for_loop` control flow.
   [(#1468)](https://github.com/PennyLaneAI/catalyst/pull/1468)
+  [(#1509)](https://github.com/PennyLaneAI/catalyst/pull/1509)
   
   To trigger the PennyLane pipeline for capturing the program as a Jaxpr, simply set
   `experimental_capture=True` in the qjit decorator.

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -389,9 +389,8 @@ def handle_for_loop(
     args = plxpr_invals[args_slice]
 
     # Add the iteration start and the qreg to the args
-    it_start = 0
-    it_start_plus_args_plus_qreg = [
-        it_start,
+    start_plus_args_plus_qreg = [
+        start,
         *args,
         self.qreg,
     ]
@@ -404,13 +403,13 @@ def handle_for_loop(
         jaxpr_body_fn,
         consts,
     )
-    converted_jaxpr_branch = jax.make_jaxpr(converted_func)(*it_start_plus_args_plus_qreg).jaxpr
+    converted_jaxpr_branch = jax.make_jaxpr(converted_func)(*start_plus_args_plus_qreg).jaxpr
     converted_closed_jaxpr_branch = jax.core.ClosedJaxpr(
         convert_constvars_jaxpr(converted_jaxpr_branch), ()
     )
 
     # Build Catalyst compatible input values
-    for_loop_invals = [start, stop, step, *consts, *it_start_plus_args_plus_qreg]
+    for_loop_invals = [start, stop, step, *consts, *start_plus_args_plus_qreg]
 
     # Config additional for loop settings
     apply_reverse_transform = isinstance(step, int) and step < 0

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -409,7 +409,7 @@ def handle_for_loop(
     )
 
     # Build Catalyst compatible input values
-    for_loop_invals = [start, stop, step, *consts, *start_plus_args_plus_qreg]
+    for_loop_invals = [*consts, start, stop, step, *start_plus_args_plus_qreg]
 
     # Config additional for loop settings
     apply_reverse_transform = isinstance(step, int) and step < 0

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -206,12 +206,12 @@ class TestCapture:
         def circuit(n, x):
 
             @qml.for_loop(0, n, 1)
-            def loop_rx(i, x):
+            def loop_rx(_, x):
                 qml.RX(x, wires=0)
                 return jnp.sin(x)
 
             # apply the for loop
-            final_x = loop_rx(x)
+            loop_rx(x)
 
             return qml.expval(qml.Z(0))
 

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -199,6 +199,26 @@ class TestCapture:
         desired = pl_circuit(theta)
         assert jnp.allclose(actual, desired)
 
+    def test_forloop_workflow(self, backend):
+        """Test the integration for a circuit with a for loop primitive."""
+
+        @qml.qnode(qml.device(backend, wires=1))
+        def circuit(n, x):
+
+            @qml.for_loop(0, n, 1)
+            def loop_rx(i, x):
+                qml.RX(x, wires=0)
+                return jnp.sin(x)
+
+            # apply the for loop
+            final_x = loop_rx(x)
+
+            return qml.expval(qml.Z(0))
+
+        default_capture_result = qml.qjit(circuit)(10, 0.3)
+        experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(10, 0.3)
+        assert default_capture_result == experimental_capture_result
+
     def test_cond_workflow_if_else(self, backend):
         """Test the integration for a circuit with a cond primitive with true and false branches."""
 

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -168,7 +168,6 @@ class TestCapture:
         desired = pl_circuit(theta)
         assert jnp.allclose(actual, desired)
 
-    @pytest.mark.xfail(reason="For not supported.")
     @pytest.mark.parametrize("theta", (jnp.pi, 0.1, 0.0))
     def test_forloop(self, backend, theta):
         """Test the integration for a circuit with a for loop."""
@@ -177,7 +176,7 @@ class TestCapture:
         @qml.qnode(qml.device(backend, wires=4))
         def catalyst_capture_circuit(x):
 
-            @qml.for_loop(1, 1, 4)
+            @qml.for_loop(1, 4, 1)
             def loop(i):
                 qml.CNOT(wires=[0, i])
                 qml.RX(x, wires=i)

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -205,7 +205,7 @@ class TestCapture:
         @qml.qnode(qml.device(backend, wires=1))
         def circuit(n, x):
 
-            @qml.for_loop(0, n, 1)
+            @qml.for_loop(1, n, 1)
             def loop_rx(_, x):
                 qml.RX(x, wires=0)
                 return jnp.sin(x)


### PR DESCRIPTION
**Context:** Currently, Catalyst cannot compile and execute captured workflows with `for_loop` control flow. E.g.:
```
dev = qml.device("lightning.qubit", wires=1)

@qml.qjit(experimental_capture=True)
@qml.qnode(dev)
def circuit(n, x):

    @qml.for_loop(0, n, 1)
    def loop_rx(i, x):
            qml.RX(x, wires=0)
            return jnp.sin(x)

    # apply the for loop
    final_x = loop_rx(x)

    return qml.expval(qml.Z(0))

circuit(10, 0.3) # Array(-0.94854724, dtype=float64)
```

**Description of the Change:** Reuse the Branch interpreter created at https://github.com/PennyLaneAI/catalyst/pull/1468

**Benefits:** Extended support for plxpr capture.

- [x] Enable pre-existent skipped test
- [x] Update changelog
- [x] Add more test cases

[sc-81880]