### PR TITLE
[frontend] outline register_transform

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -59,6 +59,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Creates a function that allows developers to register an equivalent MLIR transform for a given PLxPR transform.
+  [(#1705)](https://github.com/PennyLaneAI/catalyst/pull/1705)
+
 * Stop overriding the `num_wires` property when the operator can exist on `AnyWires`. This allows the deprecation
   of `WiresEnum` in pennylane.
   [(#1667)](https://github.com/PennyLaneAI/catalyst/pull/1667)

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -253,10 +253,9 @@ def register_transform(pl_transform, pass_name, decomposition):
 # across the map above and generates a custom handler for each transform.
 # In order to ensure early binding, we pass the PL plxpr transform and the
 # Catalyst pass as arguments whose default values are set by the loop.
+# pylint: disable-next=redefined-outer-name
 for pl_transform, (pass_name, decomposition) in transforms_to_passes.items():
-    register_transform(
-        pl_transform, pass_name, decomposition  # pylint: disable=redefined-outer-name
-    )
+    register_transform(pl_transform, pass_name, decomposition)
 
 
 class QFuncPlxprInterpreter(PlxprInterpreter):

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -201,11 +201,9 @@ transforms_to_passes = {
 }
 
 
-# This is our registration factory for PL transforms. The loop below iterates
-# across the map above and generates a custom handler for each transform.
-# In order to ensure early binding, we pass the PL plxpr transform and the
-# Catalyst pass as arguments whose default values are set by the loop.
-for pl_transform, (pass_name, decomposition) in transforms_to_passes.items():
+def register_transform(pl_transform, pass_name, decomposition):
+    """Register pennylane transforms and their conversion to Catalyst transforms"""
+
     # pylint: disable=unused-argument, too-many-arguments, cell-var-from-loop
     @WorkflowInterpreter.register_primitive(pl_transform._primitive)
     def handle_transform(
@@ -249,6 +247,14 @@ for pl_transform, (pass_name, decomposition) in transforms_to_passes.items():
             # Apply the corresponding Catalyst pass counterpart
             self._pass_pipeline.append(Pass(catalyst_pass_name))
             return self.eval(inner_jaxpr, consts, *non_const_args)
+
+
+# This is our registration factory for PL transforms. The loop below iterates
+# across the map above and generates a custom handler for each transform.
+# In order to ensure early binding, we pass the PL plxpr transform and the
+# Catalyst pass as arguments whose default values are set by the loop.
+for pl_transform, (pass_name, decomposition) in transforms_to_passes.items():
+    register_transform(pl_transform, pass_name, decomposition)
 
 
 class QFuncPlxprInterpreter(PlxprInterpreter):

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -254,6 +254,7 @@ def register_transform(pl_transform, pass_name, decomposition):
 # In order to ensure early binding, we pass the PL plxpr transform and the
 # Catalyst pass as arguments whose default values are set by the loop.
 for pl_transform, (pass_name, decomposition) in transforms_to_passes.items():
+    # pylint: disable-next=redefined-outer-name
     register_transform(pl_transform, pass_name, decomposition)
 
 

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -201,6 +201,7 @@ transforms_to_passes = {
 }
 
 
+# pylint: disable-next=redefined-outer-name
 def register_transform(pl_transform, pass_name, decomposition):
     """Register pennylane transforms and their conversion to Catalyst transforms"""
 
@@ -253,7 +254,6 @@ def register_transform(pl_transform, pass_name, decomposition):
 # across the map above and generates a custom handler for each transform.
 # In order to ensure early binding, we pass the PL plxpr transform and the
 # Catalyst pass as arguments whose default values are set by the loop.
-# pylint: disable-next=redefined-outer-name
 for pl_transform, (pass_name, decomposition) in transforms_to_passes.items():
     register_transform(pl_transform, pass_name, decomposition)
 

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -254,8 +254,9 @@ def register_transform(pl_transform, pass_name, decomposition):
 # In order to ensure early binding, we pass the PL plxpr transform and the
 # Catalyst pass as arguments whose default values are set by the loop.
 for pl_transform, (pass_name, decomposition) in transforms_to_passes.items():
-    # pylint: disable-next=redefined-outer-name
-    register_transform(pl_transform, pass_name, decomposition)
+    register_transform(
+        pl_transform, pass_name, decomposition
+    )  # pylint: disable=redefined-outer-name
 
 
 class QFuncPlxprInterpreter(PlxprInterpreter):

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -255,8 +255,8 @@ def register_transform(pl_transform, pass_name, decomposition):
 # Catalyst pass as arguments whose default values are set by the loop.
 for pl_transform, (pass_name, decomposition) in transforms_to_passes.items():
     register_transform(
-        pl_transform, pass_name, decomposition
-    )  # pylint: disable=redefined-outer-name
+        pl_transform, pass_name, decomposition  # pylint: disable=redefined-outer-name
+    )
 
 
 class QFuncPlxprInterpreter(PlxprInterpreter):


### PR DESCRIPTION
**Context:** I need to be able to register equivalence from plxpr transforms to MLIR transforms. There is this piece of code that does that, but it is not a function. 

**Description of the Change:** Outline that piece of code into its own function.

**Benefits:** I can register the equivalence from plxpr transforms to MLIR transforms.

**Possible Drawbacks:** None

**Related GitHub Issues:** Fixes #1703 
