### PR TITLE
Updating Nightly build download path

### DIFF
--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -63,6 +63,7 @@ jobs:
       with:
         merge-multiple: true
         path: dist
+        pattern: catalyst-*
 
     - name: Install rename
       run: |

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -362,7 +362,7 @@ jobs:
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: github.event_name == 'schedule'
       run: |
         MLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir" \
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \
@@ -393,7 +393,7 @@ jobs:
 
     - name: Upload Standalone Plugin Wheel Artifact
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: github.event_name == 'schedule'
       uses: actions/upload-artifact@v4
       with:
         name: standalone-plugin-manylinux_2_28_x86_64-wheel-py-${{ matrix.python_version }}.zip
@@ -423,7 +423,7 @@ jobs:
 
     - name: Download Standalone Plugin Wheel Artifact
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: github.event_name == 'schedule'
       uses: actions/download-artifact@v4
       with:
         name: standalone-plugin-manylinux_2_28_x86_64-wheel-py-${{ matrix.python_version }}.zip
@@ -453,7 +453,7 @@ jobs:
 
     - name: Install Standalone Plugin
       # Run only on Thursday at the given time (TODO: set comparison to == before merging)
-      if: github.event.schedule == '35 4 * * 4'
+      if: github.event_name == 'schedule'
       run: |
         python${{ matrix.python_version }} -m pip install standalone_plugin_wheel/wheel/*.whl --no-deps
 
@@ -467,6 +467,6 @@ jobs:
 
     - name: Run Standalone Plugin Tests
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: github.event_name == 'schedule'
       run: |
         python${{ matrix.python_version }} -m pytest standalone_plugin_wheel/standalone_plugin/test -n auto

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -356,7 +356,7 @@ jobs:
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: github.event_name == 'schedule'
       run: |
         MLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir" \
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \
@@ -387,7 +387,7 @@ jobs:
 
     - name: Upload Standalone Plugin Wheel Artifact
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: github.event_name == 'schedule'
       uses: actions/upload-artifact@v4
       with:
         name: standalone-plugin-macos_arm64-wheel-py-${{ matrix.python_version }}.zip
@@ -424,7 +424,7 @@ jobs:
 
     - name: Download Standalone Plugin Wheel Artifact
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: github.event_name == 'schedule'
       uses: actions/download-artifact@v4
       with:
         name: standalone-plugin-macos_arm64-wheel-py-${{ matrix.python_version }}.zip
@@ -456,7 +456,7 @@ jobs:
 
     - name: Install Standalone Plugin
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: github.event_name == 'schedule'
       run: |
         python${{ matrix.python_version }} -m pip install standalone_plugin_wheel/wheel/*.whl --no-deps
 
@@ -470,6 +470,6 @@ jobs:
 
     - name: Run Standalone Plugin Tests
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: github.event_name == 'schedule'
       run: |
         python${{ matrix.python_version }} -m pytest standalone_plugin_wheel/standalone_plugin/test -n auto

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -322,7 +322,7 @@ jobs:
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: github.event_name == 'schedule'
       run: |
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \
         MLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir" \
@@ -353,7 +353,7 @@ jobs:
 
     - name: Upload Standalone Plugin Wheel Artifact
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: github.event_name == 'schedule'
       uses: actions/upload-artifact@v4
       with:
         name: standalone-plugin-macos_x86_64-wheel-py-${{ matrix.python_version }}.zip
@@ -383,7 +383,7 @@ jobs:
 
     - name: Download Standalone Plugin Wheel Artifact
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: github.event_name == 'schedule'
       uses: actions/download-artifact@v4
       with:
         name: standalone-plugin-macos_x86_64-wheel-py-${{ matrix.python_version }}.zip
@@ -413,7 +413,7 @@ jobs:
 
     - name: Install Standalone Plugin
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: github.event_name == 'schedule'
       run: |
         python${{ matrix.python_version }} -m pip install standalone_plugin_wheel/wheel/*.whl --no-deps
 
@@ -428,6 +428,6 @@ jobs:
 
     - name: Run Standalone Plugin Tests
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: github.event_name == 'schedule'
       run: |
         python${{ matrix.python_version }} -m pytest standalone_plugin_wheel/standalone_plugin/test -n auto


### PR DESCRIPTION
**Context:**
The nightly build for the standalone plugin is [unable to find the plugin files ](https://github.com/PennyLaneAI/catalyst/actions/runs/14586255969/job/40912963093). This step in the nightly release workflow had [not been run](https://github.com/PennyLaneAI/catalyst/actions/runs/14507591127/job/40701985590) for an unknown amount of time. The if conditions for the cronjobs all of the wheel builds were not becoming `true`.

**Description of the Change:**
Adding a pattern to the `actions/download-artifact@v4` job.

**Benefits:**
Nightly builds get uploaded.

**Possible Drawbacks:**

**Related GitHub Issues:**
