### PR TITLE
update deprecated import location for noise related transforms

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -10,7 +10,7 @@ enzyme=v0.0.180
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt
-pennylane=0.43.0.dev8
+pennylane=0.43.0.dev9
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -15,6 +15,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Update imports for noise transforms from `pennylane.transforms` to `pennylane.noise`.
+  [(#1918)](https://github.com/PennyLaneAI/catalyst/pull/1918)
+
 * `from_plxpr` now supports adjoint and ctrl operations and transforms,
   `Hermitian` observables, `for_loop` outside qnodes, and `while_loop` outside QNode's.
   [(#1844)](https://github.com/PennyLaneAI/catalyst/pull/1844)
@@ -30,4 +33,5 @@
 This release contains contributions from (in alphabetical order):
 
 Christina Lee,
+Andrija Paurevic,
 Paul Haochen Wang.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -33,4 +33,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.42.0
 pennylane-lightning==0.42.0
-pennylane==0.43.0.dev8
+pennylane==0.43.0.dev9

--- a/frontend/catalyst/api_extensions/error_mitigation.py
+++ b/frontend/catalyst/api_extensions/error_mitigation.py
@@ -119,7 +119,7 @@ def mitigate_with_zne(
 
     .. code-block:: python
 
-        from pennylane.transforms import exponential_extrapolate
+        from pennylane.noise import exponential_extrapolate
 
         dev = qml.device("lightning.qubit", wires=2, shots=100000)
 
@@ -234,7 +234,7 @@ class ZNECallable(CatalystCallable):
 
 def polynomial_extrapolation(degree):
     """utility to generate polynomial fitting functions of arbitrary degree"""
-    return functools.partial(qml.transforms.poly_extrapolate, order=degree)
+    return functools.partial(qml.noise.poly_extrapolate, order=degree)
 
 
 ## PRIVATE ##

--- a/frontend/test/pytest/test_mitigation.py
+++ b/frontend/test/pytest/test_mitigation.py
@@ -19,7 +19,7 @@ import jax
 import numpy as np
 import pennylane as qml
 import pytest
-from pennylane.noise import exponential_extrapolate
+from pennylane.noise import exponential_extrapolate, poly_extrapolate
 
 import catalyst
 from catalyst.api_extensions.error_mitigation import (
@@ -356,7 +356,7 @@ def test_zne_with_extrap_kwargs():
         return catalyst.mitigate_with_zne(
             circuit,
             scale_factors=[1, 3, 5, 7],
-            extrapolate=qml.noise.poly_extrapolate,
+            extrapolate=poly_extrapolate,
             extrapolate_kwargs={"order": 2},
         )()
 
@@ -381,7 +381,7 @@ def test_exponential_extrapolation_with_kwargs():
         return catalyst.mitigate_with_zne(
             circuit,
             scale_factors=[1, 3, 5, 7],
-            extrapolate=qml.noise.exponential_extrapolate,
+            extrapolate=exponential_extrapolate,
             extrapolate_kwargs={"asymptote": 3},
         )()
 

--- a/frontend/test/pytest/test_mitigation.py
+++ b/frontend/test/pytest/test_mitigation.py
@@ -19,7 +19,7 @@ import jax
 import numpy as np
 import pennylane as qml
 import pytest
-from pennylane.transforms import exponential_extrapolate
+from pennylane.noise import exponential_extrapolate
 
 import catalyst
 from catalyst.api_extensions.error_mitigation import (
@@ -356,7 +356,7 @@ def test_zne_with_extrap_kwargs():
         return catalyst.mitigate_with_zne(
             circuit,
             scale_factors=[1, 3, 5, 7],
-            extrapolate=qml.transforms.poly_extrapolate,
+            extrapolate=qml.noise.poly_extrapolate,
             extrapolate_kwargs={"order": 2},
         )()
 
@@ -381,7 +381,7 @@ def test_exponential_extrapolation_with_kwargs():
         return catalyst.mitigate_with_zne(
             circuit,
             scale_factors=[1, 3, 5, 7],
-            extrapolate=qml.transforms.exponential_extrapolate,
+            extrapolate=qml.noise.exponential_extrapolate,
             extrapolate_kwargs={"asymptote": 3},
         )()
 

--- a/frontend/test/pytest/test_transform.py
+++ b/frontend/test/pytest/test_transform.py
@@ -70,7 +70,7 @@ def test_add_noise(backend):
 
         noise_model = qml.NoiseModel({fcond1: noise1, fcond2: noise2}, t1=2.0, t2=0.2)
 
-        @partial(qml.transforms.add_noise, noise_model=noise_model)
+        @partial(qml.noise.add_noise, noise_model=noise_model)
         @qml.qnode(qml.device(device_name, wires=2), interface="jax")
         def qfunc(w, x, y, z):
             qml.RX(w, wires=0)
@@ -372,7 +372,7 @@ def test_insert(backend):
     def qnode_builder(device_name):
         """Builder"""
 
-        @partial(qml.transforms.insert, op=qml.X, op_args=(), position="end")
+        @partial(qml.noise.insert, op=qml.X, op_args=(), position="end")
         @qml.qnode(qml.device(device_name, wires=2), interface="jax")
         def qfunc(w, x, y, z):
             qml.RX(w, wires=0)
@@ -653,10 +653,10 @@ class TestMitigate:
             """Builder"""
 
             @partial(
-                qml.transforms.mitigate_with_zne,
+                qml.noise.mitigate_with_zne,
                 scale_factors=[1.0, 2.0, 3.0],
-                folding=qml.transforms.fold_global,
-                extrapolate=qml.transforms.poly_extrapolate,
+                folding=qml.noise.fold_global,
+                extrapolate=qml.noise.poly_extrapolate,
                 extrapolate_kwargs={"order": 2},
             )
             @qml.qnode(qml.device(device_name, wires=2), interface="jax")


### PR DESCRIPTION
**Context:**

https://github.com/PennyLaneAI/pennylane/pull/7854 deprecated the location of noise related transforms.

**Description of the Change:**

Updates import locations.

[sc-95231]
