### PR TITLE
Fix failing wheels due to missing mbqc dialect module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ wheel:
 	# Copy mlir bindings & compiler driver to frontend/mlir_quantum
 	mkdir -p $(MK_DIR)/frontend/mlir_quantum/dialects
 	cp -R $(COPY_FLAGS) $(DIALECTS_BUILD_DIR)/python_packages/quantum/mlir_quantum/runtime $(MK_DIR)/frontend/mlir_quantum/runtime
-	for file in gradient quantum _ods_common catalyst mitigation _transform; do \
+	for file in gradient quantum _ods_common catalyst mbqc mitigation _transform; do \
 		cp $(COPY_FLAGS) $(DIALECTS_BUILD_DIR)/python_packages/quantum/mlir_quantum/dialects/*$${file}* $(MK_DIR)/frontend/mlir_quantum/dialects ; \
 	done
 	mkdir -p $(MK_DIR)/frontend/bin

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -104,6 +104,7 @@
   ](https://docs.pennylane.ai/en/stable/code/api/pennylane.ftqc.measure_arbitrary_basis.html), are
   now QJIT-compatible with program capture enabled.
   [(#1645)](https://github.com/PennyLaneAI/catalyst/pull/1645)
+  [(#1710)](https://github.com/PennyLaneAI/catalyst/pull/1710)
 
 * The utility function `EnsureFunctionDeclaration` is refactored into the `Utils` of the `Catalyst`
   dialect, instead of being duplicated in each individual dialect.


### PR DESCRIPTION
**Context:** The wheels were failing to build correctly due to the mbqc dialect python module not being available (e.g. https://github.com/PennyLaneAI/catalyst/actions/runs/14797406520)

**Description of the Change:** Adds the mbqc dialect module to list of files to copy when building the wheels.