### PR TITLE
Fix issue 1586: Display Catalyst Version in `quantum-opt --version` Output

### DIFF
--- a/mlir/CMakeLists.txt
+++ b/mlir/CMakeLists.txt
@@ -121,6 +121,26 @@ FetchContent_Declare(tomlplusplus
 )
 FetchContent_MakeAvailable(tomlplusplus)
 
+################################################################################
+## Generate frontend_catalyst_version_py.h from frontend/catalyst/_version.py ##
+################################################################################
+
+function(make_version_hpp_file input_file output_file)
+    file(READ ${input_file} input_content)
+    if (input_content MATCHES "__version__ = \"([^\"]+)\"")
+        set(version_number "${CMAKE_MATCH_1}")
+    else()
+        message(WARNING "Could not find Catalyst version in ${input_file}")
+        set(version_number "unknown")
+    endif()
+    set(header_content "static constexpr const char *CATALYST_VERSION = \"${version_number}\";")
+    file(WRITE ${output_file} "${header_content}")
+endfunction(make_version_hpp_file)
+
+make_version_hpp_file(
+    "${PROJECT_SOURCE_DIR}/../frontend/catalyst/_version.py"
+    "${PROJECT_BINARY_DIR}/include/Catalyst/Utils/frontend_catalyst_version_py.h"
+)
 
 ######################
 ## Catalyst Sources ##

--- a/mlir/include/Catalyst/Utils/PrintVersion.h
+++ b/mlir/include/Catalyst/Utils/PrintVersion.h
@@ -1,0 +1,22 @@
+// Copyright 2025 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "llvm/Support/raw_ostream.h"
+
+namespace catalyst {
+
+void printVersion(llvm::raw_ostream &os);
+
+} // namespace catalyst

