### PR TITLE
[tests] remove hard coded python version from lit tests

### DIFF
--- a/frontend/test/lit/lit.cfg.py
+++ b/frontend/test/lit/lit.cfg.py
@@ -36,7 +36,7 @@ config.test_exec_root = getattr(config, "frontend_test_dir", ".lit")
 config.environment["ASAN_OPTIONS"] = "detect_leaks=0,detect_container_overflow=0"
 
 # Define substitutions used at the top of lit test files, e.g. %PYTHON.
-python_executable = getattr(config, "python_executable", "python3.10")
+python_executable = getattr(config, "python_executable", "python")
 
 if "Address" in getattr(config, "llvm_use_sanitizer", ""):
     # With sanitized builds, Python tests require some preloading magic to run.


### PR DESCRIPTION
**Context:** Recently upgraded OS in my virtual machine. Reinstalled from scratch. Noticed this hard coded version.

**Description of the Change:** Remove hard coded python version from lit tests.

**Benefits:** Users / developers will be able to run lit tests with other python versions.

**Possible Drawbacks:** None?

**Related GitHub Issues:**
