### PR TITLE
Turn off verifier

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -39,6 +39,11 @@
       return qml.expval(qml.Z(0))
   ```
 
+* Changes to reduce compile time:
+
+  - Turn off MLIR's verifier.
+    [(#1513)](https://github.com/PennyLaneAI/catalyst/pull/1513)
+
 <h3>Breaking changes 💔</h3>
 
 <h3>Deprecations 👋</h3>

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -301,6 +301,8 @@ class Compiler:
         if self.options.checkpoint_stage:
             cmd += ["--checkpoint-stage", self.options.checkpoint_stage]
 
+        cmd += ["-verify-each=false"]
+
         pipeline_str = ""
         for pipeline in self.options.get_pipelines():
             pipeline_name, passes = pipeline

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -513,7 +513,7 @@ LogicalResult preparePassManager(PassManager &pm, const CompilerOptions &options
     };
 
     MlirOptMainConfig config = MlirOptMainConfig::createFromCLOptions();
-    pm.enableVerifier(config.shouldVerifyPasses());
+    pm.enableVerifier(false);
     if (failed(applyPassManagerCLOptions(pm)))
         return failure();
     if (failed(config.setupPassPipeline(pm)))

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -513,7 +513,7 @@ LogicalResult preparePassManager(PassManager &pm, const CompilerOptions &options
     };
 
     MlirOptMainConfig config = MlirOptMainConfig::createFromCLOptions();
-    pm.enableVerifier(false);
+    pm.enableVerifier(config.shouldVerifyPasses());
     if (failed(applyPassManagerCLOptions(pm)))
         return failure();
     if (failed(config.setupPassPipeline(pm)))


### PR DESCRIPTION
**Context:** Verification runs after every pass. This increases compilation time.

**Description of the Change:** Turn off verifier. To enable the verifier for gradients we run a nested pipeline where verification is enabled only for a single pass. This allows a couple of tests that check if zne and callback without gradients are reachable from a grad operation.

**Benefits:** Reduce compilation time.

**Possible Drawbacks:** No verification between passes. But we can enable them manually when debugging.

**Related GitHub Issues:** None
