### PR TITLE
[Frontend] Fixes conversion from PLxPR to JAXPR with quantum primitives

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -256,6 +256,9 @@
 * MLIR plugins can now be specified via lists and tuples, not just sets.
   [(#1812)](https://github.com/PennyLaneAI/catalyst/pull/1812)
 
+* Fixes the conversion of PLxPR to JAXPR with quantum primitives when using control flow.
+  [(#1809)](https://github.com/PennyLaneAI/catalyst/pull/1809)
+
 <h3>Internal changes ⚙️</h3>
 
 * `null.qubit` can now support an optional `track_resources` argument which allows it to record which gates are executed.

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -478,6 +478,7 @@ def handle_state_prep(self, *invals, n_wires, **kwargs):
 def handle_cond(self, *plxpr_invals, jaxpr_branches, consts_slices, args_slice):
     """Handle the conversion from plxpr to Catalyst jaxpr for the cond primitive"""
     args = plxpr_invals[args_slice]
+    self.actualize_qreg()
     args_plus_qreg = [*args, self.qreg]  # Add the qreg to the args
     converted_jaxpr_branches = []
     all_consts = []
@@ -554,6 +555,7 @@ def handle_for_loop(
     args = plxpr_invals[args_slice]
 
     # Add the iteration start and the qreg to the args
+    self.actualize_qreg()
     start_plus_args_plus_qreg = [
         start,
         *args,
@@ -612,6 +614,7 @@ def handle_while_loop(
     args_slice,
 ):
     """Handle the conversion from plxpr to Catalyst jaxpr for the while loop primitive"""
+    self.actualize_qreg()
     consts_body = plxpr_invals[body_slice]
     consts_cond = plxpr_invals[cond_slice]
     args = plxpr_invals[args_slice]

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -326,6 +326,7 @@ class PLxPRToQuantumJaxprInterpreter(PlxprInterpreter):
             # Note: since `getattr` checks specifically for qreg, we can't
             # define qreg inside the init function.
             self.qreg = qinsert_p.bind(self.qreg, orig_wire, wire)
+        self.wire_map = {}
 
     def interpret_operation(self, op):
         """Re-bind a pennylane operation as a catalyst instruction."""

--- a/frontend/test/lit/test_from_plxpr.py
+++ b/frontend/test/lit/test_from_plxpr.py
@@ -1,0 +1,113 @@
+# Copyright 2025 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# RUN: %PYTHON %s | FileCheck %s
+
+import pennylane as qml
+import catalyst
+
+def test_conditional_capture():
+
+    qml.capture.enable()
+
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    def captured_circuit(x: float):
+        m = qml.measure(0)
+        # CHECK: [[QREG:%.+]] = quantum.insert
+        # CHECK: [[QREG_3:%.+]] = scf.if
+        # CHECK:    [[QREG_2:%.+]] = quantum.insert [[QREG]][ 0]
+        # CHECK:    scf.yield [[QREG_2]]
+        # CHECK: else
+        # CHECK:     scf.yield [[QREG]]
+        # CHECK: quantum.compbasis qreg [[QREG_3]] : !quantum.obs
+        qml.cond(m, lambda: (qml.X(0), None)[1])()
+        return qml.state()
+
+    @qml.qjit
+    def main(x: float):
+        return captured_circuit(x)
+
+    print(main.mlir)
+
+    qml.capture.enable()
+
+test_conditional_capture()
+
+def test_loop_capture():
+
+    qml.capture.enable()
+
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    def captured_circuit(x: float):
+        m = qml.measure(0)
+
+        # CHECK: [[QREG:%.+]] = quantum.insert
+        # CHECK: [[QREG_4:%.+]] = scf.for {{.*}} iter_args([[QREG_2:%.+]] = [[QREG]]
+        # CHECK:   [[QREG_3:%.+]] = quantum.insert [[QREG_2]]
+        # CHECK:   scf.yield [[QREG_3]]
+        # CHECK: quantum.compbasis qreg [[QREG_4]]
+        @qml.for_loop(0, 2, 1)
+        def loop_fn(_):
+            qml.Hadamard(0)
+
+        loop_fn()
+
+        return qml.state()
+
+    @qml.qjit
+    def main(x: float):
+        return captured_circuit(x)
+
+    print(main.mlir)
+
+    qml.capture.disable()
+
+test_loop_capture()
+
+def test_while_capture():
+
+    qml.capture.enable()
+
+
+    # CHECK: [[QREG:%.+]] = quantum.insert
+    # CHECK: [[PAIR:%.+]]:2 = scf.while {{.*}} [[QREG2:%.+]] = [[QREG]]
+    # CHECK:     [[QREG3:%.+]] = quantum.insert [[QREG2:%.+]]
+    # CHECK:     scf.yield {{.*}} [[QREG3]]
+    # CHECK: quantum.compbasis qreg [[PAIR]]#1
+    @qml.qnode(qml.device("null.qubit", wires=1))
+    def captured_circuit(x: float):
+        m = qml.measure(0)
+
+        def less_than_10(x):
+            return x[0] < 10
+
+        @qml.while_loop(less_than_10)
+        def loop(v):
+            qml.Hadamard(0)
+            return v[0] + 1, v[1]
+
+        loop((0, 1))
+        return qml.state()
+        
+
+    @qml.qjit
+    def main(x: float):
+        return captured_circuit(x)
+
+    print(main.mlir)
+
+    qml.capture.disable()
+
+test_while_capture()
+


### PR DESCRIPTION
**Context:** #1808 

**Description of the Change:** Adds calls to actualize before generating control flow. Actualize will also "forget" the cached variables it has already inserted.

**Benefits:** Correct IR generation.

**Related GitHub Issues:** Fixes #1808 
