### PR TITLE
Prepare for Catalyst RC v0.12.0

### DIFF
--- a/doc/dev/release_notes.rst
+++ b/doc/dev/release_notes.rst
@@ -3,7 +3,7 @@ Release notes
 
 This page contains the release notes for Catalyst.
 
-.. mdinclude:: ../releases/changelog-dev.md
+.. mdinclude:: ../releases/changelog-0.12.0.md
 
 .. mdinclude:: ../releases/changelog-0.11.0.md
 

--- a/doc/releases/changelog-0.11.0.md
+++ b/doc/releases/changelog-0.11.0.md
@@ -1,4 +1,4 @@
-# Release 0.11.0 (current release)
+# Release 0.11.0
 
 <h3>New features since last release</h3>
 

--- a/doc/releases/changelog-0.12.0.md
+++ b/doc/releases/changelog-0.12.0.md
@@ -1,4 +1,4 @@
-# Release 0.12.0 (development release)
+# Release 0.12.0 (current release)
 
 <h3>New features since last release</h3>
 

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.12.0-dev72"
+__version__ = "0.12.0"


### PR DESCRIPTION
**Context:** Preparing for the Catalyst v0.12.0 release candidate (RC).

**Description of the Change:** 
- Update versions in release notes and _version.py.
- Updated the changelogs