### PR TITLE
Add single-qubit alloc and dealloc conversion patterns

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,11 +4,6 @@
 
 <h3>Improvements 🛠</h3>
 
-* Conversion patterns for the single-qubit `quantum.alloc_qb` and `quantum.dealloc_qb` operations
-  have been added for lowering to the LLVM dialect. These conversion patterns allow for execution of
-  programs containing these operations.
-  [(#1920)](https://github.com/PennyLaneAI/catalyst/pull/1920)
-
 <h3>Breaking changes 💔</h3>
 
 * The JAX version used by Catalyst is updated to 0.6.2.
@@ -31,6 +26,11 @@
   of QEC operations. The main use case is to analyze the depth of a circuit.
   Also, this is a preliminary step towards supporting parallel execution of QEC layers.
   [(#1917)](https://github.com/PennyLaneAI/catalyst/pull/1917)
+
+* Conversion patterns for the single-qubit `quantum.alloc_qb` and `quantum.dealloc_qb` operations
+  have been added for lowering to the LLVM dialect. These conversion patterns allow for execution of
+  programs containing these operations.
+  [(#1920)](https://github.com/PennyLaneAI/catalyst/pull/1920)
 
 <h3>Documentation 📝</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,6 +4,11 @@
 
 <h3>Improvements 🛠</h3>
 
+* Conversion patterns for the single-qubit `quantum.alloc_qb` and `quantum.dealloc_qb` operations
+  have been added for lowering to the LLVM dialect. These conversion patterns allow for execution of
+  programs containing these operations.
+  [(#1920)](https://github.com/PennyLaneAI/catalyst/pull/1920)
+
 <h3>Breaking changes 💔</h3>
 
 * The JAX version used by Catalyst is updated to 0.6.2.
@@ -33,6 +38,7 @@
 
 This release contains contributions from (in alphabetical order):
 
+Joey Carter,
 Sengthai Heng,
 Christina Lee,
 Paul Haochen Wang.

--- a/mlir/test/Quantum/ConversionTest.mlir
+++ b/mlir/test/Quantum/ConversionTest.mlir
@@ -129,6 +129,19 @@ func.func @alloc(%c : i64) {
 
 // -----
 
+// CHECK: llvm.func @__catalyst__rt__qubit_allocate() -> !llvm.ptr
+
+// CHECK-LABEL: @alloc_qb
+func.func @alloc_qb() {
+
+    // CHECK: llvm.call @__catalyst__rt__qubit_allocate()
+    %0 = quantum.alloc_qb : !quantum.bit
+
+    return
+}
+
+// -----
+
 // CHECK: llvm.func @__catalyst__rt__qubit_release_array(!llvm.ptr)
 
 // CHECK-LABEL: @dealloc
@@ -136,6 +149,19 @@ func.func @dealloc(%r : !quantum.reg) {
 
     // CHECK: llvm.call @__catalyst__rt__qubit_release_array(%arg0)
     quantum.dealloc %r : !quantum.reg
+
+    return
+}
+
+// -----
+
+// CHECK: llvm.func @__catalyst__rt__qubit_release(!llvm.ptr)
+
+// CHECK-LABEL: @dealloc_qb
+func.func @dealloc_qb(%q : !quantum.bit) {
+
+    // CHECK: llvm.call @__catalyst__rt__qubit_release(%arg0)
+    quantum.dealloc_qb %q : !quantum.bit
 
     return
 }


### PR DESCRIPTION
**Context:** The `quantum.alloc_qb` and `quantum.dealloc_qb` ops were recently added to the Quantum dialect in #1664 to allocate and deallocate individual qubits not associate with a quantum register. In order to execute programs containing these quantum ops, we require conversion patterns to lower them to the LLVM dialect.

**Description of the Change:** This PR adds the conversion patterns to lower the `quantum.alloc_qb` and `quantum.dealloc_qb` ops to the LLVM dialect. The conversion patterns replace these ops with calls to the `__catalyst__rt__qubit_allocate()` and `__catalyst__rt__qubit_release()` runtime stubs, respectively.

Example:

```mlir
%0 = quantum.alloc_qb : !quantum.bit
quantum.dealloc_qb %0 : !quantum.bit
```

is converted to

```mlir
llvm.func @__catalyst__rt__qubit_allocate() -> !llvm.ptr
llvm.func @__catalyst__rt__qubit_release(!llvm.ptr)

%0 = llvm.call @__catalyst__rt__qubit_allocate() : () -> !llvm.ptr
llvm.call @__catalyst__rt__qubit_release(%0) : (!llvm.ptr) -> ()
```

**Benefits:** This change will allow for execution of programs contains these single-qubit alloc and dealloc ops.

**Possible Drawbacks:** Note that execution of programs containing `quantum.dealloc_qb` ops on simulator devices is currently limited to the `null.qubit` device only, as there is an issue with the `ReleaseQubit()` method in the `lightning.qubit` device. For more, see the ongoing discussion here: https://github.com/PennyLaneAI/catalyst/pull/1807#discussion_r2146160060.