### PR TITLE
Add python lit test coverage

### DIFF
--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -515,7 +515,7 @@ jobs:
        
     - name: Run Python Pytest/Lit Tests
       run: |
-        COVERAGE_REPORT="coverage.xml" \
+        COVERAGE_REPORT=".coverage" \
         DIALECTS_BUILD_DIR="$(pwd)/quantum-build" \
         LLVM_BUILD_DIR="$(pwd)/llvm-build" \
         make coverage-frontend ENABLE_OQD=ON

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -515,7 +515,7 @@ jobs:
        
     - name: Run Python Pytest/Lit Tests
       run: |
-        COVERAGE_REPORT="xml:coverage.xml -p no:warnings" \
+        COVERAGE_REPORT="coverage.xml" \
         DIALECTS_BUILD_DIR="$(pwd)/quantum-build" \
         LLVM_BUILD_DIR="$(pwd)/llvm-build" \
         make coverage-frontend ENABLE_OQD=ON

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -517,6 +517,7 @@ jobs:
       run: |
         COVERAGE_REPORT="xml:coverage.xml -p no:warnings" \
         DIALECTS_BUILD_DIR="$(pwd)/quantum-build" \
+        LLVM_BUILD_DIR="$(pwd)/llvm-build" \
         make coverage-frontend ENABLE_OQD=ON
         mv coverage.xml coverage-${{ github.job }}.xml
 

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -515,8 +515,13 @@ jobs:
 
     - name: Run Python Lit Tests
       run: |
-        python3 llvm-build/bin/llvm-lit -sv frontend/test/lit -j$(nproc)
+        ENABLE_LIT_COVERAGE=1 COVERAGE_FILE=.coverage.lit python3 llvm-build/bin/llvm-lit -sv frontend/test/lit -j$(nproc)
+        if [ -f .coverage.lit ]; then
+          echo "Converting Lit Coverage to XML"
+          coverage xml --data-file=.coverage.lit -o coverage-lit.xml
+        fi
 
+       
     - name: Run Python Pytest Tests
       run: |
         COVERAGE_REPORT="xml:coverage.xml -p no:warnings" \

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -515,7 +515,7 @@ jobs:
        
     - name: Run Python Pytest/Lit Tests
       run: |
-        COVERAGE_REPORT=".coverage" \
+        COVERAGE_REPORT="xml" \
         DIALECTS_BUILD_DIR="$(pwd)/quantum-build" \
         LLVM_BUILD_DIR="$(pwd)/llvm-build" \
         make coverage-frontend ENABLE_OQD=ON

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -512,17 +512,8 @@ jobs:
         echo "OQD_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
         echo "CATALYST_BIN_DIR=$(pwd)/quantum-build/bin" >> $GITHUB_ENV
         chmod +x $(pwd)/quantum-build/bin/catalyst  # artifact upload does not preserve permissions
-
-    - name: Run Python Lit Tests
-      run: |
-        ENABLE_LIT_COVERAGE=1 COVERAGE_FILE=.coverage.lit python3 llvm-build/bin/llvm-lit -sv frontend/test/lit -j$(nproc)
-        if [ -f .coverage.lit ]; then
-          echo "Converting Lit Coverage to XML"
-          coverage xml --data-file=.coverage.lit -o coverage-lit.xml
-        fi
-
        
-    - name: Run Python Pytest Tests
+    - name: Run Python Pytest/Lit Tests
       run: |
         COVERAGE_REPORT="xml:coverage.xml -p no:warnings" \
         DIALECTS_BUILD_DIR="$(pwd)/quantum-build" \

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -525,6 +525,7 @@ jobs:
     - name: Run Python Pytest Tests
       run: |
         COVERAGE_REPORT="xml:coverage.xml -p no:warnings" \
+        DIALECTS_BUILD_DIR="$(pwd)/quantum-build" \
         make coverage-frontend ENABLE_OQD=ON
         mv coverage.xml coverage-${{ github.job }}.xml
 

--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ coverage: coverage-frontend coverage-runtime
 
 lit-coverage:
 	@echo "Running lit tests with coverage"
