### PR TITLE
Update jax to 0.6.2

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -1,7 +1,7 @@
 # Always update the version check in catalyst.__init__ when changing the JAX version.
 # To update JAX version alongside compatible dependency tags, run the following script:
 # python3 .github/workflows/set_dep_versions.py {JAX_version}
-jax=0.6.0
+jax=0.6.2
 mhlo=617a9361d186199480c080c9e8c474a5e30c22d1
 llvm=179d30f8c3fddd3c85056fd2b8e877a4a8513158
 enzyme=v0.0.180

--- a/.dep-versions
+++ b/.dep-versions
@@ -10,7 +10,7 @@ enzyme=v0.0.180
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt
-pennylane=0.42.0
+pennylane=0.43.0.dev8
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ frontend:
 	# 351c13e5b6dfec90863ef64f137a28da7426f38a (Apr.26): Checkpoint, last commit of Apr.26
 	# ef015a0d3f8effa3d313c7d692d9241a54a99922 (Apr.29): the "inline literals" change
 	#pip install git+https://github.com/jax-ml/jax.git@603f73016cdd6c576b819524ea270972439ff5c5
+	pip install git+https://github.com/PennyLaneAI/pennylane.git@bump-jax-0.6.2
 
 .PHONY: mlir llvm mhlo enzyme dialects runtime oqc
 mlir:

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ frontend:
 	# 351c13e5b6dfec90863ef64f137a28da7426f38a (Apr.26): Checkpoint, last commit of Apr.26
 	# ef015a0d3f8effa3d313c7d692d9241a54a99922 (Apr.29): the "inline literals" change
 	#pip install git+https://github.com/jax-ml/jax.git@603f73016cdd6c576b819524ea270972439ff5c5
-	pip install git+https://github.com/PennyLaneAI/pennylane.git@bump-jax-0.6.2
+	pip install git+https://github.com/PennyLaneAI/pennylane.git@875f0693a19fd9217305745bdbf945224151588e
 
 .PHONY: mlir llvm mhlo enzyme dialects runtime oqc
 mlir:

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ frontend:
 	#   i.e. source_info is back in
 	# 351c13e5b6dfec90863ef64f137a28da7426f38a (Apr.26): Checkpoint, last commit of Apr.26
 	# ef015a0d3f8effa3d313c7d692d9241a54a99922 (Apr.29): the "inline literals" change
-	pip install git+https://github.com/jax-ml/jax.git@ef015a0d3f8effa3d313c7d692d9241a54a99922
+	#pip install git+https://github.com/jax-ml/jax.git@603f73016cdd6c576b819524ea270972439ff5c5
 
 .PHONY: mlir llvm mhlo enzyme dialects runtime oqc
 mlir:

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,12 @@ frontend:
 	$(PYTHON) -m pip uninstall -y pennylane
 	$(PYTHON) -m pip install -e . --extra-index-url https://test.pypi.org/simple $(PIP_VERBOSE_FLAG)
 	rm -r frontend/pennylane_catalyst.egg-info
+	# View jax commits at
+	# https://github.com/jax-ml/jax/commit/<commit-hash>
+	#0.6.0: 127aa7621868cb77e552b5d1f90e4a42b09c13fa, Apr.16
+	#0.6.2: 1ad05bb26105f23ee7728b36cca12901fe70e187, Jun.17
+	# Some big milestones:
+	# 1d652ab7f4346a974cf5888ab23713e1a9c2ddba: the "source_info change"
 
 .PHONY: mlir llvm mhlo enzyme dialects runtime oqc
 mlir:

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,8 @@ frontend:
 	# Somewhere here: reverts the "reverts the source_info change (492cd3d9)"
 	#   i.e. source_info is back in
 	# 351c13e5b6dfec90863ef64f137a28da7426f38a (Apr.26): Checkpoint, last commit of Apr.26
-	pip install git+https://github.com/jax-ml/jax.git@351c13e5b6dfec90863ef64f137a28da7426f38a
+	# ef015a0d3f8effa3d313c7d692d9241a54a99922 (Apr.29): the "inline literals" change
+	pip install git+https://github.com/jax-ml/jax.git@ef015a0d3f8effa3d313c7d692d9241a54a99922
 
 .PHONY: mlir llvm mhlo enzyme dialects runtime oqc
 mlir:

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,8 @@ frontend:
 	# 1d652ab7f4346a974cf5888ab23713e1a9c2ddba (Apr.17): the "source_info change"
 	# 492cd3d9313cfd45e8bd63a8f51aa63d92924cd5 (Apr.18): reverts the source_info change (1d652ab7)
 	# f1803bef692b6d91815b02ec643980d9ab9b5132 (Apr.22): Checkpoint, last commit of Apr.22
-	pip install git+https://github.com/jax-ml/jax.git@f1803bef692b6d91815b02ec643980d9ab9b5132
+	# d4dd0c4985cd8046a2b97efbd9798e0ebf397c8f (Apr.23): Checkpoint, last commit of Apr.23
+	pip install git+https://github.com/jax-ml/jax.git@d4dd0c4985cd8046a2b97efbd9798e0ebf397c8f
 
 .PHONY: mlir llvm mhlo enzyme dialects runtime oqc
 mlir:

--- a/Makefile
+++ b/Makefile
@@ -122,9 +122,11 @@ frontend:
 	# https://github.com/jax-ml/jax/commit/<commit-hash>
 	#0.6.0: 127aa7621868cb77e552b5d1f90e4a42b09c13fa, Apr.16
 	#0.6.2: 1ad05bb26105f23ee7728b36cca12901fe70e187, Jun.17
-	# Some big milestones:
+	#
+	# Some big milestones (this list is completely in chronological order):
 	# 1d652ab7f4346a974cf5888ab23713e1a9c2ddba: the "source_info change"
-	pip install git+https://github.com/jax-ml/jax.git@1d652ab7f4346a974cf5888ab23713e1a9c2ddba
+	# 492cd3d9313cfd45e8bd63a8f51aa63d92924cd5: reverts the source_info change (1d652ab7)
+	pip install git+https://github.com/jax-ml/jax.git@492cd3d9313cfd45e8bd63a8f51aa63d92924cd5
 
 .PHONY: mlir llvm mhlo enzyme dialects runtime oqc
 mlir:

--- a/Makefile
+++ b/Makefile
@@ -118,22 +118,6 @@ frontend:
 	$(PYTHON) -m pip uninstall -y pennylane
 	$(PYTHON) -m pip install -e . --extra-index-url https://test.pypi.org/simple $(PIP_VERBOSE_FLAG)
 	rm -r frontend/pennylane_catalyst.egg-info
-	# View jax commits at
-	# https://github.com/jax-ml/jax/commit/<commit-hash>
-	#0.6.0: 127aa7621868cb77e552b5d1f90e4a42b09c13fa, Apr.16
-	#0.6.2: 1ad05bb26105f23ee7728b36cca12901fe70e187, Jun.17
-	#
-	# Some big milestones (this list is completely in chronological order):
-	# 1d652ab7f4346a974cf5888ab23713e1a9c2ddba (Apr.17): the "source_info change"
-	# 492cd3d9313cfd45e8bd63a8f51aa63d92924cd5 (Apr.18): reverts the source_info change (1d652ab7)
-	# f1803bef692b6d91815b02ec643980d9ab9b5132 (Apr.22): Checkpoint, last commit of Apr.22
-	# d4dd0c4985cd8046a2b97efbd9798e0ebf397c8f (Apr.23): Checkpoint, last commit of Apr.23
-	# Somewhere here: reverts the "reverts the source_info change (492cd3d9)"
-	#   i.e. source_info is back in
-	# 351c13e5b6dfec90863ef64f137a28da7426f38a (Apr.26): Checkpoint, last commit of Apr.26
-	# ef015a0d3f8effa3d313c7d692d9241a54a99922 (Apr.29): the "inline literals" change
-	#pip install git+https://github.com/jax-ml/jax.git@603f73016cdd6c576b819524ea270972439ff5c5
-	pip install git+https://github.com/PennyLaneAI/pennylane.git@875f0693a19fd9217305745bdbf945224151588e
 
 .PHONY: mlir llvm mhlo enzyme dialects runtime oqc
 mlir:

--- a/Makefile
+++ b/Makefile
@@ -124,9 +124,10 @@ frontend:
 	#0.6.2: 1ad05bb26105f23ee7728b36cca12901fe70e187, Jun.17
 	#
 	# Some big milestones (this list is completely in chronological order):
