### PR TITLE
run rc sync after the version bump

### DIFF
--- a/.github/workflows/rc_sync.yaml
+++ b/.github/workflows/rc_sync.yaml
@@ -7,9 +7,9 @@ name: Sync release candidate with main
 
 # Controls when the workflow will run
 on:
-  # Scheduled trigger every weekday at 2:47am UTC
+  # Scheduled trigger every weekday at 1:47am EST (6:47am UTC)
   schedule:
-  - cron:  '47 2 * * 1-5'
+  - cron:  '47 6 * * 1-5'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
**Context:**

Currently the nightly version bump is run after the rc sync action which causes a merge conflict due to different dev versions between the rc and main branch.

**Description of the Change:**

Run the rc sync action after the nightly version bump.

**Benefits:**

No more merge conflicts for rc sync PRs

**Possible Drawbacks:**

**Related GitHub Issues:**
