### PR TITLE
Change "ancilla" to "auxiliary"

### DIFF
--- a/demos/qml/tutorial_learningshallow.ipynb
+++ b/demos/qml/tutorial_learningshallow.ipynb
@@ -248,14 +248,14 @@
     "with solving the original goal of finding a global inversion\n",
     "$U V = \\mathbb{1}$? The authors introduce a clever trick that they coin\n",
     "[circuit sewing]{.title-ref}. It works by swapping out the decoupled\n",
-    "qubit with an ancilla register and restoring (\\\"repairing\\\") the unitary\n",
+    "qubit with an auxiliary register and restoring (\\\"repairing\\\") the unitary\n",
     "on the remaining wires. Let us walk through this process step by step.\n",
     "\n",
     "We already saw how to decouple qubit $0$ in `local_inversion()` above.\n",
-    "We continue by swapping out the decoupled wire with an ancilla qubit and\n",
+    "We continue by swapping out the decoupled wire with an auxiliary qubit and\n",
     "\\\"repairing\\\" the circuit by applying $V^\\dagger_0$. (This is called\n",
     "\\\"repairing\\\" because $V_1$ can now decouple qubit 1, which would not be\n",
-    "possible in general without that step.) We label all ancilla wires by\n",
+    "possible in general without that step.) We label all auxiliary wires by\n",
     "`[n + 0, n + 1, .. 2n-1]` to have an easy 1-to-1 correspondence and we\n",
     "see that qubit `1` is successfully decoupled. For completeness, we also\n",
     "check that the swapped out qubit (now moved to wire `n + 0`) is\n",
@@ -531,14 +531,14 @@
    "metadata": {},
    "source": [
     "It is such that the action of $U^\\text{test}$ on\n",
-    "$|0 \\rangle^{\\otimes n}$ is reverted when tracing out the ancilla\n",
+    "$|0 \\rangle^{\\otimes n}$ is reverted when tracing out the auxiliary\n",
     "qubits. From the paper we know that, in fact, the action of the sewn\n",
     "$V^\\text{sew}$ overall is\n",
     "\n",
     "$$V^\\text{sew} |0^{\\otimes 2n}\\rangle = U \\otimes U^\\dagger |0^{\\otimes 2n}\\rangle.$$\n",
     "\n",
     "$U$ acts on the first `n` qubits, whereas $U^\\dagger$ acts on the `n`\n",
-    "ancilla qubits.\n"
+    "auxiliary qubits.\n"
    ]
   },
   {


### PR DESCRIPTION
**Context:**
A new policy was added across PL ecosystem to favor "auxiliary" over "ancilla" everywhere in the codebase.   