### PR TITLE
Cherry pick nightly rc wheel upload workflow to rc branch 

### DIFF
--- a/.github/workflows/build-nightly-release-candidate.yaml
+++ b/.github/workflows/build-nightly-release-candidate.yaml
@@ -1,0 +1,95 @@
+name: Build Release Branch Nightly for TestPyPI
+
+on:
+  schedule:
+    # Run from July 8th to July 13th at 02:00 UTC (10:00 PM EDT)
+    - cron: "0 2 8-13 7 *"
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build from'
+        required: true
+        default: 'v0.12.0-rc'
+
+jobs:
+  setup:
+    name: Setup the release
+    runs-on: ubuntu-24.04-arm
+    outputs:
+      branch: ${{ steps.set_branch.outputs.branch }}
+    steps:
+    - name: Set branch
+      id: set_branch
+      run: echo "branch=${{ github.event.inputs.branch || 'v0.12.0-rc' }}" >> $GITHUB_OUTPUT
+
+    - name: Checkout Catalyst repo release branch
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ steps.set_branch.outputs.branch }}
+        ssh-key: ${{ secrets.NIGHTLY_VERSION_UPDATE_DEPLOY_KEY }}
+
+    - name: Bump RC version
+      run: |
+        python $GITHUB_WORKSPACE/.github/workflows/set_rc_version.py
+
+    - name: Push new version
+      run: |
+        git config --global user.email '${{ secrets.AUTO_UPDATE_VERSION_RINGO_EMAIL }}'
+        git config --global user.name "ringo-but-quantum"
+        git add $GITHUB_WORKSPACE/frontend/catalyst/_version.py
+        git commit -m "[no ci] bump nightly rc version"
+        git push
+
+  # Only build the most popular configurations on a nightly schedule to save PyPI storage.
+
+  linux-x86:
+    name: Build on Linux x86-64
+    needs: [setup]
+    uses: ./.github/workflows/build-wheel-linux-x86_64.yaml
+    with:
+      branch: ${{ needs.setup.outputs.branch }}
+
+  linux-aarch:
+    name: Build on Linux aarch64
+    needs: [setup]
+    uses: ./.github/workflows/build-wheel-linux-arm64.yaml
+    with:
+      branch: ${{ needs.setup.outputs.branch }}
+
+  macos-arm:
+    name: Build on macOS arm64
+    needs: [setup]
+    uses: ./.github/workflows/build-wheel-macos-arm64.yaml
+    with:
+      branch: ${{ needs.setup.outputs.branch }}
+
+  upload:
+    name: Prepare & Upload wheels to TestPyPI
+    needs: [linux-x86, macos-arm, linux-aarch]
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download wheels
+      uses: actions/download-artifact@v4
+      with:
+        merge-multiple: true
+        path: dist
+
+    - name: Install rename
+      run: |
+        sudo apt install rename
+
+    - name: Prepare wheels
+      run: |
+        rename "s/linux/manylinux_2_28/" dist/PennyLane_Catalyst-*
+        rename "s/macosx_14_0_universal2/macosx_13_0_arm64/" dist/PennyLane_Catalyst-*
+        rename "s/macosx_14/macosx_13/" dist/PennyLane_Catalyst-*
+
+    - name: Upload wheels
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        packages-dir: dist
+        verbose: true

--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -30,6 +30,11 @@ on:
         type: boolean
         required: false
         default: false
+      branch:
+        description: 'Branch to build from'
+        required: true
+        default: 'main'
+        type: string
 
 concurrency:
   group: Build Catalyst Wheel on Linux (arm64)-${{ github.ref }}
@@ -68,6 +73,8 @@ jobs:
     steps:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.branch }}
 
     - name: Cache LLVM Source
       id: cache-llvm-source

--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -32,7 +32,7 @@ on:
         default: false
       branch:
         description: 'Branch to build from'
-        required: true
+        required: false
         default: 'main'
         type: string
 
@@ -74,7 +74,7 @@ jobs:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.branch }}
+        ref: ${{ inputs.branch || github.ref }}
 
     - name: Cache LLVM Source
       id: cache-llvm-source

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -32,7 +32,7 @@ on:
         default: false
       branch:
         description: 'Branch to build from'
-        required: true
+        required: false
         default: 'main'
         type: string
 
@@ -85,7 +85,7 @@ jobs:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.branch }}
+        ref: ${{ inputs.branch || github.ref }}
 
     - name: Set Ownership in Container
       run: |

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -30,6 +30,11 @@ on:
         type: boolean
         required: false
         default: false
+      branch:
+        description: 'Branch to build from'
+        required: true
+        default: 'main'
+        type: string
 
 concurrency:
   group: Build Catalyst Wheel on Linux (x86_64)-${{ github.ref }}
@@ -79,6 +84,8 @@ jobs:
     steps:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.branch }}
 
     - name: Set Ownership in Container
       run: |

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -32,7 +32,7 @@ on:
         default: false
       branch:
         description: 'Branch to build from'
-        required: true
+        required: false
         default: 'main'
         type: string
 
@@ -76,7 +76,7 @@ jobs:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.branch }}
+        ref: ${{ inputs.branch || github.ref }}
 
     # Python 3.10 was dropped from the GH images on macOS arm
     - name: Install Python 3.10

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -30,6 +30,11 @@ on:
         type: boolean
         required: false
         default: false
+      branch:
+        description: 'Branch to build from'
+        required: true
+        default: 'main'
+        type: string
 
 env:
   MACOSX_DEPLOYMENT_TARGET: 14.0
@@ -70,6 +75,8 @@ jobs:
     steps:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.branch }}
 
     # Python 3.10 was dropped from the GH images on macOS arm
     - name: Install Python 3.10

--- a/.github/workflows/set_rc_version.py
+++ b/.github/workflows/set_rc_version.py
@@ -1,0 +1,52 @@
+# Copyright 2025 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module bumps the Catalyst development version by one unit.
+"""
+
+import os
+import re
+
+version_file_path = os.path.join(os.path.dirname(__file__), "../../frontend/catalyst/_version.py")
+
+assert os.path.isfile(version_file_path)
+
+with open(version_file_path, "r+", encoding="UTF-8") as f:
+    lines = f.readlines()
+
+    version_line = lines[-1]
+    assert "__version__ = " in version_line
+
+    # Try to match version with RC suffix first
+    pattern = r"(\d+).(\d+).(\d+)-rc(\d+)"
+    match = re.search(pattern, version_line)
+
+    if match:
+        # Case 1: Version has RC suffix
+        major, minor, bug, rc = match.groups()
+        replacement = f'__version__ = "{major}.{minor}.{bug}-rc{int(rc)+1}"\n'
+    else:
+        # Case 2: Version has no RC suffix
+        base_pattern = r"(\d+).(\d+).(\d+)"
+        base_match = re.search(base_pattern, version_line)
+        assert base_match, "Version string must be in format X.Y.Z or X.Y.Z-rcN"
+        major, minor, bug = base_match.groups()
+        replacement = f'__version__ = "{major}.{minor}.{bug}-rc0"\n'
+
+    lines[-1] = replacement
+
+    f.seek(0)
+    f.writelines(lines)
+    f.truncate()


### PR DESCRIPTION
**Context:**
The original PRs for the nightly rc wheel upload was merged to main but turns out that we need the  `.github/workflows/set_rc_version.py` file to be in the rc branch since the workflow checks out the rc branch before reading that file. 

**Description of the Change:**
Cherry picked the two PRs that was just merged to main to exist in the rc branch as well. 
Note that all the files are within the `.github/workflows` folder, so it has no impact on the release itself.
