### PR TITLE
Enable variable-length arrays extension for runtime test suite

### DIFF
--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -11,6 +11,10 @@ if(RUNTIME_ENABLE_WARNINGS AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
     add_compile_options("-Wno-maybe-uninitialized")
 endif()
 
+# Issue raised by https://github.com/llvm/llvm-project/issues/62836
+# Here to enable the variable-length array extension within the test suite to eliminate the need for C malloc
+add_compile_options("-Wno-vla-extension")
+
 FetchContent_MakeAvailable(Catch2)
 
 # Locate PyBind11


### PR DESCRIPTION
**Context:**

Issue raised by [https://github.com/llvm/llvm-project/issues/62836](https://github.com/llvm/llvm-project/issues/62836), current clang would treat the use of variable-length array as an error.

In `runtime/tests/Test_NullQubit.cpp` L74 (as shown below), for the C code, allocate  a variable-length array may cause the compilation failure. `make test-runtime` could reproduce this issue.
```
double buffer[shots * n];
MemRefT_double_2d result = {buffer, buffer, 0, {shots, n}, {n, 1}};
```

**Description of the Change:**

Instead of allocating the array with `malloc`, just allow the compiler to compile a variable-length array only for this test-suite by adding `-Wno-vla-extension` in CMake.

**Benefits:**

Compile success on newest clang version

**Possible Drawbacks:**

**Related GitHub Issues:**
