### PR TITLE
Use grad context for hashing the generated stablehlo program

### DIFF
--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -510,7 +510,7 @@ def _grad_lowering(ctx, *args, jaxpr, fn, grad_params):
     new_argnums = [num + offset for num in argnums]
     argnum_numpy = np.array(new_argnums)
     diffArgIndices = ir.DenseIntElementsAttr.get(argnum_numpy)
-    func_op = lower_jaxpr(ctx, jaxpr)
+    func_op = lower_jaxpr(ctx, jaxpr, ("grad",))
 
     symbol_ref = get_symbolref(ctx, func_op)
     output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
@@ -585,7 +585,7 @@ def _value_and_grad_lowering(ctx, *args, jaxpr, fn, grad_params):
     val_result_types = flat_output_types[: len(flat_output_types) - len(argnums)]
     gradient_result_types = flat_output_types[len(flat_output_types) - len(argnums) :]
 
-    func_op = lower_jaxpr(ctx, jaxpr)
+    func_op = lower_jaxpr(ctx, jaxpr, ("grad",))
 
     symbol_ref = get_symbolref(ctx, func_op)
     return ValueAndGradOp(
@@ -635,7 +635,7 @@ def _jvp_lowering(ctx, *args, jaxpr, fn, grad_params):
     func_args = consts_and_args[: len(func_call_jaxpr.invars)]
     tang_args = consts_and_args[len(func_call_jaxpr.invars) :]
 
-    func_op = lower_jaxpr(ctx, jaxpr)
+    func_op = lower_jaxpr(ctx, jaxpr, ("grad",))
 
     assert (
         len(flat_output_types) % 2 == 0
@@ -688,7 +688,7 @@ def _vjp_lowering(ctx, *args, jaxpr, fn, grad_params):
     func_result_types = flat_output_types[: len(flat_output_types) - len(argnums)]
     vjp_result_types = flat_output_types[len(flat_output_types) - len(argnums) :]
 
-    func_op = lower_jaxpr(ctx, jaxpr)
+    func_op = lower_jaxpr(ctx, jaxpr, ("grad",))
 
     symbol_ref = get_symbolref(ctx, func_op)
     return VJPOp(


### PR DESCRIPTION
**Context:** After PR #1562, a single function could have multiple JAXPR representations based on whether it was under a grad context or not. This made the previous hash based on the function id create possible conflicts. To address this, we hashed on the jaxpr string representation. (We cannot hash on the jax object itself since they are unique).

The JAXPR string representation can be very long and hashing over long strings can take a long time.

**Description of the Change:** Instead of hashing the string representation, add a simple key to denote whether it is inside a grad context or not.

**Benefits:** Reduced compilation time.

**Possible Drawbacks:** The cache key is getting more complicated. Maybe the drawbacks outweight the benefits now?

**Related GitHub Issues:**
