### PR TITLE
Raise an error when rebuilding a PyTree leaf from a ShapedArray

### DIFF
--- a/frontend/catalyst/tracing/type_signatures.py
+++ b/frontend/catalyst/tracing/type_signatures.py
@@ -82,7 +82,10 @@ def get_abstract_signature(args):
 
     abstract_args = [shaped_abstractify(arg) for arg in flat_args]
 
-    return tree_unflatten(treedef, abstract_args)
+    if all(not isinstance(arg, jax.core.ShapedArray) for arg in abstract_args):
+        return tree_unflatten(treedef, abstract_args)
+
+    raise TypeError("Cannot reconstruct a PyTree leaf from a ShapedArray")
 
 
 def verify_static_argnums_type(static_argnums):


### PR DESCRIPTION
**Context:** Trying to reconstruct a PyTree leaf from a ShapedArray fails.

**Description of the Change:** Before unflattening a previously flattened arg list, check if any of the abstracted args is a ShapedArray. If this is true, raise an error.

**Benefits:** Capture the error before JAX tree unflatten function, which might give details to the user which are too low level.

**Related GitHub Issues:** #339 
