### PR TITLE
Fix AutoGraph fallback for certain iteration targets

### DIFF
--- a/benchmark/catalyst_benchmark/measurements.py
+++ b/benchmark/catalyst_benchmark/measurements.py
@@ -131,9 +131,7 @@ def measure_compile_catalyst(a: ParsedArguments) -> BenchmarkResult:
             expansion_strategy="device",
         )
     elif a.problem == "chemvqe":
-        from catalyst_benchmark.test_cases.chemvqe_catalyst import (
-            ProblemCVQE as Problem,
-        )
+        from catalyst_benchmark.test_cases.chemvqe_catalyst import ProblemCVQE as Problem
         from catalyst_benchmark.test_cases.chemvqe_catalyst import (
             qcompile,
             workflow,
@@ -145,15 +143,9 @@ def measure_compile_catalyst(a: ParsedArguments) -> BenchmarkResult:
             expansion_strategy="device",
         )
     elif a.problem == "chemvqe-hybrid":
-        from catalyst_benchmark.test_cases.chemvqe_catalyst import (
-            ProblemCVQE as Problem,
-        )
-        from catalyst_benchmark.test_cases.chemvqe_catalyst import (
-            qcompile_hybrid as qcompile,
-        )
-        from catalyst_benchmark.test_cases.chemvqe_catalyst import (
-            workflow_hybrid as workflow,
-        )
+        from catalyst_benchmark.test_cases.chemvqe_catalyst import ProblemCVQE as Problem
+        from catalyst_benchmark.test_cases.chemvqe_catalyst import qcompile_hybrid as qcompile
+        from catalyst_benchmark.test_cases.chemvqe_catalyst import workflow_hybrid as workflow
 
         p = Problem(
             qml.device("lightning.qubit", wires=a.nqubits),
@@ -215,9 +207,7 @@ def measure_runtime_catalyst(a: ParsedArguments) -> BenchmarkResult:
         p = Problem(qml.device("lightning.qubit", wires=a.nqubits), a.nlayers)
 
     elif a.problem == "chemvqe":
-        from catalyst_benchmark.test_cases.chemvqe_catalyst import (
-            ProblemCVQE as Problem,
-        )
+        from catalyst_benchmark.test_cases.chemvqe_catalyst import ProblemCVQE as Problem
         from catalyst_benchmark.test_cases.chemvqe_catalyst import (
             qcompile,
             workflow,
@@ -225,15 +215,9 @@ def measure_runtime_catalyst(a: ParsedArguments) -> BenchmarkResult:
 
         p = Problem(qml.device("lightning.qubit", wires=a.nqubits), diff_method=a.vqe_diff_method)
     elif a.problem == "chemvqe-hybrid":
-        from catalyst_benchmark.test_cases.chemvqe_catalyst import (
-            ProblemCVQE as Problem,
-        )
-        from catalyst_benchmark.test_cases.chemvqe_catalyst import (
-            qcompile_hybrid as qcompile,
-        )
-        from catalyst_benchmark.test_cases.chemvqe_catalyst import (
-            workflow_hybrid as workflow,
-        )
+        from catalyst_benchmark.test_cases.chemvqe_catalyst import ProblemCVQE as Problem
+        from catalyst_benchmark.test_cases.chemvqe_catalyst import qcompile_hybrid as qcompile
+        from catalyst_benchmark.test_cases.chemvqe_catalyst import workflow_hybrid as workflow
 
         p = Problem(qml.device("lightning.qubit", wires=a.nqubits), diff_method=a.vqe_diff_method)
     elif a.problem == "qft":
@@ -302,9 +286,7 @@ def measure_compile_pennylanejax(a: ParsedArguments) -> BenchmarkResult:
         )
 
     elif a.problem == "chemvqe":
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
-            ProblemCVQE as Problem,
-        )
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import ProblemCVQE as Problem
         from catalyst_benchmark.test_cases.chemvqe_pennylane import (
             qcompile,
             size,
@@ -319,18 +301,12 @@ def measure_compile_pennylanejax(a: ParsedArguments) -> BenchmarkResult:
             expansion_strategy="device",
         )
     elif a.problem == "chemvqe-hybrid":
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
-            ProblemCVQE as Problem,
-        )
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
-            qcompile_hybrid as qcompile,
-        )
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import ProblemCVQE as Problem
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import qcompile_hybrid as qcompile
         from catalyst_benchmark.test_cases.chemvqe_pennylane import (
             size,
         )
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
-            workflow_hybrid as workflow,
-        )
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import workflow_hybrid as workflow
 
         p = Problem(
             qml.device(device, wires=a.nqubits),
@@ -400,9 +376,7 @@ def measure_runtime_pennylanejax(a: ParsedArguments) -> BenchmarkResult:
         p = Problem(qml.device(device, wires=a.nqubits), a.nlayers, interface=interface)
 
     elif a.problem == "chemvqe":
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
-            ProblemCVQE as Problem,
-        )
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import ProblemCVQE as Problem
         from catalyst_benchmark.test_cases.chemvqe_pennylane import (
             qcompile,
             size,
@@ -416,18 +390,12 @@ def measure_runtime_pennylanejax(a: ParsedArguments) -> BenchmarkResult:
             diff_method=a.vqe_diff_method,
         )
     elif a.problem == "chemvqe-hybrid":
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
-            ProblemCVQE as Problem,
-        )
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
-            qcompile_hybrid as qcompile,
-        )
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import ProblemCVQE as Problem
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import qcompile_hybrid as qcompile
         from catalyst_benchmark.test_cases.chemvqe_pennylane import (
             size,
         )
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
-            workflow_hybrid as workflow,
-        )
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import workflow_hybrid as workflow
 
         p = Problem(
             qml.device(device, wires=a.nqubits),
@@ -492,9 +460,7 @@ def measure_compile_pennylane(a: ParsedArguments) -> BenchmarkResult:
             expansion_strategy="device",
         )
     elif a.problem == "chemvqe":
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
-            ProblemCVQE as Problem,
-        )
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import ProblemCVQE as Problem
         from catalyst_benchmark.test_cases.chemvqe_pennylane import (
             qcompile,
             size,
@@ -508,18 +474,12 @@ def measure_compile_pennylane(a: ParsedArguments) -> BenchmarkResult:
             expansion_strategy="device",
         )
     elif a.problem == "chemvqe-hybrid":
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
-            ProblemCVQE as Problem,
-        )
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
-            qcompile_hybrid as qcompile,
-        )
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import ProblemCVQE as Problem
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import qcompile_hybrid as qcompile
         from catalyst_benchmark.test_cases.chemvqe_pennylane import (
             size,
         )
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
-            workflow_hybrid as workflow,
-        )
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import workflow_hybrid as workflow
 
         p = Problem(
             qml.device(device, wires=a.nqubits),
@@ -575,9 +535,7 @@ def measure_runtime_pennylane(a: ParsedArguments) -> BenchmarkResult:
 
         p = Problem(qml.device(device, wires=a.nqubits), a.nlayers)
     elif a.problem == "chemvqe":
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
-            ProblemCVQE as Problem,
-        )
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import ProblemCVQE as Problem
         from catalyst_benchmark.test_cases.chemvqe_pennylane import (
             qcompile,
             size,
@@ -590,18 +548,12 @@ def measure_runtime_pennylane(a: ParsedArguments) -> BenchmarkResult:
             diff_method=a.vqe_diff_method,
         )
     elif a.problem == "chemvqe-hybrid":
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
-            ProblemCVQE as Problem,
-        )
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
-            qcompile_hybrid as qcompile,
-        )
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import ProblemCVQE as Problem
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import qcompile_hybrid as qcompile
         from catalyst_benchmark.test_cases.chemvqe_pennylane import (
             size,
         )
