### PR TITLE
[LLVM] Patch LLVM to avoid cache when comparing mutually exclusive regions

### DIFF
--- a/mlir/Makefile
+++ b/mlir/Makefile
@@ -56,6 +56,10 @@ all: llvm mhlo enzyme dialects plugin
 
 .PHONY: llvm
 llvm:
+	@if cd llvm-project; git apply --check $(MK_DIR)/patches/llvm*.patch; then \
+		git apply $(MK_DIR)/patches/llvm*.patch; \
+	fi
+
 	@echo "build LLVM and MLIR enabling Python bindings"
 	cmake -G Ninja -S llvm-project/llvm -B $(LLVM_BUILD_DIR) \
 		-DCMAKE_BUILD_TYPE=$(BUILD_TYPE) \

--- a/mlir/patches/llvm-disable-region-cache-for-bufferization.patch
+++ b/mlir/patches/llvm-disable-region-cache-for-bufferization.patch
@@ -1,0 +1,25 @@
+From f90b9bab9cfcc821117421a8b983f04ce72f6771 Mon Sep 17 00:00:00 2001
+From: Erick Ochoa Lopez <erick.ochoalopez@xanadu.ai>
+Date: Tue, 8 Jul 2025 16:39:07 +0000
+Subject: [PATCH 1/1] commit
+
+---
+ mlir/lib/Dialect/Bufferization/Transforms/OneShotAnalysis.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mlir/lib/Dialect/Bufferization/Transforms/OneShotAnalysis.cpp b/mlir/lib/Dialect/Bufferization/Transforms/OneShotAnalysis.cpp
+index 1eaf999d11c0..fc667326509e 100644
+--- a/mlir/lib/Dialect/Bufferization/Transforms/OneShotAnalysis.cpp
++++ b/mlir/lib/Dialect/Bufferization/Transforms/OneShotAnalysis.cpp
+@@ -705,7 +705,7 @@ hasReadAfterWriteInterference(const DenseSet<OpOperand *> &usesRead,
+         // Note: If ops are executed multiple times (e.g., because they are
+         //       inside a loop), mutually exclusive regions may be executed
+         //       multiple times.
+-        if (state.insideMutuallyExclusiveRegions(readingOp,
++        if (insideMutuallyExclusiveRegions(readingOp,
+                                                  conflictingWritingOp)) {
+           LLVM_DEBUG(llvm::dbgs() << "  no conflict: read and write are in "
+                                      "mutually exclusive regions\n");
+-- 
+2.43.0
+


### PR DESCRIPTION
**Context:** Profiling large programs of interest found that this cache is problematic when compiling functions with very large bodies. This cache may be beneficial for medium sized programs. MLIR is not optimized for machine generated code where functions can be 100k lines of code. Removing this cache finds that the compilation time reduces a 20%.

**Description of the Change:** Patch LLVM to avoid using a cache for comparing mutually exclusive regions.

**Benefits:** Reduced compilation times for very large programs.

**Possible Drawbacks:** This may impact other smaller programs of interests. 

**Related GitHub Issues:**

Part 2 of [sc-93707]
