### PR TITLE
`for_loop` and `while_loop` conversion support outside a QNode

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -13,10 +13,11 @@
 <h3>Internal changes ⚙️</h3>
 
 * `from_plxpr` now supports adjoint and ctrl operations and transforms,
-  and `Hermitian` observables.
+  `Hermitian` observables, `for_loop` outside qnodes, and `while_loop` outside QNode's.
   [(#1844)](https://github.com/PennyLaneAI/catalyst/pull/1844)
   [(#1850)](https://github.com/PennyLaneAI/catalyst/pull/1850)
   [(#1903)](https://github.com/PennyLaneAI/catalyst/pull/1903)
+  [(#1896)](https://github.com/PennyLaneAI/catalyst/pull/1896)
 
 
 <h3>Documentation 📝</h3>

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.13.0-dev6"
+__version__ = "0.13.0-dev7"

--- a/frontend/catalyst/from_plxpr/control_flow.py
+++ b/frontend/catalyst/from_plxpr/control_flow.py
@@ -129,7 +129,7 @@ def workflow_for_loop(
         start,
         stop,
         step,
-        stop if apply_reverse_transform else start,
+        start,
         *args,
         body_jaxpr=converted_closed_jaxpr_branch,
         body_nconsts=len(consts),

--- a/frontend/catalyst/from_plxpr/control_flow.py
+++ b/frontend/catalyst/from_plxpr/control_flow.py
@@ -114,7 +114,6 @@ def workflow_for_loop(
 
     consts = plxpr_invals[consts_slice]
 
-
     converter = copy(self)
     evaluator = partial(converter.eval, jaxpr_body_fn, consts)
 

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -1564,11 +1564,11 @@ class TestControlFlow:
         qml.capture.enable()
 
         if reverse:
-            start, stop, step = 6, 0, -2 # 6, 4, 2
+            start, stop, step = 6, 0, -2  # 6, 4, 2
         else:
-            start, stop, step = 2, 7, 2 # 2, 4, 6
+            start, stop, step = 2, 7, 2  # 2, 4, 6
 
-        @qml.qnode(qml.device('lightning.qubit', wires=1))
+        @qml.qnode(qml.device("lightning.qubit", wires=1))
         def c(x):
             qml.RX(x, 0)
             return qml.expval(qml.Z(0))
@@ -1580,27 +1580,27 @@ class TestControlFlow:
                 return c(i) + x
 
             return g(i0)
-    
+
         out = f(3.0)
-        assert qml.math.allclose(out, 3+jnp.cos(2)+jnp.cos(4)+jnp.cos(6))
+        assert qml.math.allclose(out, 3 + jnp.cos(2) + jnp.cos(4) + jnp.cos(6))
 
     def test_while_loop(self):
         """Test that a outside a qnode can be executed."""
         qml.capture.enable()
 
-        @qml.qnode(qml.device('lightning.qubit', wires=1))
+        @qml.qnode(qml.device("lightning.qubit", wires=1))
         def circuit(x):
-            qml.RX(x,0)
+            qml.RX(x, 0)
             return qml.expval(qml.Z(0))
 
         @qml.qjit
         def f(x):
 
-            const = jnp.array([0,1,2])
-            
+            const = jnp.array([0, 1, 2])
+
             @qml.while_loop(lambda i, y: i < jnp.sum(const))
             def g(i, y):
-                return i+1, y+circuit(i)
+                return i + 1, y + circuit(i)
 
             return g(0, x)
 
@@ -1608,7 +1608,6 @@ class TestControlFlow:
         assert qml.math.allclose(ind, 3)
         expected = 1.0 + jnp.cos(0) + jnp.cos(1) + jnp.cos(2)
         assert qml.math.allclose(res, expected)
-
 
 
 def test_adjoint_transform_integration():

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -1555,6 +1555,62 @@ class TestCapture:
         qml.capture.disable()
 
 
+class TestControlFlow:
+
+    @pytest.mark.parametrize("reverse", (True, False))
+    def test_for_loop_outside_qnode(self, reverse):
+        """Test that a for loop outside qnode can be executed."""
+
+        qml.capture.enable()
+
+        if reverse:
+            start, stop, step = 6, 0, -2 # 6, 4, 2
+        else:
+            start, stop, step = 2, 7, 2 # 2, 4, 6
+
+        @qml.qnode(qml.device('lightning.qubit', wires=1))
+        def c(x):
+            qml.RX(x, 0)
+            return qml.expval(qml.Z(0))
+
+        @qml.qjit
+        def f(i0):
+            @qml.for_loop(start, stop, step)
+            def g(i, x):
+                return c(i) + x
+
+            return g(i0)
+    
+        out = f(3.0)
+        assert qml.math.allclose(out, 3+jnp.cos(2)+jnp.cos(4)+jnp.cos(6))
+
+    def test_while_loop(self):
+        """Test that a outside a qnode can be executed."""
+        qml.capture.enable()
+
+        @qml.qnode(qml.device('lightning.qubit', wires=1))
+        def circuit(x):
+            qml.RX(x,0)
+            return qml.expval(qml.Z(0))
+
+        @qml.qjit
+        def f(x):
+
+            const = jnp.array([0,1,2])
+            
+            @qml.while_loop(lambda i, y: i < jnp.sum(const))
+            def g(i, y):
+                return i+1, y+circuit(i)
+
+            return g(0, x)
+
+        ind, res = f(1.0)
+        assert qml.math.allclose(ind, 3)
+        expected = 1.0 + jnp.cos(0) + jnp.cos(1) + jnp.cos(2)
+        assert qml.math.allclose(res, expected)
+
+
+
 def test_adjoint_transform_integration():
     """Test that adjoint transforms can be used with capture enabled."""
 

--- a/frontend/test/pytest/test_capture_integration.py
+++ b/frontend/test/pytest/test_capture_integration.py
@@ -1556,6 +1556,7 @@ class TestCapture:
 
 
 class TestControlFlow:
+    """Integration tests for control flow."""
 
     @pytest.mark.parametrize("reverse", (True, False))
     def test_for_loop_outside_qnode(self, reverse):

--- a/frontend/test/pytest/test_from_plxpr.py
+++ b/frontend/test/pytest/test_from_plxpr.py
@@ -844,7 +844,7 @@ class TestControlFlow:
                 return i + y
 
             return g(x)
-        
+
         x = jax.numpy.array([0, 0, 0])
 
         plxpr = jax.make_jaxpr(f)(x)


### PR DESCRIPTION
**Context:**

We are trying to make plxpr a frontend for catalyst, so we need to improve the coverage of the `from_plxpr` conversion. 

**Description of the Change:**

Register a conversion for `for_loop` and `while_loop` when they live outside the qnode.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-93193]
