### PR TITLE
Updates to version script

### DIFF
--- a/.github/workflows/set_dep_versions.py
+++ b/.github/workflows/set_dep_versions.py
@@ -39,6 +39,11 @@ if not match:
     url = f"https://raw.githubusercontent.com/google/jax/jaxlib-v{jax_version}/third_party/xla/workspace.bzl"
     response = requests.get(url)
     match = re.search(r'XLA_COMMIT = "([a-zA-Z0-9]*)"', response.text)
+if not match:
+    # It looks like starting version 5.0 there are no new releases of jaxlib and only of jax
+    url = f"https://raw.githubusercontent.com/jax-ml/jax/jax-v{jax_version}/third_party/xla/workspace.bzl"
+    response = requests.get(url)
+    match = re.search(r'XLA_COMMIT = "([a-zA-Z0-9]*)"', response.text)
 xla_commit = match.group(1)
 
 url = f"https://raw.githubusercontent.com/openxla/xla/{xla_commit}/third_party/llvm/workspace.bzl"

--- a/.github/workflows/set_dep_versions.py
+++ b/.github/workflows/set_dep_versions.py
@@ -51,6 +51,7 @@ response = requests.get(url)
 match = re.search(r'LLVM_COMMIT = "([a-zA-Z0-9]*)"', response.text)
 llvm_commit = match.group(1)
 
+
 # If the XLA commit is an "Integrate LLVM" commit we need to get the piper_id directly from there
 # to look up the corresponding mlir-hlo commit.
 url = f"https://api.github.com/repos/openxla/xla/commits?sha={xla_commit}&per_page=1"
@@ -68,6 +69,11 @@ else:
     match = re.search(r"PiperOrigin-RevId: ([0-9]*)", response[0]["commit"]["message"])
     piper_id = match.group(1)
 
+title = f"Integrate+LLVM+at+llvm/llvm-project@{llvm_commit[:12]}"
+url = f"https://api.github.com/search/commits?q=repo:openxla/stablehlo+{title}&per_page=1"
+responses = requests.get(url).json()
+stablehlo_commit = responses["items"][0]["sha"]
+
 url = f"https://api.github.com/search/commits?q=repo:tensorflow/mlir-hlo+{piper_id}"
 response = requests.get(url).json()
 hlo_commit = response["items"][0]["sha"]
@@ -83,6 +89,7 @@ jax={jax_version}
 mhlo={hlo_commit}
 llvm={llvm_commit}
 enzyme={enzyme_commit}
+stablehlo={stablehlo_commit}
 """
     )
 


### PR DESCRIPTION
**Context:** 
* j[axlib stopped being tagged after version 0.4.32](https://github.com/jax-ml/jax/releases)
* [mlir-hlo was removed in version 0.4.32](https://github.com/jax-ml/jax/blob/a39b6232be9b435fb3c8a82445708b7f8f71081d/CHANGELOG.md?plain=1#L482-L484)
* [JAX's organization changed from google to jax-ml](https://github.com/jax-ml/jax/discussions/23319)

**Description of the Change:**
* take into account those changes in the script that looks for dependencies.

**Benefits:** Easier to look for dependencies.