--- a/mlir/lib/Catalyst/Utils/CMakeLists.txt
+++ b/mlir/lib/Catalyst/Utils/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_library(MLIRCatalystUtils
     CallGraph.cpp
     EnsureFunctionDeclaration.cpp
+    PrintVersion.cpp
     SCFUtils.cpp
     StaticAllocas.cpp
     TBAAUtils.cpp

--- a/mlir/lib/Catalyst/Utils/PrintVersion.cpp
+++ b/mlir/lib/Catalyst/Utils/PrintVersion.cpp
@@ -1,0 +1,22 @@
+// Copyright 2025 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Catalyst/Utils/PrintVersion.h"
+#include "Catalyst/Utils/frontend_catalyst_version_py.h" // CATALYST_VERSION
+
+namespace catalyst {
+
+void printVersion(llvm::raw_ostream &os) { os << "Catalyst version " << CATALYST_VERSION << "\n"; }
+
+} // namespace catalyst

--- a/mlir/tools/quantum-opt/CMakeLists.txt
+++ b/mlir/tools/quantum-opt/CMakeLists.txt
@@ -42,7 +42,7 @@ function(make_version_hpp_file input_file output_file)
         message(WARNING "Could not find version regex in ${input_file}")
         set(version_number "unknown")
     endif()
-    set(header_content "const char* CATALYST_VERSION = \"${version_number}\";")
+    set(header_content "static constexpr const char *CATALYST_VERSION = \"${version_number}\";")
     file(WRITE ${output_file} "${header_content}")
 endfunction(make_version_hpp_file)
 

--- a/mlir/tools/quantum-opt/CMakeLists.txt
+++ b/mlir/tools/quantum-opt/CMakeLists.txt
@@ -32,3 +32,21 @@ target_link_libraries(quantum-opt PRIVATE ${LIBS})
 llvm_update_compile_flags(quantum-opt)
 mlir_check_all_link_libraries(quantum-opt)
 export_executable_symbols_for_plugins(quantum-opt)
+
+# Read catalyst/frontend/catalyst/_version.py, extract the version, and write it out to a C++ header file
+function(make_version_hpp_file input_file output_file)
+    file(READ ${input_file} input_content)
+    if (input_content MATCHES "__version__ = \"([^\"]+)\"")
+        set(version_number "${CMAKE_MATCH_1}")
+    else()
+        message(WARNING "Could not find version regex in ${input_file}")
+        set(version_number "unknown")
+    endif()
+    set(header_content "const char* CATALYST_VERSION = \"${version_number}\";")
+    file(WRITE ${output_file} "${header_content}")
+endfunction(make_version_hpp_file)
+
+make_version_hpp_file(
+    "${PROJECT_SOURCE_DIR}/../frontend/catalyst/_version.py"
+    "${PROJECT_BINARY_DIR}/include/frontend_catalyst_version_py.hpp"
+)

--- a/mlir/tools/quantum-opt/CMakeLists.txt
+++ b/mlir/tools/quantum-opt/CMakeLists.txt
@@ -23,6 +23,7 @@ set(LIBS
     MhloRegisterDialects
     StablehloRegister
     MLIRCatalystTest
+    MLIRCatalystUtils
     MLIRTestDialect
     ${ALL_MHLO_PASSES}
 )
@@ -32,21 +33,3 @@ target_link_libraries(quantum-opt PRIVATE ${LIBS})
 llvm_update_compile_flags(quantum-opt)
 mlir_check_all_link_libraries(quantum-opt)
 export_executable_symbols_for_plugins(quantum-opt)
-
-# Read catalyst/frontend/catalyst/_version.py, extract the version, and write it out to a C++ header file
-function(make_version_hpp_file input_file output_file)
-    file(READ ${input_file} input_content)
-    if (input_content MATCHES "__version__ = \"([^\"]+)\"")
-        set(version_number "${CMAKE_MATCH_1}")
-    else()
-        message(WARNING "Could not find version regex in ${input_file}")
-        set(version_number "unknown")
-    endif()
-    set(header_content "static constexpr const char *CATALYST_VERSION = \"${version_number}\";")
-    file(WRITE ${output_file} "${header_content}")
-endfunction(make_version_hpp_file)
-
-make_version_hpp_file(
-    "${PROJECT_SOURCE_DIR}/../frontend/catalyst/_version.py"
-    "${PROJECT_BINARY_DIR}/include/frontend_catalyst_version_py.hpp"
-)

--- a/mlir/tools/quantum-opt/quantum-opt.cpp
+++ b/mlir/tools/quantum-opt/quantum-opt.cpp
@@ -12,12 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <filesystem>  // path
-#include <fstream>  // ifstream
-#include <regex>  //regex
+#include <filesystem> // path
+#include <fstream>    // ifstream
+#include <regex>      //regex
 
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/raw_ostream.h"
 #include "mhlo/IR/register.h"
 #include "mhlo/transforms/passes.h"
 #include "mlir/Dialect/Func/Extensions/AllExtensions.h"
@@ -27,6 +25,8 @@
 #include "mlir/InitAllPasses.h"
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 #include "stablehlo/dialect/Register.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include "mhlo/IR/hlo_ops.h"
 
@@ -45,13 +45,14 @@
 #include "Quantum/Transforms/BufferizableOpInterfaceImpl.h"
 #include "Quantum/Transforms/Passes.h"
 
-#include "frontend_catalyst_version_py.hpp"  // CATALYST_VERSION
+#include "frontend_catalyst_version_py.hpp" // CATALYST_VERSION
 
 namespace test {
 void registerTestDialect(mlir::DialectRegistry &);
 } // namespace test
 
-void printCatalystVersion(llvm::raw_ostream &os) {
+void printCatalystVersion(llvm::raw_ostream &os)
+{
     os << "Catalyst version " << CATALYST_VERSION << "\n";
 }
 

--- a/mlir/tools/quantum-opt/quantum-opt.cpp
+++ b/mlir/tools/quantum-opt/quantum-opt.cpp
@@ -45,30 +45,14 @@
 #include "Quantum/Transforms/BufferizableOpInterfaceImpl.h"
 #include "Quantum/Transforms/Passes.h"
 
+#include "frontend_catalyst_version_py.hpp"  // CATALYST_VERSION
+
 namespace test {
 void registerTestDialect(mlir::DialectRegistry &);
 } // namespace test
 
-consteval std::string getCatalystVersion() {
-    auto version = std::string{};
-    auto version_file_path = std::filesystem::path{ "../../../../frontend/catalyst/_version.py" };
-    auto version_file = std::ifstream{ version_file_path.string() };
-    auto line = std::string{};
-    while (std::getline(version_file, line)) {
-        auto version_regex = std::regex{ "__version__ = \"([^\"]+)\"" };
-        auto matches = std::smatch{};
-        if (std::regex::match(line, matches, version_regex)) {
-            version = matches[0].str();
-            break;
-        }
-    }
-    return version;
-}
-
-constinit const CATALYST_VERSION = getCatalystVersion();
-
 void printCatalystVersion(llvm::raw_ostream &os) {
-    os << "Catalyst version " << CATALYST_VERSION << std::endl;
+    os << "Catalyst version " << CATALYST_VERSION << "\n";
 }
 
 int main(int argc, char **argv)

--- a/mlir/tools/quantum-opt/quantum-opt.cpp
+++ b/mlir/tools/quantum-opt/quantum-opt.cpp
@@ -33,6 +33,7 @@
 #include "Catalyst/IR/CatalystDialect.h"
 #include "Catalyst/Transforms/BufferizableOpInterfaceImpl.h"
 #include "Catalyst/Transforms/Passes.h"
+#include "Catalyst/Utils/PrintVersion.h"
 #include "Gradient/IR/GradientDialect.h"
 #include "Gradient/Transforms/BufferizableOpInterfaceImpl.h"
 #include "Gradient/Transforms/Passes.h"
@@ -45,20 +46,13 @@
 #include "Quantum/Transforms/BufferizableOpInterfaceImpl.h"
 #include "Quantum/Transforms/Passes.h"
 
-#include "frontend_catalyst_version_py.hpp" // CATALYST_VERSION
-
 namespace test {
 void registerTestDialect(mlir::DialectRegistry &);
 } // namespace test
 
-void printCatalystVersion(llvm::raw_ostream &os)
-{
-    os << "Catalyst version " << CATALYST_VERSION << "\n";
-}
-
 int main(int argc, char **argv)
 {
-    llvm::cl::AddExtraVersionPrinter(printCatalystVersion);
+    llvm::cl::AddExtraVersionPrinter(catalyst::printVersion);
     mlir::registerAllPasses();
     catalyst::registerAllCatalystPasses();
     mlir::mhlo::registerAllMhloPasses();

--- a/mlir/unittests/CMakeLists.txt
+++ b/mlir/unittests/CMakeLists.txt
@@ -10,3 +10,4 @@ function(add_catalyst_unittest test_dirname)
 endfunction()
 
 add_subdirectory(Example)
+add_subdirectory(Utils)

--- a/mlir/unittests/Utils/CMakeLists.txt
+++ b/mlir/unittests/Utils/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_catalyst_unittest(CatalystUtilsTests
+    PrintVersion.cpp
+)
+
+target_link_libraries(CatalystUtilsTests PRIVATE
+    MLIRCatalystUtils
+)

--- a/mlir/unittests/Utils/PrintVersion.cpp
+++ b/mlir/unittests/Utils/PrintVersion.cpp
@@ -1,0 +1,27 @@
+// Copyright 2024 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "Catalyst/Utils/PrintVersion.h"
+
+#include "gmock/gmock.h" // HasSubstr
+
+namespace {
+TEST(MLIRCatalystUtils, VersionIsNotUnknown)
+{
+    auto output = std::string{};
+    auto rss = llvm::raw_string_ostream{output};
+    catalyst::printVersion(rss);
+    EXPECT_THAT(output, ::testing::Not(::testing::HasSubstr("unknown")));
+}
+} // namespace


### PR DESCRIPTION
**Context:**
Catalyst version is maintained at `frontend/catalyst/_version.py`.
We want to have it accessible from the C++ Catalyst libraries and tools, for example from `quantum-opt`.

**Description of the Change:**
There are still a few things that C++ cannot do at compile time, like reading and parsing a Python file.
On top of that, there are the issues of:
- How to access a file in a different project (e.g., `frontend` project from `mlir` project).
- How to locate a given source file during runtime. For example, you could run `quantum-opt` from anywhere, and `_version.py` may not be even accessible.
But we can do some things at CMake configure time, as suggested in the description of the issue:
  >  an alternative such as pulling the version from the Git metadata or generating it at build time would be great.

This PR:
1. Updates `mlir/CMakeLists.txt` to generate `include/Catalyst/Utils/frontend_catalyst_version_py.h` from `frontend/catalyst/_version.py`. This file just contains a `static constexpr const char *CATALYST_VERSION` with the value parsed from the Python file.
2. Adds a `catalyst::printVersion(llvm::raw_ostream&)` function to MLIRCatalystUtils library. This functions just prints `CATALYST_VERSION` to an LLVM raw ostream.
3. Uses that function from `tools/quantum-opt/quantum-opt.cpp` to display the Catalyst version when invoked via `quantum-opt --version`.
4. Adds a new unit test binary, `CatalystsUtilsTests`, with only one test that checks that the catalyst version is not `unknown` (the default value when the version couldn't be parsed from `_version.py`).

**Benefits:**
1. We still have a single source of truth in `frontend/catalyst/_version.py`.
2. The version is set in the C++ code during CMake configure time (so accessible during runtime).

**Possible Drawbacks:**
- Current implementation prints the LLVM version before the Catalyst version, because the Catalyst version is an extra .

**Related GitHub Issues:**
#1586