### PR TITLE
Remove test that checked that multi-controlled global-phase decomposition raises a warning

### DIFF
--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -1666,14 +1666,6 @@ class TestDecomposition:
         with pytest.raises(DecompositionUndefinedError):
             op.decomposition()
 
-    def test_global_phase_decomp_raises_warning(self):
-        """Test that ctrl(GlobalPhase).decomposition() raises a warning."""
-        op = qml.ctrl(qml.GlobalPhase(1.23), control=[0, 1])
-        with pytest.warns(
-            UserWarning, match="Multi-Controlled-GlobalPhase currently decomposes to nothing"
-        ):
-            assert op.decomposition() == []
-
     def test_control_on_zero(self):
         """Test decomposition applies PauliX gates to flip any control-on-zero wires."""
 


### PR DESCRIPTION
**Context:** A decomposition for multi-controlled global phases was recently added in PennyLane: PennyLaneAI/pennylane#6936. Catalyst contained a test `test_global_phase_decomp_raises_warning` that checked that such decompositions raise a warning. This test is therefore no longer needed and can be removed.

**Description of the Change:** Removes the test `test_global_phase_decomp_raises_warning`.

**Benefits:** This test is currently failing with PennyLane `latest`. Removing it will fix the pytest failure.