### PR TITLE
Register --test-loop-unrolling

### DIFF
--- a/mlir/lib/Driver/CMakeLists.txt
+++ b/mlir/lib/Driver/CMakeLists.txt
@@ -26,6 +26,7 @@ set(LIBS
     ${extension_libs}
     ${translation_libs}
     MLIROptLib
+    MLIRSCFTestPasses
     MLIRCatalyst
     catalyst-transforms
     MLIRQuantum

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -83,6 +83,14 @@ using namespace catalyst;
 using namespace catalyst::driver;
 namespace cl = llvm::cl;
 
+namespace mlir {
+
+namespace test {
+    void registerTestLoopUnrollingPass();
+}
+
+}
+
 namespace catalyst::utils {
 
 /**
@@ -959,6 +967,7 @@ int QuantumDriverMainFromCL(int argc, char **argv)
 
     // Create dialect registry
     DialectRegistry registry;
+    mlir::test::registerTestLoopUnrollingPass();
     registerAllPasses();
     registerAllCatalystPasses();
     registerAllCatalystPipelines();


### PR DESCRIPTION
**Context:** For internal researchers interested in function specialization, constant propagation, CSE, and loop unrolling, this PR registers the pass `--test-loop-unrolling` from the upstream MLIR repository into Catalyst.

**Description of the Change:** Changes in build system and registering test loop unrolling.

**Benefits:** Loop unrolling can be called as a pass.

```
(env2) ubuntu@heartfelt-jackdaw:~/Code/catalyst2$ ./mlir/build/bin/catalyst --help | grep -A 10 test-loop-unrolling 
      --test-loop-unrolling                                  -   Tests loop unrolling transformation
        --annotate                                           - Annotate unrolled iterations.
        --loop-depth=<uint>                                  - Loop depth.
        --unroll-factor=<ulong>                              - Loop unroll factor.
        --unroll-full                                        - Full unroll loops.
        --unroll-up-to-factor                                - Loop unroll up to factor.
```

**Possible Drawbacks:**

**Related GitHub Issues:**
