### PR TITLE
Add .venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ doc/code/api
 
 # Development
 venv
+.venv
 
 # Cache files
 .cache


### PR DESCRIPTION
**Context:**
Creating a new environment using vscode creates a`.venv` folder instead of `venv`. 

**Description of the Change:**
add .venv to gitignore

**Benefits:**
easier development on vscode

**Possible Drawbacks:**

**Related GitHub Issues:**
