### PR TITLE
Change logic around *when* standalone plugin is built

### DIFF
--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -35,7 +35,7 @@ env:
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
   # If event_name is NOT schedule, default to false
-  BUILD_STANDALONE_PLUGIN: ${{ inputs.build_standalone_plugin != '' && format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' && 'true' || 'false' }}
+  BUILD_STANDALONE_PLUGIN: ${{ format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' || false }}
 
 jobs:
   check_if_wheel_build_required:

--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -17,6 +17,10 @@ on:
     inputs:
       build_standalone_plugin:
         description: 'Build the standalone plugin wheel'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
         required: false
         default: 'false'
   workflow_call:

--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -35,7 +35,7 @@ env:
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
   # If event_name is NOT schedule, default to false
-  BUILD_STANDALONE_PLUGIN: ${{ inputs.build_standalone_plugin || github.event_name == 'schedule' || 'false' }}
+  BUILD_STANDALONE_PLUGIN: ${{ (inputs.build_standalone_plugin == true || inputs.build_standalone_plugin == 'true') && 'true' || (github.event_name == 'schedule' && 'true') || 'false' }}
 
 jobs:
   check_if_wheel_build_required:

--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -39,7 +39,7 @@ env:
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
   # If event_name is NOT schedule, default to false
-  BUILD_STANDALONE_PLUGIN: ${{ format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' || false }}
+  BUILD_STANDALONE_PLUGIN: ${{ format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' }}
 
 jobs:
   check_if_wheel_build_required:

--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -14,11 +14,28 @@ on:
     # Thursdays we test the standalone plugin
     - cron: '35 4 * * 4'
   workflow_dispatch:
+    inputs:
+      build_standalone_plugin:
+        description: 'Build the standalone plugin wheel'
+        required: false
+        default: 'false'
   workflow_call:
+    inputs:
+      build_standalone_plugin:
+        description: 'Build the standalone plugin wheel'
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: Build Catalyst Wheel on Linux (arm64)-${{ github.ref }}
   cancel-in-progress: true
+
+env:
+  # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
+  # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
+  # If event_name is NOT schedule, default to false
+  BUILD_STANDALONE_PLUGIN: ${{ inputs.build_standalone_plugin || github.event_name == 'schedule' || 'false' }}
 
 jobs:
   check_if_wheel_build_required:
@@ -337,7 +354,7 @@ jobs:
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time
-      if: github.event_name == 'schedule'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
         MLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir" \
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \
@@ -368,7 +385,7 @@ jobs:
 
     - name: Upload Standalone Plugin Wheel Artifact
       # Run only on Thursday at the given time
-      if: github.event_name == 'schedule'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: standalone-plugin-linux_arm_64-wheel-py-${{ matrix.python_version }}.zip
@@ -398,7 +415,7 @@ jobs:
 
     - name: Download Standalone Plugin Wheel Artifact
       # Run only on Thursday at the given time
-      if: github.event_name == 'schedule'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       uses: actions/download-artifact@v4
       with:
         name: standalone-plugin-linux_arm_64-wheel-py-${{ matrix.python_version }}.zip
@@ -428,7 +445,7 @@ jobs:
 
     - name: Install Standalone Plugin
       # Run only on Thursday at the given time
-      if: github.event_name == 'schedule'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
         python${{ matrix.python_version }} -m pip install standalone_plugin_wheel/wheel/*.whl --no-deps
 
@@ -442,6 +459,6 @@ jobs:
 
     - name: Run Standalone Plugin Tests
       # Run only on Thursday at the given time
-      if: github.event_name == 'schedule'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
         python${{ matrix.python_version }} -m pytest standalone_plugin_wheel/standalone_plugin/test -n auto

--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -35,7 +35,7 @@ env:
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
   # If event_name is NOT schedule, default to false
-  BUILD_STANDALONE_PLUGIN: ${{ (inputs.build_standalone_plugin == true || inputs.build_standalone_plugin == 'true') && 'true' || (github.event_name == 'schedule' && 'true') || 'false' }}
+  BUILD_STANDALONE_PLUGIN: ${{ inputs.build_standalone_plugin != '' && format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' && 'true' || 'false' }}
 
 jobs:
   check_if_wheel_build_required:

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -17,6 +17,10 @@ on:
     inputs:
       build_standalone_plugin:
         description: 'Build the standalone plugin wheel'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
         required: false
         default: 'false'
   workflow_call:

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -35,7 +35,7 @@ env:
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
   # If event_name is NOT schedule, default to false
-  BUILD_STANDALONE_PLUGIN: ${{ (inputs.build_standalone_plugin == true || inputs.build_standalone_plugin == 'true') && 'true' || (github.event_name == 'schedule' && 'true') || 'false' }}
+  BUILD_STANDALONE_PLUGIN: ${{ inputs.build_standalone_plugin != '' && format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' && 'true' || 'false' }}
 
 jobs:
   determine_runner:

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -39,7 +39,7 @@ env:
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
   # If event_name is NOT schedule, default to false
-  BUILD_STANDALONE_PLUGIN: ${{ format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' || false }}
+  BUILD_STANDALONE_PLUGIN: ${{ format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' }}
 
 jobs:
   determine_runner:

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -35,7 +35,7 @@ env:
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
   # If event_name is NOT schedule, default to false
-  BUILD_STANDALONE_PLUGIN: ${{ inputs.build_standalone_plugin || github.event_name == 'schedule' || 'false' }}
+  BUILD_STANDALONE_PLUGIN: ${{ (inputs.build_standalone_plugin == true || inputs.build_standalone_plugin == 'true') && 'true' || (github.event_name == 'schedule' && 'true') || 'false' }}
 
 jobs:
   determine_runner:

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -35,7 +35,7 @@ env:
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
   # If event_name is NOT schedule, default to false
-  BUILD_STANDALONE_PLUGIN: ${{ inputs.build_standalone_plugin != '' && format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' && 'true' || 'false' }}
+  BUILD_STANDALONE_PLUGIN: ${{ format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' || false }}
 
 jobs:
   determine_runner:

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -14,11 +14,28 @@ on:
     # Thursdays we test the standalone plugin
     - cron: '35 4 * * 4'
   workflow_dispatch:
+    inputs:
+      build_standalone_plugin:
+        description: 'Build the standalone plugin wheel'
+        required: false
+        default: 'false'
   workflow_call:
+    inputs:
+      build_standalone_plugin:
+        description: 'Build the standalone plugin wheel'
+        type: boolean
+        required: false
+        default: false
 
 concurrency:
   group: Build Catalyst Wheel on Linux (x86_64)-${{ github.ref }}
   cancel-in-progress: true
+
+env:
+  # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
+  # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
+  # If event_name is NOT schedule, default to false
+  BUILD_STANDALONE_PLUGIN: ${{ inputs.build_standalone_plugin || github.event_name == 'schedule' || 'false' }}
 
 jobs:
   determine_runner:
@@ -362,7 +379,7 @@ jobs:
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
         MLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir" \
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \
@@ -393,7 +410,7 @@ jobs:
 
     - name: Upload Standalone Plugin Wheel Artifact
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: standalone-plugin-manylinux_2_28_x86_64-wheel-py-${{ matrix.python_version }}.zip
@@ -423,7 +440,7 @@ jobs:
 
     - name: Download Standalone Plugin Wheel Artifact
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       uses: actions/download-artifact@v4
       with:
         name: standalone-plugin-manylinux_2_28_x86_64-wheel-py-${{ matrix.python_version }}.zip
@@ -452,8 +469,8 @@ jobs:
         python${{ matrix.python_version }} -m pip install dist/*.whl --extra-index-url https://test.pypi.org/simple
 
     - name: Install Standalone Plugin
-      # Run only on Thursday at the given time (TODO: set comparison to == before merging)
-      if: github.event.schedule == '35 4 * * 4'
+      # Run only on Thursday at the given time
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
         python${{ matrix.python_version }} -m pip install standalone_plugin_wheel/wheel/*.whl --no-deps
 
@@ -467,6 +484,6 @@ jobs:
 
     - name: Run Standalone Plugin Tests
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
         python${{ matrix.python_version }} -m pytest standalone_plugin_wheel/standalone_plugin/test -n auto

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -33,7 +33,7 @@ env:
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
   # If event_name is NOT schedule, default to false
-  BUILD_STANDALONE_PLUGIN: ${{ (inputs.build_standalone_plugin == true || inputs.build_standalone_plugin == 'true') && 'true' || (github.event_name == 'schedule' && 'true') || 'false' }}
+  BUILD_STANDALONE_PLUGIN: ${{ inputs.build_standalone_plugin != '' && format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' && 'true' || 'false' }}
 
 concurrency:
   group: Build Catalyst Wheel on macOS (arm64)-${{ github.ref }}

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -14,10 +14,26 @@ on:
     # Thursdays we test the standalone plugin
     - cron: '35 4 * * 4'
   workflow_dispatch:
+    inputs:
+      build_standalone_plugin:
+        description: 'Build the standalone plugin wheel'
+        required: false
+        default: 'false'
   workflow_call:
+    inputs:
+      build_standalone_plugin:
+        description: 'Build the standalone plugin wheel'
+        type: boolean
+        required: false
+        default: false
 
 env:
   MACOSX_DEPLOYMENT_TARGET: 14.0
+
+  # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
+  # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
+  # If event_name is NOT schedule, default to false
+  BUILD_STANDALONE_PLUGIN: ${{ inputs.build_standalone_plugin || github.event_name == 'schedule' || 'false' }}
 
 concurrency:
   group: Build Catalyst Wheel on macOS (arm64)-${{ github.ref }}
@@ -356,7 +372,7 @@ jobs:
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
         MLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir" \
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \
@@ -387,7 +403,7 @@ jobs:
 
     - name: Upload Standalone Plugin Wheel Artifact
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: standalone-plugin-macos_arm64-wheel-py-${{ matrix.python_version }}.zip
@@ -424,7 +440,7 @@ jobs:
 
     - name: Download Standalone Plugin Wheel Artifact
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       uses: actions/download-artifact@v4
       with:
         name: standalone-plugin-macos_arm64-wheel-py-${{ matrix.python_version }}.zip
@@ -456,7 +472,7 @@ jobs:
 
     - name: Install Standalone Plugin
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
         python${{ matrix.python_version }} -m pip install standalone_plugin_wheel/wheel/*.whl --no-deps
 
@@ -470,6 +486,6 @@ jobs:
 
     - name: Run Standalone Plugin Tests
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
         python${{ matrix.python_version }} -m pytest standalone_plugin_wheel/standalone_plugin/test -n auto

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -17,6 +17,10 @@ on:
     inputs:
       build_standalone_plugin:
         description: 'Build the standalone plugin wheel'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
         required: false
         default: 'false'
   workflow_call:

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -33,7 +33,7 @@ env:
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
   # If event_name is NOT schedule, default to false
-  BUILD_STANDALONE_PLUGIN: ${{ inputs.build_standalone_plugin != '' && format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' && 'true' || 'false' }}
+  BUILD_STANDALONE_PLUGIN: ${{ format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' || false }}
 
 concurrency:
   group: Build Catalyst Wheel on macOS (arm64)-${{ github.ref }}

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -33,7 +33,7 @@ env:
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
   # If event_name is NOT schedule, default to false
-  BUILD_STANDALONE_PLUGIN: ${{ inputs.build_standalone_plugin || github.event_name == 'schedule' || 'false' }}
+  BUILD_STANDALONE_PLUGIN: ${{ (inputs.build_standalone_plugin == true || inputs.build_standalone_plugin == 'true') && 'true' || (github.event_name == 'schedule' && 'true') || 'false' }}
 
 concurrency:
   group: Build Catalyst Wheel on macOS (arm64)-${{ github.ref }}

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -37,7 +37,7 @@ env:
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
   # If event_name is NOT schedule, default to false
-  BUILD_STANDALONE_PLUGIN: ${{ format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' || false }}
+  BUILD_STANDALONE_PLUGIN: ${{ format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' }}
 
 concurrency:
   group: Build Catalyst Wheel on macOS (arm64)-${{ github.ref }}

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -33,7 +33,7 @@ env:
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
   # If event_name is NOT schedule, default to false
-  BUILD_STANDALONE_PLUGIN: ${{ (inputs.build_standalone_plugin == true || inputs.build_standalone_plugin == 'true') && 'true' || (github.event_name == 'schedule' && 'true') || 'false' }}
+  BUILD_STANDALONE_PLUGIN: ${{ inputs.build_standalone_plugin != '' && format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' && 'true' || 'false' }}
 
 concurrency:
   group: Build Catalyst Wheel on macOS (x86_64)-${{ github.ref }}

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -37,7 +37,7 @@ env:
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
   # If event_name is NOT schedule, default to false
-  BUILD_STANDALONE_PLUGIN: ${{ format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' || false }}
+  BUILD_STANDALONE_PLUGIN: ${{ format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' }}
 
 concurrency:
   group: Build Catalyst Wheel on macOS (x86_64)-${{ github.ref }}

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -17,6 +17,10 @@ on:
     inputs:
       build_standalone_plugin:
         description: 'Build the standalone plugin wheel'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
         required: false
         default: 'false'
   workflow_call:

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -14,10 +14,26 @@ on:
     # Thursdays we test the standalone plugin
     - cron: '35 4 * * 4'
   workflow_dispatch:
+    inputs:
+      build_standalone_plugin:
+        description: 'Build the standalone plugin wheel'
+        required: false
+        default: 'false'
   workflow_call:
+    inputs:
+      build_standalone_plugin:
+        description: 'Build the standalone plugin wheel'
+        type: boolean
+        required: false
+        default: false
 
 env:
   MACOSX_DEPLOYMENT_TARGET: 13
+
+  # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
+  # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
+  # If event_name is NOT schedule, default to false
+  BUILD_STANDALONE_PLUGIN: ${{ inputs.build_standalone_plugin || github.event_name == 'schedule' || 'false' }}
 
 concurrency:
   group: Build Catalyst Wheel on macOS (x86_64)-${{ github.ref }}
@@ -322,7 +338,7 @@ jobs:
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \
         MLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir" \
@@ -353,7 +369,7 @@ jobs:
 
     - name: Upload Standalone Plugin Wheel Artifact
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: standalone-plugin-macos_x86_64-wheel-py-${{ matrix.python_version }}.zip
@@ -383,7 +399,7 @@ jobs:
 
     - name: Download Standalone Plugin Wheel Artifact
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       uses: actions/download-artifact@v4
       with:
         name: standalone-plugin-macos_x86_64-wheel-py-${{ matrix.python_version }}.zip
@@ -413,7 +429,7 @@ jobs:
 
     - name: Install Standalone Plugin
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
         python${{ matrix.python_version }} -m pip install standalone_plugin_wheel/wheel/*.whl --no-deps
 
@@ -428,6 +444,6 @@ jobs:
 
     - name: Run Standalone Plugin Tests
       # Run only on Thursday at the given time
-      if: github.event.schedule == '35 4 * * 4'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
         python${{ matrix.python_version }} -m pytest standalone_plugin_wheel/standalone_plugin/test -n auto

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -33,7 +33,7 @@ env:
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
   # If event_name is NOT schedule, default to false
-  BUILD_STANDALONE_PLUGIN: ${{ inputs.build_standalone_plugin != '' && format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' && 'true' || 'false' }}
+  BUILD_STANDALONE_PLUGIN: ${{ format('{0}', inputs.build_standalone_plugin) || github.event_name == 'schedule' || false }}
 
 concurrency:
   group: Build Catalyst Wheel on macOS (x86_64)-${{ github.ref }}

--- a/.github/workflows/build-wheel-macos-x86_64.yaml
+++ b/.github/workflows/build-wheel-macos-x86_64.yaml
@@ -33,7 +33,7 @@ env:
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
   # If event_name is NOT schedule, default to false
-  BUILD_STANDALONE_PLUGIN: ${{ inputs.build_standalone_plugin || github.event_name == 'schedule' || 'false' }}
+  BUILD_STANDALONE_PLUGIN: ${{ (inputs.build_standalone_plugin == true || inputs.build_standalone_plugin == 'true') && 'true' || (github.event_name == 'schedule' && 'true') || 'false' }}
 
 concurrency:
   group: Build Catalyst Wheel on macOS (x86_64)-${{ github.ref }}

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.12.0-dev11"
+__version__ = "0.12.0-dev12"


### PR DESCRIPTION
**Context:**
Currently, the nightly build is failing due to the standalone plugin being built and uploaded, where it shouldn't be built in the first place.

Issue: When a github action is called using `workflow_call` the `github.event_name` is not updated. This is something I was unaware of prior to this.

A good question now would be, why not just align the arm64 workflow if-statements to that of the other workflows, the expression being `github.event.scheulde == '35 4 * * 4'`. The rationale explained in the Benefits section.

**Description of the Change:**
This PR updates the logic around when we build the standalone plugins.

A new input is added to the four `build-wheel-` workflows. The input being `build_standalone_plugin`, and it defaults to false.

Then we set an environment variable `BUILD_STANDALONE_PLUGIN` based on the following logic:
- Does the input exist? 
    - If yes, use the value of the input to determine if standalone plugin build needed or not
    - If no, go to next
- Is the event_name 'schedule'?
    - If yes, build standalone plugin
    - If no, return false.

This environment variable is then used in the steps to determine if the step should be run or not.

**Benefits:**
A minor benefit of this is that the steps themselves are more readable, in that, `env.BUILD_STANDALONE_PLUGIN == 'true'` is easy to read and know what the goal is.

The bigger, benefit is that it is best that we do not tie ourselves to what the actual cron schedule is to build the standalone plugin. Though I am sure it is a value that doesn't change too frequently, with the current implementation, a change to the schedule would require re-writing all the if-expressions, moreso, what if we wanted to start building the standalone plugin twice a week? Or more?

The implementation proposed here moves us away from having to rely on the value(s) of the cron schedule.


Another benefit is that we can opt-in to building standalone plugin when we call these workflows from workflow_displatch or workflow_call.

**Possible Drawbacks:**
Possibility of bugs, but I have tested a build [here](https://github.com/PennyLaneAI/catalyst/actions/runs/14619875471) which finished without errors.

**Related GitHub Issues:**
[sc-89680]