### PR TITLE
Drop support for mac x86

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ In addition, we also provide a Python frontend for [PennyLane](https://pennylane
 
 ## Installation
 
-Catalyst is officially supported on Linux (x86_64, aarch64) and macOS (arm64, x86_64) platforms,
+Catalyst is officially supported on Linux (x86_64, aarch64) and macOS (arm64) platforms,
 and pre-built binaries are being distributed via the Python Package Index (PyPI) for Python versions 3.10 and
 higher. To install it, simply run the following ``pip`` command:
 

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -2,7 +2,7 @@ Installation
 ============
 
 
-Catalyst is officially supported on Linux (x86_64, aarch64) and macOS (arm64, x86_64)
+Catalyst is officially supported on Linux (x86_64, aarch64) and macOS (arm64)
 platforms, and pre-built binaries are being distributed via the Python Package Index (PyPI) for
 Python versions 3.10 and higher. To install it, simply run the following ``pip`` command:
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -64,6 +64,11 @@
   will handle direct decomposition of PPRs into PPMs.
   [(#1688)](https://github.com/PennyLaneAI/catalyst/pull/1688)
 
+* Support for Mac x86 has been removed. This is because [JAX has
+also dropped support for them since 0.5.0](https://github.com/jax-ml/jax/blob/main/CHANGELOG.md#jax-050-jan-17-2025),
+with the rationale being that such machines are becoming increasingly scarce.
+  [(#???)](https://github.com/PennyLaneAI/catalyst/pull/???)
+
 <h3>Deprecations 👋</h3>
 
 <h3>Bug fixes 🐛</h3>


### PR DESCRIPTION
**Context:**
Jax dropped mac x86 since 0.5.0: https://github.com/jax-ml/jax/blob/main/CHANGELOG.md#jax-050-jan-17-2025
As a result, we should drop it too if we want to update to latest jax. 

**Description of the Change:**
Drop catalyst support for mac x86.

**Benefits:**
Quicker CI; keeping up with jax versions. 

**Possible Drawbacks:**
Dropped support for a platform :(
