### PR TITLE
Fix a failing test on latest/latest due to a new PL gate metadata

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -10,7 +10,7 @@ enzyme=v0.0.180
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt
-pennylane=0.42.0-dev33
+pennylane=0.42.0-dev48
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -33,4 +33,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.42.0-dev16
 pennylane-lightning==0.42.0-dev16
-pennylane==0.42.0-dev33
+pennylane==0.42.0-dev48

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -850,6 +850,10 @@ class TestControlledMiscMethods:
         control_wires = qml.wires.Wires((1, 2))
         control_values = (False, False)  # (0, 0)
         work_wires = qml.wires.Wires(3)
+        # A work_wire_type will be kept until dynamic qubit allocation is supported in PL
+        # Default value is "dirty"
+        # https://github.com/PennyLaneAI/pennylane/pull/7612
+        work_wire_type = "dirty"
 
         op = C_ctrl(target, control_wires, control_values=control_values, work_wires=work_wires)
 
@@ -857,10 +861,11 @@ class TestControlledMiscMethods:
         assert data[0] is target
         assert len(data) == 1
 
-        assert len(metadata) == 3
+        assert len(metadata) == 4
         assert metadata[0] == control_wires
         assert metadata[1] == control_values
         assert metadata[2] == work_wires
+        assert metadata[3] == work_wire_type
 
         assert hash(metadata)
 


### PR DESCRIPTION
**Context:**
PL added a new metadata to controlled gates https://github.com/PennyLaneAI/pennylane/pull/7612
We thus need to update our tests that check for the number of metadata.

**Benefits:**
latest/latest does not fail

