### PR TITLE
Change rc wheel upload runner to x86 

### DIFF
--- a/.github/workflows/build-nightly-release-candidate.yaml
+++ b/.github/workflows/build-nightly-release-candidate.yaml
@@ -66,7 +66,7 @@ jobs:
   upload:
     name: Prepare & Upload wheels to TestPyPI
     needs: [linux-x86, macos-arm, linux-aarch]
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-24.04
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 


### PR DESCRIPTION
**Context:**
the job that uploads wheels to test PyPi need to be an x86 runner, but the nightly wheel build workflow uses an arm runner which causes an error while uploading.