### PR TITLE
[Frontend] Make AOT happen for any function annotated with `AbstractValue` signatures

### DIFF
--- a/frontend/catalyst/tracing/type_signatures.py
+++ b/frontend/catalyst/tracing/type_signatures.py
@@ -22,6 +22,7 @@ import inspect
 from typing import Callable
 
 import jax
+from jax.core import AbstractValue
 from jax._src.core import shaped_abstractify
 from jax._src.interpreters.partial_eval import infer_lambda_input_type
 from jax._src.pjit import _flat_axes_specs
@@ -56,7 +57,7 @@ def params_are_annotated(fn: Callable):
     are_annotated = all(annotation is not inspect.Parameter.empty for annotation in annotations)
     if not are_annotated:
         return False
-    return all(isinstance(annotation, (type, jax.core.ShapedArray)) for annotation in annotations)
+    return all(isinstance(annotation, (type, AbstractValue)) for annotation in annotations)
 
 
 def get_type_annotations(fn: Callable):


### PR DESCRIPTION
**Context:** In preparation for quantum subroutines, I found the need to compile the following function:

```python
@catalyst.qjit(target="mlir")
def identity(x : AbstractQreg()):
    return x
print(identity.mlir)
```

However, one small impediment was this check for types to decide whether AOT compilation is possible or not.

**Description of the Change:** Generalize small check to decide whether AOT compilation is possible or not by relying on `isinstance` of `AbstractValue` over `ShapedArray`. `ShapedArray` is derived from `AbstractValue`

**Benefits:** More general code, small progress towards quantum subroutines.
