### PR TITLE
Add new workflow to security scan

### DIFF
--- a/.github/workflows/code_security_scan.yml
+++ b/.github/workflows/code_security_scan.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs: 
   code_security_scan:
+    if: github.event.pull_request.draft == false
     uses: XanaduAI/cloud-actions/.github/workflows/static_code_vulnerability_analysis.yml@sc-86314-sec-scanning
     with:
       github-repository: ${{ github.repository }}

--- a/.github/workflows/code_security_scan.yml
+++ b/.github/workflows/code_security_scan.yml
@@ -1,0 +1,26 @@
+name: Code Security Scan
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: code-security-scan-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs: 
+  code_security_scan:
+    uses: XanaduAI/cloud-actions/.github/workflows/static_code_vulnerability_analysis.yml@sc-86314-sec-scanning
+    with:
+      github-repository: ${{ github.repository }}
+      repository-ref: ${{ github.ref }}
+      runner_name: ubuntu-latest
+      scan_directory: frontend/catalyst
+      
+      # We error out CI if any high severity issues are found
+      # All other errors are still printed to logs
+      semgrep-error-on-impact: HIGH
+      semgrep-error-on-severity: ERROR
+      bandit-error-on-severity: HIGH
+

--- a/.github/workflows/code_security_scan.yml
+++ b/.github/workflows/code_security_scan.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs: 
   code_security_scan:
     if: github.event.pull_request.draft == false
-    uses: XanaduAI/cloud-actions/.github/workflows/static_code_vulnerability_analysis.yml@sc-86314-sec-scanning
+    uses: XanaduAI/cloud-actions/.github/workflows/static_code_vulnerability_analysis.yml@main
     with:
       github-repository: ${{ github.repository }}
       repository-ref: ${{ github.ref }}


### PR DESCRIPTION
**Context:**
This pull request adds a new workflow to enable Code Security scanning to pennylane using [bandit](https://github.com/PyCQA/bandit) and [semgrep](https://semgrep.dev/).

Both tools use a pre-existing set of rules to scan the code heuristically and flag anything that could potentially be a security issue.

**Description of the Change:**
The workflow introduced uses a re-usable action introduced in XanaduAI/cloud-actions#67.

Bandit scans source code and creates an AST which is then matched against it's rules.
Semgrep uses heuristic matching, but is able to support multiple languages.

The configuration is setup so that CI will fail if there is an issue flagged by either tool with a severity of "HIGH".

**Benefits:**
Basic security code scanning introduced. 

**Possible Drawbacks:**
PRs can be blocked if a false positive HIGH severity issue is flagged. However, both tools provide ways to suppress false positives at the line or file level.

**Related GitHub Issues:**
None. [sc-86314]