### PR TITLE
Update to jax 0.6.2

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -1,7 +1,7 @@
 # Always update the version check in catalyst.__init__ when changing the JAX version.
 # To update JAX version alongside compatible dependency tags, run the following script:
 # python3 .github/workflows/set_dep_versions.py {JAX_version}
-jax=0.6.0
+jax=0.6.2
 mhlo=617a9361d186199480c080c9e8c474a5e30c22d1
 llvm=179d30f8c3fddd3c85056fd2b8e877a4a8513158
 enzyme=v0.0.180

--- a/frontend/catalyst/__init__.py
+++ b/frontend/catalyst/__init__.py
@@ -23,7 +23,7 @@ from os.path import dirname
 
 import jaxlib as _jaxlib
 
-_jaxlib_version = "0.6.0"
+_jaxlib_version = "0.6.2"
 if _jaxlib.__version__ != _jaxlib_version:
     import warnings
 

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -20,12 +20,14 @@ with control flow, including conditionals, for loops, and while loops.
 # pylint: disable=too-many-lines
 
 import inspect
+from functools import partial
 from typing import Any, Callable, List
 
 import jax
 import jax.numpy as jnp
 import pennylane as qml
 from jax._src.tree_util import PyTreeDef, tree_unflatten, treedef_is_leaf
+from jax._src.source_info_util import current as current_source_info
 from jax.api_util import debug_info
 from jax.core import AbstractValue
 from pennylane import QueuingManager
@@ -676,7 +678,8 @@ class CondCallable:
             with EvaluationContext.frame_tracing_context(debug_info=wfun.debug_info) as inner_trace:
                 with QueuingManager.stop_recording(), quantum_tape:
                     res_classical_tracers = [
-                        inner_trace.to_jaxpr_tracer(t) for t in wfun.call_wrapped()
+                        inner_trace.to_jaxpr_tracer(t, current_source_info())
+                        for t in wfun.call_wrapped()
                     ]
             explicit_return_tys = collapse(out_sig.out_type(), res_classical_tracers)
             hybridRegion = HybridOpRegion(inner_trace, quantum_tape, [], explicit_return_tys)
@@ -742,6 +745,7 @@ class CondCallable:
             all_jaxprs, all_consts, all_noimplouts
         )
         branch_jaxprs = jaxpr_pad_consts(all_jaxprs)
