### PR TITLE
Audit Compiler build infrastructure (part 1)

### DIFF
--- a/frontend/catalyst/__init__.py
+++ b/frontend/catalyst/__init__.py
@@ -67,19 +67,6 @@ if not INSTALLED:
 # pylint: disable=protected-access
 sys.modules["mlir_quantum.ir"] = __import__("jaxlib.mlir.ir").mlir.ir
 sys.modules["mlir_quantum._mlir_libs"] = __import__("jaxlib.mlir._mlir_libs").mlir._mlir_libs
-# C++ extensions to the dialects are mocked out.
-sys.modules["mlir_quantum._mlir_libs._quantumDialects.gradient"] = types.ModuleType(
-    "mlir_quantum._mlir_libs._quantumDialects.gradient"
-)
-sys.modules["mlir_quantum._mlir_libs._quantumDialects.quantum"] = types.ModuleType(
-    "mlir_quantum._mlir_libs._quantumDialects.quantum"
-)
-sys.modules["mlir_quantum._mlir_libs._quantumDialects.catalyst"] = types.ModuleType(
-    "mlir_quantum._mlir_libs._quantumDialects.catalyst"
-)
-sys.modules["mlir_quantum._mlir_libs._quantumDialects.mitigation"] = types.ModuleType(
-    "mlir_quantum._mlir_libs._quantumDialects.mitigation"
-)
 
 from catalyst import debug, logging, passes
 from catalyst.api_extensions import *

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -59,6 +59,17 @@ list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
 list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
 list(APPEND CMAKE_MODULE_PATH "${MHLO_CMAKE_DIR}")
 list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/modules")
+
+# Policy CMP0175 was introduced in CMake 4.31 and raises warnings in the upstream CMake modules.
+# Policy CMP0177 was introduced in CMake 4.31 and raises warnings in the upstream CMake modules.
+# TODO: Remove once they (and us) have updated their code to deal with it.
+if(POLICY CMP0175)
+  cmake_policy(SET CMP0175 OLD)
+endif()
+if(POLICY CMP0177)
+  cmake_policy(SET CMP0177 OLD)
+endif()
+
 include(TableGen)
 include(AddLLVM)
 include(AddMLIR)

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -7,9 +7,6 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 20 CACHE STRING "C++ standard to conform to")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# LLVM source code triggers a cpp20 warning
-add_compile_options(-Wno-ambiguous-reversed-operator)
-
 find_package(MLIR REQUIRED CONFIG)
 find_package(MHLO REQUIRED CONFIG)
 
@@ -68,13 +65,17 @@ set(CATALYST_MAIN_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include)
 set(CATALYST_GEN_INCLUDE_DIR ${PROJECT_BINARY_DIR}/include)
 set(CATALYST_LIB_DIR ${PROJECT_BINARY_DIR})
 
-include_directories(${LLVM_INCLUDE_DIRS}
-                    ${MLIR_INCLUDE_DIRS}
-                    ${MHLO_INCLUDE_DIRS}
-                    ${MLIRHLO_DIR}/stablehlo
-                    ${MLIRHLO_BUILD_DIR}/stablehlo
-		    ${CATALYST_MAIN_INCLUDE_DIR}
-		    ${CATALYST_GEN_INCLUDE_DIR})
+include_directories(SYSTEM
+  ${LLVM_INCLUDE_DIRS}
+  ${MLIR_INCLUDE_DIRS}
+  ${MHLO_INCLUDE_DIRS}
+  ${MLIRHLO_DIR}/stablehlo
+  ${MLIRHLO_BUILD_DIR}/stablehlo
+)
+include_directories(
+  ${CATALYST_MAIN_INCLUDE_DIR}
+  ${CATALYST_GEN_INCLUDE_DIR}
+)
 link_directories(${LLVM_BUILD_LIBRARY_DIR})
 add_definitions(${LLVM_DEFINITIONS})
 
@@ -118,7 +119,7 @@ else()
         LINK_COMPONENTS Support # llvm::raw_ostream
         BUILDTREE_ONLY
       )
