### PR TITLE
Replace the VLA use with standard C++ code

### DIFF
--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -11,10 +11,6 @@ if(RUNTIME_ENABLE_WARNINGS AND (CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
     add_compile_options("-Wno-maybe-uninitialized")
 endif()
 
-# Issue raised by https://github.com/llvm/llvm-project/issues/62836
-# Here to enable the variable-length array extension within the test suite to eliminate the need for C malloc
-add_compile_options("-Wno-vla-extension")
-
 FetchContent_MakeAvailable(Catch2)
 
 # Locate PyBind11

--- a/runtime/tests/Test_NullQubit.cpp
+++ b/runtime/tests/Test_NullQubit.cpp
@@ -91,8 +91,9 @@ TEST_CASE("Test automatic qubit management", "[NullQubit]")
     size_t n = __catalyst__rt__num_qubits();
     CHECK(n == 3);
 
-    double buffer[shots * n];
-    MemRefT_double_2d result = {buffer, buffer, 0, {shots, n}, {n, 1}};
+    std::vector<double> buffer(shots * n);
+    MemRefT_double_2d result = {buffer.data(), buffer.data(), 0, {shots, n}, {n, 1}};
+
     __catalyst__qis__Sample(&result, n);
 
     __catalyst__rt__qubit_release_array(qs);


### PR DESCRIPTION
**Description of the Change:**

Previously, we enable VLA in tests to pass the test suite `runtime/tests/Test_NullQubit.cpp` #1875 But seems it's not the standard C++, and after discussed, the use of vector here wouldn't affect the `__catalyst_*` functions. So just wrap it with a vector and pass the internal data to `MemRefT_double_2d`.