### PR TITLE
Fixed a bug when autograph is used with a pass like merge-rotations

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -65,6 +65,10 @@
   give incorrect results for circuits containing `qml.StatePrep`.
   [(#1491)](https://github.com/PennyLaneAI/catalyst/pull/1491)
 
+* Fixes an issue ([(#1501)](https://github.com/PennyLaneAI/catalyst/issues/1501)) where using 
+  autograph in conjunction with catalyst passes causes a crash.
+  [(#1541)](https://github.com/PennyLaneAI/catalyst/pull/1541)
+
 <h3>Internal changes ⚙️</h3>
 
 * Updated the call signature for the PLXPR `qnode_prim` primitive.

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -577,6 +577,10 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
         # For QNode calls, since the class is not part of the Catalyst package, we manually add a
         # wrapper to correctly forward the quantum function call to autograph.
         if isinstance(fn, qml.QNode):
+            pass_pipeline = kwargs.pop("pass_pipeline", []) if kwargs is not None else []
+            new_kwargs = {}
+            if pass_pipeline:
+                new_kwargs["pass_pipeline"] = pass_pipeline
 
             @functools.wraps(fn.func)
             def qnode_call_wrapper():
@@ -585,7 +589,7 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
             # Copy the original qnode but replace its function.
             new_qnode = copy.copy(fn)
             new_qnode.func = qnode_call_wrapper
-            return new_qnode()
+            return new_qnode(**new_kwargs)
 
         return ag_converted_call(fn, args, kwargs, caller_fn_scope, options)
 

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -578,9 +578,7 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
         # wrapper to correctly forward the quantum function call to autograph.
         if isinstance(fn, qml.QNode):
             pass_pipeline = kwargs.pop("pass_pipeline", []) if kwargs is not None else []
-            new_kwargs = {}
-            if pass_pipeline:
-                new_kwargs["pass_pipeline"] = pass_pipeline
+            new_kwargs = {"pass_pipeline": pass_pipeline} if pass_pipeline else {}
 
             @functools.wraps(fn.func)
             def qnode_call_wrapper():

--- a/frontend/test/lit/test_peephole_optimizations.py
+++ b/frontend/test/lit/test_peephole_optimizations.py
@@ -272,6 +272,32 @@ def test_pipeline_lowering_globloc_override():
 
 test_pipeline_lowering_globloc_override()
 
+#
+# autograph
+#
+
+
+def test_single_pass_with_autograph():
+    """
+    Test tha peephole optimization work with autograph
+    """
+
+    @qjit(autograph=True, target="mlir")
+    @merge_rotations
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    def f(x: float):
+        qml.RX(x, wires=0)
+        qml.RX(x, wires=0)
+        qml.Hadamard(wires=0)
+        return qml.expval(qml.PauliZ(0))
+
+    # CHECK: transform.named_sequence @__transform_main(
+    # CHECK-NEXT: transform.apply_registered_pass "merge-rotations" to {{%.+}}
+    # CHECK-NEXT: transform.yield
+    print(f.mlir)
+
+
+test_single_pass_with_autograph()
 
 #
 # cancel_inverses

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -27,6 +27,7 @@ from numpy.testing import assert_allclose
 
 from catalyst import *
 from catalyst.autograph.transformer import TRANSFORMER
+from catalyst.passes import merge_rotations
 from catalyst.utils.dummy import dummy_func
 from catalyst.utils.exceptions import CompileError
 
@@ -406,6 +407,18 @@ class TestIntegration:
 
         # If transforms are missed, the output will be all ones.
         assert not np.all(func(0.9) == 1)
+
+    def test_passes(self):
+        dev = qml.device("lightning.qubit", wires=1)
+
+        @qml.qjit(autograph=True)
+        @merge_rotations
+        @qml.qnode(dev)
+        def func():
+            qml.Hadamard(0)
+            return qml.expval(qml.Z(0))
+
+        assert np.allclose(func(), 0.0)
 
 
 class TestCodePrinting:

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -408,18 +408,6 @@ class TestIntegration:
         # If transforms are missed, the output will be all ones.
         assert not np.all(func(0.9) == 1)
 
-    def test_passes(self):
-        dev = qml.device("lightning.qubit", wires=1)
-
-        @qml.qjit(autograph=True)
-        @merge_rotations
-        @qml.qnode(dev)
-        def func():
-            qml.Hadamard(0)
-            return qml.expval(qml.Z(0))
-
-        assert np.allclose(func(), 0.0)
-
 
 class TestCodePrinting:
     """Test that the transformed source code can be printed in different settings."""


### PR DESCRIPTION
**Context:**
issue #1501, found a bug where using autograph in conjunction with catalyst passes causes a crash. This issue is introduced by PR #1349, where the `apply_registered_pass_p` is removed and passes are appended to the qnode `kwargs`. In case of using autograph, this `kwarg` calld `pass-pipeline` is passed down to the quantum function which does not support such `kwarg` hence, causing the crash.

**Description of the Change:**
This PR resolves the issue by poping the `pass-pipeline` element from the `kwargs` before passing it to the quantum function, and instead, pass it to the call function of the newly created `qnode`

**Benefits:**
autograph can work when having catalyst pass decorators.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
[sc-84121]