### PR TITLE
Rename of operands/attributes to avoid xDSL reserved keywords

### DIFF
--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -85,12 +85,12 @@ def DeviceInitOp : Quantum_Op<"device"> {
     let arguments = (ins
         Optional<I64>:$shots,
         StrAttr:$lib,
-        StrAttr:$name,
+        StrAttr:$dev_name,
         StrAttr:$kwargs
     );
 
     let assemblyFormat = [{
-      (`shots` `(` $shots^ `)`)? `[` $lib `,` $name `,` $kwargs `]` attr-dict
+      (`shots` `(` $shots^ `)`)? `[` $lib `,` $dev_name `,` $kwargs `]` attr-dict
     }];
 
 }
@@ -619,11 +619,11 @@ def YieldOp : Quantum_Op<"yield", [Pure, ReturnLike, Terminator, ParentOneOf<["A
     let summary = "Return results from quantum program regions";
 
     let arguments = (ins
-        Variadic<QuregType>:$results
+        Variadic<QuregType>:$retvals
     );
 
     let assemblyFormat = [{
-        attr-dict ($results^ `:` type($results))?
+        attr-dict ($retvals ^ `:` type($retvals))?
     }];
 
     let builders = [

--- a/mlir/lib/Mitigation/Transforms/MitigationMethods/Zne.cpp
+++ b/mlir/lib/Mitigation/Transforms/MitigationMethods/Zne.cpp
@@ -391,7 +391,7 @@ FlatSymbolRefAttr ZneLowering::getOrInsertFoldedCircuit(Location loc, PatternRew
 
     Operation *shots = deviceInitOp.getShots().getDefiningOp();
     StringAttr lib = deviceInitOp.getLibAttr();
-    StringAttr name = deviceInitOp.getNameAttr();
+    StringAttr name = deviceInitOp.getDevNameAttr();
     StringAttr kwargs = deviceInitOp.getKwargsAttr();
 
     TypeRange originalTypes = op.getArgumentTypes();

--- a/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
@@ -196,7 +196,7 @@ struct DeviceInitOpPattern : public OpConversionPattern<DeviceInitOp> {
             catalyst::ensureFunctionDeclaration(rewriter, op, qirName, qirSignature);
 
         auto rtd_lib = op.getLib().str();
-        auto rtd_name = op.getName().str();
+        auto rtd_name = op.getDevName().str();
         auto rtd_kwargs = op.getKwargs().str();
 
         auto rtd_lib_gs = getGlobalString(loc, rewriter, rtd_lib,


### PR DESCRIPTION
**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
