### PR TITLE
Fix autograph when using qml.ctrl/adjoint on an operator object

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -245,6 +245,10 @@
 * Autographs and catalyst pipeline fix.
   [(#1599)](https://github.com/PennyLaneAI/catalyst/pull/1599)
 
+* Fixes an issue ([(#1339)](https://github.com/PennyLaneAI/catalyst/issues/1339)) where using
+  autograph with control/adjoint functions used on operator objects causes a crash.
+  [(#1605)](https://github.com/PennyLaneAI/catalyst/pull/1605)
+
 <h3>Internal changes ⚙️</h3>
 
 * Updated the call signature for the PLXPR `qnode_prim` primitive.

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -371,6 +371,19 @@ class TestIntegration:
         assert np.allclose(fn(3)[0], tuple([jnp.array(6.0), jnp.array(9.0)]))
         assert np.allclose(fn(3)[1], tuple([jnp.array(2.0), jnp.array(6.0)]))
 
+    def test_ctrl_with_autograph(self):
+        """Test that qml.ctrl works when an operation is passed as argument."""
+        dev = qml.device("lightning.qubit", wires=2)
+
+        @qml.qjit(autograph=True)
+        @qml.qnode(dev)
+        def circuit():
+            qml.ctrl(qml.PauliX, control=1)(0)
+            return qml.probs(wires=0)
+
+        assert hasattr(circuit.user_function, "ag_unconverted")
+        assert jnp.allclose(circuit(), jnp.array([1.0, 0.0]))
+
     def test_tape_transform(self):
         """Test if tape transform is applied when autograph is on."""
 

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -397,6 +397,34 @@ class TestIntegration:
         assert hasattr(circuit.user_function, "ag_unconverted")
         assert jnp.allclose(circuit(), jnp.array([0.0, 1.0]))
 
+    def test_adjoint_no_argument(self):
+        """Test that passing no argument to qml.adjoint raises an error."""
+        with pytest.raises(ValueError, match="adjoint requires at least one argument"):
+            dev = qml.device("lightning.qubit", wires=2)
+
+            @qml.qjit(autograph=True)
+            @qml.qnode(dev)
+            def circuit():
+                qml.adjoint()
+                return qml.probs(wires=0)
+
+            circuit()
+
+    def test_adjoint_wrong_argument_type(self):
+        """Test that passing a non-callable/non-Operation to qml.adjoint raises an error."""
+        with pytest.raises(
+            ValueError, match="First argument to adjoint must be callable or an Operation"
+        ):
+            dev = qml.device("lightning.qubit", wires=2)
+
+            @qml.qjit(autograph=True)
+            @qml.qnode(dev)
+            def circuit():
+                qml.adjoint(3)
+                return qml.probs(wires=0)
+
+            circuit()
+
     def test_tape_transform(self):
         """Test if tape transform is applied when autograph is on."""
 

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -384,6 +384,19 @@ class TestIntegration:
         assert hasattr(circuit.user_function, "ag_unconverted")
         assert jnp.allclose(circuit(), jnp.array([1.0, 0.0]))
 
+    def test_adjoint_with_operation_as_argument(self):
+        """Test that qml.adjoint works when an operation is passed as argument."""
+        dev = qml.device("lightning.qubit", wires=2)
+
+        @qml.qjit(autograph=True)
+        @qml.qnode(dev)
+        def circuit():
+            qml.adjoint(qml.PauliX(0))
+            return qml.probs(wires=0)
+
+        assert hasattr(circuit.user_function, "ag_unconverted")
+        assert jnp.allclose(circuit(), jnp.array([0.0, 1.0]))
+
     def test_tape_transform(self):
         """Test if tape transform is applied when autograph is on."""
 

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -371,7 +371,7 @@ class TestIntegration:
         assert np.allclose(fn(3)[0], tuple([jnp.array(6.0), jnp.array(9.0)]))
         assert np.allclose(fn(3)[1], tuple([jnp.array(2.0), jnp.array(6.0)]))
 
-    def test_ctrl_with_autograph(self):
+    def test_ctrl_with_operation_as_argument(self):
         """Test that qml.ctrl works when an operation is passed as argument."""
         dev = qml.device("lightning.qubit", wires=2)
 

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -378,7 +378,7 @@ class TestIntegration:
         @qml.qjit(autograph=True)
         @qml.qnode(dev)
         def circuit():
-            qml.ctrl(qml.PauliX, control=1)(0)
+            qml.ctrl(qml.PauliX(0), control=1)
             return qml.probs(wires=0)
 
         assert hasattr(circuit.user_function, "ag_unconverted")


### PR DESCRIPTION
**Context:**
when transforming functions, autograph handles some Catalyst wrapper functions as special cases. This is added as a hotfix [here](https://github.com/PennyLaneAI/catalyst/blob/845851662af490a45bff92ec32b5d1aaef7e7b10/frontend/catalyst/autograph/ag_primitives.py#L537-L552). The hotfix assumes that catalyst wrapper functions always accept a `callable`. PR #1212 Adds two `qml` functions (`qml.adjoint` and `qml.ctrl`) to the list of specially handled wrappers. However, these are not pure wrappers in the sense that their `arg[0]` can be an operation object as opposed to a callable. 

**Description of the Change:**
Handle cases where the argument to the specially handled functions are operation objects and not callable.

TODO:
- [x] Add test for `qml.ctrl`
- [x] Add test for `qml.adjoint`
- [x] Add Changelog

**Benefits:**
autograph works in the case where `qml.ctrl` and `qml.adjoint` receive an operation as argument.

**Possible Drawbacks:**

**Related GitHub Issues:**
issue #1339 
[sc-79375]
