### PR TITLE
improve CLI verbose message

### DIFF
--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -327,7 +327,7 @@ def _options_to_cli_flags(options):
         pipeline_name, passes = pipeline
         passes_str = ";".join(passes)
         pipeline_str += f"{pipeline_name}({passes_str}),"
-    extra_args += ["--catalyst-pipeline", pipeline_str]
+    extra_args += ["--catalyst-pipeline", f'"{pipeline_str}"']
 
     for plugin in options.pass_plugins:
         extra_args += [("--load-pass-plugin", plugin)]


### PR DESCRIPTION
**Context:**
When using `qjit` with `verbose=True`, the CLI command that is printed is not reproducible if simply copied and pasted into terminal. 

**Description of the Change:**
wrapped the pipeline string with double quotation so parsing is done correctly when running the CLI via terminal.

**Benefits:**
easier debugging

**Possible Drawbacks:**
None

**Related GitHub Issues:**
