### PR TITLE
Enhance `to_ppr` pass to support full Clifford-T gate set decomposition

### DIFF
--- a/mlir/test/QEC/CliffordTToPPRTest.mlir
+++ b/mlir/test/QEC/CliffordTToPPRTest.mlir
@@ -79,9 +79,22 @@ func.func public @test_clifford_t_to_ppr_1() -> (tensor<i1>, tensor<i1>) {
 
 func.func @test_clifford_t_to_ppr_2(%q1 : !quantum.bit, %q2 : !quantum.bit) {
     // expected-error @+1 {{failed to legalize operation 'quantum.custom' that was explicitly marked illegal}}
-    %0 = quantum.custom "X"() %q1 : !quantum.bit // expected-error @+0 {{Unsupported gate. Supported gates: H, S, T, CNOT}}
+    %0 = quantum.custom "SOME_UNKNOWN_GATE"() %q1 : !quantum.bit // expected-error @+0 {{Unsupported gate. Supported gates: H, S, T, X, Y, Z, CNOT}}
     %1 = quantum.custom "S"() %0 : !quantum.bit
     %2 = quantum.custom "T"() %1 : !quantum.bit
     %3:2 = quantum.custom "CNOT"() %2, %q2 : !quantum.bit, !quantum.bit
+    func.return
+}
+
+// -----
+
+func.func @test_clifford_t_to_ppr_3(%q1 : !quantum.bit, %q2 : !quantum.bit) {
+    %0 = quantum.custom "PauliX"() %q1 : !quantum.bit
+    %1 = quantum.custom "PauliY"() %0 : !quantum.bit
+    %2 = quantum.custom "PauliZ"() %1 : !quantum.bit
+
+    // CHECK: qec.ppr ["X"](2)
+    // CHECK: qec.ppr ["Y"](2)
+    // CHECK: qec.ppr ["Z"](2)
     func.return
 }


### PR DESCRIPTION
**Context:**
`to_ppr` currently supports decomposition of H, S, T, and CNOT — enough for Clifford+T if X, Y, Z are lowered and S†= S³ and T† = T⁷. However, it would be faster to decompose those directly to PPRs.

**Description of the Change:**
Extend decomposition support in `to_ppr` to cover the full Clifford+T set by adding:
	•	S† (S dagger) -> PPR Z(-pi/4)
	•	T† (T dagger) -> PPR Z(-pi/8)
	•	Pauli gates: X, Y, Z -> PPR X(pi/2), PPR Y(pi/2), PPR Z(pi/2)

[[sc-91028]]