### PR TITLE
Remove `AnyTypeOf` in `YieldOp` since it only uses a single type

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -71,6 +71,9 @@
 * The utility function `EnsureFunctionDeclaration` is refactored into the `Utils` of the `Catalyst` dialect, instead of being duplicated in each individual dialect.
   [(#1683)](https://github.com/PennyLaneAI/catalyst/pull/1683)
 
+* Improved the definition of `YieldOp` in the quantum dialect by removing `AnyTypeOf`
+  [(#1696)](https://github.com/PennyLaneAI/catalyst/pull/1696)
+
 <h3>Documentation 📝</h3>
 
 <h3>Contributors ✍️</h3>

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -619,7 +619,7 @@ def YieldOp : Quantum_Op<"yield", [Pure, ReturnLike, Terminator, ParentOneOf<["A
     let summary = "Return results from quantum program regions";
 
     let arguments = (ins
-        Variadic<AnyTypeOf<[QuregType]>>:$results
+        Variadic<QuregType>:$results
     );
 
     let assemblyFormat = [{


### PR DESCRIPTION
**Context:** `AnyTypeOf` is used to describe a set of types. `YieldOp` uses `AnyTypeOf` but the set has size of 1.

**Description of the Change:** Remove the use of `AnyTypeOf`.

**Benefits:** Easier xDSL generation.

**Possible Drawbacks:** None

**Related GitHub Issues:** None

This has no impact on the user or the API. Not sure if a changelog is needed, but added one. Happy to discuss about it.
