### PR TITLE
Skip xDSL tests

### DIFF
--- a/frontend/test/pytest/test_mlir_plugin_interface.py
+++ b/frontend/test/pytest/test_mlir_plugin_interface.py
@@ -93,6 +93,7 @@ def test_get_options():
     assert catalyst.passes.Pass("example-pass", option=True).get_options() == "option=True"
 
 
+@pytest.mark.skip(reason="xdsl not installed in ci cd yet")
 def test_xdsl_plugin():
     """Here, we just test that we are able to run."""
 


### PR DESCRIPTION
**Context:** When wheels are tested, xdsl is not installed. Let's just merge this hot-fix and we can discuss if it is worthwhile doing so with the wheels or not.
