### PR TITLE
Fix edge-tracing bug in loops with insert sequences or cancellable/mergable gate pairs

### DIFF
--- a/mlir/lib/Quantum/Transforms/LoopBoundaryOptimizationPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/LoopBoundaryOptimizationPatterns.cpp
@@ -19,7 +19,6 @@
 
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/IR/Dominance.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Support/LogicalResult.h"
@@ -140,8 +139,8 @@ bool hasQuantumCustomPredecessor(CustomOp &op)
     return false;
 }
 
-// Return true if all operands of topOp are dominated by the bottomOp
-bool verifyDominance(CustomOp topOp, CustomOp bottomOp)
+// Return true if all operands of topOp are immediately after bottomOp in the IR
+bool verifyImmediatelyAfterwards(CustomOp topOp, CustomOp bottomOp)
 {
     for (auto [outQubit, inQubit] : llvm::zip(topOp.getOutQubits(), bottomOp.getInQubits())) {
         if (outQubit != inQubit) {
@@ -160,7 +159,7 @@ bool isValidEdgePair(const CustomOp &bottomOp, std::vector<QubitOrigin> &bottomQ
 
     if (bottomOpNonConst.getGateName() != topOpNonConst.getGateName() || topOp == bottomOp ||
         !verifyQubitOrigins(topQubitOrigins, bottomQubitOrigins) ||
-        verifyDominance(topOpNonConst, bottomOpNonConst) || hasQuantumCustomSuccessor(bottomOp) ||
+        verifyImmediatelyAfterwards(topOpNonConst, bottomOpNonConst) || hasQuantumCustomSuccessor(bottomOp) ||
         hasQuantumCustomPredecessor(topOpNonConst)) {
         return false;
     }

--- a/mlir/lib/Quantum/Transforms/LoopBoundaryOptimizationPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/LoopBoundaryOptimizationPatterns.cpp
@@ -140,7 +140,7 @@ bool hasQuantumCustomPredecessor(CustomOp &op)
 }
 
 // Return true if all operands of topOp are immediately after bottomOp in the IR
-bool verifyImmediatelyAfterwards(CustomOp topOp, CustomOp bottomOp)
+bool isSourceAndSink(CustomOp topOp, CustomOp bottomOp)
 {
     for (auto [outQubit, inQubit] : llvm::zip(topOp.getOutQubits(), bottomOp.getInQubits())) {
         if (outQubit != inQubit) {
@@ -159,7 +159,7 @@ bool isValidEdgePair(const CustomOp &bottomOp, std::vector<QubitOrigin> &bottomQ
 
     if (bottomOpNonConst.getGateName() != topOpNonConst.getGateName() || topOp == bottomOp ||
         !verifyQubitOrigins(topQubitOrigins, bottomQubitOrigins) ||
-        verifyImmediatelyAfterwards(topOpNonConst, bottomOpNonConst) || hasQuantumCustomSuccessor(bottomOp) ||
+        isSourceAndSink(topOpNonConst, bottomOpNonConst) || hasQuantumCustomSuccessor(bottomOp) ||
         hasQuantumCustomPredecessor(topOpNonConst)) {
         return false;
     }

--- a/mlir/lib/Quantum/Transforms/LoopBoundaryOptimizationPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/LoopBoundaryOptimizationPatterns.cpp
@@ -139,7 +139,9 @@ bool hasQuantumCustomPredecessor(CustomOp &op)
     return false;
 }
 
-// Return true if all operands of topOp are immediately after bottomOp in the IR
+// Return true if bottomOp is the immediate successor of topOp.
+// In this case, we don't want to perform loop boundary commutation,
+// as it would prevent a fix-point from being reached by the rewrite driver.
 bool isSourceAndSink(CustomOp topOp, CustomOp bottomOp)
 {
     for (auto [outQubit, inQubit] : llvm::zip(topOp.getOutQubits(), bottomOp.getInQubits())) {

--- a/mlir/lib/Quantum/Transforms/MergeRotationsPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/MergeRotationsPatterns.cpp
@@ -83,7 +83,8 @@ struct MergeRotationsRewritePattern : public mlir::OpRewritePattern<OpType> {
                                                  parentInQubits, opGateName, nullptr,
                                                  parentInCtrlQubits, parentInCtrlValues);
 
-        op.replaceAllUsesWith(mergeOp);
+        rewriter.replaceOp(op, mergeOp);
+        rewriter.eraseOp(parentOp);
 
         return success();
     }
@@ -122,7 +123,9 @@ struct MergeMultiRZRewritePattern : public mlir::OpRewritePattern<MultiRZOp> {
         auto mergeOp = rewriter.create<MultiRZOp>(loc, outQubitsTypes, outQubitsCtrlTypes, sumParam,
                                                   parentInQubits, nullptr, parentInCtrlQubits,
                                                   parentInCtrlValues);
-        op.replaceAllUsesWith(mergeOp);
+        rewriter.replaceOp(op, mergeOp);
+        rewriter.eraseOp(parentOp);
+
         return success();
     }
 };


### PR DESCRIPTION
**Context:**
- Fixes incorrect tracing of bottom edge operations when:
  - The loop terminator’s operations are a sequence of insert operations. 
   For example: `%18` and `%20`
   ```mlir
      . . . 
      %18 = quantum.insert %16[%extracted_2], %out_qubits_7 : !quantum.reg, !quantum.bit
      %19 = quantum.extract %18[ 0] : !quantum.reg -> !quantum.bit
      %out_qubits_8 = quantum.custom "Hadamard"() %19 : !quantum.bit
      %20 = quantum.insert %18[ 0], %out_qubits_8 : !quantum.reg, !quantum.bit
      scf.yield %20 : !quantum.reg
    }
   ```
  - The loop contains only two gates that can cancel or merge rotation. 
  For example:  `%out_qubits`  could be merge rotation with `%out_qubits_2`
  ```mlir
     %2 = scf.for %arg2 = %c0 to %1 step %c1 iter_args(%arg3 = %0) -> (!quantum.reg) {
       %6 = quantum.extract %arg3[ 0] : !quantum.reg -> !quantum.bit
       %out_qubits = quantum.custom "RX"(%cst_0) %6 : !quantum.bit
       %out_qubits_2 = quantum.custom "RX"(%cst) %out_qubits : !quantum.bit
       %7 = quantum.insert %arg3[ 0], %out_qubits_2 : !quantum.reg, !quantum.bit
       scf.yield %7 : !quantum.reg
    }
  ```
- Remove the operations that have no users in the merge rotation pass

**Description of the Change:**
- In `LoopBoundaryOptimizationPatterns.cpp`, updated `isValidEdgePair` to utilize the new `verifyDominance` function.
- In `MergeRotationsPatterns.cpp`, replaced `op.replaceAllUsesWith(mergeOp)` with `rewriter.replaceOp(op, mergeOp)` for consistency and erased the `parentOp` after replacement.

**Benefits:**
- Resolves edge-tracing bug.

[[sc-88289]]