### PR TITLE
[Build System] add quiet to supress warning

### DIFF
--- a/mlir/cmake/modules/CMakeLists.txt
+++ b/mlir/cmake/modules/CMakeLists.txt
@@ -36,7 +36,7 @@ get_property(MLIR_EXPORTS GLOBAL PROPERTY MLIR_EXPORTS)
 # QECUtils needs to be added manually since it is not in MLIR_EXPORTS
 # todo: the following two lines removed nlohmann_json as export targets, should probably be done for the other extra targets as well
 include(CMakeFindDependencyMacro)
-find_dependency(nlohmann_json)
+find_dependency(nlohmann_json QUIET)
 export(TARGETS ${MLIR_EXPORTS} QECUtils libstim tomlplusplus_tomlplusplus FILE ${catalyst_cmake_builddir}/CatalystTargets.cmake)
 
 # Generate MlirConfig.cmake for the build tree.


### PR DESCRIPTION
**Context:** Likely, due to difference between `find_dependency` and `FetchContent_{Declare,MakeAvailable}` there is a warning when building Catalyst. 

```
CMake Warning at /Users/mehrdad.malek/catalyst/venv/lib/python3.12/site-packages/cmake/data/share/cmake-3.30/Modules/CMakeFindDependencyMacro.cmake:76 (find_package):
  By not providing "Findnlohmann_json.cmake" in CMAKE_MODULE_PATH this
  project has asked CMake to find a package configuration file provided by
  "nlohmann_json", but CMake did not find one.

  Could not find a package configuration file provided by "nlohmann_json"
  with any of the following names:

    nlohmann_jsonConfig.cmake
    nlohmann_json-config.cmake

  Add the installation prefix of "nlohmann_json" to CMAKE_PREFIX_PATH or set
  "nlohmann_json_DIR" to a directory containing one of the above files.  If
  "nlohmann_json" provides a separate development package or SDK, be sure it
  has been installed.
Call Stack (most recent call first):
  cmake/modules/CMakeLists.txt:39 (find_dependency)
```

**Description of the Change:** Add QUIET to suppress warning.

**Benefits:** Less noisy builds.

**Possible Drawbacks:** It would be good to resolve this issue instead of making the warning go away.

**Related GitHub Issues:**
