### PR TITLE
Revert "Add call to python compiler (#1715)"

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.149
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt
-pennylane=0.42.0-dev33
+pennylane=0.42.0-dev27
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -2,10 +2,6 @@
 
 <h3>New features since last release</h3>
 
-* Added integration with PennyLane's experimental python compiler based on xDSL.
-  This allows developers and users to write xDSL transformations that can be used with Catalyst.
-  [(#1715)](https://github.com/PennyLaneAI/catalyst/pull/1715)
-
 * A new compilation pass called :func:`~.passes.ppr_to_ppm` has been added to Catalyst
   to decompose Pauli product rotations (PPRs), :math:`\exp(-iP_{\{x, y, z\}} \theta)`, into
   Pauli product measurements (PPMs). Non-Clifford PPR (:math:`\theta = \tfrac{\pi}{8}`) requires

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -28,10 +28,9 @@ mistune==0.8.4
 sphinxext-opengraph==0.9.0
 matplotlib==3.8.0
 lxml_html_clean
-xdsl
 
 # Pre-install PL development wheels
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.42.0-dev16
 pennylane-lightning==0.42.0-dev16
-pennylane==0.42.0-dev33
+pennylane==0.42.0-dev27

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -28,8 +28,6 @@ import warnings
 from os import path
 from typing import List, Optional
 
-from pennylane.compiler.python_compiler.impl import Compiler as PythonCompiler
-
 from catalyst.logging import debug_logger, debug_logger_init
 from catalyst.pipelines import CompileOptions
 from catalyst.utils.exceptions import CompileError
@@ -508,10 +506,7 @@ class Compiler:
             (str): filename of shared object
         """
 
-        if self.is_using_python_compiler():
-
-            compiler = PythonCompiler()
-            mlir_module = compiler.run(mlir_module)
+        self.is_using_python_compiler()
 
         return self.run_from_ir(
             mlir_module.operation.get_asm(


### PR DESCRIPTION
**Context:** Wheels are failing. Will investigate tomorrow. Possibly due to xdsl's optional jax dependency.
