### PR TITLE
Migrate `gradient` dialect to new one-shot bufferization

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -167,6 +167,7 @@
   [(#1027)](https://github.com/PennyLaneAI/catalyst/pull/1027)
   [(#1686)](https://github.com/PennyLaneAI/catalyst/pull/1686)
   [(#1708)](https://github.com/PennyLaneAI/catalyst/pull/1708)
+  [(#???)](https://github.com/PennyLaneAI/catalyst/pull/???)
 
 <h3>Documentation 📝</h3>
 

--- a/mlir/include/Gradient/Transforms/BufferizableOpInterfaceImpl.h
+++ b/mlir/include/Gradient/Transforms/BufferizableOpInterfaceImpl.h
@@ -1,0 +1,23 @@
+// Copyright 2024-2025 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+using namespace mlir;
+
+namespace catalyst {
+
+void registerBufferizableOpInterfaceExternalModels(mlir::DialectRegistry &registry);
+
+} // namespace catalyst

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -64,6 +64,7 @@
 #include "Driver/Support.h"
 #include "Gradient/IR/GradientDialect.h"
 #include "Gradient/IR/GradientInterfaces.h"
+#include "Gradient/Transforms/BufferizableOpInterfaceImpl.h"
 #include "Gradient/Transforms/Passes.h"
 #include "Ion/IR/IonDialect.h"
 #include "MBQC/IR/MBQCDialect.h"
@@ -966,6 +967,7 @@ int QuantumDriverMainFromCL(int argc, char **argv)
 
     // Register bufferization interfaces
     catalyst::registerBufferizableOpInterfaceExternalModels(registry);
+    catalyst::gradient::registerBufferizableOpInterfaceExternalModels(registry);
     catalyst::quantum::registerBufferizableOpInterfaceExternalModels(registry);
 
     // Register and parse command line options.

--- a/mlir/lib/Gradient/IR/GradientDialect.cpp
+++ b/mlir/lib/Gradient/IR/GradientDialect.cpp
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"
+#include "mlir/Interfaces/FunctionImplementation.h"
 #include "mlir/Transforms/InliningUtils.h"
 
 #include "Gradient/IR/GradientDialect.h"
 #include "Gradient/IR/GradientOps.h"
-#include "mlir/Interfaces/FunctionImplementation.h"
 
 using namespace mlir;
 using namespace catalyst::gradient;
@@ -50,6 +51,8 @@ void GradientDialect::initialize()
 #include "Gradient/IR/GradientOps.cpp.inc"
         >();
     addInterface<GradientInlinerInterface>();
+
+    declarePromisedInterfaces<bufferization::BufferizableOpInterface>();
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Gradient/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Gradient/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -1,0 +1,54 @@
+// Copyright 2024-2025 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iostream"
+#include "llvm/Support/raw_ostream.h"
+
+#include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Index/IR/IndexOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/FunctionInterfaces.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#include "Gradient/IR/GradientOps.h"
+#include "Gradient/Transforms/Passes.h"
+#include "Gradient/Utils/GradientShape.h"
+
+using namespace mlir;
+using namespace mlir::bufferization;
+using namespace catalyst::gradient;
+
+/**
+ * Implementation of the BufferizableOpInterface for use with one-shot bufferization.
+ * For more information on the interface, refer to the documentation below:
+ *  https://mlir.llvm.org/docs/Bufferization/#extending-one-shot-bufferize
+ *  https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Dialect/Bufferization/IR/BufferizableOpInterface.td#L14
+ */
+
+namespace {
+
+} // namespace
+
+void catalyst::gradient::registerBufferizableOpInterfaceExternalModels(DialectRegistry &registry)
+{
+    registry.addExtension(+[](MLIRContext *ctx, CatalystDialect *dialect) {
+       // CustomCallOp::attachInterface<CustomCallOpInterface>(*ctx);
+    });
+}

--- a/mlir/lib/Gradient/Transforms/CMakeLists.txt
+++ b/mlir/lib/Gradient/Transforms/CMakeLists.txt
@@ -2,8 +2,9 @@ set(LIBRARY_NAME gradient-transforms)
 
 file(GLOB SRC
     GradMethods/*.cpp
-    BufferizationPatterns.cpp
-    gradient_bufferize.cpp
+    BufferizableOpInterfaceImpl.cpp
+    BufferizationPatterns.cpp // remove
+    gradient_bufferize.cpp    // remove
     PreprocessingPatterns.cpp
     gradient_preprocess.cpp
     PostprocessingPatterns.cpp

--- a/mlir/tools/quantum-opt/quantum-opt.cpp
+++ b/mlir/tools/quantum-opt/quantum-opt.cpp
@@ -28,6 +28,7 @@
 #include "Catalyst/Transforms/BufferizableOpInterfaceImpl.h"
 #include "Catalyst/Transforms/Passes.h"
 #include "Gradient/IR/GradientDialect.h"
+#include "Gradient/Transforms/BufferizableOpInterfaceImpl.h"
 #include "Gradient/Transforms/Passes.h"
 #include "Ion/IR/IonDialect.h"
 #include "MBQC/IR/MBQCDialect.h"
@@ -64,6 +65,7 @@ int main(int argc, char **argv)
     registry.insert<mlir::mhlo::MhloDialect>();
 
     catalyst::registerBufferizableOpInterfaceExternalModels(registry);
+    catalyst::gradient::registerBufferizableOpInterfaceExternalModels(registry);
     catalyst::quantum::registerBufferizableOpInterfaceExternalModels(registry);
 
     return mlir::asMainReturnCode(


### PR DESCRIPTION
**Context:**
This work is based on #1027 .

As part of the mlir update, the bufferization of the custom catalyst dialects need to migrate to the new one-shot bufferization interface, as opposed to the old pattern-rewrite style bufferization passes.
See more context in #1027.

The `Quantum` dialect was migrated in #1686 .
The `Catalyst` dialect was migrated in #1708 .

**Description of the Change:**
Migrate `Gradient` dialect to one-shot bufferization.

**Benefits:**
Align with mlir practices; one step closer to updating mlir.

[sc-71487]