### PR TITLE
Do not run unnecessary pass

### DIFF
--- a/frontend/catalyst/pipelines.py
+++ b/frontend/catalyst/pipelines.py
@@ -296,7 +296,7 @@ def get_convert_to_llvm_stage(options: CompileOptions) -> List[str]:
         # of this list to here that does folding
         # add-exception-handling will fail to add async.drop_ref
         # correctly. See https://github.com/PennyLaneAI/catalyst/pull/995
-        "add-exception-handling",
+        "add-exception-handling" if options.async_qnodes else None,
         "emit-catalyst-py-interface",
         # Remove any dead casts as the final pass expects to remove all existing casts,
         # but only those that form a loop back to the original type.


### PR DESCRIPTION
**Context:** This pass which takes 6% of the time required for the convert MLIR to LLVM pass is not required unless the user is using async qnodes.

**Description of the Change:** Do not run this pass unless the user is running async qnodes.

**Benefits:** Small improvement in compilation time.

**Possible Drawbacks:** None

**Related GitHub Issues:**