+        # branch_jaxprs = all_jaxprs
         # Output types from all the branches are unified by now, we use the first branch for
         # the resulting tracers.
         out_tracers = cond_p.bind(
@@ -912,7 +916,8 @@ class ForLoopCallable:
         quantum_tape = QuantumTape()
         outer_trace = EvaluationContext.get_current_trace()
         aux_classical_tracers = [
-            outer_trace.to_jaxpr_tracer(t) for t in [self.lower_bound, self.upper_bound, self.step]
+            outer_trace.to_jaxpr_tracer(t, current_source_info())
+            for t in [self.lower_bound, self.upper_bound, self.step]
         ]
         wfun, in_sig, out_sig = deduce_signatures(
             self.body_fn,
@@ -927,11 +932,13 @@ class ForLoopCallable:
 
         with EvaluationContext.frame_tracing_context(debug_info=wfun.debug_info) as inner_trace:
             arg_classical_tracers = input_type_to_tracers(
-                in_type, inner_trace.new_arg, inner_trace.to_jaxpr_tracer
+                in_type,
+                partial(inner_trace.new_arg, source_info=current_source_info()),
+                partial(inner_trace.to_jaxpr_tracer, source_info=current_source_info()),
             )
             with QueuingManager.stop_recording(), quantum_tape:
                 res_classical_tracers = [
-                    inner_trace.to_jaxpr_tracer(t)
+                    inner_trace.to_jaxpr_tracer(t, current_source_info())
                     for t in wfun.call_wrapped(*arg_classical_tracers)
                 ]
                 out_type = out_sig.out_type()
@@ -967,7 +974,8 @@ class ForLoopCallable:
     def _call_with_classical_ctx(self, *init_state):
         outer_trace = find_top_trace([self.lower_bound, self.upper_bound, self.step])
         aux_tracers = [
-            outer_trace.to_jaxpr_tracer(t) for t in [self.lower_bound, self.upper_bound, self.step]
+            outer_trace.to_jaxpr_tracer(t, current_source_info())
+            for t in [self.lower_bound, self.upper_bound, self.step]
         ]
 
         _, in_sig, out_sig = trace_function(
@@ -1105,10 +1113,12 @@ class WhileLoopCallable:
 
         with EvaluationContext.frame_tracing_context(debug_info=cond_wffa.debug_info) as cond_trace:
             arg_classical_tracers = input_type_to_tracers(
-                in_type, cond_trace.new_arg, cond_trace.to_jaxpr_tracer
+                in_type,
+                partial(cond_trace.new_arg, source_info=current_source_info()),
+                partial(cond_trace.to_jaxpr_tracer, source_info=current_source_info()),
             )
             res_classical_tracers = [
-                cond_trace.to_jaxpr_tracer(t)
+                cond_trace.to_jaxpr_tracer(t, current_source_info())
                 for t in cond_wffa.call_wrapped(*arg_classical_tracers)
             ]
 
@@ -1127,13 +1137,15 @@ class WhileLoopCallable:
 
         with EvaluationContext.frame_tracing_context(debug_info=body_wffa.debug_info) as body_trace:
             arg_classical_tracers = input_type_to_tracers(
-                in_type, body_trace.new_arg, body_trace.to_jaxpr_tracer
+                in_type,
+                partial(body_trace.new_arg, source_info=current_source_info()),
+                partial(body_trace.to_jaxpr_tracer, source_info=current_source_info()),
             )
 
             quantum_tape = QuantumTape()
             with QueuingManager.stop_recording(), quantum_tape:
                 res_classical_tracers = [
-                    body_trace.to_jaxpr_tracer(t)
+                    body_trace.to_jaxpr_tracer(t, current_source_info())
                     for t in body_wffa.call_wrapped(*arg_classical_tracers)
                 ]
 
@@ -1228,7 +1240,9 @@ class Cond(HybridOp):
         for region in op.regions:
             with EvaluationContext.frame_tracing_context(region.trace):
                 new_qreg = AbstractQreg()
-                qreg_in = _input_type_to_tracers(region.trace.new_arg, [new_qreg])[0]
+                qreg_in = _input_type_to_tracers(
+                    partial(region.trace.new_arg, source_info=current_source_info()), [new_qreg]
+                )[0]
                 qreg_out = trace_quantum_operations(
                     region.quantum_tape, device, qreg_in, ctx, region.trace
                 ).actualize()
@@ -1250,6 +1264,9 @@ class Cond(HybridOp):
         qreg = qrp.actualize()
         all_jaxprs, _, _, all_consts = unify_convert_result_types(jaxprs, consts, nimplouts)
         branch_jaxprs = jaxpr_pad_consts(all_jaxprs)
+        # no need to pad consts anymore
+        # breakpoint()
+        # branch_jaxprs = all_jaxprs
 
         in_expanded_classical_tracers = [*self.in_classical_tracers, *sum(all_consts, []), qreg]
 
@@ -1285,7 +1302,9 @@ class ForLoop(HybridOp):
 
         with EvaluationContext.frame_tracing_context(inner_trace):
             new_qreg = AbstractQreg()
-            qreg_in = _input_type_to_tracers(inner_trace.new_arg, [new_qreg])[0]
+            qreg_in = _input_type_to_tracers(
+                partial(inner_trace.new_arg, source_info=current_source_info()), [new_qreg]
+            )[0]
             qrp_out = trace_quantum_operations(inner_tape, device, qreg_in, ctx, inner_trace)
             qreg_out = qrp_out.actualize()
 
@@ -1301,7 +1320,7 @@ class ForLoop(HybridOp):
             res_tracers = res_classical_tracers + [qreg_out]
             _, _, consts = trace_to_jaxpr(inner_trace, [], res_tracers)
             res_expanded_tracers, _ = expand_results(
-                [inner_trace.to_jaxpr_tracer(t) for t in consts],
+                [inner_trace.to_jaxpr_tracer(t, current_source_info()) for t in consts],
                 arg_expanded_tracers,
                 res_tracers,
                 expansion_strategy=expansion_strategy,
@@ -1310,7 +1329,7 @@ class ForLoop(HybridOp):
             jaxpr, _, _ = trace_to_jaxpr(inner_trace, arg_expanded_tracers, res_expanded_tracers)
 
         operand_tracers = op.in_classical_tracers
-        const_tracers = [trace.to_jaxpr_tracer(c) for c in consts]
+        const_tracers = [trace.to_jaxpr_tracer(c, current_source_info()) for c in consts]
         operand_expanded_tracers, _ = expand_args(
             operand_tracers, expansion_strategy=expansion_strategy
         )
@@ -1359,12 +1378,14 @@ class WhileLoop(HybridOp):
                 cond_trace, arg_expanded_classical_tracers, res_classical_tracers
             )
             res_expanded_classical_tracers, _ = expand_results(
-                [cond_trace.to_jaxpr_tracer(t) for t in consts],
+                [cond_trace.to_jaxpr_tracer(t, current_source_info()) for t in consts],
                 arg_expanded_classical_tracers,
                 res_classical_tracers,
                 expansion_strategy=expansion_strategy,
             )
-            _input_type_to_tracers(cond_trace.new_arg, [AbstractQreg()])
+            _input_type_to_tracers(
+                partial(cond_trace.new_arg, source_info=current_source_info()), [AbstractQreg()]
+            )
             cond_jaxpr, _, cond_consts = trace_to_jaxpr(
                 cond_trace, arg_expanded_classical_tracers, res_expanded_classical_tracers
             )
@@ -1375,7 +1396,9 @@ class WhileLoop(HybridOp):
         with EvaluationContext.frame_tracing_context(body_trace):
             region = self.regions[1]
             res_classical_tracers = region.res_classical_tracers
-            qreg_in = _input_type_to_tracers(body_trace.new_arg, [AbstractQreg()])[0]
+            qreg_in = _input_type_to_tracers(
+                partial(body_trace.new_arg, source_info=current_source_info()), [AbstractQreg()]
+            )[0]
             qrp_out = trace_quantum_operations(body_tape, device, qreg_in, ctx, body_trace)
             qreg_out = qrp_out.actualize()
             arg_expanded_tracers = expand_args(
@@ -1386,7 +1409,7 @@ class WhileLoop(HybridOp):
                 body_trace, arg_expanded_tracers, res_classical_tracers + [qreg_out]
             )
             res_expanded_tracers, _ = expand_results(
-                [body_trace.to_jaxpr_tracer(t) for t in consts],
+                [body_trace.to_jaxpr_tracer(t, current_source_info()) for t in consts],
                 arg_expanded_tracers,
                 res_classical_tracers + [qreg_out],
                 expansion_strategy=expansion_strategy,
@@ -1396,13 +1419,13 @@ class WhileLoop(HybridOp):
             )
 
         in_expanded_tracers = [
-            *[trace.to_jaxpr_tracer(c) for c in (cond_consts + body_consts)],
+            *[trace.to_jaxpr_tracer(c, current_source_info()) for c in (cond_consts + body_consts)],
             *expand_args(self.in_classical_tracers, expansion_strategy=expansion_strategy)[0],
             qrp.actualize(),
         ]
 
         out_expanded_classical_tracers = expand_results(
-            [trace.to_jaxpr_tracer(c) for c in (cond_consts + body_consts)],
+            [trace.to_jaxpr_tracer(c, current_source_info()) for c in (cond_consts + body_consts)],
             in_expanded_tracers,
             self.out_classical_tracers,
             expansion_strategy=expansion_strategy,

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -26,6 +26,7 @@ from typing import Any, Callable, List, Optional, Union
 import jax
 import pennylane as qml
 from jax._src.tree_util import tree_flatten
+from jax._src.source_info_util import current as current_source_info
 from jax.api_util import debug_info
 from jax.core import get_aval
 from pennylane import QueuingManager
@@ -427,11 +428,13 @@ class AdjointCallable:
         with EvaluationContext.frame_tracing_context(debug_info=dbg) as inner_trace:
             in_classical_tracers, _ = tree_flatten((args, kwargs))
             wffa, in_avals, _, _ = deduce_avals(self.target, args, kwargs, debug_info=dbg)
-            arg_classical_tracers = _input_type_to_tracers(inner_trace.new_arg, in_avals)
+            arg_classical_tracers = _input_type_to_tracers(
+                partial(inner_trace.new_arg, source_info=current_source_info()), in_avals
+            )
             with QueuingManager.stop_recording(), QuantumTape() as quantum_tape:
                 # FIXME: move all to_jaxpr_tracer calls into a separate function
                 res_classical_tracers = [
-                    inner_trace.to_jaxpr_tracer(t)
+                    inner_trace.to_jaxpr_tracer(t, current_source_info())
                     for t in wffa.call_wrapped(*arg_classical_tracers)
                     if isinstance(t, DynamicJaxprTracer)
                 ]
@@ -466,7 +469,9 @@ class HybridAdjoint(HybridOp):
             frame_ctx = EvaluationContext.frame_tracing_context(body_trace)
 
         with frame_ctx as body_trace:
-            qreg_in = _input_type_to_tracers(body_trace.new_arg, [AbstractQreg()])[0]
+            qreg_in = _input_type_to_tracers(
+                partial(body_trace.new_arg, source_info=current_source_info()), [AbstractQreg()]
+            )[0]
             qrp_out = trace_quantum_operations(body_tape, device, qreg_in, ctx, body_trace)
             qreg_out = qrp_out.actualize()
             body_jaxpr, _, body_consts = body_trace.frame.to_jaxpr2(

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -21,6 +21,7 @@ import copy
 import sys
 from collections.abc import Sized
 from contextlib import nullcontext
+from functools import partial
 from typing import Any, Callable, List, Optional, Union
 
 import jax

--- a/frontend/catalyst/jax_extras/patches.py
+++ b/frontend/catalyst/jax_extras/patches.py
@@ -36,6 +36,7 @@ from jax.core import AbstractValue, Tracer
 
 __all__ = (
     "get_aval2",
+    "_drop_unused_vars2",
     "_no_clean_up_dead_vars",
     "_gather_shape_rule_dynamic",
     "gather2_p",
@@ -51,6 +52,13 @@ def get_aval2(x):
         return x.aval
     else:
         return abstractify(x)
+
+
+def _drop_unused_vars2(jaxpr, constvals):
+    """
+    A patch to not drop unused vars during classical tracing of for loops.
+    """
+    return jaxpr, list(constvals)
 
 
 def _no_clean_up_dead_vars(_eqn, _env, _last_used):

--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -237,7 +237,6 @@ def sort_eqns(eqns: List[JaxprEqn], forced_order_primitives: Set[JaxprPrimitive]
     for b in boxes:
         origin.update({ov.count: b for ov in b.e.outvars})  # [1]
     for b in boxes:
-        # breakpoint()
         # b.parents = [origin[v.count] for v in b.e.invars if v.count in origin]  # [2]
         b.parents = []
         for v in b.e.invars:
@@ -255,7 +254,6 @@ def sort_eqns(eqns: List[JaxprEqn], forced_order_primitives: Set[JaxprPrimitive]
 def jaxpr_pad_consts(jaxprs: List[Jaxpr]) -> List[ClosedJaxpr]:
     """Align the constants of Jaxpr programs. Return the list of corresponding programs accepting
     the same constants."""
-    # breakpoint()
     newvar = gensym()
 
     # List of constant variables of all jaxprs, preprended with '_'

--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -244,7 +244,7 @@ def sort_eqns(eqns: List[JaxprEqn], forced_order_primitives: Set[JaxprPrimitive]
             if not isinstance(v, jax.core.Tracer):
                 # constant literal invar, no need to track def use order
                 continue
-            elif v.count in origin:
+            if v.count in origin:
                 b.parents.append(origin[v.count])
     for i, q in fixedorder:
         for b in boxes[i + 1 :]:

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1591,7 +1591,6 @@ def custom_measurement_staging_rule(
     See jax._src.interpreters.partial_eval.process_primitive and default_process_primitive,
     https://github.com/jax-ml/jax/blob/a54319ec1886ed920d50cacf10e147a743888464/jax/_src/interpreters/partial_eval.py#L1881C7-L1881C24
     """
-
     shape = _merge_dyn_shape(static_shape, dynamic_shape)
     if not dynamic_shape:
         # Some PL transforms, like @qml.batch_params, do not support dynamic shapes yet
@@ -1625,7 +1624,7 @@ def custom_measurement_staging_rule(
 #
 # sample measurement
 #
-def sample_staging_rule(jaxpr_trace, obs, *dynamic_shape, static_shape):
+def sample_staging_rule(jaxpr_trace, _src, obs, *dynamic_shape, static_shape):
     """
     The result shape of `sample_p` is (shots, num_qubits).
     """
@@ -1677,7 +1676,7 @@ def _sample_lowering(
 #
 # counts measurement
 #
-def counts_staging_rule(jaxpr_trace, obs, *dynamic_shape, static_shape):
+def counts_staging_rule(jaxpr_trace, _src, obs, *dynamic_shape, static_shape):
     """
     The result shape of `counts_p` is (tensor<Nxf64>, tensor<Nxi64>)
     where N = 2**number_of_qubits.
@@ -1799,7 +1798,7 @@ def _var_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shape=None):
 #
 # probs measurement
 #
-def probs_staging_rule(jaxpr_trace, obs, *dynamic_shape, static_shape):
+def probs_staging_rule(jaxpr_trace, _src, obs, *dynamic_shape, static_shape):
     """
     The result shape of probs_p is (2^num_qubits,).
     """
@@ -1843,7 +1842,7 @@ def _probs_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, *dynamic_s
 #
 # state measurement
 #
-def state_staging_rule(jaxpr_trace, obs, *dynamic_shape, static_shape):
+def state_staging_rule(jaxpr_trace, _src, obs, *dynamic_shape, static_shape):
     """
     The result shape of state_p is (2^num_qubits,).
     """

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -1043,7 +1043,6 @@ def trace_quantum_measurements(
                 else:
                     shape = (2**nqubits,)
                 dyn_dims, static_shape = _extract_tracers_dyn_shape(shape)
-                # breakpoint()
                 result = probs_p.bind(obs_tracers, *dyn_dims, static_shape=tuple(static_shape))
                 out_classical_tracers.append(result)
             elif type(output) is CountsMP:
@@ -1447,12 +1446,10 @@ def trace_quantum_function(
                 # Check if the measurements are nested then apply the to_jaxpr_tracer
                 def check_full_raise(arr, func):
                     if isinstance(arr, (list, tuple)):
-                        # breakpoint()
                         return type(arr)(check_full_raise(x, func) for x in arr)
                     else:
                         return func(arr)
 
-                # breakpoint()
                 meas_tracers = check_full_raise(
                     meas, partial(trace.to_jaxpr_tracer, source_info=current_source_info())
                 )

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -667,7 +667,7 @@ class QJIT(CatalystCallable):
                 self.compiled_function.shared_object.close()
 
             self.jaxpr, self.out_type, self.out_treedef, self.c_sig = self.capture(args, **kwargs)
-
+            # breakpoint()
             self.mlir_module = self.generate_ir()
             self.compiled_function, _ = self.compile()
 


### PR DESCRIPTION
**Context:**
Update to jax 0.6.2

**Description of the Change:**
1. `from jaxlib.xla_extension import PyTreeRegistry` → `from jaxlib._jax.pytree import PyTreeRegistry` https://github.com/jax-ml/jax/commit/55e408471ceaf5f0ed0e10053331d919fa2540ec
2. Jax is considering eliminating the need for `ClosedJaxpr`. Their work on this is not finished, but right now we feel the effect in the form of, sometimes the `invars` to the `equations` will be literals, instead of tracers. https://github.com/jax-ml/jax/issues/29679
3. Primitives’ custom staging rules got a new argument `source_info` https://github.com/jax-ml/jax/pull/29347
4. `DynamicJaxprTrace.to_jaxpr_tracer, new_arg` requires `source_info` https://github.com/jax-ml/jax/commit/3c2b533e8660004ca5cd1b3515e1a349239699ff
5. Unused `Var`s started to be drop during tracing https://github.com/jax-ml/jax/pull/28059. This breaks multi-step tracing like control flow. 

[sc-95175]