### PR TITLE
Add Layer and Yield operations to QEC dialect

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -16,10 +16,16 @@
   [(#1844)](https://github.com/PennyLaneAI/catalyst/pull/1844)
   [(#1850)](https://github.com/PennyLaneAI/catalyst/pull/1850)
 
+* Add `qec.layer` and `qec.yield` operations to the QEC dialect, that represent a group
+  of QEC operations. The main use case is to analyze the depth of circuit.
+  Also, this is a preliminary step towards supporting parallel execution of QEC layers.
+  [(#1917)](https://github.com/PennyLaneAI/catalyst/pull/1917)
+
 <h3>Documentation 📝</h3>
 
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
 
+Sengthai Heng
 Christina Lee

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -22,7 +22,6 @@
   [(#1903)](https://github.com/PennyLaneAI/catalyst/pull/1903)
   [(#1896)](https://github.com/PennyLaneAI/catalyst/pull/1896)
 
-
 * Add `qec.layer` and `qec.yield` operations to the QEC dialect, that represent a group
   of QEC operations. The main use case is to analyze the depth of circuit.
   Also, this is a preliminary step towards supporting parallel execution of QEC layers.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -36,4 +36,4 @@ This release contains contributions from (in alphabetical order):
 
 Sengthai Heng,
 Christina Lee,
-Paul Haochen Wang
+Paul Haochen Wang.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -22,8 +22,8 @@
   [(#1903)](https://github.com/PennyLaneAI/catalyst/pull/1903)
   [(#1896)](https://github.com/PennyLaneAI/catalyst/pull/1896)
 
-* Add `qec.layer` and `qec.yield` operations to the QEC dialect, that represent a group
-  of QEC operations. The main use case is to analyze the depth of circuit.
+* The `qec.layer` and `qec.yield` operations have been added to the QEC dialect to represent a group
+  of QEC operations. The main use case is to analyze the depth of a circuit.
   Also, this is a preliminary step towards supporting parallel execution of QEC layers.
   [(#1917)](https://github.com/PennyLaneAI/catalyst/pull/1917)
 

--- a/mlir/include/QEC/IR/QECDialect.h
+++ b/mlir/include/QEC/IR/QECDialect.h
@@ -18,6 +18,8 @@
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/Interfaces/ControlFlowInterfaces.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
 
 #include "QEC/IR/QECOpInterfaces.h"
 

--- a/mlir/include/QEC/IR/QECDialect.td
+++ b/mlir/include/QEC/IR/QECDialect.td
@@ -19,6 +19,8 @@ include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/DialectBase.td"
 include "mlir/IR/OpBase.td"
 include "mlir/IR/EnumAttr.td"
+include "mlir/Interfaces/ControlFlowInterfaces.td"  // for ReturnLike
+include "mlir/Interfaces/SideEffectInterfaces.td" // for Pure
 
 include "Quantum/IR/QuantumDialect.td"
 include "QEC/IR/QECOpInterfaces.td"
@@ -76,8 +78,12 @@ def LogicalInitKind : I32EnumAttr<"LogicalInitKind",
 // QEC dialect attributes.
 //===----------------------------------------------------------------------===//
 
-def PauliWord : TypedArrayAttrBase<StrAttr, "A product of Pauli operators, aka a Pauli word.">;
-def LogicalInit : EnumAttr<QECDialect, LogicalInitKind, "enum">;
+def PauliWord : TypedArrayAttrBase<StrAttr, "A product of Pauli operators, aka a Pauli word."> {
+    let cppNamespace = "::catalyst::qec";
+}
+def LogicalInit : EnumAttr<QECDialect, LogicalInitKind, "enum"> {
+    let cppNamespace = "::catalyst::qec";
+}
 
 //===----------------------------------------------------------------------===//
 // QEC dialect operations.
@@ -547,4 +553,66 @@ def SelectPPMeasurementOp : QEC_Op<"select.ppm"> {
     
     let hasVerifier = 1;
 }
+
+def LayerOp : QEC_Op<"layer", [SingleBlockImplicitTerminator<"YieldOp">]> {
+    let summary = "A layer operation";
+
+    let description = [{
+    The `qec.layer` operation represent a group of PPR/PPM operations 
+    that mutual commuting each other in the group or acting on different qubits.
+    
+    `qec.layer` operate on carried variables and returns the final values after termination.
+
+    The body region must contain exactly one block that terminates with `qec.yield`.
+
+    Example:
+    ```mlir
+    func.func @layer(%arg0 : !quantum.bit, %arg1 : i1) -> i1{
+        %m, %0 = qec.layer(%q0 = %arg0, %c = %arg1) : !quantum.bit, i1 {
+            %res, %q_1 = qec.ppm ["Z"](4) %q0 cond(%c): !quantum.bit
+            qec.yield %res, %q_1 : i1, !quantum.bit
+        }
+        func.return %m : i1
+    }
+    ```
+    }];
+
+    let arguments = (ins Variadic<AnyType>: $initArgs);
+
+    let results = (outs Variadic<AnyType>:$results);
+    let regions = (region SizedRegion<1>:$region);
+
+   let skipDefaultBuilders = 1;
+    let builders = [
+      OpBuilder<(ins
+        CArg<"mlir::ValueRange", "std::nullopt">:$initArgs,
+        CArg<"llvm::function_ref<void(mlir::OpBuilder &, mlir::Location, mlir::ValueRange)>",
+            "nullptr">)>
+    ];
+
+    let extraClassDeclaration = [{
+      using BodyBuilderFn =
+          llvm::function_ref<void(mlir::OpBuilder &, mlir::Location, mlir::ValueRange)>;
+
+    }];
+
+    let hasCustomAssemblyFormat = 1;
+}
+
+def YieldOp : QEC_Op<"yield", [ Pure, ReturnLike, Terminator, ParentOneOf<["LayerOp"]> ]> {
+    let summary = "Return results from a layer region";
+
+    let arguments = (ins
+        Variadic<AnyType>:$results
+    );
+
+    let assemblyFormat = [{
+        attr-dict ($results^ `:` type($results))?
+    }];
+
+    let builders = [
+        OpBuilder<(ins), [{ /* nothing to do */ }]>
+    ];
+}
+
 #endif // QEC_DIALECT

--- a/mlir/include/QEC/IR/QECDialect.td
+++ b/mlir/include/QEC/IR/QECDialect.td
@@ -78,12 +78,8 @@ def LogicalInitKind : I32EnumAttr<"LogicalInitKind",
 // QEC dialect attributes.
 //===----------------------------------------------------------------------===//
 
-def PauliWord : TypedArrayAttrBase<StrAttr, "A product of Pauli operators, aka a Pauli word."> {
-    let cppNamespace = "::catalyst::qec";
-}
-def LogicalInit : EnumAttr<QECDialect, LogicalInitKind, "enum"> {
-    let cppNamespace = "::catalyst::qec";
-}
+def PauliWord : TypedArrayAttrBase<StrAttr, "A product of Pauli operators, aka a Pauli word.">;
+def LogicalInit : EnumAttr<QECDialect, LogicalInitKind, "enum">;
 
 //===----------------------------------------------------------------------===//
 // QEC dialect operations.

--- a/mlir/include/QEC/IR/QECDialect.td
+++ b/mlir/include/QEC/IR/QECDialect.td
@@ -554,16 +554,16 @@ def LayerOp : QEC_Op<"layer", [SingleBlockImplicitTerminator<"YieldOp">]> {
     let summary = "A layer operation";
 
     let description = [{
-    The `qec.layer` operation represent a group of PPR/PPM operations 
-    that mutual commuting each other in the group or acting on different qubits.
+    The `qec.layer` operation represents a group of PPR/PPM operations that are
+    either mutually commutative within the group or act on different qubits.
     
-    `qec.layer` operate on carried variables and returns the final values after termination.
+    `qec.layer` operates on carried variables and returns the final values after termination.
 
     The body region must contain exactly one block that terminates with `qec.yield`.
 
     Example:
     ```mlir
-    func.func @layer(%arg0 : !quantum.bit, %arg1 : i1) -> i1{
+    func.func @layer(%arg0 : !quantum.bit, %arg1 : i1) -> i1 {
         %m, %0 = qec.layer(%q0 = %arg0, %c = %arg1) : !quantum.bit, i1 {
             %res, %q_1 = qec.ppm ["Z"](4) %q0 cond(%c): !quantum.bit
             qec.yield %res, %q_1 : i1, !quantum.bit
@@ -578,7 +578,7 @@ def LayerOp : QEC_Op<"layer", [SingleBlockImplicitTerminator<"YieldOp">]> {
     let results = (outs Variadic<AnyType>:$results);
     let regions = (region SizedRegion<1>:$region);
 
-   let skipDefaultBuilders = 1;
+    let skipDefaultBuilders = 1;
     let builders = [
       OpBuilder<(ins
         CArg<"mlir::ValueRange", "std::nullopt">:$initArgs,

--- a/mlir/lib/QEC/IR/QECDialect.cpp
+++ b/mlir/lib/QEC/IR/QECDialect.cpp
@@ -16,6 +16,11 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpImplementation.h"
 #include "llvm/ADT/TypeSwitch.h" // needed for enums
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/Support/LogicalResult.h>
+#include <mlir/IR/OperationSupport.h>
+#include <mlir/IR/Region.h>
+#include <tuple>
 
 #include "QEC/IR/QECDialect.h"
 #include "Quantum/IR/QuantumDialect.h"
@@ -119,4 +124,89 @@ LogicalResult FabricateOp::verify()
         return emitOpError("Logical state should not be fabricated, use `PrepareStateOp` instead.");
     }
     return mlir::success();
+}
+
+ParseResult LayerOp::parse(OpAsmParser &parser, OperationState &result)
+{
+    auto &builder = parser.getBuilder();
+
+    // Parse the optional initial iteration arguments.
+    SmallVector<OpAsmParser::Argument, 4> regionArgs;
+    SmallVector<Type, 4> regionTypes;
+    SmallVector<OpAsmParser::UnresolvedOperand, 4> operands;
+
+    // Parse assignment list and results type list.
+    if (parser.parseAssignmentList(regionArgs, operands) ||
+        parser.parseColonTypeList(regionTypes)) {
+        return failure();
+    }
+
+    if (regionArgs.size() != regionTypes.size()) {
+        return parser.emitError(parser.getNameLoc(),
+                                "mismatch in number of region-carried values and defined values");
+    }
+
+    // Set block argument types, so that they are known when parsing the region.
+    for (auto [iterArg, type] : llvm::zip_equal(regionArgs, regionTypes)) {
+        iterArg.type = type;
+    }
+
+    // Parse the body region
+    Region *body = result.addRegion();
+    if (parser.parseRegion(*body, regionArgs)) {
+        return failure();
+    }
+
+    if (!body->hasOneBlock()) {
+        return parser.emitError(parser.getNameLoc(), "LayerOp must have exactly one block");
+    }
+
+    // Get last operation in the first block and check if it is a qec.yield op
+    auto &block = body->front();
+    auto yieldOp = dyn_cast<YieldOp>(block.getTerminator());
+    if (!yieldOp) {
+        return parser.emitError(parser.getNameLoc(),
+                                "LayerOp must have a qec.yield op as its terminator");
+    }
+
+    result.addTypes(yieldOp.getOperandTypes());
+
+    LayerOp::ensureTerminator(*body, builder, result.location);
+
+    // Resolve input operands. This should be done after parsing the region to
+    // catch invalid IR where operands were defined inside of the region.
+    for (auto argOperandType : llvm::zip_equal(regionArgs, operands, regionTypes)) {
+        Type type = std::get<2>(argOperandType);
+        std::get<0>(argOperandType).type = type;
+        if (parser.resolveOperand(std::get<1>(argOperandType), type, result.operands)) {
+            return failure();
+        }
+    }
+
+    return success();
+}
+
+void LayerOp::print(OpAsmPrinter &p)
+{
+    // Prints the initialization list in the form of
+    // (%inner = %outer, %inner2 = %outer2, <...>)
+    // where 'inner' values are assumed to be region arguments and 'outer' values
+    // are regular SSA values.
+    Block::BlockArgListType blocksArgs = getBody()->getArguments();
+    ValueRange initializers = getInitArgs();
+
+    p << '(';
+    llvm::interleaveComma(llvm::zip(blocksArgs, initializers), p,
+                          [&](auto it) { p << std::get<0>(it) << " = " << std::get<1>(it); });
+    p << ')';
+
+    // Print type(s) that corresponds to the initialization list
+    if (!getInitArgs().empty())
+        p << " : " << getInitArgs().getTypes();
+    p << ' ';
+
+    // Print the regions
+    p.printRegion(getRegion(),
+                  /*printEntryBlockArgs=*/false,
+                  /*printBlockTerminators=*/!getInitArgs().empty());
 }

--- a/mlir/lib/QEC/IR/QECDialect.cpp
+++ b/mlir/lib/QEC/IR/QECDialect.cpp
@@ -16,11 +16,8 @@
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/OpImplementation.h"
 #include "llvm/ADT/TypeSwitch.h" // needed for enums
-#include <llvm/ADT/STLExtras.h>
 #include <llvm/Support/LogicalResult.h>
 #include <mlir/IR/OperationSupport.h>
-#include <mlir/IR/Region.h>
-#include <tuple>
 
 #include "QEC/IR/QECDialect.h"
 #include "Quantum/IR/QuantumDialect.h"

--- a/mlir/test/QEC/SmokeTest.mlir
+++ b/mlir/test/QEC/SmokeTest.mlir
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// RUN: quantum-opt %s
+// RUN: quantum-opt %s | FileCheck %s
 
 func.func @foo(%q1 : !quantum.bit, %q2 : !quantum.bit) {
     qec.ppr ["X", "Z"] (4) %q1, %q2 : !quantum.bit, !quantum.bit
@@ -51,25 +51,43 @@ func.func @baz(%q1 : !quantum.bit, %q2 : !quantum.bit) {
 
 func.func @layer(%arg0 : !quantum.bit, %arg1 : !quantum.bit) -> i1{
 
+// CHECK:func.func @layer([[Q0:%.+]]: !quantum.bit, [[Q1:%.+]]: !quantum.bit) -> i1 {
+
     %0 = qec.layer(%q0 = %arg0) : !quantum.bit {
         %q_1 = qec.ppr ["Z"](4) %q0 : !quantum.bit
         qec.yield %q_1 : !quantum.bit
     }
 
-    %1:2 = qec.layer(%q0 = %0, %q1 = %arg0): !quantum.bit, !quantum.bit {
+    // CHECK: [[q0:%.+]] = qec.layer([[arg_0:%.+]] = [[Q0]]) : !quantum.bit {
+    // CHECK:   [[q_0:%.+]] = qec.ppr ["Z"](4) [[arg_0]] : !quantum.bit
+    // CHECK:   qec.yield [[q_0]] : !quantum.bit
+
+    %1:2 = qec.layer(%q0 = %0, %q1 = %arg1): !quantum.bit, !quantum.bit {
         %q_1:2 = qec.ppr ["X", "Y"](4) %q0, %q1 : !quantum.bit, !quantum.bit
         qec.yield %q_1#0, %q_1#1 : !quantum.bit, !quantum.bit
     }
 
-    %res, %2:2 = qec.layer(%q0 = %0, %q1 = %arg0): !quantum.bit, !quantum.bit {
-        %q_1:3 = qec.ppm ["X", "Z"] %1#0, %1#1 : !quantum.bit, !quantum.bit
+    // CHECK:  [[q1:%.+]]:2 = qec.layer([[arg_0:%.+]] = [[q0]], [[arg_1:%.+]] = [[Q1]]) : !quantum.bit, !quantum.bit {
+    // CHECK:   [[q_1:%.+]]:2 = qec.ppr ["X", "Y"](4) [[arg_0]], [[arg_1]] : !quantum.bit, !quantum.bit
+    // CHECK:   qec.yield [[q_1]]#0, [[q_1]]#1 : !quantum.bit, !quantum.bit
+
+    %res, %2:2 = qec.layer(%q0 = %1#0, %q1 = %1#1): !quantum.bit, !quantum.bit {
+        %q_1:3 = qec.ppm ["X", "Z"] %q0, %q1 : !quantum.bit, !quantum.bit
         qec.yield %q_1#0, %q_1#1, %q_1#2 : i1, !quantum.bit, !quantum.bit
     }
+
+    // CHECK:  [[q2:%.+]]:3 = qec.layer([[arg_0:%.+]] = [[q1]]#0, [[arg_1:%.+]] = [[q1]]#1) : !quantum.bit, !quantum.bit {
+    // CHECK:  [[M:%.+]], [[O:%.+]]:2 = qec.ppm ["X", "Z"] [[arg_0]], [[arg_1]] : !quantum.bit, !quantum.bit
+    // CHECK:  qec.yield [[M]], [[O]]#0, [[O]]#1 : i1, !quantum.bit, !quantum.bit
 
     %res_1, %3:2 = qec.layer(%q0 = %2#0, %q1 = %2#1, %m = %res): !quantum.bit, !quantum.bit, i1 {
         %q_res, %q_1:2 = qec.ppm ["X", "Z"] %q0, %q1 cond(%m): !quantum.bit, !quantum.bit
         qec.yield %q_res, %q_1#0, %q_1#1 : i1, !quantum.bit, !quantum.bit
     }
+
+    // CHECK:  [[q3:%.+]]:3 = qec.layer([[A0:%.+]] = [[q2]]#1, [[A1:%.+]] = [[q2]]#2, [[A2:%.+]] = [[q2]]#0) : !quantum.bit, !quantum.bit, i1 {
+    // CHECK:  [[M:%.+]], [[O:%.+]]:2 = qec.ppm ["X", "Z"] [[A0]], [[A1]] cond([[A2]]) : !quantum.bit, !quantum.bit
+    // CHECK:  qec.yield [[M]], [[O]]#0, [[O]]#1 : i1, !quantum.bit, !quantum.bit
 
     func.return %res_1 : i1
 }

--- a/mlir/test/QEC/SmokeTest.mlir
+++ b/mlir/test/QEC/SmokeTest.mlir
@@ -48,3 +48,28 @@ func.func @baz(%q1 : !quantum.bit, %q2 : !quantum.bit) {
     %1:2 = qec.ppr ["Y", "Y"] (4) %0, %q2 cond(%m_0) : !quantum.bit, !quantum.bit
     func.return
 }
+
+func.func @layer(%arg0 : !quantum.bit, %arg1 : !quantum.bit) -> i1{
+
+    %0 = qec.layer(%q0 = %arg0) : !quantum.bit {
+        %q_1 = qec.ppr ["Z"](4) %q0 : !quantum.bit
+        qec.yield %q_1 : !quantum.bit
+    }
+
+    %1:2 = qec.layer(%q0 = %0, %q1 = %arg0): !quantum.bit, !quantum.bit {
+        %q_1:2 = qec.ppr ["X", "Y"](4) %q0, %q1 : !quantum.bit, !quantum.bit
+        qec.yield %q_1#0, %q_1#1 : !quantum.bit, !quantum.bit
+    }
+
+    %res, %2:2 = qec.layer(%q0 = %0, %q1 = %arg0): !quantum.bit, !quantum.bit {
+        %q_1:3 = qec.ppm ["X", "Z"] %1#0, %1#1 : !quantum.bit, !quantum.bit
+        qec.yield %q_1#0, %q_1#1, %q_1#2 : i1, !quantum.bit, !quantum.bit
+    }
+
+    %res_1, %3:2 = qec.layer(%q0 = %2#0, %q1 = %2#1, %m = %res): !quantum.bit, !quantum.bit, i1 {
+        %q_res, %q_1:2 = qec.ppm ["X", "Z"] %q0, %q1 cond(%m): !quantum.bit, !quantum.bit
+        qec.yield %q_res, %q_1#0, %q_1#1 : i1, !quantum.bit, !quantum.bit
+    }
+
+    func.return %res_1 : i1
+}


### PR DESCRIPTION
**Context:**
Introduced `LayerOp` and `YieldOp` to the QEC dialect, enabling the representation of a group of mutually commuting operations or operations that act on different qubits. The `LayerOp` requires a single block that terminates with a `qec.yield` operation.

**Benefits:**
This addition enhances the expressiveness of the QEC dialect, enabling circuit depth analysis and possibly leading to layer-based backend execution.

**Example:**
```mlir
    func.func @layer(%arg0 : !quantum.bit, %arg1 : i1) -> i1{
        %m, %0 = qec.layer(%q0 = %arg0, %c = %arg1) : !quantum.bit, i1 {
            %res, %q_1 = qec.ppm ["Z"](4) %q0 cond(%c): !quantum.bit
            qec.yield %res, %q_1 : i1, !quantum.bit
        }
        func.return %m : i1
    }
```

[[sc-95171]]
