### PR TITLE
Add support for StatePrep and BasisState in QJIT with PLxPR program capture

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -19,8 +19,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* Catalyst now correctly supports `qml.StatePrep()` operations in the experimental PennyLane
-  program-capture pipeline.
+* Catalyst now correctly supports `qml.StatePrep()` and `qml.BasisState()` operations in the
+  experimental PennyLane program-capture pipeline.
   [(#1631)](https://github.com/PennyLaneAI/catalyst/pull/1631)
 
 <h3>Internal changes ⚙️</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -19,6 +19,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Catalyst now correctly supports `qml.StatePrep()` operations in the experimental PennyLane
+  program-capture pipeline.
+  [(#1631)](https://github.com/PennyLaneAI/catalyst/pull/1631)
+
 <h3>Internal changes ⚙️</h3>
 
 <h3>Documentation 📝</h3>

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -322,7 +322,6 @@ class QFuncPlxprInterpreter(PlxprInterpreter):
         """Re-bind a pennylane operation as a catalyst instruction."""
 
         in_qubits = [self.get_wire(w) for w in op.wires]
-
         out_qubits = qinst_p.bind(
             *[*in_qubits, *op.data],
             op=op.name,
@@ -331,28 +330,9 @@ class QFuncPlxprInterpreter(PlxprInterpreter):
             ctrl_len=0,
             adjoint=False,
         )
-
         for wire_values, new_wire in zip(op.wires, out_qubits):
             self.wire_map[wire_values] = new_wire
 
-        return out_qubits
-
-    def _interpret_and_bind_basis_state_op(self, op, in_qubits):
-        """Helper function for `interpret_operation` for BasisState ops."""
-        basis_state = jax.lax.convert_element_type(op.parameters[0], jnp.dtype(jnp.bool))
-        out_qubits = set_basis_state_p.bind(*in_qubits, basis_state)
-        return out_qubits
-
-    def _interpret_and_bind_state_prep_op(self, op, in_qubits):
-        """Helper function for `interpret_operation` for StatePrep ops."""
-        # jnp.complex128 is the top element in the type promotion lattice so it is ok to do
-        # this: https://jax.readthedocs.io/en/latest/type_promotion.html
-        state_vector = jax.lax.convert_element_type(op.parameters[0], jnp.dtype(jnp.complex128))
-
-        err_msg = "State vector must have shape (2**wires,)"
-        assert state_vector.shape == (2 ** len(in_qubits),), err_msg
-
-        out_qubits = set_state_p.bind(*in_qubits, state_vector)
         return out_qubits
 
     def _obs(self, obs):

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -451,8 +451,8 @@ def handle_state_prep(self, *invals, n_wires, **kwargs):
     # https://jax.readthedocs.io/en/latest/type_promotion.html
     state = jax.lax.convert_element_type(state_inval, jnp.dtype(jnp.complex128))
     wires = [self.get_wire(w) for w in wires_inval]
-
     out_wires = set_state_p.bind(*wires, state)
+
     for wire_values, new_wire in zip(wires_inval, out_wires):
         self.wire_map[wire_values] = new_wire
 

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -324,20 +324,13 @@ class QFuncPlxprInterpreter(PlxprInterpreter):
         in_qubits = [self.get_wire(w) for w in op.wires]
 
         if isinstance(op, qml.BasisState):
-            basis_state = jax.lax.convert_element_type(op.parameters[0], jnp.dtype(jnp.bool))
-            out_qubits = set_basis_state_p.bind(*in_qubits, basis_state)
+            out_qubits = self._interpret_and_bind_basis_state_op(op, in_qubits)
 
         elif isinstance(op, qml.StatePrep):
-            # jnp.complex128 is the top element in the type promotion lattice so it is ok to do
-            # this: https://jax.readthedocs.io/en/latest/type_promotion.html
-            state_vector = jax.lax.convert_element_type(op.parameters[0], jnp.dtype(jnp.complex128))
-
-            err_msg = "State vector must have shape (2**wires,)"
-            assert state_vector.shape == (2 ** len(in_qubits),), err_msg
-
-            out_qubits = set_state_p.bind(*in_qubits, state_vector)
+            out_qubits = self._interpret_and_bind_state_prep_op(op, in_qubits)
 
         else:
+            # Assume all other ops reaching this point are general quantum instructions
             out_qubits = qinst_p.bind(
                 *[*in_qubits, *op.data],
                 op=op.name,
@@ -350,6 +343,24 @@ class QFuncPlxprInterpreter(PlxprInterpreter):
         for wire_values, new_wire in zip(op.wires, out_qubits):
             self.wire_map[wire_values] = new_wire
 
+        return out_qubits
+
+    def _interpret_and_bind_basis_state_op(self, op, in_qubits):
+        """Helper function for `interpret_operation` for BasisState ops."""
+        basis_state = jax.lax.convert_element_type(op.parameters[0], jnp.dtype(jnp.bool))
+        out_qubits = set_basis_state_p.bind(*in_qubits, basis_state)
+        return out_qubits
+
+    def _interpret_and_bind_state_prep_op(self, op, in_qubits):
+        """Helper function for `interpret_operation` for StatePrep ops."""
+        # jnp.complex128 is the top element in the type promotion lattice so it is ok to do
+        # this: https://jax.readthedocs.io/en/latest/type_promotion.html
+        state_vector = jax.lax.convert_element_type(op.parameters[0], jnp.dtype(jnp.complex128))
+
+        err_msg = "State vector must have shape (2**wires,)"
+        assert state_vector.shape == (2 ** len(in_qubits),), err_msg
+
+        out_qubits = set_state_p.bind(*in_qubits, state_vector)
         return out_qubits
 
     def _obs(self, obs):

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -65,6 +65,7 @@ from catalyst.jax_primitives import (
     quantum_kernel_p,
     qunitary_p,
     sample_p,
+    set_state_p,
     state_p,
     var_p,
     while_p,
@@ -319,14 +320,20 @@ class QFuncPlxprInterpreter(PlxprInterpreter):
         """Re-bind a pennylane operation as a catalyst instruction."""
 
         in_qubits = [self.get_wire(w) for w in op.wires]
-        out_qubits = qinst_p.bind(
-            *[*in_qubits, *op.data],
-            op=op.name,
-            qubits_len=len(op.wires),
-            params_len=len(op.data),
-            ctrl_len=0,
-            adjoint=False,
-        )
+
+        if isinstance(op, qml.StatePrep):
+            out_qubits = set_state_p.bind(*[*in_qubits, *op.data])
+
+        else:
+            out_qubits = qinst_p.bind(
+                *[*in_qubits, *op.data],
+                op=op.name,
+                qubits_len=len(op.wires),
+                params_len=len(op.data),
+                ctrl_len=0,
+                adjoint=False,
+            )
+
         for wire_values, new_wire in zip(op.wires, out_qubits):
             self.wire_map[wire_values] = new_wire
 

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -177,6 +177,22 @@ class TestCapture:
 
         assert jnp.allclose(actual, desired)
 
+    def test_state_prep(self, backend):
+        """Test the integration for a circuit with StatePrep."""
+        dev = qml.device(backend, wires=1)
+
+        @qml.qnode(dev)
+        def circuit(init_state):
+            qml.StatePrep(init_state, wires=0)
+            return qml.state()
+
+        init_state = jnp.array([1.0 + 0.0j, 1.0 + 0.0j], dtype="complex") / jnp.sqrt(2)
+
+        desired = circuit(init_state)
+        actual = qjit(circuit, experimental_capture=True)(init_state)
+
+        assert jnp.allclose(actual, desired)
+
     @pytest.mark.xfail(reason="Adjoint not supported.")
     @pytest.mark.parametrize("theta, val", [(jnp.pi, 0), (-100.0, 1)])
     def test_adjoint(self, backend, theta, val):

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -177,7 +177,15 @@ class TestCapture:
 
         assert jnp.allclose(actual, desired)
 
-    def test_state_prep(self, backend):
+    @pytest.mark.parametrize(
+        "init_state",
+        [
+            jnp.array([1.0, 0.0], dtype="complex"),
+            jnp.array([0.0, 1.0], dtype="complex"),
+            jnp.array([1.0, 1.0], dtype="complex") / jnp.sqrt(2),
+        ],
+    )
+    def test_state_prep(self, backend, init_state):
         """Test the integration for a circuit with StatePrep."""
         dev = qml.device(backend, wires=1)
 
@@ -190,6 +198,23 @@ class TestCapture:
 
         desired = circuit(init_state)
         actual = qjit(circuit, experimental_capture=True)(init_state)
+
+        assert jnp.allclose(actual, desired)
+
+    @pytest.mark.parametrize(
+        "basis_state", [jnp.array([0, 0]), jnp.array([0, 1]), jnp.array([1, 0]), jnp.array([1, 1])]
+    )
+    def test_basis_state(self, backend, basis_state):
+        """Test the integration for a circuit with BasisState."""
+        dev = qml.device(backend, wires=2)
+
+        @qml.qnode(dev)
+        def circuit(_basis_state):
+            qml.BasisState(_basis_state, wires=[0, 1])
+            return qml.state()
+
+        desired = circuit(basis_state)
+        actual = qjit(circuit, experimental_capture=True)(basis_state)
 
         assert jnp.allclose(actual, desired)
 

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -180,9 +180,11 @@ class TestCapture:
     @pytest.mark.parametrize(
         "init_state",
         [
-            jnp.array([1.0, 0.0], dtype="complex"),
-            jnp.array([0.0, 1.0], dtype="complex"),
-            jnp.array([1.0, 1.0], dtype="complex") / jnp.sqrt(2),
+            jnp.array([1.0, 0.0], dtype=jnp.complex128),
+            jnp.array([0.0, 1.0], dtype=jnp.complex128),
+            jnp.array([1.0, 1.0], dtype=jnp.complex128) / jnp.sqrt(2.0),
+            jnp.array([0.0, 1.0], dtype=jnp.float64),
+            jnp.array([0, 1], dtype=jnp.int64),
         ],
     )
     def test_state_prep(self, backend, init_state):
@@ -193,8 +195,6 @@ class TestCapture:
         def circuit(init_state):
             qml.StatePrep(init_state, wires=0)
             return qml.state()
-
-        init_state = jnp.array([1.0 + 0.0j, 1.0 + 0.0j], dtype="complex") / jnp.sqrt(2)
 
         desired = circuit(init_state)
         actual = qjit(circuit, experimental_capture=True)(init_state)

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -178,43 +178,53 @@ class TestCapture:
         assert jnp.allclose(actual, desired)
 
     @pytest.mark.parametrize(
-        "init_state",
+        "n_wires, basis_state",
         [
-            jnp.array([1.0, 0.0], dtype=jnp.complex128),
-            jnp.array([0.0, 1.0], dtype=jnp.complex128),
-            jnp.array([1.0, 1.0], dtype=jnp.complex128) / jnp.sqrt(2.0),
-            jnp.array([0.0, 1.0], dtype=jnp.float64),
-            jnp.array([0, 1], dtype=jnp.int64),
+            (1, jnp.array([0])),
+            (1, jnp.array([1])),
+            (2, jnp.array([0, 0])),
+            (2, jnp.array([0, 1])),
+            (2, jnp.array([1, 0])),
+            (2, jnp.array([1, 1])),
         ],
     )
-    def test_state_prep(self, backend, init_state):
-        """Test the integration for a circuit with StatePrep."""
-        dev = qml.device(backend, wires=1)
-
-        @qml.qnode(dev)
-        def circuit(init_state):
-            qml.StatePrep(init_state, wires=0)
-            return qml.state()
-
-        desired = circuit(init_state)
-        actual = qjit(circuit, experimental_capture=True)(init_state)
-
-        assert jnp.allclose(actual, desired)
-
-    @pytest.mark.parametrize(
-        "basis_state", [jnp.array([0, 0]), jnp.array([0, 1]), jnp.array([1, 0]), jnp.array([1, 1])]
-    )
-    def test_basis_state(self, backend, basis_state):
+    def test_basis_state(self, backend, n_wires, basis_state):
         """Test the integration for a circuit with BasisState."""
-        dev = qml.device(backend, wires=2)
+        dev = qml.device(backend, wires=n_wires)
 
         @qml.qnode(dev)
         def circuit(_basis_state):
-            qml.BasisState(_basis_state, wires=[0, 1])
+            qml.BasisState(_basis_state, wires=list(range(n_wires)))
             return qml.state()
 
         desired = circuit(basis_state)
         actual = qjit(circuit, experimental_capture=True)(basis_state)
+
+        assert jnp.allclose(actual, desired)
+
+    @pytest.mark.parametrize(
+        "n_wires, init_state",
+        [
+            (1, jnp.array([1.0, 0.0], dtype=jnp.complex128)),
+            (1, jnp.array([0.0, 1.0], dtype=jnp.complex128)),
+            (1, jnp.array([1.0, 1.0], dtype=jnp.complex128) / jnp.sqrt(2.0)),
+            (1, jnp.array([0.0, 1.0], dtype=jnp.float64)),
+            (1, jnp.array([0, 1], dtype=jnp.int64)),
+            (2, jnp.array([1.0, 0.0, 0.0, 0.0], dtype=jnp.complex128)),
+            (2, jnp.array([0.0, 1.0, 0.0, 0.0], dtype=jnp.complex128)),
+        ],
+    )
+    def test_state_prep(self, backend, n_wires, init_state):
+        """Test the integration for a circuit with StatePrep."""
+        dev = qml.device(backend, wires=n_wires)
+
+        @qml.qnode(dev)
+        def circuit(init_state):
+            qml.StatePrep(init_state, wires=list(range(n_wires)))
+            return qml.state()
+
+        desired = circuit(init_state)
+        actual = qjit(circuit, experimental_capture=True)(init_state)
 
         assert jnp.allclose(actual, desired)
 


### PR DESCRIPTION
**Context:** Currently, when you try to execute a circuit containing `qml.StatePrep()` through the QJIT pipeline with PLxPR program capture enabled it results in an error, since the operation is bound to the `qinst_p` primitive rather than the `set_state_p` primitive. `qinst_p` primitives expect input parameters to be of type `float64`, but `StatePrep` can have complex input values, hence the error (see issue #1630 for details).

**Description of the Change:** Binds `qml.StatePrep` operations to the `set_state_p` primitive to correctly support StatePrep in QJIT with PLxPR program capture. This PR also adds support for `qml.BasisState()` in QJIT with PLxPR capture since it is closely related to StatePrep. 

**Related GitHub Issues:** Fixes #1630

[[sc-88638](https://app.shortcut.com/xanaduai/story/88638/make-qml-stateprep-qjit-compatible-with-plxpr-program-capture), [sc-88653](https://app.shortcut.com/xanaduai/story/88653/stateprep-not-supported-in-qjit-with-plxpr-program-capture-enabled)]
