### PR TITLE
Fix an error message

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -213,7 +213,7 @@
   This includes `probs(), state(), sample(), counts()`.
     [(#1565)](https://github.com/PennyLaneAI/catalyst/pull/1565)
 
-* Fix an error message.
+* Improve error message for ZNE.
   [(#1603)](https://github.com/PennyLaneAI/catalyst/pull/1603)
 
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -213,6 +213,10 @@
   This includes `probs(), state(), sample(), counts()`.
     [(#1565)](https://github.com/PennyLaneAI/catalyst/pull/1565)
 
+* Fix an error message.
+  [(#1603)](https://github.com/PennyLaneAI/catalyst/pull/1603)
+
+
 <h3>Breaking changes 💔</h3>
 
 <h3>Deprecations 👋</h3>

--- a/frontend/catalyst/api_extensions/error_mitigation.py
+++ b/frontend/catalyst/api_extensions/error_mitigation.py
@@ -32,8 +32,20 @@ from catalyst.jax_tracer import Function
 from catalyst.utils.callables import CatalystCallable
 
 
-def _is_odd_positive(numbers_list):
-    return all(isinstance(i, int) and i > 0 and i % 2 != 0 for i in numbers_list)
+def _check_is_odd_positive(numbers_list):
+    for n in numbers_list:
+        if not isinstance(n, int):
+            msg = f"Found non-integer {n} in scale_factors {numbers_list}.\n"
+            msg += "Only odd positive integers are allowed in scale_factors"
+            raise TypeError(msg)
+        if n < 0:
+            msg = "Found negative number {n} in scale_factors {numbers_list}.\n"
+            msg += "Only odd positive integers are allowed in scale_factors"
+            raise ValueError(msg)
+        if n % 2 == 0:
+            msg = f"Found even positive {n} in scale_factors {numbers_list}.\n"
+            msg += "Only odd positive integers are allowed in scale_factors"
+            raise ValueError(msg)
 
 
 ## API ##
@@ -140,8 +152,7 @@ def mitigate_with_zne(
     elif extrapolate_kwargs is not None:
         extrapolate = functools.partial(extrapolate, **extrapolate_kwargs)
 
-    if not _is_odd_positive(scale_factors):
-        raise ValueError(f"The scale factors must be positive odd integers: {scale_factors}")
+    _check_is_odd_positive(scale_factors)
 
     return ZNECallable(fn, scale_factors, extrapolate, folding)
 

--- a/frontend/catalyst/api_extensions/error_mitigation.py
+++ b/frontend/catalyst/api_extensions/error_mitigation.py
@@ -141,7 +141,7 @@ def mitigate_with_zne(
         extrapolate = functools.partial(extrapolate, **extrapolate_kwargs)
 
     if not _is_odd_positive(scale_factors):
-        raise ValueError("The scale factors must be positive odd integers: {scale_factors}")
+        raise ValueError(f"The scale factors must be positive odd integers: {scale_factors}")
 
     return ZNECallable(fn, scale_factors, extrapolate, folding)
 

--- a/frontend/test/pytest/test_mitigation.py
+++ b/frontend/test/pytest/test_mitigation.py
@@ -151,7 +151,15 @@ def test_scale_factors_value_error(scale_factors):
         mitigated_function(0.1)
 
 
-@pytest.mark.parametrize("scale_factors", [[jax.numpy.array([1, 3])], jax.numpy.array([1, 3]), [1.0, 3.0], [complex(1, 0), complex(3, 0)]])
+@pytest.mark.parametrize(
+    "scale_factors",
+    [
+        [jax.numpy.array([1, 3])],
+        jax.numpy.array([1, 3]),
+        [1.0, 3.0],
+        [complex(1, 0), complex(3, 0)],
+    ],
+)
 def test_scale_factors_type_error(scale_factors):
     """Test that when using non-integer, it raises a TypeError."""
 

--- a/frontend/test/pytest/test_mitigation.py
+++ b/frontend/test/pytest/test_mitigation.py
@@ -151,7 +151,7 @@ def test_scale_factors_value_error(scale_factors):
         mitigated_function(0.1)
 
 
-@pytest.mark.parametrize("scale_factors", [[1.0, 3.0], [complex(1, 0), complex(3, 0)]])
+@pytest.mark.parametrize("scale_factors", [[jax.numpy.array([1, 3])], [1.0, 3.0], [complex(1, 0), complex(3, 0)]])
 def test_scale_factors_type_error(scale_factors):
     """Test that when using non-integer, it raises a TypeError."""
 

--- a/frontend/test/pytest/test_mitigation.py
+++ b/frontend/test/pytest/test_mitigation.py
@@ -151,7 +151,7 @@ def test_scale_factors_value_error(scale_factors):
         mitigated_function(0.1)
 
 
-@pytest.mark.parametrize("scale_factors", [[jax.numpy.array([1, 3])], [1.0, 3.0], [complex(1, 0), complex(3, 0)]])
+@pytest.mark.parametrize("scale_factors", [[jax.numpy.array([1, 3])], jax.numpy.array([1, 3]), [1.0, 3.0], [complex(1, 0), complex(3, 0)]])
 def test_scale_factors_type_error(scale_factors):
     """Test that when using non-integer, it raises a TypeError."""
 


### PR DESCRIPTION
**Context:** An error message was formatted as an f-string but was just a regular string.

**Description of the Change:** Make error string an f-string.

**Benefits:** Better error messages.
