### PR TITLE
Enable verbose pypi upload

### DIFF
--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -80,3 +80,4 @@ jobs:
       with:
         repository-url: https://test.pypi.org/legacy/
         packages-dir: dist
+        verbose: true


### PR DESCRIPTION
This is to help us debug the current upload failures, but we can also leave this on permanently I think, that will make it easier to identify issues in the future.