### PR TITLE
Add postselect to assembly format for MeasureOP and MeasureInBasisOp #1699

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -89,5 +89,5 @@ Sengthai Heng,
 David Ittah,
 Christina Lee,
 Erick Ochoa Lopez,
-Paul Haochen Wang,
-Ritu Thombre
+Ritu Thombre,
+Paul Haochen Wang.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -75,6 +75,9 @@
 * Improved the definition of `YieldOp` in the quantum dialect by removing `AnyTypeOf`
   [(#1696)](https://github.com/PennyLaneAI/catalyst/pull/1696)
 
+* Added ```postselect``` to ```assemblyFormat``` to ```MeasureOp``` in QuantumOp.td and ```MeasureInBasisOp``` in MBQCOps.td
+  [(#1732)](https://github.com/PennyLaneAI/catalyst/pull/1732)
+
 <h3>Documentation 📝</h3>
 
 <h3>Contributors ✍️</h3>
@@ -86,4 +89,5 @@ Sengthai Heng,
 David Ittah,
 Christina Lee,
 Erick Ochoa Lopez,
-Paul Haochen Wang.
+Paul Haochen Wang,
+Ritu Thombre

--- a/mlir/include/MBQC/IR/MBQCOps.td
+++ b/mlir/include/MBQC/IR/MBQCOps.td
@@ -87,7 +87,7 @@ def MeasureInBasisOp : MBQC_Op<"measure_in_basis"> {
     );
 
     let assemblyFormat = [{
-        `[` $plane `,` $angle `]` $in_qubit attr-dict `:` type(results)
+        `[` $plane `,` $angle `]` $in_qubit (`postselect` $postselect^)? attr-dict `:` type(results)
     }];
 }
 

--- a/mlir/test/MBQC/ConversionTest.mlir
+++ b/mlir/test/MBQC/ConversionTest.mlir
@@ -78,7 +78,7 @@ func.func @testXYPostSelect0(%q1 : !quantum.bit) {
     // CHECK: [[plane:%.+]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK: [[postselect:%.+]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK: llvm.call @__catalyst__mbqc__measure_in_basis(%arg0, [[plane]], [[angle]], [[postselect]])
-    %res, %new_q = mbqc.measure_in_basis [XY, %angle] %q1 {postselect = 0 : i32} : i1, !quantum.bit
+    %res, %new_q = mbqc.measure_in_basis [XY, %angle] %q1 postselect 0 : i1, !quantum.bit
     func.return
 }
 
@@ -94,6 +94,6 @@ func.func @testXYPostSelect1(%q1 : !quantum.bit) {
     // CHECK: [[plane:%.+]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK: [[postselect:%.+]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK: llvm.call @__catalyst__mbqc__measure_in_basis(%arg0, [[plane]], [[angle]], [[postselect]])
-    %res, %new_q = mbqc.measure_in_basis [XY, %angle] %q1 {postselect = 1 : i32} : i1, !quantum.bit
+    %res, %new_q = mbqc.measure_in_basis [XY, %angle] %q1 postselect 1 : i1, !quantum.bit
     func.return
 }

--- a/mlir/test/MBQC/DialectTest.mlir
+++ b/mlir/test/MBQC/DialectTest.mlir
@@ -50,7 +50,7 @@ func.func @testInvalid(%q1 : !quantum.bit) {
 
 func.func @testPostSelect0(%q1 : !quantum.bit) {
     %angle = arith.constant 3.141592653589793 : f64
-    %res, %new_q = mbqc.measure_in_basis [XY, %angle] %q1 {postselect = 0 : i32} : i1, !quantum.bit
+    %res, %new_q = mbqc.measure_in_basis [XY, %angle] %q1 postselect 0 : i1, !quantum.bit
     func.return
 }
 
@@ -58,7 +58,7 @@ func.func @testPostSelect0(%q1 : !quantum.bit) {
 
 func.func @testPostSelect1(%q1 : !quantum.bit) {
     %angle = arith.constant 3.141592653589793 : f64
-    %res, %new_q = mbqc.measure_in_basis [XY, %angle] %q1 {postselect = 1 : i32} : i1, !quantum.bit
+    %res, %new_q = mbqc.measure_in_basis [XY, %angle] %q1 postselect 1 : i1, !quantum.bit
     func.return
 }
 
@@ -67,7 +67,7 @@ func.func @testPostSelect1(%q1 : !quantum.bit) {
 func.func @testPostSelectInvalid(%q1 : !quantum.bit) {
     %angle = arith.constant 3.141592653589793 : f64
     // expected-error@below {{op attribute 'postselect' failed to satisfy constraint}}
-    %res, %new_q = mbqc.measure_in_basis [XY, %angle] %q1 {postselect = -1 : i32} : i1, !quantum.bit
+    %res, %new_q = mbqc.measure_in_basis [XY, %angle] %q1 postselect -1 : i1, !quantum.bit
     func.return
 }
 
@@ -76,6 +76,6 @@ func.func @testPostSelectInvalid(%q1 : !quantum.bit) {
 func.func @testPostSelectInvalid(%q1 : !quantum.bit) {
     %angle = arith.constant 3.141592653589793 : f64
     // expected-error@below {{op attribute 'postselect' failed to satisfy constraint}}
-    %res, %new_q = mbqc.measure_in_basis [XY, %angle] %q1 {postselect = 2 : i32} : i1, !quantum.bit
+    %res, %new_q = mbqc.measure_in_basis [XY, %angle] %q1 postselect 2 : i1, !quantum.bit
     func.return
 }

--- a/mlir/test/Quantum/ConversionTest.mlir
+++ b/mlir/test/Quantum/ConversionTest.mlir
@@ -440,7 +440,7 @@ func.func @measure(%q : !quantum.bit) -> !quantum.bit {
     // CHECK: [[postselect:%.+]] = llvm.mlir.constant(0 : i32) : i32
 
     // CHECK: llvm.call @__catalyst__qis__Measure(%arg0, [[postselect]])
-    %res, %new_q = quantum.measure %q {postselect = 0 : i32} : i1, !quantum.bit
+    %res, %new_q = quantum.measure %q postselect 0 : i1, !quantum.bit
 
     // CHECK: return %arg0
     return %new_q : !quantum.bit


### PR DESCRIPTION
**Context:** 

**Description of the Change:** add postselect to assembly format to MeasureOp in QuantumOps and MeasureInBasisOp in MBQCOps

**Benefits:** easier xDSL generation from table gen

**Possible Drawbacks:** None

**Related GitHub Issues:** Fixes #1690, #1699
