### PR TITLE
Test stable/stable without building catalyst

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -42,9 +42,12 @@ jobs:
         git checkout v0.11.0-rc
 
     - name: Install deps
+      if: ${{ inputs.catalyst != 'stable' }}
       run: |
         sudo apt-get update
         sudo apt-get install -y cmake ninja-build ccache libomp-dev libasan6 lld
+
+    - name: Install deps (Python)
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
         pip install amazon-braket-pennylane-plugin
@@ -52,45 +55,58 @@ jobs:
 
     - name: Get Catalyst Build Dependencies (latest)
       uses: actions/cache/restore@v4
+      if: ${{ inputs.catalyst != 'stable' }}
       with:
         path: mlir/llvm-project
         key: llvm-${{ needs.constants.outputs.llvm_version }}-default-source
         enableCrossOsArchive: True
         fail-on-cache-miss: True
     - uses: actions/cache/restore@v4
+      if: ${{ inputs.catalyst != 'stable' }}
       with:
         path: llvm-build
         key: ${{ runner.os }}-llvm-${{ needs.constants.outputs.llvm_version }}-ci-build-gcc
         fail-on-cache-miss: True
     - uses: actions/cache/restore@v4
+      if: ${{ inputs.catalyst != 'stable' }}
       with:
         path: mlir/mlir-hlo
         key: mhlo-${{ needs.constants.outputs.mhlo_version }}-default-source
         enableCrossOsArchive: True
         fail-on-cache-miss: True
     - uses: actions/cache/restore@v4
+      if: ${{ inputs.catalyst != 'stable' }}
       with:
         path: mhlo-build
         key: ${{ runner.os }}-mhlo-${{ needs.constants.outputs.mhlo_version }}-ci-build-gcc
         fail-on-cache-miss: True
     - uses: actions/cache/restore@v4
+      if: ${{ inputs.catalyst != 'stable' }}
       with:
         path:  mlir/Enzyme
         key: enzyme-${{ needs.constants.outputs.enzyme_version }}-default-source
         enableCrossOsArchive: True
         fail-on-cache-miss: True
     - uses: actions/cache@v4
+      if: ${{ inputs.catalyst != 'stable' }}
       with:
         path: enzyme-build
         key: ${{ runner.os }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-ci-build-gcc
         fail-on-cache-miss: True
     - uses: actions/cache/restore@v4
+      if: ${{ inputs.catalyst != 'stable' }}
       with:
         path: .ccache
         key: ${{ runner.os }}-ccache-${{ github.run_id }}
         restore-keys: ${{ runner.os }}-ccache-
 
-    - name: Install Catalyst (latest/stable/release-candidate)
+    - name: Install Catalyst (stable)
+      if: ${{ inputs.catalyst == 'stable' }}
+      run: |
+        pip install pennylane-catalyst
+
+    - name: Install Catalyst (latest/release-candidate)
+      if: ${{ inputs.catalyst != 'stable' }}
       run: |
         CCACHE_DIR="$(pwd)/.ccache" \
         C_COMPILER=$(which gcc }}) \
@@ -156,6 +172,7 @@ jobs:
         pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.41.0-rc0
 
     - name: Add Frontend Dependencies to PATH
+      if: ${{ inputs.catalyst != 'stable' }}
       run: |
         echo "PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum" >> $GITHUB_ENV
         echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV


### PR DESCRIPTION
Bypasses the need to download caches from GitHub.

