### PR TITLE
[jax update] Update jax to 0.5.3

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -25,6 +25,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* The version of JAX used by Catalyst is updated to 0.5.3.
+  [(#???)](https://github.com/PennyLaneAI/catalyst/pull/???)
+
 <h3>Documentation 📝</h3>
 
 <h3>Contributors ✍️</h3>
@@ -32,4 +35,5 @@
 This release contains contributions from (in alphabetical order):
 
 Joey Carter,
-Erick Ochoa Lopez.
+Erick Ochoa Lopez,
+Paul Haochen Wang.


### PR DESCRIPTION
**Context:**
This is the main branch for updating jax to 0.5.3.

We will do this version-by-version. Each version should come in as a PR/commit. 
This allows us to run CI frequently at each version. 

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
