### PR TITLE
Fix failures when automatic qubit management is used with global phase ops

### DIFF
--- a/doc/releases/changelog-0.12.0.md
+++ b/doc/releases/changelog-0.12.0.md
@@ -127,6 +127,7 @@
 
 * Catalyst now supports automatic qubit management.
   [(#1788)](https://github.com/PennyLaneAI/catalyst/pull/1788)
+  [(#???)](https://github.com/PennyLaneAI/catalyst/pull/???)
 
   The number of wires does not need to be speficied during device initialization,
   and instead will be automatically managed by the Catalyst Runtime.

--- a/frontend/catalyst/pipelines.py
+++ b/frontend/catalyst/pipelines.py
@@ -204,6 +204,10 @@ def get_enforce_runtime_invariants_stage(_options: CompileOptions) -> List[str]:
         # tapes will generate multiple qnodes. One for each tape.
         # Split multiple tapes enforces that invariant.
         "split-multiple-tapes",
+        # Automatic qubit management mode must have global phase gates
+        # at the end, otherwise global phase does not know how many qubits
+        # to act on.
+        "delay-global-phase-in-AQM",
         # Run the transform sequence defined in the MLIR module
         "builtin.module(apply-transform-sequence)",
         # Nested modules are something that will be used in the future

--- a/frontend/test/pytest/test_automatic_qubit_management.py
+++ b/frontend/test/pytest/test_automatic_qubit_management.py
@@ -151,3 +151,21 @@ def test_state(backend):
     ref, observed = (qjit(qml.qnode(dev)(circuit))() for dev in devices)
     assert ref.shape == observed.shape
     assert np.allclose(ref, observed)
+
+
+def test_global_phase(backend):
+    """
+    Test that a circuit with a global phase operation can be executed
+    correctly with automatic qubit management.
+    """
+
+    def circuit():
+        qml.GlobalPhase(0.123)
+        qml.PauliX(wires=0)
+        return qml.state()
+
+    wires = [1, None]
+    devices = [qml.device(backend, wires=wire) for wire in wires]
+    ref, observed = (qjit(qml.qnode(dev)(circuit))() for dev in devices)
+    assert ref.shape == observed.shape
+    assert np.allclose(ref, observed)

--- a/mlir/include/Quantum/Transforms/Passes.h
+++ b/mlir/include/Quantum/Transforms/Passes.h
@@ -34,5 +34,6 @@ std::unique_ptr<mlir::Pass> createDisentangleCNOTPass();
 std::unique_ptr<mlir::Pass> createDisentangleSWAPPass();
 std::unique_ptr<mlir::Pass> createIonsDecompositionPass();
 std::unique_ptr<mlir::Pass> createLoopBoundaryOptimizationPass();
+std::unique_ptr<mlir::Pass> createDelayGlobalPhaseInAQMPass();
 
 } // namespace catalyst

--- a/mlir/include/Quantum/Transforms/Passes.td
+++ b/mlir/include/Quantum/Transforms/Passes.td
@@ -77,6 +77,12 @@ def SplitMultipleTapesPass : Pass<"split-multiple-tapes"> {
     let constructor = "catalyst::createSplitMultipleTapesPass()";
 }
 
+def DelayGlobalPhaseInAQMPass : Pass<"delay-global-phase-in-AQM"> {
+    let summary = "Move all global phase ops after the final gate op in automatic qubit managing mode";
+
+    let constructor = "catalyst::createDelayGlobalPhaseInAQMPass()";
+}
+
 // ----- Quantum circuit transformation passes begin ----- //
 // For example, automatic compiler peephole opts, etc.
 

--- a/mlir/lib/Catalyst/Transforms/RegisterAllPasses.cpp
+++ b/mlir/lib/Catalyst/Transforms/RegisterAllPasses.cpp
@@ -67,4 +67,5 @@ void catalyst::registerAllCatalystPasses()
     mlir::registerPass(catalyst::createGatesToPulsesPass);
     mlir::registerPass(catalyst::createLoopBoundaryOptimizationPass);
     mlir::registerPass(catalyst::createMBQCConversionPass);
+    mlir::registerPass(catalyst::createDelayGlobalPhaseInAQMPass);
 }

--- a/mlir/lib/Driver/Pipelines.cpp
+++ b/mlir/lib/Driver/Pipelines.cpp
@@ -34,6 +34,7 @@ namespace driver {
 void createEnforceRuntimeInvariantsPipeline(OpPassManager &pm)
 {
     pm.addPass(catalyst::createSplitMultipleTapesPass());
+    pm.addPass(catalyst::createDelayGlobalPhaseInAQMPass());
     pm.addNestedPass<ModuleOp>(catalyst::createApplyTransformSequencePass());
     pm.addPass(catalyst::createInlineNestedModulePass());
 }

--- a/mlir/lib/Quantum/Transforms/CMakeLists.txt
+++ b/mlir/lib/Quantum/Transforms/CMakeLists.txt
@@ -20,6 +20,7 @@ file(GLOB SRC
     IonsDecompositionPatterns.cpp
     loop_boundary_optimization.cpp
     LoopBoundaryOptimizationPatterns.cpp
+    delay_global_phase_in_AQM.cpp
 )
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)

--- a/mlir/lib/Quantum/Transforms/delay_global_phase_in_AQM.cpp
+++ b/mlir/lib/Quantum/Transforms/delay_global_phase_in_AQM.cpp
@@ -1,0 +1,130 @@
+// Copyright 2025 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define DEBUG_TYPE "delay-global-phase-in-AQM"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
+
+#include "Catalyst/IR/CatalystDialect.h"
+#include "Quantum/IR/QuantumOps.h"
+
+using namespace mlir;
+using namespace catalyst::quantum;
+
+namespace catalyst {
+namespace quantum {
+
+#define GEN_PASS_DEF_DELAYGLOBALPHASEINAQMPASS
+#define GEN_PASS_DECL_DELAYGLOBALPHASEINAQMPASS
+#include "Quantum/Transforms/Passes.h.inc"
+
+struct DelayGlobalPhaseInAQMPass : impl::DelayGlobalPhaseInAQMPassBase<DelayGlobalPhaseInAQMPass> {
+    using DelayGlobalPhaseInAQMPassBase::DelayGlobalPhaseInAQMPassBase;
+
+    Operation *findLastGateOp(Operation *module)
+    {
+        // Find the last gate op that's not a globalphase op
+        Operation *finalGate = nullptr;
+        module->walk([&](Operation *op) {
+            if (isa<quantum::CustomOp>(op) || isa<quantum::SetStateOp>(op) ||
+                isa<quantum::SetBasisStateOp>(op) || isa<quantum::MultiRZOp>(op) ||
+                isa<quantum::QubitUnitaryOp>(op)) {
+                finalGate = op;
+                return WalkResult::advance();
+            }
+            else {
+                return WalkResult::skip();
+            }
+        });
+        return finalGate;
+    }
+
+    void runOnOperation() final
+    {
+        Operation *module = getOperation();
+        mlir::IRRewriter builder(module->getContext());
+        mlir::Location loc = module->getLoc();
+
+        // Get the device
+        // Is there an easy way other than just walking?
+        quantum::DeviceInitOp deviceInitOp;
+        size_t _devCount = 0;
+        module->walk([&](quantum::DeviceInitOp dev) {
+            deviceInitOp = dev;
+            _devCount++;
+        });
+        if (_devCount == 0) {
+            // Not a qnode, nothing to do
+            return;
+        }
+        assert(_devCount == 1 && "A qfunc must have exactly one device init op.");
+
+        if (!deviceInitOp.getAutoQubitManagement()) {
+            // Not in AQM mode, nothing to do
+            return;
+        }
+
+        // Find the last gate op that's not a globalphase op
+        Operation *finalGate = findLastGateOp(module);
+        llvm::errs() << "final: " << *finalGate << "\n";
+        builder.setInsertionPointAfter(finalGate);
+
+        // Clump all global phases and create one after the last gate op
+        SmallVector<Value> phases;
+        SmallVector<quantum::GlobalPhaseOp> gphaseRemovalWorklist;
+        module->walk([&](quantum::GlobalPhaseOp gphaseOp) {
+            assert(gphaseOp.getInCtrlQubits().size() == 0 &&
+                   "Gloabl phase ops with control qubits is not yet supported with automatic qubit "
+                   "management mode.");
+
+            if (gphaseOp.getAdjoint()) {
+                phases.push_back(
+                    builder.create<arith::NegFOp>(loc, gphaseOp.getParams()).getResult());
+            }
+            else {
+                phases.push_back(gphaseOp.getParams());
+            }
+            gphaseRemovalWorklist.push_back(gphaseOp);
+        });
+
+        if (phases.size() == 0) {
+            // No gphase ops, nothing to do
+            return;
+        }
+
+        Value accumedPhase = phases[0];
+        for (size_t i = 1; i < phases.size(); i++) {
+            accumedPhase = builder.create<arith::AddFOp>(loc, accumedPhase, phases[i]).getResult();
+        }
+        builder.create<quantum::GlobalPhaseOp>(loc, TypeRange{}, accumedPhase, false, ValueRange{},
+                                               ValueRange{});
+
+        for (auto op : gphaseRemovalWorklist) {
+            op->erase();
+        }
+    }
+};
+
+} // namespace quantum
+
+std::unique_ptr<Pass> createDelayGlobalPhaseInAQMPass()
+{
+    return std::make_unique<quantum::DelayGlobalPhaseInAQMPass>();
+}
+
+} // namespace catalyst

--- a/mlir/test/Quantum/DelayGlobalPhaseInAQM.mlir
+++ b/mlir/test/Quantum/DelayGlobalPhaseInAQM.mlir
@@ -1,0 +1,60 @@
+// Copyright 2025 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RUN: quantum-opt --delay-global-phase-in-AQM --split-input-file -verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL: test_basic_case
+func.func @test_basic_case(%phase: f64, %q: !quantum.bit, %shots: i64) {
+    quantum.device shots(%shots) ["", "", ""] {auto_qubit_management}
+
+    quantum.gphase(%phase) :
+    %2 = quantum.custom "Hadamard"() %q : !quantum.bit
+
+    return
+}
+
+// -----
+// CHECK-LABEL: test_sandwhiched
+func.func @test_sandwhiched(%phase: f64, %q: !quantum.bit, %shots: i64) {
+    quantum.device shots(%shots) ["", "", ""] {auto_qubit_management}
+
+    quantum.gphase(%phase) :
+    %2 = quantum.custom "Hadamard"() %q : !quantum.bit
+    quantum.gphase(%phase) :
+
+    return
+}
+
+// -----
+// CHECK-LABEL: test_adjoint
+func.func @test_adjoint(%phase: f64, %q: !quantum.bit, %shots: i64) {
+    quantum.device shots(%shots) ["", "", ""] {auto_qubit_management}
+
+    quantum.gphase(%phase) {adjoint} :
+    quantum.gphase(%phase) :
+    %2 = quantum.custom "Hadamard"() %q : !quantum.bit
+
+    return
+}
+
+// -----
+// CHECK-LABEL: test_not_aqm
+func.func @test_not_aqm(%phase: f64, %q: !quantum.bit, %shots: i64) {
+    quantum.device shots(%shots) ["", "", ""]
+
+    quantum.gphase(%phase) :
+    %2 = quantum.custom "Hadamard"() %q : !quantum.bit
+
+    return
+}


### PR DESCRIPTION
**Context:**
Global phase ops fail in automatic qubit management mode. 
This is because when global phase is encountered in runtime in AQM, the qubits used by the gates after the global phase have not been allocated.

**Description of the Change:**
Delay global phase ops to the end, after all the regular gates.
This is possible because global phase ops commutes with everything, provided there are no control qubits on the global phase.

**Benefits:**
Global phase works with automatic qubit management mode.

**Possible Drawbacks:**
Global phases with control qubits still do not work with automatic qubit management mode. 

**Related GitHub Issues:**
closes #1862 

[sc-94808]