### PR TITLE
[frontend] verify parameter shift rules

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -130,6 +130,7 @@
 
 * Catalyst now decomposes non-differentiable gates when in a gradient method.
   [(#1562)](https://github.com/PennyLaneAI/catalyst/pull/1562)
+  [(#1568)](https://github.com/PennyLaneAI/catalyst/pull/1568)
   [(#1569)](https://github.com/PennyLaneAI/catalyst/pull/1569)
 
   Gates that are constant, such as when all parameters are Python or NumPy data types, are not

--- a/frontend/catalyst/device/decomposition.py
+++ b/frontend/catalyst/device/decomposition.py
@@ -211,6 +211,10 @@ def catalyst_acceptance(
     op: qml.operation.Operator, capabilities: DeviceCapabilities, grad_method: Union[str, None]
 ) -> Union[str, None]:
     """Check whether an Operator is supported and returns the name of the operation or None."""
+
+    if not is_differentiable(op, capabilities, grad_method):
+        return None
+
     if isinstance(op, qml.ops.Adjoint):
         match = catalyst_acceptance(op.base, capabilities, grad_method)
         if match and is_invertible(op.base, capabilities):
@@ -223,9 +227,6 @@ def catalyst_acceptance(
         match = catalyst_acceptance(op.base, capabilities, grad_method)
         if match and is_controllable(op.base, capabilities):
             return match
-
-    elif not is_differentiable(op, capabilities, grad_method):
-        return None
 
     elif is_supported(op, capabilities):
         return op.name

--- a/frontend/catalyst/device/op_support.py
+++ b/frontend/catalyst/device/op_support.py
@@ -71,12 +71,19 @@ def _is_grad_recipe_same_as_catalyst(op):
 def _are_param_frequencies_same_as_catalyst(op):
     """Check if the parameter frequencies are all close to 1."""
 
-    if not hasattr(op, "parameter_frequencies"):
-        return True
+    try:
+        if not hasattr(op, "parameter_frequencies"):
+            return True
 
-    is_valid_len = len(op.data) == len(op.parameter_frequencies)
-    if not is_valid_len:
-        return False
+        is_valid_len = len(op.data) == len(op.parameter_frequencies)
+        if not is_valid_len:
+            return False
+    except qml.operation.ParameterFrequenciesUndefinedError:
+        # This is a little bit counter intuitive.
+        # op.parameter_frequencies failed because there were no parameter frequencies defined.
+        # and since one of our conditions was that if there are no parameter frequencies
+        # defined this check should succeed, well then we return true.
+        return True
 
     with jax.ensure_compile_time_eval():
         # We use jax.ensure_compile_time_eval

--- a/frontend/catalyst/device/op_support.py
+++ b/frontend/catalyst/device/op_support.py
@@ -51,7 +51,6 @@ def _is_grad_recipe_same_as_catalyst(op):
 
     for _, grad_recipe in zip(op.data, op.grad_recipe, strict=True):
         left, right = grad_recipe
-        msg = f"{op.name} has incompatible grad_recipe {op.grad_recipe}"
         try:
             with jax.ensure_compile_time_eval():
                 # exp_param_shift_rule_{left,right} are constants in Catalyst
@@ -65,7 +64,7 @@ def _is_grad_recipe_same_as_catalyst(op):
                     obs_param_shift_rule_right, exp_param_shift_rule_right
                 )
             return bool(is_left_valid and is_right_valid)
-        except jax.errors.TracerBoolConversionError as exc:
+        except jax.errors.TracerBoolConversionError:
             return False
 
 

--- a/frontend/catalyst/device/op_support.py
+++ b/frontend/catalyst/device/op_support.py
@@ -130,10 +130,7 @@ def _paramshift_op_checker(op):
     if _has_parameter_frequencies(op):
         return _are_param_frequencies_same_as_catalyst(op)
 
-    if isinstance(op, HybridOp):
-        return True
-
-    return False
+    return isinstance(op, HybridOp)
 
 
 def _adjoint_diff_op_checker(op, capabilities):

--- a/frontend/catalyst/device/op_support.py
+++ b/frontend/catalyst/device/op_support.py
@@ -120,7 +120,7 @@ def _paramshift_op_checker(op):
 
     if type(op) in (qml.ops.Controlled, qml.ops.ControlledOp):
         # Cannot take param shift of controlled ops.
-        # It will always be four term shift rule.
+        # It will always be at least a four term shift rule.
         return False
 
     if _has_grad_recipe(op):

--- a/frontend/catalyst/device/op_support.py
+++ b/frontend/catalyst/device/op_support.py
@@ -50,6 +50,7 @@ def _is_grad_recipe_same_as_catalyst(op):
     if not any(map(lambda x: x, op.grad_recipe)):
         return True
 
+    valid = True
     for _, grad_recipe in zip(op.data, op.grad_recipe, strict=True):
         left, right = grad_recipe
         try:
@@ -64,9 +65,10 @@ def _is_grad_recipe_same_as_catalyst(op):
                 is_right_valid = jnp.allclose(
                     obs_param_shift_rule_right, exp_param_shift_rule_right
                 )
-            return bool(is_left_valid and is_right_valid)
+                valid &= is_left_valid and is_right_valid
         except jax.errors.TracerBoolConversionError:
             return False
+    return valid
 
 
 def _are_param_frequencies_same_as_catalyst(op):

--- a/frontend/catalyst/device/op_support.py
+++ b/frontend/catalyst/device/op_support.py
@@ -129,10 +129,6 @@ def _paramshift_op_checker(op):
     if _has_parameter_frequencies(op):
         return _are_param_frequencies_same_as_catalyst(op)
 
-    if not isinstance(op, HybridOp):
-        if op.grad_method not in {"A", None}:
-            raise DifferentiableCompileError(f"{op.name} does not support analytic differentiation")
-
     return True
 
 

--- a/frontend/catalyst/device/op_support.py
+++ b/frontend/catalyst/device/op_support.py
@@ -18,6 +18,7 @@ from typing import Union
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pennylane as qml
 from pennylane.devices.capabilities import DeviceCapabilities, OperatorProperties
 from pennylane.operation import Operation, Operator
@@ -85,16 +86,7 @@ def _are_param_frequencies_same_as_catalyst(op):
         # defined this check should succeed, well then we return true.
         return True
 
-    with jax.ensure_compile_time_eval():
-        # We use jax.ensure_compile_time_eval
-        # to evaluate op.parameter_frequencies (which we expect to always be known at compile time
-        # and concrete) and compare with 1.0. Otherwise, jax may generate stablehlo
-        # operations for the jnp.allclose
-        # This is a purely stylistic choice and one may have also chosen to avoid jax and use
-        # numpy instead.
-        valid_frequencies = all(
-            map(lambda x: jnp.allclose(jnp.array(x), 1.0), op.parameter_frequencies)
-        )
+    valid_frequencies = all(map(lambda x: np.allclose(np.array(x), 1.0), op.parameter_frequencies))
 
     return valid_frequencies
 

--- a/frontend/catalyst/device/op_support.py
+++ b/frontend/catalyst/device/op_support.py
@@ -68,7 +68,7 @@ def _is_grad_recipe_same_as_catalyst(op):
         return False
 
     valid = True
-    for _, grad_recipe in zip(op.data, op.grad_recipe, strict=True):
+    for grad_recipe in op.grad_recipe:
         left, right = grad_recipe
         # exp_param_shift_rule_{left,right} are constants in Catalyst
         # we must ensure that the rules seen in the op match Catalyst's implementation.

--- a/frontend/catalyst/device/op_support.py
+++ b/frontend/catalyst/device/op_support.py
@@ -101,6 +101,15 @@ def _are_param_frequencies_same_as_catalyst(op):
 
 def _paramshift_op_checker(op):
 
+    if isinstance(op, qml.QubitUnitary):
+        # Cannot take param shift of qubit unitary.
+        return False
+
+    if type(op) in (qml.ops.Controlled, qml.ops.ControlledOp):
+        # Cannot take param shift of controlled ops.
+        # It will always be four term shift rule.
+        return False
+
     if not _is_grad_recipe_same_as_catalyst(op):
         return False
 
@@ -110,6 +119,7 @@ def _paramshift_op_checker(op):
     if not isinstance(op, HybridOp):
         if op.grad_method not in {"A", None}:
             raise DifferentiableCompileError(f"{op.name} does not support analytic differentiation")
+
     return True
 
 

--- a/frontend/catalyst/device/op_support.py
+++ b/frontend/catalyst/device/op_support.py
@@ -64,6 +64,9 @@ def _is_grad_recipe_same_as_catalyst(op):
     if _is_grad_recipe_active(op.grad_recipe):
         return False
 
+    if len(op.data) != len(op.grad_recipe):
+        return False
+
     valid = True
     for _, grad_recipe in zip(op.data, op.grad_recipe, strict=True):
         left, right = grad_recipe

--- a/frontend/catalyst/device/op_support.py
+++ b/frontend/catalyst/device/op_support.py
@@ -17,14 +17,12 @@
 from typing import Union
 
 import jax
-import jax.numpy as jnp
 import numpy as np
 import pennylane as qml
 from pennylane.devices.capabilities import DeviceCapabilities, OperatorProperties
 from pennylane.operation import Operation, Operator
 
 from catalyst.api_extensions import MidCircuitMeasure
-from catalyst.jax_tracer import HybridOp
 from catalyst.utils.exceptions import DifferentiableCompileError
 
 EMPTY_PROPERTIES = OperatorProperties()
@@ -44,7 +42,9 @@ def is_supported(op: Operator, capabilities: DeviceCapabilities) -> bool:
 
 def _is_grad_recipe_same_as_catalyst(op):
     """Checks that the grad_recipe for the op matches the hard coded one in Catalyst."""
-    _is_active = lambda x: isinstance(x, jax.core.Tracer)
+
+    def _is_active(maybe_tracer):
+        return isinstance(maybe_tracer, jax.core.Tracer)
 
     def _is_grad_recipe_active(grad_recipe):
         active = False

--- a/frontend/catalyst/device/op_support.py
+++ b/frontend/catalyst/device/op_support.py
@@ -17,6 +17,7 @@
 from typing import Union
 
 import jax
+import jax.numpy as jnp
 import pennylane as qml
 from pennylane.devices.capabilities import DeviceCapabilities, OperatorProperties
 from pennylane.operation import Operation, Operator
@@ -40,7 +41,71 @@ def is_supported(op: Operator, capabilities: DeviceCapabilities) -> bool:
     return op.name in capabilities.operations
 
 
+def _check_grad_recipe(op):
+    """Checks that the grad_recipe for the op matches the hard coded one in Catalyst."""
+    if not hasattr(op, "grad_recipe"):
+        return
+
+    if not any(map(lambda x: x, op.grad_recipe)):
+        return
+
+    for _, grad_recipe in zip(op.data, op.grad_recipe, strict=True):
+        left, right = grad_recipe
+        msg = f"{op.name} has incompatible grad_recipe {op.grad_recipe}"
+        try:
+            with jax.ensure_compile_time_eval():
+                # exp_param_shift_rule_{left,right} are constants in Catalyst
+                # we must ensure that the rules seen in the op match Catalyst's implementation.
+                exp_param_shift_rule_left = jnp.array([0.5, 1.0, jnp.pi / 2])
+                exp_param_shift_rule_right = jnp.array([-0.5, 1.0, -jnp.pi / 2])
+                obs_param_shift_rule_left = jnp.array(left)
+                obs_param_shift_rule_right = jnp.array(right)
+                is_left_valid = jnp.allclose(obs_param_shift_rule_left, exp_param_shift_rule_left)
+                is_right_valid = jnp.allclose(
+                    obs_param_shift_rule_right, exp_param_shift_rule_right
+                )
+            if not (is_left_valid and is_right_valid):
+                raise DifferentiableCompileError(msg)
+        except jax.errors.TracerBoolConversionError as exc:
+            raise DifferentiableCompileError(msg) from exc
+
+
+def _check_param_frequencies(op):
+    """Check if the parameter frequencies are all close to 1."""
+    if not hasattr(op, "parameter_frequencies"):
+        return
+
+    is_valid_len = len(op.data) == len(op.parameter_frequencies)
+    if not is_valid_len:
+        name = op.name
+        len_data = len(op.data)
+        len_freq = len(op.parameter_frequencies)
+        msg = f"{name} has different number of parameters {len_data} and frequencies {len_freq}"
+        raise DifferentiableCompileError(msg)
+
+    with jax.ensure_compile_time_eval():
+        # We use jax.ensure_compile_time_eval
+        # to evaluate op.parameter_frequencies (which we expect to always be known at compile time
+        # and concrete) and compare with 1.0. Otherwise, jax may generate stablehlo
+        # operations for the jnp.allclose
+        # This is a purely stylistic choice and one may have also chosen to avoid jax and use
+        # numpy instead.
+        valid_frequencies = all(
+            map(lambda x: jnp.allclose(jnp.array(x), 1.0), op.parameter_frequencies)
+        )
+
+    if not valid_frequencies:
+        raise DifferentiableCompileError(
+            f"{op.name} has invalid parameter_frequencies values {op.parameter_frequencies}"
+        )
+
+
 def _paramshift_op_checker(op):
+
+    _check_grad_recipe(op)
+
+    _check_param_frequencies(op)
+
     if not isinstance(op, HybridOp):
         if op.grad_method not in {"A", None}:
             raise DifferentiableCompileError(f"{op.name} does not support analytic differentiation")

--- a/frontend/catalyst/device/op_support.py
+++ b/frontend/catalyst/device/op_support.py
@@ -23,6 +23,7 @@ from pennylane.devices.capabilities import DeviceCapabilities, OperatorPropertie
 from pennylane.operation import Operation, Operator
 
 from catalyst.api_extensions import MidCircuitMeasure
+from catalyst.jax_tracer import HybridOp
 from catalyst.utils.exceptions import DifferentiableCompileError
 
 EMPTY_PROPERTIES = OperatorProperties()
@@ -129,7 +130,10 @@ def _paramshift_op_checker(op):
     if _has_parameter_frequencies(op):
         return _are_param_frequencies_same_as_catalyst(op)
 
-    return True
+    if isinstance(op, HybridOp):
+        return True
+
+    return False
 
 
 def _adjoint_diff_op_checker(op, capabilities):

--- a/frontend/test/lit/test_gradient.py
+++ b/frontend/test/lit/test_gradient.py
@@ -297,8 +297,7 @@ def test_diff_dynamic_paramshift(params: jax.core.ShapedArray([2], float)):
     # CHECK-NOT: set_state
     # COM: Rot is supported by the two-term shift rule
     # CHECK: "Rot"
-    # COM: TODO: this should be a CHECK-NOT after PS rules are implemented in #1568
-    # CHECK: unitary
+    # CHECK-NOT: unitary
     return grad(cost)(params)
 
 

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -2068,6 +2068,7 @@ class TestParameterShiftVerificationUnitTests:
 
     def test_no_grad_recipe_no_param_frequencies(self):
         """No grad recipe, no param shift, not hybrid op => no grad"""
+
         class DummyOp(qml.operation.Operator):
             def __init__(self, wires=None):
                 super().__init__(0.0, wires=wires)

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -2066,6 +2066,18 @@ class TestParameterShiftVerificationUnitTests:
         op = qml.QubitUnitary(jnp.array([[1, 1], [1, -1]]), wires=0)
         assert not _paramshift_op_checker(op)
 
+    def test_no_grad_recipe_no_param_frequencies(self):
+        """No grad recipe, no param shift, not hybrid op => no grad"""
+        class DummyOp(qml.operation.Operator):
+            def __init__(self, wires=None):
+                super().__init__(0.0, wires=wires)
+
+            @property
+            def num_params(self):
+                return 1
+
+        assert not _paramshift_op_checker(DummyOp(wires=[0]))
+
 
 class TestParameterShiftVerificationIntegrationTests:
     """Test to verify operations / observables / measurements when doing parameter shift.

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -790,6 +790,7 @@ def test_ps_probs(backend):
     assert np.allclose(result, reference)
 
 
+@pytest.mark.xfail(reason="Issue #1571 https://github.com/PennyLaneAI/catalyst/issues/1571")
 @pytest.mark.parametrize("gate_n_inputs", [(qml.CRX, [1]), (qml.CRot, [1, 2, 3])])
 def test_ps_four_term_rule(backend, gate_n_inputs):
     """Operations with the 4-term shift rule need to be decomposed to be differentiated."""

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -44,7 +44,7 @@ from catalyst.device.op_support import (
     _is_grad_recipe_same_as_catalyst,
 )
 
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,missing-function-docstring,missing-class-docstring
 
 
 class TestGradShape:
@@ -790,7 +790,6 @@ def test_ps_probs(backend):
     assert np.allclose(result, reference)
 
 
-@pytest.mark.xfail(reason="should pass once #1568 is merged")
 @pytest.mark.parametrize("gate_n_inputs", [(qml.CRX, [1]), (qml.CRot, [1, 2, 3])])
 def test_ps_four_term_rule(backend, gate_n_inputs):
     """Operations with the 4-term shift rule need to be decomposed to be differentiated."""

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1942,6 +1942,24 @@ class TestParameterShiftVerificationUnitTests:
 
         assert not _has_grad_recipe(DummyOp(wires=[0]))
 
+    def test_check_grad_recipe_different_size(self):
+        """len(grad_recipe) != len(op.data)"""
+
+        class DummyOp(qml.operation.Operator):
+            def __init__(self, wires=None):
+                param = 0.0
+                super().__init__(param, wires=wires)
+
+            @property
+            def num_params(self):
+                return 1
+
+            @property
+            def grad_recipe(self):
+                return ([[0.5, 1.0, np.pi / 2], [-0.5, 1.0, -np.pi / 2]], [[0.5, 1.0, np.pi / 2], [-0.5, 1.0, -np.pi / 2]])
+
+        assert not _is_grad_recipe_same_as_catalyst(DummyOp(wires=[0]))
+
     def test_check_grad_recipe_different(self):
         """Check exception is raised when invalid grad_recipe is found"""
 

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1956,7 +1956,10 @@ class TestParameterShiftVerificationUnitTests:
 
             @property
             def grad_recipe(self):
-                return ([[0.5, 1.0, np.pi / 2], [-0.5, 1.0, -np.pi / 2]], [[0.5, 1.0, np.pi / 2], [-0.5, 1.0, -np.pi / 2]])
+                return (
+                    [[0.5, 1.0, np.pi / 2], [-0.5, 1.0, -np.pi / 2]],
+                    [[0.5, 1.0, np.pi / 2], [-0.5, 1.0, -np.pi / 2]],
+                )
 
         assert not _is_grad_recipe_same_as_catalyst(DummyOp(wires=[0]))
 
@@ -2070,10 +2073,10 @@ class TestParameterShiftVerificationIntegrationTests:
     Source of truth obtained from shortcut story: 84819
     """
 
-    def test_is_mcm(self):
+    def test_is_mcm(self, backend):
         """No mcm"""
 
-        device = qml.device("lightning.qubit", wires=1)
+        device = qml.device(backend, wires=1)
 
         with pytest.raises(DifferentiableCompileError, match="MidCircuitMeasure is not allowed"):
 
@@ -2084,9 +2087,9 @@ class TestParameterShiftVerificationIntegrationTests:
                 measure(0)
                 return qml.expval(qml.PauliZ(wires=0))
 
-    def test_all_arguments_are_constant(self):
+    def test_all_arguments_are_constant(self, backend):
         """When all arguments are constant they do not contribute to the gradient"""
-        device = qml.device("lightning.qubit", wires=1)
+        device = qml.device(backend, wires=1)
 
         # Yes, this test does not have an assertion.
         # The test is that this does not produce an assertion.
@@ -2098,9 +2101,9 @@ class TestParameterShiftVerificationIntegrationTests:
             qml.RX(0.0, wires=[0])
             return qml.expval(qml.PauliZ(wires=0))
 
-    def test_grad_recipe_dynamic(self):
+    def test_grad_recipe_dynamic(self, backend):
         """Raise exception when there is an op with a grad_recipe that's dynamic"""
-        device = qml.device("lightning.qubit", wires=1)
+        device = qml.device(backend, wires=1)
 
         class RX(qml.RX):
             @property
@@ -2118,9 +2121,9 @@ class TestParameterShiftVerificationIntegrationTests:
                 RX(x, wires=[0])
                 return qml.expval(qml.PauliZ(wires=0))
 
-    def test_grad_recipe_static(self):
+    def test_grad_recipe_static(self, backend):
         """Raise exception when there is an op with a mismatching grad_recipe"""
-        device = qml.device("lightning.qubit", wires=1)
+        device = qml.device(backend, wires=1)
 
         class RX(qml.RX):
             @property
@@ -2136,9 +2139,9 @@ class TestParameterShiftVerificationIntegrationTests:
                 RX(x, wires=[0])
                 return qml.expval(qml.PauliZ(wires=0))
 
-    def test_parameter_frequencies(self):
+    def test_parameter_frequencies(self, backend):
         """Raise exception when when there is an lengths are mismatched."""
-        device = qml.device("lightning.qubit", wires=1)
+        device = qml.device(backend, wires=1)
 
         class RX(qml.RX):
             @property
@@ -2155,9 +2158,9 @@ class TestParameterShiftVerificationIntegrationTests:
                 RX(x, wires=[0])
                 return qml.expval(qml.PauliZ(wires=0))
 
-    def test_parameter_frequencies_not_one(self):
+    def test_parameter_frequencies_not_one(self, backend):
         """When there is an op without parameter_frequencies, ps gradient should fail"""
-        device = qml.device("lightning.qubit", wires=1)
+        device = qml.device(backend, wires=1)
 
         class RX(qml.RX):
             @property

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -41,6 +41,7 @@ from catalyst import (
 from catalyst.compiler import get_lib_path
 from catalyst.device.op_support import (
     _are_param_frequencies_same_as_catalyst,
+    _has_grad_recipe,
     _is_grad_recipe_same_as_catalyst,
     _paramshift_op_checker,
 )
@@ -1928,7 +1929,7 @@ class TestParameterShiftVerificationUnitTests:
         # a family of ops that do not have grad recipe are control flow ops
         class DummyOp(qml.operation.Operator): ...
 
-        assert _is_grad_recipe_same_as_catalyst(DummyOp(wires=[0]))
+        assert not _has_grad_recipe(DummyOp(wires=[0]))
 
     def test_check_grad_recipe_empty(self):
         """Some grad recipes are defined but are filled with Nones"""
@@ -1938,7 +1939,7 @@ class TestParameterShiftVerificationUnitTests:
             def grad_recipe(self):
                 return [None]
 
-        assert _is_grad_recipe_same_as_catalyst(DummyOp(wires=[0]))
+        assert not _has_grad_recipe(DummyOp(wires=[0]))
 
     def test_check_grad_recipe_different(self):
         """Check exception is raised when invalid grad_recipe is found"""

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -46,6 +46,7 @@ from catalyst.device.op_support import (
     _is_grad_recipe_same_as_catalyst,
     _paramshift_op_checker,
 )
+from catalyst.jax_tracer import HybridOp
 
 # pylint: disable=too-many-lines,missing-function-docstring,missing-class-docstring
 
@@ -2078,6 +2079,15 @@ class TestParameterShiftVerificationUnitTests:
                 return 1
 
         assert not _paramshift_op_checker(DummyOp(wires=[0]))
+
+    def test_hybrid_op(self):
+        """HybridOp => grad"""
+
+        class DummyOp(HybridOp):
+            def __init__(self):
+                super().__init__([], [], [])
+
+        assert _paramshift_op_checker(DummyOp())
 
 
 class TestParameterShiftVerificationIntegrationTests:

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -39,6 +39,7 @@ from catalyst import (
     vmap,
 )
 from catalyst.compiler import get_lib_path
+from catalyst.device.op_support import _check_grad_recipe, _check_param_frequencies
 
 # pylint: disable=too-many-lines
 
@@ -1912,6 +1913,232 @@ class TestGradientMethodErrors:
 
         with pytest.raises(ValueError, match="Invalid gradient method: invalid_method"):
             qjit(grad(f))
+
+
+class TestParameterShiftVerificationUnitTests:
+    """Unit tests for parameter shift verification"""
+
+    def test_check_grad_recipe_no_grad_recipe(self):
+        """Check that if grad recipe is not defined, no exception gets triggered"""
+
+        # a family of ops that do not have grad recipe are control flow ops
+        class DummyOp(qml.operation.Operator): ...
+
+        _check_grad_recipe(DummyOp(wires=[0]))
+
+    def test_check_grad_recipe_empty(self):
+        """Some grad recipes are defined but are filled with Nones"""
+
+        class DummyOp(qml.operation.Operator):
+            @property
+            def grad_recipe(self):
+                return [None]
+
+        _check_grad_recipe(DummyOp(wires=[0]))
+
+    def test_check_grad_recipe_different(self):
+        """Check exception is raised when invalid grad_recipe is found"""
+
+        class DummyOp(qml.operation.Operator):
+            def __init__(self, wires=None):
+                param = 0.0
+                super().__init__(param, wires=wires)
+
+            @property
+            def num_params(self):
+                return 1
+
+            @property
+            def grad_recipe(self):
+                return ([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],)
+
+        with pytest.raises(DifferentiableCompileError, match=".* incompatible grad_recipe.*"):
+            _check_grad_recipe(DummyOp(wires=[0]))
+
+    def test_check_grad_recipe_dynamic(self):
+        """Check exception is raised when dynamic grad recipe is found"""
+
+        class DummyOp(qml.operation.Operator):
+            def __init__(self, param, wires=None):
+                self.param = param
+                super().__init__(param, wires=wires)
+
+            @property
+            def num_params(self):
+                return 1
+
+            @property
+            def grad_recipe(self):
+                return ([[0.5, self.param, jnp.pi / 2], [-0.5, 1.0, -jnp.pi / 2]],)
+
+        def program(x):
+            _check_grad_recipe(DummyOp(x, wires=[0]))
+
+        with pytest.raises(DifferentiableCompileError, match=".* incompatible grad_recipe.*"):
+            jax.make_jaxpr(program)(0.0)
+
+    def test_check_param_frequencies(self):
+        """No param frequencies attr"""
+
+        class DummyOp(qml.operation.Operator): ...
+
+        assert not hasattr(DummyOp, "parameter_frequencies")
+        _check_param_frequencies(DummyOp(wires=[0]))
+
+    def test_check_param_frequencies_different_length(self):
+        """Check exception is raised when frequencies length mismatches parameter length"""
+
+        class DummyOp(qml.operation.Operator):
+            def __init__(self, wires=None):
+                super().__init__(0.0, wires=wires)
+
+            @property
+            def num_params(self):
+                return 1
+
+            @property
+            def parameter_frequencies(self):
+                return [1.0, 1.0]
+
+        with pytest.raises(
+            DifferentiableCompileError,
+            match=".* different number of parameters.* and frequencies.*",
+        ):
+            _check_param_frequencies(DummyOp(wires=[0]))
+
+    def test_check_invalid_frequencies(self):
+        """Check exception is raised when invalid frequencies are found"""
+
+        class DummyOp(qml.operation.Operator):
+            def __init__(self, wires=None):
+                super().__init__(0.0, wires=wires)
+
+            @property
+            def num_params(self):
+                return 1
+
+            @property
+            def parameter_frequencies(self):
+                return [0.0]
+
+        with pytest.raises(DifferentiableCompileError, match=".* invalid parameter_frequencies.*"):
+            _check_param_frequencies(DummyOp(wires=[0]))
+
+
+class TestParameterShiftVerificationIntegrationTests:
+    """Test to verify operations / observables / measurements when doing parameter shift.
+
+    Source of truth obtained from shortcut story: 84819
+    """
+
+    def test_is_mcm(self):
+        """No mcm"""
+
+        device = qml.device("lightning.qubit", wires=1)
+
+        with pytest.raises(DifferentiableCompileError, match="MidCircuitMeasure is not allowed"):
+
+            @qml.qjit
+            @grad
+            @qml.qnode(device, diff_method="parameter-shift")
+            def circuit(_: float):
+                measure(0)
+                return qml.expval(qml.PauliZ(wires=0))
+
+    def test_all_arguments_are_constant(self):
+        """When all arguments are constant they do not contribute to the gradient"""
+        device = qml.device("lightning.qubit", wires=1)
+
+        # Yes, this test does not have an assertion.
+        # The test is that this does not produce an assertion.
+
+        @qml.qjit
+        @grad
+        @qml.qnode(device, diff_method="parameter-shift")
+        def circuit(_: float):
+            qml.RX(0.0, wires=[0])
+            return qml.expval(qml.PauliZ(wires=0))
+
+    def test_grad_recipe_dynamic(self):
+        """Raise exception when there is an op with a grad_recipe that's dynamic"""
+        device = qml.device("lightning.qubit", wires=1)
+
+        class RX(qml.RX):
+            @property
+            def grad_recipe(self):
+                x = self.data[0]
+                c = 0.5 / jnp.sin(x)
+                return ([[c, 0.0, 2 * x], [-c, 0.0, 0.0]],)
+
+        with pytest.raises(DifferentiableCompileError, match=".*incompatible grad_recipe.*"):
+
+            @qml.qjit
+            @grad
+            @qml.qnode(device, diff_method="parameter-shift")
+            def circuit(x: float):
+                RX(x, wires=[0])
+                return qml.expval(qml.PauliZ(wires=0))
+
+    def test_grad_recipe_static(self):
+        """Raise exception when there is an op with a mismatching grad_recipe"""
+        device = qml.device("lightning.qubit", wires=1)
+
+        class RX(qml.RX):
+            @property
+            def grad_recipe(self):
+                return ([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]],)
+
+        with pytest.raises(DifferentiableCompileError, match=".*incompatible grad_recipe.*"):
+
+            @qml.qjit
+            @grad
+            @qml.qnode(device, diff_method="parameter-shift")
+            def circuit(x: float):
+                RX(x, wires=[0])
+                return qml.expval(qml.PauliZ(wires=0))
+
+    def test_parameter_frequencies(self):
+        """Raise exception when when there is an lengths are mismatched."""
+        device = qml.device("lightning.qubit", wires=1)
+
+        class RX(qml.RX):
+            @property
+            def parameter_frequencies(self):
+                # Only one parameter but two frequencies is an error
+                return (1.0, 1.0)
+
+        with pytest.raises(
+            DifferentiableCompileError,
+            match=".* different number of parameters.* and frequencies.*",
+        ):
+
+            @qml.qjit
+            @grad
+            @qml.qnode(device, diff_method="parameter-shift")
+            def circuit(x: float):
+                RX(x, wires=[0])
+                return qml.expval(qml.PauliZ(wires=0))
+
+    def test_parameter_frequencies_not_one(self):
+        """When there is an op without parameter_frequencies, parameter-shift gradient should fail"""
+        device = qml.device("lightning.qubit", wires=1)
+
+        class RX(qml.RX):
+            @property
+            def parameter_frequencies(self):
+                # Only one parameter but two frequencies is an error
+                return (2.0,)
+
+        with pytest.raises(
+            DifferentiableCompileError, match=".*invalid parameter_frequencies values.*"
+        ):
+
+            @qml.qjit
+            @grad
+            @qml.qnode(device, diff_method="parameter-shift")
+            def circuit(x: float):
+                RX(x, wires=[0])
+                return qml.expval(qml.PauliZ(wires=0))
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -2020,6 +2020,12 @@ class TestParameterShiftVerificationUnitTests:
 
         assert not _are_param_frequencies_same_as_catalyst(DummyOp(wires=[0]))
 
+    def test_undefined_frequencies(self):
+        """Test ParameterFrequenciesUndefinedError"""
+
+        op = qml.ops.op_math.Exp(qml.PauliX(0), 1)
+        assert _are_param_frequencies_same_as_catalyst(op)
+
 
 class TestParameterShiftVerificationIntegrationTests:
     """Test to verify operations / observables / measurements when doing parameter shift.

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -2112,7 +2112,7 @@ class TestParameterShiftVerificationIntegrationTests:
                 return qml.expval(qml.PauliZ(wires=0))
 
     def test_parameter_frequencies_not_one(self):
-        """When there is an op without parameter_frequencies, parameter-shift gradient should fail"""
+        """When there is an op without parameter_frequencies, ps gradient should fail"""
         device = qml.device("lightning.qubit", wires=1)
 
         class RX(qml.RX):

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -42,6 +42,7 @@ from catalyst.compiler import get_lib_path
 from catalyst.device.op_support import (
     _are_param_frequencies_same_as_catalyst,
     _is_grad_recipe_same_as_catalyst,
+    _paramshift_op_checker,
 )
 
 # pylint: disable=too-many-lines,missing-function-docstring,missing-class-docstring
@@ -2025,6 +2026,11 @@ class TestParameterShiftVerificationUnitTests:
 
         op = qml.ops.op_math.Exp(qml.PauliX(0), 1)
         assert _are_param_frequencies_same_as_catalyst(op)
+
+    def test_qubit_unitary(self):
+        """QubitUnitary is not a differentiable gate in Catalyst"""
+        op = qml.QubitUnitary(jnp.array([[1, 1], [1, -1]]), wires=0)
+        assert not _paramshift_op_checker(op)
 
 
 class TestParameterShiftVerificationIntegrationTests:

--- a/frontend/test/pytest/test_verification.py
+++ b/frontend/test/pytest/test_verification.py
@@ -32,7 +32,6 @@ from catalyst import (
     ctrl,
     for_loop,
     grad,
-    while_loop,
 )
 from catalyst.api_extensions import HybridAdjoint, HybridCtrl
 from catalyst.compiler import get_lib_path

--- a/frontend/test/pytest/test_verification.py
+++ b/frontend/test/pytest/test_verification.py
@@ -871,48 +871,6 @@ class TestParameterShiftMethodVerification:
             def cir(x: float):
                 return grad(f)(x)
 
-    @patch.object(qml.RX, "grad_method", "F")
-    def test_paramshift_gate_simple(self):
-        """Test that taking a parameter-shift gradient of a tape containing a parameterized
-        operation that doesn't support analytic differentiation raises an error."""
-
-        @qml.qnode(qml.device("lightning.qubit", wires=1), diff_method="parameter-shift")
-        def f(x):
-            qml.RX(x, 0)
-            return qml.expval(qml.PauliX(0))
-
-        with pytest.raises(
-            DifferentiableCompileError, match="RX does not support analytic differentiation"
-        ):
-
-            @qml.qjit
-            def cir(x: float):
-                return grad(f)(x)
-
-    @patch.object(qml.RX, "grad_method", "F")
-    def test_paramshift_gate_while(self):
-        """Test that taking a parameter-shift gradient of a tape containing a WhileLoop HybridOp
-        containing a parameterized operation that doesn't support analytic differentiation raises
-        an error."""
-
-        @qml.qnode(qml.device("lightning.qubit", wires=1), diff_method="parameter-shift")
-        def f(x):
-            @while_loop(lambda s: s > 0)
-            def loop(s):
-                qml.RX(x, 0)
-                return s + 1
-
-            loop(0)
-            return qml.expval(qml.PauliX(0))
-
-        with pytest.raises(
-            DifferentiableCompileError, match="RX does not support analytic differentiation"
-        ):
-
-            @qml.qjit
-            def cir(x: float):
-                return grad(f)(x)
-
 
 def test_no_state_returns():
     """Test state returns are rejected in gradients."""


### PR DESCRIPTION
**Context:** verify that the user program's semantics match the code generated by Catalyst when using parameter shift and gradients.

**Description of the Change:** 

* if grad_recipe per parameter matches Catalyst's, continue
* if parameter_frequency per parameter is close to 1., continue
* else verification failed

**Benefits:** mismatched semantics will decompose gates or fail verification

**Possible Drawbacks:** None

**Related GitHub Issues:** None

[sc-84819]