### PR TITLE
Update a test to use np.allclose instead of `==`

### DIFF
--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -16,6 +16,7 @@
 
 from functools import partial
 
+import numpy as np
 import jax.numpy as jnp
 import pennylane as qml
 import pytest
@@ -1381,7 +1382,7 @@ class TestCapture:
             qml.RZ(0.4, wires=0)
             return qml.expval(qml.PauliZ(0))
 
-        assert circuit() == capture_result
+        assert np.allclose(circuit(), capture_result)
 
     def test_transform_commute_controlled_workflow(self, backend):
         """Test the integration for a circuit with a 'commute_controlled' transform."""


### PR DESCRIPTION
**Context:**
A test is mysteriously failing on ARM machines: https://github.com/PennyLaneAI/catalyst/actions/runs/16077576091/job/45378065361#step:12:178

```
FAILED frontend/test/pytest/test_capture_integration.py::TestCapture::test_transform_single_qubit_fusion_workflow[lightning.qubit] - assert Array(-0.50022394, dtype=float64) == Array(-0.50022394, dtype=float64)
```

The results do look the same. The leading theory is it's a floating point error.

**Description of the Change:**
Change to `numpy.allclose`. 

