### PR TITLE
Fix pass decorator order

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -219,7 +219,7 @@
   [(#1768)](https://github.com/PennyLaneAI/catalyst/pull/1768)
 
 * Stacked python decorators for built-in catalyst passes are now applied in the correct order.
-  [(#???)](https://github.com/PennyLaneAI/catalyst/pull/???)
+  [(#1798)](https://github.com/PennyLaneAI/catalyst/pull/1798)
 
 <h3>Internal changes ⚙️</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -218,6 +218,9 @@
 * `make all` now correctly compiles the standalone plugin with the same compiler used to compile LLVM and MLIR.
   [(#1768)](https://github.com/PennyLaneAI/catalyst/pull/1768)
 
+* Stacked python decorators for built-in catalyst passes are now applied in the correct order.
+  [(#???)](https://github.com/PennyLaneAI/catalyst/pull/???)
+
 <h3>Internal changes ⚙️</h3>
 
 * `null.qubit` can now support an optional `track_resources` argument which allows it to record which gates are executed.

--- a/frontend/catalyst/passes/pass_api.py
+++ b/frontend/catalyst/passes/pass_api.py
@@ -72,8 +72,11 @@ class PassPipelineWrapper(QNodeWrapper):
     def __call__(self, *args, **kwargs):
         if EvaluationContext.is_tracing():
             pass_pipeline = kwargs.pop("pass_pipeline", [])
-            pass_pipeline += dictionary_to_list_of_passes(
-                self.pass_name_or_pipeline, *self.flags, **self.valued_options
+            pass_pipeline = (
+                dictionary_to_list_of_passes(
+                    self.pass_name_or_pipeline, *self.flags, **self.valued_options
+                )
+                + pass_pipeline
             )
             kwargs["pass_pipeline"] = pass_pipeline
         return super().__call__(*args, **kwargs)

--- a/frontend/test/lit/test_peephole_optimizations.py
+++ b/frontend/test/lit/test_peephole_optimizations.py
@@ -278,10 +278,10 @@ def test_chained_pipeline_lowering():
     """
     pipeline1 = {
         "cancel_inverses": {},
-        "merge_rotations": {},
     }
     pipeline2 = {
         "cancel_inverses": {},
+        "merge_rotations": {},
     }
 
     @qjit()
@@ -343,8 +343,8 @@ def test_chained_pipeline_lowering_keep_original():
     # COM: The qnode after pipeline2
     # CHECK: transform.named_sequence @__transform_main
     # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "remove-chained-self-inverse" to {{%.+}}
-    # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "remove-chained-self-inverse" to {{%.+}}
     # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "merge-rotations" to {{%.+}}
+    # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "remove-chained-self-inverse" to {{%.+}}
     # CHECK-NEXT: transform.yield
     print(test_chained_pipeline_lowering_keep_original_workflow.mlir)
 
@@ -358,8 +358,8 @@ def test_chained_apply_passes():
     """
 
     @qjit()
-    @apply_pass("remove-chained-self-inverse")
     @apply_pass("merge-rotations")
+    @apply_pass("remove-chained-self-inverse")
     @qml.qnode(qml.device("lightning.qubit", wires=2))
     def test_chained_apply_passes_workflow(x: float):
         qml.Hadamard(wires=[1])
@@ -406,8 +406,8 @@ def test_chained_apply_passes_keep_original():
     # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "remove-chained-self-inverse" to {{%.+}}
     # COM: The qnode after merge_rotations
     # CHECK: transform.named_sequence @__transform_main
-    # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "merge-rotations" to {{%.+}}
     # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "remove-chained-self-inverse" to {{%.+}}
+    # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "merge-rotations" to {{%.+}}
     # CHECK-NEXT: transform.yield
     print(test_chained_apply_passes_keep_original_workflow.mlir)
 
@@ -421,8 +421,8 @@ def test_chained_peephole_passes():
     """
 
     @qjit()
-    @cancel_inverses
     @merge_rotations
+    @cancel_inverses
     @qml.qnode(qml.device("lightning.qubit", wires=2))
     def test_chained_peephole_passes_workflow(x: float):
         qml.Hadamard(wires=[1])
@@ -469,8 +469,8 @@ def test_chained_peephole_passes_keep_original():
     # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "remove-chained-self-inverse" to {{%.+}}
     # COM: The qnode after merge_rotations
     # CHECK: transform.named_sequence @__transform_main
-    # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "merge-rotations" to {{%.+}}
     # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "remove-chained-self-inverse" to {{%.+}}
+    # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "merge-rotations" to {{%.+}}
     # CHECK-NEXT: transform.yield
     print(test_chained_peephole_passes_keep_original_workflow.mlir)
 
@@ -569,8 +569,8 @@ def test_stacked_pass_for_loop_autograph():
     # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "remove-chained-self-inverse" to {{%.+}}
     # CHECK-NEXT: {{%.+}} = transform.apply_registered_pass "merge-rotations" to {{%.+}}
     # CHECK-NEXT: transform.yield
-    @cancel_inverses
     @merge_rotations
+    @cancel_inverses
     @qml.qnode(qml.device("null.qubit", wires=1))
     def circuit(n_iter: int):
         for _ in range(n_iter):

--- a/frontend/test/lit/test_ppr_ppm.py
+++ b/frontend/test/lit/test_ppr_ppm.py
@@ -60,8 +60,8 @@ def test_commute_ppr():
     pipe = [("pipe", ["enforce-runtime-invariants-pipeline"])]
 
     @qjit(pipelines=pipe, target="mlir")
-    @to_ppr
     @commute_ppr
+    @to_ppr
     @qml.qnode(qml.device("null.qubit", wires=2))
     def cir_commute_ppr():
         qml.H(0)
@@ -91,8 +91,8 @@ def test_commute_ppr_max_pauli_size():
     pipe = [("pipe", ["enforce-runtime-invariants-pipeline"])]
 
     @qjit(pipelines=pipe, target="mlir")
-    @to_ppr
     @commute_ppr(max_pauli_size=2)
+    @to_ppr
     @qml.qnode(qml.device("null.qubit", wires=2))
     def cir_commute_ppr_max_pauli_size():
         qml.CNOT([0, 2])
@@ -122,8 +122,8 @@ def test_merge_ppr_ppm():
     pipe = [("pipe", ["enforce-runtime-invariants-pipeline"])]
 
     @qjit(pipelines=pipe, target="mlir")
-    @to_ppr
     @merge_ppr_ppm
+    @to_ppr
     @qml.qnode(qml.device("null.qubit", wires=2))
     def cir_merge_ppr_ppm():
         qml.H(0)
@@ -150,8 +150,8 @@ def test_merge_ppr_ppm_max_pauli_size():
     pipe = [("pipe", ["enforce-runtime-invariants-pipeline"])]
 
     @qjit(pipelines=pipe, target="mlir")
-    @to_ppr
     @merge_ppr_ppm(max_pauli_size=1)
+    @to_ppr
     @qml.qnode(qml.device("null.qubit", wires=2))
     def cir_merge_ppr_ppm_max_pauli_size():
         qml.CNOT([0, 2])
@@ -182,14 +182,14 @@ def test_ppr_to_ppm():
     @qjit(pipelines=pipe, target="mlir")
     def circuit_ppr_to_ppm():
 
-        @to_ppr
         @ppr_to_ppm
+        @to_ppr
         @qml.qnode(device)
         def cir_default():
             qml.S(0)
 
-        @to_ppr
         @ppr_to_ppm(decompose_method="clifford-corrected", avoid_y_measure=True)
+        @to_ppr
         @qml.qnode(device)
         def cir_inject_magic_state():
             qml.T(0)

--- a/frontend/test/pytest/test_peephole_optimizations.py
+++ b/frontend/test/pytest/test_peephole_optimizations.py
@@ -173,8 +173,8 @@ def test_chained_passes():
     """
 
     @qjit()
-    @cancel_inverses
     @merge_rotations
+    @cancel_inverses
     @qml.qnode(qml.device("lightning.qubit", wires=2))
     def test_chained_apply_passes_workflow(x: float):
         qml.Hadamard(wires=[1])
@@ -217,8 +217,8 @@ def test_commute_ppr():
     @qjit(pipelines=pipe, target="mlir")
     def test_commute_ppr_workflow():
 
-        @to_ppr
         @commute_ppr
+        @to_ppr
         @qml.qnode(qml.device("lightning.qubit", wires=2))
         def f():
             qml.H(0)
@@ -243,8 +243,8 @@ def test_merge_ppr_ppm():
     @qjit(pipelines=pipe, target="mlir")
     def test_merge_ppr_ppm_workflow():
 
-        @to_ppr
         @merge_ppr_ppm
+        @to_ppr
         @qml.qnode(qml.device("lightning.qubit", wires=2))
         def f():
             qml.H(0)
@@ -268,8 +268,8 @@ def test_ppr_to_ppm():
     @qjit(pipelines=pipe, target="mlir")
     def test_ppr_to_ppm_workflow():
 
-        @to_ppr
         @ppr_to_ppm
+        @to_ppr
         @qml.qnode(qml.device("lightning.qubit", wires=2))
         def f():
             qml.H(0)
@@ -303,8 +303,8 @@ def test_ppr_to_ppm_inject_magic_state():
     @qjit(pipelines=pipe, target="mlir")
     def test_ppr_to_ppm_workflow():
 
-        @to_ppr
         @ppr_to_ppm(decompose_method="clifford-corrected", avoid_y_measure=True)
+        @to_ppr
         @qml.qnode(qml.device("lightning.qubit", wires=2))
         def f():
             qml.H(0)
@@ -336,18 +336,18 @@ def test_commute_ppr_and_merge_ppr_ppm_with_max_pauli_size():
 
         device = qml.device("lightning.qubit", wires=2)
 
-        @to_ppr
-        @commute_ppr(max_pauli_size=2)
         @merge_ppr_ppm
+        @commute_ppr(max_pauli_size=2)
+        @to_ppr
         @qml.qnode(device)
         def f():
             qml.CNOT([0, 2])
             qml.T(0)
             return measure(0), measure(1)
 
-        @to_ppr
-        @commute_ppr
         @merge_ppr_ppm(max_pauli_size=1)
+        @commute_ppr
+        @to_ppr
         @qml.qnode(device)
         def g():
             qml.CNOT([0, 2])


### PR DESCRIPTION
**Context:**
When chaining the catalyst pass decorators, the order in the transform sequence is reversed than the order suggested by the python decorator application.  
```python
@qjit
@catalyst.passes.cancel_inverses
@catalyst.passes.merge_rotations
@qml.qnode(dev)
def circuit():
    ...

print(circuit.mlir)

###################
....
    module attributes {transform.with_named_sequence} {
      transform.named_sequence @__transform_main(%arg0: !transform.op<"builtin.module">) {
        %0 = transform.apply_registered_pass "remove-chained-self-inverse" to %arg0 : (!transform.op<"builtin.module">) -> !transform.op<"builtin.module">
        %1 = transform.apply_registered_pass "merge-rotations" to %0 : (!transform.op<"builtin.module">) -> !transform.op<"builtin.module">
        transform.yield 
      }
    }
....
```

**Description of the Change:**
Register the passes in the reverse order (with respect to its current buggy order)

**Benefits:**
Bug fix!

**Related GitHub Issues:** closes #1797 

[sc-92945]