### PR TITLE
[Frontend] consts on subroutines

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -365,6 +365,7 @@
 * Support for quantum subroutines was added.
   This feature is expected to improve compilation times for large quantum programs.
   [(#1774)](https://github.com/PennyLaneAI/catalyst/pull/1774)
+  [(#1828)](https://github.com/PennyLaneAI/catalyst/pull/1828)
 
 * PennyLane's arbitrary-basis measurement operations, such as
   :func:`qml.ftqc.measure_arbitrary_basis() <pennylane.ftqc.measure_arbitrary_basis>`, are now

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -25,7 +25,6 @@ import pennylane as qml
 from jax._src.sharding_impls import UNSPECIFIED
 from jax.extend.core import ClosedJaxpr, Jaxpr
 from jax.extend.linear_util import wrap_init
-from jax.interpreters.partial_eval import convert_constvars_jaxpr
 from pennylane.capture import PlxprInterpreter, qnode_prim
 from pennylane.capture.expand_transforms import ExpandTransformsInterpreter
 from pennylane.capture.primitives import measure_prim as plxpr_measure_prim

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -426,10 +426,7 @@ def handle_subroutine(self, *args, **kwargs):
         return converter.qreg_manager.get(), *retvals
 
     if not transformed:
-        converted_jaxpr_branch = jax.make_jaxpr(wrapper)(self.qreg_manager.get(), *args).jaxpr
-        converted_closed_jaxpr_branch = ClosedJaxpr(
-            convert_constvars_jaxpr(converted_jaxpr_branch), ()
-        )
+        converted_closed_jaxpr_branch = jax.make_jaxpr(wrapper)(self.qreg_manager.get(), *args)
         self.subroutine_cache[plxpr] = converted_closed_jaxpr_branch
     else:
         converted_closed_jaxpr_branch = transformed


### PR DESCRIPTION
**Context:** One of the biggest features in subroutines was to preserve constants in the function they were defined. However, idiomatic code removes constants. When implementing subroutines idiomatic code was used instead of taking constants into account.

**Description of the Change:** Keep constants around.

**Benefits:** Correct code.

**Possible Drawbacks:**

**Related GitHub Issues:**