-	ENABLE_LIT_COVERAGE=1 cmake --build $(DIALECTS_BUILD_DIR) --target check-frontend
+	ENABLE_LIT_COVERAGE=1 COVERAGE_FILE=.coverage.lit $(LLVM_BUILD_DIR)/bin/llvm-lit -sv frontend/test/lit -j$(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
 
 coverage-frontend:
 ifeq ($(ENABLE_ASAN),ON)

--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ endif
 ifeq ($(COVERAGE_REPORT),term-missing)
 	$(PYTHON) -m coverage report --show-missing
 else
-	$(PYTHON) -m coverage report --data-file=$(COVERAGE_REPORT)
+	$(PYTHON) -m coverage xml --data-file=$(COVERAGE_REPORT)
 endif
 ifeq ($(TEST_BRAKET), NONE)
 	$(ASAN_COMMAND) $(PYTHON) -m pytest frontend/test/async_tests --tb=native --backend=$(TEST_BACKEND) --tb=native

--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,7 @@ coverage: coverage-frontend coverage-runtime
 
 lit-coverage:
 	@echo "Running lit tests with coverage"
-	ENABLE_LIT_COVERAGE=1 COVERAGE_FILE=.coverage.lit $(LLVM_BUILD_DIR)/bin/llvm-lit -sv frontend/test/lit -j$(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
+	ENABLE_LIT_COVERAGE=1 COVERAGE_FILE=$(MK_DIR)/.coverage.lit $(LLVM_BUILD_DIR)/bin/llvm-lit -sv frontend/test/lit -j$(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
 
 coverage-frontend:
 ifeq ($(ENABLE_ASAN),ON)

--- a/Makefile
+++ b/Makefile
@@ -313,18 +313,18 @@ ifneq ($(findstring clang,$(C_COMPILER)),clang)
 endif
 endif
 	@echo "Generating coverage report for the frontend"
-	$(ASAN_COMMAND) $(PYTHON) -m pytest frontend/test/pytest $(PYTEST_FLAGS) --cov=catalyst --tb=native --cov-report=
-	$(ASAN_COMMAND) $(PYTHON) -m pytest frontend/test/test_oqc/oqc $(PYTEST_FLAGS) --cov=catalyst --cov-append --tb=native --cov-report=
+	COVERAGE_FILE=$(MK_DIR)/.coverage.pytest $(ASAN_COMMAND) $(PYTHON) -m pytest frontend/test/pytest $(PYTEST_FLAGS) --cov=catalyst --tb=native --cov-report=
+	COVERAGE_FILE=$(MK_DIR)/.coverage.pytest $(ASAN_COMMAND) $(PYTHON) -m pytest frontend/test/test_oqc/oqc $(PYTEST_FLAGS) --cov=catalyst --cov-append --tb=native --cov-report=
 ifeq ($(ENABLE_OQD), ON)
-	$(ASAN_COMMAND) $(PYTHON) -m pytest frontend/test/test_oqd/oqd $(PYTEST_FLAGS) --cov=catalyst --cov-append --tb=native --cov-report=
+	COVERAGE_FILE=$(MK_DIR)/.coverage.pytest $(ASAN_COMMAND) $(PYTHON) -m pytest frontend/test/test_oqd/oqd $(PYTEST_FLAGS) --cov=catalyst --cov-append --tb=native --cov-report=
 endif
 	$(ASAN_COMMAND) $(MAKE) lit-coverage
-	coverage combine --append .coverage.lit .coverage
+	$(PYTHON) -m coverage combine --data-file=$(MK_DIR)/.coverage.combined $(MK_DIR)/.coverage.lit $(MK_DIR)/.coverage.pytest
 	@echo "=== Generating final coverage report with format: $(COVERAGE_REPORT) ==="
 ifeq ($(COVERAGE_REPORT),term-missing)
-	$(PYTHON) -m coverage report --show-missing
+	$(PYTHON) -m coverage report --data-file=$(MK_DIR)/.coverage.combined --show-missing
 else
-	$(PYTHON) -m coverage xml --data-file=$(COVERAGE_REPORT)
+	$(PYTHON) -m coverage $(COVERAGE_REPORT) --data-file=$(MK_DIR)/.coverage.combined
 endif
 ifeq ($(TEST_BRAKET), NONE)
 	$(ASAN_COMMAND) $(PYTHON) -m pytest frontend/test/async_tests --tb=native --backend=$(TEST_BACKEND) --tb=native

--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ ifeq ($(ENABLE_OQD), ON)
 	$(ASAN_COMMAND) $(PYTHON) -m pytest frontend/test/test_oqd/oqd $(PYTEST_FLAGS) --cov=catalyst --cov-append --tb=native --cov-report=
 endif
 	$(ASAN_COMMAND) $(MAKE) lit-coverage
-	coverage combine .coverage.lit .coverage
+	coverage combine --append .coverage.lit .coverage
 	@echo "=== Generating final coverage report with format: $(COVERAGE_REPORT) ==="
 ifeq ($(COVERAGE_REPORT),term-missing)
 	$(PYTHON) -m coverage report --show-missing

--- a/Makefile
+++ b/Makefile
@@ -321,7 +321,7 @@ endif
 ifeq ($(COVERAGE_REPORT),term-missing)
 	$(PYTHON) -m coverage report --show-missing
 else
-	$(PYTHON) -m coverage report --$(COVERAGE_REPORT)
+	$(PYTHON) -m coverage report --data-file=$(COVERAGE_REPORT)
 endif
 ifeq ($(TEST_BRAKET), NONE)
 	$(ASAN_COMMAND) $(PYTHON) -m pytest frontend/test/async_tests --tb=native --backend=$(TEST_BACKEND) --tb=native

--- a/frontend/test/lit/lit.cfg.py
+++ b/frontend/test/lit/lit.cfg.py
@@ -59,7 +59,9 @@ if (
 
 if os.environ.get("ENABLE_LIT_COVERAGE", "0") == "1":
     project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../"))
-    config.environment["COVERAGE_FILE"] = os.environ.get("COVERAGE_FILE", os.path.join(project_root, ".coverage.lit"))
+    config.environment["COVERAGE_FILE"] = os.environ.get(
+        "COVERAGE_FILE", os.path.join(project_root, ".coverage.lit")
+    )
     python_executable = f"{python_executable} -m coverage run --source=catalyst --append"
 
 config.substitutions.append(("%PYTHON", python_executable))

--- a/frontend/test/lit/lit.cfg.py
+++ b/frontend/test/lit/lit.cfg.py
@@ -63,7 +63,9 @@ if os.environ.get("ENABLE_LIT_COVERAGE", "0") == "1":
     config.environment["COVERAGE_FILE"] = os.environ.get(
         "COVERAGE_FILE", os.path.join(project_root, ".coverage.lit")
     )
-    python_executable = f"{python_executable} -m coverage run --source={catalyst_source} --append"
+    python_executable = (
+        f"{python_executable} -m coverage run --source={catalyst_source} --append --branch"
+    )
 
 config.substitutions.append(("%PYTHON", python_executable))
 
@@ -92,6 +94,21 @@ try:
 except AttributeError:
     from lit.llvm.config import LLVMConfig  # fmt:skip
     llvm_config = LLVMConfig(lit_config, config)
+
+    # When running outside CMake context (e.g., make lit-coverage),
+    # we need to manually set up the LLVM tools path
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../"))
+    llvm_tools_dir = os.path.join(project_root, "mlir", "llvm-project", "build", "bin")
+    quantum_bin_dir = os.path.join(project_root, "mlir", "build", "bin")
+
+    if os.path.exists(llvm_tools_dir):
+        llvm_config.with_environment("PATH", llvm_tools_dir, append_path=True)
+        # Add tool substitutions to ensure we use the right FileCheck
+        llvm_config.add_tool_substitutions(["FileCheck"], [llvm_tools_dir])
+
+    if os.path.exists(quantum_bin_dir):
+        llvm_config.with_environment("PATH", quantum_bin_dir, append_path=True)
+
     llvm_config.with_system_environment("PYTHONPATH")
     llvm_config.with_system_environment("RUNTIME_LIB_DIR")
     llvm_config.with_system_environment("MLIR_LIB_DIR")

--- a/frontend/test/lit/lit.cfg.py
+++ b/frontend/test/lit/lit.cfg.py
@@ -57,6 +57,11 @@ if (
     else:
         assert False, "Testing with sanitized builds requires Linux or MacOS"
 
+if os.environ.get("ENABLE_LIT_COVERAGE", "0") == "1":
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../"))
+    config.environment["COVERAGE_FILE"] = os.environ.get("COVERAGE_FILE", os.path.join(project_root, ".coverage.lit"))
+    python_executable = f"{python_executable} -m coverage run --source=catalyst --append"
+
 config.substitutions.append(("%PYTHON", python_executable))
 
 # Define PATH when running frontend tests from an mlir build target.

--- a/frontend/test/lit/lit.cfg.py
+++ b/frontend/test/lit/lit.cfg.py
@@ -59,10 +59,11 @@ if (
 
 if os.environ.get("ENABLE_LIT_COVERAGE", "0") == "1":
     project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../"))
+    catalyst_source = os.path.join(project_root, "frontend", "catalyst")
     config.environment["COVERAGE_FILE"] = os.environ.get(
         "COVERAGE_FILE", os.path.join(project_root, ".coverage.lit")
     )
-    python_executable = f"{python_executable} -m coverage run --source=catalyst --append"
+    python_executable = f"{python_executable} -m coverage run --source={catalyst_source} --append"
 
 config.substitutions.append(("%PYTHON", python_executable))
 


### PR DESCRIPTION
**Context:**
Currently, Catalyst's code coverage reporting only includes Python pytest tests, missing coverage from lit tests. This could result in an incomplete picture of the actual coverage, especially as the Python compiler would rely on lit tests for testing its core compilation functionality.

**Description of the Change:**
This PR combines lit test coverage with the existing pytest coverage. In particular, it adds a new `lit-coverage` target for running lit tests with coverage enabled and updates `coverage-frontend` to combine pytest and lit coverage data using `coverage combine`.

**Benefits:**
More accurate overall coverage metrics

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-95508]