### PR TITLE
Update mlir version to have closure-aware backward slice

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -1,7 +1,7 @@
 # Always update the version check in catalyst.__init__ when changing the JAX version.
 jax=0.4.28
 mhlo=89a891c986650c33df76885f5620e0a92150d90f
-llvm=3a8316216807d64a586b971f51695e23883331f7
+llvm=d97bc388fd9ef8bc38353f93ff42d894ddc4a271
 enzyme=v0.0.149
 
 # Always remove custom PL/LQ versions before release.


### PR DESCRIPTION
**Context:**
Proposal: we update the mlir commit we track to see https://github.com/llvm/llvm-project/pull/114452

When using backward slice to track def-use chains, sometimes there are closure variables not explicitly visible as an operand, e.g.
```
    %7 = quantum.insert %5[%2], %out_qubits : !quantum.reg, !quantum.bit
    %8 = scf.if %1 -> (!quantum.reg) {
      %15 = quantum.extract %7[ 0] : !quantum.reg -> !quantum.bit
      %out_qubits_5 = quantum.custom "RZ"(%cst_1) %15 : !quantum.bit
      %16 = quantum.insert %7[ 0], %out_qubits_5 : !quantum.reg, !quantum.bit
      scf.yield %16 : !quantum.reg
    } else {
      scf.yield %7 : !quantum.reg
    }
    %9 = quantum.extract %8[%0] : !quantum.reg -> !quantum.bit
    %10 = quantum.extract %8[ 1] : !quantum.reg -> !quantum.bit
    %out_qubits_4:2 = quantum.custom "CNOT"() %9, %10 : !quantum.bit, !quantum.bit
    %11 = quantum.insert %8[%0], %out_qubits_4#0 : !quantum.reg, !quantum.bit
```
when running backward slice on `%11` to track all necessary previous values that dominate `%11`, the current mlir commit we track cannot detect `%7`, because `%7` is not an explicit operand of the `scf.if` op, but implicitly captured by region closure. The proposed commit to track adds a new option, `omitUsesFromAbove` , to the mlir backward slice analysis, and can be turned off to include clousure variables.

**Description of the Change:**
Update the mlir commit we track

**Benefits:**
New mlir features available

**Possible Drawbacks:**
Updating versions might break things
