### PR TITLE
Move json and toml cmake `fetchcontent`s to root mlir directory

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -102,6 +102,26 @@ include_directories(SYSTEM
 link_directories(${LLVM_BUILD_LIBRARY_DIR})
 add_definitions(${LLVM_DEFINITIONS})
 
+
+# Include json and toml dependency
+include(FetchContent)
+
+FetchContent_Declare(json
+    URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
+    URL_HASH  SHA256=d6c65aca6b1ed68e7a182f4757257b107ae403032760ed6ef121c9d55e81757d
+    DOWNLOAD_EXTRACT_TIMESTAMP true
+    SYSTEM
+)
+FetchContent_MakeAvailable(json)
+
+FetchContent_Declare(tomlplusplus
+    GIT_REPOSITORY https://github.com/marzer/tomlplusplus.git
+    GIT_TAG v3.4.0
+    SYSTEM
+)
+FetchContent_MakeAvailable(tomlplusplus)
+
+
 ######################
 ## Catalyst Sources ##
 ######################

--- a/mlir/lib/Ion/Transforms/CMakeLists.txt
+++ b/mlir/lib/Ion/Transforms/CMakeLists.txt
@@ -26,23 +26,6 @@ target_include_directories(${LIBRARY_NAME} PUBLIC
                            ${PROJECT_SOURCE_DIR}/include
                            ${CMAKE_BINARY_DIR}/include)
 
-include(FetchContent)
-
-FetchContent_Declare(tomlplusplus
-    GIT_REPOSITORY https://github.com/marzer/tomlplusplus.git
-    GIT_TAG v3.4.0
-    SYSTEM
-)
-FetchContent_MakeAvailable(tomlplusplus)
-
-FetchContent_Declare(json
-    URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
-    URL_HASH  SHA256=d6c65aca6b1ed68e7a182f4757257b107ae403032760ed6ef121c9d55e81757d
-    DOWNLOAD_EXTRACT_TIMESTAMP true
-    SYSTEM
-)
-FetchContent_MakeAvailable(json)
-
 target_link_libraries(${LIBRARY_NAME} PRIVATE
     tomlplusplus::tomlplusplus
     nlohmann_json::nlohmann_json

--- a/mlir/lib/QEC/Transforms/CMakeLists.txt
+++ b/mlir/lib/QEC/Transforms/CMakeLists.txt
@@ -33,18 +33,11 @@ set(DEPENDS
 add_mlir_library(${LIBRARY_NAME} STATIC ${SRC} LINK_LIBS PRIVATE ${LIBS} DEPENDS ${DEPENDS})
 target_compile_features(${LIBRARY_NAME} PUBLIC cxx_std_20)
 
-include(FetchContent)
-FetchContent_Declare(json
-    URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.tar.xz
-    URL_HASH  SHA256=d6c65aca6b1ed68e7a182f4757257b107ae403032760ed6ef121c9d55e81757d
-    DOWNLOAD_EXTRACT_TIMESTAMP true
-    SYSTEM
-)
-FetchContent_MakeAvailable(json)
 target_link_libraries(${LIBRARY_NAME} 
     PRIVATE nlohmann_json::nlohmann_json
 )
 
+# Disable warning from json library
 if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
 set_source_files_properties(
     CountPPMSpecs.cpp


### PR DESCRIPTION
**Context:**
Multiple dialects are now using the `json` cpp library.  

**Description of the Change:**
We just `fetchcontent` once from the mlir root directory, instead of downloading them once per dialect.

**Benefits:**
Faster build. 
