### PR TITLE
Expose oqd pipeline into its own API function

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -119,6 +119,9 @@
   - Catalyst now generates OpenAPL programs for Pennylane circuits of up to two qubits using the OQD device.
     [(#1517)](https://github.com/PennyLaneAI/catalyst/pull/1517)
 
+  - The end-to-end compilation pipeline for OQD devices is available as an API function.
+    [(#1545)](https://github.com/PennyLaneAI/catalyst/pull/1545)
+
 * Update source code to comply with changes requested by black v25.1.0
   [(#1490)](https://github.com/PennyLaneAI/catalyst/pull/1490)
 

--- a/frontend/catalyst/third_party/oqd/__init__.py
+++ b/frontend/catalyst/third_party/oqd/__init__.py
@@ -15,6 +15,6 @@
 This submodule contains classes for the OQD device and its properties.
 """
 
-from .oqd_device import OQDDevice
+from .oqd_device import OQDDevice, OQDDevicePipeline
 
-__all__ = ["OQDDevice"]
+__all__ = ["OQDDevice", "OQDDevicePipeline"]

--- a/frontend/catalyst/third_party/oqd/oqd_device.py
+++ b/frontend/catalyst/third_party/oqd/oqd_device.py
@@ -29,6 +29,54 @@ from catalyst.compiler import get_lib_path
 BACKENDS = ["default"]
 
 
+def OQDDevicePipeline(device, qubit, gate):
+    """
+    Generate the compilation pipeline for an OQD device.
+
+    Args:
+        device (str): the path to the device toml file specifications.
+        qubit (str): the path to the qubit toml file specifications.
+        gate (str): the path to the gate toml file specifications.
+
+    Returns:
+        A list of tuples, with each tuple being a stage in the compilation pipeline.
+        When using ``keep_intermediate=True`` from :func:`~.qjit`, the kept stages
+        correspond to the tuples.
+    """
+    return [
+        (
+            "device-agnostic-pipeline",
+            [
+                "enforce-runtime-invariants-pipeline",
+                "hlo-lowering-pipeline",
+                "quantum-compilation-pipeline",
+                "bufferization-pipeline",
+            ],
+        ),
+        (
+            "oqd_pipeline",
+            [
+                "func.func(ions-decomposition)",
+                "func.func(quantum-to-ion{"
+                + "device-toml-loc="
+                + device
+                + " qubit-toml-loc="
+                + qubit
+                + " gate-to-pulse-toml-loc="
+                + gate
+                + "})",
+                "convert-ion-to-llvm",
+            ],
+        ),
+        (
+            "llvm-dialect-lowering-pipeline",
+            [
+                "llvm-dialect-lowering-pipeline",
+            ],
+        ),
+    ]
+
+
 class OQDDevice(Device):
     """The OQD device allows access to the hardware devices from OQD using Catalyst."""
 

--- a/frontend/test/test_oqd/oqd/test_openapl_generation.py
+++ b/frontend/test/test_oqd/oqd/test_openapl_generation.py
@@ -21,7 +21,7 @@ import pennylane as qml
 import pytest
 
 from catalyst import qjit
-from catalyst.third_party.oqd import OQDDevice
+from catalyst.third_party.oqd import OQDDevice, OQDDevicePipeline
 
 
 class TestOpenAPL:
@@ -29,41 +29,9 @@ class TestOpenAPL:
 
     test_path = os.path.dirname(__file__)
     toml_path = os.path.join(test_path, "calibration_data/")
-    oqd_pipelines = [
-        (
-            "device-agnostic-pipeline",
-            [
-                "enforce-runtime-invariants-pipeline",
-                "hlo-lowering-pipeline",
-                "quantum-compilation-pipeline",
-                "bufferization-pipeline",
-            ],
-        ),
-        (
-            "oqd_pipeline",
-            [
-                "func.func(ions-decomposition)",
-                "func.func(quantum-to-ion{"
-                + "device-toml-loc="
-                + toml_path
-                + "device.toml "
-                + "qubit-toml-loc="
-                + toml_path
-                + "qubit.toml "
-                + "gate-to-pulse-toml-loc="
-                + toml_path
-                + "gate.toml"
-                + "})",
-                "convert-ion-to-llvm",
-            ],
-        ),
-        (
-            "llvm-dialect-lowering-pipeline",
-            [
-                "llvm-dialect-lowering-pipeline",
-            ],
-        ),
-    ]
+    oqd_pipelines = OQDDevicePipeline(
+        toml_path + "device.toml", toml_path + "qubit.toml", toml_path + "gate.toml"
+    )
 
     output_f = "__openapl__output.json"
 


### PR DESCRIPTION
**Context:**
While we still need to discuss on device-specific pipelines #1500 , in the mean time we should at least provide the OQD device pipeline as a packaged entity, instead of requiring the user to specify it manually.

**Description of the Change:**
Export the OQD pipeline used in the OQD integration test into its own API function.

**Benefits:**
Users no longer need to specify the entire OQD pipeline during use.

