### PR TITLE
:warning: :construction: disable line count

### DIFF
--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -612,7 +612,7 @@ LogicalResult runLowering(const CompilerOptions &options, MLIRContext *ctx, Modu
                                                  pipeline, clHasManualPipeline, moduleOp))) {
             return failure();
         }
-        catalyst::utils::LinesCount::ModuleOp(moduleOp);
+        //catalyst::utils::LinesCount::ModuleOp(moduleOp);
     }
     return success();
 }
@@ -669,7 +669,7 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
     enum InputType inType = InputType::OTHER;
     if (mlirModule) {
         inType = InputType::MLIR;
-        catalyst::utils::LinesCount::ModuleOp(*mlirModule);
+        //catalyst::utils::LinesCount::ModuleOp(*mlirModule);
         output.isCheckpointFound = options.checkpointStage == "mlir";
     }
     else {
@@ -684,7 +684,7 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
         }
         inType = InputType::LLVMIR;
         output.isCheckpointFound = options.checkpointStage == "llvm_ir";
-        catalyst::utils::LinesCount::Module(*llvmModule);
+        //catalyst::utils::LinesCount::Module(*llvmModule);
     }
     if (failed(verifyInputType(options, inType))) {
         return failure();
@@ -728,7 +728,7 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
         }
 
         inType = InputType::LLVMIR;
-        catalyst::utils::LinesCount::Module(*llvmModule);
+        //catalyst::utils::LinesCount::Module(*llvmModule);
 
         if (options.keepIntermediate) {
             std::string tmp;
@@ -773,7 +773,7 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
                 return failure();
             }
             coroLLVMPassesTiming.stop();
-            catalyst::utils::LinesCount::Module(*llvmModule.get());
+            //catalyst::utils::LinesCount::Module(*llvmModule.get());
         }
 
         if (enzymeRun) {
@@ -783,7 +783,7 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
                 return failure();
             }
             o2PassesTiming.stop();
-            catalyst::utils::LinesCount::Module(*llvmModule.get());
+            //catalyst::utils::LinesCount::Module(*llvmModule.get());
 
             TimingScope enzymePassesTiming = llcTiming.nest("Enzyme passes");
             if (failed(timer::timer(runEnzymePasses, "runEnzymePasses", /* add_endl */ false,
@@ -791,7 +791,7 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
                 return failure();
             }
             enzymePassesTiming.stop();
-            catalyst::utils::LinesCount::Module(*llvmModule.get());
+            //catalyst::utils::LinesCount::Module(*llvmModule.get());
         }
 
         TimingScope outputTiming = llcTiming.nest("compileObject");


### PR DESCRIPTION
**Context:** Only as a proof of concept. Line counting depends on the string representation and takes too long for large programs.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
