### PR TITLE
Fix wheels file names in nightly build action

### DIFF
--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -78,7 +78,6 @@ jobs:
         rename "s/macosx_14_0_universal2/macosx_13_0_arm64/" dist/pennylane_catalyst-*
         rename "s/macosx_14/macosx_13/" dist/PennyLane_Catalyst-*
         rename "s/macosx_14/macosx_13/" dist/pennylane_catalyst-*
-        rename "s/pennylane_catalyst/PennyLane_Catalyst/" dist/*.whl
 
     - name: Upload wheels
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.11.0-dev46"
+__version__ = "0.11.0-dev47"


### PR DESCRIPTION
This is a follow-up to #1542, which did not fully fix the wheels file-naming patterns for the nightly-build action.

This change removes the step that replaced `pennylane_catalyst` with `PennyLane_Catalyst` in the wheels file names after fixing up the platform name string. Removing this step ensures that the wheels file name and the files contained within the wheels follow the same naming convention.

The wheels renaming step in the nightly-build action continues to perform the `rename` command on wheels files with both the `pennylane_catalyst-*` and `PennyLane_Catalyst-*` spellings. While we now expect setuptools to always generate wheels with the lowercase spelling, this should ensure the wheels get the correct platform string should this change in the future.