### PR TITLE
Add a builtin MBQC pipeline for MBQC workloads

### DIFF
--- a/frontend/catalyst/passes/builtin_pipelines.py
+++ b/frontend/catalyst/passes/builtin_pipelines.py
@@ -1,0 +1,57 @@
+# Copyright 2025 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This module exposes built-in Catalyst MLIR pass pipelines to the frontend."""
+
+from typing import List, Tuple
+
+from catalyst.pipelines import CompileOptions, get_stages, insert_before_pass
+
+PipelineStages = List[Tuple[str, List[str]]]
+
+
+def mbqc_pipeline() -> PipelineStages:
+    """Return the pipeline stages for MBQC workloads.
+
+    The MBQC pipeline is identical to the default Catalyst pipeline, but with the MBQC-to-LLVM
+    dialect-conversion pass inserted immediately before the Quantum-to-LLVM dialect-conversion pass
+    in the ``MLIRToLLVMDialect`` pipeline stage.
+
+    Returns:
+        PipelineStages: The list of pipeline stages.
+    """
+    options = CompileOptions()  # Use all default compile options
+    stages = get_stages(options)  # Get list of default pipeline stages
+
+    # Find the MLIR-to-LLVM dialect-conversion stage, 'MLIRToLLVMDialect'
+    stage_names = [item[0] for item in stages]
+    llvm_dialect_conversion_stage_name = "MLIRToLLVMDialect"
+
+    assert (
+        llvm_dialect_conversion_stage_name in stage_names
+    ), f"Stage 'MLIRToLLVMDialect' not found in default pipeline stages"
+
+    llvm_dialect_conversion_stage_index = stage_names.index(llvm_dialect_conversion_stage_name)
+
+    _, pipeline = stages[llvm_dialect_conversion_stage_index]
+
+    assert len(pipeline) > 0, f"Pipeline for stage 'MLIRToLLVMDialect' is empty"
+
+    # Insert (in-place) the "convert-mbqc-to-llvm" pass immediately before the
+    # "convert-quantum-to-llvm" pass in the MLIRToLLVMDialect pipeline
+    insert_before_pass(
+        pipeline, ref_pass="convert-quantum-to-llvm", new_pass="convert-mbqc-to-llvm"
+    )
+
+    return stages

--- a/frontend/catalyst/pipelines.py
+++ b/frontend/catalyst/pipelines.py
@@ -313,3 +313,57 @@ def get_stages(options):
     stages["BufferizationPass"] = get_bufferization_stage(options)
     stages["MLIRToLLVMDialect"] = get_convert_to_llvm_stage(options)
     return list(stages.items())
+
+
+def insert_after_pass(pipeline: list[str], ref_pass: str, new_pass: str) -> None:
+    """Insert a pass into an existing pass pipeline at the position after the given reference pass.
+
+    Args:
+        pipeline (list[str]): An existing pass pipeline, given as a list of passes.
+        ref_pass (str): The name of the reference pass after which the new pass is inserted.
+        new_pass (str): The name of the pass to insert.
+
+    Raises:
+        ValueError: If `ref_pass` is not found in the pass pipeline.
+
+    Example:
+        >>> pipeline = ["pass1", "pass2"]
+        >>> insert_after_pass(pipeline, "pass1", "new_pass")
+        >>> pipeline
+        ['pass1', 'new_pass', 'pass2']
+    """
+    try:
+        ref_index = pipeline.index(ref_pass)
+    except ValueError as e:
+        raise ValueError(
+            f"Cannot insert pass '{new_pass}' into pipeline; reference pass '{ref_pass}' not found"
+        ) from e
+
+    pipeline.insert(ref_index + 1, new_pass)
+
+
+def insert_before_pass(pipeline: list[str], ref_pass: str, new_pass: str) -> None:
+    """Insert a pass into an existing pass pipeline at the position before the given reference pass.
+
+    Args:
+        pipeline (list[str]): An existing pass pipeline, given as a list of passes.
+        ref_pass (str): The name of the reference pass before which the new pass is inserted.
+        new_pass (str): The name of the pass to insert.
+
+    Raises:
+        ValueError: If `ref_pass` is not found in the pass pipeline.
+
+    Example:
+        >>> pipeline = ["pass1", "pass2"]
+        >>> insert_before_pass(pipeline, "pass1", "new_pass")
+        >>> pipeline
+        ['new_pass', 'pass1', 'pass2']
+    """
+    try:
+        ref_index = pipeline.index(ref_pass)
+    except ValueError as e:
+        raise ValueError(
+            f"Cannot insert pass '{new_pass}' into pipeline; reference pass '{ref_pass}' not found"
+        ) from e
+
+    pipeline.insert(ref_index, new_pass)

