### PR TITLE
Update a test for a new manual decomposition in core

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -10,7 +10,7 @@ enzyme=v0.0.180
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt
-pennylane=0.42.0-dev48
+pennylane=0.42.0-dev67
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -33,4 +33,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.42.0-dev16
 pennylane-lightning==0.42.0-dev16
-pennylane==0.42.0-dev48
+pennylane==0.42.0-dev67

--- a/frontend/test/lit/test_decomposition.py
+++ b/frontend/test/lit/test_decomposition.py
@@ -170,44 +170,30 @@ test_decompose_qubitunitary()
 
 
 def test_decompose_singleexcitationplus():
-    """Test decomposition of single excitation plus."""
+    """
+    Test decomposition of single excitation plus.
+    See
+    https://github.com/PennyLaneAI/pennylane/blob/master/pennylane/ops/qubit/qchem_ops.py
+    for the decomposition of qml.SingleExcitationPlus
+    """
     dev = get_custom_device_without(2, discards={"SingleExcitationPlus", "C(SingleExcitationPlus)"})
 
     @qjit(target="mlir")
     @qml.qnode(dev)
     # CHECK-LABEL: public @jit_decompose_singleexcitationplus
     def decompose_singleexcitationplus(theta: float):
-        # CHECK-NOT: name = "SingleExcitationPlus"
-        # CHECK: [[a_scalar_tensor_float_2:%.+]] = stablehlo.constant dense<2.{{[0]+}}e+00>
-        # CHECK-NOT: name = "SingleExcitationPlus"
-        # CHECK: [[b_theta_div_2:%.+]] = stablehlo.divide %arg0, [[a_scalar_tensor_float_2]]
-        # CHECK-NOT: name = "SingleExcitationPlus"
-        # CHECK: [[a_theta_div_2:%.+]] = stablehlo.divide %arg0, [[a_scalar_tensor_float_2]]
-        # CHECK-NOT: name = "SingleExcitationPlus"
-        # CHECK: [[s0q0:%.+]] = quantum.custom "PauliX"
-        # CHECK-NOT: name = "SingleExcitationPlus"
-        # CHECK: [[s0q1:%.+]] = quantum.custom "PauliX"
-        # CHECK-NOT: name = "SingleExcitationPlus"
-        # CHECK: [[a_theta_div_2_scalar:%.+]] = tensor.extract [[a_theta_div_2]]
-        # CHECK-NOT: name = "SingleExcitationPlus"
-        # CHECK: [[s1:%.+]]:2 = quantum.custom "ControlledPhaseShift"([[a_theta_div_2_scalar]]) [[s0q1]], [[s0q0]]
-        # CHECK-NOT: name = "SingleExcitationPlus"
-        # CHECK: [[s2q1:%.+]] = quantum.custom "PauliX"() [[s1]]#1
-        # CHECK-NOT: name = "SingleExcitationPlus"
-        # CHECK: [[s2q0:%.+]] = quantum.custom "PauliX"() [[s1]]#0
-        # CHECK-NOT: name = "SingleExcitationPlus"
-        # CHECK: [[b_theta_div_2_scalar:%.+]] = tensor.extract [[b_theta_div_2]]
-        # CHECK-NOT: name = "SingleExcitationPlus"
-        # CHECK: [[s3:%.+]]:2 = quantum.custom "ControlledPhaseShift"([[b_theta_div_2_scalar]]) [[s2q1]], [[s2q0]]
-        # CHECK-NOT: name = "SingleExcitationPlus"
-        # CHECK: [[s4:%.+]]:2 = quantum.custom "CNOT"() [[s3]]#0, [[s3]]#1
-        # CHECK-NOT: name = "SingleExcitationPlus"
-        # CHECK: [[theta_scalar:%.+]] = tensor.extract %arg0
-        # CHECK-NOT: name = "SingleExcitationPlus"
-        # CHECK: [[s5:%.+]]:2 = quantum.custom "CRY"([[theta_scalar]]) [[s4]]#1, [[s4]]#0
-        # CHECK-NOT: name = "SingleExcitationPlus"
-        # CHECK: [[s6:%.+]]:2 = quantum.custom "CNOT"() [[s5]]#1, [[s5]]#0
-        # CHECK-NOT: name = "SingleExcitationPlus"
+        # CHECK-NOT: "SingleExcitationPlus"
+        # CHECK: quantum.custom "Hadamard"
+        # CHECK: quantum.custom "CNOT"
+        # CHECK: quantum.custom "RY"
+        # CHECK: quantum.custom "RY"
+        # CHECK: quantum.custom "CY"
+        # CHECK: quantum.custom "S"
+        # CHECK: quantum.custom "Hadamard"
+        # CHECK: quantum.custom "RZ"
+        # CHECK: quantum.custom "CNOT"
+        # CHECK: quantum.gphase
+
         qml.SingleExcitationPlus(theta, wires=[0, 1])
         return measure(wires=0)
 

--- a/frontend/test/pytest/test_preprocess.py
+++ b/frontend/test/pytest/test_preprocess.py
@@ -14,7 +14,6 @@
 """Test for the device preprocessing."""
 import platform
 from dataclasses import replace
-from typing import List
 
 import numpy as np
 import pennylane as qml
@@ -109,42 +108,6 @@ class CustomDevice(Device):
 CustomDevice.capabilities.operations.pop("BlockEncode")
 
 
