### PR TITLE
Bump to jax 0.4.38

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -1,5 +1,5 @@
 # Always update the version check in catalyst.__init__ when changing the JAX version.
-jax=0.4.36
+jax=0.4.38
 mhlo=89a891c986650c33df76885f5620e0a92150d90f
 llvm=3a8316216807d64a586b971f51695e23883331f7
 enzyme=v0.0.149

--- a/frontend/catalyst/__init__.py
+++ b/frontend/catalyst/__init__.py
@@ -23,7 +23,7 @@ from os.path import dirname
 
 import jaxlib as _jaxlib
 
-_jaxlib_version = "0.4.36"
+_jaxlib_version = "0.4.38"
 if _jaxlib.__version__ != _jaxlib_version:
     import warnings
 

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -22,6 +22,7 @@ import jax
 import jax.core
 import jax.numpy as jnp
 import pennylane as qml
+from jax.extend.core import ClosedJaxpr, Jaxpr
 from jax.extend.linear_util import wrap_init
 from jax.interpreters.partial_eval import convert_constvars_jaxpr
 from pennylane.capture import PlxprInterpreter, qnode_prim
@@ -97,11 +98,11 @@ def _get_device_kwargs(device) -> dict:
 
 # code example has long lines
 # pylint: disable=line-too-long
-def from_plxpr(plxpr: jax.core.ClosedJaxpr) -> Callable[..., jax.core.Jaxpr]:
+def from_plxpr(plxpr: ClosedJaxpr) -> Callable[..., Jaxpr]:
     """Convert PennyLane variant jaxpr to Catalyst variant jaxpr.
 
     Args:
-        jaxpr (jax.core.ClosedJaxpr): PennyLane variant jaxpr
+        jaxpr (ClosedJaxpr): PennyLane variant jaxpr
 
     Returns:
         Callable: A function that accepts the same arguments as the plxpr and returns catalyst
@@ -544,9 +545,7 @@ def handle_for_loop(
         consts,
     )
     converted_jaxpr_branch = jax.make_jaxpr(converted_func)(*start_plus_args_plus_qreg).jaxpr
-    converted_closed_jaxpr_branch = jax.core.ClosedJaxpr(
-        convert_constvars_jaxpr(converted_jaxpr_branch), ()
-    )
+    converted_closed_jaxpr_branch = ClosedJaxpr(convert_constvars_jaxpr(converted_jaxpr_branch), ())
 
     # Build Catalyst compatible input values
     for_loop_invals = [*consts, start, stop, step, *start_plus_args_plus_qreg]
@@ -596,7 +595,7 @@ def handle_while_loop(
         consts_body,
     )
     converted_body_jaxpr_branch = jax.make_jaxpr(converted_body_func)(*args_plus_qreg).jaxpr
-    converted_body_closed_jaxpr_branch = jax.core.ClosedJaxpr(
+    converted_body_closed_jaxpr_branch = ClosedJaxpr(
         convert_constvars_jaxpr(converted_body_jaxpr_branch), ()
     )
 
@@ -607,7 +606,7 @@ def handle_while_loop(
         consts_cond,
     )
     converted_cond_jaxpr_branch = jax.make_jaxpr(converted_cond_func)(*args_plus_qreg).jaxpr
-    converted_cond_closed_jaxpr_branch = jax.core.ClosedJaxpr(
+    converted_cond_closed_jaxpr_branch = ClosedJaxpr(
         convert_constvars_jaxpr(converted_cond_jaxpr_branch), ()
     )
 

--- a/frontend/catalyst/jax_extras/lowering.py
+++ b/frontend/catalyst/jax_extras/lowering.py
@@ -24,7 +24,7 @@ from jax._src.interpreters.mlir import _module_name_regex
 from jax._src.sharding_impls import AxisEnv, ReplicaAxisContext
 from jax._src.source_info_util import new_name_stack
 from jax._src.util import wrap_name
-from jax.core import ClosedJaxpr
+from jax.extend.core import ClosedJaxpr
 from jax.interpreters.mlir import (
     AxisContext,
     LoweringParameters,

--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -35,7 +35,7 @@ from typing import (
 
 import jax
 from jax import ShapeDtypeStruct
-from jax._src.core import DBIdx
+from jax._src.core import DBIdx, InDBIdx, InputType, OutDBIdx, OutputType
 from jax._src.interpreters.mlir import _module_name_regex, register_lowering
 from jax._src.interpreters.partial_eval import (
     _input_type_to_tracers,
@@ -51,13 +51,8 @@ from jax._src.util import safe_map, unzip2, wraps
 from jax.api_util import flatten_fun
 from jax.core import (
     AbstractValue,
-    ClosedJaxpr,
     DShapedArray,
-    InDBIdx,
-    InputType,
     Jaxpr,
-    OutDBIdx,
-    OutputType,
 )
 from jax.core import Primitive as JaxprPrimitive
 from jax.core import (
@@ -68,7 +63,7 @@ from jax.core import (
     gensym,
     new_jaxpr_eqn,
 )
-from jax.extend.core import JaxprEqn
+from jax.extend.core import ClosedJaxpr, JaxprEqn
 from jax.extend.linear_util import transformation_with_aux, wrap_init
 from jax.interpreters.partial_eval import (
     DynamicJaxprTrace,

--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -56,7 +56,6 @@ from jax.core import (
     InDBIdx,
     InputType,
     Jaxpr,
-    JaxprEqn,
     OutDBIdx,
     OutputType,
 )
@@ -69,6 +68,7 @@ from jax.core import (
     gensym,
     new_jaxpr_eqn,
 )
+from jax.extend.core import JaxprEqn
 from jax.extend.linear_util import transformation_with_aux, wrap_init
 from jax.interpreters.partial_eval import (
     DynamicJaxprTrace,


### PR DESCRIPTION
**Context:**
Bump to jax 0.4.38

At this version, we clean up some deprecated jax internals that have been moved to new locations.
1. `jax.core.ClosedJaxpr, JaxprEqn` -> `jax.extend.core.*`
2. `jax.core.InDBIdx, InputType, OutDBIdx, OutputType` -> `jax._src.core.*`
