### PR TITLE
take into account pass-pipeline-wrapper in autograph

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -237,6 +237,9 @@
   chained catalyst passe decorators causes a crash.
   [(#1576)](https://github.com/PennyLaneAI/catalyst/pull/1576)
 
+* Autographs and catalyst pipeline fix.
+  [(#1599)](https://github.com/PennyLaneAI/catalyst/pull/1599)
+
 <h3>Internal changes ⚙️</h3>
 
 * Updated the call signature for the PLXPR `qnode_prim` primitive.

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -490,9 +490,6 @@ def get_source_code_info(tb_frame):
                 if isinstance(obj, qml.QNode):
                     ag_source_map = obj.ag_source_map
                     break
-                if isinstance(obj, PassPipelineWrapper):
-                    ag_source_map = obj.qnode.ag_source_map
-                    break
                 if isinstance(obj, catalyst.QJIT):
                     ag_source_map = obj.user_function.ag_source_map
                     break

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -35,6 +35,7 @@ from pennylane.queuing import AnnotatedQueue
 
 import catalyst
 from catalyst.jax_extras import DynamicJaxprTracer, ShapedArray
+from catalyst.passes.pass_api import PassPipelineWrapper
 from catalyst.tracing.contexts import EvaluationContext
 from catalyst.utils.callables import CatalystCallable
 from catalyst.utils.exceptions import AutoGraphError
@@ -488,6 +489,9 @@ def get_source_code_info(tb_frame):
                 obj = frame.frame.f_locals["self"]
                 if isinstance(obj, qml.QNode):
                     ag_source_map = obj.ag_source_map
+                    break
+                if isinstance(obj, PassPipelineWrapper):
+                    ag_source_map = obj.qnode.ag_source_map
                     break
                 if isinstance(obj, catalyst.QJIT):
                     ag_source_map = obj.user_function.ag_source_map

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -35,7 +35,6 @@ from pennylane.queuing import AnnotatedQueue
 
 import catalyst
 from catalyst.jax_extras import DynamicJaxprTracer, ShapedArray
-from catalyst.passes.pass_api import PassPipelineWrapper
 from catalyst.tracing.contexts import EvaluationContext
 from catalyst.utils.callables import CatalystCallable
 from catalyst.utils.exceptions import AutoGraphError

--- a/frontend/catalyst/autograph/transformer.py
+++ b/frontend/catalyst/autograph/transformer.py
@@ -71,8 +71,11 @@ class CatalystTransformer(PyToPy):
             new_obj = copy.copy(obj)
             new_obj.func = new_fn
         elif isinstance(obj, PassPipelineWrapper):
-            new_obj = copy.copy(obj.qnode)
-            new_obj.func = new_fn
+            new_qnode = copy.copy(obj.qnode)
+            new_qnode.func = new_fn
+            new_obj = PassPipelineWrapper(
+                new_qnode, obj.pass_name_or_pipeline, *obj.flags, **obj.valued_options
+            )
 
         return new_obj, module, source_map
 

--- a/frontend/catalyst/autograph/transformer.py
+++ b/frontend/catalyst/autograph/transformer.py
@@ -233,8 +233,10 @@ def autograph_source(fn):
     # Unwrap known objects to get the function actually transformed by autograph.
     if isinstance(fn, catalyst.QJIT):
         fn = fn.original_function
-    if isinstance(fn, (qml.QNode, PassPipelineWrapper)):
+    if isinstance(fn, qml.QNode):
         fn = fn.func
+    if isinstance(fn, QNodeWrapper):
+        fn = fn.original_qnode
 
     if TRANSFORMER.has_cache(fn):
         new_fn = TRANSFORMER.get_cached_function(fn)

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -26,6 +26,7 @@ from jax.errors import TracerBoolConversionError
 from numpy.testing import assert_allclose
 
 from catalyst import *
+from catalyst import passes
 from catalyst.autograph.transformer import TRANSFORMER
 from catalyst.utils.dummy import dummy_func
 from catalyst.utils.exceptions import CompileError
@@ -2299,10 +2300,12 @@ class TestJaxIndexOperatorUpdate:
 
 
 class TestWithPassPipelineWrapper:
+    """Test with passes"""
+
     def test_with_pass_pipeline_wrapper(self):
         """this test should work. So there are no asserts"""
 
-        @qjit(autograph=True)
+        @qml.qjit(autograph=True)
         @passes.merge_rotations
         @qml.qnode(qml.device("null.qubit", wires=1))
         def circuit(n_iter: int):

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -138,6 +138,24 @@ class TestSourceCodeInfo:
             except RuntimeError as e:
                 assert e.args == ("Test failure",)
 
+    def test_qnode_with_pass(self):
+        """Test source info retrieval for a qnode decorated with a pass."""
+        from catalyst.autograph.ag_primitives import get_source_code_info
+
+        try:
+
+            @qml.qjit(autograph=True)
+            @passes.merge_rotations
+            @qml.qnode(qml.device("null.qubit", wires=1))
+            def circuit(n: int):
+                for _ in range(5):
+                    raise RuntimeError("Test failure")
+                return 0
+
+        except RuntimeError as e:
+            breakpoint()
+            result = get_source_code_info(traceback.extract_tb(e.__traceback__, limit=1)[0])
+
 
 class TestIntegration:
     """Test that the autograph transformations trigger correctly in different settings."""

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -2265,8 +2265,8 @@ class TestJaxIndexOperatorUpdate:
         assert jnp.allclose(result, jnp.array([10, 4, 6, 2, 2]))
         assert jnp.allclose(result, expected)
 
-    def test_unsopported_cases(self):
-        """Test that TypeError is raised in unsopported cases."""
+    def test_unsupported_cases(self):
+        """Test that TypeError is raised in unsupported cases."""
 
         @qjit(autograph=True)
         def workflow(x):
@@ -2296,6 +2296,23 @@ class TestJaxIndexOperatorUpdate:
 
             with pytest.raises(TypeError, match="JAX arrays are immutable"):
                 test_array_index(x)
+
+
+class TestWithPassPipelineWrapper:
+    def test_with_pass_pipeline_wrapper(self):
+        """this test should work. So there are no asserts"""
+
+        @qjit(autograph=True)
+        @passes.merge_rotations
+        @qml.qnode(qml.device("null.qubit", wires=1))
+        def circuit(n_iter: int):
+            for _ in range(n_iter):
+                qml.RX(0.1, wires=0)
+                qml.T(0)
+                qml.RX(0.2, wires=0)
+            return qml.expval(qml.PauliZ(0))
+
+        circuit(10)
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -153,7 +153,6 @@ class TestSourceCodeInfo:
                 return 0
 
         except RuntimeError as e:
-            breakpoint()
             result = get_source_code_info(traceback.extract_tb(e.__traceback__, limit=1)[0])
 
 

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -138,23 +138,6 @@ class TestSourceCodeInfo:
             except RuntimeError as e:
                 assert e.args == ("Test failure",)
 
-    def test_qnode_with_pass(self):
-        """Test source info retrieval for a qnode decorated with a pass."""
-        from catalyst.autograph.ag_primitives import get_source_code_info
-
-        try:
-
-            @qml.qjit(autograph=True)
-            @passes.merge_rotations
-            @qml.qnode(qml.device("null.qubit", wires=1))
-            def circuit(n: int):
-                for _ in range(5):
-                    raise RuntimeError("Test failure")
-                return 0
-
-        except RuntimeError as e:
-            result = get_source_code_info(traceback.extract_tb(e.__traceback__, limit=1)[0])
-
 
 class TestIntegration:
     """Test that the autograph transformations trigger correctly in different settings."""


### PR DESCRIPTION
**Context:** Autograph had some special handling for qnodes. PassPipelineWrapper are essentially qnodes. So they also need some special handling.

**Description of the Change:** Add special handling for PassPipelineWrapper in the autograph module.

**Benefits:**

```python
import pennylane as qml
from catalyst import qjit, passes

@qjit(autograph=True, keep_intermediate=True)
@passes.merge_rotations
@qml.qnode(qml.device("null.qubit", wires=1))
def circuit(n_iter: int):
    for _ in range(n_iter):
        qml.RX(0.1, wires=0)
        qml.T(0)
        qml.RX(0.2, wires=0)
    return qml.expval(qml.PauliZ(0))

print(circuit(10))
```

works

**Possible Drawbacks:** unclear how to get `get_source_code_info` to work with passes at the moment.

**Related GitHub Issues:**
[[sc-87887]]