### PR TITLE
Bump Pennylane and Lightning versions [DO NOT MERGE]

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,8 +8,8 @@ enzyme=v0.0.149
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt
-pennylane=0.41.0-dev56
+# pennylane=0.41.0-dev56
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'
-lightning=0.41.0-dev22
+# lightning=0.41.0-dev22

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -449,6 +449,11 @@ jobs:
 
     - name: Install Catalyst
       run: |
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning==0.41.0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.41.0
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.41.0-rc0
+        # -------------------------------------------------------------------- #
         python${{ matrix.python_version }} -m pip install dist/*.whl --extra-index-url https://test.pypi.org/simple
 
     - name: Install Standalone Plugin

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -452,6 +452,11 @@ jobs:
 
     - name: Install Catalyst
       run: |
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning==0.41.0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.41.0
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.41.0-rc0
+        # -------------------------------------------------------------------- #
         python${{ matrix.python_version }} -m pip install dist/*.whl --extra-index-url https://test.pypi.org/simple
 
     - name: Install Standalone Plugin

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -409,6 +409,11 @@ jobs:
 
     - name: Install Catalyst
       run: |
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning==0.41.0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.41.0
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.41.0-rc0
+        # -------------------------------------------------------------------- #
         python${{ matrix.python_version }} -m pip install dist/*.whl --extra-index-url https://test.pypi.org/simple
 
     - name: Install Standalone Plugin

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -443,6 +443,11 @@ jobs:
         # macOS requirements.txt
         python3 -m pip install cuda-quantum==0.6.0
         python3 -m pip install oqc-qcaas-client
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning==0.41.0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.41.0
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.41.0-rc0
+        # -------------------------------------------------------------------- #
         make frontend
 
     - name: Install PennyLane release candidate
@@ -544,6 +549,11 @@ jobs:
         sudo apt-get install -y python3 python3-pip libomp-dev libasan6 make ninja-build
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning==0.41.0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.41.0
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.41.0-rc0
+        # -------------------------------------------------------------------- #
         make frontend
 
     - name: Install PennyLane release candidate
@@ -625,6 +635,11 @@ jobs:
         sudo apt-get install -y python3 python3-pip libomp-dev libasan6 make ninja-build
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning==0.41.0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.41.0
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.41.0-rc0
+        # -------------------------------------------------------------------- #
         make frontend
 
     - name: Install PennyLane release candidate

--- a/.github/workflows/scripts/linux_arm64/rh8/test_wheels.sh
+++ b/.github/workflows/scripts/linux_arm64/rh8/test_wheels.sh
@@ -35,6 +35,11 @@ export PATH=/catalyst/llvm-build/bin:/opt/_internal/cpython-${PYTHON_MAJOR_MINOR
 /usr/bin/python3 -m pip install oqc-qcaas-client
 
 # Install Catalyst wheel
+# TODO: --- remove workaround before merging to main ----------------- #
+pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning==0.41.0
+pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.41.0
+pip install git+https://github.com/PennyLaneAI/pennylane@v0.41.0-rc0
+# -------------------------------------------------------------------- #
 /usr/bin/python3 -m pip install /catalyst/dist/*.whl --extra-index-url https://test.pypi.org/simple
 
 # Test Catalyst

--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,9 @@ frontend:
 	@echo "install Catalyst Frontend"
 	# Uninstall pennylane before updating Catalyst, since pip will not replace two development
 	# versions of a package with the same version tag (e.g. 0.38-dev0).
-	$(PYTHON) -m pip uninstall -y pennylane
+	# TODO: --- enable the following line before merging to main ------------- #
+	# $(PYTHON) -m pip uninstall -y pennylane
+	# ------------------------------------------------------------------------ #
 	$(PYTHON) -m pip install -e . --extra-index-url https://test.pypi.org/simple $(PIP_VERBOSE_FLAG)
 	rm -r frontend/PennyLane_Catalyst.egg-info
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -30,6 +30,6 @@ lxml_html_clean
 
 # Pre-install PL development wheels
 --extra-index-url https://test.pypi.org/simple/
-pennylane-lightning-kokkos==0.41.0-dev22
-pennylane-lightning==0.41.0-dev22
-pennylane==0.41.0-dev56
+pennylane-lightning-kokkos==0.41.0
+pennylane-lightning==0.41.0
+pennylane @ git+https://github.com/pennylaneAI/pennylane@v0.41.0-rc0

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ jax_version = dep_versions.get("jax")
 pl_version = dep_versions.get("pennylane")
 lq_version = dep_versions.get("lightning")
 
-pl_min_release = "0.40"
+pl_min_release = "0.41.0"
 lq_min_release = pl_min_release
 
 if pl_version is not None:


### PR DESCRIPTION
**Context:**

Bump the PennyLane and Lightning minimum versions in preparation for the Catalyst 0.11.0 release. These changes ensure we can build the wheels after the Lightning release and before the core PennyLane release.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