-	# 1d652ab7f4346a974cf5888ab23713e1a9c2ddba: the "source_info change"
-	# 492cd3d9313cfd45e8bd63a8f51aa63d92924cd5: reverts the source_info change (1d652ab7)
-	pip install git+https://github.com/jax-ml/jax.git@492cd3d9313cfd45e8bd63a8f51aa63d92924cd5
+	# 1d652ab7f4346a974cf5888ab23713e1a9c2ddba (Apr.17): the "source_info change"
+	# 492cd3d9313cfd45e8bd63a8f51aa63d92924cd5 (Apr.18): reverts the source_info change (1d652ab7)
+	# f1803bef692b6d91815b02ec643980d9ab9b5132 (Apr.22): Checkpoint, last commit of Apr.22
+	pip install git+https://github.com/jax-ml/jax.git@f1803bef692b6d91815b02ec643980d9ab9b5132
 
 .PHONY: mlir llvm mhlo enzyme dialects runtime oqc
 mlir:

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,10 @@ frontend:
 	# 492cd3d9313cfd45e8bd63a8f51aa63d92924cd5 (Apr.18): reverts the source_info change (1d652ab7)
 	# f1803bef692b6d91815b02ec643980d9ab9b5132 (Apr.22): Checkpoint, last commit of Apr.22
 	# d4dd0c4985cd8046a2b97efbd9798e0ebf397c8f (Apr.23): Checkpoint, last commit of Apr.23
-	pip install git+https://github.com/jax-ml/jax.git@d4dd0c4985cd8046a2b97efbd9798e0ebf397c8f
+	# Somewhere here: reverts the "reverts the source_info change (492cd3d9)"
+	#   i.e. source_info is back in
+	# 351c13e5b6dfec90863ef64f137a28da7426f38a (Apr.26): Checkpoint, last commit of Apr.26
+	pip install git+https://github.com/jax-ml/jax.git@351c13e5b6dfec90863ef64f137a28da7426f38a
 
 .PHONY: mlir llvm mhlo enzyme dialects runtime oqc
 mlir:

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ frontend:
 	#0.6.2: 1ad05bb26105f23ee7728b36cca12901fe70e187, Jun.17
 	# Some big milestones:
 	# 1d652ab7f4346a974cf5888ab23713e1a9c2ddba: the "source_info change"
+	pip install git+https://github.com/jax-ml/jax.git@1d652ab7f4346a974cf5888ab23713e1a9c2ddba
 
 .PHONY: mlir llvm mhlo enzyme dialects runtime oqc
 mlir:

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -6,6 +6,9 @@
 
 <h3>Breaking changes 💔</h3>
 
