### PR TITLE
Fix typo when renaming wheels

### DIFF
--- a/.github/workflows/build-nightly-release-candidate.yaml
+++ b/.github/workflows/build-nightly-release-candidate.yaml
@@ -83,9 +83,9 @@ jobs:
 
     - name: Prepare wheels
       run: |
-        rename "s/linux/manylinux_2_28/" dist/PennyLane_Catalyst-*
-        rename "s/macosx_14_0_universal2/macosx_13_0_arm64/" dist/PennyLane_Catalyst-*
-        rename "s/macosx_14/macosx_13/" dist/PennyLane_Catalyst-*
+        rename "s/linux/manylinux_2_28/" dist/pennylane_catalyst-*
+        rename "s/macosx_14_0_universal2/macosx_13_0_arm64/" dist/pennylane_catalyst-*
+        rename "s/macosx_14/macosx_13/" dist/pennylane_catalyst-*
 
     - name: Upload wheels
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Fixed a typo when renaming wheels in the nightly wheel upload workflow for rc branch
