### PR TITLE
bump jax to 0.5.1

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -1,5 +1,5 @@
 # Always update the version check in catalyst.__init__ when changing the JAX version.
-jax=0.5.0
+jax=0.5.1
 mhlo=89a891c986650c33df76885f5620e0a92150d90f
 llvm=3a8316216807d64a586b971f51695e23883331f7
 enzyme=v0.0.149

--- a/frontend/catalyst/__init__.py
+++ b/frontend/catalyst/__init__.py
@@ -23,7 +23,7 @@ from os.path import dirname
 
 import jaxlib as _jaxlib
 
-_jaxlib_version = "0.5.0"
+_jaxlib_version = "0.5.1"
 if _jaxlib.__version__ != _jaxlib_version:
     import warnings
 

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -725,7 +725,10 @@ class CondCallable:
 
         def _trace(branch_fn):
             _, in_sig, out_sig = trace_function(
-                branch_fn, *(), expansion_strategy=cond_expansion_strategy()
+                branch_fn,
+                *(),
+                expansion_strategy=cond_expansion_strategy(),
+                debug_info=debug_info("cond_classical_call", branch_fn, [], {}),
             )
             return in_sig, out_sig
 
@@ -971,6 +974,9 @@ class ForLoopCallable:
             self.body_fn,
             *(aux_tracers[0], *init_state),
             expansion_strategy=self.expansion_strategy,
