### PR TITLE
Add a more sophisticated test for from_plxpr qreg manager

### DIFF
--- a/frontend/test/pytest/test_from_plxpr_qregmanager.py
+++ b/frontend/test/pytest/test_from_plxpr_qregmanager.py
@@ -33,7 +33,6 @@ Quoted from the object's docstring:
        - `QubitManager[i] = new_qubit_value`
 """
 # pylint: disable=use-implicit-booleaness-not-comparison
-import copy
 import textwrap
 
 import pytest
@@ -43,7 +42,7 @@ from jax.extend.core import Primitive
 from jax.interpreters.partial_eval import DynamicJaxprTrace
 
 from catalyst.from_plxpr.qreg_manager import QregManager
-from catalyst.jax_primitives import qalloc_p, qextract_p
+from catalyst.jax_primitives import AbstractQbit, AbstractQreg, qalloc_p, qextract_p
 from catalyst.utils.exceptions import CompileError
 
 
@@ -66,10 +65,10 @@ qreg_mock_op_p = Primitive("qreg_mock_op")
 
 
 @qreg_mock_op_p.def_abstract_eval
-def _qreg_mock_op_abstract_eval(qreg):
-    # Use a copy so the mock returns a completely independent, second qreg object
+def _qreg_mock_op_abstract_eval(qreg):  # pylint: disable=unused-argument
+    # Return a completely independent, second qreg object
     # This is to mimic real ops
-    return copy.copy(qreg)
+    return AbstractQreg()
 
 
 # A mock primitive that takes in a qubit and returns a qubit
@@ -79,9 +78,9 @@ qubit_mock_op_p.multiple_results = True
 
 @qubit_mock_op_p.def_abstract_eval
 def _qubit_mock_op_abstract_eval(*qubits):
-    # Use a copy so the mock returns a completely independent, second qubit object
+    # Return a completely independent, second list of qubit objects
     # This is to mimic real ops
-    return [copy.copy(qubit) for qubit in qubits]
+    return [AbstractQbit()] * len(qubits)
 
 
 def _interpret_operation(wires, qreg_manager):


### PR DESCRIPTION
**Context:**
There are some "requests" for making the UI of the from_plxpr qreg manager clearer. I added a end-to-end test to illustrate.

**Description of the Change:**
Add an end-to-end test for from_plxpr qreg manager. 
The test is a qubit op, then a qreg op, then a qubit op.

**Benefits:**
More test coverage. 
Illustration of internal object's use. 

**Possible Drawbacks:**
Ideally I want to export something like a `_bind_qubit/qreg_primitive()` function to automatically update the manager with new qubit and qreg values. However this was a bit difficult since it is not unified across primitives which argument in `*args` is the qubits.
