### PR TITLE
frontend passes for disentangle CNOT and SWAP

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -196,8 +196,9 @@
 * `static_argnums` on `qjit` can now be specified with program capture through PLxPR.
   [(#1810)](https://github.com/PennyLaneAI/catalyst/pull/1810)
 
-* Python frontend functions added to Catalyst for two MLIR passes and can be used to decorate a 
-  QNode using: :func:`~.passes.disentangle_cnot` and :func:`~.passes.disentangle_swap`. 
+* Two new Python pass decorators, :func:`~.passes.disentangle_cnot` and 
+  :func:`~.passes.disentangle_swap`, have been added. They apply their corresponding MLIR passes 
+  `--disentangle-CNOT` and `--disentangle-SWAP` respectively. 
   [(#1823)](https://github.com/PennyLaneAI/catalyst/pull/1823)
 
 <h3>Breaking changes 💔</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -188,6 +188,10 @@
 * `static_argnums` on `qjit` can now be specified with program capture through PLxPR.
   [(#1810)](https://github.com/PennyLaneAI/catalyst/pull/1810)
 
+* Python frontend functions added to Catalyst for two MLIR passes and can be used to decorate a 
+  QNode using: :func:`~.passes.disentangle_cnot` and :func:`~.passes.disentangle_swap`. 
+  [(#1823)](https://github.com/PennyLaneAI/catalyst/pull/1823)
+
 <h3>Breaking changes 💔</h3>
 
 * (Device Developers Only) The `QuantumDevice` interface in the Catalyst Runtime plugin system

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -197,7 +197,7 @@
   [(#1810)](https://github.com/PennyLaneAI/catalyst/pull/1810)
 
 * Two new Python pass decorators, :func:`~.passes.disentangle_cnot` and 
-  :func:`~.passes.disentangle_swap`, have been added. They apply their corresponding MLIR passes 
+  :func:`~.passes.disentangle_swap` have been added. They apply their corresponding MLIR passes 
   `--disentangle-CNOT` and `--disentangle-SWAP` respectively. 
   [(#1823)](https://github.com/PennyLaneAI/catalyst/pull/1823)
 

--- a/frontend/catalyst/passes/__init__.py
+++ b/frontend/catalyst/passes/__init__.py
@@ -36,6 +36,8 @@ as load and run external MLIR passes from plugins.
 from catalyst.passes.builtin_passes import (
     cancel_inverses,
     commute_ppr,
+    disentangle_cnot,
+    disentangle_swap,
     get_ppm_specs,
     ions_decomposition,
     merge_ppr_ppm,
@@ -50,6 +52,8 @@ __all__ = (
     "to_ppr",
     "commute_ppr",
     "cancel_inverses",
+    "disentangle_cnot",
+    "disentangle_swap",
     "get_ppm_specs",
     "ions_decomposition",
     "merge_rotations",

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -189,7 +189,7 @@ def disentangle_cnot(qnode):
         }
         func.func public @circuit_0() -> tensor<4xcomplex<f64>> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
             %c0_i64 = arith.constant 0 : i64
-            quantum.device shots(%c0_i64) ["/Users/ritu.thombre/Desktop/catalyst/.venv/lib/python3.12/site-packages/pennylane_lightning/liblightning_qubit_catalyst.dylib", "LightningSimulator", "{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}"]
+            quantum.device["catalyst/utils/../lib/librtd_lightning.dylib", "LightningSimulator", "{'shots': 0, 'mcmc': False, 'num_burnin': 0, 'kernel_name': None}"]
             %0 = quantum.alloc( 2) : !quantum.reg
             %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
             %out_qubits = quantum.custom "PauliX"() %1 : !quantum.bit
@@ -277,10 +277,10 @@ def disentangle_swap(qnode):
         func.func public @circuit_0() -> tensor<4xcomplex<f64>> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
             %c0_i64 = arith.constant 0 : i64
             %cst = arith.constant 0.78539816339744828 : f64
-            quantum.device shots(%c0_i64) ["/Users/ritu.thombre/Desktop/catalyst/.venv/lib/python3.12/site-packages/pennylane_lightning/liblightning_qubit_catalyst.dylib", "LightningSimulator", "{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}"]
+            quantum.device["catalyst/utils/../lib/librtd_lightning.dylib", "LightningSimulator", "{'shots': 0, 'mcmc': False, 'num_burnin': 0, 'kernel_name': None}"]
             %0 = quantum.alloc( 2) : !quantum.reg
             %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
-            %out_qubits = quantum.custom "PauliX"() %1 : !quantum.bit
+            %out_qubits = quantum.custom "PauliX"() %1 : !quantum.bit5
             %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
             %out_qubits_0 = quantum.custom "RX"(%cst) %2 : !quantum.bit
             %out_qubits_1 = quantum.custom "PauliX"() %out_qubits_0 : !quantum.bit
@@ -308,6 +308,11 @@ def disentangle_swap(qnode):
 
     .. code-block:: mlir
 
+        %0 = quantum.alloc( 2) : !quantum.reg
+        %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+        %out_qubits = quantum.custom "PauliX"() %1 : !quantum.bit5
+        %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+        %out_qubits_0 = quantum.custom "RX"(%cst) %2 : !quantum.bit
         %out_qubits_1 = quantum.custom "PauliX"() %out_qubits_0 : !quantum.bit
         %out_qubits_2:2 = quantum.custom "CNOT"() %out_qubits_1, %out_qubits : !quantum.bit, !quantum.bit
         %out_qubits_3:2 = quantum.custom "CNOT"() %out_qubits_2#1, %out_qubits_2#0 : !quantum.bit, !quantum.bit

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -136,8 +136,10 @@ def cancel_inverses(qnode):
     """
     return PassPipelineWrapper(qnode, "remove-chained-self-inverse")
 
+
 def disentangle_cnot(qnode):
     return PassPipelineWrapper(qnode, "disentangle-CNOT")
+
 
 def disentangle_swap(qnode):
     return PassPipelineWrapper(qnode, "disentangle-SWAP")

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -138,10 +138,180 @@ def cancel_inverses(qnode):
 
 
 def disentangle_cnot(qnode):
+    """
+    Specify that the ``-disentangle-CNOT`` MLIR compiler pass
+    for simplifying CNOT gates should be applied to the decorated
+    QNode during :func:`~.qjit` compilation.
+
+    Args:
+        fn (QNode): the QNode to apply the disentangle CNOT compiler pass to
+
+    Returns:
+        ~.QNode:
+
+    **Example**
+
+    .. code-block:: python
+
+    import pennylane as qml
+    from catalyst import qjit
+    from catalyst.debug import get_compilation_stage
+    from catalyst.passes import disentangle_cnot
+
+    dev = qml.device("lightning.qubit", wires=2)
+
+    @qjit(keep_intermediate=True)
+    @disentangle_cnot
+    @qml.qnode(dev)
+    def circuit():
+        # first qubit in |1>
+        qml.X(0)
+        # second qubit in |0>
+        # current state : |10>
+        qml.CNOT([0,1]) # state after CNOT : |11>
+        return qml.state()
+
+    >>> circuit()
+    [0.+0.j  0.+0.j  0.+0.j  1.+0.j]
+
+    Note that the QNode will be unchanged in Python, and will continue
+    to include keep CNOT gates gates when inspected with Python (for example,
+    with :func:`~.draw`).
+
+    To instead view the optimized circuit, the MLIR must be viewed
+    after the ``"QuantumCompilationPass"`` stage:
+
+    >>> print(get_compilation_stage(circuit, stage="QuantumCompilationPass"))
+    module @circuit {
+        func.func public @jit_circuit() -> tensor<4xcomplex<f64>> attributes {llvm.emit_c_interface} {
+            %0 = call @circuit_0() : () -> tensor<4xcomplex<f64>>
+            return %0 : tensor<4xcomplex<f64>>
+        }
+        func.func public @circuit_0() -> tensor<4xcomplex<f64>> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
+            %c0_i64 = arith.constant 0 : i64
+            quantum.device shots(%c0_i64) ["/Users/ritu.thombre/Desktop/catalyst/.venv/lib/python3.12/site-packages/pennylane_lightning/liblightning_qubit_catalyst.dylib", "LightningSimulator", "{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}"]
+            %0 = quantum.alloc( 2) : !quantum.reg
+            %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+            %out_qubits = quantum.custom "PauliX"() %1 : !quantum.bit
+            %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+            %out_qubits_0 = quantum.custom "PauliX"() %2 : !quantum.bit
+            %3 = quantum.insert %0[ 0], %out_qubits : !quantum.reg, !quantum.bit
+            %4 = quantum.insert %3[ 1], %out_qubits_0 : !quantum.reg, !quantum.bit
+            %5 = quantum.compbasis qreg %4 : !quantum.obs
+            %6 = quantum.state %5 : tensor<4xcomplex<f64>>
+            quantum.dealloc %4 : !quantum.reg
+            quantum.device_release
+            return %6 : tensor<4xcomplex<f64>>
+        }
+        func.func @setup() {
+            quantum.init
+            return
+        }
+        func.func @teardown() {
+            quantum.finalize
+            return
+        }
+    }
+
+    It can be seen that the CNOT(0,1) has been replaced with X(1)
+
+    .. code-block:: mlir
+
+        %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+        %out_qubits_0 = quantum.custom "PauliX"() %2 : !quantum.bit
+    """
     return PassPipelineWrapper(qnode, "disentangle-CNOT")
 
 
 def disentangle_swap(qnode):
+    """
+    Specify that the ``-disentangle-SWAP`` MLIR compiler pass
+    for simplifying CNOT gates should be applied to the decorated
+    QNode during :func:`~.qjit` compilation.
+
+    Args:
+        fn (QNode): the QNode to apply the disentangle SWAP compiler pass to
+
+    Returns:
+        ~.QNode:
+
+    **Example**
+
+    .. code-block:: python
+
+    import pennylane as qml
+    from pennylane import numpy as np
+    from catalyst import qjit
+    from catalyst.debug import get_compilation_stage
+    from catalyst.passes import disentangle_swap
+
+    dev = qml.device("lightning.qubit", wires=2)
+
+    @qjit(keep_intermediate=True)
+    @disentangle_swap
+    @qml.qnode(dev)
+    def circuit():
+        # first qubit in |1>
+        qml.X(0)
+        # second qubit in non-basis
+        qml.RX(np.pi/4,1)
+        qml.SWAP([0,1])
+        return qml.state()
+
+    >>> circuit()
+    [0.+0.j  0.92387953+0.j  0.+0.j  0.-0.38268343j]
+
+    Note that the QNode will be unchanged in Python, and will continue
+    to include keep SWAP gates gates when inspected with Python (for example,
+    with :func:`~.draw`).
+
+    To instead view the optimized circuit, the MLIR must be viewed
+    after the ``"QuantumCompilationPass"`` stage:
+
+    >>> print(get_compilation_stage(circuit, stage="QuantumCompilationPass"))
+    module @circuit {
+        func.func public @jit_circuit() -> tensor<4xcomplex<f64>> attributes {llvm.emit_c_interface} {
+            %0 = call @circuit_0() : () -> tensor<4xcomplex<f64>>
+            return %0 : tensor<4xcomplex<f64>>
+        }
+        func.func public @circuit_0() -> tensor<4xcomplex<f64>> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
+            %c0_i64 = arith.constant 0 : i64
+            %cst = arith.constant 0.78539816339744828 : f64
+            quantum.device shots(%c0_i64) ["/Users/ritu.thombre/Desktop/catalyst/.venv/lib/python3.12/site-packages/pennylane_lightning/liblightning_qubit_catalyst.dylib", "LightningSimulator", "{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}"]
+            %0 = quantum.alloc( 2) : !quantum.reg
+            %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+            %out_qubits = quantum.custom "PauliX"() %1 : !quantum.bit
+            %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+            %out_qubits_0 = quantum.custom "RX"(%cst) %2 : !quantum.bit
+            %out_qubits_1 = quantum.custom "PauliX"() %out_qubits_0 : !quantum.bit
+            %out_qubits_2:2 = quantum.custom "CNOT"() %out_qubits_1, %out_qubits : !quantum.bit, !quantum.bit
+            %out_qubits_3:2 = quantum.custom "CNOT"() %out_qubits_2#1, %out_qubits_2#0 : !quantum.bit, !quantum.bit
+            %3 = quantum.insert %0[ 0], %out_qubits_3#0 : !quantum.reg, !quantum.bit
+            %4 = quantum.insert %3[ 1], %out_qubits_3#1 : !quantum.reg, !quantum.bit
+            %5 = quantum.compbasis qreg %4 : !quantum.obs
+            %6 = quantum.state %5 : tensor<4xcomplex<f64>>
+            quantum.dealloc %4 : !quantum.reg
+            quantum.device_release
+            return %6 : tensor<4xcomplex<f64>>
+        }
+        func.func @setup() {
+            quantum.init
+            return
+        }
+        func.func @teardown() {
+            quantum.finalize
+            return
+        }
+    }
+
+    It can be seen that the SWAP(0,1) has been replaced with the folliowing
+
+    .. code-block:: mlir
+
+        %out_qubits_1 = quantum.custom "PauliX"() %out_qubits_0 : !quantum.bit
+        %out_qubits_2:2 = quantum.custom "CNOT"() %out_qubits_1, %out_qubits : !quantum.bit, !quantum.bit
+        %out_qubits_3:2 = quantum.custom "CNOT"() %out_qubits_2#1, %out_qubits_2#0 : !quantum.bit, !quantum.bit
+    """
     return PassPipelineWrapper(qnode, "disentangle-SWAP")
 
 

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -22,8 +22,8 @@ from catalyst.compiler import _options_to_cli_flags, _quantum_opt
 from catalyst.passes.pass_api import PassPipelineWrapper
 from catalyst.utils.exceptions import CompileError
 
-# pylint: disable=line-too-long
-# pylint: too-many-lines
+# pylint: disable=line-too-long, too-many-lines
+
 
 ## API ##
 def cancel_inverses(qnode):

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -22,6 +22,7 @@ from catalyst.compiler import _options_to_cli_flags, _quantum_opt
 from catalyst.passes.pass_api import PassPipelineWrapper
 from catalyst.utils.exceptions import CompileError
 
+# pylint: line-too-long
 
 ## API ##
 def cancel_inverses(qnode):

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -136,6 +136,12 @@ def cancel_inverses(qnode):
     """
     return PassPipelineWrapper(qnode, "remove-chained-self-inverse")
 
+def disentangle_cnot(qnode):
+    return PassPipelineWrapper(qnode, "disentangle-CNOT")
+
+def disentangle_swap(qnode):
+    return PassPipelineWrapper(qnode, "disentangle-SWAP")
+
 
 def merge_rotations(qnode):
     """

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -184,6 +184,9 @@ def disentangle_cnot(qnode):
     after the ``"QuantumCompilationPass"`` stage:
 
     >>> print(get_compilation_stage(circuit, stage="QuantumCompilationPass"))
+
+    .. code-block:: mlir
+
     module @circuit {
         func.func public @jit_circuit() -> tensor<4xcomplex<f64>> attributes {llvm.emit_c_interface} {
             %0 = call @circuit_0() : () -> tensor<4xcomplex<f64>>
@@ -271,6 +274,9 @@ def disentangle_swap(qnode):
     after the ``"QuantumCompilationPass"`` stage:
 
     >>> print(get_compilation_stage(circuit, stage="QuantumCompilationPass"))
+
+    .. code-block:: mlir
+
     module @circuit {
         func.func public @jit_circuit() -> tensor<4xcomplex<f64>> attributes {llvm.emit_c_interface} {
             %0 = call @circuit_0() : () -> tensor<4xcomplex<f64>>

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -155,23 +155,23 @@ def disentangle_cnot(qnode):
 
     .. code-block:: python
 
-    import pennylane as qml
-    from catalyst import qjit
-    from catalyst.debug import get_compilation_stage
-    from catalyst.passes import disentangle_cnot
+        import pennylane as qml
+        from catalyst import qjit
+        from catalyst.debug import get_compilation_stage
+        from catalyst.passes import disentangle_cnot
 
-    dev = qml.device("lightning.qubit", wires=2)
+        dev = qml.device("lightning.qubit", wires=2)
 
-    @qjit(keep_intermediate=True)
-    @disentangle_cnot
-    @qml.qnode(dev)
-    def circuit():
-        # first qubit in |1>
-        qml.X(0)
-        # second qubit in |0>
-        # current state : |10>
-        qml.CNOT([0,1]) # state after CNOT : |11>
-        return qml.state()
+        @qjit(keep_intermediate=True)
+        @disentangle_cnot
+        @qml.qnode(dev)
+        def circuit():
+            # first qubit in |1>
+            qml.X(0)
+            # second qubit in |0>
+            # current state : |10>
+            qml.CNOT([0,1]) # state after CNOT : |11>
+            return qml.state()
 
     >>> circuit()
     [0.+0.j  0.+0.j  0.+0.j  1.+0.j]
@@ -187,36 +187,36 @@ def disentangle_cnot(qnode):
 
     .. code-block:: mlir
 
-    module @circuit {
-        func.func public @jit_circuit() -> tensor<4xcomplex<f64>> attributes {llvm.emit_c_interface} {
-            %0 = call @circuit_0() : () -> tensor<4xcomplex<f64>>
-            return %0 : tensor<4xcomplex<f64>>
+        module @circuit {
+            func.func public @jit_circuit() -> tensor<4xcomplex<f64>> attributes {llvm.emit_c_interface} {
+                %0 = call @circuit_0() : () -> tensor<4xcomplex<f64>>
+                return %0 : tensor<4xcomplex<f64>>
+            }
+            func.func public @circuit_0() -> tensor<4xcomplex<f64>> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
+                %c0_i64 = arith.constant 0 : i64
+                quantum.device["catalyst/utils/../lib/librtd_lightning.dylib", "LightningSimulator", "{'shots': 0, 'mcmc': False, 'num_burnin': 0, 'kernel_name': None}"]
+                %0 = quantum.alloc( 2) : !quantum.reg
+                %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+                %out_qubits = quantum.custom "PauliX"() %1 : !quantum.bit
+                %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+                %out_qubits_0 = quantum.custom "PauliX"() %2 : !quantum.bit
+                %3 = quantum.insert %0[ 0], %out_qubits : !quantum.reg, !quantum.bit
+                %4 = quantum.insert %3[ 1], %out_qubits_0 : !quantum.reg, !quantum.bit
+                %5 = quantum.compbasis qreg %4 : !quantum.obs
+                %6 = quantum.state %5 : tensor<4xcomplex<f64>>
+                quantum.dealloc %4 : !quantum.reg
+                quantum.device_release
+                return %6 : tensor<4xcomplex<f64>>
+            }
+            func.func @setup() {
+                quantum.init
+                return
+            }
+            func.func @teardown() {
+                quantum.finalize
+                return
+            }
         }
-        func.func public @circuit_0() -> tensor<4xcomplex<f64>> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
-            %c0_i64 = arith.constant 0 : i64
-            quantum.device["catalyst/utils/../lib/librtd_lightning.dylib", "LightningSimulator", "{'shots': 0, 'mcmc': False, 'num_burnin': 0, 'kernel_name': None}"]
-            %0 = quantum.alloc( 2) : !quantum.reg
-            %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
-            %out_qubits = quantum.custom "PauliX"() %1 : !quantum.bit
-            %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
-            %out_qubits_0 = quantum.custom "PauliX"() %2 : !quantum.bit
-            %3 = quantum.insert %0[ 0], %out_qubits : !quantum.reg, !quantum.bit
-            %4 = quantum.insert %3[ 1], %out_qubits_0 : !quantum.reg, !quantum.bit
-            %5 = quantum.compbasis qreg %4 : !quantum.obs
-            %6 = quantum.state %5 : tensor<4xcomplex<f64>>
-            quantum.dealloc %4 : !quantum.reg
-            quantum.device_release
-            return %6 : tensor<4xcomplex<f64>>
-        }
-        func.func @setup() {
-            quantum.init
-            return
-        }
-        func.func @teardown() {
-            quantum.finalize
-            return
-        }
-    }
 
     It can be seen that the CNOT(0,1) has been replaced with X(1)
 
@@ -231,7 +231,7 @@ def disentangle_cnot(qnode):
 def disentangle_swap(qnode):
     """
     Specify that the ``-disentangle-SWAP`` MLIR compiler pass
-    for simplifying CNOT gates should be applied to the decorated
+    for simplifying SWAP gates should be applied to the decorated
     QNode during :func:`~.qjit` compilation.
 
     Args:
@@ -244,24 +244,24 @@ def disentangle_swap(qnode):
 
     .. code-block:: python
 
-    import pennylane as qml
-    from pennylane import numpy as np
-    from catalyst import qjit
-    from catalyst.debug import get_compilation_stage
-    from catalyst.passes import disentangle_swap
+        import pennylane as qml
+        from pennylane import numpy as np
+        from catalyst import qjit
+        from catalyst.debug import get_compilation_stage
+        from catalyst.passes import disentangle_swap
 
-    dev = qml.device("lightning.qubit", wires=2)
+        dev = qml.device("lightning.qubit", wires=2)
 
-    @qjit(keep_intermediate=True)
-    @disentangle_swap
-    @qml.qnode(dev)
-    def circuit():
-        # first qubit in |1>
-        qml.X(0)
-        # second qubit in non-basis
-        qml.RX(np.pi/4,1)
-        qml.SWAP([0,1])
-        return qml.state()
+        @qjit(keep_intermediate=True)
+        @disentangle_swap
+        @qml.qnode(dev)
+        def circuit():
+            # first qubit in |1>
+            qml.X(0)
+            # second qubit in non-basis
+            qml.RX(np.pi/4,1)
+            qml.SWAP([0,1])
+            return qml.state()
 
     >>> circuit()
     [0.+0.j  0.92387953+0.j  0.+0.j  0.-0.38268343j]
@@ -277,40 +277,40 @@ def disentangle_swap(qnode):
 
     .. code-block:: mlir
 
-    module @circuit {
-        func.func public @jit_circuit() -> tensor<4xcomplex<f64>> attributes {llvm.emit_c_interface} {
-            %0 = call @circuit_0() : () -> tensor<4xcomplex<f64>>
-            return %0 : tensor<4xcomplex<f64>>
+        module @circuit {
+            func.func public @jit_circuit() -> tensor<4xcomplex<f64>> attributes {llvm.emit_c_interface} {
+                %0 = call @circuit_0() : () -> tensor<4xcomplex<f64>>
+                return %0 : tensor<4xcomplex<f64>>
+            }
+            func.func public @circuit_0() -> tensor<4xcomplex<f64>> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
+                %c0_i64 = arith.constant 0 : i64
+                %cst = arith.constant 0.78539816339744828 : f64
+                quantum.device["catalyst/utils/../lib/librtd_lightning.dylib", "LightningSimulator", "{'shots': 0, 'mcmc': False, 'num_burnin': 0, 'kernel_name': None}"]
+                %0 = quantum.alloc( 2) : !quantum.reg
+                %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+                %out_qubits = quantum.custom "PauliX"() %1 : !quantum.bit5
+                %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+                %out_qubits_0 = quantum.custom "RX"(%cst) %2 : !quantum.bit
+                %out_qubits_1 = quantum.custom "PauliX"() %out_qubits_0 : !quantum.bit
+                %out_qubits_2:2 = quantum.custom "CNOT"() %out_qubits_1, %out_qubits : !quantum.bit, !quantum.bit
+                %out_qubits_3:2 = quantum.custom "CNOT"() %out_qubits_2#1, %out_qubits_2#0 : !quantum.bit, !quantum.bit
+                %3 = quantum.insert %0[ 0], %out_qubits_3#0 : !quantum.reg, !quantum.bit
+                %4 = quantum.insert %3[ 1], %out_qubits_3#1 : !quantum.reg, !quantum.bit
+                %5 = quantum.compbasis qreg %4 : !quantum.obs
+                %6 = quantum.state %5 : tensor<4xcomplex<f64>>
+                quantum.dealloc %4 : !quantum.reg
+                quantum.device_release
+                return %6 : tensor<4xcomplex<f64>>
+            }
+            func.func @setup() {
+                quantum.init
+                return
+            }
+            func.func @teardown() {
+                quantum.finalize
+                return
+            }
         }
-        func.func public @circuit_0() -> tensor<4xcomplex<f64>> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
-            %c0_i64 = arith.constant 0 : i64
-            %cst = arith.constant 0.78539816339744828 : f64
-            quantum.device["catalyst/utils/../lib/librtd_lightning.dylib", "LightningSimulator", "{'shots': 0, 'mcmc': False, 'num_burnin': 0, 'kernel_name': None}"]
-            %0 = quantum.alloc( 2) : !quantum.reg
-            %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
-            %out_qubits = quantum.custom "PauliX"() %1 : !quantum.bit5
-            %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
-            %out_qubits_0 = quantum.custom "RX"(%cst) %2 : !quantum.bit
-            %out_qubits_1 = quantum.custom "PauliX"() %out_qubits_0 : !quantum.bit
-            %out_qubits_2:2 = quantum.custom "CNOT"() %out_qubits_1, %out_qubits : !quantum.bit, !quantum.bit
-            %out_qubits_3:2 = quantum.custom "CNOT"() %out_qubits_2#1, %out_qubits_2#0 : !quantum.bit, !quantum.bit
-            %3 = quantum.insert %0[ 0], %out_qubits_3#0 : !quantum.reg, !quantum.bit
-            %4 = quantum.insert %3[ 1], %out_qubits_3#1 : !quantum.reg, !quantum.bit
-            %5 = quantum.compbasis qreg %4 : !quantum.obs
-            %6 = quantum.state %5 : tensor<4xcomplex<f64>>
-            quantum.dealloc %4 : !quantum.reg
-            quantum.device_release
-            return %6 : tensor<4xcomplex<f64>>
-        }
-        func.func @setup() {
-            quantum.init
-            return
-        }
-        func.func @teardown() {
-            quantum.finalize
-            return
-        }
-    }
 
     It can be seen that the SWAP(0,1) has been replaced with the folliowing
 

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -22,7 +22,8 @@ from catalyst.compiler import _options_to_cli_flags, _quantum_opt
 from catalyst.passes.pass_api import PassPipelineWrapper
 from catalyst.utils.exceptions import CompileError
 
-# pylint: line-too-long
+# pylint: disable=line-too-long
+# pylint: too-many-lines
 
 ## API ##
 def cancel_inverses(qnode):

--- a/frontend/catalyst/passes/pass_api.py
+++ b/frontend/catalyst/passes/pass_api.py
@@ -375,6 +375,8 @@ def dictionary_to_list_of_passes(pass_pipeline: PipelineDict | str, *flags, **va
 def _API_name_to_pass_name():
     return {
         "cancel_inverses": "remove-chained-self-inverse",
+        "disentangle_cnot": "disentangle-CNOT",
+        "disentangle_swap": "disentangle-SWAP",
         "merge_rotations": "merge-rotations",
         "ions_decomposition": "ions-decomposition",
         "to_ppr": "to-ppr",

--- a/frontend/test/pytest/test_peephole_optimizations.py
+++ b/frontend/test/pytest/test_peephole_optimizations.py
@@ -141,12 +141,12 @@ def test_pipeline_functionality(theta, backend):
 
 
 ### Test bad usages of pass decorators ###
-def test_cancel_inverses_bad_usages():
+def test_passes_bad_usages():
     """
     Tests that an error is raised when cancel_inverses is not used properly
     """
 
-    def test_cancel_inverses_not_on_qnode():
+    def test_passes_not_on_qnode():
         def classical_func():
             return 42.42
 
@@ -180,7 +180,7 @@ def test_cancel_inverses_bad_usages():
         ):
             disentangle_swap(classical_func)
 
-    test_cancel_inverses_not_on_qnode()
+    test_passes_not_on_qnode()
 
 
 def test_chained_passes():
@@ -231,12 +231,14 @@ def test_disentangle_passes():
         qml.SWAP(wires=[0, 1])  # state after SWAP |11>
         return qml.state()
 
-    assert "disentangle-CNOT" in circuit_with_disentangle_passes.mlir
-    assert "disentangle-SWAP" in circuit_with_disentangle_passes.mlir
+    input_mlir_string = circuit_with_disentangle_passes.mlir
+    assert "disentangle-CNOT" in input_mlir_string
+    assert "disentangle-SWAP" in input_mlir_string
 
     # both SWAP and CNOT should be removed by the disentangle passes
-    assert "CNOT" not in circuit_with_disentangle_passes.mlir_opt
-    assert "SWAP" not in circuit_with_disentangle_passes.mlir_opt
+    transformed_mlir_string = circuit_with_disentangle_passes.mlir_opt
+    assert "CNOT" not in transformed_mlir_string
+    assert "SWAP" not in transformed_mlir_string
 
     assert np.allclose(circuit_with_no_disentangle_passes(), circuit_with_disentangle_passes())
 


### PR DESCRIPTION
**Context:** [Relaxed peephole optimization](https://arxiv.org/pdf/2012.07711) for Hackweek

**Description of the Change:** 
Add Python API function for `disentangle-CNOT` and `disentangle-SWAP` passes.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:** closes #1419 

**Example**

```python
import pennylane as qml
from catalyst import qjit
from catalyst.passes import disentangle_swap 

from catalyst.debug import get_compilation_stage

dev = qml.device("lightning.qubit", wires=2)

@qjit(keep_intermediate=True)
@disentangle_swap
@qml.qnode(dev)
def circuit():
    qml.X(0)
    qml.X(1)
    qml.SWAP([0,1])
    return qml.expval(qml.PauliZ(0))

print(get_compilation_stage(circuit, stage="QuantumCompilationPass"))

```

Output: SWAP removed

```pycon
module @circuit {
  func.func public @jit_circuit() -> tensor<f64> attributes {llvm.emit_c_interface} {
    %0 = call @circuit_0() : () -> tensor<f64>
    return %0 : tensor<f64>
  }
  func.func public @circuit_0() -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
    %c0_i64 = arith.constant 0 : i64
    quantum.device shots(%c0_i64) ["/Users/ritu.thombre/Desktop/catalyst/.venv/lib/python3.12/site-packages/pennylane_lightning/liblightning_qubit_catalyst.dylib", "LightningSimulator", "{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}"]
    %0 = quantum.alloc( 2) : !quantum.reg
    %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
    %out_qubits = quantum.custom "PauliX"() %1 : !quantum.bit
    %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
    %out_qubits_0 = quantum.custom "PauliX"() %2 : !quantum.bit
    %3 = quantum.namedobs %out_qubits[ PauliZ] : !quantum.obs
    %4 = quantum.expval %3 : f64
    %from_elements = tensor.from_elements %4 : tensor<f64>
    %5 = quantum.insert %0[ 0], %out_qubits : !quantum.reg, !quantum.bit
    %6 = quantum.insert %5[ 1], %out_qubits_0 : !quantum.reg, !quantum.bit
    quantum.dealloc %6 : !quantum.reg
    quantum.device_release
    return %from_elements : tensor<f64>
  }
  func.func @setup() {
    quantum.init
    return
  }
  func.func @teardown() {
    quantum.finalize
    return
  }
}
```

[sc-81502]
