### PR TITLE
use `dataclass.replace` to update `ExecutionConfig` or `MCMConfig`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -258,6 +258,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Use `dataclass.replace` to update `ExecutionConfig` and `MCMConfig` rather than mutating properties.
+  [(#1814)](https://github.com/PennyLaneAI/catalyst/pull/1814)
+
 * `null.qubit` can now support an optional `track_resources` argument which allows it to record which gates are executed.
   [(#1619)](https://github.com/PennyLaneAI/catalyst/pull/1619)
 

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -20,7 +20,7 @@ import itertools
 import logging
 import weakref
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
 from functools import partial, reduce
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
@@ -143,7 +143,7 @@ def _make_execution_config(qnode):
 
     execution_config = qml.devices.ExecutionConfig()
     if qnode:
-        execution_config.gradient_method = _in_gradient_tracing(qnode)
+        execution_config = replace(execution_config, gradient_method=_in_gradient_tracing(qnode))
 
     return execution_config
 

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -19,8 +19,8 @@ the default behaviour and replacing it with a function-like "QNode" primitive.
 """
 import logging
 from copy import copy
-from typing import Callable, Sequence
 from dataclasses import replace
+from typing import Callable, Sequence
 
 import jax.numpy as jnp
 import pennylane as qml

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -15,12 +15,12 @@
 """Test built-in differentiation support in Catalyst."""
 
 import platform
+from dataclasses import replace
 
 import jax
 import numpy as np
 import pennylane as qml
 import pytest
-from dataclasses import replace
 from jax import numpy as jnp
 from jax.tree_util import tree_all, tree_flatten, tree_map, tree_structure
 

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -20,6 +20,7 @@ import jax
 import numpy as np
 import pennylane as qml
 import pytest
+from dataclasses import replace
 from jax import numpy as jnp
 from jax.tree_util import tree_all, tree_flatten, tree_map, tree_structure
 
@@ -1858,7 +1859,7 @@ class TestGradientMethodErrors:
             def preprocess(self, execution_config=None):
                 """Device preprocessing function."""
                 program, config = lightning_device.preprocess(execution_config)
-                config.gradient_method = grad_method
+                config = replace(config, gradient_method=grad_method)
                 return program, config
 
             @staticmethod


### PR DESCRIPTION
**Context:**

We are freezing the dataclasses `ExecutionConfig` or `MCMConfig` in Pennylane (https://github.com/PennyLaneAI/pennylane/pull/7697) so they are no longer mutable. Turns out there are external Catalyst tests that failed since there are some files in this repo that are mutating the configuration.

**Description of the Change:**

Use `dataclass.replace` to update various properties of the dataclass so we don't mutate.

**Benefits:** Not in place mutating the execution configuration.

**Possible Drawbacks:** None identified.

[sc-93592]
