### PR TITLE
[Frontend] Update import path for Python compiler

### DIFF
--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -510,7 +510,7 @@ class Compiler:
             # We keep this module here to keep xDSL requirement optional
             # Only move this is it has been decided that xDSL is no longer optional.
             # pylint: disable-next=import-outside-toplevel
-            from pennylane.compiler.python_compiler.impl import Compiler as PythonCompiler
+            from pennylane.compiler.python_compiler import Compiler as PythonCompiler
 
             compiler = PythonCompiler()
             mlir_module = compiler.run(mlir_module)


### PR DESCRIPTION
**Context:** An update in Python compiler moved the Compiler class to a different import path.

**Description of the Change:** Change the import path here in Catalyst.

**Benefits:** Everything still works.