### PR TITLE
Remove constraint on CMake Version<4 and add the support for handling CMAKE_OSX_SYSROOT

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pybind11>=2.12.0
 PyYAML
 
 # Compiler toolchain available via PIP
-cmake>=3.26,<4
+cmake>=3.26
 ninja
 
 # formatting/linting

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -93,16 +93,8 @@ if(NOT EXISTS ${CMAKE_BINARY_DIR}/lib/liblapacke.3.dylib)
             # get the realpath of the SDK path
             get_filename_component(OSX_SDK_PATH ${XCRUN_SDK_PATH} REALPATH)
         else()
-            # Fallback to the latest SDK available under /Library/Developer/CommandLineTools/SDKs/
-            execute_process(
-                COMMAND ls /Library/Developer/CommandLineTools/SDKs/
-                COMMAND grep "MacOSX[0-9][0-9]*\\.[0-9][0-9]*\\.sdk"
-                COMMAND sort -V
-                COMMAND tail -1
-                OUTPUT_VARIABLE LATEST_SDK_NAME
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-            )
-            set(OSX_SDK_PATH "/Library/Developer/CommandLineTools/SDKs/${LATEST_SDK_NAME}")
+            message(FATAL_ERROR "Failed to get the official SDK path since xcrun failed, try to run "
+                    "`xcrun --sdk macosx --show-sdk-path` for more information")
         endif()
     endif()
 

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -75,31 +75,31 @@ add_subdirectory(tests)
 
 if(APPLE AND (${CMAKE_SYSTEM_PROCESSOR} STREQUAL arm64))
 
-execute_process(
-    COMMAND bash -c "xcrun --sdk macosx --show-sdk-path"
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    OUTPUT_VARIABLE OSX_SDK_SYMBOL_PATH
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    RESULT_VARIABLE CMD_RESULT
-)
-
-get_filename_component(SEARCH_DIR ${OSX_SDK_SYMBOL_PATH} DIRECTORY)
-file(GLOB CANDIDATE_FILES "${SEARCH_DIR}/MacOSX*.sdk")
-set(HIGHEST_VERSION "0")
-set(OSX_SDK_LATEST_PATH "${OSX_SDK_SYMBOL_PATH}")
-
-foreach(CURRENT_FILE IN LISTS CANDIDATE_FILES)
-    get_filename_component(CURRENT_FILENAME ${CURRENT_FILE} NAME)
-    string(REGEX MATCH [=[MacOSX(.*)\.sdk$]=] _REGEX_DUMMY "${CURRENT_FILENAME}")
-    set(CURRENT_VERSION "${CMAKE_MATCH_1}")
-    if(CURRENT_VERSION VERSION_GREATER HIGHEST_VERSION)
-        set(HIGHEST_VERSION ${CURRENT_VERSION})
-        set(OSX_SDK_PATH ${CURRENT_FILE})
-    endif()
-endforeach()
-
 # Don't rerun external project everytime we configure the runtime build.
 if(NOT EXISTS ${CMAKE_BINARY_DIR}/lib/liblapacke.3.dylib)
