### PR TITLE
Improve keep_intermediate to enable keeping IR after each pass

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -95,6 +95,14 @@
   performance by eliminating indirect conversion.
   [(#1738)](https://github.com/PennyLaneAI/catalyst/pull/1738)
 
+* The `keep_intermediate` argument in the `qjit` decorator now accepts a new value that allows for
+  saving intermediate files after each pass. The updated possible options for this argument are:
+  * `False` or `0` or `"none"`: No intermediate files are kept.
+  * `True` or `1` or `"pipeline"`: Intermediate files are saved after each pipeline.
+  * `2` or `"pass"`: Intermediate files are saved after each pass.
+  The default value is `False`.
+  [(#1791)](https://github.com/PennyLaneAI/catalyst/pull/1791)
+
 <h3>Breaking changes 💔</h3>
 
 * (Device Developers Only) The `QuantumDevice` interface in the Catalyst Runtime plugin system

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -97,7 +97,7 @@
 
 * The `keep_intermediate` argument in the `qjit` decorator now accepts a new value that allows for
   saving intermediate files after each pass. The updated possible options for this argument are:
-  * `False` or `0` or `"none"`: No intermediate files are kept.
+  * `False` or `0` or `"none"` or `None` : No intermediate files are kept.
   * `True` or `1` or `"pipeline"`: Intermediate files are saved after each pipeline.
   * `2` or `"pass"`: Intermediate files are saved after each pass.
   The default value is `False`.

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -344,7 +344,7 @@ def _options_to_cli_flags(options):
 
     if options.keep_intermediate:
         extra_args += ["--keep-intermediate"]
-        
+
     if options.keep_intermediate >= KeepIntermediateLevel.PASS:
         extra_args += ["--save-ir-after-each=pass"]
 

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -342,7 +342,7 @@ def _options_to_cli_flags(options):
     if not options.lower_to_llvm:
         extra_args += [("--tool", "opt")]
 
-    if options.keep_intermediate >= KeepIntermediateLevel.BASIC:
+    if options.keep_intermediate >= KeepIntermediateLevel.PIPELINE:
         extra_args += ["--keep-intermediate"]
 
     if options.verbose:
@@ -351,7 +351,7 @@ def _options_to_cli_flags(options):
     if options.async_qnodes:  # pragma: nocover
         extra_args += ["--async-qnodes"]
 
-    if options.keep_intermediate >= KeepIntermediateLevel.DEBUG:
+    if options.keep_intermediate >= KeepIntermediateLevel.PASS:
         extra_args += ["--save-ir-after-each=pass"]
 
     return extra_args

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -342,17 +342,17 @@ def _options_to_cli_flags(options):
     if not options.lower_to_llvm:
         extra_args += [("--tool", "opt")]
 
-    if options.keep_intermediate >= KeepIntermediateLevel.PIPELINE:
+    if options.keep_intermediate:
         extra_args += ["--keep-intermediate"]
+        
+    if options.keep_intermediate >= KeepIntermediateLevel.PASS:
+        extra_args += ["--save-ir-after-each=pass"]
 
     if options.verbose:
         extra_args += ["--verbose"]
 
     if options.async_qnodes:  # pragma: nocover
         extra_args += ["--async-qnodes"]
-
-    if options.keep_intermediate >= KeepIntermediateLevel.PASS:
-        extra_args += ["--save-ir-after-each=pass"]
 
     return extra_args
 

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -29,7 +29,7 @@ from os import path
 from typing import List, Optional
 
 from catalyst.logging import debug_logger, debug_logger_init
-from catalyst.pipelines import CompileOptions
+from catalyst.pipelines import CompileOptions, KeepIntermediateLevel
 from catalyst.utils.exceptions import CompileError
 from catalyst.utils.filesystem import Directory
 from catalyst.utils.runtime_environment import get_cli_path, get_lib_path
@@ -342,7 +342,7 @@ def _options_to_cli_flags(options):
     if not options.lower_to_llvm:
         extra_args += [("--tool", "opt")]
 
-    if options.keep_intermediate:
+    if options.keep_intermediate >= KeepIntermediateLevel.BASIC:
         extra_args += ["--keep-intermediate"]
 
     if options.verbose:
@@ -350,6 +350,9 @@ def _options_to_cli_flags(options):
 
     if options.async_qnodes:  # pragma: nocover
         extra_args += ["--async-qnodes"]
+
+    if options.keep_intermediate >= KeepIntermediateLevel.DEBUG:
+        extra_args += ["--save-ir-after-each=pass"]
 
     return extra_args
 

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -118,10 +118,15 @@ def qjit(
         async_qnodes (bool): Experimental support for automatically executing
             QNodes asynchronously, if supported by the device runtime.
         target (str): the compilation target
-        keep_intermediate (bool): Whether or not to store the intermediate files throughout the
-            compilation. If ``True``, intermediate representations are available via the
-            :attr:`~.QJIT.mlir`, :attr:`~.QJIT.mlir_opt`, :attr:`~.QJIT.jaxpr`,
-            and :attr:`~.QJIT.qir`, representing different stages in the optimization process.
+        keep_intermediate (Union[str, int, bool]): Level controlling intermediate file generation.
+            - ``False`` or ``0`` or ``"none"`` (default): No intermediate files are kept.
+            - ``True`` or ``1`` or ``"basic"``: Standard intermediate files are kept.
+            - ``2`` or ``"debug"``: Standard intermediate files are kept, and IR is saved after each pass.
+            If enabled, intermediate representations are also available via the following attributes:
+            - :attr:`~.QJIT.jaxpr`: JAX program representation
+            - :attr:`~.QJIT.mlir`: MLIR representation after canonicalization
+            - :attr:`~.QJIT.mlir_opt`: MLIR representation after optimization
+            - :attr:`~.QJIT.qir`: QIR in LLVM IR form
         verbose (bool): If ``True``, the tools and flags used by Catalyst behind the scenes are
             printed out.
         logfile (Optional[TextIOWrapper]): File object to write verbose messages to (default -

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -119,7 +119,7 @@ def qjit(
             QNodes asynchronously, if supported by the device runtime.
         target (str): the compilation target
         keep_intermediate (Union[str, int, bool]): Level controlling intermediate file generation.
-            - ``False`` or ``0`` or ``"none"`` (default): No intermediate files are kept.
+            - ``False`` or ``0`` or ``"none"`` or ``None`` (default): No intermediate file is kept.
             - ``True`` or ``1`` or ``"pipeline"``: Intermediate files are saved after each pipeline.
             - ``2`` or ``"pass"``: Intermediate files are saved after each pass.
             If enabled, intermediate representations are available via the following attributes:

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -120,9 +120,8 @@ def qjit(
         target (str): the compilation target
         keep_intermediate (Union[str, int, bool]): Level controlling intermediate file generation.
             - ``False`` or ``0`` or ``"none"`` (default): No intermediate files are kept.
-            - ``True`` or ``1`` or ``"basic"``: Standard intermediate files are kept.
-            - ``2`` or ``"debug"``: Standard intermediate files are kept, and IR is saved after 
-            each pass.
+            - ``True`` or ``1`` or ``"pipeline"``: Intermediate files are saved after each pipeline.
+            - ``2`` or ``"pass"``: Intermediate files are saved after each pass.
             If enabled, intermediate representations are available via the following attributes:
             - :attr:`~.QJIT.jaxpr`: JAX program representation
             - :attr:`~.QJIT.mlir`: MLIR representation after canonicalization

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -121,8 +121,9 @@ def qjit(
         keep_intermediate (Union[str, int, bool]): Level controlling intermediate file generation.
             - ``False`` or ``0`` or ``"none"`` (default): No intermediate files are kept.
             - ``True`` or ``1`` or ``"basic"``: Standard intermediate files are kept.
-            - ``2`` or ``"debug"``: Standard intermediate files are kept, and IR is saved after each pass.
-            If enabled, intermediate representations are also available via the following attributes:
+            - ``2`` or ``"debug"``: Standard intermediate files are kept, and IR is saved after 
+            each pass.
+            If enabled, intermediate representations are available via the following attributes:
             - :attr:`~.QJIT.jaxpr`: JAX program representation
             - :attr:`~.QJIT.mlir`: MLIR representation after canonicalization
             - :attr:`~.QJIT.mlir_opt`: MLIR representation after optimization

--- a/frontend/catalyst/pipelines.py
+++ b/frontend/catalyst/pipelines.py
@@ -47,10 +47,12 @@ class KeepIntermediateLevel(enum.IntEnum):
 
 
 def _parse_keep_intermediate(
-    level: Union[str, int, bool, KeepIntermediateLevel, None]
+    level: Union[str, int, bool, KeepIntermediateLevel, None],
 ) -> KeepIntermediateLevel:
     """Parse the keep_intermediate value into a KeepIntermediateLevel enum."""
-    if level is None:
+    if isinstance(level, KeepIntermediateLevel):
+        return level
+    elif level is None:
         return KeepIntermediateLevel.NONE
     elif isinstance(level, bool):
         return KeepIntermediateLevel.PIPELINE if level else KeepIntermediateLevel.NONE
@@ -69,8 +71,7 @@ def _parse_keep_intermediate(
                 f"Invalid string for keep_intermediate: {level}. "
                 "Valid strings are 'none', 'pipeline', 'pass'."
             ) from e
-    elif not isinstance(level, KeepIntermediateLevel):
-        raise TypeError(f"Invalid type for keep_intermediate: {type(level)}.")
+    raise TypeError(f"Invalid type for keep_intermediate: {type(level)}.")
 
 
 # pylint: disable=too-many-instance-attributes
@@ -83,7 +84,7 @@ class CompileOptions:
             Default is ``False``
         logfile (Optional[TextIOWrapper]): the logfile to write output to.
             Default is ``sys.stderr``
-        keep_intermediate (Optional[Union[str, int, bool]]): Level controlling intermediate file 
+        keep_intermediate (Optional[Union[str, int, bool]]): Level controlling intermediate file
         generation.
             - ``False`` or ``0`` or ``"none"`` (default): No intermediate files are kept.
             - ``True`` or ``1`` or ``"pipeline"``: Intermediate files are saved after each pipeline.

--- a/frontend/catalyst/pipelines.py
+++ b/frontend/catalyst/pipelines.py
@@ -47,13 +47,13 @@ class KeepIntermediateLevel(enum.IntEnum):
 
 
 def _parse_keep_intermediate(
-    level: Union[str, int, bool],
+    level: Union[str, int, bool, None],
 ) -> KeepIntermediateLevel:
     """Parse the keep_intermediate value into a KeepIntermediateLevel enum."""
     match level:
         case 0 | 1 | 2:
             return KeepIntermediateLevel(level)
-        case "none":
+        case "none" | None:
             return KeepIntermediateLevel.NONE
         case "pipeline":
             return KeepIntermediateLevel.PIPELINE

--- a/frontend/catalyst/pipelines.py
+++ b/frontend/catalyst/pipelines.py
@@ -56,10 +56,12 @@ class CompileOptions:
             Default is ``False``
         logfile (Optional[TextIOWrapper]): the logfile to write output to.
             Default is ``sys.stderr``
-        keep_intermediate (Optional[Union[str, int, bool]]): Level controlling intermediate file generation.
+        keep_intermediate (Optional[Union[str, int, bool]]): Level controlling intermediate file 
+        generation.
             - ``False`` or ``0`` or ``"none"`` (default): No intermediate files are kept.
             - ``True`` or ``1`` or ``"basic"``: Standard intermediate files are kept.
-            - ``2`` or ``"debug"``: Standard intermediate files are kept, and IR is saved after each pass.
+            - ``2`` or ``"debug"``: Standard intermediate files are kept, and IR is saved after 
+            each pass.
         pipelines (Optional[List[Tuple[str,List[str]]]]): A list of tuples. The first entry of the
             tuple corresponds to the name of a pipeline. The second entry of the tuple corresponds
             to a list of MLIR passes.

--- a/frontend/catalyst/pipelines.py
+++ b/frontend/catalyst/pipelines.py
@@ -47,31 +47,23 @@ class KeepIntermediateLevel(enum.IntEnum):
 
 
 def _parse_keep_intermediate(
-    level: Union[str, int, bool, KeepIntermediateLevel, None],
+    level: Union[str, int, bool],
 ) -> KeepIntermediateLevel:
     """Parse the keep_intermediate value into a KeepIntermediateLevel enum."""
-    if isinstance(level, KeepIntermediateLevel):
-        return level
-    elif level is None:
-        return KeepIntermediateLevel.NONE
-    elif isinstance(level, bool):
-        return KeepIntermediateLevel.PIPELINE if level else KeepIntermediateLevel.NONE
-    elif isinstance(level, int):
-        try:
+    match level:
+        case 0 | 1 | 2:
             return KeepIntermediateLevel(level)
-        except ValueError as e:
+        case "none":
+            return KeepIntermediateLevel.NONE
+        case "pipeline":
+            return KeepIntermediateLevel.PIPELINE
+        case "pass":
+            return KeepIntermediateLevel.PASS
+        case _:
             raise ValueError(
-                f"Invalid int for keep_intermediate: {level}. " "Valid integers are 0, 1, 2."
-            ) from e
-    elif isinstance(level, str):
-        try:
-            return KeepIntermediateLevel[level.upper()]
-        except KeyError as e:
-            raise ValueError(
-                f"Invalid string for keep_intermediate: {level}. "
-                "Valid strings are 'none', 'pipeline', 'pass'."
-            ) from e
-    raise TypeError(f"Invalid type for keep_intermediate: {type(level)}.")
+                f"Invalid value for keep_intermediate: {level}. "
+                "Valid values are True, False, 0, 1, 2, 'none', 'pipeline', 'pass'."
+            )
 
 
 # pylint: disable=too-many-instance-attributes

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -96,6 +96,7 @@ class TestCompilerOptions:
     @pytest.mark.parametrize(
         "input_value, expected_level",
         [
+            (None, KeepIntermediateLevel.NONE),
             (False, KeepIntermediateLevel.NONE),
             (True, KeepIntermediateLevel.PIPELINE),
             (0, KeepIntermediateLevel.NONE),
@@ -130,7 +131,6 @@ class TestCompilerOptions:
         flags = _options_to_cli_flags(options)
         assert "--keep-intermediate" in flags
         assert "--save-ir-after-each=pass" not in flags
-        assert flags.count("--save-ir-after-each=pass") <= 1
 
     def test_options_to_cli_flags_keep_intermediate_debug(self):
         """Test _options_to_cli_flags with KeepIntermediateLevel.PASS."""
@@ -138,7 +138,6 @@ class TestCompilerOptions:
         flags = _options_to_cli_flags(options)
         assert "--keep-intermediate" in flags
         assert "--save-ir-after-each=pass" in flags
-        assert flags.count("--save-ir-after-each=pass") == 1
 
 
 class TestCompilerWarnings:

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -126,7 +126,7 @@ class TestCompilerOptions:
             (
                 "invalid_string",
                 ValueError,
-                "Invalid string for keep_intermediate: invalid_string. Valid strings are 'none', 'basic', 'debug'.",
+                "Invalid string for keep_intermediate: Valid strings are 'none', 'basic', 'debug'.",
             ),
             (3.0, TypeError, "Invalid type for keep_intermediate: <class 'float'>."),
             ([], TypeError, "Invalid type for keep_intermediate: <class 'list'>."),

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -98,19 +98,19 @@ class TestCompilerOptions:
         [
             (None, KeepIntermediateLevel.NONE),
             (False, KeepIntermediateLevel.NONE),
-            (True, KeepIntermediateLevel.BASIC),
+            (True, KeepIntermediateLevel.PIPELINE),
             (0, KeepIntermediateLevel.NONE),
-            (1, KeepIntermediateLevel.BASIC),
-            (2, KeepIntermediateLevel.DEBUG),
+            (1, KeepIntermediateLevel.PIPELINE),
+            (2, KeepIntermediateLevel.PASS),
             ("none", KeepIntermediateLevel.NONE),
             ("NONE", KeepIntermediateLevel.NONE),
-            ("basic", KeepIntermediateLevel.BASIC),
-            ("BASIC", KeepIntermediateLevel.BASIC),
-            ("debug", KeepIntermediateLevel.DEBUG),
-            ("DEBUG", KeepIntermediateLevel.DEBUG),
+            ("pipeline", KeepIntermediateLevel.PIPELINE),
+            ("PIPELINE", KeepIntermediateLevel.PIPELINE),
+            ("pass", KeepIntermediateLevel.PASS),
+            ("PASS", KeepIntermediateLevel.PASS),
             (KeepIntermediateLevel.NONE, KeepIntermediateLevel.NONE),
-            (KeepIntermediateLevel.BASIC, KeepIntermediateLevel.BASIC),
-            (KeepIntermediateLevel.DEBUG, KeepIntermediateLevel.DEBUG),
+            (KeepIntermediateLevel.PIPELINE, KeepIntermediateLevel.PIPELINE),
+            (KeepIntermediateLevel.PASS, KeepIntermediateLevel.PASS),
         ],
     )
     def test_keep_intermediate_levels_conversion(self, input_value, expected_level):
@@ -126,7 +126,8 @@ class TestCompilerOptions:
             (
                 "invalid_string",
                 ValueError,
-                "Invalid string for keep_intermediate: Valid strings are 'none', 'basic', 'debug'.",
+                "Invalid string for keep_intermediate: invalid_string. Valid strings are 'none',"
+                " 'pipeline', 'pass'.",
             ),
             (3.0, TypeError, "Invalid type for keep_intermediate: <class 'float'>."),
             ([], TypeError, "Invalid type for keep_intermediate: <class 'list'>."),
@@ -145,16 +146,16 @@ class TestCompilerOptions:
         assert "--save-ir-after-each=pass" not in flags
 
     def test_options_to_cli_flags_keep_intermediate_basic(self):
-        """Test _options_to_cli_flags with KeepIntermediateLevel.BASIC."""
-        options = CompileOptions(keep_intermediate=KeepIntermediateLevel.BASIC)
+        """Test _options_to_cli_flags with KeepIntermediateLevel.PIPELINE."""
+        options = CompileOptions(keep_intermediate=KeepIntermediateLevel.PIPELINE)
         flags = _options_to_cli_flags(options)
         assert "--keep-intermediate" in flags
         assert "--save-ir-after-each=pass" not in flags
         assert flags.count("--save-ir-after-each=pass") <= 1
 
     def test_options_to_cli_flags_keep_intermediate_debug(self):
-        """Test _options_to_cli_flags with KeepIntermediateLevel.DEBUG."""
-        options = CompileOptions(keep_intermediate=KeepIntermediateLevel.DEBUG)
+        """Test _options_to_cli_flags with KeepIntermediateLevel.PASS."""
+        options = CompileOptions(keep_intermediate=KeepIntermediateLevel.PASS)
         flags = _options_to_cli_flags(options)
         assert "--keep-intermediate" in flags
         assert "--save-ir-after-each=pass" in flags

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -96,21 +96,14 @@ class TestCompilerOptions:
     @pytest.mark.parametrize(
         "input_value, expected_level",
         [
-            (None, KeepIntermediateLevel.NONE),
             (False, KeepIntermediateLevel.NONE),
             (True, KeepIntermediateLevel.PIPELINE),
             (0, KeepIntermediateLevel.NONE),
             (1, KeepIntermediateLevel.PIPELINE),
             (2, KeepIntermediateLevel.PASS),
             ("none", KeepIntermediateLevel.NONE),
-            ("NONE", KeepIntermediateLevel.NONE),
             ("pipeline", KeepIntermediateLevel.PIPELINE),
-            ("PIPELINE", KeepIntermediateLevel.PIPELINE),
             ("pass", KeepIntermediateLevel.PASS),
-            ("PASS", KeepIntermediateLevel.PASS),
-            (KeepIntermediateLevel.NONE, KeepIntermediateLevel.NONE),
-            (KeepIntermediateLevel.PIPELINE, KeepIntermediateLevel.PIPELINE),
-            (KeepIntermediateLevel.PASS, KeepIntermediateLevel.PASS),
         ],
     )
     def test_keep_intermediate_levels_conversion(self, input_value, expected_level):
@@ -118,24 +111,10 @@ class TestCompilerOptions:
         options = CompileOptions(keep_intermediate=input_value)
         assert options.keep_intermediate == expected_level
 
-    @pytest.mark.parametrize(
-        "invalid_input, error_type, error_match",
-        [
-            (3, ValueError, "Invalid int for keep_intermediate: 3. Valid integers are 0, 1, 2."),
-            (-1, ValueError, "Invalid int for keep_intermediate: -1. Valid integers are 0, 1, 2."),
-            (
-                "invalid_string",
-                ValueError,
-                "Invalid string for keep_intermediate: invalid_string. Valid strings are 'none',"
-                " 'pipeline', 'pass'.",
-            ),
-            (3.0, TypeError, "Invalid type for keep_intermediate: <class 'float'>."),
-            ([], TypeError, "Invalid type for keep_intermediate: <class 'list'>."),
-        ],
-    )
-    def test_keep_intermediate_invalid_inputs(self, invalid_input, error_type, error_match):
+    @pytest.mark.parametrize("invalid_input", [3, -1, "invalid_string", 3.0, []])
+    def test_keep_intermediate_invalid_inputs(self, invalid_input):
         """Test that invalid inputs for keep_intermediate raise appropriate errors."""
-        with pytest.raises(error_type, match=error_match):
+        with pytest.raises(ValueError, match=f"Invalid value for keep_intermediate: "):
             CompileOptions(keep_intermediate=invalid_input)
 
     def test_options_to_cli_flags_keep_intermediate_none(self):

--- a/frontend/test/pytest/test_compiler.py
+++ b/frontend/test/pytest/test_compiler.py
@@ -114,7 +114,7 @@ class TestCompilerOptions:
     @pytest.mark.parametrize("invalid_input", [3, -1, "invalid_string", 3.0, []])
     def test_keep_intermediate_invalid_inputs(self, invalid_input):
         """Test that invalid inputs for keep_intermediate raise appropriate errors."""
-        with pytest.raises(ValueError, match=f"Invalid value for keep_intermediate: "):
+        with pytest.raises(ValueError, match="Invalid value for keep_intermediate:"):
             CompileOptions(keep_intermediate=invalid_input)
 
     def test_options_to_cli_flags_keep_intermediate_none(self):


### PR DESCRIPTION
**Context:**
`keep_intermediate` is a boolean flag that if enabled, keeps the intermediate IR files after each pipeline. However, it is quite common that a developer needs the IR after a specific pass, which is not accessible in the current format via `keep_intermediate`.

**Description of the Change:**
Added a third level to the `keep_intermediate` that enables accessing the IR in a more fine grained format i.e. after each pass. 
Note that this is not a breaking change, meaning that the current behaviour of `keep_intermediate` is kept intact. 
With this PR, the user can provide three different levels of printing:
- `False` or `0` or `"none"` (default): No intermediate files are kept.
- `True` or `1` or `"basic"`: Standard intermediate files are kept (IR after each pipeline).
- `2` or `"debug"`: Standard intermediate files are kept, and IR is saved after each pass.


**Benefits:**
easier development and debugging

**Possible Drawbacks:**

**Related GitHub Issues:**
