### PR TITLE
Eliminate clang-tidy dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ PyYAML
 # formatting/linting
 black
 clang-format==14.*
-clang-tidy~=16.0
 pylint
 isort
 

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -10,7 +10,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # Compiler options
 option(ENABLE_CODE_COVERAGE "Enable code coverage" OFF)
 option(ENABLE_ADDRESS_SANITIZER "Enable address sanitizer" OFF)
-option(RUNTIME_CLANG_TIDY "Enable Clang Tidy" OFF)
 
 option(ENABLE_OPENQASM "Build OpenQasm backend device" OFF)
 option(ENABLE_OQD "Build OQD backend device" OFF)

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -40,7 +40,6 @@ help:
 	@echo "  test               to run the Catalyst runtime test suite"
 	@echo "  format [check=1]   to apply C++ formatter; use with 'check=1' to check instead of modify (requires clang-format)"
 	@echo "  format [version=?] to apply C++ formatter; use with 'version={version}' to run clang-format-{version} instead of clang-format"
-	@echo "  check-tidy         to build Catalyst Runtime with RUNTIME_CLANG_TIDY=ON (requires clang-tidy)"
 
 .PHONY: configure
 configure:
@@ -115,7 +114,7 @@ endif
 .PHONY: clean
 clean:
 	@echo "clean build files"
-	rm -rf $(RT_BUILD_DIR) $(RT_BUILD_DIR)_cov cov coverage.info $(MK_DIR)/BuildTidy
+	rm -rf $(RT_BUILD_DIR) $(RT_BUILD_DIR)_cov cov coverage.info
 
 .PHONY: format
 format:
@@ -124,14 +123,3 @@ ifdef check
 else
 	$(PYTHON) ../bin/format.py $(if $(version:-=),--cfversion $(version)) .
 endif
-
-.PHONY: check-tidy
-check-tidy:
-	@echo "build Catalyst Runtime with RUNTIME_CLANG_TIDY=ON"
-	cmake -G Ninja -B $(MK_DIR)/BuildTidy . \
-		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \
-		-DCMAKE_C_COMPILER=$(C_COMPILER) \
-		-DCMAKE_CXX_COMPILER=$(CXX_COMPILER) \
-		-DRUNTIME_CLANG_TIDY=ON
-
-	cmake --build $(MK_DIR)/BuildTidy --target rt_capi -j$(NPROC)

--- a/runtime/lib/backend/openqasm/CMakeLists.txt
+++ b/runtime/lib/backend/openqasm/CMakeLists.txt
@@ -1,14 +1,3 @@
-if(RUNTIME_CLANG_TIDY)
-    if(NOT DEFINED CLANG_TIDY_BINARY)
-        set(CLANG_TIDY_BINARY clang-tidy)
-    endif()
-    message(STATUS "Using CLANG_TIDY_BINARY=${CLANG_TIDY_BINARY}")
-    set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_BINARY};
-        -extra-arg=-std=c++20;
-        --use-color;
-    )
-endif()
-
 # nanobind suggests including these lines to configure CMake to perform an optimized release build
 # by default unless another build type is specified. Without this addition, binding code may run
 # slowly and produce large binaries.


### PR DESCRIPTION
This is just a proposal, let me know if there are any objections :) 

With lightning devices migrated out of Catalyst, the only remaining code affected by the clang-tidy option is the OpenQASM device code. The option is also disabled by default and not run in any CI scripts, so I propose to remove it entirely for simplicity.