### PR TITLE
Adding external contributors label to external pull requests

### DIFF
--- a/.github/workflows/check-external-contributor.yml
+++ b/.github/workflows/check-external-contributor.yml
@@ -1,0 +1,18 @@
+name: External Contributor Check
+on:
+  pull_request_target:
+    types: 
+      - opened   
+  
+jobs:
+  check-external:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR and label
+        with:
+          github_organization: "${{ github.repository_owner }}"
+          github_team: "external-collaborators"
+          github_token: ${{secrets.PENNYLANE_EXTERNAL_LABEL_MEMBER_CHECK}}
+          github_username: "${{ github.actor }}"
+        uses: XanaduAI/cloud-actions/label-external-pull-request@main
+        


### PR DESCRIPTION
----------------------------------------------------------------------------------------------------------

**Context:**
- Currently it is not possible to look through the PRs opened and sort by external PRs. This change uses the label-external-pull-request action to label external requests in this repository.

**Description of the Change:**
- adds a workflow to run label-external-pull-request on external requests from forks.

**Benefits:**
- It's easier to filter external pull requests 

**Possible Drawbacks:**

**Related GitHub Issues:**