-      target_include_directories(llvm_gtest
+      target_include_directories(llvm_gtest SYSTEM
         PUBLIC
         "${UNITTEST_DIR}/googletest/include"
         "${UNITTEST_DIR}/googlemock/include"

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -7,6 +7,27 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 20 CACHE STRING "C++ standard to conform to")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# Required so as not to always use the cached option from the mlir build.
+option(QUANTUM_ENABLE_BINDINGS_PYTHON "Enable quantum dialect python bindings" OFF)
+option(CATALYST_ENABLE_WARNINGS "Enable -Wall and -Werror" ON)
+
+message(STATUS "LLVM_USE_SANITIZER is ${LLVM_USE_SANITIZER}.")
+message(STATUS "CATALYST_ENABLE_WARNINGS is ${CATALYST_ENABLE_WARNINGS}.")
+
+if ("${LLVM_USE_SANITIZER}" STREQUAL "Address")
+  add_compile_options(-fsanitize=address)
+  add_link_options(-fsanitize=address)
+endif()
+
+if(CATALYST_ENABLE_WARNINGS)
+    set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
+    add_compile_options(-Wall)
+endif()
+
+#########################
+## Handle Dependencies ##
+#########################
+
 find_package(MLIR REQUIRED CONFIG)
 find_package(MHLO REQUIRED CONFIG)
 
@@ -17,25 +38,6 @@ message(STATUS "Using MHLOConfig.cmake in: ${MHLO_DIR}")
 set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
 set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
 set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
-
-# Required so as not to always use the cached option from the mlir build.
-option(QUANTUM_ENABLE_BINDINGS_PYTHON "Enable quantum dialect python bindings" OFF)
-option(CATALYST_ENABLE_WARNINGS "Enable -Wall and -Werror" ON)
-
-message(STATUS "LLVM_USE_SANITIZER is ${LLVM_USE_SANITIZER}.")
-message(STATUS "CATALYST_ENABLE_WARNINGS is ${CATALYST_ENABLE_WARNINGS}.")
-
-if(LLVM_USE_SANITIZER)
-  if ("${LLVM_USE_SANITIZER}" STREQUAL "Address")
-    add_compile_options(-fsanitize=address)
-    add_link_options(-fsanitize=address)
-  endif()
-endif()
-
-if(CATALYST_ENABLE_WARNINGS)
-    set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
-    add_compile_options(-Wall)
-endif()
 
 # Taken from mlir-hlo/mhlo/transforms/CMakeLists.txt.
 # Unfortunately, AllMhloPasses doesn't appear to be exported.
@@ -66,7 +68,7 @@ include(HandleLLVMOptions)
 # bindings). We need to filter out those linker flags for now. TODO: remove once we update past
 # https://github.com/llvm/llvm-project/commit/1f0e0da3af783fd2bb5e23bc2b97141abac68926
 if(APPLE)
-string(REPLACE "-Wl,-undefined -Wl,suppress" "" CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS}")
+  string(REPLACE "-Wl,-undefined -Wl,suppress" "" CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS}")
 endif()
 
 if(QUANTUM_ENABLE_BINDINGS_PYTHON)
@@ -88,17 +90,32 @@ include_directories(SYSTEM
   ${MLIRHLO_DIR}/stablehlo
   ${MLIRHLO_BUILD_DIR}/stablehlo
 )
+link_directories(${LLVM_BUILD_LIBRARY_DIR})
+add_definitions(${LLVM_DEFINITIONS})
+
+######################
+## Catalyst Sources ##
+######################
+
 include_directories(
   ${CATALYST_MAIN_INCLUDE_DIR}
   ${CATALYST_GEN_INCLUDE_DIR}
 )
-link_directories(${LLVM_BUILD_LIBRARY_DIR})
-add_definitions(${LLVM_DEFINITIONS})
-
 
 add_subdirectory(include)
 add_subdirectory(lib)
 add_subdirectory(tools)
+
+if(QUANTUM_ENABLE_BINDINGS_PYTHON)
+  message(STATUS "Enabling Python API")
+  add_subdirectory(python)
+endif()
+
+add_subdirectory(cmake/modules)
+
+####################
+## Catalyst Tests ##
+####################
 
 ##############################################################################
 # The following subsection of code                                           #
@@ -166,10 +183,3 @@ endif()
 ######################
 
 add_subdirectory(test)
-
-if(QUANTUM_ENABLE_BINDINGS_PYTHON)
-  message(STATUS "Enabling Python API")
-  add_subdirectory(python)
-endif()
-
-add_subdirectory(cmake/modules)

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -53,6 +53,13 @@ include(AddLLVM)
 include(AddMLIR)
 include(HandleLLVMOptions)
 
+# LLVM's CMake options generate linker warnings on macOS when building modules (e.g. the Python
+# bindings). We need to filter out those linker flags for now. TODO: remove once we update past
+# https://github.com/llvm/llvm-project/commit/1f0e0da3af783fd2bb5e23bc2b97141abac68926
+if(APPLE)
+string(REPLACE "-Wl,-undefined -Wl,suppress" "" CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS}")
+endif()
+
 if(QUANTUM_ENABLE_BINDINGS_PYTHON)
   include(MLIRDetectPythonEnv)
   mlir_configure_python_dev_packages()

--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -14,18 +14,27 @@ message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 message(STATUS "Using MHLOConfig.cmake in: ${MHLO_DIR}")
 
-# Required so as not to always use the cached option from the mlir build.
-option(QUANTUM_ENABLE_BINDINGS_PYTHON "Enable quantum dialect python bindings" OFF)
-
 set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/bin)
 set(LLVM_LIBRARY_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/lib)
 set(MLIR_BINARY_DIR ${CMAKE_BINARY_DIR})
