### PR TITLE
Enable oqd pytests in PR CI

### DIFF
--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -611,6 +611,58 @@ jobs:
       run: |
         make pytest TEST_BRAKET=LOCAL
 
+  frontend-tests-oqd-device:
+    name: Frontend Tests (backend="oqd")
+    needs: [constants, llvm, runtime, quantum, determine_runner]
+    runs-on: ${{ needs.determine_runner.outputs.runner_group }}
+    strategy:
+      matrix:
+        compiler: ${{ fromJson(needs.constants.outputs.compilers) }}
+
+    steps:
+    - name: Checkout Catalyst repo
+      uses: actions/checkout@v4
+
+    - name: Install Deps
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y python3 python3-pip libomp-dev libasan6 make ninja-build
+        python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
+        python3 -m pip install -r requirements.txt
+        make frontend
+
+    - name: Get Cached LLVM Build
+      id: cache-llvm-build
+      uses: actions/cache@v4
+      with:
+        path: llvm-build
+        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-ci-build-${{ matrix.compiler }}
+        fail-on-cache-miss: true
+
+    - name: Download Quantum Build Artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: quantum-build-${{ matrix.compiler }}
+        path: quantum-build
+
+    - name: Download Catalyst-Runtime Artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: runtime-build-${{ matrix.compiler }}
+        path: runtime-build/lib
+
+    - name: Add Frontend Dependencies to PATH
+      run: |
+        echo "PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum" >> $GITHUB_ENV
+        echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
+        echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
+        echo "CATALYST_BIN_DIR=$(pwd)/quantum-build/bin" >> $GITHUB_ENV
+        chmod +x $(pwd)/quantum-build/bin/catalyst  # artifact upload does not preserve permissions
+
+    - name: Run Python Pytest Tests
+      run: |
+        pytest frontend/test/test_oqd -n auto
+
   runtime-device-tests:
     name: Third-Party Device Tests (C++)
     needs: [constants, runtime, determine_runner]

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -478,6 +478,7 @@ jobs:
         echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
         echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
         echo "OQC_LIB_DIR=$(pwd)/oqc-build" >> $GITHUB_ENV
+        echo "OQD_LIB_DIR=$(pwd)/oqd-build" >> $GITHUB_ENV
         echo "CATALYST_BIN_DIR=$(pwd)/quantum-build/bin" >> $GITHUB_ENV
         chmod +x $(pwd)/quantum-build/bin/catalyst  # artifact upload does not preserve permissions
 

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -478,7 +478,6 @@ jobs:
         echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
         echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
         echo "OQC_LIB_DIR=$(pwd)/oqc-build" >> $GITHUB_ENV
-        echo "OQD_LIB_DIR=$(pwd)/oqd-build" >> $GITHUB_ENV
         echo "CATALYST_BIN_DIR=$(pwd)/quantum-build/bin" >> $GITHUB_ENV
         chmod +x $(pwd)/quantum-build/bin/catalyst  # artifact upload does not preserve permissions
 
@@ -658,6 +657,7 @@ jobs:
         echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
         echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
         echo "CATALYST_BIN_DIR=$(pwd)/quantum-build/bin" >> $GITHUB_ENV
+        echo "OQD_LIB_DIR=$(pwd)/oqd-build" >> $GITHUB_ENV
         chmod +x $(pwd)/quantum-build/bin/catalyst  # artifact upload does not preserve permissions
 
     - name: Run Python Pytest Tests

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -478,6 +478,7 @@ jobs:
         echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
         echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
         echo "OQC_LIB_DIR=$(pwd)/oqc-build" >> $GITHUB_ENV
+        echo "OQD_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
         echo "CATALYST_BIN_DIR=$(pwd)/quantum-build/bin" >> $GITHUB_ENV
         chmod +x $(pwd)/quantum-build/bin/catalyst  # artifact upload does not preserve permissions
 
@@ -488,7 +489,7 @@ jobs:
     - name: Run Python Pytest Tests
       run: |
         COVERAGE_REPORT="xml:coverage.xml -p no:warnings" \
-        make coverage-frontend
+        make coverage-frontend ENABLE_OQD=ON
         mv coverage.xml coverage-${{ github.job }}.xml
 
     - name: Upload to Codecov
@@ -610,59 +611,6 @@ jobs:
     - name: Run Python Pytest Tests
       run: |
         make pytest TEST_BRAKET=LOCAL
