### PR TITLE
Add primitive and operation for num_qubits runtime stub

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -305,9 +305,6 @@
   target gate set.
   [(#1763)](https://github.com/PennyLaneAI/catalyst/pull/1763)
 
-* Upgraded action runners from Ubuntu22.04 to Ubuntu24.04.
-  [(#1728)](https://github.com/PennyLaneAI/catalyst/pull/1728)
-
 * The runtime CAPI function `__catalyst__rt__num_qubits` now has a corresponding jax primitive
   `num_qubits_p` and quantum dialect operation `NumQubitsOp`.
   [(#1793)](https://github.com/PennyLaneAI/catalyst/pull/1793)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -305,7 +305,15 @@
   target gate set.
   [(#1763)](https://github.com/PennyLaneAI/catalyst/pull/1763)
 
-* Upgraded action runners from Ubuntu22.04 to Ubuntu24.04. [(#1728)](https://github.com/PennyLaneAI/catalyst/pull/1728)
+* Upgraded action runners from Ubuntu22.04 to Ubuntu24.04.
+  [(#1728)](https://github.com/PennyLaneAI/catalyst/pull/1728)
+
+* The runtime CAPI function `__catalyst__rt__num_qubits` now has a corresponding jax primitive
+  `num_qubits_p` and quantum dialect operation `NumQubitsOp`.
+  [(#1793)](https://github.com/PennyLaneAI/catalyst/pull/1793)
+
+  For measurements whose shapes depend on the number of qubits, they now properly retrieve the
+  number of qubits through this new operation when it is dynamic.
 
 <h3>Documentation 📝</h3>
 

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -83,6 +83,7 @@ from mlir_quantum.dialects.quantum import (
     MeasureOp,
     MultiRZOp,
     NamedObsOp,
+    NumQubitsOp,
     ProbsOp,
     QubitUnitaryOp,
     SampleOp,
@@ -247,6 +248,7 @@ device_init_p = Primitive("device_init")
 device_init_p.multiple_results = True
 device_release_p = Primitive("device_release")
 device_release_p.multiple_results = True
+num_qubits_p = Primitive("num_qubits")
 qalloc_p = Primitive("qalloc")
 qdealloc_p = Primitive("qdealloc")
 qdealloc_p.multiple_results = True
@@ -843,6 +845,31 @@ def _device_release_abstract_eval():
 def _device_release_lowering(jax_ctx: mlir.LoweringRuleContext):
     DeviceReleaseOp()  # end of qnode
     return ()
+
+
+#
+# num_qubits_p
+#
+@num_qubits_p.def_impl
+def _num_qubits_def_impl(ctx):  # pragma: no cover
+    raise NotImplementedError()
+
+
+@num_qubits_p.def_abstract_eval
+def _num_qubits_abstract_eval():
+    return core.ShapedArray((), jax.numpy.int64)
+
+
+def _num_qubits_lowering(jax_ctx: mlir.LoweringRuleContext):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    result_type = ir.IntegerType.get_signless(64, ctx)
+    nqubits = NumQubitsOp(result_type).result
+
+    result_from_elements_op = ir.RankedTensorType.get((), result_type)
+    from_elements_op = FromElementsOp(result_from_elements_op, nqubits)
+    return from_elements_op.results
 
 
 #
@@ -2313,6 +2340,7 @@ CUSTOM_LOWERING_RULES = (
     (qextract_p, _qextract_lowering),
     (qinsert_p, _qinsert_lowering),
     (qinst_p, _qinst_lowering),
+    (num_qubits_p, _num_qubits_lowering),
     (gphase_p, _gphase_lowering),
     (unitary_p, _unitary_lowering),
     (measure_p, _measure_lowering),

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -850,11 +850,6 @@ def _device_release_lowering(jax_ctx: mlir.LoweringRuleContext):
 #
 # num_qubits_p
 #
-@num_qubits_p.def_impl
-def _num_qubits_def_impl(ctx):  # pragma: no cover
-    raise NotImplementedError()
-
-
 @num_qubits_p.def_abstract_eval
 def _num_qubits_abstract_eval():
     return core.ShapedArray((), jax.numpy.int64)

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -86,6 +86,7 @@ from catalyst.jax_primitives import (
     hamiltonian_p,
     hermitian_p,
     namedobs_p,
+    num_qubits_p,
     probs_p,
     qalloc_p,
     qdealloc_p,
@@ -985,7 +986,8 @@ def trace_quantum_measurements(
                 )
 
             d_wires = (
-                device.wires[0]
+                # device.wires[0]
+                num_qubits_p.bind()
                 if catalyst.device.qjit_device.is_dynamic_wires(device.wires)
                 else len(device.wires)
             )

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -986,7 +986,6 @@ def trace_quantum_measurements(
                 )
 
             d_wires = (
-                # device.wires[0]
                 num_qubits_p.bind()
                 if catalyst.device.qjit_device.is_dynamic_wires(device.wires)
                 else len(device.wires)

--- a/frontend/test/lit/test_measurements.py
+++ b/frontend/test/lit/test_measurements.py
@@ -141,9 +141,9 @@ print(test_sample_dynamic.mlir)
 def sample_dynamic_qubits(num_qubits):
     @qml.qnode(qml.device("lightning.qubit", wires=num_qubits, shots=37))
     def circ():
+        # CHECK: [[nqubits:%.+]] = quantum.num_qubits : i64
         # CHECK: quantum.compbasis
-        # CHECK: [[deTen:%.+]] = tensor.extract %arg0[] : tensor<i64>
-        # CHECK: {{%.+}} = quantum.sample {{%.+}} shape [[deTen]] : tensor<37x?xf64>
+        # CHECK: {{%.+}} = quantum.sample {{%.+}} shape [[nqubits]] : tensor<37x?xf64>
         return qml.sample()
 
     return circ()
@@ -243,7 +243,9 @@ def counts_dynamic_qubits(num_qubits):
     @qml.qnode(qml.device("lightning.qubit", wires=num_qubits, shots=37))
     def circ():
         # CHECK: [[one:%.+]] = stablehlo.constant dense<1> : tensor<i64>
-        # CHECK: [[shape:%.+]] = stablehlo.shift_left [[one]], %arg0 : tensor<i64>
+        # CHECK: [[nqubits:%.+]] = quantum.num_qubits : i64
+        # CHECK: [[toTen:%.+]] = tensor.from_elements [[nqubits]] : tensor<i64>
+        # CHECK: [[shape:%.+]] = stablehlo.shift_left [[one]], [[toTen]] : tensor<i64>
         # CHECK: [[deTen:%.+]] = tensor.extract [[shape]][] : tensor<i64>
         # CHECK: {{%.+}}, {{%.+}} = quantum.counts {{%.+}} shape [[deTen]] : tensor<?xf64>, tensor<?xi64>
         return qml.counts()
@@ -619,7 +621,9 @@ def probs_dynamic_without_wires(num_qubits):
     @qml.qnode(qml.device("lightning.qubit", wires=num_qubits))
     def circ():
         # CHECK: [[one:%.+]] = stablehlo.constant dense<1> : tensor<i64>
-        # CHECK: [[shape:%.+]] = stablehlo.shift_left [[one]], %arg0 : tensor<i64>
+        # CHECK: [[nqubits:%.+]] = quantum.num_qubits : i64
+        # CHECK: [[toTen:%.+]] = tensor.from_elements [[nqubits]] : tensor<i64>
+        # CHECK: [[shape:%.+]] = stablehlo.shift_left [[one]], [[toTen]] : tensor<i64>
         # CHECK: [[deTen:%.+]] = tensor.extract [[shape]][] : tensor<i64>
         # CHECK: {{%.+}} = quantum.probs {{%.+}} shape [[deTen]] : tensor<?xf64>
         return qml.probs()
@@ -662,7 +666,9 @@ def state_dynamic(num_qubits):
     @qml.qnode(qml.device("lightning.qubit", wires=num_qubits))
     def circ():
         # CHECK: [[one:%.+]] = stablehlo.constant dense<1> : tensor<i64>
-        # CHECK: [[shape:%.+]] = stablehlo.shift_left [[one]], %arg0 : tensor<i64>
+        # CHECK: [[nqubits:%.+]] = quantum.num_qubits : i64
+        # CHECK: [[toTen:%.+]] = tensor.from_elements [[nqubits]] : tensor<i64>
+        # CHECK: [[shape:%.+]] = stablehlo.shift_left [[one]], [[toTen]] : tensor<i64>
         # CHECK: [[deTen:%.+]] = tensor.extract [[shape]][] : tensor<i64>
         # CHECK: {{%.+}} = quantum.state {{%.+}} shape [[deTen]] : tensor<?xcomplex<f64>>
         return qml.state()

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -100,6 +100,18 @@ def DeviceReleaseOp : Quantum_Op<"device_release"> {
     }];
 }
 
+def NumQubitsOp : Quantum_Op<"num_qubits"> {
+    let summary = "Get the number of currently allocated qubits.";
+
+    let results = (outs
+        I64:$num_qubits
+    );
+
+    let assemblyFormat = [{
+        attr-dict `:` type(results)
+    }];
+}
+
 // -----
 
 class Memory_Op<string mnemonic, list<Trait> traits = []> : Quantum_Op<mnemonic, traits>;

--- a/mlir/test/Quantum/ConversionTest.mlir
+++ b/mlir/test/Quantum/ConversionTest.mlir
@@ -90,6 +90,17 @@ func.func @device() {
 
 // -----
 
+// CHECK: llvm.func @__catalyst__rt__num_qubits()
+
+// CHECK-LABEL: @num_qubits
+func.func @num_qubits() {
+    // CHECK: {{%.+}} = llvm.call @__catalyst__rt__num_qubits() : () -> i64
+    %0 = quantum.num_qubits : i64
+    return
+}
+
+// -----
+
 ///////////////////////
 // Memory Management //
 ///////////////////////


### PR DESCRIPTION
**Context:**
There is [a helper function in the runtime](https://github.com/PennyLaneAI/catalyst/blob/2bc8d7acaa1d4a57cd91c985ab34bb7d6816035e/runtime/lib/capi/RuntimeCAPI.cpp#L393) that gets the number of allocated qubits:
```C
int64_t __catalyst__rt__num_qubits()
{
    return static_cast<int64_t>(getQuantumDevicePtr()->GetNumQubits());
}
```
The device function `GetNumQubits()` just returns the number of allocated qubits. This is now guaranteed now that we have the device API properly documented for device implementors in #1680 !

This was meant to be a convenience helper function. However, with more and more dynamic qubit work coming up, the ability to have an SSA value for the dynamic number of qubits in the IR will be helpful (e.g. for bufferizing measurement ops whose result shapes depend on the number of qubits, etc.)

**Description of the Change:**
- Add corresponding primitive and operation for the runtime stub `__catalyst__rt__num_qubits`.
- Qubit-invariant compilation retrieves number of qubits through this new primitive, instead of hacking its way by taking the tracer on the pennylane `Wires` object's zeroth entry (which is only there due to an accidental implementation detail). This has two advantages:
  - less hacky
  - more testing coverage for the new num_qubits primitive and operation!

**Benefits:**
An SSA variable will be available in the IR for the number of qubits anytime and anywhere.
This will also enable automatic qubit management, since there by definition we don't know the number of qubits until we are in runtime.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
[sc-86500]