+* The JAX version used by Catalyst is updated to 0.6.2.
+  [(#1897)](https://github.com/PennyLaneAI/catalyst/pull/1897)
+
 <h3>Deprecations 👋</h3>
 
 <h3>Bug fixes 🐛</h3>
@@ -25,4 +28,5 @@
 
 This release contains contributions from (in alphabetical order):
 
-Christina Lee
+Christina Lee,
+Paul Haochen Wang.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -33,4 +33,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.42.0
 pennylane-lightning==0.42.0
-pennylane==0.42.0
+pennylane==0.43.0.dev8

--- a/frontend/catalyst/__init__.py
+++ b/frontend/catalyst/__init__.py
@@ -23,7 +23,7 @@ from os.path import dirname
 
 import jaxlib as _jaxlib
 
-_jaxlib_version = "0.6.0"
+_jaxlib_version = "0.6.2"
 if _jaxlib.__version__ != _jaxlib_version:
     import warnings
 

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -20,11 +20,13 @@ with control flow, including conditionals, for loops, and while loops.
 # pylint: disable=too-many-lines
 
 import inspect
+from functools import partial
 from typing import Any, Callable, List
 
 import jax
 import jax.numpy as jnp
 import pennylane as qml
+from jax._src.source_info_util import current as current_source_info
 from jax._src.tree_util import PyTreeDef, tree_unflatten, treedef_is_leaf
 from jax.api_util import debug_info
 from jax.core import AbstractValue
@@ -676,7 +678,8 @@ class CondCallable:
             with EvaluationContext.frame_tracing_context(debug_info=wfun.debug_info) as inner_trace:
                 with QueuingManager.stop_recording(), quantum_tape:
                     res_classical_tracers = [
-                        inner_trace.to_jaxpr_tracer(t) for t in wfun.call_wrapped()
+                        inner_trace.to_jaxpr_tracer(t, source_info=current_source_info())
+                        for t in wfun.call_wrapped()
                     ]
             explicit_return_tys = collapse(out_sig.out_type(), res_classical_tracers)
             hybridRegion = HybridOpRegion(inner_trace, quantum_tape, [], explicit_return_tys)
@@ -912,7 +915,8 @@ class ForLoopCallable:
         quantum_tape = QuantumTape()
         outer_trace = EvaluationContext.get_current_trace()
         aux_classical_tracers = [
-            outer_trace.to_jaxpr_tracer(t) for t in [self.lower_bound, self.upper_bound, self.step]
+            outer_trace.to_jaxpr_tracer(t, source_info=current_source_info())
+            for t in [self.lower_bound, self.upper_bound, self.step]
         ]
         wfun, in_sig, out_sig = deduce_signatures(
             self.body_fn,
@@ -927,11 +931,13 @@ class ForLoopCallable:
 
         with EvaluationContext.frame_tracing_context(debug_info=wfun.debug_info) as inner_trace:
             arg_classical_tracers = input_type_to_tracers(
-                in_type, inner_trace.new_arg, inner_trace.to_jaxpr_tracer
+                in_type,
+                partial(inner_trace.new_arg, source_info=current_source_info()),
+                partial(inner_trace.to_jaxpr_tracer, source_info=current_source_info()),
             )
             with QueuingManager.stop_recording(), quantum_tape:
                 res_classical_tracers = [
-                    inner_trace.to_jaxpr_tracer(t)
+                    inner_trace.to_jaxpr_tracer(t, source_info=current_source_info())
                     for t in wfun.call_wrapped(*arg_classical_tracers)
                 ]
                 out_type = out_sig.out_type()
@@ -967,7 +973,8 @@ class ForLoopCallable:
     def _call_with_classical_ctx(self, *init_state):
         outer_trace = find_top_trace([self.lower_bound, self.upper_bound, self.step])
         aux_tracers = [
-            outer_trace.to_jaxpr_tracer(t) for t in [self.lower_bound, self.upper_bound, self.step]
+            outer_trace.to_jaxpr_tracer(t, source_info=current_source_info())
+            for t in [self.lower_bound, self.upper_bound, self.step]
         ]
 
         _, in_sig, out_sig = trace_function(
@@ -1105,10 +1112,12 @@ class WhileLoopCallable:
 
         with EvaluationContext.frame_tracing_context(debug_info=cond_wffa.debug_info) as cond_trace:
             arg_classical_tracers = input_type_to_tracers(
-                in_type, cond_trace.new_arg, cond_trace.to_jaxpr_tracer
+                in_type,
+                partial(cond_trace.new_arg, source_info=current_source_info()),
+                partial(cond_trace.to_jaxpr_tracer, source_info=current_source_info()),
             )
             res_classical_tracers = [
-                cond_trace.to_jaxpr_tracer(t)
+                cond_trace.to_jaxpr_tracer(t, source_info=current_source_info())
                 for t in cond_wffa.call_wrapped(*arg_classical_tracers)
             ]
 
@@ -1127,13 +1136,15 @@ class WhileLoopCallable:
 
         with EvaluationContext.frame_tracing_context(debug_info=body_wffa.debug_info) as body_trace:
             arg_classical_tracers = input_type_to_tracers(
-                in_type, body_trace.new_arg, body_trace.to_jaxpr_tracer
+                in_type,
+                partial(body_trace.new_arg, source_info=current_source_info()),
+                partial(body_trace.to_jaxpr_tracer, source_info=current_source_info()),
             )
 
             quantum_tape = QuantumTape()
             with QueuingManager.stop_recording(), quantum_tape:
                 res_classical_tracers = [
-                    body_trace.to_jaxpr_tracer(t)
+                    body_trace.to_jaxpr_tracer(t, source_info=current_source_info())
                     for t in body_wffa.call_wrapped(*arg_classical_tracers)
                 ]
 
@@ -1228,7 +1239,9 @@ class Cond(HybridOp):
         for region in op.regions:
             with EvaluationContext.frame_tracing_context(region.trace):
                 new_qreg = AbstractQreg()
-                qreg_in = _input_type_to_tracers(region.trace.new_arg, [new_qreg])[0]
+                qreg_in = _input_type_to_tracers(
+                    partial(region.trace.new_arg, source_info=current_source_info()), [new_qreg]
+                )[0]
                 qreg_out = trace_quantum_operations(
                     region.quantum_tape, device, qreg_in, ctx, region.trace
                 ).actualize()
@@ -1285,7 +1298,9 @@ class ForLoop(HybridOp):
 
         with EvaluationContext.frame_tracing_context(inner_trace):
             new_qreg = AbstractQreg()
-            qreg_in = _input_type_to_tracers(inner_trace.new_arg, [new_qreg])[0]
+            qreg_in = _input_type_to_tracers(
+                partial(inner_trace.new_arg, source_info=current_source_info()), [new_qreg]
+            )[0]
             qrp_out = trace_quantum_operations(inner_tape, device, qreg_in, ctx, inner_trace)
             qreg_out = qrp_out.actualize()
 
@@ -1301,7 +1316,7 @@ class ForLoop(HybridOp):
             res_tracers = res_classical_tracers + [qreg_out]
             _, _, consts = trace_to_jaxpr(inner_trace, [], res_tracers)
             res_expanded_tracers, _ = expand_results(
-                [inner_trace.to_jaxpr_tracer(t) for t in consts],
+                [inner_trace.to_jaxpr_tracer(t, source_info=current_source_info()) for t in consts],
                 arg_expanded_tracers,
                 res_tracers,
                 expansion_strategy=expansion_strategy,
@@ -1310,7 +1325,9 @@ class ForLoop(HybridOp):
             jaxpr, _, _ = trace_to_jaxpr(inner_trace, arg_expanded_tracers, res_expanded_tracers)
 
         operand_tracers = op.in_classical_tracers
-        const_tracers = [trace.to_jaxpr_tracer(c) for c in consts]
+        const_tracers = [
+            trace.to_jaxpr_tracer(c, source_info=current_source_info()) for c in consts
+        ]
         operand_expanded_tracers, _ = expand_args(
             operand_tracers, expansion_strategy=expansion_strategy
         )
@@ -1359,12 +1376,14 @@ class WhileLoop(HybridOp):
                 cond_trace, arg_expanded_classical_tracers, res_classical_tracers
             )
             res_expanded_classical_tracers, _ = expand_results(
-                [cond_trace.to_jaxpr_tracer(t) for t in consts],
+                [cond_trace.to_jaxpr_tracer(t, source_info=current_source_info()) for t in consts],
                 arg_expanded_classical_tracers,
                 res_classical_tracers,
                 expansion_strategy=expansion_strategy,
             )
-            _input_type_to_tracers(cond_trace.new_arg, [AbstractQreg()])
+            _input_type_to_tracers(
+                partial(cond_trace.new_arg, source_info=current_source_info()), [AbstractQreg()]
+            )
             cond_jaxpr, _, cond_consts = trace_to_jaxpr(
                 cond_trace, arg_expanded_classical_tracers, res_expanded_classical_tracers
             )
@@ -1375,7 +1394,9 @@ class WhileLoop(HybridOp):
         with EvaluationContext.frame_tracing_context(body_trace):
             region = self.regions[1]
             res_classical_tracers = region.res_classical_tracers
-            qreg_in = _input_type_to_tracers(body_trace.new_arg, [AbstractQreg()])[0]
+            qreg_in = _input_type_to_tracers(
+                partial(body_trace.new_arg, source_info=current_source_info()), [AbstractQreg()]
+            )[0]
             qrp_out = trace_quantum_operations(body_tape, device, qreg_in, ctx, body_trace)
             qreg_out = qrp_out.actualize()
             arg_expanded_tracers = expand_args(
@@ -1386,7 +1407,7 @@ class WhileLoop(HybridOp):
                 body_trace, arg_expanded_tracers, res_classical_tracers + [qreg_out]
             )
             res_expanded_tracers, _ = expand_results(
-                [body_trace.to_jaxpr_tracer(t) for t in consts],
+                [body_trace.to_jaxpr_tracer(t, source_info=current_source_info()) for t in consts],
                 arg_expanded_tracers,
                 res_classical_tracers + [qreg_out],
                 expansion_strategy=expansion_strategy,
@@ -1396,13 +1417,19 @@ class WhileLoop(HybridOp):
             )
 
         in_expanded_tracers = [
-            *[trace.to_jaxpr_tracer(c) for c in (cond_consts + body_consts)],
+            *[
+                trace.to_jaxpr_tracer(c, source_info=current_source_info())
+                for c in (cond_consts + body_consts)
+            ],
             *expand_args(self.in_classical_tracers, expansion_strategy=expansion_strategy)[0],
             qrp.actualize(),
         ]
 
         out_expanded_classical_tracers = expand_results(
-            [trace.to_jaxpr_tracer(c) for c in (cond_consts + body_consts)],
+            [
+                trace.to_jaxpr_tracer(c, source_info=current_source_info())
+                for c in (cond_consts + body_consts)
+            ],
             in_expanded_tracers,
             self.out_classical_tracers,
             expansion_strategy=expansion_strategy,

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -20,13 +20,11 @@ with control flow, including conditionals, for loops, and while loops.
 # pylint: disable=too-many-lines
 
 import inspect
-from functools import partial
 from typing import Any, Callable, List
 
 import jax
 import jax.numpy as jnp
 import pennylane as qml
-from jax._src.source_info_util import current as current_source_info
 from jax._src.tree_util import PyTreeDef, tree_unflatten, treedef_is_leaf
 from jax.api_util import debug_info
 from jax.core import AbstractValue
@@ -678,8 +676,7 @@ class CondCallable:
             with EvaluationContext.frame_tracing_context(debug_info=wfun.debug_info) as inner_trace:
                 with QueuingManager.stop_recording(), quantum_tape:
                     res_classical_tracers = [
-                        inner_trace.to_jaxpr_tracer(t, source_info=current_source_info())
-                        for t in wfun.call_wrapped()
+                        inner_trace.to_jaxpr_tracer(t) for t in wfun.call_wrapped()
                     ]
             explicit_return_tys = collapse(out_sig.out_type(), res_classical_tracers)
             hybridRegion = HybridOpRegion(inner_trace, quantum_tape, [], explicit_return_tys)
@@ -915,8 +912,7 @@ class ForLoopCallable:
         quantum_tape = QuantumTape()
         outer_trace = EvaluationContext.get_current_trace()
         aux_classical_tracers = [
-            outer_trace.to_jaxpr_tracer(t, source_info=current_source_info())
-            for t in [self.lower_bound, self.upper_bound, self.step]
+            outer_trace.to_jaxpr_tracer(t) for t in [self.lower_bound, self.upper_bound, self.step]
         ]
         wfun, in_sig, out_sig = deduce_signatures(
             self.body_fn,
@@ -931,13 +927,11 @@ class ForLoopCallable:
 
         with EvaluationContext.frame_tracing_context(debug_info=wfun.debug_info) as inner_trace:
             arg_classical_tracers = input_type_to_tracers(
-                in_type,
-                partial(inner_trace.new_arg, source_info=current_source_info()),
-                partial(inner_trace.to_jaxpr_tracer, source_info=current_source_info()),
+                in_type, inner_trace.new_arg, inner_trace.to_jaxpr_tracer
             )
             with QueuingManager.stop_recording(), quantum_tape:
                 res_classical_tracers = [
-                    inner_trace.to_jaxpr_tracer(t, source_info=current_source_info())
+                    inner_trace.to_jaxpr_tracer(t)
                     for t in wfun.call_wrapped(*arg_classical_tracers)
                 ]
                 out_type = out_sig.out_type()
@@ -973,8 +967,7 @@ class ForLoopCallable:
     def _call_with_classical_ctx(self, *init_state):
         outer_trace = find_top_trace([self.lower_bound, self.upper_bound, self.step])
         aux_tracers = [
-            outer_trace.to_jaxpr_tracer(t, source_info=current_source_info())
-            for t in [self.lower_bound, self.upper_bound, self.step]
+            outer_trace.to_jaxpr_tracer(t) for t in [self.lower_bound, self.upper_bound, self.step]
         ]
 
         _, in_sig, out_sig = trace_function(
@@ -1112,12 +1105,10 @@ class WhileLoopCallable:
 
         with EvaluationContext.frame_tracing_context(debug_info=cond_wffa.debug_info) as cond_trace:
             arg_classical_tracers = input_type_to_tracers(
-                in_type,
-                partial(cond_trace.new_arg, source_info=current_source_info()),
-                partial(cond_trace.to_jaxpr_tracer, source_info=current_source_info()),
+                in_type, cond_trace.new_arg, cond_trace.to_jaxpr_tracer
             )
             res_classical_tracers = [
-                cond_trace.to_jaxpr_tracer(t, source_info=current_source_info())
+                cond_trace.to_jaxpr_tracer(t)
                 for t in cond_wffa.call_wrapped(*arg_classical_tracers)
             ]
 
@@ -1136,15 +1127,13 @@ class WhileLoopCallable:
 
         with EvaluationContext.frame_tracing_context(debug_info=body_wffa.debug_info) as body_trace:
             arg_classical_tracers = input_type_to_tracers(
-                in_type,
-                partial(body_trace.new_arg, source_info=current_source_info()),
-                partial(body_trace.to_jaxpr_tracer, source_info=current_source_info()),
+                in_type, body_trace.new_arg, body_trace.to_jaxpr_tracer
             )
 
             quantum_tape = QuantumTape()
             with QueuingManager.stop_recording(), quantum_tape:
                 res_classical_tracers = [
-                    body_trace.to_jaxpr_tracer(t, source_info=current_source_info())
+                    body_trace.to_jaxpr_tracer(t)
                     for t in body_wffa.call_wrapped(*arg_classical_tracers)
                 ]
 
@@ -1239,9 +1228,7 @@ class Cond(HybridOp):
         for region in op.regions:
             with EvaluationContext.frame_tracing_context(region.trace):
                 new_qreg = AbstractQreg()
-                qreg_in = _input_type_to_tracers(
-                    partial(region.trace.new_arg, source_info=current_source_info()), [new_qreg]
-                )[0]
+                qreg_in = _input_type_to_tracers(region.trace.new_arg, [new_qreg])[0]
                 qreg_out = trace_quantum_operations(
                     region.quantum_tape, device, qreg_in, ctx, region.trace
                 ).actualize()
@@ -1298,9 +1285,7 @@ class ForLoop(HybridOp):
 
         with EvaluationContext.frame_tracing_context(inner_trace):
             new_qreg = AbstractQreg()
-            qreg_in = _input_type_to_tracers(
-                partial(inner_trace.new_arg, source_info=current_source_info()), [new_qreg]
-            )[0]
+            qreg_in = _input_type_to_tracers(inner_trace.new_arg, [new_qreg])[0]
             qrp_out = trace_quantum_operations(inner_tape, device, qreg_in, ctx, inner_trace)
             qreg_out = qrp_out.actualize()
 
@@ -1316,7 +1301,7 @@ class ForLoop(HybridOp):
             res_tracers = res_classical_tracers + [qreg_out]
             _, _, consts = trace_to_jaxpr(inner_trace, [], res_tracers)
             res_expanded_tracers, _ = expand_results(
-                [inner_trace.to_jaxpr_tracer(t, source_info=current_source_info()) for t in consts],
+                [inner_trace.to_jaxpr_tracer(t) for t in consts],
                 arg_expanded_tracers,
                 res_tracers,
                 expansion_strategy=expansion_strategy,
@@ -1325,9 +1310,7 @@ class ForLoop(HybridOp):
             jaxpr, _, _ = trace_to_jaxpr(inner_trace, arg_expanded_tracers, res_expanded_tracers)
 
         operand_tracers = op.in_classical_tracers
-        const_tracers = [
-            trace.to_jaxpr_tracer(c, source_info=current_source_info()) for c in consts
-        ]
+        const_tracers = [trace.to_jaxpr_tracer(c) for c in consts]
         operand_expanded_tracers, _ = expand_args(
             operand_tracers, expansion_strategy=expansion_strategy
         )
@@ -1376,14 +1359,12 @@ class WhileLoop(HybridOp):
                 cond_trace, arg_expanded_classical_tracers, res_classical_tracers
             )
             res_expanded_classical_tracers, _ = expand_results(
-                [cond_trace.to_jaxpr_tracer(t, source_info=current_source_info()) for t in consts],
+                [cond_trace.to_jaxpr_tracer(t) for t in consts],
                 arg_expanded_classical_tracers,
                 res_classical_tracers,
                 expansion_strategy=expansion_strategy,
             )
-            _input_type_to_tracers(
-                partial(cond_trace.new_arg, source_info=current_source_info()), [AbstractQreg()]
-            )
+            _input_type_to_tracers(cond_trace.new_arg, [AbstractQreg()])
             cond_jaxpr, _, cond_consts = trace_to_jaxpr(
                 cond_trace, arg_expanded_classical_tracers, res_expanded_classical_tracers
             )
@@ -1394,9 +1375,7 @@ class WhileLoop(HybridOp):
         with EvaluationContext.frame_tracing_context(body_trace):
             region = self.regions[1]
             res_classical_tracers = region.res_classical_tracers
-            qreg_in = _input_type_to_tracers(
-                partial(body_trace.new_arg, source_info=current_source_info()), [AbstractQreg()]
-            )[0]
+            qreg_in = _input_type_to_tracers(body_trace.new_arg, [AbstractQreg()])[0]
             qrp_out = trace_quantum_operations(body_tape, device, qreg_in, ctx, body_trace)
             qreg_out = qrp_out.actualize()
             arg_expanded_tracers = expand_args(
@@ -1407,7 +1386,7 @@ class WhileLoop(HybridOp):
                 body_trace, arg_expanded_tracers, res_classical_tracers + [qreg_out]
             )
             res_expanded_tracers, _ = expand_results(
-                [body_trace.to_jaxpr_tracer(t, source_info=current_source_info()) for t in consts],
+                [body_trace.to_jaxpr_tracer(t) for t in consts],
                 arg_expanded_tracers,
                 res_classical_tracers + [qreg_out],
                 expansion_strategy=expansion_strategy,
@@ -1417,19 +1396,13 @@ class WhileLoop(HybridOp):
             )
 
         in_expanded_tracers = [
-            *[
-                trace.to_jaxpr_tracer(c, source_info=current_source_info())
-                for c in (cond_consts + body_consts)
-            ],
+            *[trace.to_jaxpr_tracer(c) for c in (cond_consts + body_consts)],
             *expand_args(self.in_classical_tracers, expansion_strategy=expansion_strategy)[0],
             qrp.actualize(),
         ]
 
         out_expanded_classical_tracers = expand_results(
-            [
-                trace.to_jaxpr_tracer(c, source_info=current_source_info())
-                for c in (cond_consts + body_consts)
-            ],
+            [trace.to_jaxpr_tracer(c) for c in (cond_consts + body_consts)],
             in_expanded_tracers,
             self.out_classical_tracers,
             expansion_strategy=expansion_strategy,

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -16,6 +16,7 @@
 This module contains public API functions for quantum operators which are not
 included in PennyLane, or whose behaviour needs to be adapted for Catalyst.
 """
+
 import copy
 import sys
 from collections.abc import Sized

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -16,16 +16,15 @@
 This module contains public API functions for quantum operators which are not
 included in PennyLane, or whose behaviour needs to be adapted for Catalyst.
 """
+
 import copy
 import sys
 from collections.abc import Sized
 from contextlib import nullcontext
-from functools import partial
 from typing import Any, Callable, List, Optional, Union
 
 import jax
 import pennylane as qml
-from jax._src.source_info_util import current as current_source_info
 from jax._src.tree_util import tree_flatten
 from jax.api_util import debug_info
 from jax.core import get_aval
@@ -428,13 +427,11 @@ class AdjointCallable:
         with EvaluationContext.frame_tracing_context(debug_info=dbg) as inner_trace:
             in_classical_tracers, _ = tree_flatten((args, kwargs))
             wffa, in_avals, _, _ = deduce_avals(self.target, args, kwargs, debug_info=dbg)
-            arg_classical_tracers = _input_type_to_tracers(
-                partial(inner_trace.new_arg, source_info=current_source_info()), in_avals
-            )
+            arg_classical_tracers = _input_type_to_tracers(inner_trace.new_arg, in_avals)
             with QueuingManager.stop_recording(), QuantumTape() as quantum_tape:
                 # FIXME: move all to_jaxpr_tracer calls into a separate function
                 res_classical_tracers = [
-                    inner_trace.to_jaxpr_tracer(t, source_info=current_source_info())
+                    inner_trace.to_jaxpr_tracer(t)
                     for t in wffa.call_wrapped(*arg_classical_tracers)
                     if isinstance(t, DynamicJaxprTracer)
                 ]
@@ -469,9 +466,7 @@ class HybridAdjoint(HybridOp):
             frame_ctx = EvaluationContext.frame_tracing_context(body_trace)
 
         with frame_ctx as body_trace:
-            qreg_in = _input_type_to_tracers(
-                partial(body_trace.new_arg, source_info=current_source_info()), [AbstractQreg()]
-            )[0]
+            qreg_in = _input_type_to_tracers(body_trace.new_arg, [AbstractQreg()])[0]
             qrp_out = trace_quantum_operations(body_tape, device, qreg_in, ctx, body_trace)
             qreg_out = qrp_out.actualize()
             body_jaxpr, _, body_consts = body_trace.frame.to_jaxpr2(

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -16,15 +16,16 @@
 This module contains public API functions for quantum operators which are not
 included in PennyLane, or whose behaviour needs to be adapted for Catalyst.
 """
-
 import copy
 import sys
 from collections.abc import Sized
 from contextlib import nullcontext
+from functools import partial
 from typing import Any, Callable, List, Optional, Union
 
 import jax
 import pennylane as qml
+from jax._src.source_info_util import current as current_source_info
 from jax._src.tree_util import tree_flatten
 from jax.api_util import debug_info
 from jax.core import get_aval
@@ -427,11 +428,13 @@ class AdjointCallable:
         with EvaluationContext.frame_tracing_context(debug_info=dbg) as inner_trace:
             in_classical_tracers, _ = tree_flatten((args, kwargs))
             wffa, in_avals, _, _ = deduce_avals(self.target, args, kwargs, debug_info=dbg)
-            arg_classical_tracers = _input_type_to_tracers(inner_trace.new_arg, in_avals)
+            arg_classical_tracers = _input_type_to_tracers(
+                partial(inner_trace.new_arg, source_info=current_source_info()), in_avals
+            )
             with QueuingManager.stop_recording(), QuantumTape() as quantum_tape:
                 # FIXME: move all to_jaxpr_tracer calls into a separate function
                 res_classical_tracers = [
-                    inner_trace.to_jaxpr_tracer(t)
+                    inner_trace.to_jaxpr_tracer(t, source_info=current_source_info())
                     for t in wffa.call_wrapped(*arg_classical_tracers)
                     if isinstance(t, DynamicJaxprTracer)
                 ]
@@ -466,7 +469,9 @@ class HybridAdjoint(HybridOp):
             frame_ctx = EvaluationContext.frame_tracing_context(body_trace)
 
         with frame_ctx as body_trace:
-            qreg_in = _input_type_to_tracers(body_trace.new_arg, [AbstractQreg()])[0]
+            qreg_in = _input_type_to_tracers(
+                partial(body_trace.new_arg, source_info=current_source_info()), [AbstractQreg()]
+            )[0]
             qrp_out = trace_quantum_operations(body_tape, device, qreg_in, ctx, body_trace)
             qreg_out = qrp_out.actualize()
             body_jaxpr, _, body_consts = body_trace.frame.to_jaxpr2(

--- a/frontend/catalyst/jax_extras/__init__.py
+++ b/frontend/catalyst/jax_extras/__init__.py
@@ -57,6 +57,7 @@ from catalyst.jax_extras.tracing import (
     infer_output_type_python,
     input_type_to_tracers,
     jaxpr_pad_consts,
+    make_from_node_data_and_children,
     make_jaxpr2,
     make_jaxpr_effects,
     new_inner_tracer,

--- a/frontend/catalyst/jax_extras/patches.py
+++ b/frontend/catalyst/jax_extras/patches.py
@@ -35,11 +35,19 @@ from jax._src.lax.slicing import (
 from jax.core import AbstractValue, Tracer
 
 __all__ = (
+    "_drop_unused_vars2",
     "get_aval2",
     "_no_clean_up_dead_vars",
     "_gather_shape_rule_dynamic",
     "gather2_p",
 )
+
+
+def _drop_unused_vars2(jaxpr, constvals):
+    """
+    A patch to not drop unused vars during classical tracing of control flow.
+    """
+    return jaxpr, list(constvals)
 
 
 def get_aval2(x):

--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -21,6 +21,7 @@ import logging
 from contextlib import ExitStack, contextmanager
 from copy import copy
 from dataclasses import dataclass
+from functools import partial
 from typing import (
     Any,
     Callable,
@@ -46,7 +47,7 @@ from jax._src.lax.control_flow import _initial_style_jaxpr
 from jax._src.lax.slicing import _gather_lower, gather_p
 from jax._src.linear_util import annotate
 from jax._src.pjit import _extract_implicit_args, _flat_axes_specs
-from jax._src.source_info_util import current as jax_current
+from jax._src.source_info_util import current as current_source_info
 from jax._src.util import safe_map, unzip2, wraps
 from jax.api_util import flatten_fun
 from jax.core import (
@@ -380,7 +381,7 @@ def deduce_signatures(
     """
     flat_args, in_tree = tree_flatten((args, kwargs))
     trace: DynamicJaxprTrace = find_top_trace(flat_args)
-    flat_tracers = [trace.to_jaxpr_tracer(a) for a in flat_args]
+    flat_tracers = [trace.to_jaxpr_tracer(a, source_info=current_source_info()) for a in flat_args]
     in_expanded_args, in_type = expand_args(flat_tracers, expansion_strategy=expansion_strategy)
     wf = wrap_init(f, debug_info=debug_info)
     wf, out_tree_promise = flatten_fun(wf, in_tree)
@@ -434,7 +435,7 @@ def trace_to_jaxpr(
 def new_inner_tracer(trace: DynamicJaxprTrace, aval) -> DynamicJaxprTracer:
     """Create a JAX tracer tracing an abstract value ``aval`, without specifying its source
     primitive."""
-    dt = DynamicJaxprTracer(trace, aval, jax_current())
+    dt = DynamicJaxprTracer(trace, aval, current_source_info())
     trace.frame.tracers.append(dt)
     trace.frame.tracer_to_var[id(dt)] = trace.frame.newvar(aval)
     return dt
@@ -735,14 +736,14 @@ def infer_output_type_python(
     """
 
     trace: DynamicJaxprTrace = find_top_trace(expanded_inputs)
-    outputs = [trace.to_jaxpr_tracer(t) for t in outputs]
+    outputs = [trace.to_jaxpr_tracer(t, source_info=current_source_info()) for t in outputs]
 
     # Calculate the constants. We need it to set InDBIdx correctly
     _, _, consts = trace_to_jaxpr(trace, expanded_inputs, outputs)
 
     # Calculate output type containing the correct De Brjuin indices
     expanded_outputs, out_type = infer_output_type(
-        [trace.to_jaxpr_tracer(t) for t in consts],
+        [trace.to_jaxpr_tracer(t, source_info=current_source_info()) for t in consts],
         expanded_inputs,
         outputs,
         expansion_strategy,
@@ -901,8 +902,8 @@ class DynshapePrimitive(JaxprPrimitive):
         # explicitness.
 
         trace = find_top_trace(args)
-        tracers = map(trace.to_jaxpr_tracer, args)
-        source_info = jax_current()
+        tracers = map(partial(trace.to_jaxpr_tracer, source_info=current_source_info()), args)
+        source_info = current_source_info()
 
         in_type = infer_lambda_input_type(None, tracers)
         out_type, effects = self.abstract_eval(*in_type, **params)

--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -77,7 +77,7 @@ from jax.tree_util import (
     tree_unflatten,
     treedef_is_leaf,
 )
-from jaxlib.xla_extension import PyTreeRegistry
+from jaxlib._jax.pytree import PyTreeRegistry
 
 from catalyst.jax_extras.patches import gather2_p, get_aval2
 from catalyst.logging import debug_logger
@@ -252,7 +252,7 @@ def sort_eqns(eqns: List[JaxprEqn], forced_order_primitives: Set[JaxprPrimitive]
 def jaxpr_pad_consts(jaxprs: List[Jaxpr]) -> List[ClosedJaxpr]:
     """Align the constants of Jaxpr programs. Return the list of corresponding programs accepting
     the same constants."""
-    newvar = gensym("_")
+    newvar = gensym()
 
     # List of constant variables of all jaxprs, preprended with '_'
     all_mangled_constvars: List[List[Var]] = []

--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -236,7 +236,13 @@ def sort_eqns(eqns: List[JaxprEqn], forced_order_primitives: Set[JaxprPrimitive]
     for b in boxes:
         origin.update({ov.count: b for ov in b.e.outvars})  # [1]
     for b in boxes:
-        b.parents = [origin[v.count] for v in b.e.invars if v.count in origin]  # [2]
+        b.parents = []
+        for v in b.e.invars:
+            if not isinstance(v, jax._src.core.Var):
+                # constant literal invar, no need to track def use order
+                continue
+            if v.count in origin:
+                b.parents.append(origin[v.count])  # [2]
     for i, q in fixedorder:
         for b in boxes[i + 1 :]:
             b.parents.append(q)  # [3]

--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -82,6 +82,7 @@ from jaxlib._jax.pytree import PyTreeRegistry
 from catalyst.jax_extras.patches import gather2_p, get_aval2
 from catalyst.logging import debug_logger
 from catalyst.tracing.type_signatures import verify_static_argnums_type
+from catalyst.utils.exceptions import CompileError
 from catalyst.utils.patching import Patcher
 
 # pylint: disable=protected-access

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1625,7 +1625,7 @@ def custom_measurement_staging_rule(
 #
 # sample measurement
 #
-def sample_staging_rule(jaxpr_trace, obs, *dynamic_shape, static_shape):
+def sample_staging_rule(jaxpr_trace, _src, obs, *dynamic_shape, static_shape):
     """
     The result shape of `sample_p` is (shots, num_qubits).
     """
@@ -1677,7 +1677,7 @@ def _sample_lowering(
 #
 # counts measurement
 #
-def counts_staging_rule(jaxpr_trace, obs, *dynamic_shape, static_shape):
+def counts_staging_rule(jaxpr_trace, _src, obs, *dynamic_shape, static_shape):
     """
     The result shape of `counts_p` is (tensor<Nxf64>, tensor<Nxi64>)
     where N = 2**number_of_qubits.
@@ -1799,7 +1799,7 @@ def _var_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shape=None):
 #
 # probs measurement
 #
-def probs_staging_rule(jaxpr_trace, obs, *dynamic_shape, static_shape):
+def probs_staging_rule(jaxpr_trace, _src, obs, *dynamic_shape, static_shape):
     """
     The result shape of probs_p is (2^num_qubits,).
     """
@@ -1843,7 +1843,7 @@ def _probs_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, *dynamic_s
 #
 # state measurement
 #
-def state_staging_rule(jaxpr_trace, obs, *dynamic_shape, static_shape):
+def state_staging_rule(jaxpr_trace, _src, obs, *dynamic_shape, static_shape):
     """
     The result shape of state_p is (2^num_qubits,).
     """

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -29,6 +29,7 @@ import jax
 import jax.numpy as jnp
 import pennylane as qml
 from jax._src.lax.lax import _extract_tracers_dyn_shape
+from jax._src.source_info_util import current as current_source_info
 from jax.api_util import debug_info as jdb
 from jax.core import get_aval
 from pennylane import QubitUnitary, QueuingManager
@@ -215,9 +216,12 @@ def retrace_with_result_types(jaxpr: ClosedJaxpr, target_types: List[ShapedArray
     with_qreg = isinstance(target_types[-1], AbstractQreg)
     with EvaluationContext(EvaluationMode.CLASSICAL_COMPILATION) as ctx:
         with EvaluationContext.frame_tracing_context() as trace:
-            in_tracers = _input_type_to_tracers(trace.new_arg, jaxpr.in_avals)
+            in_tracers = _input_type_to_tracers(
+                partial(trace.new_arg, source_info=current_source_info()), jaxpr.in_avals
+            )
             out_tracers = [
-                trace.to_jaxpr_tracer(t) for t in eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, *in_tracers)
+                trace.to_jaxpr_tracer(t, source_info=current_source_info())
+                for t in eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, *in_tracers)
             ]
             out_tracers_, target_types_ = (
                 (out_tracers[:-1], target_types[:-1]) if with_qreg else (out_tracers, target_types)
@@ -1250,8 +1254,14 @@ def trace_post_processing(trace, post_processing: Callable, pp_args, debug_info=
 
         # wffa will take as an input a flatten tracers.
         # After wffa is called, then the shape becomes available in out_tree_promise.
-        in_tracers = [trace.to_jaxpr_tracer(t) for t in tree_flatten(pp_args)[0]]
-        out_tracers = [trace.to_jaxpr_tracer(t) for t in wffa.call_wrapped(*in_tracers)]
+        in_tracers = [
+            trace.to_jaxpr_tracer(t, source_info=current_source_info())
+            for t in tree_flatten(pp_args)[0]
+        ]
+        out_tracers = [
+            trace.to_jaxpr_tracer(t, source_info=current_source_info())
+            for t in wffa.call_wrapped(*in_tracers)
+        ]
         cur_trace = EvaluationContext.get_current_trace()
         jaxpr, out_type, consts = cur_trace.frame.to_jaxpr2(out_tracers, wffa.debug_info)
         closed_jaxpr = ClosedJaxpr(jaxpr, consts)
@@ -1289,7 +1299,9 @@ def trace_function(
 
     with EvaluationContext.frame_tracing_context(debug_info=wfun.debug_info) as trace:
         arg_expanded_tracers = input_type_to_tracers(
-            in_sig.in_type, trace.new_arg, trace.to_jaxpr_tracer
+            in_sig.in_type,
+            partial(trace.new_arg, source_info=current_source_info()),
+            partial(trace.to_jaxpr_tracer, source_info=current_source_info()),
         )
         res_expanded_tracers = wfun.call_wrapped(*arg_expanded_tracers)
 
@@ -1345,7 +1357,9 @@ def trace_quantum_function(
             wffa, in_avals, keep_inputs, out_tree_promise = deduce_avals(
                 f, args, kwargs, static_argnums, debug_info
             )
-            in_classical_tracers = _input_type_to_tracers(trace.new_arg, in_avals)
+            in_classical_tracers = _input_type_to_tracers(
+                partial(trace.new_arg, source_info=current_source_info()), in_avals
+            )
             with QueuingManager.stop_recording(), quantum_tape:
                 # Quantum tape transformations happen at the end of tracing
                 in_classical_tracers = [t for t, k in zip(in_classical_tracers, keep_inputs) if k]
@@ -1438,7 +1452,9 @@ def trace_quantum_function(
                     else:
                         return func(arr)
 
-                meas_tracers = check_full_raise(meas, trace.to_jaxpr_tracer)
+                meas_tracers = check_full_raise(
+                    meas, partial(trace.to_jaxpr_tracer, source_info=current_source_info())
+                )
                 if len(snapshot_results) > 0:
                     # redefine meas_trees PyTree to have same PyTreeRegistry as Snapshot PyTree
                     meas_trees = jax.tree_util.tree_structure(

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -57,7 +57,6 @@ from catalyst.jax_extras import (
     InputSignature,
     OutputSignature,
     PyTreeDef,
-    PyTreeRegistry,
     ShapedArray,
     _input_type_to_tracers,
     cond_expansion_strategy,

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -29,7 +29,6 @@ import jax
 import jax.numpy as jnp
 import pennylane as qml
 from jax._src.lax.lax import _extract_tracers_dyn_shape
-from jax._src.source_info_util import current as current_source_info
 from jax.api_util import debug_info as jdb
 from jax.core import get_aval
 from pennylane import QubitUnitary, QueuingManager
@@ -216,12 +215,9 @@ def retrace_with_result_types(jaxpr: ClosedJaxpr, target_types: List[ShapedArray
     with_qreg = isinstance(target_types[-1], AbstractQreg)
     with EvaluationContext(EvaluationMode.CLASSICAL_COMPILATION) as ctx:
         with EvaluationContext.frame_tracing_context() as trace:
-            in_tracers = _input_type_to_tracers(
-                partial(trace.new_arg, source_info=current_source_info()), jaxpr.in_avals
-            )
+            in_tracers = _input_type_to_tracers(trace.new_arg, jaxpr.in_avals)
             out_tracers = [
-                trace.to_jaxpr_tracer(t, source_info=current_source_info())
-                for t in eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, *in_tracers)
+                trace.to_jaxpr_tracer(t) for t in eval_jaxpr(jaxpr.jaxpr, jaxpr.consts, *in_tracers)
             ]
             out_tracers_, target_types_ = (
                 (out_tracers[:-1], target_types[:-1]) if with_qreg else (out_tracers, target_types)
@@ -1254,14 +1250,8 @@ def trace_post_processing(trace, post_processing: Callable, pp_args, debug_info=
 
         # wffa will take as an input a flatten tracers.
         # After wffa is called, then the shape becomes available in out_tree_promise.
-        in_tracers = [
-            trace.to_jaxpr_tracer(t, source_info=current_source_info())
-            for t in tree_flatten(pp_args)[0]
-        ]
-        out_tracers = [
-            trace.to_jaxpr_tracer(t, source_info=current_source_info())
-            for t in wffa.call_wrapped(*in_tracers)
-        ]
+        in_tracers = [trace.to_jaxpr_tracer(t) for t in tree_flatten(pp_args)[0]]
+        out_tracers = [trace.to_jaxpr_tracer(t) for t in wffa.call_wrapped(*in_tracers)]
         cur_trace = EvaluationContext.get_current_trace()
         jaxpr, out_type, consts = cur_trace.frame.to_jaxpr2(out_tracers, wffa.debug_info)
         closed_jaxpr = ClosedJaxpr(jaxpr, consts)
@@ -1299,9 +1289,7 @@ def trace_function(
 
     with EvaluationContext.frame_tracing_context(debug_info=wfun.debug_info) as trace:
         arg_expanded_tracers = input_type_to_tracers(
-            in_sig.in_type,
-            partial(trace.new_arg, source_info=current_source_info()),
-            partial(trace.to_jaxpr_tracer, source_info=current_source_info()),
+            in_sig.in_type, trace.new_arg, trace.to_jaxpr_tracer
         )
         res_expanded_tracers = wfun.call_wrapped(*arg_expanded_tracers)
 
@@ -1357,9 +1345,7 @@ def trace_quantum_function(
             wffa, in_avals, keep_inputs, out_tree_promise = deduce_avals(
                 f, args, kwargs, static_argnums, debug_info
             )
-            in_classical_tracers = _input_type_to_tracers(
-                partial(trace.new_arg, source_info=current_source_info()), in_avals
-            )
+            in_classical_tracers = _input_type_to_tracers(trace.new_arg, in_avals)
             with QueuingManager.stop_recording(), quantum_tape:
                 # Quantum tape transformations happen at the end of tracing
                 in_classical_tracers = [t for t, k in zip(in_classical_tracers, keep_inputs) if k]
@@ -1452,9 +1438,7 @@ def trace_quantum_function(
                     else:
                         return func(arr)
 
-                meas_tracers = check_full_raise(
-                    meas, partial(trace.to_jaxpr_tracer, source_info=current_source_info())
-                )
+                meas_tracers = check_full_raise(meas, trace.to_jaxpr_tracer)
                 if len(snapshot_results) > 0:
                     # redefine meas_trees PyTree to have same PyTreeRegistry as Snapshot PyTree
                     meas_trees = jax.tree_util.tree_structure(

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -1077,34 +1077,29 @@ def trace_quantum_measurements(
                     # we want to update out_tree to PyTreeDef({0: (*, *), 1: *})
                     # Jax used to have a great util called make_from_node_data_and_children
                     # but they removed it in 0.6.2, so we have to be a bit manual here
-                    def _make_from_node_data_and_children(nodes, children):
-                        if nodes is not None:
-                            # dictionary
-                            mock_dict = dict(zip(nodes, children))
-                            for node_key, child_tree_def in mock_dict.items():
-                                size = len(child_tree_def.children())
-                                if size == 0:
-                                    # No children, just the leave itself
-                                    mock_dict[node_key] = 0
-                                else:
-                                    mock_dict[node_key] = (0,) * size
+                    def _make_from_node_data_and_children(node_data, children):
+                        node_type, node_value = node_data
+
+                        def get_replacement_value(child_tree_def):
+                            size = len(child_tree_def.children())
+                            return 0 if size == 0 else (0,) * size
+
+                        if node_type is dict:
+                            mock_dict = {
+                                node_key: get_replacement_value(child_tree_def)
+                                for node_key, child_tree_def in zip(node_value, children)
+                            }
                             _, out_tree_def = jax.tree_util.tree_flatten(mock_dict)
-                            return out_tree_def
                         else:
-                            # list
-                            mock_list = []
-                            for child_tree_def in children:
-                                size = len(child_tree_def.children())
-                                if size == 0:
-                                    # No children, just the leave itself
-                                    mock_list.append(0)
-                                else:
-                                    mock_list.append((0,) * size)
+                            mock_list = [
+                                get_replacement_value(child_tree_def) for child_tree_def in children
+                            ]
                             _, out_tree_def = jax.tree_util.tree_flatten(mock_list)
-                            return out_tree_def
+
+                        return out_tree_def
 
                     out_tree = _make_from_node_data_and_children(
-                        out_tree.node_data()[1], meas_return_trees_children
+                        out_tree.node_data(), meas_return_trees_children
                     )
 
                 else:

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -1103,7 +1103,7 @@ def trace_quantum_measurements(
                             )
                             _, out_tree_def = jax.tree_util.tree_flatten(mock_list)
                         else:
-                            raise CompileError("Unknown pytree node type")
+                            raise CompileError("Unknown pytree node type")  # pragma: no-cover
 
                         return out_tree_def
 

--- a/frontend/test/lit/test_autograph.py
+++ b/frontend/test/lit/test_autograph.py
@@ -578,7 +578,9 @@ def f():
 @qjit(autograph=True)
 def disable_autograph_decorator_jax(x: float, n: int):
     """Checks that Autograph is disabled for a given function."""
-    # CHECK: body_jaxpr={ lambda ; d:i64[] e:f64[]. let f:f64[] = add e 36.0 in (f,) }
+    # CHECK: body_jaxpr={ lambda ; d:i64[] e:f64[]. let
+    # CHECK:     f:f64[] = add e 36.0:f64[]
+    # CHECK:   in (f,) }
     for _ in range(n):
         x = x + f()
     return x
@@ -605,7 +607,7 @@ def g():
 @qjit(autograph=True)
 def enable_autograph_decorator_jax(x: float, n: int):
     """Checks that Autograph is enabled for a given function."""
-    # CHECK: branch_jaxprs=[{ lambda ; . let  in (36,) }, { lambda ; . let  in (216,) }]
+    # CHECK: branch_jaxprs=[{ lambda ; . let  in (36:i64[],) }, { lambda ; . let  in (216:i64[],) }]
     for _ in range(n):
         x = x + g()
     return x
@@ -632,7 +634,7 @@ def h():
 @qjit(autograph=True)
 def disable_autograph_context_manager_jax():
     """Checks that Autograph is disabled for a given context."""
-    # CHECK: { lambda ; . let in (36.4,) }
+    # CHECK: { lambda ; . let in (36.4:f64[],) }
     x = 0.4
     with disable_autograph:
         x += h()
@@ -660,7 +662,7 @@ def func():
 @qjit(autograph=True)
 def enable_autograph_context_manager_jax():
     """Checks that Autograph is enabled with no context."""
-    # CHECK: branch_jaxprs=[{ lambda ; . let  in (36,) }, { lambda ; . let  in (216,) }]
+    # CHECK: branch_jaxprs=[{ lambda ; . let  in (36:i64[],) }, { lambda ; . let  in (216:i64[],) }]
     x = 0.4
     x += func()
     return x
@@ -677,7 +679,7 @@ print(enable_autograph_context_manager_jax.jaxpr)
 @qjit(autograph=True, autograph_include=["catalyst.utils.dummy"])
 def include_module_to_autograph(x: float, n: int):
     """Checks that a module is included to Autograph conversion."""
-    # CHECK: branch_jaxprs=[{ lambda ; . let  in (36,) }, { lambda ; . let  in (216,) }]
+    # CHECK: branch_jaxprs=[{ lambda ; . let  in (36:i64[],) }, { lambda ; . let  in (216:i64[],) }]
     for _ in range(n):
         x = x + dummy_func(6)
     return x
@@ -694,7 +696,9 @@ print(include_module_to_autograph.jaxpr)
 @qjit(autograph=True)
 def excluded_module_from_autograph(x: float, n: int):
     """Checks that a module is excluded from Autograph conversion."""
-    # CHECK: body_jaxpr={ lambda ; d:i64[] e:f64[]. let f:f64[] = add e 36.0 in (f,) }
+    # CHECK: body_jaxpr={ lambda ; d:i64[] e:f64[]. let
+    # CHECK:     f:f64[] = add e 36.0:f64[]
+    # CHECK:   in (f,) }
     for _ in range(n):
         x = x + dummy_func(6)
     return x

--- a/frontend/test/lit/test_jax_dynamic_api.py
+++ b/frontend/test/lit/test_jax_dynamic_api.py
@@ -61,7 +61,7 @@ def test_qjit_dynamic_result(a):
     # CHECK:       { lambda ; [[a:.]]:i64[]. let
     # CHECK:         [[b:.]]:i64[] = add [[a]] 1
     # CHECK:         [[c:.]]:f64[[[b]]] = {{[a-z_0-9.]+\[[^]]*}}
-    # CHECK:           ] 1.0 [[b]]
+    # CHECK:           ] 1.0:f64[] [[b]]
     # CHECK:       in ([[b]], [[c]]) }
     return jnp.ones((a + 1,), dtype=float)
 

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -34,10 +34,10 @@ class TestCondToJaxpr:
         expected = dedent(
             """
             { lambda ; a:i64[]. let
-                b:bool[] = eq a 5
+                b:bool[] = eq a 5:i64[]
                 c:i64[] = cond[
-                  branch_jaxprs=[{ lambda ; a:i64[] b_:i64[]. let c:i64[] = integer_pow[y=2] a in (c,) },
-                                 { lambda ; a_:i64[] b:i64[]. let c:i64[] = integer_pow[y=3] b in (c,) }]
+                  branch_jaxprs=[{ lambda ; a:i64[] b:i64[]. let c:i64[] = integer_pow[y=2] a in (c,) },
+                                 { lambda ; a:i64[] b:i64[]. let c:i64[] = integer_pow[y=3] b in (c,) }]
                   nimplicit_outputs=0
                 ] b a a
               in (c,) }

--- a/frontend/test/pytest/test_from_plxpr_qregmanager.py
+++ b/frontend/test/pytest/test_from_plxpr_qregmanager.py
@@ -242,16 +242,16 @@ class TestQubitValues:
         with take_current_trace() as trace:
             # Checking via jaxpr internals is a bit tedious here
             # So let's just check the string...
-            observed_jaxpr = str(trace.to_jaxpr([], None)[0])
+            observed_jaxpr = str(trace.to_jaxpr([], None, None)[0])
             expected = """\
             { lambda ; . let
-                a:AbstractQreg() = qalloc 42
-                b:AbstractQbit() = qextract a 0
-                c:AbstractQbit() = qextract a 1
-                d:AbstractQbit() = qextract a 2
-                e:AbstractQreg() = qinsert a 0 b
-                f:AbstractQreg() = qinsert e 1 c
-                _:AbstractQreg() = qinsert f 2 d
+                a:AbstractQreg() = qalloc 42:i64[]
+                b:AbstractQbit() = qextract a 0:i64[]
+                c:AbstractQbit() = qextract a 1:i64[]
+                d:AbstractQbit() = qextract a 2:i64[]
+                e:AbstractQreg() = qinsert a 0:i64[] b
+                f:AbstractQreg() = qinsert e 1:i64[] c
+                _:AbstractQreg() = qinsert f 2:i64[] d
               in () }"""
             expected = textwrap.dedent(expected)
             assert observed_jaxpr == expected
@@ -328,17 +328,17 @@ class TestQregAndQubit:
 
         with take_current_trace() as trace:
             # Check full jaxpr
-            observed_jaxpr = str(trace.to_jaxpr([], None)[0])
+            observed_jaxpr = str(trace.to_jaxpr([], None, None)[0])
             expected = """\
             { lambda ; . let
-                a:AbstractQreg() = qalloc 42
-                b:AbstractQbit() = qextract a 0
-                c:AbstractQbit() = qextract a 1
+                a:AbstractQreg() = qalloc 42:i64[]
+                b:AbstractQbit() = qextract a 0:i64[]
+                c:AbstractQbit() = qextract a 1:i64[]
                 d:AbstractQbit() e:AbstractQbit() = qubit_mock_op b c
-                f:AbstractQreg() = qinsert a 0 d
-                g:AbstractQreg() = qinsert f 1 e
+                f:AbstractQreg() = qinsert a 0:i64[] d
+                g:AbstractQreg() = qinsert f 1:i64[] e
                 h:AbstractQreg() = qreg_mock_op g
-                i:AbstractQbit() = qextract h 0
+                i:AbstractQbit() = qextract h 0:i64[]
                 _:AbstractQbit() = qubit_mock_op i
               in () }"""
             expected = textwrap.dedent(expected)

--- a/frontend/test/pytest/test_from_plxpr_qregmanager.py
+++ b/frontend/test/pytest/test_from_plxpr_qregmanager.py
@@ -36,6 +36,7 @@ Quoted from the object's docstring:
 import textwrap
 
 import pytest
+from jax._src.core import Literal
 from jax.api_util import debug_info as jdb
 from jax.core import set_current_trace, take_current_trace
 from jax.extend.core import Primitive
@@ -155,7 +156,8 @@ class TestQubitValues:
             # Check that the extract primitive follows the wire index in the qreg manager
             # __getitem__ method
             extract_p_index_invar = trace.frame.eqns[-1].invars[-1]
-            assert trace.frame.constvar_to_val[extract_p_index_invar] == 0
+            assert isinstance(extract_p_index_invar, Literal)
+            assert extract_p_index_invar.val == 0
 
     def test_no_overwriting_extract(self):
         """Test that no new qubit is extracted when indexing into an existing wire"""
@@ -183,10 +185,9 @@ class TestQubitValues:
 
         # Also check with actual jaxpr variables
         with take_current_trace() as trace:
-            var_to_tracer = dict((v, t_id) for t_id, v in trace.frame.tracer_to_var.items())
             gate_out_qubits = trace.frame.eqns[-1].outvars
-            assert id(qreg_manager[0]) == var_to_tracer[gate_out_qubits[0]]
-            assert id(qreg_manager[1]) == var_to_tracer[gate_out_qubits[1]]
+            assert trace.frame.tracer_to_var[id(qreg_manager[0])] == gate_out_qubits[0]
+            assert trace.frame.tracer_to_var[id(qreg_manager[1])] == gate_out_qubits[1]
 
     def test_iter(self):
         """Test __iter__ in the qreg manager"""
@@ -217,10 +218,9 @@ class TestQubitValues:
 
         # Also check with actual jaxpr variables
         with take_current_trace() as trace:
-            var_to_tracer = dict((v, t_id) for t_id, v in trace.frame.tracer_to_var.items())
             gate_out_qubits = trace.frame.eqns[-1].outvars
-            assert id(qreg_manager[0]) == var_to_tracer[gate_out_qubits[0]]
-            assert id(qreg_manager[1]) == var_to_tracer[gate_out_qubits[1]]
+            assert trace.frame.tracer_to_var[id(qreg_manager[0])] == gate_out_qubits[0]
+            assert trace.frame.tracer_to_var[id(qreg_manager[1])] == gate_out_qubits[1]
 
     def test_insert_all_dangling_qubits(self):
         """

--- a/frontend/test/pytest/test_jax_dynamic_api.py
+++ b/frontend/test/pytest/test_jax_dynamic_api.py
@@ -20,6 +20,7 @@ import numpy as np
 import pennylane as qml
 import pytest
 from jax import numpy as jnp
+from jax._src.source_info_util import current as current_source_info
 from numpy import array_equal
 from numpy.testing import assert_allclose
 
@@ -1124,9 +1125,14 @@ def test_trace_to_jaxpr():
             return i < 3
 
         with EvaluationContext.frame_tracing_context() as trace:
-            sz2 = trace.to_jaxpr_tracer(sz)
-            i = trace.new_arg(ShapedArray(shape=[], dtype=jnp.dtype("int64")))
-            a = trace.new_arg(DShapedArray(shape=[sz2], dtype=jnp.dtype("float64")))
+            sz2 = trace.to_jaxpr_tracer(sz, source_info=current_source_info())
+            i = trace.new_arg(
+                ShapedArray(shape=[], dtype=jnp.dtype("int64")), source_info=current_source_info()
+            )
+            a = trace.new_arg(
+                DShapedArray(shape=[sz2], dtype=jnp.dtype("float64")),
+                source_info=current_source_info(),
+            )
             r = f(i, a)
 
             jaxpr, _, _ = trace_to_jaxpr(trace, [i, a], [r])

--- a/frontend/test/pytest/test_jax_dynamic_api.py
+++ b/frontend/test/pytest/test_jax_dynamic_api.py
@@ -20,7 +20,6 @@ import numpy as np
 import pennylane as qml
 import pytest
 from jax import numpy as jnp
-from jax._src.source_info_util import current as current_source_info
 from numpy import array_equal
 from numpy.testing import assert_allclose
 
@@ -1125,14 +1124,9 @@ def test_trace_to_jaxpr():
             return i < 3
 
         with EvaluationContext.frame_tracing_context() as trace:
-            sz2 = trace.to_jaxpr_tracer(sz, source_info=current_source_info())
-            i = trace.new_arg(
-                ShapedArray(shape=[], dtype=jnp.dtype("int64")), source_info=current_source_info()
-            )
-            a = trace.new_arg(
-                DShapedArray(shape=[sz2], dtype=jnp.dtype("float64")),
-                source_info=current_source_info(),
-            )
+            sz2 = trace.to_jaxpr_tracer(sz)
+            i = trace.new_arg(ShapedArray(shape=[], dtype=jnp.dtype("int64")))
+            a = trace.new_arg(DShapedArray(shape=[sz2], dtype=jnp.dtype("float64")))
             r = f(i, a)
 
             jaxpr, _, _ = trace_to_jaxpr(trace, [i, a], [r])

--- a/frontend/test/pytest/test_loops.py
+++ b/frontend/test/pytest/test_loops.py
@@ -34,13 +34,17 @@ class TestLoopToJaxpr:
             """
             { lambda ; a:f64[]. let
                 b:i64[] c:f64[] = while_loop[
-                  body_jaxpr={ lambda ; d:i64[] e:f64[]. let f:i64[] = add d 1 in (f, e) }
+                  body_jaxpr={ lambda ; d:i64[] e:f64[]. let
+                      f:i64[] = add d 1:i64[]
+                    in (f, e) }
                   body_nconsts=0
-                  cond_jaxpr={ lambda ; g:i64[] h:f64[]. let i:bool[] = lt g 10 in (i,) }
+                  cond_jaxpr={ lambda ; g:i64[] h:f64[]. let
+                      i:bool[] = lt g 10:i64[]
+                    in (i,) }
                   cond_nconsts=0
                   nimplicit=0
                   preserve_dimensions=True
-                ] 0 a
+                ] 0:i64[] a
               in (b, c) }
             """
         )
@@ -64,12 +68,12 @@ class TestLoopToJaxpr:
                 c:i64[] d:f64[] = for_loop[
                   apply_reverse_transform=False
                   body_jaxpr={ lambda ; e:i64[] f:i64[] g:f64[]. let
-                      h:i64[] = add f 1
+                      h:i64[] = add f 1:i64[]
                     in (h, g) }
                   body_nconsts=0
                   nimplicit=0
                   preserve_dimensions=True
-                ] 0 b 1 0 0 a
+                ] 0:i64[] b 1:i64[] 0:i64[] 0:i64[] a
               in (c, d) }
         """
         )


### PR DESCRIPTION
**Context:**
Updating jax from 0.6.0 to 0.6.2. 

**Description of the Change:**
1. A few jaxpr internals started requiring a `source_info` argument. https://github.com/jax-ml/jax/pull/28103
   At any point in the program, the current source info at that point can be retrieved by `jax._src.source_info.current()`.
   The impacted functions are 
   - `DynamicJaxprTrace.to_jaxpr_tracer, new_arg`
   - Primitives with custom staging rules (https://github.com/jax-ml/jax/pull/29347). For us, this is `sample_p, counts_p, probs_p, state_p`. For core pennylane this is updated in https://github.com/PennyLaneAI/pennylane/pull/7887
2. Literals are now inlined into jaxpr equations https://github.com/jax-ml/jax/pull/28233. This has the following impacts:
   - Firstly, when printing jaxpr, the types of literals are now printed. This required a few lit-ish tests to update.
   - When topoligically sorting equations, the invars to equations are not necessaily all `Var`s, but can now be `Literal`s as well. In the sorting algorithm we tap into the internals of `Var`, but this would break if an invar is a `Literal`. This is actually very easy to fix, as literals do not effect topological ordering and do not need to be dealt with, so we just skip over them during sorting
3. In the same above jax commit, during tracing they now drop unused variables. Concretely, right before exiting `DynamicJaxprTrace.to_jaxpr (and to_jaxpr2)`, they now call `_drop_unused_var()` on the traced jaxpr. This is usually fine, but in our control flow's tracing, we trace the classical part of the inner region first before tracing the quantum tape (see [`HybridOp`](https://github.com/PennyLaneAI/catalyst/blob/main/frontend/catalyst/jax_tracer.py#L416)). This means the classical variables used by the quantum tape, which is "unused" at the end of the classical tracing, will be dropped, and breaks quantum tracing. So we patch `_drop_unused_var()` to do nothing when tracing the classical part of control flow ops.
4. `PytreeDef.make_from_node_data_and_children()` has been removed (with no replacement) https://github.com/jax-ml/jax/pull/29491. I do this manually now.


[sc-95175]