### PR TITLE
Fix typo: change wrong pass name to 'EnforceRuntimeInvariantsPass'

### DIFF
--- a/frontend/catalyst/pipelines.py
+++ b/frontend/catalyst/pipelines.py
@@ -152,7 +152,7 @@ class CompileOptions:
         """Returns all stages in order for compilation"""
         # Dictionaries in python are ordered
         stages = {}
-        stages["EnforeRuntimeInvariantsPass"] = get_enforce_runtime_invariants_stage(self)
+        stages["EnforceRuntimeInvariantsPass"] = get_enforce_runtime_invariants_stage(self)
         stages["HLOLoweringPass"] = get_hlo_lowering_stage(self)
         stages["QuantumCompilationPass"] = get_quantum_compilation_stage(self)
         stages["BufferizationPass"] = get_bufferization_stage(self)
@@ -312,7 +312,7 @@ def get_stages(options):
     """Returns all stages in order for compilation"""
     # Dictionaries in python are ordered
     stages = {}
-    stages["EnforeRuntimeInvariantsPass"] = get_enforce_runtime_invariants_stage(options)
+    stages["EnforceRuntimeInvariantsPass"] = get_enforce_runtime_invariants_stage(options)
     stages["HLOLoweringPass"] = get_hlo_lowering_stage(options)
     stages["QuantumCompilationPass"] = get_quantum_compilation_stage(options)
     stages["BufferizationPass"] = get_bufferization_stage(options)


### PR DESCRIPTION
**Context:** A pass is wrongly named as `EnforeRuntimeInvariantsPass`.

**Description of the Change:** Rename it as `EnforceRuntimeInvariantsPass`.