### PR TITLE
load all dialects preemptively

### DIFF
--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -647,6 +647,9 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
     // TODO: FIXME:
     // Let's try to enable multithreading. Do not forget to protect the printing.
     ctx.disableMultithreading();
+    // The transform dialect doesn't appear to load dependent dialects
+    // fpr named passes.
+    ctx.loadAllAvailableDialects();
 
     ScopedDiagnosticHandler scopedHandler(
         &ctx, [&](Diagnostic &diag) { diag.print(options.diagnosticStream); });


### PR DESCRIPTION
**Context:** The transform dialect appears not to load dependent dialects of transformations.

**Description of the Change:** Load all dialects preemptively.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
