### PR TITLE
Stop using AnyWires in prep for deprecation

### DIFF
--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -39,7 +39,7 @@ from pennylane.measurements import (
     StateMP,
     VarianceMP,
 )
-from pennylane.operation import AnyWires, Operation, Operator, Wires
+from pennylane.operation import Operation, Operator, Wires
 from pennylane.ops import Adjoint, Controlled, ControlledOp
 from pennylane.tape import QuantumTape
 from pennylane.transforms.core import TransformProgram
@@ -441,7 +441,6 @@ class HybridOp(Operator):
     def _no_binder(self, *_):
         raise RuntimeError("{self} does not support JAX binding")  # pragma: no cover
 
-    num_wires = AnyWires
     binder: Callable = _no_binder
 
     @debug_logger_init

--- a/frontend/test/pytest/device/test_decomposition.py
+++ b/frontend/test/pytest/device/test_decomposition.py
@@ -124,8 +124,6 @@ class TestControlledDecomposition:
         class OpWithNoMatrix(qml.operation.Operation):
             """Op without a matrix"""
 
-            num_wires = qml.operation.AnyWires
-
             def matrix(self):
                 """matrix undefined"""
                 raise NotImplementedError()
@@ -143,8 +141,6 @@ class TestControlledDecomposition:
 
         class UnknownOp(qml.operation.Operation):
             """An unknown operation"""
-
-            num_wires = qml.operation.AnyWires
 
             def matrix(self):
                 """The matrix"""

--- a/frontend/test/pytest/test_preprocess.py
+++ b/frontend/test/pytest/test_preprocess.py
@@ -157,8 +157,6 @@ class TestDecomposition:
         class OpWithNoMatrix(qml.operation.Operation):
             """Op without matrix."""
 
-            num_wires = qml.operation.AnyWires
-
             def matrix(self, wire_order=None):
                 """Matrix is overriden."""
                 raise NotImplementedError()


### PR DESCRIPTION
**Context:**

See PennyLane PR's https://github.com/PennyLaneAI/pennylane/pull/7312 and https://github.com/PennyLaneAI/pennylane/pull/7313 .

We want to stop using `WiresEnum` in favor of just having the default `num_wires = None` to indicate that the number of wires should not be validated. 

**Description of the Change:**

Stop setting `num_wires` when it is `AllWires` and just depend on inheriting the default.

**Benefits:**

Allows us to clean up the operator interface.

**Possible Drawbacks:**

**Related GitHub Issues:**
