### PR TITLE
Replace 'qml.qjit' usage with 'qjit' in tests

### DIFF
--- a/frontend/test/lit/test_mcmc.py
+++ b/frontend/test/lit/test_mcmc.py
@@ -19,8 +19,10 @@ Test that mcmc, num_burnin, and kernel_name are set in MLIR
 
 import pennylane as qml
 
+from catalyst import qjit
 
-@qml.qjit
+
+@qjit
 @qml.qnode(
     qml.device(
         "lightning.qubit",

--- a/frontend/test/lit/test_meta_ops.py
+++ b/frontend/test/lit/test_meta_ops.py
@@ -16,9 +16,11 @@
 
 import pennylane as qml
 
+from catalyst import qjit
+
 
 # CHECK-LABEL: @adjoint_adjoint
-@qml.qjit(target="mlir")
+@qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=1))
 def adjoint_adjoint():
     qml.adjoint(qml.adjoint(qml.S(0)))
@@ -33,7 +35,7 @@ print(adjoint_adjoint.mlir)
 
 
 # CHECK-LABEL: @adjoint_ctrl_adjoint
-@qml.qjit(target="mlir")
+@qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=2))
 def adjoint_ctrl_adjoint():
     qml.adjoint(qml.ctrl(qml.adjoint(qml.S(0)), control=1))

--- a/frontend/test/lit/test_mid_circuit_measurement.py
+++ b/frontend/test/lit/test_mid_circuit_measurement.py
@@ -16,10 +16,10 @@
 
 import pennylane as qml
 
-from catalyst import measure
+from catalyst import measure, qjit
 
 
-@qml.qjit(target="mlir")
+@qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=1))
 def circuit(x: float):
     qml.RX(x, wires=0)

