### PR TITLE
Add support for `qml.measure` in Catalyst's PlxPR pipeline

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -233,7 +233,7 @@
 
   Note that using `qml.measure()` in this way binds the operation to :func:`catalyst.measure`, which
   may behave differently than `qml.measure()` in a native PennyLane circuit, as described in the
-  :doc:`Measurements section <measurements>` of the quick start guide. In regular QJIT-compiled
+  Measurements section of the :doc:`quick start guide <quick_start>`. In regular QJIT-compiled
   workloads (without program capture enabled), you must continue to use :func:`catalyst.measure`.
 
 <h3>Documentation 📝</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -190,9 +190,9 @@
   This runtime stub is currently for mock execution only and should be treated as a placeholder
   operation. Internally, it functions just as a computational-basis measurement instruction.
 
-* PennyLane's arbitrary-basis measurement operations, such as [`qml.ftqc.measure_arbitrary_basis()`
-  ](https://docs.pennylane.ai/en/stable/code/api/pennylane.ftqc.measure_arbitrary_basis.html), are
-  now QJIT-compatible with program capture enabled.
+* PennyLane's arbitrary-basis measurement operations, such as
+  :func:`qml.ftqc.measure_arbitrary_basis() <pennylane.ftqc.measure_arbitrary_basis>`, are now
+  QJIT-compatible with program capture enabled.
   [(#1645)](https://github.com/PennyLaneAI/catalyst/pull/1645)
   [(#1710)](https://github.com/PennyLaneAI/catalyst/pull/1710)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -227,6 +227,16 @@
 * The unused helper function `genArgMapFunction` in the `--lower-gradients` pass is removed.
   [(#1753)](https://github.com/PennyLaneAI/catalyst/pull/1753)
 
+* The `qml.measure()` operation for mid-circuit measurements can now be used in QJIT-compiled
+  circuits with program capture enabled.
+  [(#1766)](https://github.com/PennyLaneAI/catalyst/pull/1766)
+
+  Note that using `qml.measure()` in this way binds the operation to :func:`catalyst.measure`, which
+  may behave differently than `qml.measure()` in an native PennyLane circuit, as described in the
+  :doc:`Measurements section <quick_start#measurements>` of the quick start guide. In regular
+  QJIT-compiled workloads (without program capture enabled), you must continue to use
+  :func:`catalyst.measure`.
+
 <h3>Documentation 📝</h3>
 
 * The header (logo+title) images in the README and in the overview on RtD have been updated,

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -270,9 +270,10 @@
   [(#1766)](https://github.com/PennyLaneAI/catalyst/pull/1766)
 
   Note that using `qml.measure()` in this way binds the operation to :func:`catalyst.measure`, which
-  may behave differently than `qml.measure()` in a native PennyLane circuit, as described in the
-  Measurements section of the :doc:`quick start guide <quick_start>`. In regular QJIT-compiled
-  workloads (without program capture enabled), you must continue to use :func:`catalyst.measure`.
+  behaves differently than `qml.measure()` in a native PennyLane circuit, as described in the
+  *Functionality differences from PennyLane* section of the
+  :doc:`sharp bits and debugging tips <sharp_bits>` guide. In regular QJIT-compiled workloads
+  (without program capture enabled), you must continue to use :func:`catalyst.measure`.
 
 <h3>Documentation 📝</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -232,10 +232,9 @@
   [(#1766)](https://github.com/PennyLaneAI/catalyst/pull/1766)
 
   Note that using `qml.measure()` in this way binds the operation to :func:`catalyst.measure`, which
-  may behave differently than `qml.measure()` in an native PennyLane circuit, as described in the
-  :doc:`Measurements section <quick_start#measurements>` of the quick start guide. In regular
-  QJIT-compiled workloads (without program capture enabled), you must continue to use
-  :func:`catalyst.measure`.
+  may behave differently than `qml.measure()` in a native PennyLane circuit, as described in the
+  :doc:`Measurements section <measurements>` of the quick start guide. In regular QJIT-compiled
+  workloads (without program capture enabled), you must continue to use :func:`catalyst.measure`.
 
 <h3>Documentation 📝</h3>
 

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -649,7 +649,7 @@ def handle_while_loop(
 
 
 @QFuncPlxprInterpreter.register_primitive(plxpr_measure_prim)
-def handle_measure_in_basis(self, wire, reset, postselect):
+def handle_measure(self, wire, reset, postselect):
     """Handle the conversion from plxpr to Catalyst jaxpr for the mid-circuit measure primitive."""
 
     in_wire = self.get_wire(wire)

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -29,6 +29,7 @@ from pennylane.capture import PlxprInterpreter, qnode_prim
 from pennylane.capture.expand_transforms import ExpandTransformsInterpreter
 from pennylane.capture.primitives import cond_prim as plxpr_cond_prim
 from pennylane.capture.primitives import for_loop_prim as plxpr_for_loop_prim
+from pennylane.capture.primitives import measure_prim as plxpr_measure_prim
 from pennylane.capture.primitives import while_loop_prim as plxpr_while_loop_prim
 from pennylane.ftqc.primitives import measure_in_basis_prim as plxpr_measure_in_basis_prim
 from pennylane.ops.functions.map_wires import _map_wires_transform as pl_map_wires
@@ -58,6 +59,7 @@ from catalyst.jax_primitives import (
     for_p,
     gphase_p,
     measure_in_basis_p,
+    measure_p,
     namedobs_p,
     probs_p,
     qalloc_p,
@@ -644,6 +646,30 @@ def handle_while_loop(
 
     # Return only the output values that match the plxpr output values
     return outvals
+
+
+@QFuncPlxprInterpreter.register_primitive(plxpr_measure_prim)
+def handle_measure_in_basis(self, wire, reset, postselect):
+    """Handle the conversion from plxpr to Catalyst jaxpr for the mid-circuit measure primitive."""
+
+    in_wire = self.get_wire(wire)
+
+    result, out_wire = measure_p.bind(in_wire, postselect=postselect)
+
+    if reset:
+        # Constants need to be passed as input values for some reason I forgot about.
+        correction = jaxpr_pad_consts(
+            [
+                jax.make_jaxpr(lambda: qinst_p.bind(in_wire, op="PauliX", qubits_len=1))().jaxpr,
+                jax.make_jaxpr(lambda: out_wire)().jaxpr,
+            ]
+        )
+        out_wire = cond_p.bind(
+            result, in_wire, out_wire, branch_jaxprs=correction, nimplicit_outputs=None
+        )[0]
+
+    self.wire_map[wire] = out_wire
+    return result
 
 
 # pylint: disable=unused-argument, too-many-positional-arguments

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1842,7 +1842,7 @@ def _cond_lowering(
                     true_jaxpr.jaxpr,
                     if_ctx.name_stack,
                     mlir.TokenSet(),
-                    [mlir.ir_constants(c) for c in true_jaxpr.consts],
+                    [mlir.ir_constant(c) for c in true_jaxpr.consts],  # is never hit in our tests
                     *flat_args_plus_consts,
                     dim_var_values=jax_ctx.dim_var_values,
                 )

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -388,6 +388,32 @@ class TestCapture:
 
         assert capture_result == expected_result
 
+    def test_measure_postselect(self, backend):
+        """Test the integration for a circuit with a mid-circuit measurement using postselect.
+
+        See note in test_measure() above for discussion on testing strategy.
+        """
+        device = qml.device(backend, wires=1)
+
+        # Capture enabled
+
+        qml.capture.enable()
+
+        @qjit
+        @qml.qnode(device)
+        def captured_circuit():
+            qml.H(wires=0)
+            qml.measure(wires=0, postselect=1)
+            return qml.expval(qml.Z(0))
+
+        capture_result = captured_circuit()
+
+        qml.capture.disable()
+
+        expected_result = -1
+
+        assert capture_result == expected_result
+
     @pytest.mark.parametrize("theta", (jnp.pi, 0.1, 0.0))
     def test_forloop(self, backend, theta):
         """Test the integration for a circuit with a for loop."""

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -349,9 +349,11 @@ class TestCapture:
 
         assert jnp.allclose(capture_result, circuit(theta))
 
-    @pytest.mark.parametrize("reset", [False, True])
-    @pytest.mark.parametrize("op", [qml.I, qml.X])
-    def test_measure(self, backend, reset, op):
+    @pytest.mark.parametrize(
+        "reset, op, expected",
+        [(False, qml.I, 1), (False, qml.X, -1), (True, qml.I, 1), (True, qml.X, 1)],
+    )
+    def test_measure(self, backend, reset, op, expected):
         """Test the integration for a circuit with a mid-circuit measurement.
 
         We do not currently have full feature parity between PennyLane's `measure` and Catalyst's.
@@ -360,8 +362,6 @@ class TestCapture:
         returns correct results.
         """
         device = qml.device(backend, wires=1)
-
-        # Capture enabled
 
         qml.capture.enable()
 
@@ -376,17 +376,7 @@ class TestCapture:
 
         qml.capture.disable()
 
-        if reset:
-            expected_result = 1
-        else:
-            if op is qml.I:
-                expected_result = 1
-            elif op is qml.X:
-                expected_result = -1
-            else:
-                raise AssertionError(f"Unexpected op '{op.__name__}'")
-
-        assert capture_result == expected_result
+        assert capture_result == expected
 
     def test_measure_postselect(self, backend):
         """Test the integration for a circuit with a mid-circuit measurement using postselect.
@@ -394,8 +384,6 @@ class TestCapture:
         See note in test_measure() above for discussion on testing strategy.
         """
         device = qml.device(backend, wires=1)
-
-        # Capture enabled
 
         qml.capture.enable()
 

--- a/frontend/test/pytest/test_mbqc.py
+++ b/frontend/test/pytest/test_mbqc.py
@@ -106,7 +106,6 @@ def test_measure_y():
     assert -1.0 <= result <= 1.0
 
 
-@pytest.mark.xfail(reason="qml.ftqc.measure_z is not yet supported with program capture")
 def test_measure_z():
     """Test the compilation of the qml.ftqc.measure_z function, which performs a mid-circuit
     measurement in the Pauli Z basis. Including for completeness; measure_z() dispatches directly to


### PR DESCRIPTION
The [`qml.measure()`](https://docs.pennylane.ai/en/stable/code/api/pennylane.measure.html) operation for mid-circuit measurements can now be used in QJIT-compiled circuits with program capture enabled. For example:

```python
import pennylane as qml
from catalyst import qjit

device = qml.device("lightning.qubit", wires=1)

qml.capture.enable()

@qjit
@qml.qnode(device)
def circuit():
    qml.X(wires=0)
    qml.measure(wires=0, reset=reset)
    return qml.expval(qml.Z(0))
```

```pycon
>>> circuit()
-1.0
```

Note that using `qml.measure()` in this way binds the operation to [`catalyst.measure()`](https://docs.pennylane.ai/projects/catalyst/en/stable/code/api/catalyst.measure.html), which may behave differently than `qml.measure()` in a native PennyLane circuit, as described in the [Functionality differences from PennyLane](https://docs.pennylane.ai/projects/catalyst/en/stable/dev/sharp_bits.html#functionality-differences-from-pennylane) section of the sharp bits and debugging tips guide. In regular QJIT-compiled workloads (_without_ program capture enabled), you must continue to use `catalyst.measure()`.