### PR TITLE
add fixture to disable capture if there's an error

### DIFF
--- a/frontend/test/pytest/test_quantum_subroutine.py
+++ b/frontend/test/pytest/test_quantum_subroutine.py
@@ -24,6 +24,7 @@ from catalyst.utils.exceptions import CompileError
 
 pytestmark = pytest.mark.usefixtures("disable_capture")
 
+
 def test_classical_subroutine():
     """Dummy test"""
 


### PR DESCRIPTION
**Context:** If an exception occurs in a test, it is known that capture won't be disabled automatically.

**Description of the Change:** Add fixture to disable capture after tests run.

**Benefits:** No errors in CI/CD.