### PR TITLE
Update the dev requirement for building Runtime

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,9 @@ nanobind>=2.4
 pybind11>=2.12.0
 PyYAML
 
+# Runtime requires the Development.SABIModule component, added in cmake 3.26:
+cmake >= 3.26
+
 # formatting/linting
 black
 clang-format~=20.1


### PR DESCRIPTION
**Context:**
The runtime requires the `Development.SABIModule` component which is added in cmake 3.26. This short PR updates the dev requirements to ensure that the runtime is always built with a compatible cmake.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
