### PR TITLE
Prepare for next development cycle

### DIFF
--- a/doc/dev/release_notes.rst
+++ b/doc/dev/release_notes.rst
@@ -3,6 +3,8 @@ Release notes
 
 This page contains the release notes for Catalyst.
 
+.. mdinclude:: ../releases/changelog-dev.md
+
 .. mdinclude:: ../releases/changelog-0.12.0.md
 
 .. mdinclude:: ../releases/changelog-0.11.0.md

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1,0 +1,20 @@
+# Release 0.13.0 (development release)
+
+<h3>New features since last release</h3>
+
+<h3>Improvements 🛠</h3>
+
+<h3>Breaking changes 💔</h3>
+
+<h3>Deprecations 👋</h3>
+
+<h3>Bug fixes 🐛</h3>
+
+<h3>Internal changes ⚙️</h3>
+
+<h3>Documentation 📝</h3>
+
+<h3>Contributors ✍️</h3>
+
+This release contains contributions from (in alphabetical order):
+

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.12.0"
+__version__ = "0.13.0-dev0"


### PR DESCRIPTION
**Context:** Setting up the repository for the next development cycle after v release.

**Description of the Change:** 
- Add new changelog-dev.md file for v0.13.0
- Add changelog-dev reference to release_notes.rst
- Update version in _version.py to 0.13.0
- Update rc_sync.yml to replace the previous release manager username with 