### PR TITLE
[ci] Checking out source if it is not on the cache

### DIFF
--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -204,6 +204,7 @@ jobs:
         path: mlir/llvm-project
         key: llvm-${{ needs.constants.outputs.llvm_version }}-default-source
         enableCrossOsArchive: true
+        fail-on-cache-miss: true
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build
@@ -669,7 +670,6 @@ jobs:
           path: mlir/llvm-project
           key: llvm-${{ needs.constants.outputs.llvm_version }}-default-source
           enableCrossOsArchive: true
-          fail-on-cache-miss: true
 
       - name: Clone LLVM Submodule
         if: steps.cache-llvm-source.outputs.cache-hit != 'true'

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -56,7 +56,14 @@ jobs:
           path: mlir/llvm-project
           key: llvm-${{ needs.constants.outputs.llvm_version }}-default-source
           enableCrossOsArchive: true
-          fail-on-cache-miss: true
+
+      - name: Clone LLVM Submodule
+        if: steps.cache-llvm-source.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: llvm/llvm-project
+          ref: ${{ needs.constants.outputs.llvm_version }}
+          path: mlir/llvm-project
 
       - name: Build Catalyst-Runtime
         run: |
@@ -197,7 +204,6 @@ jobs:
         path: mlir/llvm-project
         key: llvm-${{ needs.constants.outputs.llvm_version }}-default-source
         enableCrossOsArchive: true
-        fail-on-cache-miss: true
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build
@@ -664,6 +670,14 @@ jobs:
           key: llvm-${{ needs.constants.outputs.llvm_version }}-default-source
           enableCrossOsArchive: true
           fail-on-cache-miss: true
+
+      - name: Clone LLVM Submodule
+        if: steps.cache-llvm-source.outputs.cache-hit != 'true'
+        uses: actions/checkout@v4
+        with:
+          repository: llvm/llvm-project
+          ref: ${{ needs.constants.outputs.llvm_version }}
+          path: mlir/llvm-project
 
       - name: Run the main runtime test suite for coverage
         run: |


### PR DESCRIPTION
**Context:** For some reason the LLVM source got kicked out of the cache (?)

**Description of the Change:** Since now the runtime depends on the LLVM source for the MLIR Execution Engine's header files and it runs first, we should restore it when it is not available.

**Benefits:** CI should work again.

**Possible Drawbacks:**

**Related GitHub Issues:**
