### PR TITLE
RC branch CI to test against other rc branches (!!!REVERT BEFORE RELEASE)

### DIFF
--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -450,7 +450,7 @@ jobs:
       run: |
         pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.41.0-rc0
 
-    - name: Install PennyLane-Lightning release candidate
+    - name: Checkout PennyLane-Lightning release branch
       if: github.event.pull_request.base.ref == 'v0.11.0-rc'
       uses: actions/checkout@v4
       with:
@@ -458,6 +458,9 @@ jobs:
         ref: v0.41.0_rc
         path: lightning_build
         fetch-depth: 0
+
+    - name: Install PennyLane-Lightning release candidate
+      if: github.event.pull_request.base.ref == 'v0.11.0-rc'
       run: |
         # Lightning-Kokkos can no longer be installed with pip from git
         cd lightning_build
@@ -548,7 +551,7 @@ jobs:
       run: |
         pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.41.0-rc0
 
-    - name: Install PennyLane-Lightning release candidate
+    - name: Checkout PennyLane-Lightning release branch
       if: github.event.pull_request.base.ref == 'v0.11.0-rc'
       uses: actions/checkout@v4
       with:
@@ -556,6 +559,9 @@ jobs:
         ref: v0.41.0_rc
         path: lightning_build
         fetch-depth: 0
+
+    - name: Install PennyLane-Lightning release candidate
+      if: github.event.pull_request.base.ref == 'v0.11.0-rc'
       run: |
         # Lightning-Kokkos can no longer be installed with pip from git
         cd lightning_build
@@ -626,7 +632,7 @@ jobs:
       run: |
         pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.41.0-rc0
 
-    - name: Install PennyLane-Lightning release candidate
+    - name: Checkout PennyLane-Lightning release branch
       if: github.event.pull_request.base.ref == 'v0.11.0-rc'
       uses: actions/checkout@v4
       with:
@@ -634,6 +640,9 @@ jobs:
         ref: v0.41.0_rc
         path: lightning_build
         fetch-depth: 0
+
+    - name: Install PennyLane-Lightning release candidate
+      if: github.event.pull_request.base.ref == 'v0.11.0-rc'
       run: |
         # Lightning-Kokkos can no longer be installed with pip from git
         cd lightning_build

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -445,8 +445,6 @@ jobs:
         python3 -m pip install oqc-qcaas-client
         make frontend
 
-    # TODO: ------------ remove before merging to main --------------------- #
-    # Install pennylane and pennylane-lightning rc versions for the testing during feature freeze
     - name: Install PennyLane release candidate
       if: github.event.pull_request.base.ref == 'v0.11.0-rc'
       run: |
@@ -467,7 +465,6 @@ jobs:
         pip install --no-deps --force .
         PL_BACKEND=lightning_kokkos python scripts/configure_pyproject_toml.py
         pip install --no-deps --force .
-    # ------------------------------------------------------------------- #
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build
@@ -546,8 +543,6 @@ jobs:
         python3 -m pip install -r requirements.txt
         make frontend
 
-    # TODO: ------------ remove before merging to main --------------------- #
-    # Install pennylane and pennylane-lightning rc versions for the testing during feature freeze
     - name: Install PennyLane release candidate
       if: github.event.pull_request.base.ref == 'v0.11.0-rc'
       run: |
@@ -568,7 +563,6 @@ jobs:
         pip install --no-deps --force .
         PL_BACKEND=lightning_kokkos python scripts/configure_pyproject_toml.py
         pip install --no-deps --force .
-    # ------------------------------------------------------------------- #
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build
@@ -627,8 +621,6 @@ jobs:
         python3 -m pip install -r requirements.txt
         make frontend
 
-    # TODO: ------------ remove before merging to main --------------------- #
-    # Install pennylane and pennylane-lightning rc versions for the testing during feature freeze
     - name: Install PennyLane release candidate
       if: github.event.pull_request.base.ref == 'v0.11.0-rc'
       run: |
@@ -649,7 +641,6 @@ jobs:
         pip install --no-deps --force .
         PL_BACKEND=lightning_kokkos python scripts/configure_pyproject_toml.py
         pip install --no-deps --force .
-    # ------------------------------------------------------------------- #
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -579,6 +579,29 @@ jobs:
         python3 -m pip install -r requirements.txt
         make frontend
 
+    # TODO: ------------ remove before merging to main --------------------- #
+    # Install pennylane and pennylane-lightning rc versions for the testing during feature freeze
+    - name: Install PennyLane release candidate
+      if: github.event.pull_request.base.ref == 'v0.11.0-rc'
+      run: |
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.41.0-rc0
+
+    - name: Install PennyLane-Lightning release candidate
+      if: github.event.pull_request.base.ref == 'v0.11.0-rc'
+      uses: actions/checkout@v4
+      with:
+        repository: PennyLaneAI/pennylane-lightning
+        ref: v0.41.0_rc
+        path: lightning_build
+        fetch-depth: 0
+      run: |
+        # Lightning-Kokkos can no longer be installed with pip from git
+        cd lightning_build
+        pip install --no-deps --force .
+        PL_BACKEND=lightning_kokkos python scripts/configure_pyproject_toml.py
+        pip install --no-deps --force .
+    # ------------------------------------------------------------------- #
+
     - name: Get Cached LLVM Build
       id: cache-llvm-build
       uses: actions/cache@v4

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -445,6 +445,29 @@ jobs:
         python3 -m pip install oqc-qcaas-client
         make frontend
 