-def _get_pennylane_decomposition(op: qml.operation.Operation):
-    """
-    Compute the core PennyLane decomposition for the gate.
-    """
-    params = op.parameters
-    wires = op.wires
-    return op.compute_decomposition(*params, wires)
-
-
-def _check_mlir_gate_strings(decomp: List[qml.operation.Operation], mlir: str):
-    """
-    Check that all ops in a decomposition are covered in an mlir.
-    """
-    ledger = {}
-
-    def _create_or_increment(key):
-        if key in ledger:
-            ledger[key] += 1
-        else:
-            ledger[key] = 1
-
-    for op in decomp:
-        # Three special ops do not go through quantum.custom
-        if isinstance(op, qml.GlobalPhase):
-            _create_or_increment("quantum.gphase")
-        elif isinstance(op, qml.MultiRZ):
-            _create_or_increment("quantum.multirz")
-        elif isinstance(op, qml.QubitUnitary):
-            _create_or_increment("quantum.unitary")
-        else:
-            _create_or_increment(op.name)
-
-    for op_name, count in ledger.items():
-        assert mlir.count(op_name) == count
-
-
 class TestDecomposition:
     """Test the preprocessing transforms implemented in Catalyst."""
 
@@ -152,18 +115,17 @@ class TestDecomposition:
         """Test the decompose transform as part of the Catalyst pipeline."""
         dev = NullQubit(wires=4, shots=None)
 
+        @qjit
         @qml.qnode(dev)
         def circuit(theta: float):
             qml.SingleExcitationPlus(theta, wires=[0, 1])
             return qml.state()
 
-        theta = 0.1
-        op = circuit.construct([theta], {})._ops[0]
-        decomp = _get_pennylane_decomposition(op)
-
         mlir = qjit(circuit, target="mlir").mlir
+        assert "Hadamard" in mlir
+        assert "CNOT" in mlir
+        assert "RY" in mlir
         assert "SingleExcitationPlus" not in mlir
-        _check_mlir_gate_strings(decomp, mlir)
 
     def test_decompose_ops_to_unitary(self):
         """Test the decompose ops to unitary transform."""
@@ -180,13 +142,12 @@ class TestDecomposition:
         """Test the decompose ops to unitary transform as part of the Catalyst pipeline."""
         dev = CustomDevice(wires=4, shots=None)
 
+        @qjit
         @qml.qnode(dev)
         def circuit():
             qml.BlockEncode(np.array([[1, 1, 1], [0, 1, 0]]), wires=[0, 1, 2])
             return qml.state()
 
-        # qml.BlockEncode does not have a well-defined decomposition from core PennyLane
-        # so we check manually
         mlir = qjit(circuit, target="mlir").mlir
         assert "quantum.unitary" in mlir
         assert "BlockEncode" not in mlir
@@ -310,6 +271,7 @@ class TestPreprocessHybridOp:
 
         dev = qml.device("lightning.qubit", wires=1)
 
+        @qjit
         @qml.qnode(dev)
         def circuit(x: float, y: float):
             qml.RY(y, 0)
@@ -331,6 +293,7 @@ class TestPreprocessHybridOp:
 
         dev = qml.device("lightning.qubit", wires=[0, 1])
 
+        @qjit
         @qml.qnode(dev)
         def circuit(phi: float):
             OtherHadamard(wires=0)

--- a/frontend/test/pytest/test_preprocess.py
+++ b/frontend/test/pytest/test_preprocess.py
@@ -115,7 +115,6 @@ class TestDecomposition:
         """Test the decompose transform as part of the Catalyst pipeline."""
         dev = NullQubit(wires=4, shots=None)
 
-        @qjit
         @qml.qnode(dev)
         def circuit(theta: float):
             qml.SingleExcitationPlus(theta, wires=[0, 1])
@@ -142,7 +141,6 @@ class TestDecomposition:
         """Test the decompose ops to unitary transform as part of the Catalyst pipeline."""
         dev = CustomDevice(wires=4, shots=None)
 
-        @qjit
         @qml.qnode(dev)
         def circuit():
             qml.BlockEncode(np.array([[1, 1, 1], [0, 1, 0]]), wires=[0, 1, 2])
@@ -271,7 +269,6 @@ class TestPreprocessHybridOp:
 
         dev = qml.device("lightning.qubit", wires=1)
 
-        @qjit
         @qml.qnode(dev)
         def circuit(x: float, y: float):
             qml.RY(y, 0)
@@ -293,7 +290,6 @@ class TestPreprocessHybridOp:
 
         dev = qml.device("lightning.qubit", wires=[0, 1])
 
-        @qjit
         @qml.qnode(dev)
         def circuit(phi: float):
             OtherHadamard(wires=0)
@@ -341,7 +337,6 @@ class TestPreprocessHybridOp:
 
         dev = qml.device("lightning.qubit", wires=2)
 
-        @qjit
         @qml.qnode(dev)
         def circuit(n: int, x: float):
             OtherHadamard(wires=0)

--- a/frontend/test/pytest/test_preprocess.py
+++ b/frontend/test/pytest/test_preprocess.py
@@ -122,9 +122,9 @@ class TestDecomposition:
             return qml.state()
 
         mlir = qjit(circuit, target="mlir").mlir
-        assert "PauliX" in mlir
+        assert "Hadamard" in mlir
         assert "CNOT" in mlir
-        assert "ControlledPhaseShift" in mlir
+        assert "RY" in mlir
         assert "SingleExcitationPlus" not in mlir
 
     def test_decompose_ops_to_unitary(self):


### PR DESCRIPTION
**Context:**
The manual decomposition of `SingleExcitationPlus` was updated in core https://github.com/PennyLaneAI/pennylane/pull/7771

**Description of the Change:**
Change the gates we are checking for to follow the new decomposition.

**Benefits:**
Tests pass.
Latest/latest passes.

