### PR TITLE
run split-multiple-tapes in a module

### DIFF
--- a/mlir/test/Quantum/SplitMultipleTapesTest.mlir
+++ b/mlir/test/Quantum/SplitMultipleTapesTest.mlir
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// RUN: quantum-opt %s --pass-pipeline="builtin.module(func.func(split-multiple-tapes))" --split-input-file --verify-diagnostics | FileCheck %s
+// RUN: quantum-opt %s --pass-pipeline="builtin.module(split-multiple-tapes)" --split-input-file --verify-diagnostics | FileCheck %s
 
 // Test that --split-multiple-tapes pass correctly outlines each tape into its own function and calls the outlined functions.
 // A tape is the operations between a "quantum.device" and a "quantum.device_release", inclusive.


### PR DESCRIPTION
**Context:** Split multiple-tapes creates new functions. This means it can't be a function level pass, it must be a module level pass.

**Description of the Change:** Changes the test to run split-multiple-tapes in a module.

It is unclear if this will fix the stochastic bug, but it is clear it is a step in the right direction. I have some changes attempting to use renameToUnique but I am a bit unhappy with them at the moment.