+            debug_info=debug_info(
+                "forloop_classical_call", self.body_fn, (aux_tracers[0], *init_state), {}
+            ),
         )
 
         in_expanded_tracers = [
@@ -1159,10 +1165,16 @@ class WhileLoopCallable:
 
     def _call_with_classical_ctx(self, *init_state):
         _, _, out_cond_sig = trace_function(
-            self.cond_fn, *init_state, expansion_strategy=self.expansion_strategy
+            self.cond_fn,
+            *init_state,
+            expansion_strategy=self.expansion_strategy,
+            debug_info=debug_info("whileloop_classical_call_cond_fn", self.cond_fn, init_state, {}),
         )
         _, in_body_sig, out_body_sig = trace_function(
-            self.body_fn, *init_state, expansion_strategy=self.expansion_strategy
+            self.body_fn,
+            *init_state,
+            expansion_strategy=self.expansion_strategy,
+            debug_info=debug_info("whileloop_classical_call_body_fn", self.body_fn, init_state, {}),
         )
 
         _check_single_bool_value(out_cond_sig.out_tree(), out_cond_sig.out_jaxpr().out_avals)

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -664,11 +664,15 @@ class CondCallable:
         for branch_fn in self.branch_fns + [self.otherwise_fn]:
             quantum_tape = QuantumTape()
             # Cond branches take no arguments
+            #breakpoint()
             wfun, in_sig, out_sig = deduce_signatures(
-                branch_fn, [], {}, expansion_strategy=self.expansion_strategy
+                branch_fn, [], {}, expansion_strategy=self.expansion_strategy,
+                #debug_info=outer_trace.frame.debug_info
+                debug_info=None
             )
             assert len(in_sig.in_type) == 0
             with EvaluationContext.frame_tracing_context() as inner_trace:
+                #breakpoint()
                 with QueuingManager.stop_recording(), quantum_tape:
                     res_classical_tracers = [
                         inner_trace.to_jaxpr_tracer(t) for t in wfun.call_wrapped()
@@ -1213,7 +1217,7 @@ class Cond(HybridOp):
                     region.res_classical_tracers + [qreg_out],
                     expansion_strategy=self.expansion_strategy,
                 )
-
+                #breakpoint()
                 jaxpr, out_type, const = trace_to_jaxpr(region.trace, [], res_expanded_tracers)
 
                 jaxprs.append(jaxpr)

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -466,7 +466,7 @@ class HybridAdjoint(HybridOp):
             qrp_out = trace_quantum_operations(body_tape, device, qreg_in, ctx, body_trace)
             qreg_out = qrp_out.actualize()
             body_jaxpr, _, body_consts = body_trace.frame.to_jaxpr2(
-                res_classical_tracers + [qreg_out]
+                res_classical_tracers + [qreg_out], body_trace.frame.debug_info
             )
 
         qreg = qrp.actualize()

--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -428,9 +428,7 @@ def trace_to_jaxpr(
     This method would remove return values related to sizes of tensors when compiling with
     dynamically sized tensors.
     """
-    jaxpr, tracers, consts = trace.frame.to_jaxpr2(
-        (*outputs, *inputs)
-    )  # , trace.frame.debug_info) # not yet in 0.4.36
+    jaxpr, tracers, consts = trace.frame.to_jaxpr2((*outputs, *inputs), trace.frame.debug_info)
     del jaxpr._outvars[len(outputs) :]
     return jaxpr, tracers, consts
 

--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -405,7 +405,6 @@ def deduce_avals(f: Callable, args, kwargs, static_argnums=None, debug_info=None
     and returning expanded flatten results. Calculate input abstract values and output_tree promise.
     The promise must be called after the resulting wrapped function is evaluated."""
     # TODO: deprecate in favor of `deduce_signatures`
-    #breakpoint()
     wf = wrap_init(f, debug_info=debug_info)
     if static_argnums:
         verify_static_argnums_type(static_argnums)
@@ -429,7 +428,6 @@ def trace_to_jaxpr(
     This method would remove return values related to sizes of tensors when compiling with
     dynamically sized tensors.
     """
-    #breakpoint()
     jaxpr, tracers, consts = trace.frame.to_jaxpr2((*outputs, *inputs), None)
     del jaxpr._outvars[len(outputs) :]
     return jaxpr, tracers, consts
@@ -459,12 +457,12 @@ def make_jaxpr2(
     fun: Callable,
     static_argnums: Any | None = None,
     abstracted_axes: Any | None = None,
-    debug_info = None,
+    debug_info=None,
 ) -> Callable[..., (tuple[ClosedJaxpr, PyTreeDef])]:
     """A customized version of ``jax.make_jaxpr``, compatible with the JAX dynamic API."""
+
     # TODO: Use `deduce_signatures` here. Ideally, unify this function with the
     # `jax_tracer.trace_function` function.
-    #breakpoint()
     def abstractify(args, kwargs):
         flat_args, in_tree = tree_flatten((args, kwargs))
         axes_specs = _flat_axes_specs(abstracted_axes, *args, **kwargs)
@@ -484,7 +482,6 @@ def make_jaxpr2(
             (jax._src.interpreters.partial_eval, "get_aval", get_aval2),
             (jax._src.lax.slicing, "gather_p", gather2_p),
         ), ExitStack():
-            #breakpoint()
             f = wrap_init(fun, debug_info=debug_info)
             if static_argnums:
                 argnums = [static_argnums] if isinstance(static_argnums, int) else static_argnums

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1986,7 +1986,7 @@ def _for_loop_lowering(
 
         # Iterate from 0 to the number of iterations (ceil((stop - start) / step))
         distance = SubIOp(stop_val, start_val)
-        num_iterations = CeilDivSIOp(distance, step_val)
+        num_iterations = CeilDivSIOp(distance.result, step_val)
         lower_bound, upper_bound, step = zero, num_iterations, one
 
     for_op_scf = ForOp(lower_bound, upper_bound, step, iter_args=loop_args)

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -2263,4 +2263,4 @@ def _scalar_abstractify(t):
 
 
 pytype_aval_mappings[type] = _scalar_abstractify
-pytype_aval_mappings[jax._src.numpy.lax_numpy._ScalarMeta] = _scalar_abstractify
+pytype_aval_mappings[jax._src.numpy.scalar_types._ScalarMeta] = _scalar_abstractify

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -2257,7 +2257,7 @@ CUSTOM_LOWERING_RULES = (
 
 def _scalar_abstractify(t):
     # pylint: disable=protected-access
-    if t in {int, float, complex, bool} or isinstance(t, jax._src.numpy.lax_numpy._ScalarMeta):
+    if t in {int, float, complex, bool} or isinstance(t, jax._src.numpy.scalar_types._ScalarMeta):
         return core.ShapedArray([], dtype=t, weak_type=True)
     raise TypeError(f"Argument type {t} is not a valid JAX type.")
 

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -187,7 +187,9 @@ class Function:
 
     @debug_logger
     def __call__(self, *args, **kwargs):
-        jaxpr, _, out_tree = make_jaxpr2(self.fn)(*args, **kwargs)
+        jaxpr, _, out_tree = make_jaxpr2(self.fn, debug_info=kwargs.pop("debug_info", None))(
+            *args, **kwargs
+        )
 
         def _eval_jaxpr(*args, **kwargs):
             return jax.core.eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, *args, **kwargs)

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -1201,8 +1201,9 @@ def trace_post_processing(trace, post_processing: Callable, pp_args, debug_info=
         # tape. The tracers are all flat in pp_args.
 
         # We need to deduce the type/shape/tree of the post_processing.
-        #breakpoint()
-        wffa, _, _, out_tree_promise = deduce_avals(post_processing, (pp_args,), {}, debug_info=debug_info)
+        wffa, _, _, out_tree_promise = deduce_avals(
+            post_processing, (pp_args,), {}, debug_info=debug_info
+        )
 
         # wffa will take as an input a flatten tracers.
         # After wffa is called, then the shape becomes available in out_tree_promise.
@@ -1235,7 +1236,6 @@ def trace_function(
         InputSignature of the resulting Jaxpr program
         OutputSignature of the resulting Jaxpr program
     """
-    #breakpoint()
     wfun, in_sig, out_sig = deduce_signatures(
         fun, args, kwargs, expansion_strategy=expansion_strategy
     )
@@ -1384,7 +1384,6 @@ def trace_quantum_function(
                 # Deallocate the register after the current tape is finished
                 # This dealloc primitive also serves as the tape cut when splitting tapes
                 qdealloc_p.bind(qreg_out)
-        #breakpoint()
         closed_jaxpr, out_type, out_tree = trace_post_processing(
             trace, post_processing, transformed_results, debug_info
         )

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -1237,7 +1237,11 @@ def trace_function(
         OutputSignature of the resulting Jaxpr program
     """
     wfun, in_sig, out_sig = deduce_signatures(
-        fun, args, kwargs, expansion_strategy=expansion_strategy
+        fun,
+        args,
+        kwargs,
+        expansion_strategy=expansion_strategy,
+        debug_info=kwargs.pop("debug_info", None),
     )
 
     with EvaluationContext.frame_tracing_context() as trace:

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -1207,9 +1207,7 @@ def trace_post_processing(trace, post_processing: Callable, pp_args):
         in_tracers = [trace.to_jaxpr_tracer(t) for t in tree_flatten(pp_args)[0]]
         out_tracers = [trace.to_jaxpr_tracer(t) for t in wffa.call_wrapped(*in_tracers)]
         cur_trace = EvaluationContext.get_current_trace()
-        jaxpr, out_type, consts = cur_trace.frame.to_jaxpr2(
-            out_tracers
-        )  # , cur_trace.frame.debug_info)  # not yet in 0.5.0
+        jaxpr, out_type, consts = cur_trace.frame.to_jaxpr2(out_tracers, cur_trace.frame.debug_info)
         closed_jaxpr = ClosedJaxpr(jaxpr, consts)
         return closed_jaxpr, out_type, out_tree_promise()
 

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -26,6 +26,7 @@ import warnings
 import jax
 import jax.numpy as jnp
 import pennylane as qml
+from jax.api_util import debug_info
 from jax.interpreters import mlir
 from jax.tree_util import tree_flatten, tree_unflatten
 
@@ -712,6 +713,8 @@ class QJIT(CatalystCallable):
         dynamic_sig = get_abstract_signature(dynamic_args)
         full_sig = merge_static_args(dynamic_sig, args, static_argnums)
 
+        dbg = debug_info("qjit_capture", self.user_function, args, kwargs)
+
         if qml.capture.enabled():
             with Patcher(
                 (
@@ -731,6 +734,12 @@ class QJIT(CatalystCallable):
             default_pass_pipeline = self.compile_options.circuit_transform_pipeline
             pass_pipeline = params.get("pass_pipeline", default_pass_pipeline)
             params["pass_pipeline"] = pass_pipeline
+            params["debug_info"] = dbg
+            #breakpoint()
+            #  dbg = debug_info(
+            # 'jit', fun, args, kwargs, static_argnums=ji.static_argnums,
+            # static_argnames=ji.static_argnames, sourceinfo=ji.fun_sourceinfo,
+            # signature=ji.fun_signature)
             return QFunc.__call__(
                 qnode,
                 *args,
@@ -747,6 +756,7 @@ class QJIT(CatalystCallable):
                 abstracted_axes,
                 full_sig,
                 kwargs,
+                dbg
             )
             self.compile_options.pass_plugins.update(plugins)
             self.compile_options.dialect_plugins.update(plugins)

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -735,11 +735,7 @@ class QJIT(CatalystCallable):
             pass_pipeline = params.get("pass_pipeline", default_pass_pipeline)
             params["pass_pipeline"] = pass_pipeline
             params["debug_info"] = dbg
-            #breakpoint()
-            #  dbg = debug_info(
-            # 'jit', fun, args, kwargs, static_argnums=ji.static_argnums,
-            # static_argnames=ji.static_argnames, sourceinfo=ji.fun_sourceinfo,
-            # signature=ji.fun_signature)
+
             return QFunc.__call__(
                 qnode,
                 *args,
@@ -751,12 +747,7 @@ class QJIT(CatalystCallable):
         ):
             # TODO: improve PyTree handling
             jaxpr, out_type, treedef, plugins = trace_to_jaxpr(
-                self.user_function,
-                static_argnums,
-                abstracted_axes,
-                full_sig,
-                kwargs,
-                dbg
+                self.user_function, static_argnums, abstracted_axes, full_sig, kwargs, dbg
             )
             self.compile_options.pass_plugins.update(plugins)
             self.compile_options.dialect_plugins.update(plugins)

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -129,6 +129,7 @@ class QFunc:
 
         static_argnums = kwargs.pop("static_argnums", ())
         out_tree_expected = kwargs.pop("_out_tree_expected", [])
+        debug_info = kwargs.pop("debug_info", None)
 
         def _eval_quantum(*args, **kwargs):
             closed_jaxpr, out_type, out_tree, out_tree_exp = trace_quantum_function(
@@ -138,6 +139,7 @@ class QFunc:
                 kwargs,
                 self,
                 static_argnums,
+                debug_info,
             )
 
             out_tree_expected.append(out_tree_exp)
@@ -149,7 +151,7 @@ class QFunc:
             return tree_unflatten(out_tree, res_flat)
 
         flattened_fun, _, _, out_tree_promise = deduce_avals(
-            _eval_quantum, args, kwargs, static_argnums
+            _eval_quantum, args, kwargs, static_argnums, debug_info
         )
         dynamic_args = filter_static_args(args, static_argnums)
         args_flat = tree_flatten((dynamic_args, kwargs))[0]

--- a/frontend/catalyst/tracing/contexts.py
+++ b/frontend/catalyst/tracing/contexts.py
@@ -188,7 +188,7 @@ class EvaluationContext:
     @classmethod
     @contextmanager
     def frame_tracing_context(
-        cls, trace: Optional[DynamicJaxprTrace] = None, debug_info = None
+        cls, trace: Optional[DynamicJaxprTrace] = None, debug_info=None
     ) -> ContextManager[DynamicJaxprTrace]:
         """Start a new JAX tracing frame, e.g. to trace a region of some
         :class:`~.jax_tracer.HybridOp`. Not applicable in non-tracing evaluation modes."""
@@ -202,7 +202,6 @@ class EvaluationContext:
                     if isinstance(current_trace, DynamicJaxprTrace)
                     else debug_info
                 )
-                #breakpoint()
                 new_trace = DynamicJaxprTrace(debug_info)
 
         with set_current_trace(new_trace):

--- a/frontend/catalyst/tracing/contexts.py
+++ b/frontend/catalyst/tracing/contexts.py
@@ -192,16 +192,10 @@ class EvaluationContext:
     ) -> ContextManager[DynamicJaxprTrace]:
         """Start a new JAX tracing frame, e.g. to trace a region of some
         :class:`~.jax_tracer.HybridOp`. Not applicable in non-tracing evaluation modes."""
-        with take_current_trace() as current_trace:
+        with take_current_trace():
             if trace is not None:
                 new_trace = trace
             else:
-                # Propagate debug info whenever possible
-                debug_info = (
-                    current_trace.frame.debug_info
-                    if isinstance(current_trace, DynamicJaxprTrace)
-                    else debug_info
-                )
                 new_trace = DynamicJaxprTrace(debug_info)
 
         with set_current_trace(new_trace):

--- a/frontend/catalyst/tracing/contexts.py
+++ b/frontend/catalyst/tracing/contexts.py
@@ -188,7 +188,7 @@ class EvaluationContext:
     @classmethod
     @contextmanager
     def frame_tracing_context(
-        cls, trace: Optional[DynamicJaxprTrace] = None
+        cls, trace: Optional[DynamicJaxprTrace] = None, debug_info = None
     ) -> ContextManager[DynamicJaxprTrace]:
         """Start a new JAX tracing frame, e.g. to trace a region of some
         :class:`~.jax_tracer.HybridOp`. Not applicable in non-tracing evaluation modes."""
@@ -196,11 +196,13 @@ class EvaluationContext:
             if trace is not None:
                 new_trace = trace
             else:
+                # Propagate debug info whenever possible
                 debug_info = (
                     current_trace.frame.debug_info
                     if isinstance(current_trace, DynamicJaxprTrace)
-                    else None
+                    else debug_info
                 )
+                #breakpoint()
                 new_trace = DynamicJaxprTrace(debug_info)
 
         with set_current_trace(new_trace):


### PR DESCRIPTION
**Context:**
Bump jax to 0.5.1.

In this version, jax added a `DebugInfo` to `linear_util.wrap_init` and `Jaxpr` https://github.com/jax-ml/jax/issues/26480. 
