### PR TITLE
Fix ubuntu24 compatability

### DIFF
--- a/.github/workflows/CPL_stable-stable-stable.yaml
+++ b/.github/workflows/CPL_stable-stable-stable.yaml
@@ -1,8 +1,8 @@
 name: Check CPL stable/stable/stable
 
 on:
-  # schedule:
-  #   - cron: "20 10 * * 1-5"
+  schedule:
+    - cron: "20 10 * * 1-5"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -13,16 +13,16 @@ on:
         required: true
         type: string
 
-# concurrency:
-#   group: ${{ github.workflow }}-${{ github.ref }}
-#   cancel-in-progress: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   constants:
     name: "Set build matrix"
     uses: ./.github/workflows/constants.yaml
-    # with:
-    #   use_release_tag: ${{ inputs.catalyst == 'stable' }}
+    with:
+      use_release_tag: ${{ inputs.catalyst == 'stable' }}
 
   check-config:
     name: Build Configuration
@@ -34,12 +34,12 @@ jobs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-    # - if: ${{ inputs.catalyst == 'stable' }}
-    #   run: |
-    #     git checkout $(git tag | sort -V | tail -1)
-    # - if: ${{ inputs.catalyst == 'release-candidate' }}
-    #   run: |
-    #     git checkout v0.11.0-rc
+    - if: ${{ inputs.catalyst == 'stable' }}
+      run: |
+        git checkout $(git tag | sort -V | tail -1)
+    - if: ${{ inputs.catalyst == 'release-candidate' }}
+      run: |
+        git checkout v0.11.0-rc
 
     - name: Set up Python # Ensure python3.10 is used
       uses: actions/setup-python@v5
@@ -110,7 +110,7 @@ jobs:
         make catalyst
 
     - name: Install PennyLane-Lightning (stable)
-      # if: ${{ inputs.lightning == 'stable' }}
+      if: ${{ inputs.lightning == 'stable' }}
       run: |
         pip install --no-deps --force pennylane-lightning
         pip install --no-deps --force pennyLane-lightning-kokkos
@@ -151,7 +151,7 @@ jobs:
         pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@master
 
     - name: Install PennyLane (stable)
-      # if: ${{ inputs.pennylane == 'stable' }}
+      if: ${{ inputs.pennylane == 'stable' }}
       run: |
         pip install --no-deps --force pennylane
 


### PR DESCRIPTION
**Context:**
The workflow `CPL stable/stable/stable / Build Configuration` is failing after the ubuntu-24.04 upgrade. The default version of python in ubuntu24 is 3.12, the [workflow fails](https://github.com/PennyLaneAI/catalyst/actions/runs/15464703564/job/43534000796) when it tries to grep python 3.10 because it doesn't exist/ 
**Description of the Change:**
Add `actions/setup-python@v5` to check pennylane compatability.
**Benefits:**
Python3.10 gets installed and the pipeline uses the correct python version.
**Possible Drawbacks:**
None
**Related GitHub Issues:**
