### PR TITLE
Bump to jax 0.6.0

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -1,5 +1,5 @@
 # Always update the version check in catalyst.__init__ when changing the JAX version.
-jax=0.5.3
+jax=0.6.0
 mhlo=89a891c986650c33df76885f5620e0a92150d90f
 llvm=3a8316216807d64a586b971f51695e23883331f7
 enzyme=v0.0.149

--- a/frontend/catalyst/__init__.py
+++ b/frontend/catalyst/__init__.py
@@ -23,7 +23,7 @@ from os.path import dirname
 
 import jaxlib as _jaxlib
 
-_jaxlib_version = "0.5.3"
+_jaxlib_version = "0.6.0"
 if _jaxlib.__version__ != _jaxlib_version:
     import warnings
 


### PR DESCRIPTION
**Context:**
Bump to jax 0.6.0.

Note that we need to wait for core PL to finish updating to 0.5.3. 
