### PR TITLE
[WIP :construction: ] Automatic qubit management

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -74,6 +74,10 @@
   Array([0.25, 0.25, 0.25, 0.25], dtype=float64))
   ```
 
+* Catalyst now supports automatic qubit management.
+  (Add explanation and examples here.)
+  [(#???)](https://github.com/PennyLaneAI/catalyst/pull/???)
+
 <h3>Improvements 🛠</h3>
 
 * The behaviour of measurement processes executed on `null.qubit` with QJIT is now more in line with

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -548,6 +548,8 @@ def is_dynamic_wires(wires: qml.wires.Wires):
     If the number of wires is dynamic, the Wires object contains a single tracer that
     represents the number of wires.
     """
+    # Automatic qubit management mode should not encounter this query
+    assert wires is not None
     return (len(wires) == 1) and (isinstance(wires[0], DynamicJaxprTracer))
 
 
@@ -555,7 +557,8 @@ def check_device_wires(wires):
     """Validate requirements Catalyst imposes on device wires."""
 
     if wires is None:
-        raise AttributeError("Catalyst does not support device instances without set wires.")
+        # Automatic qubit management mode, nothing to check
+        return
 
     if len(wires) >= 2 or (not is_dynamic_wires(wires)):
         # A dynamic number of wires correspond to a single tracer for the number

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -301,7 +301,11 @@ class QFuncPlxprInterpreter(PlxprInterpreter):
     def setup(self):
         """Initialize the stateref and bind the device."""
         if self.stateref is None:
-            device_init_p.bind(self._shots, **_get_device_kwargs(self._device))
+            device_init_p.bind(
+                self._shots,
+                auto_qubit_management=(self._device.wires is None),
+                **_get_device_kwargs(self._device),
+            )
             self.stateref = {"qreg": qalloc_p.bind(len(self._device.wires)), "wire_map": {}}
 
     # pylint: disable=attribute-defined-outside-init

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -811,12 +811,17 @@ def _zne_lowering(ctx, *args, folding, jaxpr, fn):
 # device_init
 #
 @device_init_p.def_abstract_eval
-def _device_init_abstract_eval(shots, rtd_lib, rtd_name, rtd_kwargs):
+def _device_init_abstract_eval(shots, auto_qubit_management, rtd_lib, rtd_name, rtd_kwargs):
     return ()
 
 
 def _device_init_lowering(
-    jax_ctx: mlir.LoweringRuleContext, shots: ir.Value, rtd_lib, rtd_name, rtd_kwargs
+    jax_ctx: mlir.LoweringRuleContext,
+    shots: ir.Value,
+    auto_qubit_management,
+    rtd_lib,
+    rtd_name,
+    rtd_kwargs,
 ):
     ctx = jax_ctx.module_context.context
     ctx.allow_unregistered_dialects = True
@@ -827,6 +832,7 @@ def _device_init_lowering(
         ir.StringAttr.get(rtd_name),
         ir.StringAttr.get(rtd_kwargs),
         shots=shots_value,
+        auto_qubit_management=auto_qubit_management,
     )
 
     return ()

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -984,11 +984,19 @@ def trace_quantum_measurements(
                     "Use qml.sample() instead."
                 )
 
-            d_wires = (
-                device.wires[0]
-                if catalyst.device.qjit_device.is_dynamic_wires(device.wires)
-                else len(device.wires)
-            )
+            # d_wires = (
+            #     device.wires[0]
+            #     if catalyst.device.qjit_device.is_dynamic_wires(device.wires)
+            #     else len(device.wires)
+            # )
+            if device.wires is None:
+                # Automatic qubit management mode, TODO: what here???
+                d_wires = 0
+                pass
+            elif catalyst.device.qjit_device.is_dynamic_wires(device.wires):
+                d_wires = device.wires[0]
+            else:
+                d_wires = len(device.wires)
             m_wires = output.wires if output.wires else None
             obs_tracers, nqubits = trace_observables(output.obs, qrp, m_wires)
             nqubits = d_wires if nqubits is None else nqubits
@@ -1385,11 +1393,16 @@ def trace_quantum_function(
                 device_shots = get_device_shots(device) or 0
                 device_init_p.bind(
                     device_shots,
+                    auto_qubit_management=(device.wires is None),
                     rtd_lib=device.backend_lib,
                     rtd_name=device.backend_name,
                     rtd_kwargs=str(device.backend_kwargs),
                 )
-                if catalyst.device.qjit_device.is_dynamic_wires(device.wires):
+                if device.wires is None:
+                    # Automatic qubit management mode
+                    # We start with 0 wires and allocate new wires in runtime as we encounter them.
+                    qreg_in = qalloc_p.bind(0)
+                elif catalyst.device.qjit_device.is_dynamic_wires(device.wires):
                     # When device has dynamic wires, the device.wires iterable object
                     # has a single value, which is the tracer for the number of wires
                     qreg_in = qalloc_p.bind(device.wires[0])

--- a/frontend/test/pytest/test_automatic_qubit_management.py
+++ b/frontend/test/pytest/test_automatic_qubit_management.py
@@ -1,0 +1,36 @@
+# Copyright 2025 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This file contains tests for automatic qubit management.
+Automatic qubit management refers to when the user does not specify the total number of wires
+during device initialization.
+"""
+
+import numpy as np
+import pennylane as qml
+import pytest
+
+import catalyst
+from catalyst import qjit
+
+
+def test_probs(backend):
+
+    def circuit():
+        qml.PauliX(wires=0)
+        return qml.probs(wires=[2, 3])
+
+    ref = qjit(qml.qnode(qml.device(backend, wires=4))(circuit))()
+    observed = qjit(qml.qnode(qml.device(backend))(circuit))()
+    assert np.allclose(ref, observed)

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -81,6 +81,7 @@ def DeviceInitOp : Quantum_Op<"device"> {
 
     let arguments = (ins
         Optional<I64>:$shots,
+        UnitAttr:$auto_qubit_management,
         StrAttr:$lib,
         StrAttr:$device_name,
         StrAttr:$kwargs
@@ -90,6 +91,18 @@ def DeviceInitOp : Quantum_Op<"device"> {
       (`shots` `(` $shots^ `)`)? `[` $lib `,` $device_name `,` $kwargs `]` attr-dict
     }];
 
+    let builders = [
+        OpBuilder<
+        // Convenience builder for a device not in automatic qubit management mode
+        (ins
+             "mlir::Value":$shots,
+             "mlir::StringAttr":$lib,
+             "mlir::StringAttr":$device_name,
+             "mlir::StringAttr":$kwargs
+        ),[{
+            DeviceInitOp::build($_builder, $_state, shots, false, lib, device_name, kwargs);
+        }]>,
+    ];
 }
 
 def DeviceReleaseOp : Quantum_Op<"device_release"> {

--- a/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
@@ -187,11 +187,13 @@ struct DeviceInitOpPattern : public OpConversionPattern<DeviceInitOp> {
 
         Type charPtrType = LLVM::LLVMPointerType::get(rewriter.getContext());
         Type int64Type = IntegerType::get(rewriter.getContext(), 64);
+        Type int1Type = IntegerType::get(rewriter.getContext(), 1);
         Type qirSignature = LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(ctx),
                                                         {/* rtd_lib = */ charPtrType,
                                                          /* rtd_name = */ charPtrType,
                                                          /* rtd_kwargs = */ charPtrType,
-                                                         /* shots = */ int64Type});
+                                                         /* shots = */ int64Type,
+                                                         /*auto_qubit_management = */ int1Type});
         LLVM::LLVMFuncOp fnDecl =
             catalyst::ensureFunctionDeclaration(rewriter, op, qirName, qirSignature);
 
@@ -216,6 +218,10 @@ struct DeviceInitOpPattern : public OpConversionPattern<DeviceInitOp> {
         else {
             operands.push_back(shots);
         }
+
+        Value autoQubitManagement = rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI1Type(),
+                                                                      op.getAutoQubitManagement());
+        operands.push_back(autoQubitManagement);
 
         rewriter.create<LLVM::CallOp>(loc, fnDecl, operands);
 

--- a/runtime/include/RuntimeCAPI.h
+++ b/runtime/include/RuntimeCAPI.h
@@ -24,8 +24,8 @@ extern "C" {
 
 // Quantum Runtime Instructions
 void __catalyst__rt__fail_cstr(const char *);
-void __catalyst__rt__initialize(uint32_t *seed);
-void __catalyst__rt__device_init(int8_t *, int8_t *, int8_t *, int64_t shots);
+void __catalyst__rt__initialize(uint32_t *);
+void __catalyst__rt__device_init(int8_t *, int8_t *, int8_t *, int64_t, bool);
 void __catalyst__rt__device_release();
 void __catalyst__rt__finalize();
 void __catalyst__rt__toggle_recorder(bool);

--- a/runtime/lib/capi/ExecutionContext.hpp
+++ b/runtime/lib/capi/ExecutionContext.hpp
@@ -166,6 +166,7 @@ class RTDevice {
     std::string rtd_lib;
     std::string rtd_name;
     std::string rtd_kwargs;
+    bool auto_qubit_management;
 
     std::unique_ptr<SharedLibraryManager> rtd_dylib{nullptr};
     std::unique_ptr<QuantumDevice> rtd_qdevice{nullptr};
@@ -258,6 +259,9 @@ class RTDevice {
     [[nodiscard]] auto getDeviceName() const -> const std::string & { return rtd_name; }
 
     void setDeviceStatus(RTDeviceStatus new_status) noexcept { status = new_status; }
+
+    void setDeviceAutoQubitManagementMode(bool mode) { auto_qubit_management = mode; }
+    bool getDeviceAutoQubitManagementMode() { return auto_qubit_management; }
 
     [[nodiscard]] auto getDeviceStatus() const -> RTDeviceStatus { return status; }
 


### PR DESCRIPTION
**Context:**
We wish to support automatic qubit management, i.e. when the user does not specify the number of wires in device initialization
```python
@qjit
def workflow():
    dev = qml.device("lightning.qubit") # no wires here!
    @qml.qnode(dev)
    def circuit():
        qml.PauliX(wires=0)
        return qml.probs(wires=[2,3])  # non qjit is [1,0,0,0]
    return circuit()
```

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**
Potential out-of-memory error might be encountered in runtime.

**Related GitHub Issues:**
