### PR TITLE
Gradient activity analysis as a JAX interpreter

### DIFF
--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -903,7 +903,9 @@ class ForLoopCallable:
 
     def _call_with_quantum_ctx(self, ctx: JaxTracingContext, *init_state):
         quantum_tape = QuantumTape()
-        outer_trace = ctx.trace
+        outer_trace = find_top_trace([self.lower_bound, self.upper_bound, self.step])
+        if outer_trace.level < ctx.trace.level:
+            outer_trace = ctx.trace
         aux_classical_tracers = [
             outer_trace.full_raise(t) for t in [self.lower_bound, self.upper_bound, self.step]
         ]

--- a/frontend/catalyst/api_extensions/differentiation.py
+++ b/frontend/catalyst/api_extensions/differentiation.py
@@ -44,6 +44,7 @@ from catalyst.jax_primitives import (
 )
 from catalyst.jax_tracer import Function, mark_gradient_tracing
 from catalyst.tracing.contexts import EvaluationContext, GradContext
+from catalyst.tracing.interpreters import trace_diffargs
 from catalyst.utils.callables import CatalystCallable
 from catalyst.utils.exceptions import DifferentiableCompileError
 
@@ -806,8 +807,10 @@ def _make_jaxpr_check_differentiable(
     """Gets the jaxpr of a differentiable function. Perform the required additional checks and
     return the output tree."""
     method = grad_params.method
+    argnums = grad_params.argnums
+    f_tagged = trace_diffargs(f, argnums)
     with mark_gradient_tracing(method):
-        jaxpr, shape = jax.make_jaxpr(f, return_shape=True)(*args, **kwargs)
+        jaxpr, shape = jax.make_jaxpr(f_tagged, return_shape=True)(*args, **kwargs)
     _, out_tree = tree_flatten(shape)
 
     for pos, arg in enumerate(jaxpr.in_avals):

--- a/frontend/catalyst/device/verification.py
+++ b/frontend/catalyst/device/verification.py
@@ -212,12 +212,13 @@ def verify_operations(tape: QuantumTape, grad_method, qjit_device):
         in_control = _ctrl_op_checker(op, in_control)
 
         # check validity based on grad method if using
-        has_active_args = any(isinstance(arg, ADTracer) and arg.active for arg in op.data)
-        if grad_method is not None and has_active_args:
+        if grad_method is not None:
             _mcm_op_checker(op)
-            if grad_method == "adjoint":
+
+            has_active_args = any(isinstance(arg, ADTracer) and arg.active for arg in op.data)
+            if grad_method == "adjoint" and has_active_args:
                 _adj_diff_op_checker(op)
-            elif grad_method == "parameter-shift":
+            elif grad_method == "parameter-shift" and has_active_args:
                 _paramshift_op_checker(op)
 
         return (in_inverse, in_control)

--- a/frontend/catalyst/device/verification.py
+++ b/frontend/catalyst/device/verification.py
@@ -38,6 +38,7 @@ from pennylane.tape import QuantumTape
 from catalyst.api_extensions import HybridAdjoint, HybridCtrl, MidCircuitMeasure
 from catalyst.jax_tracer import HybridOp, has_nested_tapes, nested_quantum_regions
 from catalyst.tracing.contexts import EvaluationContext
+from catalyst.tracing.interpreters import ADTracer
 from catalyst.utils.exceptions import CompileError, DifferentiableCompileError
 
 
@@ -211,7 +212,8 @@ def verify_operations(tape: QuantumTape, grad_method, qjit_device):
         in_control = _ctrl_op_checker(op, in_control)
 
         # check validity based on grad method if using
-        if grad_method is not None:
+        has_active_args = any(isinstance(arg, ADTracer) and arg.active for arg in op.data)
+        if grad_method is not None and has_active_args:
             _mcm_op_checker(op)
             if grad_method == "adjoint":
                 _adj_diff_op_checker(op)

--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -956,6 +956,7 @@ class DynshapePrimitive(JaxprPrimitive):
             # `abstract_eval` returned `out_type` calculated for empty constants.
             [],
             tracers,
+            # TODO: does not work with ADTrace since it assumes what the top_trace is
             maker=lambda a: DynamicJaxprTracer(trace, a, source_info),
         )
 

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -546,6 +546,8 @@ def trace_to_jaxpr(func, static_argnums, abstracted_axes, args, kwargs):
             "static_argnums": static_argnums,
             "abstracted_axes": abstracted_axes,
         }
+        # This generates two entries in the trace stack, one from the EvaluationContext,
+        # the other in make_jaxpr. (TODO: deduplicate?)
         with EvaluationContext(EvaluationMode.CLASSICAL_COMPILATION):
             jaxpr, out_type, out_treedef = make_jaxpr2(func, **make_jaxpr_kwargs)(*args, **kwargs)
             plugins = EvaluationContext.get_plugins()
