### PR TITLE
Replace `shots=` kwarg in qnode calls wit h `set_shots`

### DIFF
--- a/frontend/test/pytest/test_measurements_shots_results.py
+++ b/frontend/test/pytest/test_measurements_shots_results.py
@@ -586,9 +586,7 @@ class TestOtherMeasurements:
         assert result[0].dtype == np.int64
 
         # qml.counts
-        for r, e in zip(
-            result[1][0], expected(x, qml.counts(all_outcomes=True)).keys()
-        ):
+        for r, e in zip(result[1][0], expected(x, qml.counts(all_outcomes=True)).keys()):
             assert format(int(r), "02b") == e
         assert sum(result[1][1]) == 10000
         assert result[1][0].dtype == np.int64


### PR DESCRIPTION
**Context:**
See https://github.com/PennyLaneAI/pennylane/pull/7906 for on-going deprecation of the shots= kwarg of QNode calls. Now we can use set_shots to assign the shots value to a qnode.

**Description of the Change:**
`frontend/test/pytest/test_measurements_shots_results.py`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[[sc-95617](https://app.shortcut.com/xanaduai/story/95617)]