### PR TITLE
Bump Pennylane and Lightning versions prior to the release

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -10,8 +10,8 @@ enzyme=v0.0.180
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt
-pennylane=0.42.0-dev68
+# pennylane=0.42.0-dev68
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'
-lightning=0.42.0-dev45
+# lightning=0.42.0-dev45

--- a/.dep-versions
+++ b/.dep-versions
@@ -10,8 +10,8 @@ enzyme=v0.0.180
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt
-pennylane=0.42.0-dev67
+pennylane=0.42.0-dev68
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'
-lightning=0.42.0-dev16
+lightning=0.42.0-dev45

--- a/.github/workflows/build-nightly-release-candidate.yaml
+++ b/.github/workflows/build-nightly-release-candidate.yaml
@@ -1,0 +1,95 @@
+name: Build Release Branch Nightly for TestPyPI
+
+on:
+  schedule:
+    # Run from July 8th to July 13th at 02:00 UTC (10:00 PM EDT)
+    - cron: "0 2 8-13 7 *"
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build from'
+        required: true
+        default: 'v0.12.0-rc'
+
+jobs:
+  setup:
+    name: Setup the release
+    runs-on: ubuntu-24.04-arm
+    outputs:
+      branch: ${{ steps.set_branch.outputs.branch }}
+    steps:
+    - name: Set branch
+      id: set_branch
+      run: echo "branch=${{ github.event.inputs.branch || 'v0.12.0-rc' }}" >> $GITHUB_OUTPUT
+
+    - name: Checkout Catalyst repo release branch
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ steps.set_branch.outputs.branch }}
+        ssh-key: ${{ secrets.NIGHTLY_VERSION_UPDATE_DEPLOY_KEY }}
+
+    - name: Bump RC version
+      run: |
+        python $GITHUB_WORKSPACE/.github/workflows/set_rc_version.py
+
+    - name: Push new version
+      run: |
+        git config --global user.email '${{ secrets.AUTO_UPDATE_VERSION_RINGO_EMAIL }}'
+        git config --global user.name "ringo-but-quantum"
+        git add $GITHUB_WORKSPACE/frontend/catalyst/_version.py
+        git commit -m "[no ci] bump nightly rc version"
+        git push
+
+  # Only build the most popular configurations on a nightly schedule to save PyPI storage.
+
+  linux-x86:
+    name: Build on Linux x86-64
+    needs: [setup]
+    uses: ./.github/workflows/build-wheel-linux-x86_64.yaml
+    with:
+      branch: ${{ needs.setup.outputs.branch }}
+
+  linux-aarch:
+    name: Build on Linux aarch64
+    needs: [setup]
+    uses: ./.github/workflows/build-wheel-linux-arm64.yaml
+    with:
+      branch: ${{ needs.setup.outputs.branch }}
+
+  macos-arm:
+    name: Build on macOS arm64
+    needs: [setup]
+    uses: ./.github/workflows/build-wheel-macos-arm64.yaml
+    with:
+      branch: ${{ needs.setup.outputs.branch }}
+
+  upload:
+    name: Prepare & Upload wheels to TestPyPI
+    needs: [linux-x86, macos-arm, linux-aarch]
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download wheels
+      uses: actions/download-artifact@v4
+      with:
+        merge-multiple: true
+        path: dist
+
+    - name: Install rename
+      run: |
+        sudo apt install rename
+
+    - name: Prepare wheels
+      run: |
+        rename "s/linux/manylinux_2_28/" dist/PennyLane_Catalyst-*
+        rename "s/macosx_14_0_universal2/macosx_13_0_arm64/" dist/PennyLane_Catalyst-*
+        rename "s/macosx_14/macosx_13/" dist/PennyLane_Catalyst-*
+
+    - name: Upload wheels
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        packages-dir: dist
+        verbose: true

--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -30,6 +30,11 @@ on:
         type: boolean
         required: false
         default: false
+      branch:
+        description: 'Branch to build from'
+        required: false
+        default: 'main'
+        type: string
 
 concurrency:
   group: Build Catalyst Wheel on Linux (arm64)-${{ github.ref }}
@@ -68,6 +73,8 @@ jobs:
     steps:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.branch || github.ref }}
 
     - name: Cache LLVM Source
       id: cache-llvm-source

