### PR TITLE
Use explicit device_release primitive in the frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ help:
 
 .PHONY: all catalyst
 all: runtime oqc mlir frontend
-catalyst: runtime dialects plugin frontend
+catalyst: runtime dialects plugin frontend oqc
 
 .PHONY: frontend
 frontend:

--- a/doc/dev/sharp_bits.rst
+++ b/doc/dev/sharp_bits.rst
@@ -740,7 +740,7 @@ a single RX gate is being applied due to the rotation gate merger:
           g:f64[1] = add d f
           h:f64[1] = slice[limit_indices=(1,) start_indices=(0,) strides=(1,)] g
           i:f64[] = squeeze[dimensions=(0,)] h
-           = qdevice[
+           = device_init[
             rtd_kwargs={'shots': 0, 'mcmc': False}
             rtd_lib=/usr/local/lib/python3.10/dist-packages/catalyst/utils/../lib/librtd_lightning.so
             rtd_name=LightningSimulator

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -33,6 +33,18 @@
   Finally, the `PrintState` and the `One`/`Zero` utility functions have been removed, since they
   did not serve a convincing purpose.
 
+* (Frontend Developers Only) Some Catalyst primitives for JAX have been renamed, and the qubit
+  deallocation primitive has been split into deallocation and a separate device release primitive.
+  [(#1720)](https://github.com/PennyLaneAI/catalyst/pull/1720)
+
+  - `qunitary_p` is now `unitary_p` (unchanged)
+  - `qmeasure_p` is now `measure_p` (unchanged)
+  - `qdevice_p` is now `device_init_p` (unchanged)
+  - `qdealloc_p` no longer releases the device, thus it can be used at any point of a quantum
+     execution scope
+  - `device_release_p` is a new primitive that must be used to mark the end of a quantum execution
+     scope, which will release the quantum device
+
 * Catalyst has removed the `experimental_capture` keyword from the `qjit` decorator in favour of
   unified behaviour with PennyLane.
   [(#1657)](https://github.com/PennyLaneAI/catalyst/pull/1657)

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -42,7 +42,7 @@ from catalyst.jax_extras import (
     deduce_avals,
     new_inner_tracer,
 )
-from catalyst.jax_primitives import AbstractQreg, adjoint_p, qmeasure_p
+from catalyst.jax_primitives import AbstractQreg, adjoint_p, measure_p
 from catalyst.jax_tracer import (
     HybridOp,
     HybridOpRegion,
@@ -323,7 +323,7 @@ def ctrl(
 class MidCircuitMeasure(HybridOp):
     """Operation representing a mid-circuit measurement."""
 
-    binder = qmeasure_p.bind
+    binder = measure_p.bind
 
     # pylint: disable=too-many-arguments
     def __init__(

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -52,6 +52,7 @@ from catalyst.jax_primitives import (
     compbasis_p,
     cond_p,
     counts_p,
+    device_init_p,
     expval_p,
     for_p,
     gphase_p,
@@ -60,16 +61,15 @@ from catalyst.jax_primitives import (
     probs_p,
     qalloc_p,
     qdealloc_p,
-    qdevice_p,
     qextract_p,
     qinsert_p,
     qinst_p,
     quantum_kernel_p,
-    qunitary_p,
     sample_p,
     set_basis_state_p,
     set_state_p,
     state_p,
+    unitary_p,
     var_p,
     while_p,
 )
@@ -136,7 +136,7 @@ def from_plxpr(plxpr: jax.core.ClosedJaxpr) -> Callable[..., jax.core.Jaxpr]:
         { lambda ; a:f64[]. let
             b:f64[4] = func[
             call_jaxpr={ lambda ; c:f64[]. let
-                qdevice[
+                device_init[
                     rtd_kwargs={'shots': 0, 'mcmc': False, 'num_burnin': 0, 'kernel_name': None}
                     rtd_lib=***
                     rtd_name=LightningSimulator
@@ -295,7 +295,7 @@ class QFuncPlxprInterpreter(PlxprInterpreter):
     def setup(self):
         """Initialize the stateref and bind the device."""
         if self.stateref is None:
-            qdevice_p.bind(self._shots, **_get_device_kwargs(self._device))
+            device_init_p.bind(self._shots, **_get_device_kwargs(self._device))
             self.stateref = {"qreg": qalloc_p.bind(len(self._device.wires)), "wire_map": {}}
 
     # pylint: disable=attribute-defined-outside-init
@@ -422,7 +422,7 @@ class QFuncPlxprInterpreter(PlxprInterpreter):
 def handle_qubit_unitary(self, *invals, n_wires):
     """Handle the conversion from plxpr to Catalyst jaxpr for the QubitUnitary primitive"""
     wires = [self.get_wire(w) for w in invals[1:]]
-    outvals = qunitary_p.bind(invals[0], *wires, qubits_len=n_wires, ctrl_len=0, adjoint=False)
+    outvals = unitary_p.bind(invals[0], *wires, qubits_len=n_wires, ctrl_len=0, adjoint=False)
     for wire_values, new_wire in zip(invals[1:], outvals):
         self.wire_map[wire_values] = new_wire
 

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -53,6 +53,7 @@ from catalyst.jax_primitives import (
     cond_p,
     counts_p,
     device_init_p,
+    device_release_p,
     expval_p,
     for_p,
     gphase_p,
@@ -303,11 +304,12 @@ class QFuncPlxprInterpreter(PlxprInterpreter):
         """Perform any final steps after processing the plxpr.
 
         For conversion to calayst, this reinserts extracted qubits and
-        deallocates the register.
+        deallocates the register, and releases the device.
         """
         if not self.actualized:
             self.actualize_qreg()
         qdealloc_p.bind(self.qreg)
+        device_release_p.bind()
         self.stateref = None
 
     def get_wire(self, wire_value) -> AbstractQbit:

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -246,8 +246,8 @@ class MeasurementPlane(Enum):
 ##############
 
 zne_p = core.Primitive("zne")
-qdevice_p = core.Primitive("qdevice")
-qdevice_p.multiple_results = True
+device_init_p = core.Primitive("device_init")
+device_init_p.multiple_results = True
 qalloc_p = core.Primitive("qalloc")
 qdealloc_p = core.Primitive("qdealloc")
 qdealloc_p.multiple_results = True
@@ -257,10 +257,10 @@ gphase_p = core.Primitive("gphase")
 gphase_p.multiple_results = True
 qinst_p = core.Primitive("qinst")
 qinst_p.multiple_results = True
-qunitary_p = core.Primitive("qunitary")
-qunitary_p.multiple_results = True
-qmeasure_p = core.Primitive("qmeasure")
-qmeasure_p.multiple_results = True
+unitary_p = core.Primitive("unitary")
+unitary_p.multiple_results = True
+measure_p = core.Primitive("measure")
+measure_p.multiple_results = True
 compbasis_p = core.Primitive("compbasis")
 namedobs_p = core.Primitive("namedobs")
 hermitian_p = core.Primitive("hermitian")
@@ -809,19 +809,19 @@ def _zne_lowering(ctx, *args, folding, jaxpr, fn):
 
 
 #
-# qdevice
+# device_init
 #
-@qdevice_p.def_impl
-def _qdevice_def_impl(ctx, shots, rtd_lib, rtd_name, rtd_kwargs):  # pragma: no cover
+@device_init_p.def_impl
+def _device_init_def_impl(ctx, shots, rtd_lib, rtd_name, rtd_kwargs):  # pragma: no cover
     raise NotImplementedError()
 
 
-@qdevice_p.def_abstract_eval
-def _qdevice_abstract_eval(shots, rtd_lib, rtd_name, rtd_kwargs):
+@device_init_p.def_abstract_eval
+def _device_init_abstract_eval(shots, rtd_lib, rtd_name, rtd_kwargs):
     return ()
 
 
-def _qdevice_lowering(
+def _device_init_lowering(
     jax_ctx: mlir.LoweringRuleContext, shots: ir.Value, rtd_lib, rtd_name, rtd_kwargs
 ):
     ctx = jax_ctx.module_context.context
@@ -1115,20 +1115,20 @@ def _qinst_lowering(
 #
 # qubit unitary operation
 #
-@qunitary_p.def_abstract_eval
-def _qunitary_abstract_eval(matrix, *qubits, qubits_len=0, ctrl_len=0, adjoint=False):
+@unitary_p.def_abstract_eval
+def _unitary_abstract_eval(matrix, *qubits, qubits_len=0, ctrl_len=0, adjoint=False):
     for idx in range(qubits_len + ctrl_len):
         qubit = qubits[idx]
         assert isinstance(qubit, AbstractQbit)
     return (AbstractQbit(),) * (qubits_len + ctrl_len)
 
 
-@qunitary_p.def_impl
-def _qunitary_def_impl(*args, **kwargs):  # pragma: no cover
+@unitary_p.def_impl
+def _unitary_def_impl(*args, **kwargs):  # pragma: no cover
     raise NotImplementedError()
 
 
-def _qunitary_lowering(
+def _unitary_lowering(
     jax_ctx: mlir.LoweringRuleContext,
     matrix: ir.Value,
     *qubits_or_controlled: tuple,
@@ -1188,20 +1188,20 @@ def _qunitary_lowering(
 
 
 #
-# qmeasure
+# measure
 #
-@qmeasure_p.def_abstract_eval
-def _qmeasure_abstract_eval(qubit, postselect: int = None):
+@measure_p.def_abstract_eval
+def _measure_abstract_eval(qubit, postselect: int = None):
     assert isinstance(qubit, AbstractQbit)
     return core.ShapedArray((), bool), qubit
 
 
-@qmeasure_p.def_impl
-def _qmeasure_def_impl(ctx, qubit, postselect: int = None):  # pragma: no cover
+@measure_p.def_impl
+def _measure_def_impl(ctx, qubit, postselect: int = None):  # pragma: no cover
     raise NotImplementedError()
 
 
-def _qmeasure_lowering(jax_ctx: mlir.LoweringRuleContext, qubit: ir.Value, postselect: int = None):
+def _measure_lowering(jax_ctx: mlir.LoweringRuleContext, qubit: ir.Value, postselect: int = None):
     ctx = jax_ctx.module_context.context
     ctx.allow_unregistered_dialects = True
 
@@ -2299,15 +2299,15 @@ def _cos_lowering2(ctx, x):
 
 CUSTOM_LOWERING_RULES = (
     (zne_p, _zne_lowering),
-    (qdevice_p, _qdevice_lowering),
+    (device_init_p, _device_init_lowering),
     (qalloc_p, _qalloc_lowering),
     (qdealloc_p, _qdealloc_lowering),
     (qextract_p, _qextract_lowering),
     (qinsert_p, _qinsert_lowering),
     (qinst_p, _qinst_lowering),
     (gphase_p, _gphase_lowering),
-    (qunitary_p, _qunitary_lowering),
-    (qmeasure_p, _qmeasure_lowering),
+    (unitary_p, _unitary_lowering),
+    (measure_p, _measure_lowering),
     (compbasis_p, _compbasis_lowering),
     (namedobs_p, _named_obs_lowering),
     (hermitian_p, _hermitian_lowering),

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -78,6 +78,7 @@ from catalyst.jax_primitives import (
     compbasis_p,
     counts_p,
     device_init_p,
+    device_release_p,
     expval_p,
     func_p,
     gphase_p,
@@ -1383,9 +1384,9 @@ def trace_quantum_function(
                 else:
                     transformed_results.append(meas_results)
 
-                # Deallocate the register after the current tape is finished
-                # This dealloc primitive also serves as the tape cut when splitting tapes
+                # Deallocate the register and release the device after the current tape is finished.
                 qdealloc_p.bind(qreg_out)
+                device_release_p.bind()
 
         closed_jaxpr, out_type, out_tree = trace_post_processing(
             ctx, trace, post_processing, transformed_results

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -77,6 +77,7 @@ from catalyst.jax_primitives import (
     AbstractQreg,
     compbasis_p,
     counts_p,
+    device_init_p,
     expval_p,
     func_p,
     gphase_p,
@@ -86,16 +87,15 @@ from catalyst.jax_primitives import (
     probs_p,
     qalloc_p,
     qdealloc_p,
-    qdevice_p,
     qextract_p,
     qinsert_p,
     qinst_p,
-    qunitary_p,
     sample_p,
     set_basis_state_p,
     set_state_p,
     state_p,
     tensorobs_p,
+    unitary_p,
     var_p,
 )
 from catalyst.logging import debug_logger, debug_logger_init
@@ -203,7 +203,7 @@ KNOWN_NAMED_OBS = (qml.Identity, qml.PauliX, qml.PauliY, qml.PauliZ, qml.Hadamar
 # Take care when adding primitives to this set in order to avoid introducing a quadratic number of
 # edges to the jaxpr equation graph in ``sort_eqns()``. Each equation with a primitive in this set
 # is constrained to occur before all subsequent equations in the quantum operations trace.
-FORCED_ORDER_PRIMITIVES = {qdevice_p, gphase_p}
+FORCED_ORDER_PRIMITIVES = {device_init_p, gphase_p}
 
 PAULI_NAMED_MAP = {
     "I": "Identity",
@@ -732,7 +732,7 @@ def trace_quantum_operations(
         elif isinstance(op, QubitUnitary):
             qubits = qrp.extract(op.wires)
             controlled_qubits = qrp.extract(controlled_wires)
-            qubits2 = qunitary_p.bind(
+            qubits2 = unitary_p.bind(
                 *[*op.parameters, *qubits, *controlled_qubits, *controlled_values],
                 qubits_len=len(qubits),
                 ctrl_len=len(controlled_qubits),
@@ -1331,7 +1331,7 @@ def trace_quantum_function(
                 # TODO: device shots is now always a concrete integer or None
                 # When PennyLane allows dynamic shots, update tracing to accept dynamic shots too
                 device_shots = get_device_shots(device) or 0
-                qdevice_p.bind(
+                device_init_p.bind(
                     device_shots,
                     rtd_lib=device.backend_lib,
                     rtd_name=device.backend_name,

--- a/frontend/catalyst/third_party/cuda/catalyst_to_cuda_interpreter.py
+++ b/frontend/catalyst/third_party/cuda/catalyst_to_cuda_interpreter.py
@@ -45,6 +45,7 @@ from catalyst.jax_primitives import (
     compbasis_p,
     cond_p,
     counts_p,
+    device_init_p,
     expval_p,
     for_p,
     func_p,
@@ -52,21 +53,20 @@ from catalyst.jax_primitives import (
     hamiltonian_p,
     hermitian_p,
     jvp_p,
-    quantum_kernel_p,
+    measure_p,
     namedobs_p,
     print_p,
     probs_p,
     qalloc_p,
     qdealloc_p,
-    qdevice_p,
     qextract_p,
     qinsert_p,
     qinst_p,
-    qmeasure_p,
-    qunitary_p,
+    quantum_kernel_p,
     sample_p,
     state_p,
     tensorobs_p,
+    unitary_p,
     var_p,
     vjp_p,
     while_p,
@@ -122,7 +122,7 @@ def remove_host_context(jaxpr):
     { lambda ; a:i64[]. let
       b:i64[] = func[
         call_jaxpr={ lambda ; c:i64[]. let
-             = qdevice[
+             = device_init[
               rtd_kwargs={'shots': 0, 'mcmc': False}
               rtd_lib=path/to/runtime...
               rtd_name=LightningSimulator
@@ -245,7 +245,7 @@ class InterpreterContext:  # pylint: disable=too-many-instance-attributes
 
 
 def change_device_to_cuda_device(ctx):
-    """Map Catalyst's qdevice_p primitive to its equivalent CUDA-quantum primitive
+    """Map Catalyst's device_init_p primitive to its equivalent CUDA-quantum primitive
     as defined in this file.
 
     From here we get shots as well.
@@ -254,7 +254,7 @@ def change_device_to_cuda_device(ctx):
     # The device here might also have some important information for
     # us. For example, the number of shots.
 
-    qdevice_eqn = get_instruction(ctx.jaxpr, qdevice_p)
+    qdevice_eqn = get_instruction(ctx.jaxpr, device_init_p)
 
     # Now we have the number of shots.
     # Shots are specified in PL at the very beginning, but in cuda
@@ -527,9 +527,9 @@ def change_counts(ctx, eqn):
 
 
 def change_measure(ctx, eqn):
-    """Change Catalyst's qmeasure_p to CUDA-quantum measure."""
+    """Change Catalyst's measure_p to CUDA-quantum measure."""
 
-    assert eqn.primitive == qmeasure_p
+    assert eqn.primitive == measure_p
 
     # Operands to measure_p
     # *qubit
@@ -717,7 +717,7 @@ INST_IMPL = {
     compbasis_p: change_compbasis,
     sample_p: change_sample,
     counts_p: change_counts,
-    qmeasure_p: change_measure,
+    measure_p: change_measure,
     expval_p: change_expval,
     namedobs_p: change_namedobs,
     hamiltonian_p: change_hamiltonian,
@@ -726,11 +726,11 @@ INST_IMPL = {
     # because they have been handled before or they are just
     # not necessary in the CUDA-quantum API.
     qdealloc_p: ignore_impl,
-    qdevice_p: ignore_impl,
+    device_init_p: ignore_impl,
     qalloc_p: ignore_impl,
     # These are unimplemented at the moment.
     zne_p: unimplemented_impl,
-    qunitary_p: unimplemented_impl,
+    unitary_p: unimplemented_impl,
     hermitian_p: unimplemented_impl,
     tensorobs_p: unimplemented_impl,
     var_p: unimplemented_impl,

--- a/frontend/catalyst/third_party/cuda/catalyst_to_cuda_interpreter.py
+++ b/frontend/catalyst/third_party/cuda/catalyst_to_cuda_interpreter.py
@@ -46,6 +46,7 @@ from catalyst.jax_primitives import (
     cond_p,
     counts_p,
     device_init_p,
+    device_release_p,
     expval_p,
     for_p,
     func_p,
@@ -727,6 +728,7 @@ INST_IMPL = {
     # not necessary in the CUDA-quantum API.
     qdealloc_p: ignore_impl,
     device_init_p: ignore_impl,
+    device_release_p: ignore_impl,
     qalloc_p: ignore_impl,
     # These are unimplemented at the moment.
     zne_p: unimplemented_impl,

--- a/frontend/test/lit/test_split_multiple_tapes.py
+++ b/frontend/test/lit/test_split_multiple_tapes.py
@@ -64,10 +64,10 @@ def test_multiple_tape_transforms():
 
     # CHECK: circuit_twotapes
     # CHECK: call_jaxpr={ lambda ;
-    # CHECK: qdevice[
+    # CHECK: device_init[
     # CHECK: ]
     # CHECK: qdealloc
-    # CHECK: qdevice[
+    # CHECK: device_init[
     # CHECK: ]
     # CHECK: qdealloc
     # CHECK-NEXT: {{.+}}:f64[] = add {{.+}} {{.+}}

--- a/frontend/test/lit/test_split_multiple_tapes.py
+++ b/frontend/test/lit/test_split_multiple_tapes.py
@@ -67,9 +67,11 @@ def test_multiple_tape_transforms():
     # CHECK: device_init[
     # CHECK: ]
     # CHECK: qdealloc
+    # CHECK-NEXT: device_release
     # CHECK: device_init[
     # CHECK: ]
     # CHECK: qdealloc
+    # CHECK-NEXT: device_release
     # CHECK-NEXT: {{.+}}:f64[] = add {{.+}} {{.+}}
     print_jaxpr(circuit_twotapes, [0.1, 0.2])
 


### PR DESCRIPTION
Currently, we only instantiate quantum dealloc primitives in the JAXPR, which are automatically lowered to a `quantum.dealloc` and `quantum.device_release` operation in MLIR. This is a blocker for dynamic allocation since we don't want to have to release the device when deallocating a register, as that would destroy any other qubits that are still active as well.

The PR is a small fix to split the deallocation primitive into explicit deallocation and device release primitives. In Catalyst they are still called together.

fixes #1701