+
+# Required so as not to always use the cached option from the mlir build.
+option(QUANTUM_ENABLE_BINDINGS_PYTHON "Enable quantum dialect python bindings" OFF)
+option(CATALYST_ENABLE_WARNINGS "Enable -Wall and -Werror" ON)
+
+message(STATUS "LLVM_USE_SANITIZER is ${LLVM_USE_SANITIZER}.")
+message(STATUS "CATALYST_ENABLE_WARNINGS is ${CATALYST_ENABLE_WARNINGS}.")
 
 if(LLVM_USE_SANITIZER)
   if ("${LLVM_USE_SANITIZER}" STREQUAL "Address")
     add_compile_options(-fsanitize=address)
     add_link_options(-fsanitize=address)
   endif()
+endif()
+
+if(CATALYST_ENABLE_WARNINGS)
+    set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
+    add_compile_options(-Wall)
 endif()
 
 # Taken from mlir-hlo/mhlo/transforms/CMakeLists.txt.

--- a/mlir/Makefile
+++ b/mlir/Makefile
@@ -1,17 +1,18 @@
-PYTHON?=$(shell which python3)
-C_COMPILER?=$(shell which clang)
-CXX_COMPILER?=$(shell which clang++)
-COMPILER_LAUNCHER?=$(shell which ccache)
+PYTHON ?= $(shell which python3)
+C_COMPILER ?= $(shell which clang)
+CXX_COMPILER ?= $(shell which clang++)
+COMPILER_LAUNCHER ?= $(shell which ccache)
 
 MK_ABSPATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MK_DIR := $(dir $(MK_ABSPATH))
-DIALECTS_BUILD_DIR?=$(MK_DIR)/build
-LLVM_BUILD_DIR?=$(MK_DIR)/llvm-project/build
-MHLO_BUILD_DIR?=$(MK_DIR)/mlir-hlo/bazel-build
-ENZYME_BUILD_DIR?=$(MK_DIR)/Enzyme/build
-RT_BUILD_DIR?=$(MK_DIR)/../runtime/build
-ENABLE_ASAN?=OFF
-BUILD_TYPE?=Release
+DIALECTS_BUILD_DIR ?= $(MK_DIR)/build
+LLVM_BUILD_DIR ?= $(MK_DIR)/llvm-project/build
+MHLO_BUILD_DIR ?= $(MK_DIR)/mlir-hlo/bazel-build
+ENZYME_BUILD_DIR ?= $(MK_DIR)/Enzyme/build
+RT_BUILD_DIR ?= $(MK_DIR)/../runtime/build
+ENABLE_ASAN ?= OFF
+STRICT_WARNINGS ?= ON
+BUILD_TYPE ?= Release
 LLVM_EXTERNAL_LIT ?= $(LLVM_BUILD_DIR)/bin/llvm-lit
 
 ifeq ($(shell uname), Darwin)
@@ -22,9 +23,9 @@ DEFAULT_ENABLE_LLD := ON
 SYMBOL_VISIBILITY := default
 endif
 
-ENABLE_LLD?=$(DEFAULT_ENABLE_LLD)
-ENABLE_ZLIB?=ON
-ENABLE_ZSTD?=OFF
+ENABLE_LLD ?= $(DEFAULT_ENABLE_LLD)
+ENABLE_ZLIB ?= ON
+ENABLE_ZSTD ?= OFF
 
 ifeq ($(ENABLE_ASAN), ON)
 USE_SANITIZER_NAMES="Address"
