### PR TITLE
Fixing demo due to removal of `coeffs` from the `Sum` class

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.149
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt
-pennylane=0.42.0-dev7
+pennylane=0.42.0-dev12
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/demos/adaptive_circuits_demo.ipynb
+++ b/demos/adaptive_circuits_demo.ipynb
@@ -202,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "6a9049c4",
    "metadata": {},
    "outputs": [
@@ -223,9 +223,8 @@
     "    qml.BasisState(hf, wires=range(qubits))\n",
     "    qml.DoubleExcitation(params[0], wires=[0, 1, 2, 3])\n",
     "    qml.DoubleExcitation(params[1], wires=[0, 1, 4, 5])\n",
-    "    return qml.expval(\n",
-    "        qml.Hamiltonian(np.array(hamiltonian.coeffs), hamiltonian.ops)\n",
-    "    )"
+    "    coeffs, ops = hamiltonian.terms()\n",
+    "    return qml.expval(qml.Hamiltonian(np.array(coeffs), ops))"
    ]
   },
   {
@@ -796,7 +795,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "c759ef3a",
    "metadata": {},
    "outputs": [],
@@ -837,10 +836,9 @@
     "        \n",
     "        apply_double()\n",
     "    catalyst.for_loop(0, num_gates, 1)(apply_gates)()\n",
-    "\n",
-    "    return qml.expval(\n",
-    "        qml.Hamiltonian(np.array(hamiltonian.coeffs), hamiltonian.ops)\n",
-    "    )\n",
+    "    \n",
+    "    coeffs, ops = hamiltonian.terms()\n",
+    "    return qml.expval(qml.Hamiltonian(np.array(coeffs), ops))\n",
     "\n",
     "\n",
     "jit_catalyst_avqe_circuit = qjit(catalyst_avqe_circuit)"

--- a/demos/adaptive_circuits_demo.ipynb
+++ b/demos/adaptive_circuits_demo.ipynb
@@ -202,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "6a9049c4",
    "metadata": {},
    "outputs": [
@@ -795,7 +795,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "c759ef3a",
    "metadata": {},
    "outputs": [],

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -32,4 +32,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.42.0-dev0
 pennylane-lightning==0.42.0-dev0
-pennylane==0.42.0-dev7
+pennylane==0.42.0-dev12


### PR DESCRIPTION
This demo in Catalyst uses code that was just removed during Deprecations and Removals for PL 0.42.

The reason why a warning message (indicating that the code was deprecated) has not been caught before is that such a demo (and potentially other ones) suppresses all warnings, including deprecation warnings coming from PL. 

I think this needs to change, for example, by suppressing all warnings except for PL deprecation warnings, because a demo using deprecated PL code should not be exposed to users.

[sc-89676]