--- a/frontend/test/lit/test_mlir_plugin.py
+++ b/frontend/test/lit/test_mlir_plugin.py
@@ -32,6 +32,7 @@ something like the following:
 
   ```python
   import pennylane as qml
+  from catalyst import qjit
   from pathlib import Path
 
   from catalyst.passes import apply_pass
@@ -43,7 +44,7 @@ something like the following:
   def bar():
     return qml.state()
 
-  @qml.qjit(keep_intermediate=True, verbose=True, pass_plugins=[plugin], dialect_plugins=[plugin])
+  @qjit(keep_intermediate=True, verbose=True, pass_plugins=[plugin], dialect_plugins=[plugin])
   def module():
     return bar()
 

--- a/frontend/test/lit/test_qfunc_caching.py
+++ b/frontend/test/lit/test_qfunc_caching.py
@@ -17,10 +17,10 @@
 import jax.numpy as jnp
 import pennylane as qml
 
-from catalyst import measure
+from catalyst import measure, qjit
 
 
-@qml.qjit(target="mlir")
+@qjit(target="mlir")
 def workflow(n: int):
     @qml.qnode(qml.device("lightning.qubit", wires=1))
     # CHECK-LABEL: public @f

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -448,7 +448,7 @@ class TestCatalyst:
     def test_adjoint_wires(self, backend):
         """Test the wires property of Adjoint"""
 
-        @qml.qjit
+        @qjit
         @qml.qnode(qml.device(backend, wires=3))
         def circuit(theta):
             def func(theta):
@@ -465,7 +465,7 @@ class TestCatalyst:
     def test_adjoint_wires_qubitunitary(self, backend):
         """Test the wires property of nested Adjoint with QubitUnitary"""
 
-        @qml.qjit
+        @qjit
         @qml.qnode(qml.device(backend, wires=3))
         def circuit():
             def func():
@@ -498,7 +498,7 @@ class TestCatalyst:
             qml.RY(theta / 2, wires=w1)
             qml.RZ(theta, wires=2)
 
-        @qml.qjit
+        @qjit
         @qml.qnode(device)
         def C_workflow(w0, w1, theta):
             qml.PauliX(wires=0)
@@ -517,7 +517,7 @@ class TestCatalyst:
     def test_adjoint_wires_controlflow(self, backend):
         """Test the wires property of Adjoint  in a conditional branch"""
 
-        @qml.qjit
+        @qjit
         @qml.qnode(qml.device(backend, wires=3))
         def circuit():
             def func(pred, theta):
@@ -1646,7 +1646,7 @@ class TestMidCircuitMeasurementAfterAdjoint:
         def subroutine():
             qml.Hadamard(wires=1)
 
-        @qml.qjit()
+        @qjit()
         @qml.qnode(qml.device("lightning.qubit", wires=2))
         def circuit():
             # Comment/uncomment to toggle bug

--- a/frontend/test/pytest/test_callback.py
+++ b/frontend/test/pytest/test_callback.py
@@ -62,7 +62,7 @@ def test_callback_no_returns_no_params(capsys):
     def my_callback() -> None:
         print("Hello erick")
 
-    @qml.qjit
+    @qjit
     def cir():
         my_callback()
         return None
@@ -82,7 +82,7 @@ def test_callback_twice(capsys):
     def my_callback():
         print("Hello erick")
 
-    @qml.qjit
+    @qjit
     def cir():
         my_callback()
         return None
@@ -94,7 +94,7 @@ def test_callback_twice(capsys):
     captured = capsys.readouterr()
     assert captured.out.strip() == "Hello erick"
 
-    @qml.qjit
+    @qjit
     def cir2():
         my_callback()
         return None
@@ -114,7 +114,7 @@ def test_callback_send_param(capsys):
     def my_callback(n) -> None:
         print(n)
 
-    @qml.qjit
+    @qjit
     def cir(n):
         my_callback(n)
         return None
@@ -132,7 +132,7 @@ def test_kwargs(capsys):
         for k, v in kwargs.items():
             print(k, v)
 
-    @qml.qjit
+    @qjit
     def cir(a, b, c):
         my_callback(a=a, b=b, c=c, d=3, e=4)
         return None
@@ -153,7 +153,7 @@ def test_simple_increment():
     def inc(arg) -> int:
         return arg + 1
 
-    @qml.qjit
+    @qjit
     def cir(arg):
         return inc(arg)
 
@@ -175,7 +175,7 @@ def test_identity_types(arg):
         that you know will be the same type as the return type."""
         return arg
 
-    @qml.qjit
+    @qjit
     def cir(x):
         return identity(x)
 
@@ -193,7 +193,7 @@ def test_identity_types_shaped_array(arg):
     def identity(arg) -> jax.core.ShapedArray([], int):
         return arg
 
-    @qml.qjit
+    @qjit
     def cir(x):
         return identity(x)
 
@@ -211,7 +211,7 @@ def test_multiple_returns(arg):
     def identity(arg) -> (int, int):
         return arg, arg
 
-    @qml.qjit
+    @qjit
     def cir(x):
         return identity(x)
 
@@ -229,7 +229,7 @@ def test_incorrect_return(arg):
     def identity(arg) -> int:
         return arg
 
-    @qml.qjit
+    @qjit
     def cir(x):
         return identity(x)
 
@@ -249,7 +249,7 @@ def test_pure_callback():
     def identity(a):
         return a
 
-    @qml.qjit
+    @qjit
     def cir(x):
         return pure_callback(identity, float)(x)
 
@@ -263,7 +263,7 @@ def test_pure_callback_decorator():
     def identity(a) -> float:
         return a
 
-    @qml.qjit
+    @qjit
     def cir(x):
         return identity(x)
 
@@ -276,7 +276,7 @@ def test_pure_callback_no_return_value():
     def identity(a):
         return a
 
-    @qml.qjit
+    @qjit
     def cir(x):
         return pure_callback(identity)(x)
 
@@ -292,7 +292,7 @@ def test_debug_callback(capsys):
     def my_own_print(a):
         print(a)
 
-    @qml.qjit
+    @qjit
     def cir(x):
         debug.callback(my_own_print)(x)
         return None
@@ -312,7 +312,7 @@ def test_debug_callback_decorator(capsys):
     def my_own_print(a):
         print(a)
 
-    @qml.qjit
+    @qjit
     def cir(x):
         my_own_print(x)
         return None
@@ -332,7 +332,7 @@ def test_debug_callback_returns_something(capsys):
         print(a)
         return 1
 
-    @qml.qjit
+    @qjit
     def cir(x):
         debug.callback(my_own_print)(x)
         return None
@@ -367,7 +367,7 @@ def test_io_callback_modify_global(capsys):
         nonlocal x
         print(x)
 
-    @qml.qjit
+    @qjit
     def cir():
         print_x()
         set_x_to(1)
@@ -390,7 +390,7 @@ def test_no_return_list(arg):
     def callback_fn(x) -> float:
         return np.sin(x)
 
-    @qml.qjit
+    @qjit
     def f(x):
         res = callback_fn(x**2)
         assert not isinstance(res, Sequence)
@@ -414,7 +414,7 @@ def test_dictionary(arg):
     def callback_fn(x) -> {"helloworld": arg}:
         return {"helloworld": x}
 
-    @qml.qjit
+    @qjit
     def f(x):
         return callback_fn(x)["helloworld"]
 
@@ -428,7 +428,7 @@ def test_tuple_out():
     def callback_fn(x) -> (bool, bool):
         return x > 1.0, x > 2.0
 
-    @qml.qjit
+    @qjit
     def f(x):
         res = callback_fn(x**2)
         assert isinstance(res, tuple) and len(res) == 2
@@ -440,7 +440,7 @@ def test_tuple_out():
 def test_numpy_ufuncs():
     """Test with numpy ufuncs."""
 
-    @qml.qjit
+    @qjit
     def f(x):
         y = pure_callback(np.sin, float)(x)
         return y
@@ -459,7 +459,7 @@ def test_accelerate_device(arg):
     def identity(x):
         return x
 
-    @qml.qjit
+    @qjit
     def qjitted_fn(x):
         return identity(x)
 
@@ -477,7 +477,7 @@ def test_accelerate_no_device(arg):
     def identity(x):
         return x
 
-    @qml.qjit
+    @qjit
     def qjitted_fn(x):
         return identity(x)
 
@@ -491,7 +491,7 @@ def test_accelerate_no_device(arg):
 def test_accelerate_no_device_inside(arg):
     """Test with no device parameter accelerate is inside qjit"""
 
-    @qml.qjit
+    @qjit
     def qjitted_fn(x):
         @accelerate
         def identity(x):
@@ -513,7 +513,7 @@ def test_accelerate_no_device_autograph(arg):
     def identity(x):
         return x
 
-    @qml.qjit(autograph=True)
+    @qjit(autograph=True)
     def qjitted_fn(x):
         return identity(x)
 
@@ -532,7 +532,7 @@ def test_accelerate_manual_jax_jit(arg):
     def identity(x):
         return x
 
-    @qml.qjit
+    @qjit
     def qjitted_fn(x):
         return identity(x)
 
@@ -546,7 +546,7 @@ def test_jax_jit_returns_nothing(capsys):
     def noop(x):
         jax.debug.print("x={x}", x=x)
 
-    @qml.qjit
+    @qjit
     def func(x: float):
         noop(x)
         return x
@@ -571,7 +571,7 @@ def test_non_jax_jittable():
     msg = "Function impossible must be jax.jit-able"
     with pytest.raises(ValueError, match=msg):
 
-        @qml.qjit
+        @qjit
         def func(x: bool):
             return impossible(x)
 
@@ -594,7 +594,7 @@ def test_that_jax_jit_is_called():
         def identity(x):
             return x
 
-        @qml.qjit
+        @qjit
         def wrapper(x):
             return identity(x)
 
@@ -610,7 +610,7 @@ def test_callback_cache():
     def hello_world():
         print("hello world")
 
-    @qml.qjit
+    @qjit
     def wrapper():
         hello_world()
         hello_world()
@@ -621,7 +621,7 @@ def test_inactive_debug_grad(capsys, arg):
     """Test that debug callback can be differentiated
     and not affects the output"""
 
-    @qml.qjit
+    @qjit
     @grad
     def identity(x: float):
         debug.print(x)
@@ -641,7 +641,7 @@ def test_inactive_debug_jacobian(capsys, arg):
     """Test that debug callback can be differentiated
     and not affects the output"""
 
-    @qml.qjit
+    @qjit
     @jacobian
     def identity(x):
         debug.print(x)
@@ -678,7 +678,7 @@ def test_active_grad_no_tape(scale):
     def bwd(_res, cot):
         return cot
 
-    @qml.qjit
+    @qjit
     @grad
     def wrapper(x):
         return scale * identity(x)
@@ -702,7 +702,7 @@ def test_active_grad_tape(scale):
     def bwd(res, cot):
         return cot * res
 
-    @qml.qjit
+    @qjit
     @grad
     def wrapper(x):
         return scale * identity(x)
@@ -728,7 +728,7 @@ def test_active_grad_many_residuals(scale, space):
     def bwd(res, cot):
         return cot * sum(res)
 
-    @qml.qjit
+    @qjit
     @grad
     def wrapper(x):
         return scale * identity(x)
@@ -757,7 +757,7 @@ def test_active_jacobian_many_residuals(scale, space):
     def bwd(res, cot):
         return cot * sum(res)
 
-    @qml.qjit
+    @qjit
     @jacobian
     def wrapper(x):
         return scale * identity(x)
@@ -790,7 +790,7 @@ def test_example_from_story(arg0, arg1):
         cos_x, sin_x, y = res  # Gets residuals computed in f_fwd
         return (cos_x * dy * y, sin_x * dy)
 
-    @qml.qjit
+    @qjit
     @grad
     def cost(x, y):
         return jnp.sin(some_func(jnp.cos(x), y))
@@ -821,7 +821,7 @@ def test_active_grad_inside_qjit(backend, scale):
     def bwd(_res, cot):
         return cot
 
-    @qml.qjit
+    @qjit
     @grad
     @qml.qnode(qml.device(backend, wires=1))
     def wrapper(x):
@@ -862,7 +862,7 @@ def test_array_input(arg):
         # parameter of the same shape
         return (jnp.array([cos_x0 * dy * x1, sin_x0 * dy]),)
 
-    @qml.qjit
+    @qjit
     @grad
     def cost(x):
         y = jnp.array([jnp.cos(x[0]), x[1]])
@@ -893,7 +893,7 @@ def test_array_in_scalar_out():
         cos_x0, sin_x0, x1 = res
         return (jnp.array([cos_x0 * dy * x1, sin_x0 * dy]),)
 
-    @qml.qjit
+    @qjit
     @grad
     def result(x):
         y = jnp.array([jnp.cos(x[0]), x[1]])
@@ -928,7 +928,7 @@ def test_scalar_in_array_out(dtype):
         x = res
         return (jnp.array([jnp.cos(x), -jnp.sin(x)]) @ dy,)
 
-    @qml.qjit
+    @qjit
     @grad
     def result(x):
         return jnp.sum(some_func(jnp.sin(x)))
@@ -961,7 +961,7 @@ def test_scalar_in_array_out_float32_wrong():
         x = res
         return (jnp.array([jnp.cos(x), -jnp.sin(x)]) @ dy,)
 
-    @qml.qjit
+    @qjit
     @grad
     def result(x):
         return jnp.sum(some_func(jnp.sin(x)))
@@ -998,7 +998,7 @@ def test_scalar_in_tuple_scalar_array_out():
         vjp1 = jnp.array([jnp.cos(x), -jnp.sin(x)]) @ dy[1]
         return (vjp0 + vjp1,)
 
-    @qml.qjit
+    @qjit
     @grad
     def result(x):
         a, b = some_func(jnp.sin(x))
@@ -1039,7 +1039,7 @@ def test_array_in_tuple_array_out():
         vjp1 = 2 * x * dy[1]
         return (vjp0 + vjp1,)
 
-    @qml.qjit
+    @qjit
     @grad
     def result(x):
         return jnp.dot(*some_func(jnp.sin(x)))
@@ -1076,7 +1076,7 @@ def test_tuple_array_in_tuple_array_out():
         vjp1 = dy[0] @ jnp.sin(x) + 2 * y * dy[1]
         return (vjp0, vjp1)
 
-    @qml.qjit
+    @qjit
     @partial(grad, argnums=[0, 1])
     def result(x, y):
         return jnp.dot(*some_func(x, y**2))
@@ -1121,7 +1121,7 @@ def test_pytree_in_pytree_out():
         vjp1 = dy["one"] @ jnp.sin(res["x"]) + 2 * res["y"] * dy["two"]
         return ({"x": vjp0, "y": vjp1},)
 
-    @qml.qjit
+    @qjit
     @grad
     def result(weights):
         weights["y"] = weights["y"] ** 2
@@ -1178,7 +1178,7 @@ def test_callback_backwards_function():
     def some_func_bwd(res, dy):
         return some_func_bwd_vjp(res, dy)
 
-    @qml.qjit
+    @qjit
     @grad
     def result(weights):
         weights["y"] = weights["y"] ** 2
@@ -1235,7 +1235,7 @@ def test_different_shapes():
     def fun_bwd(_res, cot):
         return fun_bwd_callback(cot)
 
-    @qml.qjit
+    @qjit
     @jacobian
     def wrapper(x):
         return fun_callback(x)
@@ -1287,7 +1287,7 @@ def test_multiply_two_matrices_to_get_something_with_different_dimensions():
     def matrix_multiply_bwd(_residuals, cotangents):
         return matrix_multiply_vjp(cotangents)
 
-    @qml.qjit
+    @qjit
     @jacobian
     def mul(X):
         return matrix_multiply_callback(X)
@@ -1339,7 +1339,7 @@ def test_multiply_two_matrices_to_get_something_with_different_dimensions2():
     def matrix_multiply_bwd(_residuals, cotangents):
         return matrix_multiply_vjp(cotangents)
 
-    @qml.qjit
+    @qjit
     @jacobian
     def mul(X, Y):
         return matrix_multiply_callback(X, Y)
@@ -1393,7 +1393,7 @@ def test_multiply_two_matrices_to_get_something_with_different_dimensions3():
     def matrix_multiply_bwd(_residuals, cotangents):
         return matrix_multiply_vjp(cotangents)
 
-    @qml.qjit
+    @qjit
     @jacobian(argnums=[0, 1])
     def mul(X, Y):
         return matrix_multiply_callback(X, Y)
@@ -1427,7 +1427,7 @@ def test_vjp_as_residual(arg, order):
 
         return callback_fn
 
-    @qml.qjit
+    @qjit
     @jacobian
     def hypothesis(x):
         expm = jax_callback(jax.scipy.linalg.expm, jax.ShapeDtypeStruct((2, 2), jnp.float64))
@@ -1451,7 +1451,7 @@ def test_vjp_as_residual(arg, order):
 def test_vjp_as_residual_automatic(arg, order):
     """Test automatic differentiation of accelerated function"""
 
-    @qml.qjit
+    @qjit
     @jacobian
     def hypothesis(x):
         return accelerate(jax.scipy.linalg.expm)(x)
@@ -1473,7 +1473,7 @@ def test_vjp_as_residual_automatic(arg, order):
 def test_example_from_epic(arg):
     """Test example from epic"""
 
-    @qml.qjit
+    @qjit
     @grad
     def hypothesis(x):
         expm = accelerate(jax.scipy.linalg.expm)
@@ -1493,7 +1493,7 @@ def test_example_from_epic(arg):
 def test_automatic_differentiation_of_accelerate():
     """Same but easier"""
 
-    @qml.qjit
+    @qjit
     @grad
     @accelerate
     def identity(x: float):
@@ -1543,7 +1543,7 @@ def test_error_incomplete_grad_only_reverse():
 def test_nested_accelerate_grad():
     """https://github.com/PennyLaneAI/catalyst/issues/1086"""
 
-    @qml.qjit
+    @qjit
     @grad
     def hypothesis(x):
         return accelerate(accelerate(jnp.sin))(x)

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -20,6 +20,7 @@ import pytest
 from jax.core import ShapedArray
 
 import catalyst
+from catalyst import qjit
 
 
 def circuit_aot_builder(dev):
@@ -182,7 +183,7 @@ class TestCapture:
         """Test the integration for a circuit with adjoint."""
         device = qml.device(backend, wires=2)
 
-        @qml.qjit(experimental_capture=True)
+        @qjit(experimental_capture=True)
         @qml.qnode(device)
         def catalyst_circuit(theta, val):
             qml.adjoint(qml.RY)(jnp.pi, val)
@@ -205,7 +206,7 @@ class TestCapture:
         """Test the integration for a circuit with control."""
         device = qml.device(backend, wires=3)
 
-        @qml.qjit(experimental_capture=True)
+        @qjit(experimental_capture=True)
         @qml.qnode(device)
         def catalyst_circuit(theta):
             qml.ctrl(qml.RX(theta, wires=0), control=[1], control_values=[False])
@@ -226,7 +227,7 @@ class TestCapture:
     def test_forloop(self, backend, theta):
         """Test the integration for a circuit with a for loop."""
 
-        @qml.qjit(experimental_capture=True)
+        @qjit(experimental_capture=True)
         @qml.qnode(qml.device(backend, wires=4))
         def catalyst_capture_circuit(x):
 
@@ -268,8 +269,8 @@ class TestCapture:
 
             return qml.expval(qml.Z(0))
 
-        default_capture_result = qml.qjit(circuit)(10, 0.3)
-        experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(10, 0.3)
+        default_capture_result = qjit(circuit)(10, 0.3)
+        experimental_capture_result = qjit(circuit, experimental_capture=True)(10, 0.3)
         assert default_capture_result == experimental_capture_result
 
     def test_nested_loops(self, backend):
@@ -299,8 +300,8 @@ class TestCapture:
             # Expected output: |100...>
             return qml.state()
 
-        default_capture_result = qml.qjit(circuit)(4)
-        experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(4)
+        default_capture_result = qjit(circuit)(4)
+        experimental_capture_result = qjit(circuit, experimental_capture=True)(4)
         assert jnp.allclose(default_capture_result, jnp.eye(2**4)[0])
         assert jnp.allclose(experimental_capture_result, default_capture_result)
 
@@ -324,16 +325,16 @@ class TestCapture:
 
             return qml.expval(qml.Z(0))
 
-        default_capture_result_10_iterations = qml.qjit(circuit)(0)
-        experimental_capture_result_10_iterations = qml.qjit(circuit, experimental_capture=True)(0)
+        default_capture_result_10_iterations = qjit(circuit)(0)
+        experimental_capture_result_10_iterations = qjit(circuit, experimental_capture=True)(0)
         assert default_capture_result_10_iterations == experimental_capture_result_10_iterations
 
-        default_capture_result_1_iteration = qml.qjit(circuit)(9)
-        experimental_capture_result_1_iteration = qml.qjit(circuit, experimental_capture=True)(9)
+        default_capture_result_1_iteration = qjit(circuit)(9)
+        experimental_capture_result_1_iteration = qjit(circuit, experimental_capture=True)(9)
         assert default_capture_result_1_iteration == experimental_capture_result_1_iteration
 
-        default_capture_result_0_iterations = qml.qjit(circuit)(11)
-        experimental_capture_result_0_iterations = qml.qjit(circuit, experimental_capture=True)(11)
+        default_capture_result_0_iterations = qjit(circuit)(11)
+        experimental_capture_result_0_iterations = qjit(circuit, experimental_capture=True)(11)
         assert default_capture_result_0_iterations == experimental_capture_result_0_iterations
 
     def test_while_loop_workflow_closure(self, backend):
@@ -357,8 +358,8 @@ class TestCapture:
 
             return qml.expval(qml.Z(0))
 
-        default_capture_result = qml.qjit(circuit)(0, 2)
-        experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(0, 2)
+        default_capture_result = qjit(circuit)(0, 2)
+        experimental_capture_result = qjit(circuit, experimental_capture=True)(0, 2)
         assert default_capture_result == experimental_capture_result
 
     def test_while_loop_workflow_nested(self, backend):
@@ -388,8 +389,8 @@ class TestCapture:
 
             return qml.expval(qml.Z(0))
 
-        default_capture_result = qml.qjit(circuit)(0, 0)
-        experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(0, 0)
+        default_capture_result = qjit(circuit)(0, 0)
+        experimental_capture_result = qjit(circuit, experimental_capture=True)(0, 0)
         assert default_capture_result == experimental_capture_result
 
     def test_cond_workflow_if_else(self, backend):
@@ -409,8 +410,8 @@ class TestCapture:
 
             return qml.expval(qml.Z(0))
 
-        default_capture_result = qml.qjit(circuit)(0.1)
-        experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(0.1)
+        default_capture_result = qjit(circuit)(0.1)
+        experimental_capture_result = qjit(circuit, experimental_capture=True)(0.1)
         assert default_capture_result == experimental_capture_result
 
     def test_cond_workflow_if(self, backend):
@@ -427,8 +428,8 @@ class TestCapture:
 
             return qml.expval(qml.Z(0))
 
-        default_capture_result = qml.qjit(circuit)(1.5)
-        experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(1.5)
+        default_capture_result = qjit(circuit)(1.5)
+        experimental_capture_result = qjit(circuit, experimental_capture=True)(1.5)
         assert default_capture_result == experimental_capture_result
 
     def test_cond_workflow_with_custom_primitive(self, backend):
@@ -451,8 +452,8 @@ class TestCapture:
 
             return qml.expval(qml.Z(0))
 
-        default_capture_result = qml.qjit(circuit)(0.1)
-        experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(0.1)
+        default_capture_result = qjit(circuit)(0.1)
+        experimental_capture_result = qjit(circuit, experimental_capture=True)(0.1)
         assert default_capture_result == experimental_capture_result
 
     def test_cond_workflow_with_abstract_measurement(self, backend):
@@ -475,8 +476,8 @@ class TestCapture:
 
             return qml.expval(qml.Z(0))
 
-        default_capture_result = qml.qjit(circuit)(0.1)
-        experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(0.1)
+        default_capture_result = qjit(circuit)(0.1)
+        experimental_capture_result = qjit(circuit, experimental_capture=True)(0.1)
         assert default_capture_result == experimental_capture_result
 
     def test_cond_workflow_with_simple_primitive(self, backend):
@@ -499,8 +500,8 @@ class TestCapture:
 
             return qml.expval(qml.Z(0))
 
-        default_capture_result = qml.qjit(circuit)(0.1)
-        experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(0.1)
+        default_capture_result = qjit(circuit)(0.1)
+        experimental_capture_result = qjit(circuit, experimental_capture=True)(0.1)
         assert default_capture_result == experimental_capture_result
 
     def test_cond_workflow_nested(self, backend):
@@ -527,8 +528,8 @@ class TestCapture:
 
             return qml.expval(qml.Z(0))
 
-        default_capture_result = qml.qjit(circuit)(0.1, 1.5)
-        experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(0.1, 1.5)
+        default_capture_result = qjit(circuit)(0.1, 1.5)
+        experimental_capture_result = qjit(circuit, experimental_capture=True)(0.1, 1.5)
         assert default_capture_result == experimental_capture_result
 
     def test_cond_workflow_operator(self, backend):
@@ -542,8 +543,8 @@ class TestCapture:
 
             return qml.expval(qml.Z(0))
 
-        default_capture_result = qml.qjit(circuit)(0.1)
-        experimental_capture_result = qml.qjit(circuit, experimental_capture=True)(0.1)
+        default_capture_result = qjit(circuit)(0.1)
+        experimental_capture_result = qjit(circuit, experimental_capture=True)(0.1)
         assert default_capture_result == experimental_capture_result
 
     def test_transform_cancel_inverses_workflow(self, backend):
@@ -560,10 +561,10 @@ class TestCapture:
 
             return circuit(x)
 
-        captured_func = qml.qjit(func, experimental_capture=True, target="mlir")
+        captured_func = qjit(func, experimental_capture=True, target="mlir")
         assert 'transform.apply_registered_pass "remove-chained-self-inverse"' in captured_func.mlir
 
-        no_capture_result = qml.qjit(func)(0.1)
+        no_capture_result = qjit(func)(0.1)
         experimental_capture_result = captured_func(0.1)
         assert no_capture_result == experimental_capture_result
 
@@ -581,10 +582,10 @@ class TestCapture:
 
             return circuit(x)
 
-        captured_func = qml.qjit(func, experimental_capture=True, target="mlir")
+        captured_func = qjit(func, experimental_capture=True, target="mlir")
         assert 'transform.apply_registered_pass "merge-rotations"' in captured_func.mlir
 
-        no_capture_result = qml.qjit(func)(0.1)
+        no_capture_result = qjit(func)(0.1)
         experimental_capture_result = captured_func(0.1)
         assert no_capture_result == experimental_capture_result
 
@@ -609,21 +610,17 @@ class TestCapture:
         def inverses_rotations(x: float):
             return qml.transforms.cancel_inverses(qml.transforms.merge_rotations(circuit))(x)
 
-        inverses_rotations_func = qml.qjit(
-            inverses_rotations, experimental_capture=True, target="mlir"
-        )
+        inverses_rotations_func = qjit(inverses_rotations, experimental_capture=True, target="mlir")
         assert has_catalyst_transforms(inverses_rotations_func.mlir)
 
         def rotations_inverses(x: float):
             return qml.transforms.merge_rotations(qml.transforms.cancel_inverses(circuit))(x)
 
-        rotations_inverses_func = qml.qjit(
-            rotations_inverses, experimental_capture=True, target="mlir"
-        )
+        rotations_inverses_func = qjit(rotations_inverses, experimental_capture=True, target="mlir")
         assert has_catalyst_transforms(rotations_inverses_func.mlir)
 
-        no_capture_inverses_rotations_result = qml.qjit(inverses_rotations)(0.1)
-        no_capture_rotations_inverses_result = qml.qjit(rotations_inverses)(0.1)
+        no_capture_inverses_rotations_result = qjit(inverses_rotations)(0.1)
+        no_capture_rotations_inverses_result = qjit(rotations_inverses)(0.1)
         inverses_rotations_result = inverses_rotations_func(0.1)
         rotations_inverses_result = rotations_inverses_func(0.1)
         assert (
@@ -645,12 +642,12 @@ class TestCapture:
 
             return circuit(U)
 
-        captured_func = qml.qjit(func, experimental_capture=True, target="mlir")
+        captured_func = qjit(func, experimental_capture=True, target="mlir")
         assert is_unitary_rotated(captured_func.mlir)
 
         U = qml.Rot(1.0, 2.0, 3.0, wires=0)
 
-        no_capture_result = qml.qjit(func)(U.matrix())
+        no_capture_result = qjit(func)(U.matrix())
         experimental_capture_result = captured_func(U.matrix())
         assert no_capture_result == experimental_capture_result
 
@@ -671,7 +668,7 @@ class TestCapture:
         def inverses_unitary(U: ShapedArray([2, 2], float)):
             return qml.transforms.cancel_inverses(qml.transforms.unitary_to_rot(circuit))(U)
 
-        inverses_unitary_func = qml.qjit(inverses_unitary, experimental_capture=True, target="mlir")
+        inverses_unitary_func = qjit(inverses_unitary, experimental_capture=True, target="mlir")
 
         # Catalyst 'cancel_inverses' should have been scheduled as a pass
         # whereas PL 'unitary_to_rot' should have been expanded
@@ -687,7 +684,7 @@ class TestCapture:
         def unitary_inverses(U: ShapedArray([2, 2], float)):
             return qml.transforms.unitary_to_rot(qml.transforms.cancel_inverses(circuit))(U)
 
-        unitary_inverses_func = qml.qjit(unitary_inverses, experimental_capture=True, target="mlir")
+        unitary_inverses_func = qjit(unitary_inverses, experimental_capture=True, target="mlir")
 
         # Both PL transforms should have been expaned and no Catalyst pass should have been
         # scheduled
@@ -702,8 +699,8 @@ class TestCapture:
 
         U = qml.Rot(1.0, 2.0, 3.0, wires=0)
 
-        no_capture_inverses_unitary_result = qml.qjit(inverses_unitary)(U.matrix())
-        no_capture_unitary_inverses_result = qml.qjit(unitary_inverses)(U.matrix())
+        no_capture_inverses_unitary_result = qjit(inverses_unitary)(U.matrix())
+        no_capture_unitary_inverses_result = qjit(unitary_inverses)(U.matrix())
         inverses_unitary_result = inverses_unitary_func(U.matrix())
         unitary_inverses_result = unitary_inverses_func(U.matrix())
         assert (
@@ -724,11 +721,11 @@ class TestCapture:
 
             return qml.transforms.decompose(circuit, gate_set=[qml.RX, qml.RY, qml.RZ])(x, y, z)
 
-        captured_func = qml.qjit(func, experimental_capture=True, target="mlir")
+        captured_func = qjit(func, experimental_capture=True, target="mlir")
 
         assert is_rot_decomposed(captured_func.mlir)
 
-        no_capture_result = qml.qjit(func)(1.5, 2.5, 3.5)
+        no_capture_result = qjit(func)(1.5, 2.5, 3.5)
         experimental_capture_result = captured_func(1.5, 2.5, 3.5)
         assert no_capture_result == experimental_capture_result
 
@@ -744,11 +741,11 @@ class TestCapture:
 
             return circuit(x)
 
-        captured_func = qml.qjit(func, experimental_capture=True, target="mlir")
+        captured_func = qjit(func, experimental_capture=True, target="mlir")
 
         assert is_wire_mapped(captured_func.mlir)
 
-        no_capture_result = qml.qjit(func)(1.5)
+        no_capture_result = qjit(func)(1.5)
         experimental_capture_result = captured_func(1.5)
         assert no_capture_result == experimental_capture_result
 
@@ -768,11 +765,11 @@ class TestCapture:
 
             return circuit()
 
-        captured_func = qml.qjit(func, experimental_capture=True, target="mlir")
+        captured_func = qjit(func, experimental_capture=True, target="mlir")
 
         assert is_single_qubit_fusion_applied(captured_func.mlir)
 
-        no_capture_result = qml.qjit(func)()
+        no_capture_result = qjit(func)()
         experimental_capture_result = captured_func()
         assert no_capture_result == experimental_capture_result
 
@@ -792,7 +789,7 @@ class TestCapture:
 
             return qml.transforms.commute_controlled(circuit, direction="left")()
 
-        captured_func = qml.qjit(func, experimental_capture=True, target="mlir")
+        captured_func = qjit(func, experimental_capture=True, target="mlir")
 
         assert is_controlled_pushed_back(
             captured_func.mlir, 'quantum.custom "RX"', 'quantum.custom "CNOT"'
@@ -801,7 +798,7 @@ class TestCapture:
             captured_func.mlir, 'quantum.custom "PauliX"', 'quantum.custom "CRX"'
         )
 
-        no_capture_result = qml.qjit(func)()
+        no_capture_result = qjit(func)()
         experimental_capture_result = captured_func()
         assert no_capture_result == experimental_capture_result
 
@@ -818,11 +815,11 @@ class TestCapture:
 
             return circuit()
 
-        captured_func = qml.qjit(func, experimental_capture=True, target="mlir")
+        captured_func = qjit(func, experimental_capture=True, target="mlir")
 
         assert is_amplitude_embedding_merged_and_decomposed(captured_func.mlir)
 
-        no_capture_result = qml.qjit(func)()
+        no_capture_result = qjit(func)()
         experimental_capture_result = captured_func()
         assert no_capture_result == experimental_capture_result
 
@@ -840,10 +837,10 @@ class TestCapture:
             qml.RX(0, wires=0)
             return qml.sample()
 
-        captured_func = qml.qjit(circuit, experimental_capture=False, target="mlir")
+        captured_func = qjit(circuit, experimental_capture=False, target="mlir")
 
         assert "'shots': 10" in captured_func.mlir
 
-        no_capture_result = qml.qjit(circuit)()
+        no_capture_result = qjit(circuit)()
         experimental_capture_result = captured_func()
         assert jnp.allclose(no_capture_result, experimental_capture_result)

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -748,7 +748,7 @@ class TestCondPredicateConversion:
     def test_conversion_integer(self):
         """Test entry predicate conversion from integer to bool."""
 
-        @qml.qjit()
+        @qjit()
         def workflow(x):
             n = 1
 
@@ -768,7 +768,7 @@ class TestCondPredicateConversion:
     def test_conversion_float(self):
         """Test entry predicate conversion from float to bool."""
 
-        @qml.qjit()
+        @qjit()
         def workflow(x):
             n = 2.0
 
@@ -788,7 +788,7 @@ class TestCondPredicateConversion:
     def test_jax_bool(self):
         """Test entry predicate with a JAX bool."""
 
-        @qml.qjit()
+        @qjit()
         def workflow(x):
             n = jnp.bool_(True)
 
@@ -808,7 +808,7 @@ class TestCondPredicateConversion:
     def test_else_if_conversion_integer(self):
         """Test else_if predicate conversion from integer to bool."""
 
-        @qml.qjit()
+        @qjit()
         def workflow(x):
             n = 1
 
@@ -832,7 +832,7 @@ class TestCondPredicateConversion:
     def test_conversion_int_autograph(self):
         """Test entry predicate conversion from integer to bool using Autograph."""
 
-        @qml.qjit(autograph=True)
+        @qjit(autograph=True)
         def workflow(x):
             n = 1
 
@@ -848,7 +848,7 @@ class TestCondPredicateConversion:
     def test_conversion_int_autograph_elif(self):
         """Test elif predicate conversion from integer to bool using Autograph."""
 
-        @qml.qjit(autograph=True)
+        @qjit(autograph=True)
         def workflow(x):
             n = 1
 
@@ -866,7 +866,7 @@ class TestCondPredicateConversion:
     def test_string_conversion_failed(self):
         """Test failure at converting string to bool using Autograph."""
 
-        @qml.qjit(autograph=True)
+        @qjit(autograph=True)
         def workflow(x):
             n = "fail"
 
@@ -886,7 +886,7 @@ class TestCondPredicateConversion:
     def test_array_conversion_failed(self):
         """Test failure at converting array to bool using Autograph."""
 
-        @qml.qjit(autograph=True)
+        @qjit(autograph=True)
         def workflow(x):
             n = jnp.array([[1], [2]])
 

--- a/frontend/test/pytest/test_cuda_integration.py
+++ b/frontend/test/pytest/test_cuda_integration.py
@@ -256,7 +256,7 @@ class TestCudaQ:
     def test_cuda_device_entry_point_compiler(self):
         """Test the entry point for cudaq.qjit"""
 
-        @qml.qjit(compiler="cuda_quantum")
+        @qjit(compiler="cuda_quantum")
         @qml.qnode(qml.device("softwareq.qpp", wires=1))
         def circuit(a):
             qml.RX(a, wires=[0])

--- a/frontend/test/pytest/test_from_plxpr.py
+++ b/frontend/test/pytest/test_from_plxpr.py
@@ -22,6 +22,8 @@ import pytest
 catalyst = pytest.importorskip("catalyst")
 jax = pytest.importorskip("jax")
 
+from catalyst import qjit
+
 # needs to be below the importorskip calls
 # pylint: disable=wrong-import-position,unused-argument
 from catalyst.from_plxpr import QFuncPlxprInterpreter, from_plxpr
@@ -194,7 +196,7 @@ class TestCatalystCompareJaxpr:
         assert len(catalyst_res) == 1
         assert qml.math.allclose(catalyst_res[0], -1)
 
-        qjit_obj = qml.qjit(circuit)
+        qjit_obj = qjit(circuit)
         qjit_obj(x)
         catalxpr = qjit_obj.jaxpr
         call_jaxpr_pl = get_call_jaxpr(converted)
@@ -219,7 +221,7 @@ class TestCatalystCompareJaxpr:
         catalyst_res = catalyst_execute_jaxpr(converted)(phi)
         assert qml.math.allclose(catalyst_res, np.exp(-0.5j) * np.array([1.0, 0.0]))
 
-        qjit_obj = qml.qjit(circuit)
+        qjit_obj = qjit(circuit)
         qjit_obj(0.5)
 
         catalxpr = qjit_obj.jaxpr
@@ -248,7 +250,7 @@ class TestCatalystCompareJaxpr:
         assert len(catalyst_res) == 1
         assert qml.math.allclose(catalyst_res[0], jax.numpy.cos(0.5))
 
-        qjit_obj = qml.qjit(circuit)
+        qjit_obj = qjit(circuit)
         qjit_obj(0.5)
         catalxpr = qjit_obj.jaxpr
         call_jaxpr_pl = get_call_jaxpr(converted)
@@ -280,7 +282,7 @@ class TestCatalystCompareJaxpr:
         expected = np.array([np.cos(0.5 / 2) ** 2, np.sin(0.5 / 2) ** 2])
         assert qml.math.allclose(catalyst_res[0], expected)
 
-        qjit_obj = qml.qjit(circuit)
+        qjit_obj = qjit(circuit)
         qjit_obj(0.5)
         catalxpr = qjit_obj.jaxpr
         call_jaxpr_pl = get_call_jaxpr(converted)
@@ -319,7 +321,7 @@ class TestCatalystCompareJaxpr:
 
         assert qml.math.allclose(catalyst_res[0], expected)
 
-        qjit_obj = qml.qjit(circuit)
+        qjit_obj = qjit(circuit)
         qjit_obj(phi)
         catalxpr = qjit_obj.jaxpr
         call_jaxpr_pl = get_call_jaxpr(converted)
@@ -354,7 +356,7 @@ class TestCatalystCompareJaxpr:
         expected = 1 - np.sin(x) ** 2
         assert qml.math.allclose(catalyst_res[0], expected)
 
-        qjit_obj = qml.qjit(circuit)
+        qjit_obj = qjit(circuit)
         qjit_obj(x)
         catalxpr = qjit_obj.jaxpr
         call_jaxpr_pl = get_call_jaxpr(converted)
@@ -386,7 +388,7 @@ class TestCatalystCompareJaxpr:
         expected = np.transpose(np.vstack([np.ones(50), np.zeros(50)]))
         assert qml.math.allclose(catalyst_res[0], expected)
 
-        qjit_obj = qml.qjit(circuit)
+        qjit_obj = qjit(circuit)
         qjit_obj()
         catalxpr = qjit_obj.jaxpr
         call_jaxpr_pl = get_call_jaxpr(converted)
@@ -418,7 +420,7 @@ class TestCatalystCompareJaxpr:
         expected = np.transpose(np.vstack([np.ones(50), np.zeros(50)]))
         assert qml.math.allclose(catalyst_res[0], expected)
 
-        qjit_obj = qml.qjit(circuit)
+        qjit_obj = qjit(circuit)
         qjit_obj()
         catalxpr = qjit_obj.jaxpr
         call_jaxpr_pl = converted.eqns[0].params["call_jaxpr"]
@@ -460,7 +462,7 @@ class TestCatalystCompareJaxpr:
         assert qml.math.allclose(catalyst_res[1], expected_expval_y)
         assert qml.math.allclose(catalyst_res[2], expected_probs)
 
-        qjit_obj = qml.qjit(circuit)
+        qjit_obj = qjit(circuit)
         qjit_obj(x, y, z)
         catalxpr = qjit_obj.jaxpr
         call_jaxpr_pl = get_call_jaxpr(converted)
@@ -527,7 +529,7 @@ class TestHybridPrograms:
 
         assert qml.math.allclose(expected, res[0])
 
-        qjit_obj = qml.qjit(workflow)
+        qjit_obj = qjit(workflow)
         qjit_obj(0.5)
 
         call_jaxpr_pl = get_call_jaxpr(converted)

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -86,7 +86,7 @@ def test_gradient_generate_once():
     def identity(x):
         return x
 
-    @qml.qjit
+    @qjit
     def wrap(x: float):
         diff = grad(identity)
         return diff(x) + diff(x)
@@ -1725,7 +1725,7 @@ class TestGradientErrors:
 
         with pytest.raises(DifferentiableCompileError, match="MidCircuitMeasure is not allowed"):
 
-            @qml.qjit
+            @qjit
             def cir(x: float):
                 return grad(f)(x)
 
@@ -1740,7 +1740,7 @@ class TestGradientErrors:
 
         with pytest.raises(CompileError, match=".*Compilation failed.*"):
 
-            @qml.qjit
+            @qjit
             def cir(x: float):
                 return grad(f)(x)
 
@@ -1757,7 +1757,7 @@ class TestGradientErrors:
 
         with pytest.raises(CompileError, match=".*Compilation failed.*"):
 
-            @qml.qjit
+            @qjit
             def cir(x: float):
                 return grad(g)(x)
 
@@ -2103,7 +2103,7 @@ class TestParameterShiftVerificationIntegrationTests:
 
         with pytest.raises(DifferentiableCompileError, match="MidCircuitMeasure is not allowed"):
 
-            @qml.qjit
+            @qjit
             @grad
             @qml.qnode(device, diff_method="parameter-shift")
             def circuit(_: float):
@@ -2117,7 +2117,7 @@ class TestParameterShiftVerificationIntegrationTests:
         # Yes, this test does not have an assertion.
         # The test is that this does not produce an assertion.
 
-        @qml.qjit
+        @qjit
         @grad
         @qml.qnode(device, diff_method="parameter-shift")
         def circuit(_: float):
@@ -2137,7 +2137,7 @@ class TestParameterShiftVerificationIntegrationTests:
 
         with pytest.raises(CompileError):
 
-            @qml.qjit
+            @qjit
             @grad
             @qml.qnode(device, diff_method="parameter-shift")
             def circuit(x: float):
@@ -2155,7 +2155,7 @@ class TestParameterShiftVerificationIntegrationTests:
 
         with pytest.raises(CompileError):
 
-            @qml.qjit
+            @qjit
             @grad
             @qml.qnode(device, diff_method="parameter-shift")
             def circuit(x: float):
@@ -2174,7 +2174,7 @@ class TestParameterShiftVerificationIntegrationTests:
 
         with pytest.raises(CompileError):
 
-            @qml.qjit
+            @qjit
             @grad
             @qml.qnode(device, diff_method="parameter-shift")
             def circuit(x: float):
@@ -2193,7 +2193,7 @@ class TestParameterShiftVerificationIntegrationTests:
 
         with pytest.raises(CompileError):
 
-            @qml.qjit
+            @qjit
             @grad
             @qml.qnode(device, diff_method="parameter-shift")
             def circuit(x: float):

--- a/frontend/test/pytest/test_jax_dynamic_api.py
+++ b/frontend/test/pytest/test_jax_dynamic_api.py
@@ -1142,7 +1142,7 @@ def test_trace_to_jaxpr():
 def test_abstracted_axis_no_recompilation():
     """Test that a function that does not need recompilation can be executed a second time"""
 
-    @qml.qjit(abstracted_axes=(("n",), ()))
+    @qjit(abstracted_axes=(("n",), ()))
     @qml.qnode(qml.device("lightning.qubit", wires=2))
     def circuit(x1, x2):
 

--- a/frontend/test/pytest/test_jax_linalg.py
+++ b/frontend/test/pytest/test_jax_linalg.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test that the jax linear algebra functions yield correct results when compiled with qml.qjit"""
+"""Test that the jax linear algebra functions yield correct results when compiled with catalyst.qjit"""
 
 import numpy as np
 import pytest

--- a/frontend/test/pytest/test_jax_numerical.py
+++ b/frontend/test/pytest/test_jax_numerical.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test that numerical jax functions produce correct results when compiled with qml.qjit"""
+"""Test that numerical jax functions produce correct results when compiled with catalyst.qjit"""
 
 import numpy as np
 import pennylane as qml

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -860,7 +860,7 @@ class TestDefaultAvailableIR:
     def test_mlir(self):
         """Test mlir."""
 
-        @qml.qjit  # Note that we are using the default qjit
+        @qjit  # Note that we are using the default qjit
         def f():
             return 1
 
@@ -874,7 +874,7 @@ class TestDefaultAvailableIR:
             qml.RX(x, wires=0)
             return qml.state()
 
-        @qml.qjit  # Note that we are using the default qjit
+        @qjit  # Note that we are using the default qjit
         def g(x: float):
             return f(x)
 
@@ -889,7 +889,7 @@ class TestDefaultAvailableIR:
             qml.RX(x, wires=0)
             return qml.state()
 
-        @qml.qjit  # Note that we are using the default qjit
+        @qjit  # Note that we are using the default qjit
         def g(x: float):
             return f(x)
 
@@ -899,7 +899,7 @@ class TestDefaultAvailableIR:
     def test_jaxpr_target(self, backend):
         """Test no mlir is generated for jaxpr target."""
 
-        @qml.qjit(target="jaxpr")
+        @qjit(target="jaxpr")
         @qml.qnode(qml.device(backend, wires=1))
         def f(x: float):
             qml.RX(x, wires=0)

--- a/frontend/test/pytest/test_measurement_transforms.py
+++ b/frontend/test/pytest/test_measurement_transforms.py
@@ -159,7 +159,7 @@ class TestMeasurementTransforms:
         assert "counts" in mlir
 
         theta = 1.9
-        expval_res, var_res, counts_res, probs_res = qml.qjit(transformed_circuit, seed=37)(theta)
+        expval_res, var_res, counts_res, probs_res = qjit(transformed_circuit, seed=37)(theta)
 
         expval_expected = np.sin(theta) * np.sin(theta / 2)
         var_expected = 1 - np.sin(2 * theta) ** 2
@@ -213,7 +213,7 @@ class TestMeasurementTransforms:
 
         theta = 1.9
 
-        expval_res, var_res, sample_res, probs_res = qml.qjit(transformed_circuit, seed=37)(theta)
+        expval_res, var_res, sample_res, probs_res = qjit(transformed_circuit, seed=37)(theta)
 
         expval_expected = np.sin(theta) * np.sin(theta / 2)
         var_expected = 1 - np.sin(2 * theta) ** 2
@@ -265,7 +265,7 @@ class TestMeasurementTransforms:
             assert measurement_transform in transform_program
 
             # MLIR only contains target measurement
-            @qml.qjit
+            @qjit
             @qml.qnode(dev)
             def circuit(theta: float):
                 qml.X(0)
@@ -317,7 +317,7 @@ class TestMeasurementTransforms:
             assert measurement_transform in transform_program
 
             # MLIR only contains target measurement
-            @qml.qjit
+            @qjit
             @qml.qnode(dev)
             def circuit(theta: float):
                 qml.X(0)
@@ -358,7 +358,7 @@ class TestMeasurementTransforms:
             with pytest.raises(
                 RuntimeError, match="The device does not support observables or sample/counts"
             ):
-                qml.qjit(circuit)()
+                qjit(circuit)()
 
     # pylint: disable=unnecessary-lambda
     @pytest.mark.parametrize(
@@ -385,7 +385,7 @@ class TestMeasurementTransforms:
 
         theta = 2.5
         counts_expected = circuit(theta)
-        res = qml.qjit(measurements_from_counts(circuit, dev.wires), seed=37)(theta)
+        res = qjit(measurements_from_counts(circuit, dev.wires), seed=37)(theta)
 
         # counts comparison by converting catalyst format to PL style eigvals dict
         basis_states, counts = res
@@ -437,10 +437,10 @@ class TestMeasurementTransforms:
             return measurement()
 
         theta = 2.5
-        res = qml.qjit(measurements_from_samples(circuit, dev.wires), seed=37)(theta)
+        res = qjit(measurements_from_samples(circuit, dev.wires), seed=37)(theta)
 
         if len(measurement().wires) == 1:
-            samples_expected = qml.qjit(circuit, seed=37)(theta)
+            samples_expected = qjit(circuit, seed=37)(theta)
         else:
             samples_expected = circuit(theta)
 
@@ -485,7 +485,7 @@ class TestMeasurementTransforms:
 
         dev = qml.device("lightning.qubit", wires=4, shots=shots)
 
-        @qml.qjit(seed=37)
+        @qjit(seed=37)
         @partial(measurements_from_samples, device_wires=dev.wires)
         @qml.qnode(dev)
         def circuit(theta: float):
@@ -539,7 +539,7 @@ class TestMeasurementTransforms:
 
         dev = qml.device("lightning.qubit", wires=4, shots=3000)
 
-        @qml.qjit(seed=37)
+        @qjit(seed=37)
         @partial(measurements_from_counts, device_wires=dev.wires)
         @qml.qnode(dev)
         def circuit(theta: float):
@@ -574,7 +574,7 @@ class TestMeasurementTransforms:
         with pytest.raises(
             NotImplementedError, match="not implemented with measurements_from_counts"
         ):
-            qml.qjit(circuit)
+            qjit(circuit)
 
     def test_measurement_from_samples_raises_not_implemented(self):
         """Test that an measurement not supported by the measurements_from_counts or
@@ -591,7 +591,7 @@ class TestMeasurementTransforms:
         with pytest.raises(
             NotImplementedError, match="not implemented with measurements_from_samples"
         ):
-            qml.qjit(circuit)
+            qjit(circuit)
 
     @pytest.mark.parametrize(
         "unsupported_obs",
@@ -630,7 +630,7 @@ class TestMeasurementTransforms:
         with patch(
             "catalyst.device.qjit_device.get_device_capabilities", Mock(return_value=config)
         ):
-            jitted_circuit = qml.qjit(circuit)
+            jitted_circuit = qjit(circuit)
 
             transform_program, _ = spy.spy_return
             assert split_non_commuting in transform_program
@@ -811,7 +811,7 @@ class TestMeasurementTransforms:
         with patch(
             "catalyst.device.qjit_device.get_device_capabilities", Mock(return_value=config)
         ):
-            jitted_circuit = qml.qjit(unjitted_circuit)
+            jitted_circuit = qjit(unjitted_circuit)
             assert len(jitted_circuit(1.2)) == len(expected_result) == 2
             assert np.allclose(jitted_circuit(1.2), expected_result)
 
@@ -823,7 +823,7 @@ class TestMeasurementTransforms:
         with patch(
             "catalyst.device.qjit_device.get_device_capabilities", Mock(return_value=config)
         ):
-            jitted_circuit = qml.qjit(unjitted_circuit)
+            jitted_circuit = qjit(unjitted_circuit)
             assert len(jitted_circuit(1.2)) == len(expected_result) == 2
             assert np.allclose(jitted_circuit(1.2), unjitted_circuit(1.2))
 
@@ -855,7 +855,7 @@ class TestMeasurementTransforms:
         assert "Sum" in config.observables
 
         # test case where transform should not be applied
-        jitted_circuit = qml.qjit(unjitted_circuit)
+        jitted_circuit = qjit(unjitted_circuit)
         assert len(jitted_circuit(1.2)) == len(expected_result) == 2
         assert np.allclose(jitted_circuit(1.2), expected_result)
 
@@ -867,7 +867,7 @@ class TestMeasurementTransforms:
         with patch(
             "catalyst.device.qjit_device.get_device_capabilities", Mock(return_value=config)
         ):
-            jitted_circuit = qml.qjit(unjitted_circuit)
+            jitted_circuit = qjit(unjitted_circuit)
             assert len(jitted_circuit(1.2)) == len(expected_result) == 2
             assert np.allclose(jitted_circuit(1.2), unjitted_circuit(1.2))
 
@@ -882,7 +882,7 @@ class TestTransform:
         """Test the transfom measurements_from_counts."""
         device = qml.device("lightning.qubit", wires=4, shots=1000)
 
-        @qml.qjit
+        @qjit
         @partial(measurements_from_counts, device_wires=device.wires)
         @qml.qnode(device=device)
         def circuit(a: float):

--- a/frontend/test/pytest/test_measurements_results.py
+++ b/frontend/test/pytest/test_measurements_results.py
@@ -1048,7 +1048,7 @@ class TestDensityMatrixMP:
         err_msg = "DensityMatrixMP is not a supported measurement process"
         with pytest.raises(CompileError, match=err_msg):
 
-            @qml.qjit
+            @qjit
             @qml.qnode(CustomDevice(wires=1))
             def circuit():
                 return qml.density_matrix([0])

--- a/frontend/test/pytest/test_mid_circuit_measurement.py
+++ b/frontend/test/pytest/test_mid_circuit_measurement.py
@@ -326,7 +326,7 @@ class TestMidCircuitMeasurement:
         """Test that the correct default mcm_method is chosen based on postselect_mode"""
         dev = qml.device(backend, wires=1, shots=20)
 
-        @qml.qjit
+        @qjit
         @qml.qnode(dev, mcm_method=mcm_method, postselect_mode=postselect_mode)
         def circuit(x):
             qml.RX(x, wires=0)
@@ -343,7 +343,7 @@ class TestMidCircuitMeasurement:
         """Test that the correct default mcm_method is chosen based on postselect_mode"""
         dev = qml.device(backend, wires=1, shots=20)
 
-        @qml.qjit
+        @qjit
         @qml.qnode(dev, mcm_method=mcm_method, postselect_mode=postselect_mode)
         def circuit(x):
             qml.RX(x, wires=0)
@@ -368,7 +368,7 @@ class TestMidCircuitMeasurement:
         """Test that the correct default mcm_method is chosen based on postselect_mode"""
         dev = qml.device(backend, wires=1, shots=5)
 
-        @qml.qjit
+        @qjit
         @qml.qnode(dev, mcm_method=mcm_method, postselect_mode=postselect_mode)
         def circuit(x):
             qml.RX(x, wires=0)
@@ -740,7 +740,7 @@ class TestDynamicOneShotIntegration:
         shots = 10
         dev = qml.device(backend, wires=qubits, shots=shots)
 
-        @qml.qjit
+        @qjit
         @qml.qnode(dev, mcm_method="one-shot")
         def cost():
             qml.Hadamard(0)

--- a/frontend/test/pytest/test_preprocess.py
+++ b/frontend/test/pytest/test_preprocess.py
@@ -113,7 +113,7 @@ class TestDecomposition:
         """Test the decompose transform as part of the Catalyst pipeline."""
         dev = NullQubit(wires=4, shots=None)
 
-        @qml.qjit
+        @qjit
         @qml.qnode(dev)
         def circuit(theta: float):
             qml.SingleExcitationPlus(theta, wires=[0, 1])
@@ -140,7 +140,7 @@ class TestDecomposition:
         """Test the decompose ops to unitary transform as part of the Catalyst pipeline."""
         dev = CustomDevice(wires=4, shots=None)
 
-        @qml.qjit
+        @qjit
         @qml.qnode(dev)
         def circuit():
             qml.BlockEncode(np.array([[1, 1, 1], [0, 1, 0]]), wires=[0, 1, 2])
@@ -169,7 +169,7 @@ class TestDecomposition:
             return qml.probs()
 
         with pytest.raises(CompileError, match="could not be decomposed, it might be unsupported."):
-            qml.qjit(f, target="jaxpr")
+            qjit(f, target="jaxpr")
 
 
 # tapes and regions for generating HybridOps
@@ -271,7 +271,7 @@ class TestPreprocessHybridOp:
 
         dev = qml.device("lightning.qubit", wires=1)
 
-        @qml.qjit
+        @qjit
         @qml.qnode(dev)
         def circuit(x: float, y: float):
             qml.RY(y, 0)
@@ -293,7 +293,7 @@ class TestPreprocessHybridOp:
 
         dev = qml.device("lightning.qubit", wires=[0, 1])
 
-        @qml.qjit
+        @qjit
         @qml.qnode(dev)
         def circuit(phi: float):
             OtherHadamard(wires=0)
@@ -341,7 +341,7 @@ class TestPreprocessHybridOp:
 
         dev = qml.device("lightning.qubit", wires=2)
 
-        @qml.qjit
+        @qjit
         @qml.qnode(dev)
         def circuit(n: int, x: float):
             OtherHadamard(wires=0)
@@ -374,7 +374,7 @@ class TestPreprocessHybridOp:
 
         dev = qml.device("lightning.qubit", wires=1)
 
-        @qml.qjit
+        @qjit
         @qml.qnode(dev)
         def circuit(x: float):
             @while_loop(lambda x: x < 2.0)

--- a/frontend/test/pytest/test_qnode.py
+++ b/frontend/test/pytest/test_qnode.py
@@ -132,7 +132,7 @@ def test_qnode_grad_method_stored_on_execution_config(grad_method, mocker):
         qml.RX(x, wires=0)
         return qml.expval(qml.PauliX(0))
 
-    qml.qjit(circ)(1.2)
+    qjit(circ)(1.2)
 
     assert spy.call_count == 1
     _, config = spy.spy_return
@@ -141,7 +141,7 @@ def test_qnode_grad_method_stored_on_execution_config(grad_method, mocker):
     def grad_circ(x: float):
         return grad(circ)(x)
 
-    qml.qjit(grad_circ)(1.2)
+    qjit(grad_circ)(1.2)
 
     assert spy.call_count == 2
     _, config = spy.spy_return

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -310,7 +310,7 @@ class TestCatalystControlled:
     def test_qctrl_wires(self, backend):
         """Test the wires property of HybridCtrl"""
 
-        @qml.qjit
+        @qjit
         @qml.qnode(qml.device(backend, wires=3))
         def circuit(theta):
             def func(theta):
@@ -327,7 +327,7 @@ class TestCatalystControlled:
     def test_qctrl_wires_arg_fun(self, backend):
         """Test the wires property of HybridCtrl with argument wires"""
 
-        @qml.qjit
+        @qjit
         @qml.qnode(qml.device(backend, wires=4))
         def circuit():
             def func(anc, wires):
@@ -344,7 +344,7 @@ class TestCatalystControlled:
     def test_qctrl_var_wires(self, backend):
         """Test the wires property of HybridCtrl with variable wires"""
 
-        @qml.qjit
+        @qjit
         @qml.qnode(qml.device(backend, wires=4))
         def circuit(anc, wires):
             def func(anc, wires):
@@ -361,7 +361,7 @@ class TestCatalystControlled:
     def test_qctrl_wires_nested(self, backend):
         """Test the wires property of HybridCtrl with nested branches"""
 
-        @qml.qjit
+        @qjit
         @qml.qnode(qml.device(backend, wires=4))
         def circuit(theta, w1, w2, cw1, cw2):
             def _func1():
@@ -382,7 +382,7 @@ class TestCatalystControlled:
     def test_qctrl_work_wires(self, backend):
         """Test the wires property of HybridCtrl with work-wires"""
 
-        @qml.qjit
+        @qjit
         @qml.qnode(qml.device(backend, wires=5))
         def circuit(theta):
             def _func1():
@@ -404,7 +404,7 @@ class TestCatalystControlled:
     def test_qctrl_wires_controlflow(self, backend):
         """Test the wires property of HybridCtrl with control flow branches"""
 
-        @qml.qjit
+        @qjit
         @qml.qnode(qml.device(backend, wires=3))
         def circuit(theta, w1, w2, cw):
             def _func():
@@ -510,7 +510,7 @@ class TestCatalystControlled:
             qml.ControlledSequence(qml.TrotterProduct(H, time=2.4, order=2), control=[1])
             return qml.expval(qml.PauliZ(0))
 
-        assert qml.math.allclose(qml.qjit(circuit)(), circuit())
+        assert qml.math.allclose(qjit(circuit)(), circuit())
 
     def test_distribute_controlled_with_adj(self):
         """Test that the distribute_controlled function with a PennyLane Adjoint,

--- a/frontend/test/pytest/test_skip_initial_state_prep.py
+++ b/frontend/test/pytest/test_skip_initial_state_prep.py
@@ -19,7 +19,7 @@ import pennylane as qml
 import pytest
 
 from catalyst import DifferentiableCompileError as DiffErr
-from catalyst import grad
+from catalyst import grad, qjit
 
 
 class TestExamplesFromWebsite:
@@ -39,7 +39,7 @@ class TestExamplesFromWebsite:
             return qml.state()
 
         expected = example_circuit()
-        observed = qml.qjit(example_circuit)()
+        observed = qjit(example_circuit)()
         assert jnp.allclose(expected, observed)
 
     def test_state_prep_recycled_device(self, backend):
@@ -60,7 +60,7 @@ class TestExamplesFromWebsite:
             return example_circuit(), example_circuit_doppelganger()
 
         expected = jnp.array(main())
-        observed = jnp.array(qml.qjit(main)())
+        observed = jnp.array(qjit(main)())
         assert jnp.allclose(expected, observed)
 
     def test_state_prep_i32_array(self, backend):
@@ -75,7 +75,7 @@ class TestExamplesFromWebsite:
             return qml.state()
 
         expected = example_circuit()
-        observed = qml.qjit(example_circuit)()
+        observed = qjit(example_circuit)()
         assert jnp.allclose(expected, observed)
 
     def test_basis_state(self, backend):
@@ -92,7 +92,7 @@ class TestExamplesFromWebsite:
             return qml.state()
 
         expected = example_circuit()
-        observed = qml.qjit(example_circuit)()
+        observed = qjit(example_circuit)()
         assert jnp.allclose(expected, observed)
 
     def test_basis_state_recycled_device(self, backend):
@@ -113,7 +113,7 @@ class TestExamplesFromWebsite:
             return example_circuit(), example_circuit_doppelganger()
 
         expected = jnp.array(main())
-        observed = jnp.array(qml.qjit(main)())
+        observed = jnp.array(qjit(main)())
         assert jnp.allclose(expected, observed)
 
     def test_basis_state_i32_array(self, backend):
@@ -128,7 +128,7 @@ class TestExamplesFromWebsite:
             return qml.state()
 
         expected = example_circuit()
-        observed = qml.qjit(example_circuit)()
+        observed = qjit(example_circuit)()
         assert jnp.allclose(expected, observed)
 
     @pytest.mark.parametrize("wires", [(0), (1), (2)])
@@ -143,7 +143,7 @@ class TestExamplesFromWebsite:
             return qml.state()
 
         expected = example_circuit()
-        observed = qml.qjit(example_circuit)()
+        observed = qjit(example_circuit)()
         assert jnp.allclose(expected, observed)
 
     def test_wires_with_less_than_all_basis_state(self, backend):
@@ -159,7 +159,7 @@ class TestExamplesFromWebsite:
             return qml.state()
 
         expected = example_circuit()
-        observed = qml.qjit(example_circuit)()
+        observed = qjit(example_circuit)()
         assert jnp.allclose(expected, observed)
 
 
@@ -179,14 +179,14 @@ class TestDynamicWires:
         and this optimization does not yet work for it.
         """
 
-        @qml.qjit
+        @qjit
         @qml.qnode(qml.device("lightning.qubit", wires=3))
         def example_circuit(a: int):
             qml.StatePrep(jnp.array([0, 1, 0, 0]), wires=[a, a + 1])
             return qml.state()
 
         expected = example_circuit(inp)
-        observed = qml.qjit(example_circuit)(inp)
+        observed = qjit(example_circuit)(inp)
         assert jnp.allclose(expected, observed)
 
     @pytest.mark.parametrize("inp", [(0), (1)])
@@ -205,7 +205,7 @@ class TestDynamicWires:
             return qml.state()
 
         expected = example_circuit(inp)
-        observed = qml.qjit(example_circuit)(inp)
+        observed = qjit(example_circuit)(inp)
         assert jnp.allclose(expected, observed)
 
 
@@ -219,7 +219,7 @@ class TestPossibleErrors:
 
         with pytest.raises(ValueError, match="State must be of length 2; got length 1"):
 
-            @qml.qjit
+            @qjit
             @qml.qnode(qml.device("lightning.qubit", wires=2))
             def example_circuit():
                 qml.BasisState(jnp.array([1]), wires=range(2))
@@ -231,7 +231,7 @@ class TestPossibleErrors:
         """Test that the same error is raised"""
         with pytest.raises(ValueError, match="State must be of length 2; got length 1"):
 
-            @qml.qjit
+            @qjit
             @qml.qnode(qml.device("lightning.qubit", wires=2))
             def example_circuit():
                 qml.StatePrep(jnp.array([0]), wires=[0])
@@ -249,7 +249,7 @@ class TestPossibleErrors:
         msg = "BasisState parameter must consist of 0 or 1 integers"
         with pytest.raises(RuntimeError, match=msg):
 
-            @qml.qjit
+            @qjit
             @qml.qnode(qml.device("lightning.qubit", wires=2))
             def example_circuit():
                 qml.BasisState(jnp.array([0, 2]), wires=range(2))
@@ -266,7 +266,7 @@ class TestGrad:
 
         with pytest.raises(DiffErr):
 
-            @qml.qjit
+            @qjit
             @grad
             @qml.qnode(qml.device(backend, wires=2))
             def example_circuit(a: float):
@@ -281,7 +281,7 @@ class TestGrad:
 
         with pytest.raises(DiffErr):
 
-            @qml.qjit
+            @qjit
             @grad
             @qml.qnode(qml.device(backend, wires=2))
             def example_circuit(a: float):
@@ -305,7 +305,7 @@ class TestControlled:
             return qml.state()
 
         expected = example_circuit()
-        observed = qml.qjit(example_circuit)()
+        observed = qjit(example_circuit)()
         assert jnp.allclose(expected, observed)
 
     def test_basis_state_ctrl(self):
@@ -318,7 +318,7 @@ class TestControlled:
             return qml.state()
 
         expected = example_circuit()
-        observed = qml.qjit(example_circuit)()
+        observed = qjit(example_circuit)()
         assert jnp.allclose(expected, observed)
 
 
@@ -335,7 +335,7 @@ class TestAdjoint:
             return qml.state()
 
         expected = example_circuit()
-        observed = qml.qjit(example_circuit)()
+        observed = qjit(example_circuit)()
         assert jnp.allclose(expected, observed)
 
     def test_basis_state_ctrl(self, backend):
@@ -348,5 +348,5 @@ class TestAdjoint:
             return qml.state()
 
         expected = example_circuit()
-        observed = qml.qjit(example_circuit)()
+        observed = qjit(example_circuit)()
         assert jnp.allclose(expected, observed)

--- a/frontend/test/pytest/test_verification.py
+++ b/frontend/test/pytest/test_verification.py
@@ -32,6 +32,7 @@ from catalyst import (
     ctrl,
     for_loop,
     grad,
+    qjit,
 )
 from catalyst.api_extensions import HybridAdjoint, HybridCtrl
 from catalyst.compiler import get_lib_path
@@ -152,7 +153,7 @@ def test_unsupported_ops_raise_an_error():
         return qml.expval(qml.PauliX(0))
 
     with pytest.raises(CompileError, match="UnsupportedOp is not supported"):
-        qml.qjit(f)(1.2)
+        qjit(f)(1.2)
 
 
 def queue_ops(x, wires):
@@ -194,11 +195,11 @@ class TestHybridOpVerification:
             return qml.expval(qml.PauliX(0))
 
         with pytest.raises(CompileError, match="RX.*not invertible"):
-            qml.qjit(f)(1.2)
+            qjit(f)(1.2)
 
         with pytest.raises(CompileError, match="RX.*not invertible"):
 
-            @qml.qjit
+            @qjit
             def cir(x: float):
                 return grad(f)(x)
 
@@ -227,11 +228,11 @@ class TestHybridOpVerification:
             return qml.expval(qml.PauliX(0))
 
         with pytest.raises(CompileError, match="RX.*not invertible"):
-            qml.qjit(f)(1.2)
+            qjit(f)(1.2)
 
         with pytest.raises(CompileError, match="RX.*not invertible"):
 
-            @qml.qjit
+            @qjit
             def cir(x: float):
                 return grad(f)(x)
 
@@ -254,11 +255,11 @@ class TestHybridOpVerification:
             return qml.expval(qml.PauliX(0))
 
         with pytest.raises(CompileError, match="RX.*not invertible"):
-            qml.qjit(f)(1.2)
+            qjit(f)(1.2)
 
         with pytest.raises(CompileError, match="RX.*not invertible"):
 
-            @qml.qjit
+            @qjit
             def cir(x: float):
                 return grad(f)(x)
 
@@ -275,11 +276,11 @@ class TestHybridOpVerification:
             return qml.expval(qml.PauliX(0))
 
         with pytest.raises(CompileError, match="PauliZ is not controllable"):
-            qml.qjit(f)(1.2)
+            qjit(f)(1.2)
 
         with pytest.raises(CompileError, match="PauliZ is not controllable"):
 
-            @qml.qjit
+            @qjit
             def cir(x: float):
                 return grad(f)(x)
 
@@ -308,11 +309,11 @@ class TestHybridOpVerification:
 
         with patch("catalyst.device.qjit_device.RUNTIME_OPERATIONS", runtime_ops_with_qctrl):
             with pytest.raises(CompileError, match="PauliZ is not controllable"):
-                qml.qjit(f)(1.2)
+                qjit(f)(1.2)
 
             with pytest.raises(CompileError, match="PauliZ is not controllable"):
 
-                @qml.qjit
+                @qjit
                 def cir(x: float):
                     return grad(f)(x)
 
@@ -329,11 +330,11 @@ class TestHybridOpVerification:
             return qml.expval(qml.PauliX(0))
 
         with pytest.raises(CompileError, match="HybridCtrl is not supported"):
-            qml.qjit(f)(1.2)
+            qjit(f)(1.2)
 
         with pytest.raises(CompileError, match="HybridCtrl is not supported"):
 
-            @qml.qjit
+            @qjit
             def cir(x: float):
                 return grad(f)(x)
 
@@ -351,11 +352,11 @@ class TestHybridOpVerification:
             return qml.expval(qml.PauliX(0))
 
         with pytest.raises(CompileError, match="Cannot compile PennyLane control of the hybrid op"):
-            qml.qjit(f)(1.2)
+            qjit(f)(1.2)
 
         with pytest.raises(CompileError, match="Cannot compile PennyLane control of the hybrid op"):
 
-            @qml.qjit
+            @qjit
             def cir(x: float):
                 return grad(f)(x)
 
@@ -373,11 +374,11 @@ class TestHybridOpVerification:
             return qml.expval(qml.PauliX(0))
 
         with pytest.raises(CompileError, match="Cannot compile PennyLane inverse of the hybrid op"):
-            qml.qjit(f)(1.2)
+            qjit(f)(1.2)
 
         with pytest.raises(CompileError, match="Cannot compile PennyLane inverse of the hybrid op"):
 
-            @qml.qjit
+            @qjit
             def cir(x: float):
                 return grad(f)(x)
 
@@ -416,11 +417,11 @@ class TestHybridOpVerification:
 
         with patch("catalyst.device.qjit_device.RUNTIME_OPERATIONS", runtime_ops_with_qctrl):
             with pytest.raises(CompileError, match=f"PauliZ is not {unsupported_gate_attribute}"):
-                qml.qjit(f)(1.2)
+                qjit(f)(1.2)
 
             with pytest.raises(CompileError, match=f"PauliZ is not {unsupported_gate_attribute}"):
 
-                @qml.qjit
+                @qjit
                 def cir(x: float):
                     return grad(f)(x)
 
@@ -459,11 +460,11 @@ class TestHybridOpVerification:
 
         with patch("catalyst.device.qjit_device.RUNTIME_OPERATIONS", runtime_ops_with_qctrl):
             with pytest.raises(CompileError, match=f"PauliZ is not {unsupported_gate_attribute}"):
-                qml.qjit(f)(1.2)
+                qjit(f)(1.2)
 
             with pytest.raises(CompileError, match=f"PauliZ is not {unsupported_gate_attribute}"):
 
-                @qml.qjit
+                @qjit
                 def cir(x: float):
                     return grad(f)(x)
 
@@ -479,11 +480,11 @@ class TestHybridOpVerification:
             return qml.expval(qml.PauliX(0))
 
         with pytest.raises(CompileError, match=f"PauliZ is not {unsupported_gate_attribute}"):
-            qml.qjit(f)(1.2)
+            qjit(f)(1.2)
 
         with pytest.raises(CompileError, match=f"PauliZ is not {unsupported_gate_attribute}"):
 
-            @qml.qjit
+            @qjit
             def cir(x: float):
                 return grad(f)(x)
 
@@ -499,11 +500,11 @@ class TestHybridOpVerification:
             return qml.expval(qml.PauliX(0))
 
         with pytest.raises(CompileError, match=f"PauliZ is not {unsupported_gate_attribute}"):
-            qml.qjit(f)(1.2)
+            qjit(f)(1.2)
 
         with pytest.raises(CompileError, match=f"PauliZ is not {unsupported_gate_attribute}"):
 
-            @qml.qjit
+            @qjit
             def cir(x: float):
                 return grad(f)(x)
 
@@ -523,7 +524,7 @@ class TestObservableValidation:
             return qml.expval(qml.RX(1.2, 0))
 
         with pytest.raises(CompileError, match="RX.*not supported as an observable"):
-            qml.qjit(f)()
+            qjit(f)()
 
     @pytest.mark.parametrize(
         "measurements, invalid_op",
@@ -681,7 +682,7 @@ class TestMeasurementTypeValidation:
             return qml.state()
 
         with pytest.raises(CompileError, match="Please specify shots=None."):
-            qml.qjit(f)()
+            qjit(f)()
 
     @pytest.mark.parametrize("measurement", [qml.sample, qml.counts])
     def test_sample_measurements_rejected_without_shots(self, measurement):
@@ -697,7 +698,7 @@ class TestMeasurementTypeValidation:
             return measurement()
 
         with pytest.raises(CompileError, match="Please specify a finite number of shots."):
-            qml.qjit(f)()
+            qjit(f)()
 
     def test_unsupported_measurement_types_rejected(self):
         """Test that trying to use a measurement type that is generally unsupported by
@@ -725,7 +726,7 @@ class TestMeasurementTypeValidation:
             return MyMeasurement()
 
         with pytest.raises(CompileError, match="is not a supported measurement process"):
-            qml.qjit(f)()
+            qjit(f)()
 
 
 @patch("catalyst.device.qjit_device.catalyst_decompose", null_transform)
@@ -745,7 +746,7 @@ class TestAdjointMethodVerification:
 
         with pytest.raises(DifferentiableCompileError, match="RX.*non-differentiable"):
 
-            @qml.qjit
+            @qjit
             def cir(x: float):
                 return grad(f)(x)
 
@@ -774,7 +775,7 @@ class TestAdjointMethodVerification:
 
         with pytest.raises(DifferentiableCompileError, match="PauliX.*non-differentiable"):
 
-            @qml.qjit
+            @qjit
             def cir(x: float):
                 return grad(f)(x)
 
@@ -789,7 +790,7 @@ class TestAdjointMethodVerification:
             qml.RX(x, wires=0)
             return qml.probs()
 
-        qml.qjit(f)(1.2)
+        qjit(f)(1.2)
 
     def test_non_differentiable_gate_nested_cond(self):
         """Test that taking the adjoint diff of a tape containing a parameterized operation
@@ -813,7 +814,7 @@ class TestAdjointMethodVerification:
 
         with pytest.raises(DifferentiableCompileError, match="RX.*non-differentiable"):
 
-            @qml.qjit
+            @qjit
             def cir(x: float):
                 return grad(f)(x)
 
@@ -831,7 +832,7 @@ class TestAdjointMethodVerification:
 
         with pytest.raises(DifferentiableCompileError, match="RX.*non-differentiable"):
 
-            @qml.qjit
+            @qjit
             def cir(x: float):
                 return grad(f)(x)
 
@@ -866,7 +867,7 @@ class TestParameterShiftMethodVerification:
             DifferentiableCompileError, match="PauliX does not support analytic differentiation"
         ):
 
-            @qml.qjit
+            @qjit
             def cir(x: float):
                 return grad(f)(x)
 
@@ -881,7 +882,7 @@ def test_no_state_returns():
 
     with pytest.raises(DifferentiableCompileError, match="State returns.*forbidden"):
 
-        @qml.qjit
+        @qjit
         def cir(x: float):
             return grad(f)(x)
 
@@ -896,7 +897,7 @@ def test_no_variance_returns():
 
     with pytest.raises(DifferentiableCompileError, match="Variance returns.*forbidden"):
 
-        @qml.qjit
+        @qjit
         def cir(x: float):
             return grad(f)(x)
 


### PR DESCRIPTION
**Context:** In our tests we should be using directly Catalyst `qjit` instead of PL's `qml.qjit`

**Description of the Change:** Replace 'qml.qjit' usage with 'qjit' in tests.

**Benefits:** Reduce indirection.