@@ -172,7 +173,8 @@ dialects:
 		-DLLVM_USE_SANITIZER=$(USE_SANITIZER_NAMES) \
 		-DLLVM_ENABLE_LLD=$(ENABLE_LLD) \
 		-DLLVM_ENABLE_ZLIB=$(ENABLE_ZLIB) \
-		-DLLVM_ENABLE_ZSTD=$(ENABLE_ZSTD)
+		-DLLVM_ENABLE_ZSTD=$(ENABLE_ZSTD) \
+		-DCATALYST_ENABLE_WARNINGS=$(STRICT_WARNINGS)
 
 	cmake --build $(DIALECTS_BUILD_DIR) --target check-dialects quantum-lsp-server catalyst-cli check-unit-tests
 

--- a/mlir/include/Ion/Transforms/oqd_database_types.hpp
+++ b/mlir/include/Ion/Transforms/oqd_database_types.hpp
@@ -18,7 +18,8 @@
 #include <string>
 #include <vector>
 
-namespace {
+namespace catalyst {
+namespace ion {
 
 //
 // Calibrated parameters
@@ -99,4 +100,5 @@ struct Ion {
     }
 };
 
-} // namespace
+} // namespace ion
+} // namespace catalyst

--- a/mlir/lib/CAPI/CMakeLists.txt
+++ b/mlir/lib/CAPI/CMakeLists.txt
@@ -3,7 +3,7 @@ add_mlir_public_c_api_library(QuantumCAPI
 
     LINK_LIBS PRIVATE
     MLIRCatalyst
-    MLIRCatalystTransforms
+    catalyst-transforms
     MLIRQuantum
     quantum-transforms
     MLIRQEC

--- a/mlir/lib/Catalyst/Transforms/CMakeLists.txt
+++ b/mlir/lib/Catalyst/Transforms/CMakeLists.txt
@@ -1,7 +1,6 @@
-set(LIBRARY_NAME MLIRCatalystTransforms)
+set(LIBRARY_NAME catalyst-transforms)
 
 file(GLOB SRC
-
     ApplyTransformSequencePass.cpp
     ArrayListToMemRefPass.cpp
     AsyncUtils.cpp

--- a/mlir/lib/Driver/CMakeLists.txt
+++ b/mlir/lib/Driver/CMakeLists.txt
@@ -27,7 +27,7 @@ set(LIBS
     ${translation_libs}
     MLIROptLib
     MLIRCatalyst
-    MLIRCatalystTransforms
+    catalyst-transforms
     MLIRQuantum
     quantum-transforms
     MLIRQEC

--- a/mlir/lib/Driver/CMakeLists.txt
+++ b/mlir/lib/Driver/CMakeLists.txt
@@ -5,16 +5,16 @@ message(STATUS "Using EnzymeConfig.cmake in: ${Enzyme_DIR}")
 find_library(ENZYME_LIB EnzymeStatic-${LLVM_VERSION_MAJOR} PATHS ${Enzyme_DIR}/Enzyme/)
 message(STATUS "Found Enzyme lib: ${ENZYME_LIB}")
 
-include_directories(${ENZYME_SRC_DIR}/enzyme/Enzyme)
+include_directories(SYSTEM ${ENZYME_SRC_DIR}/enzyme/Enzyme)
 
 # Experimentally found through removing items
 # from llvm/tools/llc/CMakeLists.txt.
 # It does make sense that we need the parser to parse MLIR
 # and the codegen to codegen.
 set(LLVM_LINK_COMPONENTS
-  AllTargetsAsmParsers
-  AllTargetsCodeGens
-  )
+    AllTargetsAsmParsers
+    AllTargetsCodeGens
+)
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
@@ -51,6 +51,5 @@ add_mlir_library(CatalystCompilerDriver
     Pipelines.cpp
 
     LINK_LIBS PRIVATE
-    ${EXTERNAL_LIB}
     ${LIBS}
-    )
+)

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -502,7 +502,7 @@ LogicalResult preparePassManager(PassManager &pm, const CompilerOptions &options
             s << *op;
             std::string fileName = pipelineName.str();
             if (auto funcOp = dyn_cast<mlir::func::FuncOp>(op)) {
-                fileName += "_" + funcOp.getName().str();
+                fileName += std::string("_") + funcOp.getName().str();
             }
             dumpToFile(options, output.nextPipelineDumpFilename(fileName), tmp);
         }

--- a/mlir/lib/Ion/Transforms/CMakeLists.txt
+++ b/mlir/lib/Ion/Transforms/CMakeLists.txt
@@ -39,6 +39,7 @@ FetchContent_Declare(
    json
    URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
    URL_HASH  SHA256=d6c65aca6b1ed68e7a182f4757257b107ae403032760ed6ef121c9d55e81757d
+   DOWNLOAD_EXTRACT_TIMESTAMP true
 )
 FetchContent_MakeAvailable(json)
 target_link_libraries(ion-transforms

--- a/mlir/lib/Ion/Transforms/CMakeLists.txt
+++ b/mlir/lib/Ion/Transforms/CMakeLists.txt
@@ -27,34 +27,36 @@ target_include_directories(${LIBRARY_NAME} PUBLIC
                            ${CMAKE_BINARY_DIR}/include)
 
 include(FetchContent)
-FetchContent_Declare(
-    tomlplusplus
+
+FetchContent_Declare(tomlplusplus
     GIT_REPOSITORY https://github.com/marzer/tomlplusplus.git
     GIT_TAG v3.4.0
+    SYSTEM
 )
 FetchContent_MakeAvailable(tomlplusplus)
 
-# Fetch json utilities
-FetchContent_Declare(
-   json
-   URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
-   URL_HASH  SHA256=d6c65aca6b1ed68e7a182f4757257b107ae403032760ed6ef121c9d55e81757d
-   DOWNLOAD_EXTRACT_TIMESTAMP true
+FetchContent_Declare(json
+    URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+    URL_HASH  SHA256=d6c65aca6b1ed68e7a182f4757257b107ae403032760ed6ef121c9d55e81757d
+    DOWNLOAD_EXTRACT_TIMESTAMP true
+    SYSTEM
 )
 FetchContent_MakeAvailable(json)
-target_link_libraries(ion-transforms
-    PRIVATE nlohmann_json::nlohmann_json
+
+target_link_libraries(${LIBRARY_NAME} PRIVATE
+    tomlplusplus::tomlplusplus
+    nlohmann_json::nlohmann_json
 )
 
-target_link_libraries(${LIBRARY_NAME} PRIVATE tomlplusplus::tomlplusplus)
-
-# tmol++ source has a warning which we want to ignore
-# This is because toml++ ships source-only, not an executable, so we have to compile it
+# toml++ source has a warning which we want to ignore. Surprisingly, the SYSTEM keyword does not
+# seem to affect the headers, at least with this specific warning (only present on clang, not gcc).
+if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
 set_source_files_properties(
-  ion-to-llvm.cpp
-  ConversionPatterns.cpp
-  quantum_to_ion.cpp
-  QuantumToIonPatterns.cpp
-  PROPERTIES
-  COMPILE_FLAGS "-Wno-covered-switch-default"
+    ion-to-llvm.cpp
+    ConversionPatterns.cpp
+    quantum_to_ion.cpp
+    QuantumToIonPatterns.cpp
+    PROPERTIES
+    COMPILE_FLAGS "-Wno-covered-switch-default"
 )
+endif()

--- a/mlir/lib/Ion/Transforms/quantum_to_ion.cpp
+++ b/mlir/lib/Ion/Transforms/quantum_to_ion.cpp
@@ -30,7 +30,6 @@
 #include "Quantum/IR/QuantumOps.h"
 
 using namespace mlir;
-using namespace catalyst::ion;
 
 namespace catalyst {
 namespace ion {

--- a/mlir/lib/QEC/Utils/CMakeLists.txt
+++ b/mlir/lib/QEC/Utils/CMakeLists.txt
@@ -3,11 +3,15 @@ include(FetchContent)
 FetchContent_Declare(stim
     GIT_REPOSITORY https://github.com/quantumlib/stim.git
     GIT_TAG v1.14.0
+    SYSTEM  # ignore warnings from headers
 )
 
 FetchContent_MakeAvailable(stim)
 
-add_library(QECUtils
+# Ignore all warnings from Stim library sources.
+target_compile_options(libstim PRIVATE -w)
+
+add_library(QECUtils STATIC
     PauliStringWrapper.cpp
 )
 

--- a/mlir/lib/QEC/Utils/CMakeLists.txt
+++ b/mlir/lib/QEC/Utils/CMakeLists.txt
@@ -6,6 +6,9 @@ FetchContent_Declare(stim
     SYSTEM  # ignore warnings from headers
 )
 
+# Set a more portable vectorization instruction set than whatever is available on the build machine.
+set(SIMD_WIDTH 128)
+
 FetchContent_MakeAvailable(stim)
 
 # Ignore all warnings from Stim library sources.

--- a/mlir/lib/QEC/Utils/PauliStringWrapper.cpp
+++ b/mlir/lib/QEC/Utils/PauliStringWrapper.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "stim/mem/simd_word.h"
-#include "stim/stabilizers/flex_pauli_string.h"
-#include "stim/stabilizers/pauli_string.h"
+#include <stim/mem/simd_word.h>
+#include <stim/stabilizers/flex_pauli_string.h>
+#include <stim/stabilizers/pauli_string.h>
 
 #include "QEC/Utils/PauliStringWrapper.h"
 

--- a/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
@@ -113,7 +113,7 @@ Value getModifiersPtr(Location loc, RewriterBase &rewriter, const TypeConverter 
             catalyst::getStaticAlloca(loc, rewriter, ptrType, controlledQubits.size()).getResult();
         valuePtr =
             catalyst::getStaticAlloca(loc, rewriter, boolType, controlledQubits.size()).getResult();
-        for (size_t i = 0; i < controlledQubits.size(); i++) {
+        for (int i = 0; static_cast<size_t>(i) < controlledQubits.size(); i++) {
             {
                 auto itemPtr = rewriter.create<LLVM::GEPOp>(loc, ptrType, ptrType, ctrlPtr,
                                                             llvm::ArrayRef<LLVM::GEPArg>{i}, true);

--- a/mlir/lib/Quantum/Transforms/LoopBoundaryOptimizationPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/LoopBoundaryOptimizationPatterns.cpp
@@ -106,6 +106,8 @@ bool isValidQuantumOperation(CustomOp &op, Mode mode)
         return hermitianSet.contains(gateName) || rotationsSet.contains(gateName) ||
                multiQubitSet.contains(gateName);
     }
+
+    assert(false && "Invalid Enum value for `Mode`");
 }
 
 // Determines if the given operation has any successors that are quantum CustomOps.

--- a/mlir/lib/Quantum/Transforms/PropagateSimpleStatesAnalysis.hpp
+++ b/mlir/lib/Quantum/Transforms/PropagateSimpleStatesAnalysis.hpp
@@ -208,6 +208,8 @@ class PropagateSimpleStatesAnalysis {
         case QubitState::NOT_A_BASIS:
             return "NOT_A_BASIS";
         }
+
+        assert(false && "Invalid Enum value for `QubitState`");
     }
 
     bool isZero(QubitState qs) { return qs == QubitState::ZERO; }

--- a/mlir/python/CMakeLists.txt
+++ b/mlir/python/CMakeLists.txt
@@ -5,7 +5,7 @@ add_compile_definitions("MLIR_PYTHON_PACKAGE_PREFIX=mlir_quantum.")
 
 
 ################################################################################
-# Sources
+# Declare Dialect Sources
 ################################################################################
 
 declare_mlir_python_sources(QuantumPythonSources)
@@ -44,23 +44,7 @@ declare_mlir_dialect_python_bindings(
 
 
 ################################################################################
-# Common CAPI
-################################################################################
-
-
-add_mlir_python_common_capi_library(QuantumPythonCAPI
-  INSTALL_COMPONENT QuantumPythonModules
-  INSTALL_DESTINATION python_packages/quantum/mlir_quantum/_mlir_libs
-  OUTPUT_DIRECTORY "${MLIR_BINARY_DIR}/python_packages/quantum/mlir_quantum/_mlir_libs"
-  RELATIVE_INSTALL_ROOT "../../../.."
-  DECLARED_SOURCES
-    QuantumPythonSources
-    MLIRPythonExtension.RegisterEverything
-    MLIRPythonSources.Core
-)
-
-################################################################################
-# Instantiation of all Python modules
+# Build Python Bindings (without C extension)
 ################################################################################
 
 add_mlir_python_modules(QuantumPythonModules
@@ -68,8 +52,7 @@ add_mlir_python_modules(QuantumPythonModules
   INSTALL_PREFIX "python_packages/quantum/mlir_quantum/"
   DECLARED_SOURCES
     QuantumPythonSources
-    MLIRPythonExtension.RegisterEverything
-    MLIRPythonSources
-  COMMON_CAPI_LINK_LIBS
-    QuantumPythonCAPI
+    MLIRPythonSources.Dialects         # we also use upstream dialect bindings
+    MLIRPythonSources.Core.Python      # common sources, like _ods_common.py
+    MLIRPythonSources.ExecutionEngine  # for the mlir_quantum.runtime module
   )

--- a/mlir/python/dialects/catalyst.py
+++ b/mlir/python/dialects/catalyst.py
@@ -14,5 +14,4 @@
 
 """MLIR Dialect for Catalyst dialect."""
 
-from .._mlir_libs._quantumDialects.catalyst import *  # noqa: F401
 from ._catalyst_ops_gen import *  # noqa: F401

--- a/mlir/python/dialects/gradient.py
+++ b/mlir/python/dialects/gradient.py
@@ -14,5 +14,4 @@
 
 """MLIR Dialect for Gradient dialect."""
 
-from .._mlir_libs._quantumDialects.gradient import *  # noqa: F401
 from ._gradient_ops_gen import *  # noqa: F401

--- a/mlir/python/dialects/mitigation.py
+++ b/mlir/python/dialects/mitigation.py
@@ -14,5 +14,4 @@
 
 """MLIR Dialect for mitigation dialect."""
 
-from .._mlir_libs._quantumDialects.mitigation import *  # noqa: F401
 from ._mitigation_ops_gen import *  # noqa: F401

--- a/mlir/python/dialects/quantum.py
+++ b/mlir/python/dialects/quantum.py
@@ -14,5 +14,4 @@
 
 """MLIR Dialect for Quantum dialect."""
 
-from .._mlir_libs._quantumDialects.quantum import *  # noqa: F401
 from ._quantum_ops_gen import *  # noqa: F401

--- a/mlir/tools/catalyst-cli/CMakeLists.txt
+++ b/mlir/tools/catalyst-cli/CMakeLists.txt
@@ -25,7 +25,7 @@ set(LIBS
     ${extension_libs}
     MLIROptLib
     MLIRCatalyst
-    MLIRCatalystTransforms
+    catalyst-transforms
     MLIRQuantum
     quantum-transforms
     MLIRQEC

--- a/mlir/tools/catalyst-cli/CMakeLists.txt
+++ b/mlir/tools/catalyst-cli/CMakeLists.txt
@@ -5,16 +5,16 @@ message(STATUS "Using EnzymeConfig.cmake in: ${Enzyme_DIR}")
 find_library(ENZYME_LIB EnzymeStatic-${LLVM_VERSION_MAJOR} PATHS ${Enzyme_DIR}/Enzyme/)
 message(STATUS "Found Enzyme lib: ${ENZYME_LIB}")
 
-include_directories(${ENZYME_SRC_DIR}/enzyme/Enzyme)
+include_directories(SYSTEM ${ENZYME_SRC_DIR}/enzyme/Enzyme)
 
 # Experimentally found through removing items
 # from llvm/tools/llc/CMakeLists.txt.
 # It does make sense that we need the parser to parse MLIR
 # and the codegen to codegen.
 set(LLVM_LINK_COMPONENTS
-  AllTargetsAsmParsers
-  AllTargetsCodeGens
-  )
+    AllTargetsAsmParsers
+    AllTargetsCodeGens
+)
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)

--- a/mlir/tools/quantum-opt/CMakeLists.txt
+++ b/mlir/tools/quantum-opt/CMakeLists.txt
@@ -7,7 +7,7 @@ set(LIBS
     ${extension_libs}
     MLIROptLib
     MLIRCatalyst
-    MLIRCatalystTransforms
+    catalyst-transforms
     MLIRQuantum
     quantum-transforms
     MLIRQEC


### PR DESCRIPTION
The primary, high-level goal is to enable stricter safety checks in our build systems. In addition to stricter checks, ideally, all our build recipes should produce clean, warning-free outputs, as ignoring one set of warnings can easily lead to overlooking other warnings.

This PR takes a look at the compiler (`mlir`) and improves the following:

- provide a warning-free (cmake+compiler) build across tested platforms
- enable warnings as errors and -Wall by default

The above was tested on the runtime with the following configurations:

make targets: dialects
platforms: mac + apple clang 16, linux + clang 18, linux + gcc 13

The PR does not test or enable ASAN yes, it mainly deals with warnings.