### PR TITLE
Add quantum gate commutation patterns based on canonical ordering

### DIFF
--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -468,7 +468,7 @@ def CustomOp : UnitaryGate_Op<"custom", [DifferentiableGate, NoMemoryEffect,
             if (!isStatic()) {
                 return staticValues;
             }
-            
+
             for (mlir::Value param : getParams()) {
                 auto constOp = param.getDefiningOp();
                 if (auto floatAttr = constOp->getAttrOfType<mlir::FloatAttr>("value")) {
@@ -478,7 +478,7 @@ def CustomOp : UnitaryGate_Op<"custom", [DifferentiableGate, NoMemoryEffect,
             return staticValues;
         }
     }];
-    let hasCanonicalizeMethod = 1;
+    let hasCanonicalizer = 1;
 }
 
 def GlobalPhaseOp : UnitaryGate_Op<"gphase", [DifferentiableGate, AttrSizedOperandSegments]> {
@@ -549,7 +549,7 @@ def MultiRZOp : UnitaryGate_Op<"multirz", [DifferentiableGate, NoMemoryEffect,
             return getODSOperands(getParamOperandIdx());
         }
     }];
-    
+
     let hasCanonicalizeMethod = 1;
 }
 

--- a/mlir/test/Quantum/CanonicalizationTest.mlir
+++ b/mlir/test/Quantum/CanonicalizationTest.mlir
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// RUN: quantum-opt --canonicalize --cse %s | FileCheck %s
+// RUN: quantum-opt --canonicalize --cse --split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: test_alloc_dce
 func.func @test_alloc_dce() {


### PR DESCRIPTION
**Context:**
Require canonical order for CNOT, RZ, and PauliX gates.

**Description of the Change:**

This PR adds gate commutation pattern `GateCommutationPattern` to enable the reordering of {CNOT, RZ, PauliX} into a canonical order whenever possible. This change enforces the canonical order (CNOT->RZ->PauliX) using commutation rules.

1. Implementation Method: 
Add canonicalization pattern for gate commutation through `getCanonicalizationPatterns()`, separating the implementation from the original `canonicalize()` method used for Adjoint. Now it have `GateCommutationPattern` and `AdjointCanonicalizationPattern` for canonicalization of quantum gates.

2. Commutation Rules: The pattern handles the following commutation relations:
   - $(RZ(\theta) \otimes I) \times CNOT = CNOT \times (RZ(\theta) \otimes I)$ 
     ```
     q0 ─ RZ(θ) ─■─────        ──■──── RZ(θ) ─
                 │        =>     │
     q1 ─────────⊕─────        ──⊕────────────
     ```

   - $(I \otimes PauliX) \times CNOT = CNOT \times (I \otimes PauliX)$ 
     ```
     q0 ──────────■────        ──■────────────
                  │       =>     │
     q1 ─ PauliX ─⊕────        ──⊕─── PauliX ─
     ```

   - $PauliX \times RZ(\theta) = RZ(-\theta) \times PauliX$ 
     Add `mlir::arith::NegFOp` to negate the angle of `RZ` operation. 
     ``` 
     q0 ── PauliX ─ RZ(θ) ──  =>  ── RZ(-θ) ─ PauliX ── 
     ```

3. Adds test cases for the gate commutation patterns: 
    verifying the canonical order (CNOT->RZ->PauliX) through following scenarios:
    1. CNOT and RZ commutation: 
        - test_cnot_rz_canonicalize: Verifies $(RZ(\theta) \otimes I) \times CNOT = CNOT \times (RZ(\theta) \otimes I)$ 
        - test_cnot_rz_non_commute: Confirms non-commutation when RZ is on target qubit
    2. CNOT and PauliX commutation:
        - test_cnot_pauli_x_canonicalize: Verifies $(I \otimes PauliX) \times CNOT = CNOT \times (I \otimes PauliX)$
        - test_cnot_pauli_x_non_commute: Confirms non-commutation when PauliX is on control qubit
    3. RZ and PauliX commutation: 
        - test_rz_pauli_x_canonicalize: Verifies $PauliX \times RZ(\theta) = RZ(-\theta) \times PauliX$
    5. CNOT with RZ on control qubit and PauliX on target qubit:
        - test_pauli_x_rz_cnot_canonicalize

**Benefits:**
    Enforce canonical order for CNOT, RZ, and PauliX gates. And simplifies the compilation pipeline by leveraging MLIR's built-in canonicalization framework, eliminating the need for additional passes.

**Related GitHub Issues:** #1550