@@ -1150,6 +1152,8 @@ def trace_quantum_function(
         out_tree: PyTree shapen of the result
     """
 
+    # This generates a new base main (level 0) upon entering, which is separate from the existing
+    # stack? (TODO: deduplicate?)
     with EvaluationContext(EvaluationMode.QUANTUM_COMPILATION) as ctx:
         # (1) - Classical tracing
         quantum_tape = QuantumTape(shots=device.shots)

--- a/frontend/catalyst/tracing/interpreters.py
+++ b/frontend/catalyst/tracing/interpreters.py
@@ -23,6 +23,8 @@ import jax.flatten_util
 from catalyst.jax_primitives import AbstractQbit, AbstractQreg
 
 
+# TODO: consider pytrees for argnums
+# TODO: check whether any other primitive process methods need to be implemented
 class ADTrace(jax.core.Trace):
     def pure(self, x):
         return ADTracer(self, x, active=False)

--- a/frontend/catalyst/tracing/interpreters.py
+++ b/frontend/catalyst/tracing/interpreters.py
@@ -94,7 +94,7 @@ def trace_diffargs(fun, argnums):
 
     @functools.wraps(fun)
     def diffargs_transform_wrapper(*args, **kwargs):
-        args_flat, args_tree = jax.tree_flatten(args)
+        args_flat, args_tree = jax.tree_flatten((args, kwargs))
         fun_flat, res_tree = flatten_fun(fun, args_tree)
 
         with jax.core.new_main(ADTrace) as main:
@@ -117,8 +117,8 @@ def flatten_fun(f, in_tree):
     store = Store()
 
     def flat_fun(*args_flat):
-        pytree_args = jax.tree_unflatten(in_tree, args_flat)
-        out = f(*pytree_args)
+        pytree_args, pytree_kwargs = jax.tree_unflatten(in_tree, args_flat)
+        out = f(*pytree_args, **pytree_kwargs)
         out_flat, out_tree = jax.tree_flatten(out)
         store.set_value(out_tree)
         return out_flat

--- a/frontend/catalyst/tracing/interpreters.py
+++ b/frontend/catalyst/tracing/interpreters.py
@@ -1,0 +1,137 @@
+# Copyright 2025 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module with JAX interpreters (in the tracing framework) developed for Catalyst."""
+
+import functools
+
+import jax
+import jax._src.api_util as au
+import jax._src.linear_util as lu
+import jax.flatten_util
+
+from catalyst.jax_primitives import AbstractQbit, AbstractQreg
+
+
+class ADTrace(jax.core.Trace):
+    def pure(self, x):
+        return ADTracer(self, x, active=False)
+
+    def lift(self, x):
+        return ADTracer(self, x, active=False)
+
+    def process_primitive(self, primitive, in_tracers, params):
+        # Propagate differentiability information. This should be the conservative action.
+        # TODO: Improve the algorithm by taking into account semantics of individual primitives.
+        is_active = any(tracer.active for tracer in in_tracers)
+
+        # Identity transform: Unbox tracers to send them one level down.
+        lowered_tracers = [tracer.value for tracer in in_tracers]
+        out_tracers = primitive.bind(*lowered_tracers, **params)
+        out_tracers = (out_tracers,) if not isinstance(out_tracers, (list, tuple)) else out_tracers
+
+        # Since qubit values (tracers) are cached by Catalyst's tracing machinery, it's possible
+        # to produce leaked tracers from any jaxpr transform launched within trace_quantum_function.
+        # Excluding these values from being boxed up in ADTracers will prevent such leaks.
+        results = []
+        for tracer in out_tracers:
+            if isinstance(jax.core.get_aval(tracer), (AbstractQreg, AbstractQbit)):
+                results.append(tracer)
+            else:
+                results.append(ADTracer(self, tracer, is_active))
+
+        return results if primitive.multiple_results else results[0]
+
+    def process_call(self, call_primitive, f: lu.WrappedFun, in_tracers, params):
+        # Wrap the callee to inject our ADTrace. Note f is a JAX WrappedFun.
+        argnums = [idx for idx, x in enumerate(in_tracers) if x.active]
+        f_wrapped = lu.WrappedFun(
+            trace_diffargs(f.f, argnums), f.transforms, f.stores, f.params, f.in_type, f.debug_info
+        )
+
+        lowered_tracers = [tracer.value for tracer in in_tracers]
+        out_tracers = call_primitive.bind(f_wrapped, *lowered_tracers, **params)
+
+        # TODO: Extract the differentiability of the call results.
+        assert call_primitive.multiple_results
+        return [ADTracer(self, x, bool(argnums)) for x in out_tracers]
+
+
+class ADTracer(jax.core.Tracer):
+    __slots__ = ["value", "active"]
+
+    def __init__(self, trace, value, active):
+        self._trace = trace
+        self.value = value
+        self.active = active
+
+    @property
+    def aval(self):
+        return jax.core.get_aval(self.value)
+
+    def full_lower(self):
+        if not self.active:
+            return jax.core.full_lower(self.value)
+        return self
+
+
+# Needed so that PennyLane doesn't think we are a new type of ML interface.
+ADTracer.__module__ = ADTracer.__module__.replace("catalyst", "jax", 1)
+
+
+def trace_diffargs(fun, argnums):
+
+    @functools.wraps(fun)
+    def diffargs_transform_wrapper(*args, **kwargs):
+        args_flat, args_tree = jax.tree_flatten(args)
+        fun_flat, res_tree = flatten_fun(fun, args_tree)
+
+        with jax.core.new_main(ADTrace) as main:
+            trace = ADTrace(main, jax.core.cur_sublevel())
+
+            # TODO: optimize by not instantiating ADTracers for non diff args, means the
+            #       ADTrace.process_primitive can be skipped for ops not acting on any ADTracers
+            in_tracers = [ADTracer(trace, arg, i in argnums) for i, arg in enumerate(args_flat)]
+            res_flat = fun_flat(*in_tracers)
+            out_tracers = [trace.full_raise(res) for res in res_flat]
+
+        results = [tracer.value for tracer in out_tracers]
+        return jax.tree_unflatten(res_tree(), results)
+
+    return diffargs_transform_wrapper
+
+
+# utils (should be available in JAX, but they differ somewhat from the simple Autodidax version)
+def flatten_fun(f, in_tree):
+    store = Store()
+
+    def flat_fun(*args_flat):
+        pytree_args = jax.tree_unflatten(in_tree, args_flat)
+        out = f(*pytree_args)
+        out_flat, out_tree = jax.tree_flatten(out)
+        store.set_value(out_tree)
+        return out_flat
+
+    return flat_fun, store
+
+
+class Store:
+    val = None
+
+    def set_value(self, val):
+        assert self.val is None
+        self.val = val
+
+    def __call__(self):
+        return self.val

--- a/frontend/catalyst/tracing/interpreters.py
+++ b/frontend/catalyst/tracing/interpreters.py
@@ -45,10 +45,10 @@ class ADTrace(jax.core.Trace):
         # Excluding these values from being boxed up in ADTracers will prevent such leaks.
         results = []
         for tracer in out_tracers:
-            if isinstance(jax.core.get_aval(tracer), (AbstractQreg, AbstractQbit)):
-                results.append(tracer)
-            else:
+            if isinstance(getattr(tracer, "dtype", None), jax.numpy.floating):
                 results.append(ADTracer(self, tracer, is_active))
+            else:
+                results.append(tracer)
 
         return results if primitive.multiple_results else results[0]
 

--- a/frontend/catalyst/tracing/interpreters.py
+++ b/frontend/catalyst/tracing/interpreters.py
@@ -109,6 +109,8 @@ ADTracer.__module__ = ADTracer.__module__.replace("catalyst", "jax", 1)
 
 
 def trace_diffargs(fun, argnums):
+    if not argnums:
+        return fun
 
     @functools.wraps(fun)
     def diffargs_transform_wrapper(*args, **kwargs):


### PR DESCRIPTION
This PR introduces a new JAX transform (`jax.core.Trace`) that allows us to track the gradient activity of program values. Activity determines whether a value participates in differentiation, and transitively whether an operation participates in differentiation. The transform itself does nothing (identity transform), but its tracers record the activity of values as they pass through JAX primitives. 

The starting point is the `catalyst.tracing.trace_diffargs` transform, which is applied automatically to any function supplied to Catalyst AD methods (`grad`, `jacobian`, `value_and_grad`, etc). Based on the `argnums` parameter from those high-level API functions, it will initialize tracers with the appropriate activity for the function arguments. Primitives are then interpreted using the next trace in the stack, and the activity of outputs is based on the activity of inputs (in an opaque manner, one could imagine defining "activity rules" for primitives for more fine-grained control).

While the transform generally works with higher-order primitives as well (those that trace sub-functions in a separate tracing frame), by automatically propagating itself to the nested frame, it only works if the primitive is a `CallPrimitive`. Special cases like Catalyst control flow primitives still need to be implemented, especially considering Catalyst's use of customized tracing code, which complicates the matter.

The activity analysis can in principle be used in several ways, but Catalyst will use it to skip verification and decomposition of operators based on differentiability criteria if the op does not participate in differentiation.

The following example now passes Catalyst's verification which it didn't before:
```py
# QNode/QFunc support
@qml.qnode(qml.device("lightning.qubit", wires=0))
def circ(x, y, z):

    # propagate activity through other operations
    psi = jnp.sin(y + 1)

    # as long as x and y are not in argnums, the verification passes
    qml.Rot(x, psi, 0.1, wires=0)

    # pytree support
    return {"hi": qml.expval(qml.Z(0))}

@qjit
def main(x: float, y: float, z: float):
    # Catalyst AD primitives automatically inject the activity analysis transform
    return grad(circ, argnums=[2])(x, y, z)
```

Some TODOs:
- compatibility with control flow primitives
- optimize analysis for call primitives by looking at the activity of results
- additional testing

Note that we don't want to use JAX `JVPTracer`s for this because it will try to interpret all the primitives through their JVP rules, which we don't support for our custom (quantum) primitives, and classical AD is also handled by Catalyst further down.

[sc-84808]