+    execute_process(
+        COMMAND bash -c "xcrun --sdk macosx --show-sdk-path"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        OUTPUT_VARIABLE OSX_SDK_SYMBOL_PATH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE CMD_RESULT
+    )
+
+    get_filename_component(SEARCH_DIR ${OSX_SDK_SYMBOL_PATH} DIRECTORY)
+    file(GLOB CANDIDATE_FILES "${SEARCH_DIR}/MacOSX*.sdk")
+    set(HIGHEST_VERSION "0")
+    set(OSX_SDK_LATEST_PATH "${OSX_SDK_SYMBOL_PATH}")
+
+    foreach(CURRENT_FILE IN LISTS CANDIDATE_FILES)
+        get_filename_component(CURRENT_FILENAME ${CURRENT_FILE} NAME)
+        string(REGEX MATCH [=[MacOSX(.*)\.sdk$]=] _REGEX_DUMMY "${CURRENT_FILENAME}")
+        set(CURRENT_VERSION "${CMAKE_MATCH_1}")
+        if(CURRENT_VERSION VERSION_GREATER HIGHEST_VERSION)
+            set(HIGHEST_VERSION ${CURRENT_VERSION})
+            set(OSX_SDK_PATH ${CURRENT_FILE})
+        endif()
+    endforeach()
+
     ExternalProject_Add(lapacke-accelerate
         GIT_REPOSITORY https://github.com/lepus2589/accelerate-lapacke.git
         GIT_TAG master

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -74,6 +74,30 @@ add_subdirectory(lib)
 add_subdirectory(tests)
 
 if(APPLE AND (${CMAKE_SYSTEM_PROCESSOR} STREQUAL arm64))
+
+execute_process(
+    COMMAND bash -c "xcrun --sdk macosx --show-sdk-path"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE OSX_SDK_SYMBOL_PATH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE CMD_RESULT
+)
+
+get_filename_component(SEARCH_DIR ${OSX_SDK_SYMBOL_PATH} DIRECTORY)
+file(GLOB CANDIDATE_FILES "${SEARCH_DIR}/MacOSX*.sdk")
+set(HIGHEST_VERSION "0")
+set(OSX_SDK_LATEST_PATH "${OSX_SDK_SYMBOL_PATH}")
+
+foreach(CURRENT_FILE IN LISTS CANDIDATE_FILES)
+    get_filename_component(CURRENT_FILENAME ${CURRENT_FILE} NAME)
+    string(REGEX MATCH [=[MacOSX(.*)\.sdk$]=] _REGEX_DUMMY "${CURRENT_FILENAME}")
+    set(CURRENT_VERSION "${CMAKE_MATCH_1}")
+    if(CURRENT_VERSION VERSION_GREATER HIGHEST_VERSION)
+        set(HIGHEST_VERSION ${CURRENT_VERSION})
+        set(OSX_SDK_PATH ${CURRENT_FILE})
+    endif()
+endforeach()
+
 # Don't rerun external project everytime we configure the runtime build.
 if(NOT EXISTS ${CMAKE_BINARY_DIR}/lib/liblapacke.3.dylib)
     ExternalProject_Add(lapacke-accelerate
@@ -82,6 +106,7 @@ if(NOT EXISTS ${CMAKE_BINARY_DIR}/lib/liblapacke.3.dylib)
         PREFIX _lapacke-accelerate
         CMAKE_ARGS "--preset accelerate-lapacke32"
                    "-DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/_lapacke-accelerate/install"
+                   "-DCMAKE_OSX_SYSROOT=${OSX_SDK_PATH}"
         INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install
         COMMAND cp ${CMAKE_BINARY_DIR}/_lapacke-accelerate/install/lib/liblapacke.3.dylib ${CMAKE_BINARY_DIR}/lib
         LOG_CONFIGURE ON

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -74,7 +74,6 @@ add_subdirectory(lib)
 add_subdirectory(tests)
 
 if(APPLE AND (${CMAKE_SYSTEM_PROCESSOR} STREQUAL arm64))
-
 # Don't rerun external project everytime we configure the runtime build.
 if(NOT EXISTS ${CMAKE_BINARY_DIR}/lib/liblapacke.3.dylib)
     execute_process(

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -76,28 +76,35 @@ add_subdirectory(tests)
 if(APPLE AND (${CMAKE_SYSTEM_PROCESSOR} STREQUAL arm64))
 # Don't rerun external project everytime we configure the runtime build.
 if(NOT EXISTS ${CMAKE_BINARY_DIR}/lib/liblapacke.3.dylib)
-    execute_process(
-        COMMAND bash -c "xcrun --sdk macosx --show-sdk-path"
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        OUTPUT_VARIABLE OSX_SDK_SYMBOL_PATH
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        RESULT_VARIABLE CMD_RESULT
-    )
+    if(CMAKE_OSX_SYSROOT)
+        get_filename_component(OSX_SDK_PATH ${CMAKE_OSX_SYSROOT} REALPATH)
+    else()
+        message(STATUS "CMAKE_OSX_SYSROOT is not set, using xcrun to get the official SDK path")
 
-    get_filename_component(SEARCH_DIR ${OSX_SDK_SYMBOL_PATH} DIRECTORY)
-    file(GLOB CANDIDATE_FILES "${SEARCH_DIR}/MacOSX*.sdk")
-    set(HIGHEST_VERSION "0")
-    set(OSX_SDK_LATEST_PATH "${OSX_SDK_SYMBOL_PATH}")
+        # Use xcrun to get the official SDK path
+        execute_process(
+            COMMAND xcrun --sdk macosx --show-sdk-path
+            OUTPUT_VARIABLE XCRUN_SDK_PATH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            RESULT_VARIABLE XCRUN_RESULT
+        )
 
-    foreach(CURRENT_FILE IN LISTS CANDIDATE_FILES)
-        get_filename_component(CURRENT_FILENAME ${CURRENT_FILE} NAME)
-        string(REGEX MATCH [=[MacOSX(.*)\.sdk$]=] _REGEX_DUMMY "${CURRENT_FILENAME}")
-        set(CURRENT_VERSION "${CMAKE_MATCH_1}")
-        if(CURRENT_VERSION VERSION_GREATER HIGHEST_VERSION)
-            set(HIGHEST_VERSION ${CURRENT_VERSION})
-            set(OSX_SDK_PATH ${CURRENT_FILE})
+        if(XCRUN_RESULT EQUAL 0)
+            # get the realpath of the SDK path
+            get_filename_component(OSX_SDK_PATH ${XCRUN_SDK_PATH} REALPATH)
+        else()
+            # Fallback to the latest SDK available under /Library/Developer/CommandLineTools/SDKs/
+            execute_process(
+                COMMAND ls /Library/Developer/CommandLineTools/SDKs/
+                COMMAND grep "MacOSX[0-9][0-9]*\\.[0-9][0-9]*\\.sdk"
+                COMMAND sort -V
+                COMMAND tail -1
+                OUTPUT_VARIABLE LATEST_SDK_NAME
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+            set(OSX_SDK_PATH "/Library/Developer/CommandLineTools/SDKs/${LATEST_SDK_NAME}")
         endif()
-    endforeach()
+    endif()
 
     ExternalProject_Add(lapacke-accelerate
         GIT_REPOSITORY https://github.com/lepus2589/accelerate-lapacke.git


### PR DESCRIPTION
**Context:**

When compiling catalyst from scratch. Mac user may encounter `CMAKE_OSX_SYSROOT` didn't set properly when compiling the lapacke. (may reproduce by `make runtime`)

lapacke actually run this regex expression `SDKs/MacOSX(.)\.sdk` to get the version number. Run the command `xcrun --sdk macosx --show-sdk-path` may only get the symlink `MacOSX.sdk -> MacOSX${LATEST_VERSION}.sdk` Instead of `MacOSX${LATEST_VERSION}.sdk`, but it's depend on your machine.

Note:

`CMake<4`:
Everything well, just don't set the `SDKROOT` in shell env then wouldn't be facing any issue (If it is set, CMake would use it to init the `CMAKE_OSX_SYSROOT`) and CMake has its own detection logic to figure out the path

`CMake==4`:
If `CMAKE_OSX_SYSROOT` is empty: CMake wouldn't detect the sdk path now, they leave for the user to set it explicitly.

**Description of the Change:**

Add fallback logic to automatically detect the macOS SDK path when `CMAKE_OSX_SYSROOT`
is not explicitly set. 

1. Check if `CMAKE_OSX_SYSROOT` is already set and use its realpath if available
2. Fall back to using the realpath of `xcrun --sdk macosx --show-sdk-path` to automatically
    detect the official macOS SDK path when `CMAKE_OSX_SYSROOT` is not set

**Benefits:**

Support CMake>=4, and don't need the user to set the `SDKROOT` in shell env manually 

**Related GitHub Issues:** #1726 
