### PR TITLE
Add `adjoint` to assembly format

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -71,6 +71,9 @@
 * The utility function `EnsureFunctionDeclaration` is refactored into the `Utils` of the `Catalyst` dialect, instead of being duplicated in each individual dialect.
   [(#1683)](https://github.com/PennyLaneAI/catalyst/pull/1683)
 
+* The assembly format for some MLIR operations now includes adjoint.
+  [(#1695)](https://github.com/PennyLaneAI/catalyst/pull/1695)
+
 <h3>Documentation 📝</h3>
 
 <h3>Contributors ✍️</h3>

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -446,7 +446,7 @@ def CustomOp : UnitaryGate_Op<"custom", [DifferentiableGate, NoMemoryEffect,
     ];
 
     let assemblyFormat = [{
-        $gate_name `(` $params `)` $in_qubits attr-dict ( `ctrls` `(` $in_ctrl_qubits^ `)` )?  ( `ctrlvals` `(` $in_ctrl_values^ `)` )? `:` type($out_qubits) (`ctrls` type($out_ctrl_qubits)^ )?
+        $gate_name `(` $params `)` $in_qubits (`adj` $adjoint^)? attr-dict ( `ctrls` `(` $in_ctrl_qubits^ `)` )?  ( `ctrlvals` `(` $in_ctrl_values^ `)` )? `:` type($out_qubits) (`ctrls` type($out_ctrl_qubits)^ )?
     }];
 
     let extraClassDeclaration = extraBaseClassDeclaration # [{

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -250,10 +250,14 @@ class UnitaryGate_Op<string mnemonic, list<Trait> traits = []> :
         }
 
         bool getAdjointFlag() {
-            return getAdjoint().has_value() ? getAdjoint().value() : false;
+            return getAdjoint().value_or(false);
         }
         void setAdjointFlag(bool adjoint) {
-            setAdjoint(adjoint);
+            if (adjoint) {
+               (*this)->setAttr("adjoint", mlir::UnitAttr::get(this->getContext()));
+            } else {
+               (*this)->removeAttr("adjoint");
+            }
         };
 
         mlir::ValueRange getCtrlValueOperands() {
@@ -541,7 +545,7 @@ def MultiRZOp : UnitaryGate_Op<"multirz", [DifferentiableGate, NoMemoryEffect,
     );
 
     let assemblyFormat = [{
-        `(` $theta `)` $in_qubits attr-dict ( `ctrls` `(` $in_ctrl_qubits^ `)` )?  ( `ctrlvals` `(` $in_ctrl_values^ `)` )? `:` type($out_qubits) (`ctrls` type($out_ctrl_qubits)^ )?
+        `(` $theta `)` $in_qubits (`adj` $adjoint^)? attr-dict ( `ctrls` `(` $in_ctrl_qubits^ `)` )?  ( `ctrlvals` `(` $in_ctrl_values^ `)` )? `:` type($out_qubits) (`ctrls` type($out_ctrl_qubits)^ )?
     }];
 
     let extraClassDeclaration = extraBaseClassDeclaration # [{
@@ -578,7 +582,7 @@ def QubitUnitaryOp : UnitaryGate_Op<"unitary", [ParametrizedGate, NoMemoryEffect
     );
 
     let assemblyFormat = [{
-        `(` $matrix `:` type($matrix) `)` $in_qubits attr-dict ( `ctrls` `(` $in_ctrl_qubits^ `)` )?  ( `ctrlvals` `(` $in_ctrl_values^ `)` )? `:` type($out_qubits) (`ctrls` type($out_ctrl_qubits)^ )?
+        `(` $matrix `:` type($matrix) `)` $in_qubits (`adj` $adjoint^)? attr-dict ( `ctrls` `(` $in_ctrl_qubits^ `)` )?  ( `ctrlvals` `(` $in_ctrl_values^ `)` )? `:` type($out_qubits) (`ctrls` type($out_ctrl_qubits)^ )?
     }];
 
     let extraClassDeclaration = extraBaseClassDeclaration # [{

--- a/mlir/test/Mitigation/ZneFoldingAllFullTest.mlir
+++ b/mlir/test/Mitigation/ZneFoldingAllFullTest.mlir
@@ -23,37 +23,37 @@
     // CHECK:   [[q0:%.+]] = quantum.extract [[qReg]][ 0] : !quantum.reg -> !quantum.bit
     // CHECK:   [[q0_out:%.+]] = scf.for %arg1 = [[c0]] to %arg0 step [[c1]] iter_args([[q0_in:%.+]] = [[q0]]) -> (!quantum.bit) {
     // CHECK:     [[q0_loop:%.+]] = quantum.custom "Hadamard"() [[q0_in]] : !quantum.bit
-    // CHECK:     [[q0_loop2:%.+]] = quantum.custom "Hadamard"() [[q0_loop]] {adjoint} : !quantum.bit
+    // CHECK:     [[q0_loop2:%.+]] = quantum.custom "Hadamard"() [[q0_loop]] adj : !quantum.bit
     // CHECK:     scf.yield [[q0_loop2]] : !quantum.bit
     // CHECK:   [[q0_out2:%.+]] = quantum.custom "Hadamard"() [[q0_out]] : !quantum.bit
     // CHECK:   [[q1:%.+]] = quantum.extract [[qReg]][ 1] : !quantum.reg -> !quantum.bit
     // CHECK:   [[q01_out:%.+]]:2 = scf.for %arg1 = [[c0]] to %arg0 step [[c1]] iter_args([[q01_in1:%.+]] = [[q0_out2]], [[q01_in2:%.+]] = [[q1]]) -> (!quantum.bit, !quantum.bit) {
     // CHECK:     [[q01_loop:%.+]]:2 = quantum.custom "CNOT"() [[q01_in1]], [[q01_in2]] : !quantum.bit, !quantum.bit
-    // CHECK:     [[q01_loop2:%.+]]:2 = quantum.custom "CNOT"() [[q01_loop]]#0, [[q01_loop]]#1 {adjoint} : !quantum.bit, !quantum.bit
+    // CHECK:     [[q01_loop2:%.+]]:2 = quantum.custom "CNOT"() [[q01_loop]]#0, [[q01_loop]]#1 adj : !quantum.bit, !quantum.bit
     // CHECK:     scf.yield [[q01_loop2]]#0, [[q01_loop2]]#1 : !quantum.bit, !quantum.bit
     // CHECK:   [[q01_out2:%.+]]:2 = quantum.custom "CNOT"() [[q01_out]]#0, [[q01_out]]#1 : !quantum.bit, !quantum.bit
     // CHECK:   [[q2:%.+]] = quantum.extract [[qReg]][ 2] : !quantum.reg -> !quantum.bit
     // CHECK:   [[q12_out:%.+]]:2 = scf.for %arg1 = [[c0]] to %arg0 step [[c1]] iter_args([[q12_in1:%.+]] = [[q01_out2]]#1, [[q12_in2:%.+]] = [[q2]]) -> (!quantum.bit, !quantum.bit) {
     // CHECK:     [[q12_loop:%.+]]:2 = quantum.custom "CNOT"() [[q12_in1]], [[q12_in2]] : !quantum.bit, !quantum.bit
-    // CHECK:     [[q12_loop2:%.+]]:2 = quantum.custom "CNOT"() [[q12_loop]]#0, [[q12_loop]]#1 {adjoint} : !quantum.bit, !quantum.bit
+    // CHECK:     [[q12_loop2:%.+]]:2 = quantum.custom "CNOT"() [[q12_loop]]#0, [[q12_loop]]#1 adj : !quantum.bit, !quantum.bit
     // CHECK:     scf.yield [[q12_loop2]]#0, [[q12_loop2]]#1 : !quantum.bit, !quantum.bit
     // CHECK:   [[q12_out2:%.+]]:2 = quantum.custom "CNOT"() [[q12_out]]#0, [[q12_out]]#1 : !quantum.bit, !quantum.bit
     // CHECK:   [[q1_out:%.+]] = scf.for %arg1 = [[c0]] to %arg0 step [[c1]] iter_args([[q1_in:%.+]] = [[q12_out2]]#0) -> (!quantum.bit) {
     // CHECK:     [[q1_loop:%.+]] = quantum.custom "T"() [[q1_in]] : !quantum.bit
-    // CHECK:     [[q1_loop2:%.+]] = quantum.custom "T"() [[q1_loop]] {adjoint} : !quantum.bit
+    // CHECK:     [[q1_loop2:%.+]] = quantum.custom "T"() [[q1_loop]] adj : !quantum.bit
     // CHECK:     scf.yield [[q1_loop2]] : !quantum.bit
     // CHECK:   [[q1_out2:%.+]] = quantum.custom "T"() [[q1_out]] : !quantum.bit
     // CHECK:   [[q3:%.+]] = quantum.extract [[qReg]][ 3] : !quantum.reg -> !quantum.bit
     // CHECK:   [[q23_out:%.+]]:2 = scf.for %arg1 = [[c0]] to %arg0 step [[c1]] iter_args([[q23_in1:%.+]] = [[q12_out2]]#1, [[q23_in2:%.+]] = [[q3]]) -> (!quantum.bit, !quantum.bit) {
     // CHECK:     [[q23_loop:%.+]]:2 = quantum.custom "CNOT"() [[q23_in1]], [[q23_in2]] : !quantum.bit, !quantum.bit
-    // CHECK:     [[q23_loop2:%.+]]:2 = quantum.custom "CNOT"() [[q23_loop]]#0, [[q23_loop]]#1 {adjoint} : !quantum.bit, !quantum.bit
+    // CHECK:     [[q23_loop2:%.+]]:2 = quantum.custom "CNOT"() [[q23_loop]]#0, [[q23_loop]]#1 adj : !quantum.bit, !quantum.bit
     // CHECK:     scf.yield [[q23_loop2]]#0, [[q23_loop2]]#1 : !quantum.bit, !quantum.bit
     // CHECK:   [[q23_out2:%.+]]:2 = quantum.custom "CNOT"() [[q23_out]]#0, [[q23_out]]#1 : !quantum.bit, !quantum.bit
     // CHECK:   [[q3_out:%.+]] = scf.for %arg1 = [[c0]] to %arg0 step [[c1]] iter_args([[q3_in:%.+]] = [[q23_out2]]#1) -> (!quantum.bit) {
-    // CHECK:     [[q3_loop:%.+]] = quantum.custom "T"() [[q3_in]] {adjoint} : !quantum.bit
+    // CHECK:     [[q3_loop:%.+]] = quantum.custom "T"() [[q3_in]] adj : !quantum.bit
     // CHECK:     [[q3_loop2:%.+]] = quantum.custom "T"() [[q3_loop]] : !quantum.bit
     // CHECK:     scf.yield [[q3_loop2]] : !quantum.bit
-    // CHECK:   [[q3_out2:%.+]] = quantum.custom "T"() [[q3_out]] {adjoint} : !quantum.bit
+    // CHECK:   [[q3_out2:%.+]] = quantum.custom "T"() [[q3_out]] adj : !quantum.bit
 
 
 //CHECK-LABEL: func.func @circuit() -> tensor<f64> attributes {qnode} {
@@ -70,7 +70,7 @@ func.func @circuit() -> tensor<f64> attributes {qnode} {
     %out_qubits_2 = quantum.custom "T"() %out_qubits_1#0 : !quantum.bit
     %4 = quantum.extract %0[ 3] : !quantum.reg -> !quantum.bit
     %out_qubits_3:2 = quantum.custom "CNOT"() %out_qubits_1#1, %4 : !quantum.bit, !quantum.bit
-    %out_qubits_4 = quantum.custom "T"() %out_qubits_3#1 {adjoint} : !quantum.bit
+    %out_qubits_4 = quantum.custom "T"() %out_qubits_3#1 adj : !quantum.bit
     %5 = quantum.namedobs %out_qubits_0#0[ PauliY] : !quantum.obs
     %6 = quantum.expval %5 {shots = 5 : i64} : f64
     %from_elements = tensor.from_elements %6 : tensor<f64>

--- a/mlir/test/Mitigation/ZneFoldingAllMinimalTest.mlir
+++ b/mlir/test/Mitigation/ZneFoldingAllMinimalTest.mlir
@@ -23,13 +23,13 @@
     // CHECK:   [[q0:%.+]] = quantum.extract [[qReg]][ 0] : !quantum.reg -> !quantum.bit
     // CHECK:   [[q0_out:%.+]] = scf.for %arg1 = [[c0]] to %arg0 step [[c1]] iter_args([[q0_in:%.+]] = [[q0]]) -> (!quantum.bit) {
     // CHECK:     [[q0_loop:%.+]] = quantum.custom "Hadamard"() [[q0_in]] : !quantum.bit
-    // CHECK:     [[q0_loop2:%.+]] = quantum.custom "Hadamard"() [[q0_loop]] {adjoint} : !quantum.bit
+    // CHECK:     [[q0_loop2:%.+]] = quantum.custom "Hadamard"() [[q0_loop]] adj : !quantum.bit
     // CHECK:     scf.yield [[q0_loop2]] : !quantum.bit
     // CHECK:   [[q0_out2:%.+]] = quantum.custom "Hadamard"() [[q0_out]] : !quantum.bit
     // CHECK:   [[q1:%.+]] = quantum.extract [[qReg]][ 1] : !quantum.reg -> !quantum.bit
     // CHECK:   [[q01_out:%.+]]:2 = scf.for %arg1 = [[c0]] to %arg0 step [[c1]] iter_args([[q01_in1:%.+]] = [[q0_out2]], [[q01_in2:%.+]] = [[q1]]) -> (!quantum.bit, !quantum.bit) {
     // CHECK:     [[q01_loop:%.+]]:2 = quantum.custom "CNOT"() [[q01_in1]], [[q01_in2]] : !quantum.bit, !quantum.bit
-    // CHECK:     [[q01_loop2:%.+]]:2 = quantum.custom "CNOT"() [[q01_loop]]#0, [[q01_loop]]#1 {adjoint} : !quantum.bit, !quantum.bit
+    // CHECK:     [[q01_loop2:%.+]]:2 = quantum.custom "CNOT"() [[q01_loop]]#0, [[q01_loop]]#1 adj : !quantum.bit, !quantum.bit
     // CHECK:     scf.yield [[q01_loop2]]#0, [[q01_loop2]]#1 : !quantum.bit, !quantum.bit
     // CHECK:   [[q01_out2:%.+]]:2 = quantum.custom "CNOT"() [[q01_out]]#0, [[q01_out]]#1 : !quantum.bit, !quantum.bit
     // CHECK:   [[q2:%.+]] = quantum.namedobs [[q01_out2]]#0[ PauliY] : !quantum.obs

--- a/mlir/test/Quantum/AdjointTest.mlir
+++ b/mlir/test/Quantum/AdjointTest.mlir
@@ -27,11 +27,11 @@ func.func private @workflow_plain() -> tensor<4xcomplex<f64>> attributes {} {
   %3 = quantum.insert %0[%c0_i64], %2 : !quantum.reg, !quantum.bit
   %4 = quantum.adjoint(%3) : !quantum.reg {
   // CHECK:        PauliZ
-  // CHECK-SAME:          adjoint
+  // CHECK-SAME:          adj
   // CHECK:        PauliY
-  // CHECK-SAME:          adjoint
+  // CHECK-SAME:          adj
   // CHECK:        PauliX
-  // CHECK-SAME:          adjoint
+  // CHECK-SAME:          adj
   ^bb0(%arg0: !quantum.reg):
     %10 = quantum.extract %arg0[%c0_i64] : !quantum.reg -> !quantum.bit
     %11 = quantum.custom "PauliX"() %10 : !quantum.bit
@@ -57,13 +57,13 @@ func.func private @workflow_plain() -> tensor<4xcomplex<f64>> attributes {} {
 // CHECK:      OpC
 // CHECK:      OpD
 // CHECK:      OpF
-// CHECK-SAME:      adjoint
+// CHECK-SAME:      adj
 // CHECK:      OpE
-// CHECK-SAME:      adjoint
+// CHECK-SAME:      adj
 // CHECK:      OpB
-// CHECK-SAME:      adjoint
+// CHECK-SAME:      adj
 // CHECK:      OpA
-// CHECK-SAME:      adjoint
+// CHECK-SAME:      adj
 func.func private @workflow_nested() -> tensor<4xcomplex<f64>> attributes {} {
   %c1_i64 = arith.constant 1 : i64
   %c0_i64 = arith.constant 0 : i64
@@ -182,17 +182,17 @@ func.func private @circuit(%arg0: f64, %arg1: !quantum.reg) -> !quantum.reg {
 }
 
 // CHECK:   func.func private @circuit.adjoint(%arg0: f64, %arg1: !quantum.reg) -> !quantum.reg {
-// CHECK:   quantum.custom "PauliZ"() {{%.+}} {adjoint} : !quantum.bit
-// CHECK:   quantum.custom "RX"({{%.+}}) {{%.+}} {adjoint} : !quantum.bit
-// CHECK:   quantum.custom "PauliX"() {{%.+}} {adjoint} : !quantum.bit
+// CHECK:   quantum.custom "PauliZ"() {{%.+}} adj : !quantum.bit
+// CHECK:   quantum.custom "RX"({{%.+}}) {{%.+}} adj : !quantum.bit
+// CHECK:   quantum.custom "PauliX"() {{%.+}} adj : !quantum.bit
 
 // CHECK:   func.func private @workflow_adjoint(%arg0: f64) -> tensor<4xcomplex<f64>> {
 // CHECK:   quantum.custom "RX"({{%.+}}) {{%.+}} : !quantum.bit
-// CHECK:   quantum.custom "RY"({{%.+}}) {{%.+}} {adjoint} : !quantum.bit
+// CHECK:   quantum.custom "RY"({{%.+}}) {{%.+}} adj : !quantum.bit
 // CHECK:   call @circuit.adjoint(%arg0, {{%.+}}) : (f64, !quantum.reg) -> !quantum.reg
-// CHECK:   quantum.custom "PauliZ"() {{%.+}} {adjoint} : !quantum.bit
-// CHECK:   quantum.custom "RX"({{%.+}}) {{%.+}} {adjoint} : !quantum.bit
-// CHECK:   quantum.custom "PauliX"() {{%.+}} {adjoint} : !quantum.bit
+// CHECK:   quantum.custom "PauliZ"() {{%.+}} adj : !quantum.bit
+// CHECK:   quantum.custom "RX"({{%.+}}) {{%.+}} adj : !quantum.bit
+// CHECK:   quantum.custom "PauliX"() {{%.+}} adj : !quantum.bit
 // CHECK:   quantum.custom "RY"({{%.+}}) {{%.+}} : !quantum.bit
 
 func.func private @workflow_adjoint(%arg0: f64) -> tensor<4xcomplex<f64>> attributes {} {

--- a/mlir/test/Quantum/ChainedSelfInverseTest.mlir
+++ b/mlir/test/Quantum/ChainedSelfInverseTest.mlir
@@ -285,7 +285,7 @@ func.func @test_chained_self_inverse(%arg0: tensor<2x2xf64>, %arg1: tensor<f64>)
     %2 = stablehlo.convert %arg0 : (tensor<2x2xf64>) -> tensor<2x2xcomplex<f64>>
     %out_qubits = quantum.unitary(%2 : tensor<2x2xcomplex<f64>>) %1 : !quantum.bit
     %3 = stablehlo.convert %arg0 : (tensor<2x2xf64>) -> tensor<2x2xcomplex<f64>>
-    %out_qubits_1 = quantum.unitary(%3 : tensor<2x2xcomplex<f64>>) %out_qubits {adjoint} : !quantum.bit
+    %out_qubits_1 = quantum.unitary(%3 : tensor<2x2xcomplex<f64>>) %out_qubits adj : !quantum.bit
 
     // CHECK-NOT: quantum.unitary
     // CHECK: return [[IN]]
@@ -308,10 +308,10 @@ func.func @test_chained_self_inverse(%arg0: tensor<f64>) -> !quantum.bit {
     %extracted_0 = tensor.extract %arg0[] : tensor<f64>
     %out_qubits = quantum.custom "RX"(%extracted_0) %1 : !quantum.bit
     %extracted_1 = tensor.extract %arg0[] : tensor<f64>
-    %out_qubits_1 = quantum.custom "RX"(%extracted_1) %out_qubits {adjoint} : !quantum.bit
+    %out_qubits_1 = quantum.custom "RX"(%extracted_1) %out_qubits adj : !quantum.bit
 
 
-    %out_qubits_2 = quantum.custom "RX"(%extracted_0) %out_qubits_1 {adjoint} : !quantum.bit
+    %out_qubits_2 = quantum.custom "RX"(%extracted_0) %out_qubits_1 adj : !quantum.bit
     %out_qubits_3 = quantum.custom "RX"(%extracted_1) %out_qubits_2 : !quantum.bit
 
     // CHECK-NOT: quantum.custom
@@ -333,9 +333,9 @@ func.func @test_chained_self_inverse(%arg0: tensor<f64>) -> !quantum.bit {
     %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
 
     %extracted_0 = tensor.extract %arg0[] : tensor<f64>
-    %out_qubits = quantum.custom "RX"(%extracted_0) %1 {adjoint} : !quantum.bit
+    %out_qubits = quantum.custom "RX"(%extracted_0) %1 adj : !quantum.bit
     %extracted_1 = tensor.extract %arg0[] : tensor<f64>
-    %out_qubits_1 = quantum.custom "RX"(%extracted_1) %out_qubits {adjoint} : !quantum.bit
+    %out_qubits_1 = quantum.custom "RX"(%extracted_1) %out_qubits adj : !quantum.bit
 
     // CHECK: quantum.custom
     return %out_qubits_1 : !quantum.bit
@@ -356,7 +356,7 @@ func.func @test_chained_self_inverse() -> !quantum.bit {
 
     %cst_0 = stablehlo.constant dense<1.234000e+01> : tensor<f64>
     %extracted_0 = tensor.extract %cst_0[] : tensor<f64>
-    %out_qubits_0 = quantum.custom "RY"(%extracted_0) %1 {adjoint} : !quantum.bit
+    %out_qubits_0 = quantum.custom "RY"(%extracted_0) %1 adj : !quantum.bit
 
     %cst_1 = stablehlo.constant dense<1.234000e+01> : tensor<f64>
     %extracted_1 = tensor.extract %cst_1[] : tensor<f64>
@@ -380,7 +380,7 @@ func.func @test_chained_self_inverse() -> !quantum.bit {
 
     %cst_0 = stablehlo.constant dense<1.234000e+01> : tensor<f64>
     %extracted_0 = tensor.extract %cst_0[] : tensor<f64>
-    %out_qubits_0 = quantum.custom "RY"(%extracted_0) %1 {adjoint} : !quantum.bit
+    %out_qubits_0 = quantum.custom "RY"(%extracted_0) %1 adj : !quantum.bit
 
     %cst_1 = stablehlo.constant dense<5.678000e+01> : tensor<f64>
     %extracted_1 = tensor.extract %cst_1[] : tensor<f64>
@@ -389,7 +389,7 @@ func.func @test_chained_self_inverse() -> !quantum.bit {
     return %out_qubits_1 : !quantum.bit
 }
 
-// CHECK: quantum.custom "RY"{{.+}}{adjoint}
+// CHECK: quantum.custom "RY"{{.+}}adj
 // CHECK: quantum.custom "RY"
 
 
@@ -418,7 +418,7 @@ func.func @test_chained_self_inverse() -> (!quantum.bit, !quantum.bit, !quantum.
     %3 = quantum.extract %reg[ 3] : !quantum.reg -> !quantum.bit
 
     %out_qubits:2, %out_ctrl_qubits:2 = quantum.custom "Rot"(%cst, %cst_0, %cst_1) %0, %1 ctrls(%2, %3) ctrlvals(%true, %false) : !quantum.bit, !quantum.bit ctrls !quantum.bit, !quantum.bit
-    %out_qubits_1:2, %out_ctrl_qubits_1:2 = quantum.custom "Rot"(%cst, %cst_0, %cst_1) %out_qubits#0, %out_qubits#1 {adjoint} ctrls(%out_ctrl_qubits#0, %out_ctrl_qubits#1) ctrlvals(%true, %false) : !quantum.bit, !quantum.bit ctrls !quantum.bit, !quantum.bit
+    %out_qubits_1:2, %out_ctrl_qubits_1:2 = quantum.custom "Rot"(%cst, %cst_0, %cst_1) %out_qubits#0, %out_qubits#1 adj ctrls(%out_ctrl_qubits#0, %out_ctrl_qubits#1) ctrlvals(%true, %false) : !quantum.bit, !quantum.bit ctrls !quantum.bit, !quantum.bit
 
     // CHECK-NOT: quantum.custom
     // CHECK: return [[IN0]], [[IN1]], [[IN2]], [[IN3]]
@@ -452,7 +452,7 @@ func.func @test_chained_self_inverse() -> (!quantum.bit, !quantum.bit, !quantum.
 
     // CHECK: quantum.custom
     %out_qubits:2, %out_ctrl_qubits:2 = quantum.custom "Rot"(%cst, %cst_0, %cst_1) %0, %1 ctrls(%2, %3) ctrlvals(%true, %false) : !quantum.bit, !quantum.bit ctrls !quantum.bit, !quantum.bit
-    %out_qubits_1:2, %out_ctrl_qubits_1:2 = quantum.custom "Rot"(%cst, %cst_0, %cst_1) %out_qubits#1, %out_qubits#0 {adjoint} ctrls(%out_ctrl_qubits#0, %out_ctrl_qubits#1) ctrlvals(%true, %false) : !quantum.bit, !quantum.bit ctrls !quantum.bit, !quantum.bit
+    %out_qubits_1:2, %out_ctrl_qubits_1:2 = quantum.custom "Rot"(%cst, %cst_0, %cst_1) %out_qubits#1, %out_qubits#0 adj ctrls(%out_ctrl_qubits#0, %out_ctrl_qubits#1) ctrlvals(%true, %false) : !quantum.bit, !quantum.bit ctrls !quantum.bit, !quantum.bit
 
 
     return %out_qubits_1#0, %out_qubits_1#1, %out_ctrl_qubits_1#0, %out_ctrl_qubits_1#1 : !quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit
@@ -485,7 +485,7 @@ func.func @test_chained_self_inverse() -> (!quantum.bit, !quantum.bit, !quantum.
 
     // CHECK: quantum.custom
     %out_qubits:2, %out_ctrl_qubits:2 = quantum.custom "Rot"(%cst, %cst_0, %cst_1) %0, %1 ctrls(%2, %3) ctrlvals(%true, %false) : !quantum.bit, !quantum.bit ctrls !quantum.bit, !quantum.bit
-    %out_qubits_1:2, %out_ctrl_qubits_1:2 = quantum.custom "Rot"(%cst, %cst_0, %cst_1) %out_qubits#0, %out_qubits#1 {adjoint} ctrls(%out_ctrl_qubits#1, %out_ctrl_qubits#0) ctrlvals(%true, %false) : !quantum.bit, !quantum.bit ctrls !quantum.bit, !quantum.bit
+    %out_qubits_1:2, %out_ctrl_qubits_1:2 = quantum.custom "Rot"(%cst, %cst_0, %cst_1) %out_qubits#0, %out_qubits#1 adj ctrls(%out_ctrl_qubits#1, %out_ctrl_qubits#0) ctrlvals(%true, %false) : !quantum.bit, !quantum.bit ctrls !quantum.bit, !quantum.bit
 
 
     return %out_qubits_1#0, %out_qubits_1#1, %out_ctrl_qubits_1#0, %out_ctrl_qubits_1#1 : !quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit
@@ -518,7 +518,7 @@ func.func @test_chained_self_inverse() -> (!quantum.bit, !quantum.bit, !quantum.
 
     // CHECK: quantum.custom
     %out_qubits:2, %out_ctrl_qubits:2 = quantum.custom "Rot"(%cst, %cst_0, %cst_1) %0, %1 ctrls(%2, %3) ctrlvals(%true, %false) : !quantum.bit, !quantum.bit ctrls !quantum.bit, !quantum.bit
-    %out_qubits_1:2, %out_ctrl_qubits_1:2 = quantum.custom "Rot"(%cst, %cst_0, %cst_1) %out_qubits#0, %out_qubits#1 {adjoint} ctrls(%out_ctrl_qubits#0, %out_ctrl_qubits#1) ctrlvals(%false, %true) : !quantum.bit, !quantum.bit ctrls !quantum.bit, !quantum.bit
+    %out_qubits_1:2, %out_ctrl_qubits_1:2 = quantum.custom "Rot"(%cst, %cst_0, %cst_1) %out_qubits#0, %out_qubits#1 adj ctrls(%out_ctrl_qubits#0, %out_ctrl_qubits#1) ctrlvals(%false, %true) : !quantum.bit, !quantum.bit ctrls !quantum.bit, !quantum.bit
 
 
     return %out_qubits_1#0, %out_qubits_1#1, %out_ctrl_qubits_1#0, %out_ctrl_qubits_1#1 : !quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit
@@ -551,7 +551,7 @@ func.func @test_chained_self_inverse() -> (!quantum.bit, !quantum.bit, !quantum.
 
     // CHECK: quantum.custom
     %out_qubits:2, %out_ctrl_qubits:2 = quantum.custom "Rot"(%cst, %cst_0, %cst_1) %0, %1 ctrls(%2, %3) ctrlvals(%true, %false) : !quantum.bit, !quantum.bit ctrls !quantum.bit, !quantum.bit
-    %out_qubits_1:2, %out_ctrl_qubits_1:2 = quantum.custom "Rot"(%cst_0, %cst, %cst_1) %out_qubits#0, %out_qubits#1 {adjoint} ctrls(%out_ctrl_qubits#0, %out_ctrl_qubits#1) ctrlvals(%true, %false) : !quantum.bit, !quantum.bit ctrls !quantum.bit, !quantum.bit
+    %out_qubits_1:2, %out_ctrl_qubits_1:2 = quantum.custom "Rot"(%cst_0, %cst, %cst_1) %out_qubits#0, %out_qubits#1 adj ctrls(%out_ctrl_qubits#0, %out_ctrl_qubits#1) ctrlvals(%true, %false) : !quantum.bit, !quantum.bit ctrls !quantum.bit, !quantum.bit
 
 
     return %out_qubits_1#0, %out_qubits_1#1, %out_ctrl_qubits_1#0, %out_ctrl_qubits_1#1 : !quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit
@@ -575,7 +575,7 @@ func.func @test_chained_self_inverse(%arg0: f64) -> (!quantum.bit, !quantum.bit,
     %3 = quantum.extract %0[ 2] : !quantum.reg -> !quantum.bit
 
     %mrz:3 = quantum.multirz(%arg0) %1, %2, %3 : !quantum.bit, !quantum.bit, !quantum.bit
-    %mrz_out:3 = quantum.multirz(%arg0) %mrz#0, %mrz#1, %mrz#2 {adjoint} : !quantum.bit, !quantum.bit, !quantum.bit
+    %mrz_out:3 = quantum.multirz(%arg0) %mrz#0, %mrz#1, %mrz#2 adj : !quantum.bit, !quantum.bit, !quantum.bit
 
     // CHECK-NOT: quantum.multirz
     // CHECK: return [[IN0]], [[IN1]], [[IN2]]
@@ -599,7 +599,7 @@ func.func @test_chained_self_inverse(%arg0: f64) -> (!quantum.bit, !quantum.bit,
     %3 = quantum.extract %0[ 2] : !quantum.reg -> !quantum.bit
 
     %mrz:3 = quantum.multirz(%arg0) %1, %2, %3 : !quantum.bit, !quantum.bit, !quantum.bit
-    %mrz_out:3 = quantum.multirz(%arg0) %mrz#1, %mrz#2, %mrz#0 {adjoint} : !quantum.bit, !quantum.bit, !quantum.bit
+    %mrz_out:3 = quantum.multirz(%arg0) %mrz#1, %mrz#2, %mrz#0 adj : !quantum.bit, !quantum.bit, !quantum.bit
 
     // CHECK: quantum.multirz
     return %mrz_out#0, %mrz_out#1, %mrz_out#2 : !quantum.bit, !quantum.bit, !quantum.bit


### PR DESCRIPTION
**Context:** MLIR can represent properties in an attribute dictionary when they are not yet specified in the assembly format. We can definitely keep using that. But we could also move them to the assembly format.

**Description of the Change:** Just a small proposal of changing the syntax here for having adjoint. 

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

Fixes #1692 
