### PR TITLE
Add analysis for static for loops in ppm_specs

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -38,7 +38,8 @@
   in a single pipeline.
 
   * A new function :func:`~.passes.get_ppm_specs` to get the result statistics after a PPR/PPM compilations is available. The statistics is returned in a Python dictionary.
-  [(#1794)](https://github.com/PennyLaneAI/catalyst/pull/1794). 
+  [(#1794)](https://github.com/PennyLaneAI/catalyst/pull/1794)
+  [(#???)](https://github.com/PennyLaneAI/catalyst/pull/???)
   
   Example below shows an input circuit and corresponding PPM specs.
 

--- a/mlir/include/Catalyst/Utils/CountStaticForloopIterations.h
+++ b/mlir/include/Catalyst/Utils/CountStaticForloopIterations.h
@@ -1,0 +1,26 @@
+// Copyright 2025 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+
+using namespace mlir;
+
+namespace catalyst {
+
+// Given an op in a for loop body with a static number of start, end and step,
+// compute the number of iterations that will be executed by the for loop.
+// Returns -1 if any of the above for loop information is not static.
+int64_t countStaicForloopIterations(Operation *op);
+
+} // namespace catalyst

--- a/mlir/lib/Catalyst/Utils/CMakeLists.txt
+++ b/mlir/lib/Catalyst/Utils/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_library(MLIRCatalystUtils
     CallGraph.cpp
-    TBAAUtils.cpp
-    StaticAllocas.cpp
+    CountStaticForloopIterations.cpp
     EnsureFunctionDeclaration.cpp
+    StaticAllocas.cpp
+    TBAAUtils.cpp
 )

--- a/mlir/lib/Catalyst/Utils/CountStaticForloopIterations.cpp
+++ b/mlir/lib/Catalyst/Utils/CountStaticForloopIterations.cpp
@@ -1,0 +1,83 @@
+// Copyright 2025 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cmath> // std::ceil()
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Attributes.h"
+
+using namespace mlir;
+
+namespace catalyst {
+
+static int64_t getNumIterations(int64_t lowerBound, int64_t upperBound, int64_t step)
+{
+    return std::ceil((upperBound - lowerBound) / step);
+}
+
+static int64_t getIntFromArithConstantOp(arith::ConstantOp op)
+{
+    // The magical incantation to get a cpp integer from an arith.constant op
+    assert(isa<IntegerAttr>(op.getValue()));
+    return cast<IntegerAttr>(op.getValue()).getValue().getSExtValue();
+}
+
+int64_t countStaicForloopIterations(Operation *op)
+{
+    assert(!isa<scf::ForOp>(op));
+
+    int64_t count = 1;
+    bool changed = false;
+
+    Operation *parent = op->getParentOp();
+    while (parent) {
+        if (isa<scf::ForOp>(parent)) {
+            scf::ForOp forOp = cast<scf::ForOp>(parent);
+
+            Operation *lowerBoundOp = forOp.getLowerBound().getDefiningOp();
+            if (!isa<arith::ConstantOp>(lowerBoundOp)) {
+                // Dynamic, nothing to do at this for loop
+                continue;
+            }
+            int64_t l = getIntFromArithConstantOp(cast<arith::ConstantOp>(lowerBoundOp));
+
+            Operation *upperBoundOp = forOp.getUpperBound().getDefiningOp();
+            if (!isa<arith::ConstantOp>(upperBoundOp)) {
+                // Dynamic, nothing to do at this for loop
+                continue;
+            }
+            int64_t u = getIntFromArithConstantOp(cast<arith::ConstantOp>(upperBoundOp));
+
+            Operation *stepOp = forOp.getStep().getDefiningOp();
+            if (!isa<arith::ConstantOp>(stepOp)) {
+                // Dynamic, nothing to do at this for loop
+                continue;
+            }
+            int64_t s = getIntFromArithConstantOp(cast<arith::ConstantOp>(stepOp));
+
+            count *= getNumIterations(l, u, s);
+            changed = true;
+        }
+        parent = parent->getParentOp();
+    }
+
+    if (!changed) {
+        return -1;
+    }
+
+    return count;
+}
+
+} // namespace catalyst

--- a/mlir/test/QEC/PPMSpecsTest.mlir
+++ b/mlir/test/QEC/PPMSpecsTest.mlir
@@ -322,3 +322,49 @@ func.func public @game_of_surface_code(%arg0: !quantum.bit, %arg1: !quantum.bit,
 }
 
 // -----
+
+//CHECK: {
+//CHECK:     "static_for_loop": {
+//CHECK:         "max_weight_pi4": 1,
+//CHECK:         "num_pi4_gates": 5
+//CHECK:     }
+//CHECK: }
+func.func public @static_for_loop(%arg0: !quantum.bit) {
+    %c5 = arith.constant 5 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+
+    %q = scf.for %iter = %c0 to %c5 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
+      %out_qubits = qec.ppr ["Z"](4) %arg1 : !quantum.bit
+      scf.yield %out_qubits : !quantum.bit
+    }
+
+    return
+}
+
+// -----
+
+//CHECK: {
+//CHECK:     "static_for_loop_nested": {
+//CHECK:         "max_weight_pi4": 1,
+//CHECK:         "num_pi4_gates": 30
+//CHECK:     }
+//CHECK: }
+func.func public @static_for_loop_nested(%arg0: !quantum.bit) {
+    %c5 = arith.constant 5 : index
+    %c6 = arith.constant 6 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+
+    %q = scf.for %iter = %c0 to %c6 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
+
+        %q_inner = scf.for %iter_inner = %c0 to %c5 step %c1 iter_args(%arg1_inner = %arg1) -> (!quantum.bit) {
+          %out_qubits_inner = qec.ppr ["Z"](4) %arg1_inner : !quantum.bit
+          scf.yield %out_qubits_inner : !quantum.bit
+        }
+
+        scf.yield %q_inner : !quantum.bit
+    }
+
+    return
+}


### PR DESCRIPTION
**Context:**
Currently, the `ppm_specs` pass increments the PPR count by one whenever it sees a PPR op.
This causes for loops to be incorrectly counted, since the loop body is not unrolled. 

In other words, both snippets below give the same statistics:
```python
        for i in range(15):
            qml.Hadamard(i)

vs

        for i in range(15000000):
            qml.Hadamard(i)
```

**Description of the Change:**
- Add a utility function `countStaicForloopIterations(Operation *)` that computes the number of times an operation in a static for loop will be executed. Effectively this is how many ops there will be in the IR if it was fully unrolled.
- Update `ppm_specs` pass to count using static for loop info whenever possible.

**Benefits:**
Better (i.e. "more correct") PPR gate counts.

**Possible Drawbacks:**
We can only do this during compile time for static for loops. 
For while loops, conditionals and for loops with dynamic boundary `Value`s, this cannot be done. 
For now, we just bail out and add one gate. This is ok since now `ppm_specs` only works with static IR anyway.
But maybe in the future we can print out better specs, e.g. something like `3N+7`

