### PR TITLE
Use a faster flatten list implementation, cache variables seen on frame.

### DIFF
--- a/doc/releases/changelog-0.11.0.md
+++ b/doc/releases/changelog-0.11.0.md
@@ -188,6 +188,8 @@
     [(#1524)](https://github.com/PennyLaneAI/catalyst/pull/1524)
   - Lazy IR canonicalization and LLVMIR textual generation.
     [(#1530)](https://github.com/PennyLaneAI/catalyst/pull/1530)
+  - Speed up how tracers are overwritten for hybrid ops.
+    [(#1622)](https://github.com/PennyLaneAI/catalyst/pull/1622)
 
 * Catalyst now decomposes non-differentiable gates when in a gradient method.
   [(#1562)](https://github.com/PennyLaneAI/catalyst/pull/1562)

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -481,8 +481,14 @@ class HybridOp(Operator):
         as-is.
         """
         assert self.binder is not None, "HybridOp should set a binder"
+        # Here, we are binding any of the possible hybrid ops.
+        # which includes: for_loop, while_loop, cond, measure.
+        # This will place an equation at the very end of the current list of equations.
         out_quantum_tracer = self.binder(*in_expanded_tracers, **kwargs)[-1]
+        # eqn corresponds to the current hybrid operation that was just inserted
+        # into the list of equations.
         eqn = ctx.frames[trace].eqns[-1]
+
         assert len(eqn.outvars[:-1]) == len(
             out_expanded_tracers
         ), f"{eqn.outvars=}\n{out_expanded_tracers=}"
@@ -490,6 +496,7 @@ class HybridOp(Operator):
         frame = ctx.frames[trace]
         jaxpr_variables = cached_vars.get(frame, set())
         if not jaxpr_variables:
+            # We get all variables in the current frame
             outvars = itertools.chain.from_iterable([e.outvars for e in frame.eqns])
             jaxpr_variables = set(outvars)
             jaxpr_variables.update(frame.invars)
@@ -497,15 +504,58 @@ class HybridOp(Operator):
             cached_vars[frame] = jaxpr_variables
 
         for outvar in frame.eqns[-1].outvars:
+            # With the exception of the output variables from the current equation.
             jaxpr_variables.discard(outvar)
 
         for i, t in enumerate(out_expanded_tracers):
+            # We look for what were the previous output tracers.
+            # If they haven't changed, then we leave them unchanged.
             if trace.getvar(t) in jaxpr_variables:
-                # Do not re-assign vars from other equations
                 continue
 
+            # If the variable cannot be found in the current frame
+            # it is because we have created it via new_inner_tracer
+            # which uses JAX internals to create a tracer without associating
+            # a particular variable nor binding it to an equation.
+            # So at this moment, we create a new variable for it
+            # and set it as the eqn.outvars.
+            # For example catalyst.measure always returns a tracer associated with
+            # the value true but without having it being bound to any primitive
+            #
+            #    m = new_inner_tracer(ctx.trace, get_aval(True))
+            #
+            # Then we would land here and bound that inner_trace to this primitive
+            #
+            #    a: bool, b: qubit = measure_p.bind()
+            #
+            # At the moment, it is a little bit unclear why we need this.
+            # I think it may be due to the separation between tracing the quantum
+            # part from the classical part.
+            #
+            # First we would have traced the classical part (which includes hybrid ops)
+            # and we need tracers for those values.
+            # Here we would be tracing the quantum part, and it is where we would finally
+            # bind it with the correct primitive.
+            #
+            # This seems to be the case since the measure function does not bound.
+            # But it returns this inner tracer.
+            #
+            # Then the topological sorter would sort the operations that depended
+            # on the original inner_trace accordingly.
+            #
+            # This method only gets called in a for loop for quantum operations
+            #
+            #     for op in ops:
+            #       qrp2 = None
+            #         if isinstance(op, HybridOp):
+            #            // ... snip...
+            #            qrp2 = op.trace_quantum(ctx, device, trace, qrp, **kwargs)
+            #
+            # So it should be safe to cache the tracers as we are doing it.
             eqn.outvars[i] = trace.getvar(t)
 
+        # Now, the output variables can be considered as part of the current frame.
+        # This allows us to avoid importing all equations again next time.
         jaxpr_variables.update(eqn.outvars)
         return out_quantum_tracer
 

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -491,7 +491,7 @@ class HybridOp(Operator):
                 *ctx.frames[trace].constvar_to_val.keys(),
             ]
         )
-        for i, t in zip(range(len(eqn.outvars[:-1])), out_expanded_tracers):
+        for i, t in enumerate(out_expanded_tracers):
             if trace.getvar(t) in jaxpr_variables:
                 # Do not re-assign vars from other equations
                 continue


### PR DESCRIPTION
**Context:** Flattening a list using:

```python
sum(list_of_lists, [])
```

is inefficient. Each time we use [a] + [b] a new list c is created.

**Description of the Change:** Use [`itertools.chain.chain_from_iterable`](https://docs.python.org/3/library/itertools.html#itertools.chain.from_iterable) instead. Also cache the list of jaxpr tracers seen in each frame.

**Benefits:** Faster performance in some cases.

**Possible Drawbacks:** None.

**Related GitHub Issues:**

[sc-88617]