### PR TITLE
Bump CPL rc versions

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -39,7 +39,7 @@ jobs:
         git checkout $(git tag | sort -V | tail -1)
     - if: ${{ inputs.catalyst == 'release-candidate' }}
       run: |
-        git checkout v0.11.0-rc
+        git checkout v0.12.0-rc
 
     - name: Set up Python # Ensure python3.10 is used
       uses: actions/setup-python@v5
@@ -146,7 +146,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: PennyLaneAI/pennylane-lightning
-        ref: v0.41.0_rc
+        ref: v0.42.0_rc
         path: lightning_build
         fetch-depth: 0
 
@@ -175,7 +175,7 @@ jobs:
     - name: Install PennyLane (release-candidate)
       if: ${{ inputs.pennylane == 'release-candidate' }}
       run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.41.0-rc0
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.42.0-rc0
 
     - name: Add Frontend Dependencies to PATH
       if: ${{ inputs.catalyst != 'stable' }}


### PR DESCRIPTION
**Context:**
In preparation for the Catalyst v0.12.0-rc release candidate (RC), the GitHub action must point to the corresponding RC branches of Catalyst, Pennylane, and Lightning.

**Description of the Change:**
Update the Catalyst RC branch v0.11.0-rc -> v0.12.0-rc, as well as the corresponding RC branches for Lightning and PennyLane from v0.41.0_rc to v0.42.0_rc and v0.41.0-rc0 to v0.42.0-rc0.