--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -466,6 +466,11 @@ jobs:
 
     - name: Install Catalyst
       run: |
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.42.0-rc0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning==0.42.0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.42.0
+        # -------------------------------------------------------------------- #
         python${{ matrix.python_version }} -m pip install dist/*.whl --extra-index-url https://test.pypi.org/simple
 
     - name: Install Standalone Plugin

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -30,6 +30,11 @@ on:
         type: boolean
         required: false
         default: false
+      branch:
+        description: 'Branch to build from'
+        required: false
+        default: 'main'
+        type: string
 
 concurrency:
   group: Build Catalyst Wheel on Linux (x86_64)-${{ github.ref }}
@@ -79,6 +84,8 @@ jobs:
     steps:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.branch || github.ref }}
 
     - name: Set Ownership in Container
       run: |

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -486,6 +486,11 @@ jobs:
 
     - name: Install Catalyst
       run: |
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.42.0-rc0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning==0.42.0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.42.0
+        # -------------------------------------------------------------------- #
         python${{ matrix.python_version }} -m pip install dist/*.whl --extra-index-url https://test.pypi.org/simple
 
     - name: Install Standalone Plugin

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -484,6 +484,11 @@ jobs:
 
     - name: Install Catalyst
       run: |
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.42.0-rc0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning==0.42.0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.42.0
+        # -------------------------------------------------------------------- #
         python${{ matrix.python_version }} -m pip install dist/*.whl --extra-index-url https://test.pypi.org/simple
 
     - name: Install Standalone Plugin

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -30,6 +30,11 @@ on:
         type: boolean
         required: false
         default: false
+      branch:
+        description: 'Branch to build from'
+        required: false
+        default: 'main'
+        type: string
 
 env:
   MACOSX_DEPLOYMENT_TARGET: 14.0
@@ -70,6 +75,8 @@ jobs:
     steps:
     - name: Checkout Catalyst repo
       uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.branch || github.ref }}
 
     # Python 3.10 was dropped from the GH images on macOS arm
     - name: Install Python 3.10

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -477,21 +477,21 @@ jobs:
         make frontend
 
     - name: Install PennyLane release candidate
-      if: github.event.pull_request.base.ref == '0.12.0-rc'
+      if: github.event.pull_request.base.ref == 'v0.12.0-rc'
       run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@0.42.0-rc0
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.42.0-rc0
 
     - name: Checkout PennyLane-Lightning release branch
-      if: github.event.pull_request.base.ref == '0.12.0-rc'
+      if: github.event.pull_request.base.ref == 'v0.12.0-rc'
       uses: actions/checkout@v4
       with:
         repository: PennyLaneAI/pennylane-lightning
-        ref: 0.42.0_rc
+        ref: v0.42.0_rc
         path: lightning_build
         fetch-depth: 0
 
     - name: Install PennyLane-Lightning release candidate
-      if: github.event.pull_request.base.ref == '0.12.0-rc'
+      if: github.event.pull_request.base.ref == 'v0.12.0-rc'
       run: |
         # Lightning-Kokkos can no longer be installed with pip from git
         cd lightning_build
@@ -584,21 +584,21 @@ jobs:
         make frontend
 
     - name: Install PennyLane release candidate
-      if: github.event.pull_request.base.ref == '0.12.0-rc'
+      if: github.event.pull_request.base.ref == 'v0.12.0-rc'
       run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@0.42.0-rc0
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.42.0-rc0
 
     - name: Checkout PennyLane-Lightning release branch
-      if: github.event.pull_request.base.ref == '0.12.0-rc'
+      if: github.event.pull_request.base.ref == 'v0.12.0-rc'
       uses: actions/checkout@v4
       with:
         repository: PennyLaneAI/pennylane-lightning
-        ref: 0.42.0_rc
+        ref: v0.42.0_rc
         path: lightning_build
         fetch-depth: 0
 
     - name: Install PennyLane-Lightning release candidate
-      if: github.event.pull_request.base.ref == '0.12.0-rc'
+      if: github.event.pull_request.base.ref == 'v0.12.0-rc'
       run: |
         # Lightning-Kokkos can no longer be installed with pip from git
         cd lightning_build
@@ -670,21 +670,21 @@ jobs:
         make frontend
 
     - name: Install PennyLane release candidate
-      if: github.event.pull_request.base.ref == '0.12.0-rc'
+      if: github.event.pull_request.base.ref == 'v0.12.0-rc'
       run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@0.42.0-rc0
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.42.0-rc0
 
     - name: Checkout PennyLane-Lightning release branch
-      if: github.event.pull_request.base.ref == '0.12.0-rc'
+      if: github.event.pull_request.base.ref == 'v0.12.0-rc'
       uses: actions/checkout@v4
       with:
         repository: PennyLaneAI/pennylane-lightning
-        ref: 0.42.0_rc
+        ref: v0.42.0_rc
         path: lightning_build
         fetch-depth: 0
 
     - name: Install PennyLane-Lightning release candidate
-      if: github.event.pull_request.base.ref == '0.12.0-rc'
+      if: github.event.pull_request.base.ref == 'v0.12.0-rc'
       run: |
         # Lightning-Kokkos can no longer be installed with pip from git
         cd lightning_build

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -474,31 +474,12 @@ jobs:
         # macOS requirements.txt
         python3 -m pip install cuda-quantum==0.6.0
         python3 -m pip install oqc-qcaas-client
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.42.0-rc0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning==0.42.0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.42.0
+        # -------------------------------------------------------------------- #
         make frontend
-
-    - name: Install PennyLane release candidate
-      if: github.event.pull_request.base.ref == 'v0.12.0-rc'
-      run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.42.0-rc0
-
-    - name: Checkout PennyLane-Lightning release branch
-      if: github.event.pull_request.base.ref == 'v0.12.0-rc'
-      uses: actions/checkout@v4
-      with:
-        repository: PennyLaneAI/pennylane-lightning
-        ref: v0.42.0_rc
-        path: lightning_build
-        fetch-depth: 0
-
-    - name: Install PennyLane-Lightning release candidate
-      if: github.event.pull_request.base.ref == 'v0.12.0-rc'
-      run: |
-        # Lightning-Kokkos can no longer be installed with pip from git
-        cd lightning_build
-        pip install -r requirements.txt
-        pip install --no-deps --force .
-        PL_BACKEND=lightning_kokkos python scripts/configure_pyproject_toml.py
-        pip install --no-deps --force .
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build
@@ -581,31 +562,12 @@ jobs:
         sudo apt-get install -y libomp-dev libasan6 make ninja-build
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.41.0-rc0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning==0.41.0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.41.0
+        # -------------------------------------------------------------------- #
         make frontend
-
-    - name: Install PennyLane release candidate
-      if: github.event.pull_request.base.ref == 'v0.12.0-rc'
-      run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.42.0-rc0
-
-    - name: Checkout PennyLane-Lightning release branch
-      if: github.event.pull_request.base.ref == 'v0.12.0-rc'
-      uses: actions/checkout@v4
-      with:
-        repository: PennyLaneAI/pennylane-lightning
-        ref: v0.42.0_rc
-        path: lightning_build
-        fetch-depth: 0
-
-    - name: Install PennyLane-Lightning release candidate
-      if: github.event.pull_request.base.ref == 'v0.12.0-rc'
-      run: |
-        # Lightning-Kokkos can no longer be installed with pip from git
-        cd lightning_build
-        pip install -r requirements.txt
-        pip install --no-deps --force .
-        PL_BACKEND=lightning_kokkos python scripts/configure_pyproject_toml.py
-        pip install --no-deps --force .
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build
@@ -667,31 +629,12 @@ jobs:
         sudo apt-get install -y libomp-dev libasan6 make ninja-build
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.41.0-rc0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning==0.41.0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.41.0
+        # -------------------------------------------------------------------- #
         make frontend
-
-    - name: Install PennyLane release candidate
-      if: github.event.pull_request.base.ref == 'v0.12.0-rc'
-      run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.42.0-rc0
-
-    - name: Checkout PennyLane-Lightning release branch
-      if: github.event.pull_request.base.ref == 'v0.12.0-rc'
-      uses: actions/checkout@v4
-      with:
-        repository: PennyLaneAI/pennylane-lightning
-        ref: v0.42.0_rc
-        path: lightning_build
-        fetch-depth: 0
-
-    - name: Install PennyLane-Lightning release candidate
-      if: github.event.pull_request.base.ref == 'v0.12.0-rc'
-      run: |
-        # Lightning-Kokkos can no longer be installed with pip from git
-        cd lightning_build
-        pip install -r requirements.txt
-        pip install --no-deps --force .
-        PL_BACKEND=lightning_kokkos python scripts/configure_pyproject_toml.py
-        pip install --no-deps --force .
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -476,6 +476,30 @@ jobs:
         python3 -m pip install oqc-qcaas-client
         make frontend
 
+    - name: Install PennyLane release candidate
+      if: github.event.pull_request.base.ref == '0.12.0-rc'
+      run: |
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@0.42.0-rc0
+
+    - name: Checkout PennyLane-Lightning release branch
+      if: github.event.pull_request.base.ref == '0.12.0-rc'
+      uses: actions/checkout@v4
+      with:
+        repository: PennyLaneAI/pennylane-lightning
+        ref: 0.42.0_rc
+        path: lightning_build
+        fetch-depth: 0
+
+    - name: Install PennyLane-Lightning release candidate
+      if: github.event.pull_request.base.ref == '0.12.0-rc'
+      run: |
+        # Lightning-Kokkos can no longer be installed with pip from git
+        cd lightning_build
+        pip install -r requirements.txt
+        pip install --no-deps --force .
+        PL_BACKEND=lightning_kokkos python scripts/configure_pyproject_toml.py
+        pip install --no-deps --force .
+
     - name: Get Cached LLVM Build
       id: cache-llvm-build
       uses: actions/cache@v4
@@ -559,6 +583,30 @@ jobs:
         python3 -m pip install -r requirements.txt
         make frontend
 
+    - name: Install PennyLane release candidate
+      if: github.event.pull_request.base.ref == '0.12.0-rc'
+      run: |
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@0.42.0-rc0
+
+    - name: Checkout PennyLane-Lightning release branch
+      if: github.event.pull_request.base.ref == '0.12.0-rc'
+      uses: actions/checkout@v4
+      with:
+        repository: PennyLaneAI/pennylane-lightning
+        ref: 0.42.0_rc
+        path: lightning_build
+        fetch-depth: 0
+
+    - name: Install PennyLane-Lightning release candidate
+      if: github.event.pull_request.base.ref == '0.12.0-rc'
+      run: |
+        # Lightning-Kokkos can no longer be installed with pip from git
+        cd lightning_build
+        pip install -r requirements.txt
+        pip install --no-deps --force .
+        PL_BACKEND=lightning_kokkos python scripts/configure_pyproject_toml.py
+        pip install --no-deps --force .
+
     - name: Get Cached LLVM Build
       id: cache-llvm-build
       uses: actions/cache@v4
@@ -620,6 +668,30 @@ jobs:
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
         make frontend
+
+    - name: Install PennyLane release candidate
+      if: github.event.pull_request.base.ref == '0.12.0-rc'
+      run: |
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@0.42.0-rc0
+
+    - name: Checkout PennyLane-Lightning release branch
+      if: github.event.pull_request.base.ref == '0.12.0-rc'
+      uses: actions/checkout@v4
+      with:
+        repository: PennyLaneAI/pennylane-lightning
+        ref: 0.42.0_rc
+        path: lightning_build
+        fetch-depth: 0
+
+    - name: Install PennyLane-Lightning release candidate
+      if: github.event.pull_request.base.ref == '0.12.0-rc'
+      run: |
+        # Lightning-Kokkos can no longer be installed with pip from git
+        cd lightning_build
+        pip install -r requirements.txt
+        pip install --no-deps --force .
+        PL_BACKEND=lightning_kokkos python scripts/configure_pyproject_toml.py
+        pip install --no-deps --force .
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build

--- a/.github/workflows/check-formatting.yaml
+++ b/.github/workflows/check-formatting.yaml
@@ -2,7 +2,6 @@ name: Check Code Formatting
 
 on:
   pull_request:
-    branches: [ main ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/set_rc_version.py
+++ b/.github/workflows/set_rc_version.py
@@ -1,0 +1,52 @@
+# Copyright 2025 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module bumps the Catalyst development version by one unit.
+"""
+
+import os
+import re
+
+version_file_path = os.path.join(os.path.dirname(__file__), "../../frontend/catalyst/_version.py")
+
+assert os.path.isfile(version_file_path)
+
+with open(version_file_path, "r+", encoding="UTF-8") as f:
+    lines = f.readlines()
+
+    version_line = lines[-1]
+    assert "__version__ = " in version_line
+
+    # Try to match version with RC suffix first
+    pattern = r"(\d+).(\d+).(\d+)-rc(\d+)"
+    match = re.search(pattern, version_line)
+
+    if match:
+        # Case 1: Version has RC suffix
+        major, minor, bug, rc = match.groups()
+        replacement = f'__version__ = "{major}.{minor}.{bug}-rc{int(rc)+1}"\n'
+    else:
+        # Case 2: Version has no RC suffix
+        base_pattern = r"(\d+).(\d+).(\d+)"
+        base_match = re.search(base_pattern, version_line)
+        assert base_match, "Version string must be in format X.Y.Z or X.Y.Z-rcN"
+        major, minor, bug = base_match.groups()
+        replacement = f'__version__ = "{major}.{minor}.{bug}-rc0"\n'
+
+    lines[-1] = replacement
+
+    f.seek(0)
+    f.writelines(lines)
+    f.truncate()

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,9 @@ frontend:
 	@echo "install Catalyst Frontend"
 	# Uninstall pennylane before updating Catalyst, since pip will not replace two development
 	# versions of a package with the same version tag (e.g. 0.38-dev0).
-	$(PYTHON) -m pip uninstall -y pennylane
+	# TODO: --- enable the following line before merging to main ------------- #
+	# $(PYTHON) -m pip uninstall -y pennylane
+	# ------------------------------------------------------------------------ #
 	$(PYTHON) -m pip install -e . --extra-index-url https://test.pypi.org/simple $(PIP_VERBOSE_FLAG)
 	rm -r frontend/pennylane_catalyst.egg-info
 

--- a/doc/releases/changelog-0.12.0.md
+++ b/doc/releases/changelog-0.12.0.md
@@ -340,6 +340,9 @@
 * Fixes canonicalization of insertion and extraction into quantum registers.
   [(#1840)](https://github.com/PennyLaneAI/catalyst/pull/1840)
 
+* Fixes the conversion of PLxPR to JAXPR with quantum primitives when using dynamic wires.
+  [(#1842)](https://github.com/PennyLaneAI/catalyst/pull/1842)
+
 <h3>Internal changes ⚙️</h3>
 
 * `qml.qjit` now integrates with the new `qml.set_shots` function.

--- a/doc/releases/changelog-0.12.0.md
+++ b/doc/releases/changelog-0.12.0.md
@@ -477,7 +477,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-Runor Agbaire
+Runor Agbaire,
 Joey Carter,
 Sengthai Heng,
 David Ittah,
@@ -487,5 +487,6 @@ Mehrdad Malekmohammadi,
 Anton Naim Ibrahim,
 Erick Ochoa Lopez,
 Ritu Thombre,
+Raul Torres,
 Paul Haochen Wang,
 Jake Zaia.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -31,6 +31,6 @@ lxml_html_clean
 
 # Pre-install PL development wheels
 --extra-index-url https://test.pypi.org/simple/
-pennylane-lightning-kokkos==0.42.0-dev45
-pennylane-lightning==0.42.0-dev45
-pennylane==0.42.0-dev68
+pennylane-lightning-kokkos==0.42.0
+pennylane-lightning==0.42.0
+pennylane @ git+https://github.com/pennylaneAI/pennylane@v0.42.0-rc0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -31,6 +31,6 @@ lxml_html_clean
 
 # Pre-install PL development wheels
 --extra-index-url https://test.pypi.org/simple/
-pennylane-lightning-kokkos==0.42.0-dev16
-pennylane-lightning==0.42.0-dev16
-pennylane==0.42.0-dev67
+pennylane-lightning-kokkos==0.42.0-dev45
+pennylane-lightning==0.42.0-dev45
+pennylane==0.42.0-dev68

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.12.0-rc2"
+__version__ = "0.12.0-rc3"

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.12.0-rc0"
+__version__ = "0.12.0-rc1"

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.12.0"
+__version__ = "0.12.0-rc0"

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.12.0-rc3"
+__version__ = "0.12.0-rc4"

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.12.0-rc1"
+__version__ = "0.12.0-rc2"

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -305,6 +305,8 @@ class PLxPRToQuantumJaxprInterpreter(PlxprInterpreter):
     def interpret_operation(self, op):
         """Re-bind a pennylane operation as a catalyst instruction."""
 
+        self.qreg_manager.insert_dynamic_qubits(op.wires)
+
         in_qubits = [self.qreg_manager[w] for w in op.wires]
         out_qubits = qinst_p.bind(
             *[*in_qubits, *op.data],

--- a/frontend/catalyst/from_plxpr/qreg_manager.py
+++ b/frontend/catalyst/from_plxpr/qreg_manager.py
@@ -128,6 +128,47 @@ class QregManager:
             self.abstract_qreg_val = qinsert_p.bind(self.abstract_qreg_val, index, qubit)
         self.wire_map.clear()
 
+    def insert_dynamic_qubits(self, wires):
+        """
+        When wire label is dynamic, such gates will need to interrupt analysis like cancel inverses:
+           qml.X(wires=0)
+           qml.Hadamard(wires=w)
+           qml.X(wires=0)
+        In the above, because we don't know whether `w` is `0` or not until runtime, we must not
+        cancel the inverse PauliX gates on `0`.
+
+        Thus in the IR def use chain we need to interrupt the first X gate's %out_qubit to be used
+        as the second X gate's qubit operand directly.
+        To do this, for the dynamic wire gate we insert back to the register.
+        """
+
+        # Cancel-inverses style passes only work on gates with same number of qubits
+        same_number_of_wires = len(wires) == len(self.wire_map)
+
+        all_static_requested = all(isinstance(wire, int) for wire in wires)
+        all_static_cached = all(isinstance(wire, int) for wire in self.wire_map.keys())
+        all_static = all_static_requested and all_static_cached
+
+        if all_static:
+            # no need to insert back anything if nothing is dynamic
+            return
+
+        all_dynamic = False
+        keep_cache = False
+        if same_number_of_wires:
+            # Notice that we can keep using the current qubit value in the wire_map (if one exists
+            # there) even for dynamic case if they are the same dynamic wire, i.e.
+            #   qml.gate(wires=[w0,w1])
+            #   qml.gate(wires=[w0,w1])
+            # these cases do not need to insert back
+
+            wires_all_in_cache = all(wire in self.wire_map.keys() for wire in wires)
+            all_dynamic = all(not isinstance(wire, int) for wire in wires)
+            keep_cache = wires_all_in_cache and all_dynamic
+
+        if not keep_cache:
+            self.insert_all_dangling_qubits()
+
     def __getitem__(self, index: int) -> AbstractQbit:
         """
         Get the newest ``AbstractQbit`` corresponding to a wire index.
@@ -136,6 +177,9 @@ class QregManager:
         if index in self.wire_map:
             return self.wire_map[index]
         return self.extract(index)
+
+    def __len__(self) -> int:
+        return len(self.wire_map)
 
     def __setitem__(self, index: int, qubit: AbstractQbit):
         """

--- a/frontend/test/lit/test_from_plxpr.py
+++ b/frontend/test/lit/test_from_plxpr.py
@@ -304,6 +304,7 @@ def test_single_qubit_dynamic_static_interleaved():
 
 test_single_qubit_dynamic_static_interleaved()
 
+
 def test_multi_qubit_gates_on_different_dynamic_wires():
     """Multi-qubit gates on different dynamic wires."""
 
@@ -334,5 +335,6 @@ def test_multi_qubit_gates_on_different_dynamic_wires():
 
     print(circuit.mlir)
     qml.capture.disable()
+
 
 test_multi_qubit_gates_on_different_dynamic_wires()

--- a/frontend/test/lit/test_from_plxpr.py
+++ b/frontend/test/lit/test_from_plxpr.py
@@ -14,6 +14,8 @@
 
 # RUN: %PYTHON %s | FileCheck %s
 
+# pylint: disable=line-too-long
+
 """Lit tests for the PLxPR to JAXPR with quantum primitives pipeline"""
 
 import pennylane as qml
@@ -118,3 +120,219 @@ def test_while_capture():
 
 
 test_while_capture()
+
+
+def test_dynamic_wire():
+    """Test dynamic wires no re-insertion"""
+
+    qml.capture.enable()
+    dev = qml.device("null.qubit", wires=3)
+
+    @qml.qjit(target="mlir")
+    @qml.qnode(dev)
+    def circuit(w1: int):
+        # CHECK: [[QREG:%.+]] = quantum.insert
+        # CHECK-NEXT: [[SCALAR:%.+]] = tensor.extract %arg0
+        # CHECK-NEXT: [[QBIT:%.+]] = quantum.extract [[QREG]][[[SCALAR]]]
+        # CHECK-NEXT: [[QBIT_1:%.+]] = quantum.custom "PauliY"() [[QBIT]]
+        # CHECK-NEXT: [[QBIT_2:%.+]] = quantum.custom "PauliZ"() [[QBIT_1]]
+        qml.X(0)
+        qml.Y(w1)
+        qml.Z(w1)
+        qml.X(0)
+        return qml.state()
+
+    print(circuit.mlir)
+    qml.capture.disable()
+
+
+test_dynamic_wire()
+
+
+def test_dynamic_wire_reinsertion():
+    """Test dynamic wires re-insertion"""
+
+    qml.capture.enable()
+    dev = qml.device("null.qubit", wires=3)
+
+    @qml.qjit(target="mlir")
+    @qml.qnode(dev)
+    def circuit(w1: int):
+
+        # CHECK: [[QUBIT:%.+]] = quantum.custom "PauliX"() %1 : !quantum.bit
+        # CHECK-NEXT: [[QREG:%.+]] = quantum.insert %0[ 0], [[QUBIT]] : !quantum.reg, !quantum.bit
+        # CHECK-NEXT: [[SCALAR:%.+]] = tensor.extract %arg0[] : tensor<i64>
+        # CHECK-NEXT: [[QUBIT_1:%.+]] = quantum.extract [[QREG]][[[SCALAR]]] : !quantum.reg -> !quantum.bit
+        # CHECK-NEXT: [[QUBIT_2:%.+]] = quantum.custom "PauliY"() [[QUBIT_1]]
+        # CHECK-NEXT: [[SCALAR:%.+]] = tensor.extract %arg0[] : tensor<i64>
+        # CHECK-NEXT: [[QREG_1:%.+]] = quantum.insert [[QREG]][[[SCALAR]]], [[QUBIT_2]] : !quantum.reg, !quantum.bit
+        # CHECK-NEXT: [[QUBIT_3:%.+]] = quantum.extract [[QREG_1]][ 0]
+        # CHECK-NEXT: [[QUBIT_4:%.+]] = quantum.custom "PauliX"() [[QUBIT_3]]
+        # CHECK-NEXT: [[QREG_2:%.+]] = quantum.insert [[QREG_1]][ 0], [[QUBIT_4]]
+        # CHECK-NEXT: [[SCALAR:%.+]] = tensor.extract %arg0[] : tensor<i64>
+        # CHECK-NEXT: [[QUBIT_5:%.+]] = quantum.extract [[QREG_2]][[[SCALAR]]] : !quantum.reg -> !quantum.bit
+        # CHECK-NEXT: [[QUBIT_6:%.+]] = quantum.custom "PauliZ"() [[QUBIT_5]]
+        # CHECK-NEXT: [[SCALAR:%.+]] = tensor.extract %arg0[] : tensor<i64>
+        # CHECK-NEXT: [[QREG_3:%.+]] = quantum.insert [[QREG_2]][[[SCALAR]]], [[QUBIT_6]]
+        # CHECK-NEXT: [[QUBIT_7:%.+]] = quantum.extract [[QREG_3]][ 0]
+        # CHECK-NEXT: [[QUBIT_8:%.+]] = quantum.custom "PauliX"() [[QUBIT_7]]
+        qml.X(0)
+        qml.Y(w1)
+        qml.X(0)
+        qml.Z(w1)
+        qml.X(0)
+        return qml.state()
+
+    print(circuit.mlir)
+    qml.capture.disable()
+
+
+test_dynamic_wire_reinsertion()
+
+
+def test_two_dynamic_CNOTs():
+    """Test two dynamic CNOTs"""
+
+    dev = qml.device("null.qubit", wires=3)
+
+    qml.capture.enable()
+
+    @qml.qjit(target="mlir")
+    @qml.qnode(dev)
+    def circuit(w1: int, w2: int):
+        # CHECK: [[SCALAR:%.+]] = tensor.extract %arg0
+        # CHECK-NEXT: [[QUBIT_0:%.+]] = quantum.extract {{%.+}}[[[SCALAR]]]
+        # CHECK-NEXT: [[SCALAR_2:%.+]] = tensor.extract %arg1
+        # CHECK-NEXT: [[QUBIT_1:%.+]] = quantum.extract {{%.+}}[[[SCALAR_2]]]
+        # CHECK-NEXT: [[QUBITS:%.+]]:2 = quantum.custom "CNOT"() [[QUBIT_0]], [[QUBIT_1]]
+        # CHECK-NEXT: quantum.custom "CNOT"() [[QUBITS]]#0, [[QUBITS]]#1
+        qml.CNOT(wires=[w1, w2])
+        qml.CNOT(wires=[w1, w2])
+        return qml.state()
+
+    print(circuit.mlir)
+    qml.capture.disable()
+
+
+test_two_dynamic_CNOTs()
+
+
+def test_single_qubit_dynamic():
+    """single qubit gates on two different dynamic wires one after the other"""
+
+    dev = qml.device("null.qubit", wires=3)
+
+    qml.capture.enable()
+
+    @qml.qjit(target="mlir")
+    @qml.qnode(dev)
+    def circuit(w1: int, w2: int):
+
+        # CHECK: [[REG:%.+]] = quantum.alloc
+        # CHECK-NEXT: [[QUBIT_0:%.+]] = quantum.extract [[REG]][ 0]
+        # CHECK-NEXT: [[QUBIT_0_1:%.+]] = quantum.custom "Hadamard"() [[QUBIT_0]]
+        # CHECK-NEXT: [[REG_1:%.+]] = quantum.insert [[REG]][ 0], [[QUBIT_0_1]]
+        # CHECK-NEXT: [[SCALAR:%.+]] = tensor.extract %arg0[]
+        # CHECK-NEXT: [[QUBIT_W1:%.+]] = quantum.extract [[REG_1]][[[SCALAR]]]
+        # CHECK-NEXT: [[QUBIT_W1_1:%.+]] = quantum.custom "Hadamard"() [[QUBIT_W1]]
+        # CHECK-NEXT: [[SCALAR:%.+]] = tensor.extract %arg0[]
+        # CHECK-NEXT: [[REG_2:%.+]] = quantum.insert [[REG_1]][[[SCALAR]]], [[QUBIT_W1_1]]
+        # CHECK-NEXT: [[SCALAR_1:%.+]] = tensor.extract %arg1[]
+        # CHECK-NEXT: [[QUBIT_W2:%.+]] = quantum.extract [[REG_2]][[[SCALAR_1]]]
+        # CHECK-NEXT: [[QUBIT_W2_1:%.+]] = quantum.custom "Hadamard"() [[QUBIT_W2]]
+        # CHECK-NEXT: [[SCALAR_1:%.+]] = tensor.extract %arg1[]
+        # CHECK-NEXT: [[REG_3:%.+]] = quantum.insert [[REG_2]][[[SCALAR_1]]], [[QUBIT_W2_1]]
+        # CHECK-NEXT: [[QUBIT_0_2:%.+]] = quantum.extract [[REG_3]][ 0]
+        # CHECK-NEXT: [[QUBIT_0_3:%.+]] = quantum.custom "Hadamard"() [[QUBIT_0_2]]
+        # CHECK-NEXT: quantum.insert [[REG_3]][ 0], [[QUBIT_0_3]]
+        qml.Hadamard(0)
+        qml.Hadamard(w1)
+        qml.Hadamard(w2)
+        qml.Hadamard(0)
+        return qml.state()
+
+    print(circuit.mlir)
+    qml.capture.disable()
+
+
+test_single_qubit_dynamic()
+
+
+def test_single_qubit_dynamic_static_interleaved():
+    """Single qubit gates on two different dynamic wires interleaved with static wires"""
+
+    dev = qml.device("null.qubit", wires=3)
+
+    qml.capture.enable()
+
+    @qml.qjit(target="mlir")
+    @qml.qnode(dev)
+    def circuit(w1: int, w2: int):
+
+        # CHECK: [[REG:%.+]] = quantum.alloc
+        # CHECK-NEXT: [[QUBIT_0:%.+]] = quantum.extract [[REG]][ 0]
+        # CHECK-NEXT: [[QUBIT_0_1:%.+]] = quantum.custom "Hadamard"() [[QUBIT_0]]
+        # CHECK-NEXT: [[REG_1:%.+]] = quantum.insert [[REG]][ 0], [[QUBIT_0_1]]
+        # CHECK-NEXT: [[SCALAR:%.+]] = tensor.extract %arg0[]
+        # CHECK-NEXT: [[QUBIT_W1:%.+]] = quantum.extract [[REG_1]][[[SCALAR]]]
+        # CHECK-NEXT: [[QUBIT_W1_1:%.+]] = quantum.custom "Hadamard"() [[QUBIT_W1]]
+        # CHECK-NEXT: [[SCALAR:%.+]] = tensor.extract %arg0[]
+        # CHECK-NEXT: [[REG_2:%.+]] = quantum.insert [[REG_1]][[[SCALAR]]], [[QUBIT_W1_1]]
+
+        # CHECK-NEXT: [[QUBIT_0_2:%.+]] = quantum.extract [[REG_2]][ 0]
+        # CHECK-NEXT: [[QUBIT_0_3:%.+]] = quantum.custom "Hadamard"() [[QUBIT_0_2]]
+        # CHECK-NEXT: [[REG_3:%.+]] = quantum.insert [[REG_2]][ 0], [[QUBIT_0_1]]
+
+        # CHECK-NEXT: [[SCALAR_1:%.+]] = tensor.extract %arg1[]
+        # CHECK-NEXT: [[QUBIT_W2:%.+]] = quantum.extract [[REG_3]][[[SCALAR_1]]]
+        # CHECK-NEXT: [[QUBIT_W2_1:%.+]] = quantum.custom "Hadamard"() [[QUBIT_W2]]
+        # CHECK-NEXT: [[SCALAR_1:%.+]] = tensor.extract %arg1[]
+        # CHECK-NEXT: [[REG_4:%.+]] = quantum.insert [[REG_3]][[[SCALAR_1]]], [[QUBIT_W2_1]]
+        # CHECK-NEXT: [[QUBIT_0_2:%.+]] = quantum.extract [[REG_4]][ 0]
+        # CHECK-NEXT: [[QUBIT_0_3:%.+]] = quantum.custom "Hadamard"() [[QUBIT_0_2]]
+        # CHECK-NEXT: quantum.insert [[REG_4]][ 0], [[QUBIT_0_3]]
+        qml.Hadamard(0)
+        qml.Hadamard(w1)
+        qml.Hadamard(0)
+        qml.Hadamard(w2)
+        qml.Hadamard(0)
+        return qml.state()
+
+    print(circuit.mlir)
+    qml.capture.disable()
+
+
+test_single_qubit_dynamic_static_interleaved()
+
+def test_multi_qubit_gates_on_different_dynamic_wires():
+    """Multi-qubit gates on different dynamic wires."""
+
+    dev = qml.device("null.qubit", wires=3)
+
+    qml.capture.enable()
+
+    @qml.qjit(target="mlir")
+    @qml.qnode(dev)
+    def circuit(w1: int, w2: int, w3: int):
+        # CHECK: [[SCALAR:%.+]] = tensor.extract %arg0
+        # CHECK-NEXT: [[QUBIT_0:%.+]] = quantum.extract {{%.+}}[[[SCALAR]]]
+        # CHECK-NEXT: [[SCALAR_2:%.+]] = tensor.extract %arg1
+        # CHECK-NEXT: [[QUBIT_1:%.+]] = quantum.extract {{%.+}}[[[SCALAR_2]]]
+        # CHECK-NEXT: [[QUBITS:%.+]]:2 = quantum.custom "CNOT"() [[QUBIT_0]], [[QUBIT_1]]
+        qml.CNOT(wires=[w1, w2])
+        # CHECK-NEXT: [[SCALAR:%.+]] = tensor.extract %arg0
+        # CHECK-NEXT: [[QREG:%.+]] = quantum.insert {{%.+}}[[[SCALAR]]]
+        # CHECK-NEXT: [[SCALAR_1:%.+]] = tensor.extract %arg1
+        # CHECK-NEXT: [[QREG_1:%.+]] = quantum.insert [[QREG]][[[SCALAR_1]]]
+        # CHECK-NEXT: [[SCALAR_1:%.+]] = tensor.extract %arg1
+        # CHECK-NEXT: [[QUBIT_2:%.+]] = quantum.extract [[QREG_1]][[[SCALAR_1]]]
+        # CHECK-NEXT: [[SCALAR_2:%.+]] = tensor.extract %arg2
+        # CHECK-NEXT: [[QUBIT_3:%.+]] = quantum.extract [[QREG_1]][[[SCALAR_2]]]
+        # CHECK-NEXT: [[QUBITS:%.+]]:2 = quantum.custom "CNOT"() [[QUBIT_2]], [[QUBIT_3]]
+        qml.CNOT(wires=[w2, w3])
+        return qml.state()
+
+    print(circuit.mlir)
+    qml.capture.disable()
+
+test_multi_qubit_gates_on_different_dynamic_wires()

--- a/mlir/include/Catalyst/Utils/SCFUtils.h
+++ b/mlir/include/Catalyst/Utils/SCFUtils.h
@@ -1,0 +1,35 @@
+// Copyright 2025 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mlir/IR/Operation.h"
+
+using namespace mlir;
+
+namespace catalyst {
+
+// Returns true if an operation is nested in a scf.if operation at any depth.
+bool isOpInIfOp(Operation *op);
+
+// Returns true if an operation is nested in a scf.while operation at any depth.
+bool isOpInWhileOp(Operation *op);
+
+// Given an op in a for loop body with a static number of start, end and step,
+// compute the number of iterations that will be executed by the for loop.
+// Returns -1 if any of the above for loop information is not static.
+//
+// Note: if the input op is not inside any for loop operations,
+// this method returns 1, since there would be just one "iteration".
+int64_t countStaticForloopIterations(Operation *op);
+
+} // namespace catalyst

--- a/mlir/lib/Catalyst/Utils/CMakeLists.txt
+++ b/mlir/lib/Catalyst/Utils/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_library(MLIRCatalystUtils
     CallGraph.cpp
-    TBAAUtils.cpp
-    StaticAllocas.cpp
     EnsureFunctionDeclaration.cpp
+    SCFUtils.cpp
+    StaticAllocas.cpp
+    TBAAUtils.cpp
 )

--- a/mlir/lib/Catalyst/Utils/SCFUtils.cpp
+++ b/mlir/lib/Catalyst/Utils/SCFUtils.cpp
@@ -1,0 +1,95 @@
+// Copyright 2025 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cmath> // std::ceil()
+
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/Operation.h"
+
+using namespace mlir;
+
+namespace catalyst {
+
+static int64_t getNumIterations(double lowerBound, double upperBound, double step)
+{
+    assert(upperBound >= lowerBound && step > 0);
+    return std::ceil((upperBound - lowerBound) / step);
+}
+
+static int64_t getIntFromArithConstantOp(arith::ConstantOp op)
+{
+    // The magical incantation to get a cpp integer from an arith.constant op
+    assert(isa<IntegerAttr>(op.getValue()));
+    return cast<IntegerAttr>(op.getValue()).getValue().getSExtValue();
+}
+
+template <typename OpTy> static bool hasAncestorOfType(Operation *op)
+{
+    return op->getParentOfType<OpTy>() != nullptr;
+}
+
+// Returns true if an operation is nested in a scf.if operation at any depth.
+bool isOpInIfOp(Operation *op) { return hasAncestorOfType<scf::IfOp>(op); }
+
+// Returns true if an operation is nested in a scf.while operation at any depth.
+bool isOpInWhileOp(Operation *op) { return hasAncestorOfType<scf::WhileOp>(op); }
+
+// Given an op in a for loop body with a static number of start, end and step,
+// compute the number of iterations that will be executed by the for loop.
+// Returns -1 if any of the above for loop information is not static.
+//
+// Note: if the input op is not inside any for loop operations,
+// this method returns 1, since there would be just one "iteration".
+int64_t countStaticForloopIterations(Operation *op)
+{
+    assert(!isa<scf::ForOp>(op));
+
+    int64_t count = 1;
+
+    Operation *parent = op->getParentOp();
+    while (parent) {
+        if (isa<scf::ForOp>(parent)) {
+            scf::ForOp forOp = cast<scf::ForOp>(parent);
+
+            Operation *lowerBoundOp = forOp.getLowerBound().getDefiningOp();
+            if (!lowerBoundOp || !isa<arith::ConstantOp>(lowerBoundOp)) {
+                // Dynamic
+                return -1;
+            }
+            int64_t l = getIntFromArithConstantOp(cast<arith::ConstantOp>(lowerBoundOp));
+
+            Operation *upperBoundOp = forOp.getUpperBound().getDefiningOp();
+            if (!upperBoundOp || !isa<arith::ConstantOp>(upperBoundOp)) {
+                // Dynamic
+                return -1;
+            }
+            int64_t u = getIntFromArithConstantOp(cast<arith::ConstantOp>(upperBoundOp));
+
+            Operation *stepOp = forOp.getStep().getDefiningOp();
+            if (!stepOp || !isa<arith::ConstantOp>(stepOp)) {
+                // Dynamic
+                return -1;
+            }
+            int64_t s = getIntFromArithConstantOp(cast<arith::ConstantOp>(stepOp));
+
+            count *= getNumIterations(l, u, s);
+        }
+        parent = parent->getParentOp();
+    }
+
+    return count;
+}
+
+} // namespace catalyst

--- a/mlir/lib/QEC/Transforms/CountPPMSpecs.cpp
+++ b/mlir/lib/QEC/Transforms/CountPPMSpecs.cpp
@@ -23,6 +23,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 
+#include "Catalyst/Utils/SCFUtils.h"
 #include "QEC/IR/QECDialect.h"
 #include "Quantum/IR/QuantumOps.h"
 
@@ -42,31 +43,55 @@ namespace qec {
 struct CountPPMSpecsPass : public impl::CountPPMSpecsPassBase<CountPPMSpecsPass> {
     using CountPPMSpecsPassBase::CountPPMSpecsPassBase;
 
-    void countLogicalQubit(Operation *op,
-                           llvm::DenseMap<StringRef, llvm::DenseMap<StringRef, int>> *PPMSpecs)
+    LogicalResult
+    countLogicalQubit(Operation *op,
+                      llvm::DenseMap<StringRef, llvm::DenseMap<StringRef, int>> *PPMSpecs)
     {
         uint64_t numQubits = cast<quantum::AllocOp>(op).getNqubitsAttr().value_or(0);
-        assert(numQubits != 0 && "PPM specs with dynamic number of qubits is not implemented");
+
+        if (numQubits == 0) {
+            return op->emitOpError("PPM specs with dynamic number of qubits is not supported");
+        }
+
         auto parentFuncOp = op->getParentOfType<func::FuncOp>();
         (*PPMSpecs)[parentFuncOp.getName()]["num_logical_qubits"] = numQubits;
-        return;
+        return success();
     }
 
-    void countPPM(Operation *op,
-                  llvm::DenseMap<StringRef, llvm::DenseMap<StringRef, int>> *PPMSpecs)
+    LogicalResult countPPM(qec::PPMeasurementOp op,
+                           llvm::DenseMap<StringRef, llvm::DenseMap<StringRef, int>> *PPMSpecs)
     {
+        if (isOpInIfOp(op) || isOpInWhileOp(op)) {
+            return op->emitOpError(
+                "PPM statistics is not available when there are conditionals or while loops.");
+        }
+
         auto parentFuncOp = op->getParentOfType<func::FuncOp>();
-        (*PPMSpecs)[parentFuncOp.getName()]["num_of_ppm"]++;
-        return;
+
+        // Handle when PPM op is in a static for loop
+        // Note that countStaticForloopIterations returns -1 when it bails out for
+        // dynamic loop bounds
+        // When bailing out on dynamic, just error.
+        int64_t forLoopMultiplier = countStaticForloopIterations(op);
+        if (forLoopMultiplier == -1) {
+            return op->emitOpError(
+                "PPM statistics is not available when there are dynamically sized for loops.");
+        }
+        (*PPMSpecs)[parentFuncOp.getName()]["num_of_ppm"] += forLoopMultiplier;
+        return success();
     }
 
-    void countPPR(Operation *op,
-                  llvm::DenseMap<StringRef, llvm::DenseMap<StringRef, int>> *PPMSpecs,
-                  llvm::BumpPtrAllocator *stringAllocator)
+    LogicalResult countPPR(qec::PPRotationOp op,
+                           llvm::DenseMap<StringRef, llvm::DenseMap<StringRef, int>> *PPMSpecs,
+                           llvm::BumpPtrAllocator *stringAllocator)
     {
-        int16_t rotationKind =
-            cast<qec::PPRotationOp>(op).getRotationKindAttr().getValue().getZExtValue();
-        auto PauliProductAttr = cast<qec::PPRotationOp>(op).getPauliProductAttr();
+        if (isOpInIfOp(op) || isOpInWhileOp(op)) {
+            return op->emitOpError(
+                "PPM statistics is not available when there are conditionals or while loops.");
+        }
+
+        int16_t rotationKind = op.getRotationKindAttr().getValue().getZExtValue();
+        auto PauliProductAttr = op.getPauliProductAttr();
         auto parentFuncOp = op->getParentOfType<func::FuncOp>();
         StringRef funcName = parentFuncOp.getName();
         llvm::StringSaver saver(*stringAllocator);
@@ -74,43 +99,71 @@ struct CountPPMSpecsPass : public impl::CountPPMSpecsPassBase<CountPPMSpecsPass>
             saver.save("num_pi" + std::to_string(abs(rotationKind)) + "_gates");
         StringRef maxWeightRotationKindKey =
             saver.save("max_weight_pi" + std::to_string(abs(rotationKind)));
-        (*PPMSpecs)[funcName][numRotationKindKey]++;
+
+        // Handle when PPR op is in a static for loop
+        // Note that countStaticForloopIterations returns -1 when it bails out for
+        // dynamic loop bounds
+        // When bailing out on dynamic, just error.
+        int64_t forLoopMultiplier = countStaticForloopIterations(op);
+        if (forLoopMultiplier == -1) {
+            return op->emitOpError(
+                "PPM statistics is not available when there are dynamically sized for loops.");
+        }
+        (*PPMSpecs)[funcName][numRotationKindKey] += forLoopMultiplier;
+
         (*PPMSpecs)[funcName][maxWeightRotationKindKey] =
             std::max((*PPMSpecs)[funcName][maxWeightRotationKindKey],
                      static_cast<int>(PauliProductAttr.size()));
-        return;
+        return success();
     }
-    void printSpecs()
+
+    LogicalResult printSpecs()
     {
         llvm::BumpPtrAllocator stringAllocator;
         llvm::DenseMap<StringRef, llvm::DenseMap<StringRef, int>> PPMSpecs;
         // Walk over all operations in the IR (could be ModuleOp or FuncOp)
-        getOperation()->walk([&](Operation *op) {
-            // Skip top-level container ops if desired
-            if (isa<ModuleOp>(op)) {
-                return;
-            }
-
-            else if (isa<quantum::AllocOp>(op)) {
-                countLogicalQubit(op, &PPMSpecs);
+        WalkResult wr = getOperation()->walk([&](Operation *op) {
+            if (isa<quantum::AllocOp>(op)) {
+                if (failed(countLogicalQubit(op, &PPMSpecs))) {
+                    return WalkResult::interrupt();
+                }
+                return WalkResult::advance();
             }
 
             else if (isa<qec::PPMeasurementOp>(op)) {
-                countPPM(op, &PPMSpecs);
+                if (failed(countPPM(cast<qec::PPMeasurementOp>(op), &PPMSpecs))) {
+                    return WalkResult::interrupt();
+                }
+                return WalkResult::advance();
             }
 
             else if (isa<qec::PPRotationOp>(op)) {
-                countPPR(op, &PPMSpecs, &stringAllocator);
+                if (failed(countPPR(cast<qec::PPRotationOp>(op), &PPMSpecs, &stringAllocator))) {
+                    return WalkResult::interrupt();
+                }
+                return WalkResult::advance();
+            }
+            else {
+                return WalkResult::skip();
             }
         });
+
+        if (wr.wasInterrupted()) {
+            return failure();
+        }
 
         json PPMSpecsJson = PPMSpecs;
         llvm::outs() << PPMSpecsJson.dump(4)
                      << "\n"; // dump(4) makes an indent with 4 spaces when printing JSON
-        return;
+        return success();
     }
 
-    void runOnOperation() final { printSpecs(); }
+    void runOnOperation() final
+    {
+        if (failed(printSpecs())) {
+            signalPassFailure();
+        }
+    }
 };
 
 } // namespace qec

--- a/mlir/test/QEC/PPMSpecsTest.mlir
+++ b/mlir/test/QEC/PPMSpecsTest.mlir
@@ -322,3 +322,126 @@ func.func public @game_of_surface_code(%arg0: !quantum.bit, %arg1: !quantum.bit,
 }
 
 // -----
+
+//CHECK: {
+//CHECK:     "static_for_loop": {
+//CHECK:         "max_weight_pi4": 1,
+//CHECK:         "num_of_ppm": 5,
+//CHECK:         "num_pi4_gates": 5
+//CHECK:     }
+//CHECK: }
+func.func public @static_for_loop(%arg0: !quantum.bit) {
+    %c5 = arith.constant 5 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+
+    %q = scf.for %iter = %c0 to %c5 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
+      %out_qubits = qec.ppr ["Z"](4) %arg1 : !quantum.bit
+      %mres, %out_qubits_1 = qec.ppm ["Z"] %out_qubits : !quantum.bit
+      scf.yield %out_qubits_1 : !quantum.bit
+    }
+
+    return
+}
+
+// -----
+
+//CHECK: {
+//CHECK:     "static_for_loop_bigstep": {
+//CHECK:         "max_weight_pi4": 1,
+//CHECK:         "num_of_ppm": 3,
+//CHECK:         "num_pi4_gates": 3
+//CHECK:     }
+//CHECK: }
+func.func public @static_for_loop_bigstep(%arg0: !quantum.bit) {
+    %c5 = arith.constant 5 : index
+    %c0 = arith.constant 0 : index
+    %c2 = arith.constant 2 : index
+    // COM: should be 3 iterations (0,2,4)
+
+    %q = scf.for %iter = %c0 to %c5 step %c2 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
+      %out_qubits = qec.ppr ["Z"](4) %arg1 : !quantum.bit
+      %mres, %out_qubits_1 = qec.ppm ["Z"] %out_qubits : !quantum.bit
+      scf.yield %out_qubits_1 : !quantum.bit
+    }
+
+    return
+}
+
+// -----
+
+//CHECK: {
+//CHECK:     "static_for_loop_nested": {
+//CHECK:         "max_weight_pi4": 1,
+//CHECK:         "max_weight_pi8": 1,
+//CHECK:         "num_of_ppm": 30,
+//CHECK:         "num_pi4_gates": 30,
+//CHECK:         "num_pi8_gates": 6
+//CHECK:     }
+//CHECK: }
+func.func public @static_for_loop_nested(%arg0: !quantum.bit) {
+    %c5 = arith.constant 5 : index
+    %c6 = arith.constant 6 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+
+    %q = scf.for %iter = %c0 to %c6 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
+
+        %q_inner = scf.for %iter_inner = %c0 to %c5 step %c1 iter_args(%arg1_inner = %arg1) -> (!quantum.bit) {
+          %out_qubits_inner = qec.ppr ["Z"](4) %arg1_inner : !quantum.bit
+          %mres, %out_qubits_inner_1 = qec.ppm ["Z"] %out_qubits_inner : !quantum.bit
+          scf.yield %out_qubits_inner_1 : !quantum.bit
+        }
+
+        %out_qubits = qec.ppr ["Z"](8) %q_inner : !quantum.bit
+        scf.yield %out_qubits : !quantum.bit
+    }
+
+    return
+}
+
+// -----
+
+func.func public @dynamic_for_loop_error(%arg0: !quantum.bit, %c: index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+
+    %q = scf.for %iter = %c0 to %c step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
+      %out_qubits = qec.ppr ["Z"](4) %arg1 : !quantum.bit
+      // expected-error@above {{PPM statistics is not available when there are dynamically sized for loops.}}
+      %mres, %out_qubits_1 = qec.ppm ["Z"] %out_qubits : !quantum.bit
+      scf.yield %out_qubits_1 : !quantum.bit
+    }
+
+    return
+}
+
+// -----
+
+func.func public @cond_error(%arg0: !quantum.bit, %b: i1) {
+    %out_qubits = scf.if %b -> !quantum.bit {
+        %out_qubits_t = qec.ppr ["Z"](4) %arg0 : !quantum.bit
+        // expected-error@above {{PPM statistics is not available when there are conditionals or while loops.}}
+        scf.yield %out_qubits_t : !quantum.bit
+    } else {
+        scf.yield %arg0 : !quantum.bit
+    }
+
+    return
+}
+
+// -----
+
+func.func public @while_error(%arg0: !quantum.bit, %b: i1) {
+
+    %q = scf.while (%in_qubit = %arg0) : (!quantum.bit) -> (!quantum.bit) {
+        scf.condition(%b) %in_qubit: !quantum.bit
+    } do {
+        ^bb0(%in_qubit: !quantum.bit):
+        %out_qubits = qec.ppr ["Z"](4) %in_qubit : !quantum.bit
+        // expected-error@above {{PPM statistics is not available when there are conditionals or while loops.}}
+        scf.yield %out_qubits : !quantum.bit
+    }
+
+    return
+}

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ jax_version = dep_versions.get("jax")
 pl_version = dep_versions.get("pennylane")
 lq_version = dep_versions.get("lightning")
 
-pl_min_release = "0.41.0"
+pl_min_release = "0.42.0"
 lq_min_release = pl_min_release
 
 if pl_version is not None:


### PR DESCRIPTION
**Context:**

Bump the PennyLane and Lightning minimum versions in preparation for the Catalyst 0.12.0 release. These changes ensure we can build the wheels after the Lightning release and before the core PennyLane release.