### PR TITLE
[Frontend] Insert back all wires in case of dynamic wire

### DIFF
--- a/doc/releases/changelog-0.12.0.md
+++ b/doc/releases/changelog-0.12.0.md
@@ -340,6 +340,9 @@
 * Fixes canonicalization of insertion and extraction into quantum registers.
   [(#1840)](https://github.com/PennyLaneAI/catalyst/pull/1840)
 
+* Fixes the conversion of PLxPR to JAXPR with quantum primitives when using dynamic wires.
+  [(#1842)](https://github.com/PennyLaneAI/catalyst/pull/1842)
+
 <h3>Internal changes ⚙️</h3>
 
 * `qml.qjit` now integrates with the new `qml.set_shots` function.

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -315,7 +315,7 @@ class PLxPRToQuantumJaxprInterpreter(PlxprInterpreter):
         all_static = all_static_requested and all_static_cached
         if same_number_of_wires and not all_static:
             same_wires = all(wire in self.qreg_manager for wire in op.wires)
-            all_dynamic = all(not isinstance(wire, int) for wire in op.wires)
+            all_dynamic = all(not isinstance(wire[0], int) for wire in op.wires)
             keep_cache = same_wires and all_dynamic
 
         if not (all_static or keep_cache):

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -302,9 +302,9 @@ class PLxPRToQuantumJaxprInterpreter(PlxprInterpreter):
         self.subroutine_cache = cache
         super().__init__()
 
-    def interpret_operation(self, op):
-        """Re-bind a pennylane operation as a catalyst instruction."""
-
+    def _insert_dynamic_wires(self, op):
+        """Update with insertion and extraction in the
+        presence of dynamic wires"""
         keep_cache = False
 
         same_number_of_wires = len(op.wires) == len(self.qreg_manager)
@@ -314,12 +314,17 @@ class PLxPRToQuantumJaxprInterpreter(PlxprInterpreter):
         all_dynamic = False
         all_static = all_static_requested and all_static_cached
         if same_number_of_wires and not all_static:
-            same_wires = all(wire in self.qreg_manager.wire_map.keys() for wire in op.wires)
+            wires_in_cache = all(wire in self.qreg_manager.wire_map.keys() for wire in op.wires)
             all_dynamic = all(not isinstance(wire, int) for wire in op.wires)
-            keep_cache = same_wires and all_dynamic
+            keep_cache = wires_in_cache and all_dynamic
 
         if not (all_static or keep_cache):
             self.qreg_manager.insert_all_dangling_qubits()
+
+    def interpret_operation(self, op):
+        """Re-bind a pennylane operation as a catalyst instruction."""
+
+        self._insert_dynamic_wires(op)
 
         in_qubits = [self.qreg_manager[w] for w in op.wires]
         out_qubits = qinst_p.bind(

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -314,8 +314,8 @@ class PLxPRToQuantumJaxprInterpreter(PlxprInterpreter):
         all_dynamic = False
         all_static = all_static_requested and all_static_cached
         if same_number_of_wires and not all_static:
-            same_wires = all(wire in self.qreg_manager for wire in op.wires)
-            all_dynamic = all(not isinstance(wire[0], int) for wire in op.wires)
+            same_wires = all(wire in self.qreg_manager.wire_map.keys() for wire in op.wires)
+            all_dynamic = all(not isinstance(wire, int) for wire in op.wires)
             keep_cache = same_wires and all_dynamic
 
         if not (all_static or keep_cache):

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -305,6 +305,22 @@ class PLxPRToQuantumJaxprInterpreter(PlxprInterpreter):
     def interpret_operation(self, op):
         """Re-bind a pennylane operation as a catalyst instruction."""
 
+        keep_cache = False
+
+        same_number_of_wires = len(op.wires) == len(self.qreg_manager)
+        all_static_requested = all(isinstance(wire, int) for wire in op.wires)
+        all_static_cached = all(isinstance(wire[0], int) for wire in self.qreg_manager)
+        same_wires = False
+        all_dynamic = False
+        all_static = all_static_requested and all_static_cached
+        if same_number_of_wires and not all_static:
+            same_wires = all(wire in self.qreg_manager for wire in op.wires)
+            all_dynamic = all(not isinstance(wire, int) for wire in op.wires)
+            keep_cache = same_wires and all_dynamic
+
+        if not (all_static or keep_cache):
+            self.qreg_manager.insert_all_dangling_qubits()
+
         in_qubits = [self.qreg_manager[w] for w in op.wires]
         out_qubits = qinst_p.bind(
             *[*in_qubits, *op.data],

--- a/frontend/catalyst/from_plxpr/qreg_manager.py
+++ b/frontend/catalyst/from_plxpr/qreg_manager.py
@@ -137,6 +137,9 @@ class QregManager:
             return self.wire_map[index]
         return self.extract(index)
 
+    def __len__(self) -> int:
+        return len(self.wire_map)
+
     def __setitem__(self, index: int, qubit: AbstractQbit):
         """
         Update the wire_map when a new qubit value for a wire index is produced,

--- a/frontend/test/lit/test_from_plxpr.py
+++ b/frontend/test/lit/test_from_plxpr.py
@@ -201,9 +201,9 @@ def test_two_dynamic_CNOTs():
     @qml.qnode(dev)
     def circuit(w1: int, w2: int):
         # CHECK: [[SCALAR:%.+]] = tensor.extract %arg0
-        # CHECK-NEXT: [[QUBIT_0:%.+]] = quantum.extract %0[[[SCALAR]]]
+        # CHECK-NEXT: [[QUBIT_0:%.+]] = quantum.extract {{%.+}}[[[SCALAR]]]
         # CHECK-NEXT: [[SCALAR_2:%.+]] = tensor.extract %arg1
-        # CHECK-NEXT: [[QUBIT_1:%.+]] = quantum.extract %0[[[SCALAR_2]]]
+        # CHECK-NEXT: [[QUBIT_1:%.+]] = quantum.extract {{%.+}}[[[SCALAR_2]]]
         # CHECK-NEXT: [[QUBITS:%.+]]:2 = quantum.custom "CNOT"() [[QUBIT_0]], [[QUBIT_1]]
         # CHECK-NEXT: quantum.custom "CNOT"() [[QUBITS]]#0, [[QUBITS]]#1
         qml.CNOT(wires=[w1, w2])
@@ -315,13 +315,13 @@ def test_multi_qubit_gates_on_different_dynamic_wires():
     @qml.qnode(dev)
     def circuit(w1: int, w2: int, w3: int):
         # CHECK: [[SCALAR:%.+]] = tensor.extract %arg0
-        # CHECK-NEXT: [[QUBIT_0:%.+]] = quantum.extract %0[[[SCALAR]]]
+        # CHECK-NEXT: [[QUBIT_0:%.+]] = quantum.extract {{%.+}}[[[SCALAR]]]
         # CHECK-NEXT: [[SCALAR_2:%.+]] = tensor.extract %arg1
-        # CHECK-NEXT: [[QUBIT_1:%.+]] = quantum.extract %0[[[SCALAR_2]]]
+        # CHECK-NEXT: [[QUBIT_1:%.+]] = quantum.extract {{%.+}}[[[SCALAR_2]]]
         # CHECK-NEXT: [[QUBITS:%.+]]:2 = quantum.custom "CNOT"() [[QUBIT_0]], [[QUBIT_1]]
         qml.CNOT(wires=[w1, w2])
         # CHECK-NEXT: [[SCALAR:%.+]] = tensor.extract %arg0
-        # CHECK-NEXT: [[QREG:%.+]] = quantum.insert %0[[[SCALAR]]]
+        # CHECK-NEXT: [[QREG:%.+]] = quantum.insert {{%.+}}[[[SCALAR]]]
         # CHECK-NEXT: [[SCALAR_1:%.+]] = tensor.extract %arg1
         # CHECK-NEXT: [[QREG_1:%.+]] = quantum.insert [[QREG]][[[SCALAR_1]]]
         # CHECK-NEXT: [[SCALAR_1:%.+]] = tensor.extract %arg1

--- a/frontend/test/lit/test_from_plxpr.py
+++ b/frontend/test/lit/test_from_plxpr.py
@@ -128,7 +128,6 @@ def test_dynamic_wire():
     qml.capture.enable()
     dev = qml.device("null.qubit", wires=3)
 
-
     @qml.qjit(target="mlir")
     @qml.qnode(dev)
     def circuit(w1: int):
@@ -190,6 +189,7 @@ def test_dynamic_wire_reinsertion():
 
 test_dynamic_wire_reinsertion()
 
+
 def test_two_dynamic_CNOTs():
     """Test two dynamic CNOTs"""
 
@@ -212,5 +212,6 @@ def test_two_dynamic_CNOTs():
 
     print(circuit.mlir)
     qml.capture.disable()
+
 
 test_two_dynamic_CNOTs()

--- a/frontend/test/lit/test_from_plxpr.py
+++ b/frontend/test/lit/test_from_plxpr.py
@@ -14,6 +14,8 @@
 
 # RUN: %PYTHON %s | FileCheck %s
 
+# pylint: disable=line-too-long
+
 """Lit tests for the PLxPR to JAXPR with quantum primitives pipeline"""
 
 import pennylane as qml

--- a/frontend/test/lit/test_from_plxpr.py
+++ b/frontend/test/lit/test_from_plxpr.py
@@ -215,3 +215,42 @@ def test_two_dynamic_CNOTs():
 
 
 test_two_dynamic_CNOTs()
+
+def test_single_qubit_dynamic():
+    """single qubit gates on two different dynamic wires one after the other"""
+
+    dev = qml.device("null.qubit", wires=3)
+
+    qml.capture.enable()
+
+    @qml.qjit(target="mlir")
+    @qml.qnode(dev)
+    def circuit(w1: int, w2: int):
+
+        # CHECK: [[REG:%.+]] = quantum.alloc
+        # CHECK: [[QUBIT_0:%.+]] = quantum.extract [[REG]][ 0]
+        # CHECK: [[QUBIT_0_1:%.+]] = quantum.custom "Hadamard"() [[QUBIT_0]]
+        # CHECK: [[REG_1:%.+]] = quantum.insert [[REG]][ 0], [[QUBIT_0_1]]
+        # CHECK: [[SCALAR:%.+]] = tensor.extract %arg0[]
+        # CHECK: [[QUBIT_W1:%.+]] = quantum.extract [[REG_1]][[[SCALAR]]]
+        # CHECK: [[QUBIT_W1_1:%.+]] = quantum.custom "Hadamard"() [[QUBIT_W1]]
+        # CHECK: [[SCALAR:%.+]] = tensor.extract %arg0[]
+        # CHECK: [[REG_2:%.+]] = quantum.insert [[REG_1]][[[SCALAR]]], [[QUBIT_W1_1]]
+        # CHECK: [[SCALAR_1:%.+]] = tensor.extract %arg1[]
+        # CHECK: [[QUBIT_W2:%.+]] = quantum.extract [[REG_2]][[[SCALAR_1]]]
+        # CHECK: [[QUBIT_W2_1:%.+]] = quantum.custom "Hadamard"() [[QUBIT_W2]]
+        # CHECK: [[SCALAR_1:%.+]] = tensor.extract %arg1[]
+        # CHECK: [[REG_3:%.+]] = quantum.insert [[REG_2]][[[SCALAR_1]]], [[QUBIT_W2_1]]
+        # CHECK: [[QUBIT_0_2:%.+]] = quantum.extract [[REG_3]][ 0]
+        # CHECK: [[QUBIT_0_3:%.+]] = quantum.custom "Hadamard"() [[QUBIT_0_2]]
+        # CHECK: quantum.insert [[REG_3]][ 0], [[QUBIT_0_3]]
+        qml.Hadamard(0)
+        qml.Hadamard(w1)
+        qml.Hadamard(w2)
+        qml.Hadamard(0)
+        return qml.state()
+
+    print(circuit.mlir)
+    qml.capture.disable()
+
+test_single_qubit_dynamic()


### PR DESCRIPTION
**Context:** When a wire is dynamic, one needs to take care to re-insert back all used wires back into the register. This is because we do not know which wire will be accessed and it could be any. The only safe choice is to re-insert them and extract the dynamic wire.

**Description of the Change:** If we are extracting a dynamic wire, we re-insert all qubits back into the register.

**Benefits:** Correct code.

**Possible Drawbacks:** None

**Related GitHub Issues:** closes #1841 