--- a/frontend/test/pytest/test_pipelines.py
+++ b/frontend/test/pytest/test_pipelines.py
@@ -1,0 +1,92 @@
+# Copyright 2025 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for pipeline options and utility functions.
+"""
+
+import pytest
+
+from catalyst.pipelines import insert_after_pass, insert_before_pass
+
+
+@pytest.fixture(scope="function")
+def pipeline():
+    return ["pass1", "pass2", "pass3"]
+
+
+class TestPassInsertion:
+    """Test insertion of a pass into an existing pass pipeline."""
+
+    # Tests for `insert_after_pass`
+    def test_insert_after_pass(self, pipeline):
+        """Test the ``insert_after_pass`` function with valid inputs, inserting into the middle of
+        the pipeline.
+        """
+        new_pass_1 = "new_pass_1"
+        insert_after_pass(pipeline, ref_pass="pass1", new_pass=new_pass_1)
+
+        pipeline_expected = ["pass1", new_pass_1, "pass2", "pass3"]
+        assert pipeline == pipeline_expected
+
+    def test_insert_after_pass_at_end(self, pipeline):
+        """Test the ``insert_after_pass`` function with valid inputs, inserting at the end of the
+        pipeline.
+        """
+        new_pass_1 = "new_pass_1"
+        insert_after_pass(pipeline, ref_pass="pass3", new_pass=new_pass_1)
+
+        pipeline_expected = ["pass1", "pass2", "pass3", new_pass_1]
+        assert pipeline == pipeline_expected
+
+    @pytest.mark.parametrize("ref_pass", ["not_a_pass", 1, [], None])
+    def test_insert_after_invalid_ref_pass(self, pipeline, ref_pass):
+        """Test the ``insert_after_pass`` function with an invalid reference pass name."""
+        new_pass = "new_pass_1"
+
+        with pytest.raises(ValueError, match=f"Cannot insert pass '{new_pass}' into pipeline"):
+            insert_after_pass(pipeline, ref_pass=ref_pass, new_pass=new_pass)
+
+    # Tests for `insert_before_pass`
+    def test_insert_before_pass(self, pipeline):
+        """Test the ``insert_before_pass`` function with valid inputs, inserting into the middle of
+        the pipeline.
+        """
+        new_pass_1 = "new_pass_1"
+        insert_before_pass(pipeline, ref_pass="pass2", new_pass=new_pass_1)
+
+        pipeline_expected = ["pass1", new_pass_1, "pass2", "pass3"]
+        assert pipeline == pipeline_expected
+
+    def test_insert_before_pass_at_beginning(self, pipeline):
+        """Test the ``insert_before_pass`` function with valid inputs, inserting at the beginning of
+        the pipeline.
+        """
+        new_pass_1 = "new_pass_1"
+        insert_before_pass(pipeline, ref_pass="pass1", new_pass=new_pass_1)
+
+        pipeline_expected = [new_pass_1, "pass1", "pass2", "pass3"]
+        assert pipeline == pipeline_expected
+
+    @pytest.mark.parametrize("ref_pass", ["not_a_pass", 1, [], None])
+    def test_insert_before_invalid_ref_pass(self, pipeline, ref_pass):
+        """Test the ``insert_before_pass`` function with an invalid reference pass name."""
+        new_pass = "new_pass_1"
+
+        with pytest.raises(ValueError, match=f"Cannot insert pass '{new_pass}' into pipeline"):
+            insert_before_pass(pipeline, ref_pass=ref_pass, new_pass=new_pass)
+
+
+if __name__ == "__main__":
+    pytest.main(["-x", __file__])


### PR DESCRIPTION
**Context:** When we initially added the MBQC dialect, we had to manually specify the full compilation pipeline add drop in the MBQC-to-LLVM dialect-conversion pass, `"convert-mbqc-to-llvm"`, to convert the ops in the `mbqc` dialect to the LLVM dialect. For example:

```python
mbqc_pipeline = [
    (
        "default-pipeline",
        [
            "enforce-runtime-invariants-pipeline",
            "hlo-lowering-pipeline",
            "quantum-compilation-pipeline",
            "bufferization-pipeline",
        ],
    ),
    (
        "mbqc-pipeline",
        [
            "convert-mbqc-to-llvm",
        ],
    ),
    (
        "llvm-dialect-lowering-pipeline",
        [
            "llvm-dialect-lowering-pipeline",
        ],
    ),
]

@qjit(pipelines=mbqc_pipeline)
@qml.qnode(dev)
def workload():
    ...
```

No one is going to want to type that out each time, so it would be handy to have this pipeline already defined somewhere.

**Description of the Change:** Adds a new function, `mbqc_pipeline()` to a new `passes.builtin_pipelines` module. This function first makes a copy of the default pipeline stages (from `catalyst.pipelines.get_stages()`) and inserts the mbqc-to-llvm conversion pass immediately before the quantum-to-llvm conversion pass in the `"MLIRToLLVMDialect"` stage.

This PR also adds a few helper functions, e.g. `catalyst.pipelines.insert_before_pass()` and `catalyst.pipelines.insert_after_pass()` to aid in manipulating existing pass pipelines.

**Benefits:** Less typing to specify the pass pipeline for MBQC workloads (and therefore less error-prone!)
