### PR TITLE
hoist the pulse duration calculation arithmetic out of the parallel protocol

### DIFF
--- a/mlir/include/Ion/Transforms/Passes.h
+++ b/mlir/include/Ion/Transforms/Passes.h
@@ -20,7 +20,7 @@
 
 namespace catalyst {
 
-std::unique_ptr<mlir::Pass> createQuantumToIonPass();
+std::unique_ptr<mlir::Pass> createGatesToPulsesPass();
 std::unique_ptr<mlir::Pass> createIonConversionPass();
 
 } // namespace catalyst

--- a/mlir/include/Ion/Transforms/Passes.td
+++ b/mlir/include/Ion/Transforms/Passes.td
@@ -17,8 +17,8 @@
 
 include "mlir/Pass/PassBase.td"
 
-def QuantumToIonPass : Pass<"quantum-to-ion"> {
-    let summary = "Lower a quantum circuit to an ionic pulse program.";
+def GatesToPulsesPass : Pass<"gates-to-pulses"> {
+    let summary = "Lower quantum gates to ionic pulses.";
 
     let options = [
     Option<"DeviceTomlLoc", "device-toml-loc",
@@ -41,7 +41,7 @@ def QuantumToIonPass : Pass<"quantum-to-ion"> {
         "scf::SCFDialect"
     ];
 
-    let constructor = "catalyst::createQuantumToIonPass()";
+    let constructor = "catalyst::createGatesToPulsesPass()";
 }
 
 def IonConversionPass : Pass<"convert-ion-to-llvm"> {

--- a/mlir/lib/Catalyst/Transforms/RegisterAllPasses.cpp
+++ b/mlir/lib/Catalyst/Transforms/RegisterAllPasses.cpp
@@ -63,7 +63,7 @@ void catalyst::registerAllCatalystPasses()
     mlir::registerPass(catalyst::createSplitMultipleTapesPass);
     mlir::registerPass(catalyst::createTestPass);
     mlir::registerPass(catalyst::createIonsDecompositionPass);
-    mlir::registerPass(catalyst::createQuantumToIonPass);
+    mlir::registerPass(catalyst::createGatesToPulsesPass);
     mlir::registerPass(catalyst::createLoopBoundaryOptimizationPass);
     mlir::registerPass(catalyst::createMBQCConversionPass);
 }

--- a/mlir/lib/Ion/Transforms/CMakeLists.txt
+++ b/mlir/lib/Ion/Transforms/CMakeLists.txt
@@ -3,7 +3,7 @@ set(LIBRARY_NAME ion-transforms)
 file(GLOB SRC
     ion-to-llvm.cpp
     ConversionPatterns.cpp
-    quantum_to_ion.cpp
+    gates_to_pulses.cpp
     QuantumToIonPatterns.cpp
 )
 
@@ -54,7 +54,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
 set_source_files_properties(
     ion-to-llvm.cpp
     ConversionPatterns.cpp
-    quantum_to_ion.cpp
+    gates_to_pulses.cpp
     QuantumToIonPatterns.cpp
     PROPERTIES
     COMPILE_FLAGS "-Wno-covered-switch-default"

--- a/mlir/lib/Ion/Transforms/QuantumToIonPatterns.cpp
+++ b/mlir/lib/Ion/Transforms/QuantumToIonPatterns.cpp
@@ -233,12 +233,13 @@ mlir::LogicalResult oneQubitGateToPulse(CustomOp op, mlir::PatternRewriter &rewr
         auto qubits = op.getInQubits();
         MLIRContext *ctx = op.getContext();
 
+        auto angle = op.getParams().front();
+        auto time = computePulseDuration(rewriter, loc, angle, beam.rabi, beam.detuning);
+
         auto ppOp = rewriter.create<ion::ParallelProtocolOp>(
             loc, qubits, [&](OpBuilder &builder, Location loc, ValueRange qubits) {
                 mlir::FloatAttr phase1Attr = builder.getF64FloatAttr(phase1);
                 mlir::FloatAttr phase2Attr = builder.getF64FloatAttr(phase2);
-                auto angle = op.getParams().front();
-                auto time = computePulseDuration(rewriter, loc, angle, beam.rabi, beam.detuning);
                 auto qubit = qubits.front();
                 builder.create<ion::PulseOp>(loc, PulseType::get(ctx), time, qubit, beam0toEAttr,
                                              phase1Attr);
@@ -315,6 +316,10 @@ mlir::LogicalResult MSGateToPulse(CustomOp op, mlir::PatternRewriter &rewriter,
             auto loc = op.getLoc();
             auto qubits = op.getInQubits();
 
+            auto angle = op.getParams().front();
+            auto time =
+                computePulseDuration(rewriter, loc, angle, beam.rabi, beam.detuning);
+
             // Helper function to flip the sign of each element in a vector,
             // e.g. [a, b, c] -> [-a, -b, -c]
             auto flipSign = [](const std::vector<int64_t> &v) -> std::vector<int64_t> {
@@ -326,9 +331,6 @@ mlir::LogicalResult MSGateToPulse(CustomOp op, mlir::PatternRewriter &rewriter,
             auto ppOp = rewriter.create<ion::ParallelProtocolOp>(
                 loc, qubits, [&](OpBuilder &builder, Location loc, ValueRange qubits) {
                     mlir::FloatAttr phase0Attr = builder.getF64FloatAttr(0.0);
-                    auto angle = op.getParams().front();
-                    auto time =
-                        computePulseDuration(rewriter, loc, angle, beam.rabi, beam.detuning);
                     auto qubit0 = qubits.front();
                     auto qubit1 = qubits.back();
 

--- a/mlir/lib/Ion/Transforms/gates_to_pulses.cpp
+++ b/mlir/lib/Ion/Transforms/gates_to_pulses.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2023 Xanadu Quantum Technologies Inc.
+// Copyright 2025 Xanadu Quantum Technologies Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,12 +34,12 @@ using namespace mlir;
 namespace catalyst {
 namespace ion {
 
-#define GEN_PASS_DECL_QUANTUMTOIONPASS
-#define GEN_PASS_DEF_QUANTUMTOIONPASS
+#define GEN_PASS_DECL_GATESTOPULSESPASS
+#define GEN_PASS_DEF_GATESTOPULSESPASS
 #include "Ion/Transforms/Passes.h.inc"
 
-struct QuantumToIonPass : impl::QuantumToIonPassBase<QuantumToIonPass> {
-    using QuantumToIonPassBase::QuantumToIonPassBase;
+struct GatesToPulsesPass : impl::GatesToPulsesPassBase<GatesToPulsesPass> {
+    using GatesToPulsesPassBase::GatesToPulsesPassBase;
 
     LevelAttr getLevelAttr(MLIRContext *ctx, IRRewriter &builder, Level level)
     {
@@ -80,6 +80,8 @@ struct QuantumToIonPass : impl::QuantumToIonPassBase<QuantumToIonPass> {
         auto &context = getContext();
         ConversionTarget target(context);
 
+        // Only quantum gate ops (CustomOp) must be eliminated; other quantum
+        // ops are allowed to remain.
         target.addIllegalOp<catalyst::quantum::CustomOp>();
         target.addLegalDialect<IonDialect>();
         target.markUnknownOpDynamicallyLegal([](Operation *) { return true; });
@@ -130,6 +132,6 @@ struct QuantumToIonPass : impl::QuantumToIonPassBase<QuantumToIonPass> {
 
 } // namespace ion
 
-std::unique_ptr<Pass> createQuantumToIonPass() { return std::make_unique<ion::QuantumToIonPass>(); }
+std::unique_ptr<Pass> createGatesToPulsesPass(){ return std::make_unique<ion::GatesToPulsesPass>(); }
 
 } // namespace catalyst

--- a/mlir/test/Ion/QuantumToIon.mlir
+++ b/mlir/test/Ion/QuantumToIon.mlir
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// RUN: quantum-opt %s --pass-pipeline="builtin.module(func.func(quantum-to-ion{\
+// RUN: quantum-opt %s --pass-pipeline="builtin.module(func.func(gates-to-pulses{\
 // RUN:    device-toml-loc=%S/oqd_device_parameters.toml \
 // RUN:    qubit-toml-loc=%S/oqd_qubit_parameters.toml \
 // RUN:    gate-to-pulse-toml-loc=%S/oqd_gate_decomposition_parameters.toml}))" \
@@ -115,14 +115,12 @@ func.func @example_ion_two_qubit(%arg0: f64) -> !quantum.bit  attributes {qnode}
     %2 = quantum.extract %1[ 0] : !quantum.reg -> !quantum.bit
     %3 = quantum.extract %1[ 1] : !quantum.reg -> !quantum.bit
 
-    // CHECK: [[rx1out:%.+]] = ion.parallelprotocol([[qubit0]]) : !quantum.bit {
-    // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit):
-    // CHECK-NEXT:%cst = arith.constant 12.566370614359172 : f64
-    // CHECK-NEXT:  [[remainder:%.+]] = arith.remf %arg0, %cst : f64
-    // CHECK-NEXT:  %cst_0 = arith.constant 0.000000e+00 : f64
-    // CHECK-NEXT:  [[negative:%.+]] = arith.cmpf olt, [[remainder:%.+]], %cst_0 : f64
+    // CHECK:       [[cst:%.+]] = arith.constant 12.566370614359172 : f64
+    // CHECK-NEXT:  [[remainder:%.+]] = arith.remf %arg0, [[cst:%.+]] : f64
+    // CHECK-NEXT:  [[cst_0:%.+]] = arith.constant 0.000000e+00 : f64
+    // CHECK-NEXT:  [[negative:%.+]] = arith.cmpf olt, [[remainder:%.+]], [[cst_0:%.+]] : f64
     // CHECK-NEXT:  [[normalized_angle:%.+]] = scf.if [[negative:%.+]] -> (f64) {
-    // CHECK-NEXT:    [[adjusted:%.+]] = arith.addf [[remainder:%.+]], %cst : f64
+    // CHECK-NEXT:    [[adjusted:%.+]] = arith.addf [[remainder:%.+]], [[cst:%.+]] : f64
     // CHECK-NEXT:    scf.yield [[adjusted:%.+]] : f64
     // CHECK-NEXT:  } else {
     // CHECK-NEXT:    scf.yield [[remainder:%.+]] : f64
@@ -132,6 +130,8 @@ func.func @example_ion_two_qubit(%arg0: f64) -> !quantum.bit  attributes {qnode}
     // CHECK-NEXT: [[mult:%.+]] = arith.mulf [[normalized_angle:%.+]], [[cst_2:%.+]] : f64
     // CHECK-NEXT: [[square:%.+]] = arith.mulf [[cst_1:%.+]], [[cst_1:%.+]] : f64
     // CHECK-NEXT: [[timerx1:%.+]] = arith.divf [[mult:%.+]], [[square:%.+]] : f64
+    // CHECK-NEXT: [[rx1out:%.+]] = ion.parallelprotocol([[qubit0]]) : !quantum.bit {
+    // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit):
     // CHECK-NEXT: ion.pulse([[timerx1]] : f64) %arg1 {
     // CHECK-SAME:     beam = #ion.beam<
     // CHECK-SAME:         transition_index = 0 : i64,
@@ -152,14 +152,12 @@ func.func @example_ion_two_qubit(%arg0: f64) -> !quantum.bit  attributes {qnode}
     // CHECK-NEXT: }
     %4 = quantum.custom "RX"(%arg0) %2 : !quantum.bit
 
-    // CHECK: [[ry1out:%.+]] = ion.parallelprotocol([[rx1out]]) : !quantum.bit {
-    // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit):
-    // CHECK-NEXT:%cst = arith.constant 12.566370614359172 : f64
-    // CHECK-NEXT:  [[remainder:%.+]] = arith.remf %arg0, %cst : f64
-    // CHECK-NEXT:  %cst_0 = arith.constant 0.000000e+00 : f64
-    // CHECK-NEXT:  [[negative:%.+]] = arith.cmpf olt, [[remainder:%.+]], %cst_0 : f64
+    // CHECK:       [[cst:%.+]] = arith.constant 12.566370614359172 : f64
+    // CHECK-NEXT:  [[remainder:%.+]] = arith.remf %arg0, [[cst:%.+]] : f64
+    // CHECK-NEXT:  [[cst_0:%.+]] = arith.constant 0.000000e+00 : f64
+    // CHECK-NEXT:  [[negative:%.+]] = arith.cmpf olt, [[remainder:%.+]], [[cst_0:%.+]] : f64
     // CHECK-NEXT:  [[normalized_angle:%.+]] = scf.if [[negative:%.+]] -> (f64) {
-    // CHECK-NEXT:    [[adjusted:%.+]] = arith.addf [[remainder:%.+]], %cst : f64
+    // CHECK-NEXT:    [[adjusted:%.+]] = arith.addf [[remainder:%.+]], [[cst:%.+]] : f64
     // CHECK-NEXT:    scf.yield [[adjusted:%.+]] : f64
     // CHECK-NEXT:  } else {
     // CHECK-NEXT:    scf.yield [[remainder:%.+]] : f64
@@ -169,6 +167,8 @@ func.func @example_ion_two_qubit(%arg0: f64) -> !quantum.bit  attributes {qnode}
     // CHECK-NEXT: [[mult:%.+]] = arith.mulf [[normalized_angle:%.+]], [[cst_2:%.+]] : f64
     // CHECK-NEXT: [[square:%.+]] = arith.mulf [[cst_1:%.+]], [[cst_1:%.+]] : f64
     // CHECK-NEXT: [[timery1:%.+]] = arith.divf [[mult:%.+]], [[square:%.+]] : f64
+    // CHECK-NEXT: [[ry1out:%.+]] = ion.parallelprotocol([[rx1out]]) : !quantum.bit {
+    // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit):
     // CHECK-NEXT: ion.pulse([[timery1]] : f64) %arg1 {
     // CHECK-SAME:     beam = #ion.beam<
     // CHECK-SAME:         transition_index = 0 : i64,
@@ -189,14 +189,12 @@ func.func @example_ion_two_qubit(%arg0: f64) -> !quantum.bit  attributes {qnode}
     // CHECK-NEXT: }
     %5 = quantum.custom "RY"(%arg0) %4 : !quantum.bit
 
-    // CHECK: [[rx2out:%.+]] = ion.parallelprotocol([[ry1out]]) : !quantum.bit {
-    // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit):
-    // CHECK-NEXT:%cst = arith.constant 12.566370614359172 : f64
-    // CHECK-NEXT:  [[remainder:%.+]] = arith.remf %arg0, %cst : f64
-    // CHECK-NEXT:  %cst_0 = arith.constant 0.000000e+00 : f64
-    // CHECK-NEXT:  [[negative:%.+]] = arith.cmpf olt, [[remainder:%.+]], %cst_0 : f64
+    // CHECK:       [[cst:%.+]] = arith.constant 12.566370614359172 : f64
+    // CHECK-NEXT:  [[remainder:%.+]] = arith.remf %arg0, [[cst:%.+]] : f64
+    // CHECK-NEXT:  [[cst_0:%.+]] = arith.constant 0.000000e+00 : f64
+    // CHECK-NEXT:  [[negative:%.+]] = arith.cmpf olt, [[remainder:%.+]], [[cst_0:%.+]] : f64
     // CHECK-NEXT:  [[normalized_angle:%.+]] = scf.if [[negative:%.+]] -> (f64) {
-    // CHECK-NEXT:    [[adjusted:%.+]] = arith.addf [[remainder:%.+]], %cst : f64
+    // CHECK-NEXT:    [[adjusted:%.+]] = arith.addf [[remainder:%.+]], [[cst:%.+]] : f64
     // CHECK-NEXT:    scf.yield [[adjusted:%.+]] : f64
     // CHECK-NEXT:  } else {
     // CHECK-NEXT:    scf.yield [[remainder:%.+]] : f64
@@ -206,6 +204,8 @@ func.func @example_ion_two_qubit(%arg0: f64) -> !quantum.bit  attributes {qnode}
     // CHECK-NEXT: [[mult:%.+]] = arith.mulf [[normalized_angle:%.+]], [[cst_2:%.+]] : f64
     // CHECK-NEXT: [[square:%.+]] = arith.mulf [[cst_1:%.+]], [[cst_1:%.+]] : f64
     // CHECK-NEXT: [[timerx2:%.+]] = arith.divf [[mult:%.+]], [[square:%.+]] : f64
+    // CHECK-NEXT: [[rx2out:%.+]] = ion.parallelprotocol([[ry1out]]) : !quantum.bit {
+    // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit):
     // CHECK-NEXT: ion.pulse([[timerx2]] : f64) %arg1 {
     // CHECK-SAME:     beam = #ion.beam<
     // CHECK-SAME:         transition_index = 0 : i64,
@@ -226,14 +226,12 @@ func.func @example_ion_two_qubit(%arg0: f64) -> !quantum.bit  attributes {qnode}
     // CHECK-NEXT: }
     %6 = quantum.custom "RX"(%arg0) %5 : !quantum.bit
 
-    // CHECK: [[msout:%.+]] = ion.parallelprotocol([[rx2out]], [[qubit1]]) : !quantum.bit, !quantum.bit {
-    // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit, %arg2: !quantum.bit):
-    // CHECK-NEXT:%cst = arith.constant 12.566370614359172 : f64
-    // CHECK-NEXT:  [[remainder:%.+]] = arith.remf %arg0, %cst : f64
-    // CHECK-NEXT:  %cst_0 = arith.constant 0.000000e+00 : f64
-    // CHECK-NEXT:  [[negative:%.+]] = arith.cmpf olt, [[remainder:%.+]], %cst_0 : f64
+    // CHECK:       [[cst:%.+]] = arith.constant 12.566370614359172 : f64
+    // CHECK-NEXT:  [[remainder:%.+]] = arith.remf %arg0, [[cst:%.+]] : f64
+    // CHECK-NEXT:  [[cst_0:%.+]] = arith.constant 0.000000e+00 : f64
+    // CHECK-NEXT:  [[negative:%.+]] = arith.cmpf olt, [[remainder:%.+]], [[cst_0:%.+]] : f64
     // CHECK-NEXT:  [[normalized_angle:%.+]] = scf.if [[negative:%.+]] -> (f64) {
-    // CHECK-NEXT:    [[adjusted:%.+]] = arith.addf [[remainder:%.+]], %cst : f64
+    // CHECK-NEXT:    [[adjusted:%.+]] = arith.addf [[remainder:%.+]], [[cst:%.+]] : f64
     // CHECK-NEXT:    scf.yield [[adjusted:%.+]] : f64
     // CHECK-NEXT:  } else {
     // CHECK-NEXT:    scf.yield [[remainder:%.+]] : f64
@@ -243,6 +241,8 @@ func.func @example_ion_two_qubit(%arg0: f64) -> !quantum.bit  attributes {qnode}
     // CHECK-NEXT: [[mult:%.+]] = arith.mulf [[normalized_angle:%.+]], [[cst_2:%.+]] : f64
     // CHECK-NEXT: [[square:%.+]] = arith.mulf [[cst_1:%.+]], [[cst_1:%.+]] : f64
     // CHECK-NEXT: [[timems:%.+]] = arith.divf [[mult:%.+]], [[square:%.+]] : f64
+    // CHECK-NEXT: [[msout:%.+]] = ion.parallelprotocol([[rx2out]], [[qubit1]]) : !quantum.bit, !quantum.bit {
+    // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit, %arg2: !quantum.bit):
     // CHECK-NEXT: ion.pulse([[timems]] : f64) %arg1 {
     // CHECK-SAME:     beam = #ion.beam<
     // CHECK-SAME:         transition_index = 0 : i64,
@@ -315,15 +315,12 @@ func.func @example_ion_three_qubit(%arg0: f64) -> (!quantum.bit, !quantum.bit, !
     %3 = quantum.extract %1[ 1] : !quantum.reg -> !quantum.bit
     %4 = quantum.extract %1[ 2] : !quantum.reg -> !quantum.bit
 
-    // CHECK: [[ms1out:%.+]]:2 = ion.parallelprotocol([[qubit0]], [[qubit1]]) : !quantum.bit, !quantum.bit {
-
-    // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit, %arg2: !quantum.bit):
-        // CHECK-NEXT:%cst = arith.constant 12.566370614359172 : f64
-    // CHECK-NEXT:  [[remainder:%.+]] = arith.remf %arg0, %cst : f64
-    // CHECK-NEXT:  %cst_0 = arith.constant 0.000000e+00 : f64
-    // CHECK-NEXT:  [[negative:%.+]] = arith.cmpf olt, [[remainder:%.+]], %cst_0 : f64
+    // CHECK:       [[cst:%.+]] = arith.constant 12.566370614359172 : f64
+    // CHECK-NEXT:  [[remainder:%.+]] = arith.remf %arg0, [[cst:%.+]] : f64
+    // CHECK-NEXT:  [[cst_0:%.+]] = arith.constant 0.000000e+00 : f64
+    // CHECK-NEXT:  [[negative:%.+]] = arith.cmpf olt, [[remainder:%.+]], [[cst_0:%.+]] : f64
     // CHECK-NEXT:  [[normalized_angle:%.+]] = scf.if [[negative:%.+]] -> (f64) {
-    // CHECK-NEXT:    [[adjusted:%.+]] = arith.addf [[remainder:%.+]], %cst : f64
+    // CHECK-NEXT:    [[adjusted:%.+]] = arith.addf [[remainder:%.+]], [[cst:%.+]] : f64
     // CHECK-NEXT:    scf.yield [[adjusted:%.+]] : f64
     // CHECK-NEXT:  } else {
     // CHECK-NEXT:    scf.yield [[remainder:%.+]] : f64
@@ -333,6 +330,8 @@ func.func @example_ion_three_qubit(%arg0: f64) -> (!quantum.bit, !quantum.bit, !
     // CHECK-NEXT: [[mult:%.+]] = arith.mulf [[normalized_angle:%.+]], [[cst_2:%.+]] : f64
     // CHECK-NEXT: [[square:%.+]] = arith.mulf [[cst_1:%.+]], [[cst_1:%.+]] : f64
     // CHECK-NEXT: [[timems1:%.+]] = arith.divf [[mult:%.+]], [[square:%.+]] : f64
+    // CHECK-NEXT: [[ms1out:%.+]]:2 = ion.parallelprotocol([[qubit0]], [[qubit1]]) : !quantum.bit, !quantum.bit {
+    // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit, %arg2: !quantum.bit):
     // CHECK-NEXT: ion.pulse([[timems1]] : f64) %arg1 {
     // CHECK-SAME:     beam = #ion.beam<
     // CHECK-SAME:         transition_index = 0 : i64,
@@ -385,14 +384,12 @@ func.func @example_ion_three_qubit(%arg0: f64) -> (!quantum.bit, !quantum.bit, !
     // CHECK-NEXT: }
     %5:2 = quantum.custom "MS"(%arg0) %2, %3 : !quantum.bit, !quantum.bit
 
-    // CHECK: [[ms2out:%.+]]:2 = ion.parallelprotocol([[ms1out]]#0, [[qubit2]]) : !quantum.bit, !quantum.bit {
-    // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit, %arg2: !quantum.bit):
-    // CHECK-NEXT:%cst = arith.constant 12.566370614359172 : f64
-    // CHECK-NEXT:  [[remainder:%.+]] = arith.remf %arg0, %cst : f64
-    // CHECK-NEXT:  %cst_0 = arith.constant 0.000000e+00 : f64
-    // CHECK-NEXT:  [[negative:%.+]] = arith.cmpf olt, [[remainder:%.+]], %cst_0 : f64
+    // CHECK:       [[cst:%.+]] = arith.constant 12.566370614359172 : f64
+    // CHECK-NEXT:  [[remainder:%.+]] = arith.remf %arg0, [[cst:%.+]] : f64
+    // CHECK-NEXT:  [[cst_0:%.+]] = arith.constant 0.000000e+00 : f64
+    // CHECK-NEXT:  [[negative:%.+]] = arith.cmpf olt, [[remainder:%.+]], [[cst_0:%.+]] : f64
     // CHECK-NEXT:  [[normalized_angle:%.+]] = scf.if [[negative:%.+]] -> (f64) {
-    // CHECK-NEXT:    [[adjusted:%.+]] = arith.addf [[remainder:%.+]], %cst : f64
+    // CHECK-NEXT:    [[adjusted:%.+]] = arith.addf [[remainder:%.+]], [[cst:%.+]] : f64
     // CHECK-NEXT:    scf.yield [[adjusted:%.+]] : f64
     // CHECK-NEXT:  } else {
     // CHECK-NEXT:    scf.yield [[remainder:%.+]] : f64
@@ -402,6 +399,8 @@ func.func @example_ion_three_qubit(%arg0: f64) -> (!quantum.bit, !quantum.bit, !
     // CHECK-NEXT: [[mult:%.+]] = arith.mulf [[normalized_angle:%.+]], [[cst_2:%.+]] : f64
     // CHECK-NEXT: [[square:%.+]] = arith.mulf [[cst_1:%.+]], [[cst_1:%.+]] : f64
     // CHECK-NEXT: [[timems2:%.+]] = arith.divf [[mult:%.+]], [[square:%.+]] : f64
+    // CHECK-NEXT: [[ms2out:%.+]]:2 = ion.parallelprotocol([[ms1out]]#0, [[qubit2]]) : !quantum.bit, !quantum.bit {
+    // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit, %arg2: !quantum.bit):
     // CHECK-NEXT: ion.pulse([[timems2]] : f64) %arg1 {
     // CHECK-SAME:     beam = #ion.beam<
     // CHECK-SAME:         transition_index = 0 : i64,
@@ -454,14 +453,12 @@ func.func @example_ion_three_qubit(%arg0: f64) -> (!quantum.bit, !quantum.bit, !
     // CHECK-NEXT: }
     %6:2 = quantum.custom "MS"(%arg0) %5#0, %4 : !quantum.bit, !quantum.bit
 
-    // CHECK: [[ms3out:%.+]]:2 = ion.parallelprotocol([[ms1out]]#1, [[ms2out]]#1) : !quantum.bit, !quantum.bit {
-    // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit, %arg2: !quantum.bit):
-    // CHECK-NEXT:%cst = arith.constant 12.566370614359172 : f64
-    // CHECK-NEXT:  [[remainder:%.+]] = arith.remf %arg0, %cst : f64
-    // CHECK-NEXT:  %cst_0 = arith.constant 0.000000e+00 : f64
-    // CHECK-NEXT:  [[negative:%.+]] = arith.cmpf olt, [[remainder:%.+]], %cst_0 : f64
+    // CHECK:       [[cst:%.+]] = arith.constant 12.566370614359172 : f64
+    // CHECK-NEXT:  [[remainder:%.+]] = arith.remf %arg0, [[cst:%.+]] : f64
+    // CHECK-NEXT:  [[cst_0:%.+]] = arith.constant 0.000000e+00 : f64
+    // CHECK-NEXT:  [[negative:%.+]] = arith.cmpf olt, [[remainder:%.+]], [[cst_0:%.+]] : f64
     // CHECK-NEXT:  [[normalized_angle:%.+]] = scf.if [[negative:%.+]] -> (f64) {
-    // CHECK-NEXT:    [[adjusted:%.+]] = arith.addf [[remainder:%.+]], %cst : f64
+    // CHECK-NEXT:    [[adjusted:%.+]] = arith.addf [[remainder:%.+]], [[cst:%.+]] : f64
     // CHECK-NEXT:    scf.yield [[adjusted:%.+]] : f64
     // CHECK-NEXT:  } else {
     // CHECK-NEXT:    scf.yield [[remainder:%.+]] : f64
@@ -471,6 +468,8 @@ func.func @example_ion_three_qubit(%arg0: f64) -> (!quantum.bit, !quantum.bit, !
     // CHECK-NEXT: [[mult:%.+]] = arith.mulf [[normalized_angle:%.+]], [[cst_2:%.+]] : f64
     // CHECK-NEXT: [[square:%.+]] = arith.mulf [[cst_1:%.+]], [[cst_1:%.+]] : f64
     // CHECK-NEXT: [[timems3:%.+]] = arith.divf [[mult:%.+]], [[square:%.+]] : f64
+    // CHECK-NEXT: [[ms3out:%.+]]:2 = ion.parallelprotocol([[ms1out]]#1, [[ms2out]]#1) : !quantum.bit, !quantum.bit {
+    // CHECK-NEXT: ^{{.*}}(%arg1: !quantum.bit, %arg2: !quantum.bit):
     // CHECK-NEXT: [[p1:%.+]] = ion.pulse([[timems3]] : f64) %arg1 {
     // CHECK-SAME:     beam = #ion.beam<
     // CHECK-SAME:         transition_index = 0 : i64,


### PR DESCRIPTION
**Context:**
Currently, the `quantum-to-ion` pass lowers the gates to patterns of ParallelProtocol + pulses. The semantic of ParallelProtocol is that all the instructions inside it are executed in parallel. However, we are including some arithmetic that calculates the duration of pulses within the Parallel protocol, therefore creating data dependency between the parallel instructions.
Moreover, the name of the pass `quantum-to-ion` implies a full conversion from quantum dialect to ion dialect which is not the case. We only convert quantum gates and all the other quantum operations remain intact after the pass is applied.

**Description of the Change:**
- hoisted the pulse duration calculation arithmetic out of the parallel protocol
- changed the name of the pass to `gates-to-pulses`

**Benefits:**
This prepares the ion dialect for future development.

**Possible Drawbacks:**

**Related GitHub Issues:**
