### PR TITLE
Update from_plxpr to adjust to modified qnode prim

### DIFF
--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -178,17 +178,15 @@ class WorkflowInterpreter(PlxprInterpreter):
 # pylint: disable=unused-argument, too-many-arguments
 @WorkflowInterpreter.register_primitive(qnode_prim)
 def handle_qnode(
-    self, *args, qnode, shots, device, execution_config, qfunc_jaxpr, n_consts, batch_dims=None
+    self, *args, qnode, shots, device, execution_config, qfunc_jaxpr, batch_dims=None
 ):
     """Handle the conversion from plxpr to Catalyst jaxpr for the qnode primitive"""
-    consts = args[:n_consts]
-    non_const_args = args[n_consts:]
 
-    f = partial(QFuncPlxprInterpreter(device, shots).eval, qfunc_jaxpr, consts)
+    f = partial(QFuncPlxprInterpreter(device, shots).eval, qfunc_jaxpr, [])
 
     return quantum_kernel_p.bind(
         wrap_init(f, debug_info=qfunc_jaxpr.debug_info),
-        *non_const_args,
+        *args,
         qnode=qnode,
         pipeline=self._pass_pipeline,
     )


### PR DESCRIPTION
**Context:**

In pennylane PR: https://github.com/PennyLaneAI/pennylane/pull/7050

I updated `qnode_prim` to get rid of `n_consts` as metadata. Instead, all constants are promoted to arguments. 

**Description of the Change:**

Updates use of `qnode_prim` for the new signature.

**Benefits:**

Will work with latest pennylane.

**Possible Drawbacks:**

**Related GitHub Issues:**