+    # TODO: ------------ remove before merging to main --------------------- #
+    # Install pennylane and pennylane-lightning rc versions for the testing during feature freeze
+    - name: Install PennyLane release candidate
+      if: github.event.pull_request.base.ref == 'v0.11.0-rc'
+      run: |
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.41.0-rc0
+
+    - name: Install PennyLane-Lightning release candidate
+      if: github.event.pull_request.base.ref == 'v0.11.0-rc'
+      uses: actions/checkout@v4
+      with:
+        repository: PennyLaneAI/pennylane-lightning
+        ref: v0.41.0_rc
+        path: lightning_build
+        fetch-depth: 0
+      run: |
+        # Lightning-Kokkos can no longer be installed with pip from git
+        cd lightning_build
+        pip install --no-deps --force .
+        PL_BACKEND=lightning_kokkos python scripts/configure_pyproject_toml.py
+        pip install --no-deps --force .
+    # ------------------------------------------------------------------- #
+
     - name: Get Cached LLVM Build
       id: cache-llvm-build
       uses: actions/cache@v4
@@ -521,6 +544,29 @@ jobs:
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
         make frontend
+
+    # TODO: ------------ remove before merging to main --------------------- #
+    # Install pennylane and pennylane-lightning rc versions for the testing during feature freeze
+    - name: Install PennyLane release candidate
+      if: github.event.pull_request.base.ref == 'v0.11.0-rc'
+      run: |
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.41.0-rc0
+
+    - name: Install PennyLane-Lightning release candidate
+      if: github.event.pull_request.base.ref == 'v0.11.0-rc'
+      uses: actions/checkout@v4
+      with:
+        repository: PennyLaneAI/pennylane-lightning
+        ref: v0.41.0_rc
+        path: lightning_build
+        fetch-depth: 0
+      run: |
+        # Lightning-Kokkos can no longer be installed with pip from git
+        cd lightning_build
+        pip install --no-deps --force .
+        PL_BACKEND=lightning_kokkos python scripts/configure_pyproject_toml.py
+        pip install --no-deps --force .
+    # ------------------------------------------------------------------- #
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -463,6 +463,7 @@ jobs:
       run: |
         # Lightning-Kokkos can no longer be installed with pip from git
         cd lightning_build
+        pip install -r requirements.txt
         pip install --no-deps --force .
         PL_BACKEND=lightning_kokkos python scripts/configure_pyproject_toml.py
         pip install --no-deps --force .
@@ -563,6 +564,7 @@ jobs:
       run: |
         # Lightning-Kokkos can no longer be installed with pip from git
         cd lightning_build
+        pip install -r requirements.txt
         pip install --no-deps --force .
         PL_BACKEND=lightning_kokkos python scripts/configure_pyproject_toml.py
         pip install --no-deps --force .
@@ -643,6 +645,7 @@ jobs:
       run: |
         # Lightning-Kokkos can no longer be installed with pip from git
         cd lightning_build
+        pip install -r requirements.txt
         pip install --no-deps --force .
         PL_BACKEND=lightning_kokkos python scripts/configure_pyproject_toml.py
         pip install --no-deps --force .

--- a/Makefile
+++ b/Makefile
@@ -110,12 +110,6 @@ frontend:
 	# versions of a package with the same version tag (e.g. 0.38-dev0).
 	$(PYTHON) -m pip uninstall -y pennylane
 	$(PYTHON) -m pip install -e . --extra-index-url https://test.pypi.org/simple $(PIP_VERBOSE_FLAG)
-	# TODO: ------------ remove before merging to main --------------------- #
-	# Install pennylane and pennylane-lightning rc versions for the testing during feature freeze
-	$(PYTHON) -m pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.41.0-rc0
-	$(PYTHON) -m pip install -i https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.41.0rc0
-	$(PYTHON) -m pip install -i https://test.pypi.org/simple/ PennyLane-Lightning==0.41.0rc0
-	# ------------------------------------------------------------------- #
 	rm -r frontend/PennyLane_Catalyst.egg-info
 
 .PHONY: mlir llvm mhlo enzyme dialects runtime oqc

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,12 @@ frontend:
 	# versions of a package with the same version tag (e.g. 0.38-dev0).
 	$(PYTHON) -m pip uninstall -y pennylane
 	$(PYTHON) -m pip install -e . --extra-index-url https://test.pypi.org/simple $(PIP_VERBOSE_FLAG)
+	# TODO: ------------ remove before merging to main --------------------- #
+	# Install pennylane and pennylane-lightning rc versions for the testing during feature freeze
+	$(PYTHON) -m pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.41.0-rc0
+	$(PYTHON) -m pip install -i https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.41.0rc0
+	$(PYTHON) -m pip install -i https://test.pypi.org/simple/ PennyLane-Lightning==0.41.0rc0
+	# ------------------------------------------------------------------- #
 	rm -r frontend/PennyLane_Catalyst.egg-info
 
 .PHONY: mlir llvm mhlo enzyme dialects runtime oqc


### PR DESCRIPTION
**Context:**
Currently, CIs running on the Catalyst rc branch, test Catalyst with respect to the Pennylane and Lightning versions specified in the `.dep-versions` file. However, this can cause issues when there are significant divergence between the main and rc branches in these repos.  

**Description of the Change:**
In this PR we temporarily overwrite the installation of `Pennylane`, `Pennylane-lightning`, and `Pennylane-Lightning-kokkos` to point to the RC branches.

**Benefits:**
Better testing against other rc branches and avoid any conflicts with dev branches of `Pennylane` and `Lightning`.

**Possible Drawbacks:**
This PR needs to be reverted before merging the rc branch to main.

**Related GitHub Issues:**
