### PR TITLE
Bump to jax 0.5.3 :tada: 

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -1,5 +1,5 @@
 # Always update the version check in catalyst.__init__ when changing the JAX version.
-jax=0.5.1
+jax=0.5.3
 mhlo=89a891c986650c33df76885f5620e0a92150d90f
 llvm=3a8316216807d64a586b971f51695e23883331f7
 enzyme=v0.0.149

--- a/frontend/catalyst/__init__.py
+++ b/frontend/catalyst/__init__.py
@@ -23,7 +23,7 @@ from os.path import dirname
 
 import jaxlib as _jaxlib
 
-_jaxlib_version = "0.5.1"
+_jaxlib_version = "0.5.3"
 if _jaxlib.__version__ != _jaxlib_version:
     import warnings
 

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -673,7 +673,7 @@ class CondCallable:
                 debug_info=debug_info("cond_quantum_call", branch_fn, [], {}),
             )
             assert len(in_sig.in_type) == 0
-            with EvaluationContext.frame_tracing_context() as inner_trace:
+            with EvaluationContext.frame_tracing_context(debug_info=wfun.debug_info) as inner_trace:
                 with QueuingManager.stop_recording(), quantum_tape:
                     res_classical_tracers = [
                         inner_trace.to_jaxpr_tracer(t) for t in wfun.call_wrapped()

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -925,7 +925,7 @@ class ForLoopCallable:
         )
         in_type = in_sig.in_type
 
-        with EvaluationContext.frame_tracing_context() as inner_trace:
+        with EvaluationContext.frame_tracing_context(debug_info=wfun.debug_info) as inner_trace:
             arg_classical_tracers = input_type_to_tracers(
                 in_type, inner_trace.new_arg, inner_trace.to_jaxpr_tracer
             )
@@ -1103,7 +1103,7 @@ class WhileLoopCallable:
         in_type = in_sig.in_type
         in_expanded_classical_tracers = in_sig.in_expanded_args
 
-        with EvaluationContext.frame_tracing_context() as cond_trace:
+        with EvaluationContext.frame_tracing_context(debug_info=cond_wffa.debug_info) as cond_trace:
             arg_classical_tracers = input_type_to_tracers(
                 in_type, cond_trace.new_arg, cond_trace.to_jaxpr_tracer
             )
@@ -1125,7 +1125,7 @@ class WhileLoopCallable:
 
             _check_single_bool_value(out_tree, cond_region.res_classical_tracers)
 
-        with EvaluationContext.frame_tracing_context() as body_trace:
+        with EvaluationContext.frame_tracing_context(debug_info=body_wffa.debug_info) as body_trace:
             arg_classical_tracers = input_type_to_tracers(
                 in_type, body_trace.new_arg, body_trace.to_jaxpr_tracer
             )

--- a/frontend/catalyst/api_extensions/differentiation.py
+++ b/frontend/catalyst/api_extensions/differentiation.py
@@ -27,6 +27,7 @@ import jax
 import jax.numpy as jnp
 from jax._src.api import _dtype
 from jax._src.tree_util import PyTreeDef, tree_flatten, tree_unflatten
+from jax.api_util import debug_info
 from pennylane import QNode
 
 import catalyst
