### PR TITLE
Improve error message for `mlir` and `mlir_opt`.

### DIFF
--- a/doc/releases/changelog-0.11.0.md
+++ b/doc/releases/changelog-0.11.0.md
@@ -223,6 +223,7 @@
 
 * Added `qjit.mlir_opt` property to access the optimized MLIR representation of a compiled function.
   [(#1579)](https://github.com/PennyLaneAI/catalyst/pull/1579)
+  [(#1637)](https://github.com/PennyLaneAI/catalyst/pull/1637)
 
 * Improve error message for ZNE.
   [(#1603)](https://github.com/PennyLaneAI/catalyst/pull/1603)

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -290,8 +290,11 @@ def _catalyst(*args, stdin=None):
     catalyst *args
     """
     cmd = _get_catalyst_cli_cmd(*args, stdin=stdin)
-    result = subprocess.run(cmd, input=stdin, check=True, capture_output=True, text=True)
-    return result.stdout
+    try:
+        result = subprocess.run(cmd, input=stdin, check=True, capture_output=True, text=True)
+        return result.stdout
+    except subprocess.CalledProcessError as e:
+        raise CompileError(f"catalyst failed with error code {e.returncode}: {e.stderr}") from e
 
 
 def _quantum_opt(*args, stdin=None):

--- a/frontend/test/pytest/test_debug.py
+++ b/frontend/test/pytest/test_debug.py
@@ -558,6 +558,12 @@ class TestOptionsToCliFlags:
         ).strip()
         assert expected in observed
 
+    def test_catalyst_error(self):
+        mlir = """This is invalid MLIR"""
+        msg = "custom op 'This'"
+        with pytest.raises(CompileError, match=msg):
+            to_mlir_opt(stdin=mlir)
+
 
 if __name__ == "__main__":
     pytest.main(["-x", __file__])


### PR DESCRIPTION
**Context:** `mlir` and `mlir_opt` now call the compiler, which should show errors when there are compiler errors.

**Description of the Change:** Show the compiler error to the user.

**Benefits:** Better error reporting.

**Possible Drawbacks:** None.

**Related GitHub Issues:**

[sc-88788]