### PR TITLE
Fix a bug when chained passes are used on a qnode

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -169,11 +169,11 @@
   autograph in conjunction with catalyst passes causes a crash.
   [(#1541)](https://github.com/PennyLaneAI/catalyst/pull/1541)
 
-* Fixes an issue ([(#1548)](https://github.com/PennyLaneAI/catalyst/issues/1501)) where using
+* Fixes an issue ([(#1548)](https://github.com/PennyLaneAI/catalyst/issues/1548)) where using
   autograph in conjunction with catalyst pipeline causes a crash.
   [(#1576)](https://github.com/PennyLaneAI/catalyst/pull/1576)
 
-* Fixes an issue ([(#1547)](https://github.com/PennyLaneAI/catalyst/issues/1501)) where using
+* Fixes an issue ([(#1547)](https://github.com/PennyLaneAI/catalyst/issues/1547)) where using
   chained catalyst passe decorators causes a crash.
   [(#1576)](https://github.com/PennyLaneAI/catalyst/pull/1576)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -169,6 +169,14 @@
   autograph in conjunction with catalyst passes causes a crash.
   [(#1541)](https://github.com/PennyLaneAI/catalyst/pull/1541)
 
+* Fixes an issue ([(#1548)](https://github.com/PennyLaneAI/catalyst/issues/1501)) where using
+  autograph in conjunction with catalyst pipeline causes a crash.
+  [(#1576)](https://github.com/PennyLaneAI/catalyst/pull/1576)
+
+* Fixes an issue ([(#1547)](https://github.com/PennyLaneAI/catalyst/issues/1501)) where using
+  chained catalyst passe decorators causes a crash.
+  [(#1576)](https://github.com/PennyLaneAI/catalyst/pull/1576)
+
 <h3>Internal changes ⚙️</h3>
 
 * Updated the call signature for the PLXPR `qnode_prim` primitive.

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -469,7 +469,6 @@ class QJIT(CatalystCallable):
 
     @debug_logger_init
     def __init__(self, fn, compile_options):
-        # If the function is a QnodeCaller, we need to unwrap it to get the original QNode.
         functools.update_wrapper(self, fn)
         self.original_function = fn
         self.compile_options = compile_options

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -37,7 +37,6 @@ from catalyst.debug.instruments import instrument
 from catalyst.from_plxpr import trace_from_pennylane
 from catalyst.jax_tracer import lower_jaxpr_to_mlir, trace_to_jaxpr
 from catalyst.logging import debug_logger, debug_logger_init
-from catalyst.passes.pass_api import QnodeCaller
 from catalyst.qfunc import QFunc
 from catalyst.tracing.contexts import EvaluationContext
 from catalyst.tracing.type_signatures import (
@@ -471,8 +470,6 @@ class QJIT(CatalystCallable):
     @debug_logger_init
     def __init__(self, fn, compile_options):
         # If the function is a QnodeCaller, we need to unwrap it to get the original QNode.
-        if isinstance(fn, QnodeCaller):
-            fn = fn.qnode
         functools.update_wrapper(self, fn)
         self.original_function = fn
         self.compile_options = compile_options

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -37,6 +37,7 @@ from catalyst.debug.instruments import instrument
 from catalyst.from_plxpr import trace_from_pennylane
 from catalyst.jax_tracer import lower_jaxpr_to_mlir, trace_to_jaxpr
 from catalyst.logging import debug_logger, debug_logger_init
+from catalyst.passes.pass_api import QnodeCaller
 from catalyst.qfunc import QFunc
 from catalyst.tracing.contexts import EvaluationContext
 from catalyst.tracing.type_signatures import (
@@ -469,6 +470,9 @@ class QJIT(CatalystCallable):
 
     @debug_logger_init
     def __init__(self, fn, compile_options):
+        # If the function is a QnodeCaller, we need to unwrap it to get the original QNode.
+        if isinstance(fn, QnodeCaller):
+            fn = fn.qnode
         functools.update_wrapper(self, fn)
         self.original_function = fn
         self.compile_options = compile_options

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -14,12 +14,9 @@
 
 """This module exposes built-in Catalyst MLIR passes to the frontend."""
 
-import copy
-import functools
-
 import pennylane as qml
 
-from catalyst.passes.pass_api import Pass, QnodeCaller
+from catalyst.passes.pass_api import PassPipelineWrapper, QNodeWrapper
 
 
 ## API ##
@@ -133,19 +130,7 @@ def cancel_inverses(qnode):
         %2 = quantum.namedobs %out_qubits[ PauliZ] : !quantum.obs
         %3 = quantum.expval %2 : f64
     """
-    if not (isinstance(qnode, qml.QNode) or isinstance(qnode, QnodeCaller)):
-        raise TypeError(f"A QNode is expected, got the classical function {qnode}")
-    elif isinstance(qnode, QnodeCaller):
-        qnode = qnode.qnode
-
-    @functools.wraps(qnode)
-    def wrapper(*args, **kwargs):
-        pass_pipeline = kwargs.pop("pass_pipeline", [])
-        pass_pipeline.append(Pass("remove-chained-self-inverse"))
-        kwargs["pass_pipeline"] = pass_pipeline
-        return qnode(*args, **kwargs)
-
-    return QnodeCaller(wrapper)
+    return PassPipelineWrapper(qnode, "remove-chained-self-inverse")
 
 
 def merge_rotations(qnode):
@@ -209,19 +194,7 @@ def merge_rotations(qnode):
     >>> circuit(0.54)
     Array(0.5965506257017892, dtype=float64)
     """
-    if not (isinstance(qnode, qml.QNode) or isinstance(qnode, QnodeCaller)):
-        raise TypeError(f"A QNode is expected, got the classical function {qnode}")
-    elif isinstance(qnode, QnodeCaller):
-        qnode = qnode.qnode
-
-    @functools.wraps(qnode)
-    def wrapper(*args, **kwargs):
-        pass_pipeline = kwargs.pop("pass_pipeline", [])
-        pass_pipeline.append(Pass("merge-rotations"))
-        kwargs["pass_pipeline"] = pass_pipeline
-        return qnode(*args, **kwargs)
-
-    return QnodeCaller(wrapper)
+    return PassPipelineWrapper(qnode, "merge-rotations")
 
 
 def ions_decomposition(qnode):  # pragma: nocover
@@ -343,20 +316,7 @@ def ions_decomposition(qnode):  # pragma: nocover
         %out_qubits_8 = quantum.custom "RY"(%cst_2) %out_qubits_6#1 : !quantum.bit
         %out_qubits_9 = quantum.custom "RY"(%cst_2) %out_qubits_7 : !quantum.bit
     """
-
-    if not (isinstance(qnode, qml.QNode) or isinstance(qnode, QnodeCaller)):
-        raise TypeError(f"A QNode is expected, got the classical function {qnode}")
-    elif isinstance(qnode, QnodeCaller):
-        qnode = qnode.qnode
-
-    @functools.wraps(qnode)
-    def wrapper(*args, **kwargs):
-        pass_pipeline = kwargs.pop("pass_pipeline", [])
-        pass_pipeline.append(Pass("ions-decomposition"))
-        kwargs["pass_pipeline"] = pass_pipeline
-        return qnode(*args, **kwargs)
-
-    return QnodeCaller(wrapper)
+    return PassPipelineWrapper(qnode, "ions-decomposition")
 
 
 def to_ppr(qnode):
@@ -418,16 +378,4 @@ def to_ppr(qnode):
         %mres_0, %out_qubits_1 = qec.ppm ["Z"] %10 : !quantum.bit
         . . .
     """
-    if not (isinstance(qnode, qml.QNode) or isinstance(qnode, QnodeCaller)):
-        raise TypeError(f"A QNode is expected, got the classical function {qnode}")
-    elif isinstance(qnode, QnodeCaller):
-        qnode = qnode.qnode
-
-    @functools.wraps(qnode)
-    def wrapper(*args, **kwargs):
-        pass_pipeline = kwargs.pop("pass_pipeline", [])
-        pass_pipeline.append(Pass("convert-clifford-t-to-ppr"))
-        kwargs["pass_pipeline"] = pass_pipeline
-        return qnode(*args, **kwargs)
-
-    return QnodeCaller(wrapper)
+    return PassPipelineWrapper(qnode, "convert-clifford-t-to-ppr")

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -14,9 +14,7 @@
 
 """This module exposes built-in Catalyst MLIR passes to the frontend."""
 
-import pennylane as qml
-
-from catalyst.passes.pass_api import PassPipelineWrapper, QNodeWrapper
+from catalyst.passes.pass_api import PassPipelineWrapper
 
 
 ## API ##

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -19,7 +19,7 @@ import functools
 
 import pennylane as qml
 
-from catalyst.passes.pass_api import Pass
+from catalyst.passes.pass_api import Pass, QnodeCaller
 
 
 ## API ##
@@ -133,20 +133,17 @@ def cancel_inverses(qnode):
         %2 = quantum.namedobs %out_qubits[ PauliZ] : !quantum.obs
         %3 = quantum.expval %2 : f64
     """
-    if not isinstance(qnode, qml.QNode):
+    if not (isinstance(qnode, qml.QNode) or isinstance(qnode, QnodeCaller)):
         raise TypeError(f"A QNode is expected, got the classical function {qnode}")
 
-    clone = copy.copy(qnode)
-    clone.__name__ += "_cancel_inverses"
-
-    @functools.wraps(clone)
+    @functools.wraps(qnode)
     def wrapper(*args, **kwargs):
         pass_pipeline = kwargs.pop("pass_pipeline", [])
         pass_pipeline.append(Pass("remove-chained-self-inverse"))
         kwargs["pass_pipeline"] = pass_pipeline
-        return clone(*args, **kwargs)
+        return qnode(*args, **kwargs)
 
-    return wrapper
+    return QnodeCaller(wrapper)
 
 
 def merge_rotations(qnode):
@@ -210,20 +207,17 @@ def merge_rotations(qnode):
     >>> circuit(0.54)
     Array(0.5965506257017892, dtype=float64)
     """
-    if not isinstance(qnode, qml.QNode):
+    if not (isinstance(qnode, qml.QNode) or isinstance(qnode, QnodeCaller)):
         raise TypeError(f"A QNode is expected, got the classical function {qnode}")
 
-    clone = copy.copy(qnode)
-    clone.__name__ += "_merge_rotations"
-
-    @functools.wraps(clone)
+    @functools.wraps(qnode)
     def wrapper(*args, **kwargs):
         pass_pipeline = kwargs.pop("pass_pipeline", [])
         pass_pipeline.append(Pass("merge-rotations"))
         kwargs["pass_pipeline"] = pass_pipeline
-        return clone(*args, **kwargs)
+        return qnode(*args, **kwargs)
 
-    return wrapper
+    return QnodeCaller(wrapper)
 
 
 def ions_decomposition(qnode):  # pragma: nocover
@@ -346,7 +340,7 @@ def ions_decomposition(qnode):  # pragma: nocover
         %out_qubits_9 = quantum.custom "RY"(%cst_2) %out_qubits_7 : !quantum.bit
     """
 
-    if not isinstance(qnode, qml.QNode):
+    if not (isinstance(qnode, qml.QNode) or isinstance(qnode, QnodeCaller)):
         raise TypeError(f"A QNode is expected, got the classical function {qnode}")
 
     @functools.wraps(qnode)
@@ -356,7 +350,7 @@ def ions_decomposition(qnode):  # pragma: nocover
         kwargs["pass_pipeline"] = pass_pipeline
         return qnode(*args, **kwargs)
 
-    return wrapper
+    return QnodeCaller(wrapper)
 
 
 def to_ppr(qnode):
@@ -418,17 +412,14 @@ def to_ppr(qnode):
         %mres_0, %out_qubits_1 = qec.ppm ["Z"] %10 : !quantum.bit
         . . .
     """
-    if not isinstance(qnode, qml.QNode):
+    if not (isinstance(qnode, qml.QNode) or isinstance(qnode, QnodeCaller)):
         raise TypeError(f"A QNode is expected, got the classical function {qnode}")
 
-    clone = copy.copy(qnode)
-    clone.__name__ += "_to_ppr"
-
-    @functools.wraps(clone)
+    @functools.wraps(qnode)
     def wrapper(*args, **kwargs):
         pass_pipeline = kwargs.pop("pass_pipeline", [])
         pass_pipeline.append(Pass("convert-clifford-t-to-ppr"))
         kwargs["pass_pipeline"] = pass_pipeline
-        return clone(*args, **kwargs)
+        return qnode(*args, **kwargs)
 
-    return wrapper
+    return QnodeCaller(wrapper)

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -135,6 +135,8 @@ def cancel_inverses(qnode):
     """
     if not (isinstance(qnode, qml.QNode) or isinstance(qnode, QnodeCaller)):
         raise TypeError(f"A QNode is expected, got the classical function {qnode}")
+    elif isinstance(qnode, QnodeCaller):
+        qnode = qnode.qnode
 
     @functools.wraps(qnode)
     def wrapper(*args, **kwargs):
@@ -209,6 +211,8 @@ def merge_rotations(qnode):
     """
     if not (isinstance(qnode, qml.QNode) or isinstance(qnode, QnodeCaller)):
         raise TypeError(f"A QNode is expected, got the classical function {qnode}")
+    elif isinstance(qnode, QnodeCaller):
+        qnode = qnode.qnode
 
     @functools.wraps(qnode)
     def wrapper(*args, **kwargs):
@@ -342,6 +346,8 @@ def ions_decomposition(qnode):  # pragma: nocover
 
     if not (isinstance(qnode, qml.QNode) or isinstance(qnode, QnodeCaller)):
         raise TypeError(f"A QNode is expected, got the classical function {qnode}")
+    elif isinstance(qnode, QnodeCaller):
+        qnode = qnode.qnode
 
     @functools.wraps(qnode)
     def wrapper(*args, **kwargs):
@@ -414,6 +420,8 @@ def to_ppr(qnode):
     """
     if not (isinstance(qnode, qml.QNode) or isinstance(qnode, QnodeCaller)):
         raise TypeError(f"A QNode is expected, got the classical function {qnode}")
+    elif isinstance(qnode, QnodeCaller):
+        qnode = qnode.qnode
 
     @functools.wraps(qnode)
     def wrapper(*args, **kwargs):

--- a/frontend/catalyst/passes/pass_api.py
+++ b/frontend/catalyst/passes/pass_api.py
@@ -76,7 +76,7 @@ class PassPipelineWrapper(QNodeWrapper):
                 self.pass_name_or_pipeline, *self.flags, **self.valued_options
             )
             kwargs["pass_pipeline"] = pass_pipeline
-        return self.qnode(*args, **kwargs)
+        return super().__call__(*args, **kwargs)
 
 
 def pipeline(pass_pipeline: PipelineDict):

--- a/frontend/catalyst/passes/pass_api.py
+++ b/frontend/catalyst/passes/pass_api.py
@@ -46,8 +46,9 @@ class QNodeWrapper:
         else:
             raise TypeError(f"A QNode is expected, got the classical function {qnode}")
 
-        # Update the wrapper to preserve the original function's metadata (signature, annotations, etc.)
-        # This is crucial for qjit to properly inspect the function signature and make compilation decisions.
+        # Update the wrapper to preserve the original function's metadata (signature, annotations,
+        # etc.) This is crucial for qjit to properly inspect the function signature and make
+        # compilation decisions.
         functools.update_wrapper(self, self.func)
 
     def __call__(self, *args, **kwargs):
@@ -78,6 +79,8 @@ class PassPipelineWrapper(QNodeWrapper):
         )
         kwargs["pass_pipeline"] = pass_pipeline
         return self.qnode(*args, **kwargs)
+
+
 
 
 def pipeline(pass_pipeline: PipelineDict):
@@ -172,6 +175,7 @@ def pipeline(pass_pipeline: PipelineDict):
         return PassPipelineWrapper(qnode, pass_pipeline)
 
     return _decorator
+
 
 
 def apply_pass(pass_name: str, *flags, **valued_options):
@@ -368,7 +372,6 @@ def dictionary_to_list_of_passes(pass_pipeline: PipelineDict | str, *flags, **va
         return passes
 
     return pass_pipeline
-
 
 def _API_name_to_pass_name():
     return {

--- a/frontend/catalyst/passes/pass_api.py
+++ b/frontend/catalyst/passes/pass_api.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import copy
 import functools
 from importlib.metadata import entry_points
 from pathlib import Path
@@ -169,42 +168,11 @@ def pipeline(pass_pipeline: PipelineDict):
     will always take precedence over global pass pipelines.
     """
 
-    def _decorator(qnode=None):
-        if not isinstance(qnode, qml.QNode):
-            raise TypeError(f"A QNode is expected, got the classical function {qnode}")
-
-        clone = copy.copy(qnode)
-        clone.__name__ += "_transformed"
-
-        @functools.wraps(clone)
-        def wrapper(*args, **kwargs):
-            if EvaluationContext.is_tracing():
-                passes = kwargs.pop("pass_pipeline", [])
-                passes += dictionary_to_list_of_passes(pass_pipeline)
-                kwargs["pass_pipeline"] = passes
-            return clone(*args, **kwargs)
-
-        return wrapper
+    def _decorator(qnode):
+        return PassPipelineWrapper(qnode, pass_pipeline)
 
     return _decorator
 
-
-class QnodeCaller:
-    """A wrapper class for QNodes that preserves the pass pipeline when called.
-
-    This class is used internally by pass decorators to ensure that compiler passes
-    are properly applied when the QNode is called.
-
-    Args:
-        qnode (QNode or callable): The QNode or wrapped QNode function to call
-
-    """
-
-    def __init__(self, qnode):
-        self.qnode = qnode
-
-    def __call__(self, *args, **kwargs):
-        return self.qnode(*args, **kwargs)
 
 
 def apply_pass(pass_name: str, *flags, **valued_options):
@@ -234,22 +202,7 @@ def apply_pass(pass_name: str, *flags, **valued_options):
     """
 
     def decorator(qnode):
-        if not (isinstance(qnode, qml.QNode) or isinstance(qnode, QnodeCaller)):
-            # Technically, this apply pass is general enough that it can apply to
-            # classical functions too. However, since we lack the current infrastructure
-            # to denote a function, let's limit it to qnodes
-            raise TypeError(f"A QNode is expected, got the classical function {qnode}")
-        elif isinstance(qnode, QnodeCaller):
-            qnode = qnode.qnode
-
-        @functools.wraps(qnode)
-        def qnode_call(*args, **kwargs):
-            pass_pipeline = kwargs.get("pass_pipeline", [])
-            pass_pipeline.append(Pass(pass_name, *flags, **valued_options))
-            kwargs["pass_pipeline"] = pass_pipeline
-            return qnode(*args, **kwargs)
-
-        return QnodeCaller(qnode_call)
+        return PassPipelineWrapper(qnode, pass_name, *flags, **valued_options)
 
     return decorator
 
@@ -289,22 +242,7 @@ def apply_pass_plugin(path_to_plugin: str | Path, pass_name: str, *flags, **valu
         raise FileNotFoundError(f"File '{path_to_plugin}' does not exist.")
 
     def decorator(qnode):
-        if not (isinstance(qnode, qml.QNode) or isinstance(qnode, QnodeCaller)):
-            # Technically, this apply pass is general enough that it can apply to
-            # classical functions too. However, since we lack the current infrastructure
-            # to denote a function, let's limit it to qnodes
-            raise TypeError(f"A QNode is expected, got the classical function {qnode}")
-        elif isinstance(qnode, QnodeCaller):
-            qnode = qnode.qnode
-
-        @functools.wraps(qnode)
-        def qnode_call(*args, **kwargs):
-            pass_pipeline = kwargs.get("pass_pipeline", [])
-            pass_pipeline.append(PassPlugin(path_to_plugin, pass_name, *flags, **valued_options))
-            kwargs["pass_pipeline"] = pass_pipeline
-            return qnode(*args, **kwargs)
-
-        return QnodeCaller(qnode_call)
+        return PassPipelineWrapper(qnode, pass_name, *flags, **valued_options)
 
     return decorator
 
@@ -408,22 +346,29 @@ class PassPlugin(Pass):
 
 
 ## PRIVATE ##
-def dictionary_to_list_of_passes(pass_pipeline: PipelineDict):
-    """Convert dictionary of passes into list of passes."""
+def dictionary_to_list_of_passes(pass_pipeline: PipelineDict | str, *flags, **valued_options):
+    """Convert dictionary of passes or single pass name into list of passes.
 
-    if pass_pipeline == None:
+    Args:
+        pass_pipeline: Either a dictionary of pass configurations or a single pass name.
+        *flags: Optional flags for single pass
+        **valued_options: Optional valued options for single pass
+    """
+    if pass_pipeline is None:
         return []
 
-    if type(pass_pipeline) != dict:
-        return pass_pipeline
+    if isinstance(pass_pipeline, str):
+        return [Pass(pass_pipeline, *flags, **valued_options)]
 
-    passes = []
-    pass_names = _API_name_to_pass_name()
-    for API_name, pass_options in pass_pipeline.items():
-        name = pass_names.get(API_name, API_name)
-        passes.append(Pass(name, **pass_options))
-    return passes
+    if isinstance(pass_pipeline, dict):
+        passes = []
+        pass_names = _API_name_to_pass_name()
+        for API_name, pass_options in pass_pipeline.items():
+            name = pass_names.get(API_name, API_name)
+            passes.append(Pass(name, **pass_options))
+        return passes
 
+    return pass_pipeline
 
 def _API_name_to_pass_name():
     return {

--- a/frontend/catalyst/passes/pass_api.py
+++ b/frontend/catalyst/passes/pass_api.py
@@ -46,6 +46,8 @@ class QNodeWrapper:
         else:
             raise TypeError(f"A QNode is expected, got the classical function {qnode}")
 
+        # Update the wrapper to preserve the original function's metadata (signature, annotations, etc.)
+        # This is crucial for qjit to properly inspect the function signature and make compilation decisions.
         functools.update_wrapper(self, self.func)
 
     def __call__(self, *args, **kwargs):
@@ -76,8 +78,6 @@ class PassPipelineWrapper(QNodeWrapper):
         )
         kwargs["pass_pipeline"] = pass_pipeline
         return self.qnode(*args, **kwargs)
-
-
 
 
 def pipeline(pass_pipeline: PipelineDict):
@@ -172,7 +172,6 @@ def pipeline(pass_pipeline: PipelineDict):
         return PassPipelineWrapper(qnode, pass_pipeline)
 
     return _decorator
-
 
 
 def apply_pass(pass_name: str, *flags, **valued_options):
@@ -369,6 +368,7 @@ def dictionary_to_list_of_passes(pass_pipeline: PipelineDict | str, *flags, **va
         return passes
 
     return pass_pipeline
+
 
 def _API_name_to_pass_name():
     return {

--- a/frontend/catalyst/passes/pass_api.py
+++ b/frontend/catalyst/passes/pass_api.py
@@ -239,6 +239,8 @@ def apply_pass_plugin(path_to_plugin: str | Path, pass_name: str, *flags, **valu
             # classical functions too. However, since we lack the current infrastructure
             # to denote a function, let's limit it to qnodes
             raise TypeError(f"A QNode is expected, got the classical function {qnode}")
+        elif isinstance(qnode, QnodeCaller):
+            qnode = qnode.qnode
 
         @functools.wraps(qnode)
         def qnode_call(*args, **kwargs):

--- a/frontend/catalyst/passes/pass_api.py
+++ b/frontend/catalyst/passes/pass_api.py
@@ -70,14 +70,12 @@ class PassPipelineWrapper(QNodeWrapper):
         self.valued_options = valued_options
 
     def __call__(self, *args, **kwargs):
-        if not EvaluationContext.is_tracing():
-            return self.qnode(*args, **kwargs)
-
-        pass_pipeline = kwargs.pop("pass_pipeline", [])
-        pass_pipeline += dictionary_to_list_of_passes(
-            self.pass_name_or_pipeline, *self.flags, **self.valued_options
-        )
-        kwargs["pass_pipeline"] = pass_pipeline
+        if EvaluationContext.is_tracing():
+            pass_pipeline = kwargs.pop("pass_pipeline", [])
+            pass_pipeline += dictionary_to_list_of_passes(
+                self.pass_name_or_pipeline, *self.flags, **self.valued_options
+            )
+            kwargs["pass_pipeline"] = pass_pipeline
         return self.qnode(*args, **kwargs)
 
 

--- a/frontend/catalyst/passes/pass_api.py
+++ b/frontend/catalyst/passes/pass_api.py
@@ -184,6 +184,8 @@ def apply_pass(pass_name: str, *flags, **valued_options):
             # classical functions too. However, since we lack the current infrastructure
             # to denote a function, let's limit it to qnodes
             raise TypeError(f"A QNode is expected, got the classical function {qnode}")
+        elif isinstance(qnode, QnodeCaller):
+            qnode = qnode.qnode
 
         @functools.wraps(qnode)
         def qnode_call(*args, **kwargs):

--- a/frontend/catalyst/passes/pass_api.py
+++ b/frontend/catalyst/passes/pass_api.py
@@ -81,8 +81,6 @@ class PassPipelineWrapper(QNodeWrapper):
         return self.qnode(*args, **kwargs)
 
 
-
-
 def pipeline(pass_pipeline: PipelineDict):
     """Configures the Catalyst MLIR pass pipeline for quantum circuit transformations for a QNode
     within a qjit-compiled program.
@@ -175,7 +173,6 @@ def pipeline(pass_pipeline: PipelineDict):
         return PassPipelineWrapper(qnode, pass_pipeline)
 
     return _decorator
-
 
 
 def apply_pass(pass_name: str, *flags, **valued_options):
@@ -372,6 +369,7 @@ def dictionary_to_list_of_passes(pass_pipeline: PipelineDict | str, *flags, **va
         return passes
 
     return pass_pipeline
+
 
 def _API_name_to_pass_name():
     return {

--- a/frontend/test/lit/test_peephole_optimizations.py
+++ b/frontend/test/lit/test_peephole_optimizations.py
@@ -469,12 +469,12 @@ def test_cancel_inverses_keep_original():
 
     # CHECK-LABEL: public @jit_test_cancel_inverses_keep_original_workflow0
     # CHECK: {{%.+}} = call @f_0({{%.+}})
-    # CHECK-NOT: {{%.+}} = call @f_cancel_inverses_0({{%.+}})
+    # CHECK-NOT: {{%.+}} = call @f_0({{%.+}})
     # CHECK-LABEL: public @f_0({{%.+}})
     # CHECK: {{%.+}} = quantum.custom "RX"({{%.+}}) {{%.+}} : !quantum.bit
     # CHECK-NEXT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
     # CHECK-NEXT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
-    # CHECK-NOT: public @f_cancel_inverses_0
+    # CHECK-NOT: public @f_0
     @qjit(keep_intermediate=True)
     def test_cancel_inverses_keep_original_workflow0():
         return f(1.0)
@@ -483,9 +483,9 @@ def test_cancel_inverses_keep_original():
     flush_peephole_opted_mlir_to_iostream(test_cancel_inverses_keep_original_workflow0)
 
     # CHECK-LABEL: public @jit_test_cancel_inverses_keep_original_workflow1
-    # CHECK: {{%.+}} = call @f_cancel_inverses_0({{%.+}})
+    # CHECK: {{%.+}} = call @f_0({{%.+}})
     # CHECK-NOT: {{%.+}} = call @f_0({{%.+}})
-    # CHECK-LABEL: public @f_cancel_inverses_0({{%.+}})
+    # CHECK-LABEL: public @f_0({{%.+}})
     # CHECK: {{%.+}} = quantum.custom "RX"({{%.+}}) {{%.+}} : !quantum.bit
     # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
     # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
@@ -499,12 +499,12 @@ def test_cancel_inverses_keep_original():
 
     # CHECK-LABEL: public @jit_test_cancel_inverses_keep_original_workflow2
     # CHECK: {{%.+}} = call @f_0({{%.+}})
-    # CHECK: {{%.+}} = call @f_cancel_inverses_0({{%.+}})
+    # CHECK: {{%.+}} = call @f_1_0({{%.+}})
     # CHECK-LABEL: public @f_0({{%.+}})
     # CHECK: {{%.+}} = quantum.custom "RX"({{%.+}}) {{%.+}} : !quantum.bit
     # CHECK-NEXT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
     # CHECK-NEXT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
-    # CHECK-LABEL: public @f_cancel_inverses_0({{%.+}})
+    # CHECK-LABEL: public @f_1_0({{%.+}})
     # CHECK: {{%.+}} = quantum.custom "RX"({{%.+}}) {{%.+}} : !quantum.bit
     # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
     # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit

--- a/frontend/test/lit/test_peephole_optimizations.py
+++ b/frontend/test/lit/test_peephole_optimizations.py
@@ -76,8 +76,8 @@ def test_pipeline_lowering():
     # CHECK-NEXT: transform.yield
     print_mlir(test_pipeline_lowering_workflow, 1.2)
 
-    # CHECK: {{%.+}} = call @test_pipeline_lowering_workflow_transformed_0(
-    # CHECK: func.func public @test_pipeline_lowering_workflow_transformed_0(
+    # CHECK: {{%.+}} = call @test_pipeline_lowering_workflow_0(
+    # CHECK: func.func public @test_pipeline_lowering_workflow_0(
     # CHECK: {{%.+}} = quantum.custom "RX"({{%.+}}) {{%.+}} : !quantum.bit
     # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
     # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
@@ -130,12 +130,12 @@ def test_pipeline_lowering_keep_original():
 
     # CHECK: func.func public @jit_test_pipeline_lowering_keep_original_workflow
     # CHECK: {{%.+}} = call @f_0(
-    # CHECK: {{%.+}} = call @f_transformed_0(
+    # CHECK: {{%.+}} = call @f_1_0(
     # CHECK: func.func public @f_0(
     # CHECK: {{%.+}} = quantum.custom "RX"({{%.+}}) {{%.+}} : !quantum.bit
     # CHECK: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
     # CHECK: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
-    # CHECK: func.func public @f_transformed_0(
+    # CHECK: func.func public @f_1_0(
     # CHECK: {{%.+}} = quantum.custom "RX"({{%.+}}) {{%.+}} : !quantum.bit
     # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
     # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
@@ -256,13 +256,13 @@ def test_pipeline_lowering_globloc_override():
     print_mlir(global_wf)
 
     # CHECK: func.func public @jit_global_wf()
-    # CHECK {{%.+}} = call @g(
-    # CHECK {{%.+}} = call @h_transformed(
-    # CHECK: func.func public @g_0
+    # CHECK {{%.+}} = call @g_0(
+    # CHECK {{%.+}} = call @h_0(
+    # CHECK: func.func public @g_0(
     # CHECK: {{%.+}} = quantum.custom "RX"({{%.+}}) {{%.+}} : !quantum.bit
     # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
     # CHECK-NOT: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
-    # CHECK: func.func public @h_transformed_0
+    # CHECK: func.func public @h_0
     # CHECK: {{%.+}} = quantum.custom "RX"({{%.+}}) {{%.+}} : !quantum.bit
     # CHECK: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit
     # CHECK: {{%.+}} = quantum.custom "Hadamard"() {{%.+}} : !quantum.bit

--- a/frontend/test/lit/test_peephole_optimizations.py
+++ b/frontend/test/lit/test_peephole_optimizations.py
@@ -486,7 +486,7 @@ test_chained_peephole_passes_keep_original()
 
 def test_single_pass_with_autograph():
     """
-    Test tha peephole optimization work with autograph
+    Test that peephole optimization works with autograph
     """
 
     @qjit(autograph=True, target="mlir")

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -27,7 +27,6 @@ from numpy.testing import assert_allclose
 
 from catalyst import *
 from catalyst.autograph.transformer import TRANSFORMER
-from catalyst.passes import merge_rotations
 from catalyst.utils.dummy import dummy_func
 from catalyst.utils.exceptions import CompileError
 

--- a/frontend/test/pytest/test_peephole_optimizations.py
+++ b/frontend/test/pytest/test_peephole_optimizations.py
@@ -168,6 +168,27 @@ def test_cancel_inverses_bad_usages():
 
     test_cancel_inverses_not_on_qnode()
 
+def test_chained_passes():
+    """
+    Test that chained passes are present in the transform passes.
+    """
+
+    @qjit()
+    @cancel_inverses
+    @merge_rotations
+    @qml.qnode(qml.device("lightning.qubit", wires=2))
+    def test_chained_apply_passes_workflow(x: float):
+        qml.Hadamard(wires=[1])
+        qml.RX(x, wires=[0])
+        qml.RX(-x, wires=[0])
+        qml.Hadamard(wires=[1])
+        return qml.expval(qml.PauliY(wires=0))
+
+    assert "remove-chained-self-inverse" in test_chained_apply_passes_workflow.mlir
+    assert "merge-rotations" in test_chained_apply_passes_workflow.mlir
+
+test_chained_passes()
+
 
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_peephole_optimizations.py
+++ b/frontend/test/pytest/test_peephole_optimizations.py
@@ -168,6 +168,7 @@ def test_cancel_inverses_bad_usages():
 
     test_cancel_inverses_not_on_qnode()
 
+
 def test_chained_passes():
     """
     Test that chained passes are present in the transform passes.
@@ -186,6 +187,7 @@ def test_chained_passes():
 
     assert "remove-chained-self-inverse" in test_chained_apply_passes_workflow.mlir
     assert "merge-rotations" in test_chained_apply_passes_workflow.mlir
+
 
 test_chained_passes()
 


### PR DESCRIPTION
**Context:**
In the current status of the Catalyst pass api, pass decorators recieve a qnode and return a classical wrapper function. This make stacking multiple passes/pipelines not possible. For more details please refer to Issue #1547.

In the current status of the Catalyst pass api, there is significant code duplication across different pass decorators (cancel_inverses, merge_rotations, ions_decomposition, to_ppr, etc.) and the main pass API functions (pipeline, apply_pass, apply_pass_plugin). Each of these implements similar QNode wrapping logic, type checking, and pass pipeline management. This duplication makes the code harder to maintain and increases the risk of inconsistencies.

**Description of the Change:**
Added a new QNodeWrapper class which can be used to return in the decorators. 
Added a PassPipelineWrapper class that extends QNodeWrapper to handle pass pipeline management
refactored the pass-api to eliminate duplicate codes. 

**Benefits:**
Catalyst's support for chained pass decorators is restored.
Reduced code duplicates.

**Possible Drawbacks:**
The new class hierarchy adds a layer of abstraction that might make the code slightly harder to understand. Ideally we liked for the decorators to receive and return a qnode. However, this is not possible at this point.

**Related GitHub Issues:**
closes issue #1547 
Note that as a side benefit, this PR resolves issue #1548 
[sc-85468]
[sc-85470]