### PR TITLE
Update usage of while_loop to work with latest pl in `from_plxpr`

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -32,4 +32,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.41.0-dev22
 pennylane-lightning==0.41.0-dev22
-pennylane==0.41.0-dev54
+pennylane==0.41.0-dev56

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -493,7 +493,8 @@ def handle_for_loop(
 ):
     """Handle the conversion from plxpr to Catalyst jaxpr for the for loop primitive"""
     assert jaxpr_body_fn is not None
-
+    if abstract_shapes_slice.stop != abstract_shapes_slice.start:
+        raise NotImplementedError("from_plxpr does not yet support dynamic shapes with for_loop.")
     args = plxpr_invals[args_slice]
 
     # Add the iteration start and the qreg to the args
@@ -550,7 +551,6 @@ def handle_while_loop(
     body_slice,
     cond_slice,
     args_slice,
-    abstract_shapes_slice,
 ):
     """Handle the conversion from plxpr to Catalyst jaxpr for the while loop primitive"""
     consts_body = plxpr_invals[body_slice]

--- a/frontend/test/pytest/test_from_plxpr.py
+++ b/frontend/test/pytest/test_from_plxpr.py
@@ -170,6 +170,29 @@ class TestErrors:
             from_plxpr(jaxpr)()
         qml.capture.disable()
 
+    def test_for_loop_dynamic_shapes(self, disable_capture):
+        """Test that a NotImplementedError is raised if a dynamic shape is passed to a for_loop."""
+        jax.config.update("jax_dynamic_shapes", True)
+        dev = qml.device('lightning.qubit', wires=2)
+
+        @qml.qnode(dev)
+        def circuit(i):
+            x = jax.numpy.arange(i)
+
+            @qml.for_loop(3)
+            def f(j, y):
+                return y + 1
+            
+            _ = f(x)
+            return qml.state()
+        
+        qml.capture.enable()
+        jaxpr = jax.make_jaxpr(circuit)(2)
+        with pytest.raises(NotImplementedError, match=r"does not yet support dynamic shapes"):
+            from_plxpr(jaxpr)()
+        qml.capture.disable()
+        jax.config.update("jax_dynamic_shapes", False)
+
 
 class TestCatalystCompareJaxpr:
     """Test comparing catalyst and pennylane jaxpr for a variety of situations."""


### PR DESCRIPTION
**Context:**

In [PennyLane #7084](https://github.com/PennyLaneAI/pennylane/pull/7084), I updated `while_loop` to better support dynamic shapes, and removed `abstract_shapes_slice` in the process. This is forcing a change to the signature for `while_loop`.

**Description of the Change:**

Removes `abstract_shapes_slice` from the call signature to `while_loop`.

Adds a `NotImplementedError` if abstract shapes are passed to `for_loop`. We can figure out how to implement this later. I added this since I noticed that `abstract_shapes_slice` wasn't getting used, so I thought it better to have a `NotImplementedError` then fall over in some sort of way later.

**Benefits:**

Catalyst works with latest pennylane again.

**Possible Drawbacks:**

**Related GitHub Issues:**
