### PR TITLE
make input branch not required in the wheel CI

### DIFF
--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -32,7 +32,7 @@ on:
         default: false
       branch:
         description: 'Branch to build from'
-        required: true
+        required: false
         default: 'main'
         type: string
 
@@ -74,7 +74,7 @@ jobs:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.branch }}
+        ref: ${{ inputs.branch || github.ref }}
 
     - name: Cache LLVM Source
       id: cache-llvm-source

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -32,7 +32,7 @@ on:
         default: false
       branch:
         description: 'Branch to build from'
-        required: true
+        required: false
         default: 'main'
         type: string
 
@@ -85,7 +85,7 @@ jobs:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.branch }}
+        ref: ${{ inputs.branch || github.ref }}
 
     - name: Set Ownership in Container
       run: |

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -32,7 +32,7 @@ on:
         default: false
       branch:
         description: 'Branch to build from'
-        required: true
+        required: false
         default: 'main'
         type: string
 
@@ -76,7 +76,7 @@ jobs:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.branch }}
+        ref: ${{ inputs.branch || github.ref }}
 
     # Python 3.10 was dropped from the GH images on macOS arm
     - name: Install Python 3.10


### PR DESCRIPTION
**Context:**
PR #1625 adds input branch to the wheel builder workflows in order to call them on rc branch for the rc nightly build, but it marks the input branch as required and causes a failure for the regular nightly builds on main since it calls the workflows without any input branch

**Description of the Change:**
makes the input branch no required and falls back to `github.ref` when no input branch is specified.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