-
-  frontend-tests-oqd-device:
-    name: Frontend Tests (backend="oqd")
-    needs: [constants, llvm, runtime, quantum, determine_runner]
-    runs-on: ${{ needs.determine_runner.outputs.runner_group }}
-    strategy:
-      matrix:
-        compiler: ${{ fromJson(needs.constants.outputs.compilers) }}
-
-    steps:
-    - name: Checkout Catalyst repo
-      uses: actions/checkout@v4
-
-    - name: Install Deps
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y python3 python3-pip libomp-dev libasan6 make ninja-build
-        python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
-        python3 -m pip install -r requirements.txt
-        make frontend
-
-    - name: Get Cached LLVM Build
-      id: cache-llvm-build
-      uses: actions/cache@v4
-      with:
-        path: llvm-build
-        key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-ci-build-${{ matrix.compiler }}
-        fail-on-cache-miss: true
-
-    - name: Download Quantum Build Artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: quantum-build-${{ matrix.compiler }}
-        path: quantum-build
-
-    - name: Download Catalyst-Runtime Artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: runtime-build-${{ matrix.compiler }}
-        path: runtime-build/lib
-
-    - name: Add Frontend Dependencies to PATH
-      run: |
-        echo "PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum" >> $GITHUB_ENV
-        echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
-        echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
-        echo "CATALYST_BIN_DIR=$(pwd)/quantum-build/bin" >> $GITHUB_ENV
-        echo "OQD_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
-        chmod +x $(pwd)/quantum-build/bin/catalyst  # artifact upload does not preserve permissions
-
-    - name: Run Python Pytest Tests
-      run: |
-        pytest frontend/test/test_oqd -n auto
 
   runtime-device-tests:
     name: Third-Party Device Tests (C++)

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -657,7 +657,7 @@ jobs:
         echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
         echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
         echo "CATALYST_BIN_DIR=$(pwd)/quantum-build/bin" >> $GITHUB_ENV
-        echo "OQD_LIB_DIR=$(pwd)/oqd-build" >> $GITHUB_ENV
+        echo "OQD_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
         chmod +x $(pwd)/quantum-build/bin/catalyst  # artifact upload does not preserve permissions
 
     - name: Run Python Pytest Tests

--- a/frontend/test/test_oqd/oqd/test_openapl_generation.py
+++ b/frontend/test/test_oqd/oqd/test_openapl_generation.py
@@ -70,7 +70,7 @@ class TestOpenAPL:
         @qml.qnode(oqd_dev)
         def circuit():
             qml.CNOT(wires=[0, 1])
-            return qml.counts()
+            return qml.counts(wires=0)
 
         circuit()
 

--- a/frontend/test/test_oqd/oqd/test_openapl_generation.py
+++ b/frontend/test/test_oqd/oqd/test_openapl_generation.py
@@ -44,7 +44,7 @@ class TestOpenAPL:
         @qml.qnode(oqd_dev)
         def circuit(x):
             qml.RX(x, wires=0)
-            return qml.counts()
+            return qml.counts(wires=0)
 
         circuit(np.pi / 2)
 

--- a/frontend/test/test_oqd/oqd/test_openapl_generation.py
+++ b/frontend/test/test_oqd/oqd/test_openapl_generation.py
@@ -61,7 +61,6 @@ class TestOpenAPL:
 
         assert sorted(catalyst_json.items()) == sorted(expected_json.items())
         os.remove(self.output_f)
-        assert 0==1
 
     def test_CNOT_gate(self):
         """Test OpenAPL generation for a circuit with a single CNOT circuit."""

--- a/frontend/test/test_oqd/oqd/test_openapl_generation.py
+++ b/frontend/test/test_oqd/oqd/test_openapl_generation.py
@@ -61,6 +61,7 @@ class TestOpenAPL:
 
         assert sorted(catalyst_json.items()) == sorted(expected_json.items())
         os.remove(self.output_f)
+        assert 0==1
 
     def test_CNOT_gate(self):
         """Test OpenAPL generation for a circuit with a single CNOT circuit."""


### PR DESCRIPTION
**Context:**
It was discovered that for oqd tests, CIs on PRs only run the cpp runtime device tests, not the pytests. 

**Description of the Change:**
We enable oqd pytests in CI. 

**Benefits:**
Better test coverage.

