### PR TITLE
Add helper functions to handle static arguments in customOp

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -171,6 +171,12 @@
 * Update source code to comply with changes requested by black v25.1.0
   [(#1490)](https://github.com/PennyLaneAI/catalyst/pull/1490)
 
+* Revert `StaticCustomOp` in favour of adding helper functions (`isStatic()`, `getStaticParams()` 
+  to the `CustomOp` which preserves the same functionality. More specifically, this reverts
+  [#1387] and [#1396], modifies [#1484]. 
+  [(#1558)](https://github.com/PennyLaneAI/catalyst/pull/1558)
+  [(#1555)](https://github.com/PennyLaneAI/catalyst/pull/1555)
+
 <h3>Documentation 📝</h3>
 
 <h3>Contributors ✍️</h3>

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -453,6 +453,30 @@ def CustomOp : UnitaryGate_Op<"custom", [DifferentiableGate, NoMemoryEffect,
         mlir::ValueRange getAllParams() {
             return getParams();
         }
+
+        bool isStatic() {
+            for (mlir::Value param : getParams()) {
+                if (!param.getDefiningOp() || !param.getDefiningOp()->hasTrait<mlir::OpTrait::ConstantLike>()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        std::vector<double> getStaticParams() {
+            std::vector<double> staticValues;
+            if (!isStatic()) {
+                return staticValues;
+            }
+            
+            for (mlir::Value param : getParams()) {
+                auto constOp = param.getDefiningOp();
+                if (auto floatAttr = constOp->getAttrOfType<mlir::FloatAttr>("value")) {
+                    staticValues.push_back(floatAttr.getValueAsDouble());
+                }
+            }
+            return staticValues;
+        }
     }];
     let hasCanonicalizeMethod = 1;
 }


### PR DESCRIPTION
**Context:**
The initial motivation for `StaticCustomOp` was to make working with static parameters easier by accessing literals directly and removing the need to work with SSA values. However, having both `CustomOp` and `StaticCustomOp` would require any pass that runs before `StaticCustomOp` -> `CustomOp` lowering to duplicate their logic for both types. This creates maintenance overhead and increases the risk of inconsistencies between the two implementations.

**Description of the Change:**
Added two helper functions to the `CustomOp` class to detect and extract static parameters from quantum gates.
- `isStatic()` function to check if all parameters are constants
- `getStaticParams()` function to extract constant values from parameters

Example Usage:
```cpp
// Check if parameters are static
if (customOp.isStatic()) {
    // Get the constant values
    auto staticValues = customOp.getStaticParams();
}
```

**Benefits:**
Eliminates the need for duplicate logic in passes that handle both `CustomOp` and `StaticCustomOp` and provides a unified interface for working with both static and dynamic parameters

**Possible Drawbacks:**
None

**Related GitHub Issues:**
