### PR TITLE
skip inlining

### DIFF
--- a/frontend/catalyst/pipelines.py
+++ b/frontend/catalyst/pipelines.py
@@ -223,7 +223,6 @@ def get_bufferization_stage(_options: CompileOptions) -> List[str]:
     """Returns the list of passes that performs bufferization"""
     bufferization = [
         "one-shot-bufferize{dialect-filter=memref}",
-        "inline",
         "gradient-preprocess",
         "gradient-bufferize",
         "scf-bufferize",


### PR DESCRIPTION
**Context:** Inlining creates large functions. Some passes have a complexity that grows faster than O(n) in the order of operations on functions. So large functions means larger compilation time. 

**Description of the Change:** This PR disables inlining. 

**Benefits:** Reduce compilation time

**Possible Drawbacks:** Increased runtime

**Related GitHub Issues:** At the moment this PR is just for benchmarking.
