### PR TITLE
Replace ValueRange with TypeRange for CustomOp build constructor

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -189,6 +189,9 @@
 * Redundant `OptionalAttr` is removed from `adjoint` argument in `QuantumOps.td` TableGen file
   [(#1746)](https://github.com/PennyLaneAI/catalyst/pull/1746)
 
+* `ValueRange` is replaced with `TypeRange` for creating `CustomOp` in `IonsDecompositionPatterns.cpp` to match the build constructors
+  [(#1749)](https://github.com/PennyLaneAI/catalyst/pull/1749)
+
 <h3>Documentation 📝</h3>
 
 * The header (logo+title) images in the README and in the overview on RtD have been updated,

--- a/mlir/lib/Quantum/Transforms/IonsDecompositionPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/IonsDecompositionPatterns.cpp
@@ -48,13 +48,13 @@ void oneQubitDecomp(catalyst::quantum::CustomOp op, mlir::PatternRewriter &rewri
     TypedAttr lambdaAttr = rewriter.getF64FloatAttr(lambda);
     mlir::Value lambdaValue = rewriter.create<arith::ConstantOp>(op.getLoc(), lambdaAttr);
 
-    auto rxPhi = rewriter.create<CustomOp>(op.getLoc(), outQubitsTypes, ValueRange{}, phiValue,
+    auto rxPhi = rewriter.create<CustomOp>(op.getLoc(), outQubitsTypes, TypeRange{}, phiValue,
                                            inQubits, "RX", false, ValueRange{}, ValueRange{});
-    auto ryTheta = rewriter.create<CustomOp>(op.getLoc(), outQubitsTypes, ValueRange{}, thetaValue,
+    auto ryTheta = rewriter.create<CustomOp>(op.getLoc(), outQubitsTypes, TypeRange{}, thetaValue,
                                              rxPhi.getOutQubits(), "RY", false,
                                              rxPhi.getInCtrlQubits(), rxPhi.getInCtrlValues());
     auto rxLambda =
-        rewriter.create<CustomOp>(op.getLoc(), outQubitsTypes, ValueRange{}, lambdaValue,
+        rewriter.create<CustomOp>(op.getLoc(), outQubitsTypes, TypeRange{}, lambdaValue,
                                   ryTheta.getOutQubits(), "RX", false, ValueRange{}, ValueRange{});
     op.replaceAllUsesWith(rxLambda);
 }
@@ -109,12 +109,12 @@ void cnotDecomp(catalyst::quantum::CustomOp op, mlir::PatternRewriter &rewriter)
     TypedAttr piOver2Attr = rewriter.getF64FloatAttr(PI / 2);
     mlir::Value piOver2 = rewriter.create<arith::ConstantOp>(op.getLoc(), piOver2Attr);
     auto ryPiOver2 =
-        rewriter.create<CustomOp>(op.getLoc(), outQubitsTypes.front(), ValueRange{}, piOver2,
+        rewriter.create<CustomOp>(op.getLoc(), outQubitsTypes.front(), TypeRange{}, piOver2,
                                   inQubit0, "RY", false, ValueRange{}, ValueRange{});
     SmallVector<mlir::Value> qubitsAfterRy;
     qubitsAfterRy.push_back(ryPiOver2.getOutQubits().front());
     qubitsAfterRy.push_back(inQubit1);
-    auto ms = rewriter.create<CustomOp>(op.getLoc(), outQubitsTypes, ValueRange{}, piOver2,
+    auto ms = rewriter.create<CustomOp>(op.getLoc(), outQubitsTypes, TypeRange{}, piOver2,
                                         qubitsAfterRy, "MS", false, ValueRange{}, ValueRange{});
     mlir::Value qubit0AfterMs = ms.getOutQubits().front();
     mlir::Value qubit1AfterMs = ms.getOutQubits().back();
@@ -122,15 +122,15 @@ void cnotDecomp(catalyst::quantum::CustomOp op, mlir::PatternRewriter &rewriter)
     TypedAttr minusPiOver2Attr = rewriter.getF64FloatAttr(-PI / 2);
     mlir::Value minusPiOver2 = rewriter.create<arith::ConstantOp>(op.getLoc(), minusPiOver2Attr);
     auto rxMinusPiOver2 =
-        rewriter.create<CustomOp>(op.getLoc(), outQubitsTypes.front(), ValueRange{}, minusPiOver2,
+        rewriter.create<CustomOp>(op.getLoc(), outQubitsTypes.front(), TypeRange{}, minusPiOver2,
                                   qubit0AfterMs, "RX", false, ValueRange{}, ValueRange{});
     auto firstRyMinusPiOver2 =
-        rewriter.create<CustomOp>(op.getLoc(), outQubitsTypes.front(), ValueRange{}, minusPiOver2,
+        rewriter.create<CustomOp>(op.getLoc(), outQubitsTypes.front(), TypeRange{}, minusPiOver2,
                                   qubit1AfterMs, "RY", false, ValueRange{}, ValueRange{});
 
     mlir::Value qubit0AfterRY = rxMinusPiOver2.getOutQubits().front();
     auto secondRyMinusPiOver2 =
-        rewriter.create<CustomOp>(op.getLoc(), outQubitsTypes.front(), ValueRange{}, minusPiOver2,
+        rewriter.create<CustomOp>(op.getLoc(), outQubitsTypes.front(), TypeRange{}, minusPiOver2,
                                   qubit0AfterRY, "RY", false, ValueRange{}, ValueRange{});
 
     SmallVector<mlir::Value> qubitsEnd;


### PR DESCRIPTION
**Context:**

**Description of the Change:** The 3rd argument in [L51-58](https://github.com/PennyLaneAI/catalyst/blob/8b2671bd4a175da6af64d4c51f6afd125d682a8e/mlir/lib/Quantum/Transforms/IonsDecompositionPatterns.cpp#L51-L58), [L111-134](https://github.com/PennyLaneAI/catalyst/blob/8b2671bd4a175da6af64d4c51f6afd125d682a8e/mlir/lib/Quantum/Transforms/IonsDecompositionPatterns.cpp#L111-L134) should be ```TypeRange{}``` to match the constructors below but ```ValueRange{}``` is used instead

```C++
static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange params, ::mlir::ValueRange in_qubits, ::mlir::StringAttr gate_name, /*optional*/::mlir::UnitAttr adjoint, ::mlir::ValueRange in_ctrl_qubits, ::mlir::ValueRange in_ctrl_values);
static void build(::mlir::OpBuilder &odsBuilder, ::mlir::OperationState &odsState, ::mlir::TypeRange resultTypes, ::mlir::ValueRange params, ::mlir::ValueRange in_qubits, ::llvm::StringRef gate_name, /*optional*/::mlir::UnitAttr adjoint, ::mlir::ValueRange in_ctrl_qubits, ::mlir::ValueRange in_ctrl_values);
```

**Benefits:**

**Possible Drawbacks:** None

**Related GitHub Issues:** #1748 