-        from catalyst_benchmark.test_cases.chemvqe_pennylane import (
-            workflow_hybrid as workflow,
-        )
+        from catalyst_benchmark.test_cases.chemvqe_pennylane import workflow_hybrid as workflow
 
         p = Problem(
             qml.device(device, wires=a.nqubits),

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -19,6 +19,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fix AutoGraph fallback for valid iteration targets with constant data but no length, for example
+  `itertools.product(range(2), repeat=2)`.
+  [(#1665)](https://github.com/PennyLaneAI/catalyst/pull/1665)
+
 * Catalyst now correctly supports `qml.StatePrep()` and `qml.BasisState()` operations in the
   experimental PennyLane program-capture pipeline.
   [(#1631)](https://github.com/PennyLaneAI/catalyst/pull/1631)
@@ -32,4 +36,5 @@
 This release contains contributions from (in alphabetical order):
 
 Joey Carter,
+David Ittah,
 Erick Ochoa Lopez.

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -287,20 +287,18 @@ def for_stmt(
         enum_start = None
         iteration_array = None
     elif isinstance(iteration_target, CEnumerate):
-        start, stop, step = 0, len(iteration_target.iteration_target), 1
-        enum_start = iteration_target.start_idx
         try:
+            start, stop, step = 0, len(iteration_target.iteration_target), 1
+            enum_start = iteration_target.start_idx
             iteration_array = jnp.asarray(iteration_target.iteration_target)
         except:  # pylint: disable=bare-except
-            iteration_array = None
             fallback = True
     else:
-        start, stop, step = 0, len(iteration_target), 1
-        enum_start = None
         try:
+            start, stop, step = 0, len(iteration_target), 1
+            enum_start = None
             iteration_array = jnp.asarray(iteration_target)
         except:  # pylint: disable=bare-except
-            iteration_array = None
             fallback = True
 
     if catalyst.autograph_strict_conversion and fallback:

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -33,9 +33,7 @@ from pennylane.ops.functions.map_wires import _map_wires_transform as pl_map_wir
 from pennylane.transforms import cancel_inverses as pl_cancel_inverses
 from pennylane.transforms import commute_controlled as pl_commute_controlled
 from pennylane.transforms import decompose as pl_decompose
-from pennylane.transforms import (
-    merge_amplitude_embedding as pl_merge_amplitude_embedding,
-)
+from pennylane.transforms import merge_amplitude_embedding as pl_merge_amplitude_embedding
 from pennylane.transforms import merge_rotations as pl_merge_rotations
 from pennylane.transforms import single_qubit_fusion as pl_single_qubit_fusion
 from pennylane.transforms import unitary_to_rot as pl_unitary_to_rot

--- a/frontend/catalyst/utils/jnp_to_memref.py
+++ b/frontend/catalyst/utils/jnp_to_memref.py
@@ -16,9 +16,7 @@ import numpy as np
 from mlir_quantum.runtime import (
     as_ctype,
 )
-from mlir_quantum.runtime import (
-    get_ranked_memref_descriptor as mlir_get_ranked_memref_descriptor,
-)
+from mlir_quantum.runtime import get_ranked_memref_descriptor as mlir_get_ranked_memref_descriptor
 from mlir_quantum.runtime import (
     get_unranked_memref_descriptor as mlir_get_unranked_memref_descriptor,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ extend-exclude = '''
 [tool.isort]
 py_version=311
 profile = "black"
+line_length = 100
 skip = [
   "catalyst/mlir/llvm-project",
   "frontend/catalyst/test/test_oqc/conftest.py",


### PR DESCRIPTION
Fix AutoGraph fallback for valid iteration targets with constant data but no length, for example the following program is now supported:

```py
@qml.qjit(autograph=True)
def fn(x):

    for i, j in itertools.product(range(2), repeat=2):
        x += i + j - i * j * jnp.sin(j)

    return x

>>> fn(5)
8.158529015192103
```

Fixes the bug discovered in #1340, but doesn't close it as it also contains a feature request.
[sc-89322]

(Also adjusts the line length `isort` is working with to 100, same as our other tools.)