### PR TITLE
Improve wheel renaming in Build Nightly Release action

### DIFF
--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -71,9 +71,14 @@ jobs:
     - name: Prepare wheels
       run: |
         rename "s/linux/manylinux_2_28/" dist/PennyLane_Catalyst-*
+        rename "s/linux/manylinux_2_28/" dist/pennylane_catalyst-*
         rename "s/macosx_13_0_universal2/macosx_13_0_x86_64/" dist/PennyLane_Catalyst-*
+        rename "s/macosx_13_0_universal2/macosx_13_0_x86_64/" dist/pennylane_catalyst-*
         rename "s/macosx_14_0_universal2/macosx_13_0_arm64/" dist/PennyLane_Catalyst-*
+        rename "s/macosx_14_0_universal2/macosx_13_0_arm64/" dist/pennylane_catalyst-*
         rename "s/macosx_14/macosx_13/" dist/PennyLane_Catalyst-*
+        rename "s/macosx_14/macosx_13/" dist/pennylane_catalyst-*
+        rename "s/pennylane_catalyst/PennyLane_Catalyst/" dist/*.whl
 
     - name: Upload wheels
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
In the "Prepare Wheels" job, which fixes up the platform string in the wheel filename, search and replace the platform string for wheel filenames matching both 'PennyLane_Catalyst-*' and 'pennylane_catalyst-*'. Then at the end, ensure that all wheel filenames use the correct capitalization, 'PennyLane_Catalyst'.

This resolves an issue where uploading the wheels to TestPyPI failed because the wheel names are now (for some reason we don't yet fulling understand) all lowercase, and consequently the `rename` commands do not match any files to fix up the platform name, hence the failure to upload to TestPyPI.