### PR TITLE
Minor fixes

### DIFF
--- a/frontend/catalyst/pipelines.py
+++ b/frontend/catalyst/pipelines.py
@@ -152,7 +152,7 @@ class CompileOptions:
         """Returns all stages in order for compilation"""
         # Dictionaries in python are ordered
         stages = {}
-        stages["EnforeRuntimeInvariantsPass"] = get_enforce_runtime_invariants_stage(self)
+        stages["EnforceRuntimeInvariantsPass"] = get_enforce_runtime_invariants_stage(self)
         stages["HLOLoweringPass"] = get_hlo_lowering_stage(self)
         stages["QuantumCompilationPass"] = get_quantum_compilation_stage(self)
         stages["BufferizationPass"] = get_bufferization_stage(self)
@@ -176,8 +176,8 @@ def get_enforce_runtime_invariants_stage(_options: CompileOptions) -> List[str]:
         # Since at the moment, nothing in the runtime is using them
         # and there is no lowering for them,
         # we inline them to preserve the semantics. We may choose to
-        # keep inlining modules targetting the Catalyst runtime.
-        # But qnodes targetting other backends may choose to lower
+        # keep inlining modules targeting the Catalyst runtime.
+        # But qnodes targeting other backends may choose to lower
         # this into something else.
         "inline-nested-module",
     ]
@@ -312,7 +312,7 @@ def get_stages(options):
     """Returns all stages in order for compilation"""
     # Dictionaries in python are ordered
     stages = {}
-    stages["EnforeRuntimeInvariantsPass"] = get_enforce_runtime_invariants_stage(options)
+    stages["EnforceRuntimeInvariantsPass"] = get_enforce_runtime_invariants_stage(options)
     stages["HLOLoweringPass"] = get_hlo_lowering_stage(options)
     stages["QuantumCompilationPass"] = get_quantum_compilation_stage(options)
     stages["BufferizationPass"] = get_bufferization_stage(options)

--- a/mlir/include/Quantum/IR/CMakeLists.txt
+++ b/mlir/include/Quantum/IR/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_mlir_dialect(QuantumOps quantum)
 add_mlir_interface(QuantumInterfaces)
-add_mlir_doc(QuantumDialect -gen-dialect-doc QuantumDialect Quantum/)
-add_mlir_doc(QuantumOps -gen-op-doc QuantumOps Quantum/)
-add_mlir_doc(QuantumInterfaces -gen-op-interface-docs QuantumInterfaces Quantum/)
+add_mlir_doc(QuantumDialect QuantumDialect Quantum/ -gen-dialect-doc)
+add_mlir_doc(QuantumOps QuantumOps Quantum/ -gen-op-doc)
+add_mlir_doc(QuantumInterfaces QuantumInterfaces Quantum/ -gen-op-interface-docs)
 
 set(LLVM_TARGET_DEFINITIONS QuantumOps.td)
 mlir_tablegen(QuantumEnums.h.inc -gen-enum-decls)


### PR DESCRIPTION
- One of the passes is misspelled in the frontend: 
'EnforeRuntimeInvariantsPass' -> 'Enfor**c**eRuntimeInvariantsPass'
- The `add_mlir_doc` function in the Quantum dialect is called with out of order arguments.