### PR TITLE
add Hermitian observable support to `from_plxpr`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -12,9 +12,11 @@
 
 <h3>Internal changes ⚙️</h3>
 
-* `from_plxpr` now supports adjoint and ctrl operations and transforms.
+* `from_plxpr` now supports adjoint and ctrl operations and transforms,
+  and `Hermitian` obsservables.
   [(#1844)](https://github.com/PennyLaneAI/catalyst/pull/1844)
   [(#1850)](https://github.com/PennyLaneAI/catalyst/pull/1850)
+
 
 <h3>Documentation 📝</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -13,7 +13,7 @@
 <h3>Internal changes ⚙️</h3>
 
 * `from_plxpr` now supports adjoint and ctrl operations and transforms,
-  and `Hermitian` obsservables.
+  and `Hermitian` observables.
   [(#1844)](https://github.com/PennyLaneAI/catalyst/pull/1844)
   [(#1850)](https://github.com/PennyLaneAI/catalyst/pull/1850)
   [(#1903)](https://github.com/PennyLaneAI/catalyst/pull/1903)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -16,6 +16,7 @@
   and `Hermitian` obsservables.
   [(#1844)](https://github.com/PennyLaneAI/catalyst/pull/1844)
   [(#1850)](https://github.com/PennyLaneAI/catalyst/pull/1850)
+  [(#1903)](https://github.com/PennyLaneAI/catalyst/pull/1903)
 
 
 <h3>Documentation 📝</h3>

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -71,6 +71,7 @@ from catalyst.jax_primitives import (
     state_p,
     unitary_p,
     var_p,
+    hermitian_p
 )
 from catalyst.passes.pass_api import Pass
 
@@ -355,6 +356,8 @@ class PLxPRToQuantumJaxprInterpreter(PlxprInterpreter):
         if obs.arithmetic_depth > 0:
             raise NotImplementedError("operator arithmetic not yet supported for conversion.")
         wires = [self.qreg_manager[w] for w in obs.wires]
+        if obs.name == "Hermitian":
+            return hermitian_p.bind(obs.data[0], *wires)
         return namedobs_p.bind(*wires, *obs.data, kind=obs.name)
 
     def _compbasis_obs(self, *wires):

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -56,6 +56,7 @@ from catalyst.jax_primitives import (
     device_release_p,
     expval_p,
     gphase_p,
+    hermitian_p,
     measure_in_basis_p,
     measure_p,
     namedobs_p,
@@ -71,7 +72,6 @@ from catalyst.jax_primitives import (
     state_p,
     unitary_p,
     var_p,
-    hermitian_p
 )
 from catalyst.passes.pass_api import Pass
 

--- a/frontend/test/pytest/conftest.py
+++ b/frontend/test/pytest/conftest.py
@@ -47,3 +47,14 @@ def disable_capture():
     finally:
         if qml.capture.enabled():
             qml.capture.disable()
+
+@pytest.fixture(params=["capture", "no_capture"], scope="function")
+def use_both_frontend(request):
+    if request.param == "capture":
+        qml.capture.enable()
+        try:
+            yield
+        finally:
+            qml.capture.disable()
+    else:
+        yield

--- a/frontend/test/pytest/conftest.py
+++ b/frontend/test/pytest/conftest.py
@@ -51,6 +51,7 @@ def disable_capture():
 
 @pytest.fixture(params=["capture", "no_capture"], scope="function")
 def use_both_frontend(request):
+    """Runs the test once with capture enabled and once with it disabled."""
     if request.param == "capture":
         qml.capture.enable()
         try:

--- a/frontend/test/pytest/conftest.py
+++ b/frontend/test/pytest/conftest.py
@@ -48,6 +48,7 @@ def disable_capture():
         if qml.capture.enabled():
             qml.capture.disable()
 
+
 @pytest.fixture(params=["capture", "no_capture"], scope="function")
 def use_both_frontend(request):
     if request.param == "capture":

--- a/frontend/test/pytest/test_from_plxpr.py
+++ b/frontend/test/pytest/test_from_plxpr.py
@@ -864,6 +864,7 @@ class TestHybridPrograms:
 
 
 class TestObservables:
+    """Groups tests involving different kinds of observables"""
 
     def test_hermitian(self):
         """Test a hermitian can be converted"""

--- a/frontend/test/pytest/test_from_plxpr.py
+++ b/frontend/test/pytest/test_from_plxpr.py
@@ -26,11 +26,11 @@ from catalyst.from_plxpr import from_plxpr
 from catalyst.jax_primitives import (
     adjoint_p,
     get_call_jaxpr,
+    hermitian_p,
     qalloc_p,
     qextract_p,
     qinsert_p,
     qinst_p,
-    hermitian_p
 )
 
 pytestmark = pytest.mark.usefixtures("disable_capture")
@@ -870,16 +870,16 @@ class TestObservables:
 
         qml.capture.enable()
 
-        @qml.qnode(qml.device('lightning.qubit', wires=2))
+        @qml.qnode(qml.device("lightning.qubit", wires=2))
         def c(mat):
-            return qml.expval(qml.Hermitian(mat, wires=(0,1)))
+            return qml.expval(qml.Hermitian(mat, wires=(0, 1)))
 
         mat = (qml.X(0) @ qml.Y(1)).matrix()
 
         plxpr = jax.make_jaxpr(c)(mat)
         catalyst_xpr = from_plxpr(plxpr)(mat)
 
-        qfunc = catalyst_xpr.eqns[0].params['call_jaxpr']
+        qfunc = catalyst_xpr.eqns[0].params["call_jaxpr"]
 
         assert qfunc.eqns[4].primitive == hermitian_p
         assert qfunc.eqns[4].params == {}
@@ -888,6 +888,7 @@ class TestObservables:
         assert qfunc.eqns[4].invars[2] == qfunc.eqns[3].outvars[0]
 
         assert qfunc.eqns[5].invars[0] == qfunc.eqns[4].outvars[0]
+
 
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_measurements_results.py
+++ b/frontend/test/pytest/test_measurements_results.py
@@ -167,6 +167,8 @@ class TestCounts:
 
 
 class TestExpval:
+
+    @pytest.mark.usefixtures("use_both_frontend")
     def test_named(self, backend):
         """Test expval for named observables."""
 
@@ -184,6 +186,7 @@ class TestExpval:
         observed = expval1(np.pi)
         assert np.isclose(observed, expected)
 
+    @pytest.mark.usefixtures("use_both_frontend")
     def test_hermitian_1(self, backend):
         """Test expval for Hermitian observable."""
 
@@ -204,6 +207,7 @@ class TestExpval:
         observed = expval2(np.pi / 2)
         assert np.isclose(observed, expected)
 
+    @pytest.mark.usefixtures("use_both_frontend")
     def test_hermitian_2(self, backend):
         """Test expval for Hermitian observable."""
 
@@ -393,6 +397,8 @@ class TestExpval:
 
 
 class TestVar:
+
+    @pytest.mark.usefixtures("use_both_frontend")
     def test_rx(self, backend):
         """Test var with RX."""
 
@@ -408,6 +414,7 @@ class TestVar:
         observed = var1(np.pi)
         assert np.isclose(observed, expected)
 
+    @pytest.mark.usefixtures("use_both_frontend")
     def test_hadamard(self, backend):
         """Test var with Hadamard."""
 
@@ -423,6 +430,7 @@ class TestVar:
         observed = var2(np.pi)
         assert np.isclose(observed, expected)
 
+    @pytest.mark.usefixtures("use_both_frontend")
     def test_hermitian_1(self, backend):
         """Test variance for Hermitian observable."""
 
@@ -443,6 +451,7 @@ class TestVar:
         observed = circuit(np.pi / 2)
         assert np.isclose(observed, expected)
 
+    @pytest.mark.usefixtures("use_both_frontend")
     def test_hermitian_2(self, backend):
         """Test variance for Hermitian observable."""
 

--- a/frontend/test/pytest/test_measurements_shots_results.py
+++ b/frontend/test/pytest/test_measurements_shots_results.py
@@ -24,6 +24,7 @@ from catalyst import CompileError, qjit
 class TestExpval:
     "Test expval with shots > 0"
 
+    @pytest.mark.usefixtures("use_both_frontend")
     def test_identity(self, backend, tol_stochastic):
         """Test that identity expectation value (i.e. the trace) is 1."""
         n_wires = 2
@@ -44,6 +45,7 @@ class TestExpval:
         result = qjit(circuit, seed=37)()
         assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
+    @pytest.mark.usefixtures("use_both_frontend")
     def test_pauliz(self, backend, tol_stochastic):
         """Test that PauliZ expectation value is correct"""
         n_wires = 2
@@ -64,6 +66,7 @@ class TestExpval:
         result = qjit(circuit, seed=37)()
         assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
+    @pytest.mark.usefixtures("use_both_frontend")
     def test_paulix(self, backend, tol_stochastic):
         """Test that PauliX expectation value is correct"""
         n_wires = 2
@@ -84,6 +87,7 @@ class TestExpval:
         result = qjit(circuit, seed=37)()
         assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
+    @pytest.mark.usefixtures("use_both_frontend")
     def test_pauliy(self, backend, tol_stochastic):
         """Test that PauliY expectation value is correct"""
         n_wires = 2
@@ -104,6 +108,7 @@ class TestExpval:
         result = qjit(circuit, seed=37)()
         assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
+    @pytest.mark.usefixtures("use_both_frontend")
     def test_hadamard(self, backend, tol_stochastic):
         """Test that Hadamard expectation value is correct"""
         n_wires = 2
@@ -124,6 +129,7 @@ class TestExpval:
         result = qjit(circuit, seed=37)()
         assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
+    @pytest.mark.usefixtures("use_both_frontend")
     def test_hermitian(self, backend, tol_stochastic):
         """Test expval Hermitian observables with shots."""
         n_wires = 3
@@ -233,6 +239,7 @@ class TestExpval:
 class TestVar:
     "Test var with shots > 0"
 
+    @pytest.mark.usefixtures("use_both_frontend")
     def test_identity(self, backend, tol_stochastic):
         """Test that identity variance value (i.e. the trace) is 1."""
         n_wires = 2
@@ -253,6 +260,7 @@ class TestVar:
         result = qjit(circuit, seed=37)()
         assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
+    @pytest.mark.usefixtures("use_both_frontend")
     def test_pauliz(self, backend, tol_stochastic):
         """Test that PauliZ variance value is correct"""
         n_wires = 2
@@ -273,6 +281,7 @@ class TestVar:
         result = qjit(circuit, seed=37)()
         assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
+    @pytest.mark.usefixtures("use_both_frontend")
     def test_paulix(self, backend, tol_stochastic):
         """Test that PauliX variance value is correct"""
         n_wires = 2
@@ -293,6 +302,7 @@ class TestVar:
         result = qjit(circuit, seed=37)()
         assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
+    @pytest.mark.usefixtures("use_both_frontend")
     def test_pauliy(self, backend, tol_stochastic):
         """Test that PauliY variance value is correct"""
         n_wires = 2
@@ -313,6 +323,7 @@ class TestVar:
         result = qjit(circuit, seed=37)()
         assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
+    @pytest.mark.usefixtures("use_both_frontend")
     def test_hadamard(self, backend, tol_stochastic):
         """Test that Hadamard variance value is correct"""
         n_wires = 2
@@ -333,6 +344,7 @@ class TestVar:
         result = qjit(circuit, seed=37)()
         assert np.allclose(result, expected, atol=tol_stochastic, rtol=tol_stochastic)
 
+    @pytest.mark.usefixtures("use_both_frontend")
     def test_hermitian_shots(self, backend, tol_stochastic):
         """Test var Hermitian observables with shots."""
         n_wires = 3


### PR DESCRIPTION

**Context:**

**Description of the Change:**

Adds support for measuring `qml.Hermitian` observables.

**Benefits:**

More complete coverage of the plxpr frontend.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-95506]