### PR TITLE
Update test suite for `Controlled` sparse matrix

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -63,6 +63,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Update outdated test suite for `Controlled` in alignment with the latest changes in PennyLane.
+  [(#1536)](https://github.com/PennyLaneAI/catalyst/pull/1536)
+
 * Update deprecated access to `QNode.execute_kwargs["mcm_config"]`.
   Instead `postselect_mode` and `mcm_method` should be accessed instead.
   [(#1452)](https://github.com/PennyLaneAI/catalyst/pull/1452)

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -1369,7 +1369,8 @@ class TestMatrix:
         assert qml.math.allclose(op.sparse_matrix().toarray(), op.matrix())
 
     def test_sparse_matrix_wire_order(self):
-        """Check if the user requests specific wire order, sparse_matrix() returns the same as matrix()."""
+        """Check if the user requests specific wire order, sparse_matrix() returns the 
+        same as matrix()."""
         control_wires = (0, 1, 2)
         base = qml.U2(1.234, -3.2, wires=3)
         op = Controlled(base, control_wires)

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -1369,7 +1369,7 @@ class TestMatrix:
         assert qml.math.allclose(op.sparse_matrix().toarray(), op.matrix())
 
     def test_sparse_matrix_wire_order(self):
-        """Check if the user requests specific wire order, sparse_matrix() returns the 
+        """Check if the user requests specific wire order, sparse_matrix() returns the
         same as matrix()."""
         control_wires = (0, 1, 2)
         base = qml.U2(1.234, -3.2, wires=3)

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -1368,14 +1368,16 @@ class TestMatrix:
         assert isinstance(sparse_mat, sparse.csr_matrix)
         assert qml.math.allclose(op.sparse_matrix().toarray(), op.matrix())
 
-    def test_sparse_matrix_wire_order_error(self):
-        """Check a NonImplementedError is raised if the user requests specific wire order."""
+    def test_sparse_matrix_wire_order(self):
+        """Check if the user requests specific wire order, sparse_matrix() returns the same as matrix()."""
         control_wires = (0, 1, 2)
         base = qml.U2(1.234, -3.2, wires=3)
         op = Controlled(base, control_wires)
 
-        with pytest.raises(NotImplementedError):
-            op.sparse_matrix(wire_order=[3, 2, 1, 0])
+        op_sparse = op.sparse_matrix(wire_order=[3, 2, 1, 0])
+        op_dense = op.matrix(wire_order=[3, 2, 1, 0])
+
+        assert qml.math.allclose(op_sparse.toarray(), op_dense)
 
     def test_no_matrix_defined_sparse_matrix_error(self):
         """Check that if the base gate defines neither a sparse matrix nor a dense matrix, a


### PR DESCRIPTION
**Context:**
PennyLane added the [support for sparse matrix of `Controlled`](https://github.com/PennyLaneAI/pennylane/commit/4310ab7b4b03e87fabb8933454cf4d630b9f4b4a) now. Therefore we need to update the corresponding test suite in Catalyst in case of unnecessary fails.

**Description of the Change:**
Update the affected test to be the same as PL

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
