### PR TITLE
Plxpr capture: Support the usage of shots as integer values too

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -93,6 +93,7 @@
   [(#1544)](https://github.com/PennyLaneAI/catalyst/pull/1544)
   [(#1561)](https://github.com/PennyLaneAI/catalyst/pull/1561)
   [(#1567)](https://github.com/PennyLaneAI/catalyst/pull/1567)
+  [(#1578)](https://github.com/PennyLaneAI/catalyst/pull/1578)
 
   To trigger the PennyLane pipeline for capturing the mentioned transforms,
   simply set `experimental_capture=True` in the qjit decorator. If available,

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -16,7 +16,7 @@ This submodule defines a utility for converting plxpr into Catalyst jaxpr.
 """
 # pylint: disable=protected-access
 from functools import partial
-from typing import Callable, Sequence, Union
+from typing import Callable, Sequence
 
 import jax
 import jax.core

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -260,7 +260,7 @@ class QFuncPlxprInterpreter(PlxprInterpreter):
 
     """
 
-    def __init__(self, device, shots: Union[qml.measurements.Shots, int]):
+    def __init__(self, device, shots: qml.measurements.Shots | int):
         self._device = device
         self._shots = self._extract_shots_value(shots)
         self.stateref = None
@@ -396,7 +396,7 @@ class QFuncPlxprInterpreter(PlxprInterpreter):
             return jax.lax.convert_element_type(mval, dtype)
         return mval
 
-    def _extract_shots_value(self, shots: Union[qml.measurements.Shots, int]):
+    def _extract_shots_value(self, shots: qml.measurements.Shots | int):
         """Extract the shots value according to the type"""
         if isinstance(shots, int):
             return shots

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -16,7 +16,7 @@ This submodule defines a utility for converting plxpr into Catalyst jaxpr.
 """
 # pylint: disable=protected-access
 from functools import partial
-from typing import Callable, Sequence
+from typing import Callable, Sequence, Union
 
 import jax
 import jax.core
@@ -260,9 +260,9 @@ class QFuncPlxprInterpreter(PlxprInterpreter):
 
     """
 
-    def __init__(self, device, shots: qml.measurements.Shots):
+    def __init__(self, device, shots: Union[qml.measurements.Shots, int]):
         self._device = device
-        self._shots = shots.total_shots if shots else 0
+        self._shots = self._extract_shots_value(shots)
         self.stateref = None
         self.actualized = False
         super().__init__()
@@ -395,6 +395,15 @@ class QFuncPlxprInterpreter(PlxprInterpreter):
         if dtype != mval.dtype:
             return jax.lax.convert_element_type(mval, dtype)
         return mval
+
+    def _extract_shots_value(self, shots: Union[qml.measurements.Shots, int]):
+        """Extract the shots value according to the type"""
+        if isinstance(shots, int):
+            return shots
+
+        assert isinstance(shots, qml.measurements.Shots)
+
+        return shots.total_shots if shots else 0
 
 
 @QFuncPlxprInterpreter.register_primitive(qml.QubitUnitary._primitive)

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -825,3 +825,21 @@ class TestCapture:
         no_capture_result = qml.qjit(func)()
         experimental_capture_result = captured_func()
         assert no_capture_result == experimental_capture_result
+
+    def test_shots_usage(self, backend):
+        """Test the integration for a circuit using shots explicitly."""
+
+        @qml.qnode(qml.device(backend, wires=2, shots=10))
+        def circuit(x: float):
+            @qml.for_loop(0, 2, 1)
+            def loop_0(i):
+                qml.Hadamard(wires=i)
+
+            loop_0()
+
+            qml.RX(x, wires=0)
+            return qml.sample()
+
+        captured_func = qml.qjit(circuit, experimental_capture=False, target="mlir")
+
+        assert "'shots': 10" in captured_func.mlir

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -830,16 +830,20 @@ class TestCapture:
         """Test the integration for a circuit using shots explicitly."""
 
         @qml.qnode(qml.device(backend, wires=2, shots=10))
-        def circuit(x: float):
+        def circuit():
             @qml.for_loop(0, 2, 1)
             def loop_0(i):
-                qml.Hadamard(wires=i)
+                qml.RX(0, wires=i)
 
             loop_0()
 
-            qml.RX(x, wires=0)
+            qml.RX(0, wires=0)
             return qml.sample()
 
         captured_func = qml.qjit(circuit, experimental_capture=False, target="mlir")
 
         assert "'shots': 10" in captured_func.mlir
+
+        no_capture_result = qml.qjit(circuit)()
+        experimental_capture_result = captured_func()
+        assert jnp.allclose(no_capture_result, experimental_capture_result)


### PR DESCRIPTION
**Context:** `QFuncPlxprInterpreters` reuses self._shots to instantiate a derived class called `BranchPlxprInterpreter`, but at that moment, those shots are no longer `qml.measurements.Shots` but integers.

**Description of the Change:** Consider the case of integer shots coming as arguments.

**Benefits:** Support both types.