### PR TITLE
Support Static and Dynamic Variables in PLxPR Programs with QJIT

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -127,6 +127,9 @@
   performance by eliminating indirect conversion.
   [(#1738)](https://github.com/PennyLaneAI/catalyst/pull/1738)
 
+* `static_argnums` on `qjit` can now be specified with program capture through PLxPR.
+  [(#1810)](https://github.com/PennyLaneAI/catalyst/pull/1810)
+
 <h3>Breaking changes 💔</h3>
 
 * (Device Developers Only) The `QuantumDevice` interface in the Catalyst Runtime plugin system

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -45,6 +45,7 @@ from catalyst.device import (
     extract_backend_info,
     get_device_capabilities,
 )
+from catalyst.tracing.type_signatures import filter_static_args
 from catalyst.jax_extras import jaxpr_pad_consts, make_jaxpr2, transient_jax_config
 from catalyst.jax_primitives import (
     AbstractQbit,
@@ -722,7 +723,9 @@ def handle_measure_in_basis(self, angle, wire, plane, reset, postselect):
 
 
 # pylint: disable=too-many-positional-arguments
-def trace_from_pennylane(fn, static_argnums, abstracted_axes, sig, kwargs, debug_info=None):
+def trace_from_pennylane(
+    fn, static_argnums, dynamic_argnums, abstracted_axes, sig, kwargs, debug_info=None
+):
     """Capture the JAX program representation (JAXPR) of the wrapped function, using
     PL capure module.
 
@@ -746,6 +749,6 @@ def trace_from_pennylane(fn, static_argnums, abstracted_axes, sig, kwargs, debug
         args = sig
 
         plxpr, out_type, out_treedef = make_jaxpr2(fn, **make_jaxpr_kwargs)(*args, **kwargs)
-        jaxpr = from_plxpr(plxpr)(*args, **kwargs)
+        jaxpr = from_plxpr(plxpr)(*dynamic_argnums, **kwargs)
 
     return jaxpr, out_type, out_treedef, sig

--- a/frontend/catalyst/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr.py
@@ -45,7 +45,6 @@ from catalyst.device import (
     extract_backend_info,
     get_device_capabilities,
 )
-from catalyst.tracing.type_signatures import filter_static_args
 from catalyst.jax_extras import jaxpr_pad_consts, make_jaxpr2, transient_jax_config
 from catalyst.jax_primitives import (
     AbstractQbit,

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -499,10 +499,27 @@ def trace_from_pennylane(
     PL capure module.
 
     Args:
-        args (Iterable): arguments to use for program capture
+        fn(Callable): the user function to be traced
+        static_argnums(int or Seqence[Int]): an index or a sequence of indices that specifies the
+            positions of static arguments.
+        dynamic_argnums(int or Seqence[Int]): an index or a sequence of indices that specifies the
+            positions of dynamic arguments.
+        abstracted_axes (Sequence[Sequence[str]] or Dict[int, str] or Sequence[Dict[int, str]]):
+            An experimental option to specify dynamic tensor shapes.
+            This option affects the compilation of the annotated function.
+            Function arguments with ``abstracted_axes`` specified will be compiled to ranked tensors
+            with dynamic shapes. For more details, please see the Dynamically-shaped Arrays section
+            below.
+        sig(Sequence[Any]): a tuple indicating the argument signature of the function. Static arguments
+            are indicated with their literal values, and dynamic arguments are indicated by abstract
+            values.
+        kwargs(Dict[str, Any]): keyword argumemts to the function.
+        debug_info(jax.api_util.debug_info): a source debug information object required by jaxprs.
 
     Returns:
         ClosedJaxpr: captured JAXPR
+        Tuple[Tuple[ShapedArray, bool]]: the return type of the captured JAXPR.
+            The boolean indicates whether each result is a value returned by the user function.
         PyTreeDef: PyTree metadata of the function output
         Tuple[Any]: the dynamic argument signature
     """

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -725,6 +725,7 @@ class QJIT(CatalystCallable):
                 return trace_from_pennylane(
                     self.user_function,
                     static_argnums,
+                    dynamic_args,
                     abstracted_axes,
                     full_sig,
                     kwargs,

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -1532,7 +1532,7 @@ class TestCapture:
         captured_circuit_2_mlir = captured_circuit_2.mlir
         assert "%cst = arith.constant 2.0" in captured_circuit_2_mlir
         assert 'quantum.custom "RY"(%cst)' in captured_circuit_2_mlir
-        assert "%cst = arith.constant 1.5" not in captured_circuit_1_mlir
+        assert "%cst = arith.constant 1.5" not in captured_circuit_2_mlir
 
         assert result_1 == result_2
 

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -1536,4 +1536,20 @@ class TestCapture:
 
         assert result_1 == result_2
 
+        # Test under a non qnode workflow function
+        @qjit(static_argnums=(0,))
+        def workflow(x, y):
+            @qml.qnode(qml.device(backend, wires=1))
+            def c():
+                qml.RX(x, wires=0)
+                qml.RY(y, wires=0)
+                return qml.expval(qml.PauliZ(0))
+
+            return c()
+
+        result_3 = workflow(1.5, 2.0)
+        captured_circuit_3_mlir = workflow.mlir
+        assert "%cst = arith.constant 1.5" in captured_circuit_3_mlir
+        assert 'quantum.custom "RX"(%cst)' in captured_circuit_3_mlir
+
         qml.capture.disable()

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -1523,12 +1523,14 @@ class TestCapture:
             return qml.expval(qml.PauliZ(0))
 
         result_1 = captured_circuit_1(1.5, 2.0)
-        assert "stablehlo.constant dense<1.500000e+00>" in captured_circuit_1.mlir
-        assert "stablehlo.constant dense<2.000000e+00>" not in captured_circuit_1.mlir
+        captured_circuit_1_mlir = captured_circuit_1.mlir
+        assert "stablehlo.constant dense<1.500000e+00>" in captured_circuit_1_mlir
+        assert "stablehlo.constant dense<2.000000e+00>" not in captured_circuit_1_mlir
 
         result_2 = captured_circuit_2(1.5, 2.0)
-        assert "stablehlo.constant dense<1.500000e+00>" not in captured_circuit_2.mlir
-        assert "stablehlo.constant dense<2.000000e+00>" in captured_circuit_2.mlir
+        captured_circuit_2_mlir = captured_circuit_2.mlir
+        assert "stablehlo.constant dense<1.500000e+00>" not in captured_circuit_2_mlir
+        assert "stablehlo.constant dense<2.000000e+00>" in captured_circuit_2_mlir
 
         assert result_1 == result_2
 

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -1506,7 +1506,7 @@ class TestCapture:
 
         qml.capture.enable()
 
-        # Capture in qnode level
+        # Basic test
         @qjit(static_argnums=(0,))
         @qml.qnode(qml.device(backend, wires=1))
         def captured_circuit_1(x, y):
@@ -1514,23 +1514,25 @@ class TestCapture:
             qml.RY(y, wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        # Ignore static_argnums in the qnode
+        result_1 = captured_circuit_1(1.5, 2.0)
+        captured_circuit_1_mlir = captured_circuit_1.mlir
+        assert "%cst = arith.constant 1.5" in captured_circuit_1_mlir
+        assert 'quantum.custom "RX"(%cst)' in captured_circuit_1_mlir
+        assert "%cst = arith.constant 2.0" not in captured_circuit_1_mlir
+
+        # Test that qjit static_argnums takes precedence over the one on the qnode
         @qjit(static_argnums=1)
-        @qml.qnode(qml.device(backend, wires=1), static_argnums=0)
+        @qml.qnode(qml.device(backend, wires=1), static_argnums=0)  # should be ignored
         def captured_circuit_2(x, y):
             qml.RX(x, wires=0)
             qml.RY(y, wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        result_1 = captured_circuit_1(1.5, 2.0)
-        captured_circuit_1_mlir = captured_circuit_1.mlir
-        assert "stablehlo.constant dense<1.500000e+00>" in captured_circuit_1_mlir
-        assert "stablehlo.constant dense<2.000000e+00>" not in captured_circuit_1_mlir
-
         result_2 = captured_circuit_2(1.5, 2.0)
         captured_circuit_2_mlir = captured_circuit_2.mlir
-        assert "stablehlo.constant dense<1.500000e+00>" not in captured_circuit_2_mlir
-        assert "stablehlo.constant dense<2.000000e+00>" in captured_circuit_2_mlir
+        assert "%cst = arith.constant 2.0" in captured_circuit_2_mlir
+        assert 'quantum.custom "RY"(%cst)' in captured_circuit_2_mlir
+        assert "%cst = arith.constant 1.5" not in captured_circuit_1_mlir
 
         assert result_1 == result_2
 

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -1547,7 +1547,7 @@ class TestCapture:
 
             return c()
 
-        result_3 = workflow(1.5, 2.0)
+        _ = workflow(1.5, 2.0)
         captured_circuit_3_mlir = workflow.mlir
         assert "%cst = arith.constant 1.5" in captured_circuit_3_mlir
         assert 'quantum.custom "RX"(%cst)' in captured_circuit_3_mlir


### PR DESCRIPTION
**Context:**
Control over static variables in compilation is a general necessity. At the moment, with `qml.capture.enable()`, additionally specifying a static variable in `qjit` does not work. With this epic, we want to add support for static variables in the plxpr-qjit execution pipeline.

**Description of the Change:**
- Updated the `trace_from_pennylane` function signature to include `dynamic_argnums`.
- Modified the function implementation to correctly handle dynamic arguments when calling `from_plxpr`.

 
[[sc-93318]]
