### PR TITLE
Add jaxpr constants as parameters when binding grad function.

### DIFF
--- a/doc/releases/changelog-0.11.0.md
+++ b/doc/releases/changelog-0.11.0.md
@@ -266,6 +266,9 @@
   pytrees inside a loop with autograph causes falling back to python.
   [(#1601)](https://github.com/PennyLaneAI/catalyst/pull/1601)
 
+* Closure variables are now supported with `grad` and `value_and_grad`.
+  [(#1613)](https://github.com/PennyLaneAI/catalyst/pull/1613)
+
 <h3>Internal changes ⚙️</h3>
 
 * Updated the call signature for the PLXPR `qnode_prim` primitive.

--- a/frontend/catalyst/api_extensions/differentiation.py
+++ b/frontend/catalyst/api_extensions/differentiation.py
@@ -667,7 +667,7 @@ class GradCallable(CatalystCallable):
 
                     # It always returns list as required by catalyst control-flows
                     results = value_and_grad_p.bind(
-                        *input_data_flat, jaxpr=jaxpr, fn=fn, grad_params=grad_params
+                        *input_data_flat, *jaxpr.consts, jaxpr=jaxpr, fn=fn, grad_params=grad_params
                     )
 
                     # value_and_grad returns two results: the values and the gradients,
@@ -686,7 +686,7 @@ class GradCallable(CatalystCallable):
 
                     # It always returns list as required by catalyst control-flows
                     results = grad_p.bind(
-                        *input_data_flat, jaxpr=jaxpr, fn=fn, grad_params=grad_params
+                        *input_data_flat, *jaxpr.consts, jaxpr=jaxpr, fn=fn, grad_params=grad_params
                     )
 
                     # grad returns only the gradients,

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -501,7 +501,10 @@ def _grad_lowering(ctx, *args, jaxpr, fn, grad_params):
             differentiate.
     """
     consts_len = len(jaxpr.consts)
-    consts = args[-consts_len:]
+    if consts_len:
+        consts = args[-consts_len:]
+    else:
+        consts = tuple()
     method, h, argnums = grad_params.method, grad_params.h, grad_params.expanded_argnums
     mlir_ctx = ctx.module_context.context
     finiteDiffParam = None
@@ -523,7 +526,9 @@ def _grad_lowering(ctx, *args, jaxpr, fn, grad_params):
     # such constants to numpy array types.
 
     constants = list(consts)
-    args_and_consts = constants + list(args[:consts_len])
+    len_args = len(args)
+    index = len_args - consts_len
+    args_and_consts = constants + list(args[:index])
 
     return GradOp(
         flat_output_types,
@@ -560,8 +565,13 @@ def _value_and_grad_lowering(ctx, *args, jaxpr, fn, grad_params):
         MLIR results
     """
     consts_len = len(jaxpr.consts)
-    consts = list(args[-consts_len:])
-    args = list(args[:consts_len])
+    if consts_len:
+        consts = list(args[-consts_len:])
+    else:
+        consts = list()
+    len_args = len(args)
+    index = len_args - consts_len
+    args = list(args[0:index])
     method, h, argnums = grad_params.method, grad_params.h, grad_params.expanded_argnums
     mlir_ctx = ctx.module_context.context
     new_argnums = np.array([len(jaxpr.consts) + num for num in argnums])

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -507,8 +507,8 @@ def _grad_lowering(ctx, *args, jaxpr, fn, grad_params):
             jax_array_or_tracer, jax._src.interpreters.partial_eval.DynamicJaxprTracer
         ):
             # ``ir.DenseElementsAttr.get()`` constructs a dense elements attribute from an array of
-            # element values. This doesn't support ``jaxlib.xla_extension.Array``, so we have to cast
-            # such constants to numpy array types.
+            # element values. This doesn't support ``jaxlib.xla_extension.Array``, so we have to
+            # cast such constants to numpy array types.
             const = jax_array_or_tracer
             const_type = shape_dtype_to_ir_type(const.shape, const.dtype)
             nparray = np.asarray(const)
@@ -582,8 +582,8 @@ def _value_and_grad_lowering(ctx, *args, jaxpr, fn, grad_params):
             jax_array_or_tracer, jax._src.interpreters.partial_eval.DynamicJaxprTracer
         ):
             # ``ir.DenseElementsAttr.get()`` constructs a dense elements attribute from an array of
-            # element values. This doesn't support ``jaxlib.xla_extension.Array``, so we have to cast
-            # such constants to numpy array types.
+            # element values. This doesn't support ``jaxlib.xla_extension.Array``, so we have to
+            # cast such constants to numpy array types.
             const = jax_array_or_tracer
             const_type = shape_dtype_to_ir_type(const.shape, const.dtype)
             nparray = np.asarray(const)

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -568,7 +568,7 @@ def _value_and_grad_lowering(ctx, *args, jaxpr, fn, grad_params):
     if consts_len:
         consts = list(args[-consts_len:])
     else:
-        consts = list()
+        consts = []
     len_args = len(args)
     index = len_args - consts_len
     args = list(args[0:index])

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -2201,5 +2201,41 @@ class TestParameterShiftVerificationIntegrationTests:
                 return qml.expval(qml.PauliZ(wires=0))
 
 
+def test_closure_variable():
+    """Test that grad can take closure variables"""
+
+    @qml.qjit
+    def workflow_closure(x, y):
+
+        dev = qml.device("lightning.qubit", wires=1)
+
+        @qml.qnode(dev)
+        def circuit(x):
+            qml.RX(jnp.pi * x, wires=0)
+            qml.RX(jnp.pi * y, wires=0)
+            return qml.expval(qml.PauliY(0))
+
+        g = grad(circuit)
+        return g(x)
+
+    @qml.qjit
+    def workflow_no_closure(x, y):
+
+        dev = qml.device("lightning.qubit", wires=1)
+
+        @qml.qnode(dev)
+        def circuit(x, y):
+            qml.RX(jnp.pi * x, wires=0)
+            qml.RX(jnp.pi * y, wires=0)
+            return qml.expval(qml.PauliY(0))
+
+        g = grad(circuit)
+        return g(x, y)
+
+    expected = workflow_no_closure(1.0, 0.25)
+    observed = workflow_closure(1.0, 0.25)
+    assert np.allclose(expected, observed)
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -2237,8 +2237,8 @@ def test_closure_variable_grad():
     assert np.allclose(expected, observed)
 
 
-def test_closure_variable_jacobian():
-    """Test that jacobian can take closure variables"""
+def test_closure_variable_value_and_grad():
+    """Test that value and grad can take closure variables"""
 
     @qml.qjit
     def workflow_closure(x, y):
@@ -2247,11 +2247,11 @@ def test_closure_variable_jacobian():
 
         @qml.qnode(dev)
         def circuit(x):
-            qml.RX(jnp.pi * x[0], wires=0)
-            qml.RX(jnp.pi * y[0], wires=0)
+            qml.RX(jnp.pi * x, wires=0)
+            qml.RX(jnp.pi * y, wires=0)
             return qml.expval(qml.PauliY(0))
 
-        g = jacobian(circuit)
+        g = value_and_grad(circuit)
         return g(x)
 
     @qml.qjit
@@ -2261,14 +2261,14 @@ def test_closure_variable_jacobian():
 
         @qml.qnode(dev)
         def circuit(x, y):
-            qml.RX(jnp.pi * x[0], wires=0)
-            qml.RX(jnp.pi * y[0], wires=0)
+            qml.RX(jnp.pi * x, wires=0)
+            qml.RX(jnp.pi * y, wires=0)
             return qml.expval(qml.PauliY(0))
 
-        g = jacobian(circuit)
+        g = value_and_grad(circuit)
         return g(x, y)
 
-    x, y = jnp.array([1.0]), jnp.array([0.25])
+    x, y = 1.0, 0.25
     expected = workflow_no_closure(x, y)
     observed = workflow_closure(x, y)
     assert np.allclose(expected, observed)


### PR DESCRIPTION
**Context:** The `jaxpr.consts` are not being resolved by JAX under some circumstances. (It is unclear under which circumstances this happens at the moment). However, `jaxpr.consts` are available during bind time.

**Description of the Change:** We pass `jaxpr.consts` as parameters to the jax primitive. During stablehlo generation the jaxpr.consts are mlir Values.

**Benefits:** The test passes.

**Possible Drawbacks:** This has the disadvantage of creating more parameters as opposed to statically known values. E.g., consts are now parameters as opposed to literals in the function itself. To mitigate this, we only use the parameters as opposed to literals when the literals are not made available by JAX.

**Related GitHub Issues:**

[sc-88455]