@@ -807,7 +808,9 @@ def _make_jaxpr_check_differentiable(
     return the output tree."""
     method = grad_params.method
     with mark_gradient_tracing(method):
-        jaxpr, _, out_tree = make_jaxpr2(f)(*args, **kwargs)
+        jaxpr, _, out_tree = make_jaxpr2(
+            f, debug_info=debug_info("grad make jaxpr", f, args, kwargs)
+        )(*args, **kwargs)
 
     for pos, arg in enumerate(jaxpr.in_avals):
         if arg.dtype.kind != "f" and pos in grad_params.expanded_argnums:

--- a/frontend/catalyst/api_extensions/differentiation.py
+++ b/frontend/catalyst/api_extensions/differentiation.py
@@ -47,6 +47,7 @@ from catalyst.jax_tracer import Function, mark_gradient_tracing
 from catalyst.tracing.contexts import EvaluationContext, GradContext
 from catalyst.utils.callables import CatalystCallable
 from catalyst.utils.exceptions import DifferentiableCompileError
+from catalyst.utils.types import get_shape
 
 Differentiable = Union[Function, QNode]
 
@@ -475,10 +476,10 @@ def jvp(f: Callable, params, tangents, *, method=None, h=None, argnums=None):
                     f"{_dtype(p)}, but got tangent dtype {_dtype(t)} instead."
                 )
 
-            if jnp.shape(p) != jnp.shape(t):
+            if get_shape(p) != get_shape(t):
                 raise ValueError(
                     "catalyst.jvp called with different function params and tangent shapes; "
-                    f"got function params shape {jnp.shape(p)} and tangent shape {jnp.shape(t)}"
+                    f"got function params shape {get_shape(p)} and tangent shape {get_shape(t)}"
                 )
 
         jaxpr, out_tree = _make_jaxpr_check_differentiable(fn, grad_params, *params)
@@ -585,11 +586,11 @@ def vjp(f: Callable, params, cotangents, *, method=None, h=None, argnums=None):
                     f"{_dtype(p)}, but got cotangent dtype {_dtype(t)} instead."
                 )
 
-            if jnp.shape(p) != jnp.shape(t):
+            if get_shape(p) != get_shape(t):
                 raise ValueError(
                     "catalyst.vjp called with different function output params and cotangent "
-                    f"shapes; got function output params shape {jnp.shape(p)} and cotangent shape "
-                    f"{jnp.shape(t)}"
+                    f"shapes; got function output params shape {get_shape(p)} and cotangent shape "
+                    f"{get_shape(t)}"
                 )
 
         cotangents, _ = tree_flatten(cotangents)

--- a/frontend/catalyst/api_extensions/function_maps.py
+++ b/frontend/catalyst/api_extensions/function_maps.py
@@ -26,6 +26,7 @@ from typing import Any, Callable, Optional, Union
 import jax
 import jax.numpy as jnp
 import numpy as np
+from jax.api_util import debug_info
 from jax._src.tree_util import tree_flatten, tree_leaves, tree_structure, tree_unflatten
 
 from catalyst.api_extensions.control_flow import for_loop
@@ -227,7 +228,9 @@ class VmapCallable(CatalystCallable):
         fn_args = tree_unflatten(args_tree, fn_args_flat)
 
         # Run 'fn' one time to get output-shape
-        _, shapes, init_result_tree = make_jaxpr2(self.fn)(*fn_args, **kwargs)
+        _, shapes, init_result_tree = make_jaxpr2(
+            self.fn, debug_info=debug_info("vmap", self.fn, args, kwargs)
+        )(*fn_args, **kwargs)
 
         init_result_flat = [jnp.zeros(shape=shape.shape, dtype=shape.dtype) for shape, _ in shapes]
         init_result = tree_unflatten(init_result_tree, init_result_flat)

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -182,7 +182,10 @@ def handle_qnode(
     f = partial(QFuncPlxprInterpreter(device, shots).eval, qfunc_jaxpr, consts)
 
     return quantum_kernel_p.bind(
-        wrap_init(f), *non_const_args, qnode=qnode, pipeline=self._pass_pipeline
+        wrap_init(f, debug_info=qfunc_jaxpr.debug_info),
+        *non_const_args,
+        qnode=qnode,
+        pipeline=self._pass_pipeline,
     )
 
 

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -721,7 +721,7 @@ class PredicatePlxprInterpreter(PlxprInterpreter):
         return outvals
 
 
-def trace_from_pennylane(fn, static_argnums, abstracted_axes, sig, kwargs):
+def trace_from_pennylane(fn, static_argnums, abstracted_axes, sig, kwargs, debug_info=None):
     """Capture the JAX program representation (JAXPR) of the wrapped function, using
     PL capure module.
 
@@ -739,6 +739,7 @@ def trace_from_pennylane(fn, static_argnums, abstracted_axes, sig, kwargs):
         make_jaxpr_kwargs = {
             "static_argnums": static_argnums,
             "abstracted_axes": abstracted_axes,
+            "debug_info": debug_info,
         }
 
         args = sig

--- a/frontend/catalyst/jax_extras/patches.py
+++ b/frontend/catalyst/jax_extras/patches.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import jax
+from jax._src.core import abstractify
 from jax._src.lax.slicing import (
     _argnum_weak_type,
     _gather_dtype_rule,
@@ -28,7 +29,7 @@ from jax._src.lax.slicing import (
     _sorted_dims_in_range,
     standard_primitive,
 )
-from jax.core import AbstractValue, Tracer, concrete_aval
+from jax.core import AbstractValue, Tracer
 
 __all__ = (
     "get_aval2",
@@ -46,7 +47,7 @@ def get_aval2(x):
     elif isinstance(x, Tracer):
         return x.aval
     else:
-        return concrete_aval(x)
+        return abstractify(x)
 
 
 def _no_clean_up_dead_vars(_eqn, _env, _last_used):

--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -428,7 +428,7 @@ def trace_to_jaxpr(
     This method would remove return values related to sizes of tensors when compiling with
     dynamically sized tensors.
     """
-    jaxpr, tracers, consts = trace.frame.to_jaxpr2((*outputs, *inputs), None)
+    jaxpr, tracers, consts = trace.frame.to_jaxpr2((*outputs, *inputs), trace.frame.debug_info)
     del jaxpr._outvars[len(outputs) :]
     return jaxpr, tracers, consts
 

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -189,7 +189,8 @@ class Function:
     @debug_logger
     def __call__(self, *args, **kwargs):
         jaxpr, _, out_tree = make_jaxpr2(
-            self.fn, debug_info=debug_info("Function", self.fn, args, kwargs)
+            self.fn,
+            debug_info=kwargs.pop("debug_info", debug_info("Function", self.fn, args, kwargs)),
         )(*args, **kwargs)
 
         def _eval_jaxpr(*args, **kwargs):

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -1247,7 +1247,7 @@ def trace_function(
         debug_info=kwargs.pop("debug_info", None),
     )
 
-    with EvaluationContext.frame_tracing_context() as trace:
+    with EvaluationContext.frame_tracing_context(debug_info=wfun.debug_info) as trace:
         arg_expanded_tracers = input_type_to_tracers(
             in_sig.in_type, trace.new_arg, trace.to_jaxpr_tracer
         )

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -1213,7 +1213,7 @@ def trace_post_processing(trace, post_processing: Callable, pp_args, debug_info=
         in_tracers = [trace.to_jaxpr_tracer(t) for t in tree_flatten(pp_args)[0]]
         out_tracers = [trace.to_jaxpr_tracer(t) for t in wffa.call_wrapped(*in_tracers)]
         cur_trace = EvaluationContext.get_current_trace()
-        jaxpr, out_type, consts = cur_trace.frame.to_jaxpr2(out_tracers, debug_info)
+        jaxpr, out_type, consts = cur_trace.frame.to_jaxpr2(out_tracers, wffa.debug_info)
         closed_jaxpr = ClosedJaxpr(jaxpr, consts)
         return closed_jaxpr, out_type, out_tree_promise()
 

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -454,12 +454,14 @@ class HybridOp(Operator):
         regions: List[HybridOpRegion],
         apply_reverse_transform=False,
         expansion_strategy=None,
+        debug_info=None,
     ):  # pylint: disable=too-many-arguments
         self.in_classical_tracers = in_classical_tracers
         self.out_classical_tracers = out_classical_tracers
         self.regions: List[HybridOpRegion] = regions
         self.expansion_strategy = expansion_strategy
         self.apply_reverse_transform = apply_reverse_transform
+        self.debug_info = debug_info
         super().__init__(wires=Wires(HybridOp.num_wires))
 
     def __repr__(self):

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -278,7 +278,7 @@ def _apply_result_type_conversion(
         )
 
     expanded_tracers, in_sig, out_sig = trace_function(
-        _fun, *args, expansion_strategy=cond_expansion_strategy()
+        _fun, *args, expansion_strategy=cond_expansion_strategy(), debug_info=jaxpr.debug_info
     )
 
     return expanded_tracers, in_sig, out_sig

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -877,7 +877,7 @@ class JAX_QJIT:
     def wrap_callback(qjit_function, *args, **kwargs):
         """Wrap a QJIT function inside a jax host callback."""
         data = jax.pure_callback(
-            qjit_function, qjit_function.jaxpr.out_avals, *args, vectorized=False, **kwargs
+            qjit_function, qjit_function.jaxpr.out_avals, *args, vmap_method="sequential", **kwargs
         )
 
         # Unflatten the return value w.r.t. the original PyTree definition if available

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -724,7 +724,12 @@ class QJIT(CatalystCallable):
                 ),
             ):
                 return trace_from_pennylane(
-                    self.user_function, static_argnums, abstracted_axes, full_sig, kwargs
+                    self.user_function,
+                    static_argnums,
+                    abstracted_axes,
+                    full_sig,
+                    kwargs,
+                    debug_info=dbg,
                 )
 
         def closure(qnode, *args, **kwargs):

--- a/frontend/catalyst/utils/types.py
+++ b/frontend/catalyst/utils/types.py
@@ -17,6 +17,7 @@ import inspect
 from collections.abc import Sequence
 
 import numpy as np
+from jax import numpy as jnp
 from jax._src.core import shaped_abstractify
 from jax._src.lib.mlir import ir
 
@@ -69,3 +70,13 @@ def convert_numpy_dtype_to_mlir(dtp):
     elif dtp == np.dtype(np.int64):
         return ir.IntegerType.get_signless(64)
     raise ValueError("Requested type conversion not available.")
+
+
+def get_shape(x):
+    """
+    Jax deprecated support of jnp.shape(ShapedArray) on 0.5.3.
+    This method extracts the shape from regular and ShapedArray variables.
+    """
+
+    shape = x.shape if isinstance(x, ShapedArray) else jnp.shape(x)
+    return shape

--- a/frontend/test/pytest/test_shotvector.py
+++ b/frontend/test/pytest/test_shotvector.py
@@ -38,7 +38,7 @@ class TestShotVector:
 
         assert type(circuit()) == tuple
         assert len(circuit()) == 4
-        assert jnp.shape(circuit()) == (4, 3, 1)
+        assert jnp.array(circuit()).shape == (4, 3, 1)
 
     @pytest.mark.parametrize("shots", [((3, 4),), (3,) * 4, (3, 3, 3, 3), [3, 3, 3, 3]])
     def test_multiple_sample_measurement(self, shots):
@@ -53,8 +53,8 @@ class TestShotVector:
             return [qml.sample(), qml.sample()]
 
         assert len(circuit_list()) == 2
-        assert jnp.shape(circuit_list()[0]) == (4, 3, 1)
-        assert jnp.shape(circuit_list()[1]) == (4, 3, 1)
+        assert jnp.array(circuit_list()[0]).shape == (4, 3, 1)
+        assert jnp.array(circuit_list()[1]).shape == (4, 3, 1)
 
         @qjit
         @qml.qnode(dev)
@@ -63,8 +63,8 @@ class TestShotVector:
             return {"first": qml.sample(), "second": qml.sample()}
 
         assert list(circuit_dict().keys()) == ["first", "second"]
-        assert jnp.shape(circuit_dict()["first"]) == (4, 3, 1)
-        assert jnp.shape(circuit_dict()["second"]) == (4, 3, 1)
+        assert jnp.array(circuit_dict()["first"]).shape == (4, 3, 1)
+        assert jnp.array(circuit_dict()["second"]).shape == (4, 3, 1)
 
     def test_shot_vector_with_mixes_shots_and_without_copies(self):
         """Test shot-vector with mixes shots and without copies"""
@@ -81,10 +81,10 @@ class TestShotVector:
         assert len(circuit()) == 8
 
         for i in range(5):
-            assert jnp.shape(circuit()[i]) == (20, 1)
-        assert jnp.shape(circuit()[5]) == (100, 1)
-        assert jnp.shape(circuit()[6]) == (101, 1)
-        assert jnp.shape(circuit()[7]) == (101, 1)
+            assert jnp.array(circuit()[i]).shape == (20, 1)
+        assert jnp.array(circuit()[5]).shape == (100, 1)
+        assert jnp.array(circuit()[6]).shape == (101, 1)
+        assert jnp.array(circuit()[7]).shape == (101, 1)
 
     def test_shot_vector_with_different_measurement(self):
         """Test a NotImplementedError is raised when using a shot-vector with a measurement that is not qml.sample()"""
@@ -152,10 +152,10 @@ class TestShotVector:
             }
 
         assert list(circuit().keys()) == ["first", "second", "third"]
-        assert jnp.shape(circuit()["first"]) == (4, 3, 1)
+        assert jnp.array(circuit()["first"]).shape == (4, 3, 1)
         assert circuit()["second"][0] == 100
-        assert jnp.shape(circuit()["second"][1]) == (4, 3, 1)
-        assert jnp.shape(circuit()["third"]) == (2, 4, 3, 1)
+        assert jnp.array(circuit()["second"][1]).shape == (4, 3, 1)
+        assert jnp.array(circuit()["third"]).shape == (2, 4, 3, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Context:**
Bump to jax 0.5.3

jaxlib does not ship wheels for 0.5.2, so we skip it and go to 0.5.3 directly.