### PR TITLE
[Build System] add compiler to plugin

### DIFF
--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -369,6 +369,8 @@ jobs:
       run: |
         MLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir" \
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \
+        C_COMPILER=$(which gcc) \
+        CXX_COMPILER=$(which g++) \
         make plugin-wheel
 
     - name: Build wheel

--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -365,7 +365,7 @@ jobs:
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time
-      if: env.BUILD_STANDALONE_PLUGIN == 'true'
+      # if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
         MLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir" \
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \

--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -365,7 +365,7 @@ jobs:
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time
-      # if: env.BUILD_STANDALONE_PLUGIN == 'true'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
         MLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir" \
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -394,6 +394,8 @@ jobs:
       run: |
         MLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir" \
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \
+        C_COMPILER=$(which gcc) \
+        CXX_COMPILER=$(which g++) \
         make plugin-wheel
 
     - name: Build wheel

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -390,7 +390,7 @@ jobs:
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time
-      # if: env.BUILD_STANDALONE_PLUGIN == 'true'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
         MLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir" \
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -390,7 +390,7 @@ jobs:
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time
-      if: env.BUILD_STANDALONE_PLUGIN == 'true'
+      # if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
         MLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir" \
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -383,7 +383,6 @@ jobs:
       # Run only on Thursday at the given time
       # if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
-        PYTHON=$(which python${{ matrix.python_version }}) \
         MLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir" \
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \
         make plugin-wheel

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -381,7 +381,7 @@ jobs:
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time
-      if: env.BUILD_STANDALONE_PLUGIN == 'true'
+      # if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
         MLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir" \
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -383,6 +383,7 @@ jobs:
       # Run only on Thursday at the given time
       # if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
+        PYTHON=$(which python${{ matrix.python_version }}) \
         MLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir" \
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \
         make plugin-wheel

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -381,7 +381,7 @@ jobs:
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time
-      # if: env.BUILD_STANDALONE_PLUGIN == 'true'
+      if: env.BUILD_STANDALONE_PLUGIN == 'true'
       run: |
         MLIR_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/mlir" \
         LLVM_BUILD_DIR="$GITHUB_WORKSPACE/llvm-build" \

--- a/mlir/Makefile
+++ b/mlir/Makefile
@@ -151,6 +151,7 @@ plugin:
 		-DMLIR_DIR=$(LLVM_BUILD_DIR)/lib/cmake/mlir \
 		-DLLVM_EXTERNAL_LIT=$(LLVM_EXTERNAL_LIT) \
 		-DCATALYST_TOOLS_DIR=$(DIALECTS_BUILD_DIR)/bin \
+		-DPython_EXECUTABLE=$(PYTHON) \
 		-DPython3_EXECUTABLE=$(PYTHON) \
 		-DPython3_NumPy_INCLUDE_DIRS=$$($(PYTHON) -c "import numpy as np; print(np.get_include())") \
 		standalone


### PR DESCRIPTION
**Description of the Change:** Added which compiler should be used to compile the MLIR plugin on the github action scripts. Also, the Makefile for building the wheel has been updated to use the same version for the variables `Python_Executable` and `Python3_Executable`. Otherwise, it seems that the lit test uses one python environment while installing the bindings in another.

**Benefits:** The plugin can be built successfully on CI/CD.