### PR TITLE
Seed the non qjit reference run of a test

### DIFF
--- a/frontend/test/pytest/test_measurement_transforms.py
+++ b/frontend/test/pytest/test_measurement_transforms.py
@@ -442,7 +442,11 @@ class TestMeasurementTransforms:
         if len(measurement().wires) == 1:
             samples_expected = qjit(circuit, seed=37)(theta)
         else:
-            samples_expected = circuit(theta)
+            # lightning.qubit does not support seeding.
+            # To resolve flakiness, we put the non qjit reference run on default.qubit,
+            # which can be seeded
+            ref_dev = qml.device("default.qubit", wires=4, shots=3000, seed=42)
+            samples_expected = qml.qnode(ref_dev)(circuit.func)(theta)
 
         assert res.shape == samples_expected.shape
         assert np.allclose(np.mean(res, axis=0), np.mean(samples_expected, axis=0), atol=0.05)


### PR DESCRIPTION
**Context:**
The test 
`pytest/test_measurement_transforms.py::test_measurement_from_samples_with_sample_measurement`
has a [non-qjit reference run](https://github.com/PennyLaneAI/catalyst/blob/02af052424ec4fd5ce7d4e846c3410d823e13c55/frontend/test/pytest/test_measurement_transforms.py#L445) that is unseeded and is causing some flaky test noise.

**Description of the Change:**
Since lightning.qubit does not support seeding, we use default.qubit for this reference run and seed it.

**Benefits:**
No more flaky CI failures on this test.

**Possible Drawbacks:**
I don't like using seeding to silence flaky tests. 
In our [guidance docs for flaky tests](https://github.com/PennyLaneAI/guidance-docs/blob/eae480fd82f88c5f922e4d1b5a324819a4690b8a/development/testing-guidelines.md?plain=1#L222), seeding is only 
the second suggested strategy. 
But adopting the first strategy of hypothesis testing would take more time. For now, the band-aid seed solution would have to do.
