### PR TITLE
upgrade PL and LT versions on rc

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -10,8 +10,8 @@ enzyme=v0.0.180
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt
-pennylane=0.42.0-dev67
+pennylane=0.42.0-dev68
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'
-lightning=0.42.0-dev16
+lightning=0.42.0-dev45

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -31,6 +31,6 @@ lxml_html_clean
 
 # Pre-install PL development wheels
 --extra-index-url https://test.pypi.org/simple/
-pennylane-lightning-kokkos==0.42.0-dev16
-pennylane-lightning==0.42.0-dev16
-pennylane==0.42.0-dev67
+pennylane-lightning-kokkos==0.42.0-dev45
+pennylane-lightning==0.42.0-dev45
+pennylane==0.42.0-dev68


### PR DESCRIPTION
**Context:**
We need to be able to test wheels with the latest dev versions of Pennylane and Lightning.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**
the wheels will still not include the rc branch versions of PL and LT.  

**Related GitHub Issues:**
