### PR TITLE
[Frontend] Use JAXPR representation as cache-key

### DIFF
--- a/frontend/catalyst/jax_primitives_utils.py
+++ b/frontend/catalyst/jax_primitives_utils.py
@@ -84,7 +84,7 @@ def lower_callable(ctx, callable_, call_jaxpr, pipeline=None):
 
 def get_or_create_funcop(ctx, callable_, call_jaxpr, pipeline):
     """Get funcOp from cache, or create it from scratch"""
-    key = (callable_, *pipeline)
+    key = (str(call_jaxpr), *pipeline)
     if func_op := get_cached(ctx, key):
         return func_op
     func_op = lower_callable_to_funcop(ctx, callable_, call_jaxpr)
@@ -133,7 +133,7 @@ def get_or_create_qnode_funcop(ctx, callable_, call_jaxpr, pipeline):
     Returns:
       FuncOp
     """
-    key = (callable_, *pipeline)
+    key = (str(call_jaxpr), *pipeline)
     if func_op := get_cached(ctx, key):
         return func_op
     func_op = lower_qnode_to_funcop(ctx, callable_, call_jaxpr, pipeline)


### PR DESCRIPTION
**Context:** A multiple function may have different JAXPR representations depending on whether it was differentiated or not.

**Description of the Change:** Cache based on the JAXPR representation.

**Benefits:** Cache

**Possible Drawbacks:** Will compute the textual JAXPR representation. (There is no other way to compare two JAXPRs for equality)

**Related GitHub Issues:**

Should be merged after #1562 with the test case where this was found.
