### PR TITLE
Fixes up chained self inverses

### DIFF
--- a/mlir/lib/Quantum/IR/QuantumOps.cpp
+++ b/mlir/lib/Quantum/IR/QuantumOps.cpp
@@ -132,7 +132,7 @@ LogicalResult InsertOp::canonicalize(InsertOp insert, mlir::PatternRewriter &rew
         bool oneUse = extract.getResult().hasOneUse();
 
         if ((staticallyEqual || dynamicallyEqual) && oneUse) {
-            rewriter.replaceOp(insert, extract.getQreg());
+            rewriter.replaceOp(insert, insert.getInQreg());
             rewriter.eraseOp(extract);
             return success();
         }


### PR DESCRIPTION
**Context:** As discovered by @paul0403 

```python
import pennylane as qml
import catalyst

@qml.qjit(keep_intermediate=True)
def workflow():
    @catalyst.passes.cancel_inverses
    @qml.qnode(qml.device("lightning.qubit", wires=2))
    def circuit():
        qml.Hadamard(wires=0)
        qml.Hadamard(wires=0)
        qml.Hadamard(wires=1)
        qml.Hadamard(wires=0)
        qml.Hadamard(wires=1)
        return qml.probs()
    return circuit()

print(workflow())
```

Would return [1, 0, 0, 0]

Instead of [0.5, 0, 0.5, 0]

**Description of the Change:** This PR will fix the above. The bug was found in the canonicalization of insert and extract which removes unnecessary insertion and extraction.

The code above produces the following code:

```mlir
  func.func public @circuit_0() -> tensor<4xf64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
    %c1_i64 = arith.constant 1 : i64
    %c0_i64 = arith.constant 0 : i64
    quantum.device shots(%c0_i64) ["/home/ubuntu/Code/env3/lib/python3.12/site-packages/pennylane_lightning/liblightning_qubit_catalyst.so", "LightningSimulator", "{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}"]
    %0 = quantum.alloc( 2) : !quantum.reg
    %1 = quantum.extract %0[%c0_i64] : !quantum.reg -> !quantum.bit
    %out_qubits = quantum.custom "Hadamard"() %1 : !quantum.bit
    %2 = quantum.extract %0[%c1_i64] : !quantum.reg -> !quantum.bit
    %3 = quantum.insert %0[%c0_i64], %out_qubits : !quantum.reg, !quantum.bit
    %4 = quantum.insert %3[%c1_i64], %2 : !quantum.reg, !quantum.bit
    %5 = quantum.compbasis qreg %4 : !quantum.obs
    %6 = quantum.probs %5 : tensor<4xf64>
    quantum.dealloc %4 : !quantum.reg
    quantum.device_release
    return %6 : tensor<4xf64>
  }
```

Without the change, we will replace the quantum register by the quantum register in the extract operation instead of the insert operation.

```mlir
    %1 = quantum.extract %0[%c0_i64] : !quantum.reg -> !quantum.bit
    %out_qubits = quantum.custom "Hadamard"() %1 : !quantum.bit
    %2 = quantum.extract %0[%c1_i64] : !quantum.reg -> !quantum.bit   # <--- focus on 
    %3 = quantum.insert %0[%c0_i64], %out_qubits : !quantum.reg, !quantum.bit  
    %4 = quantum.insert %3[%c1_i64], %2 : !quantum.reg, !quantum.bit # <--- these two lines
    %5 = quantum.compbasis qreg %4 : !quantum.obs
    %6 = quantum.probs %5 : tensor<4xf64>
```

If we replace the register with the extraction register

```mlir
    %1 = quantum.extract %0[%c0_i64] : !quantum.reg -> !quantum.bit  # <-- This is dead code
    %out_qubits = quantum.custom "Hadamard"() %1 : !quantum.bit  # <--- This is dead code

    %3 = quantum.insert %0[%c0_i64], %out_qubits : !quantum.reg, !quantum.bit    # <-- this is dead code

    %5 = quantum.compbasis qreg %0 : !quantum.obs # <--- this is now zero
    %6 = quantum.probs %5 : tensor<4xf64>
```

**Benefits:** Correctness

**Possible Drawbacks:**

**Related GitHub Issues:**
