### PR TITLE
Ensure canonical usage of the qjit decorator

### DIFF
--- a/demos/magic_distillation_demo.ipynb
+++ b/demos/magic_distillation_demo.ipynb
@@ -199,7 +199,7 @@
             "source": [
                 "from catalyst import qjit, while_loop\n",
                 "\n",
-                "@qjit()\n",
+                "@qjit\n",
                 "@qml.qnode(qml.device(\"lightning.qubit\", wires=5))\n",
                 "def main_circuit(random_key, r):\n",
                 "    \"\"\"The main entry point of the algorithm. The structure is as follows.\n",

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -373,7 +373,7 @@ def for_loop(lower_bound, upper_bound, step, allow_array_resizing=False):
     However, if you wish to have the for loop return differently sized arrays
     at each iteration, set ``allow_array_resizing`` to ``True``:
 
-    >>> @qjit()
+    >>> @qjit
     ... def f(N):
     ...     a = jnp.ones([N], dtype=float)
     ...     @for_loop(0, 10, 1, allow_array_resizing=True)

--- a/frontend/test/async_tests/test_async.py
+++ b/frontend/test/async_tests/test_async.py
@@ -58,7 +58,7 @@ def test_qnode_execution(backend):
     params = jnp.array([1.0, 2.0])
     compiled = qjit(async_qnodes=True)(multiple_qnodes)
     observed = compiled(params)
-    expected = qjit()(multiple_qnodes)(params)
+    expected = qjit(multiple_qnodes)(params)
     assert "async_execute_fn" in compiled.qir
     assert np.allclose(expected, observed)
 

--- a/frontend/test/lit/test_peephole_optimizations.py
+++ b/frontend/test/lit/test_peephole_optimizations.py
@@ -284,7 +284,7 @@ def test_chained_pipeline_lowering():
         "merge_rotations": {},
     }
 
-    @qjit()
+    @qjit
     @pipeline(pipeline1)
     @pipeline(pipeline2)
     @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -330,7 +330,7 @@ def test_chained_pipeline_lowering_keep_original():
     f_pipeline1 = pipeline(pipeline1)(f)
     f_pipeline2 = pipeline(pipeline2)(f_pipeline1)
 
-    @qjit()
+    @qjit
     def test_chained_pipeline_lowering_keep_original_workflow(x: float):
         return f(x), f_pipeline1(x), f_pipeline2(x)
 
@@ -357,7 +357,7 @@ def test_chained_apply_passes():
     Test that chained passes are correctly applied in sequence using apply_pass.
     """
 
-    @qjit()
+    @qjit
     @apply_pass("merge-rotations")
     @apply_pass("remove-chained-self-inverse")
     @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -395,7 +395,7 @@ def test_chained_apply_passes_keep_original():
     f_pass1 = apply_pass("remove-chained-self-inverse")(f)
     f_pass2 = apply_pass("merge-rotations")(f_pass1)
 
-    @qjit()
+    @qjit
     def test_chained_apply_passes_keep_original_workflow(x: float):
         return f(x), f_pass1(x), f_pass2(x)
 
@@ -420,7 +420,7 @@ def test_chained_peephole_passes():
     Test that chained peephole passes are correctly applied in sequence.
     """
 
-    @qjit()
+    @qjit
     @merge_rotations
     @cancel_inverses
     @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -458,7 +458,7 @@ def test_chained_peephole_passes_keep_original():
     f_pass1 = cancel_inverses(f)
     f_pass2 = merge_rotations(f_pass1)
 
-    @qjit()
+    @qjit
     def test_chained_peephole_passes_keep_original_workflow(x: float):
         return f(x), f_pass1(x), f_pass2(x)
 

--- a/frontend/test/pytest/from_plxpr/test_capture_integration.py
+++ b/frontend/test/pytest/from_plxpr/test_capture_integration.py
@@ -32,7 +32,7 @@ def circuit_aot_builder(dev):
 
     qml.capture.enable()
 
-    @catalyst.qjit()
+    @catalyst.qjit
     @qml.qnode(device=dev)
     def catalyst_circuit_aot(x: float):
         qml.Hadamard(wires=0)
@@ -136,7 +136,7 @@ class TestCapture:
 
         qml.capture.enable()
 
-        @catalyst.qjit()
+        @catalyst.qjit
         @qml.qnode(device=dev)
         def captured_circuit(x):
             qml.Hadamard(wires=0)

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -1609,7 +1609,7 @@ class TestMidCircuitMeasurementAfterAdjoint:
         def subroutine():
             qml.Hadamard(wires=1)
 
-        @qjit()
+        @qjit
         @qml.qnode(qml.device("lightning.qubit", wires=2))
         def circuit():
             # Comment/uncomment to toggle bug

--- a/frontend/test/pytest/test_assertion.py
+++ b/frontend/test/pytest/test_assertion.py
@@ -84,12 +84,12 @@ class TestAssertion:
             return True
 
         with pytest.raises(RuntimeError, match="Always raise"):
-            qjit()(circuit)()
+            qjit(circuit)()
 
         assert qjit(disable_assertions=True)(circuit)() == True
 
         with pytest.raises(RuntimeError, match="Always raise"):
-            qjit()(circuit)()
+            qjit(circuit)()
 
         assert qjit(disable_assertions=True)(circuit)() == True
 

--- a/frontend/test/pytest/test_braket_local_devices.py
+++ b/frontend/test/pytest/test_braket_local_devices.py
@@ -98,7 +98,7 @@ class TestBraketGates:
 
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
-        qjit_fn = qjit()(qml.qnode(device)(circuit))
+        qjit_fn = qjit(qml.qnode(device)(circuit))
         qml_fn = qml.qnode(qml.device("default.qubit", wires=3))(circuit)
 
         assert np.allclose(qjit_fn(), qml_fn())
@@ -134,7 +134,7 @@ class TestBraketGates:
 
             return qml.var(qml.PauliZ(0) @ qml.PauliZ(1) @ qml.PauliZ(2))
 
-        qjit_fn = qjit()(qml.qnode(device)(circuit))
+        qjit_fn = qjit(qml.qnode(device)(circuit))
         qml_fn = qml.qnode(qml.device("default.qubit", wires=3))(circuit)
 
         assert np.allclose(qjit_fn(3.14, 0.6), qml_fn(3.14, 0.6))

--- a/frontend/test/pytest/test_braket_remote_devices.py
+++ b/frontend/test/pytest/test_braket_remote_devices.py
@@ -121,7 +121,7 @@ class TestBraketGates:
 
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
-        qjit_fn = qjit()(qml.qnode(device)(circuit))
+        qjit_fn = qjit(qml.qnode(device)(circuit))
         qml_fn = qml.qnode(qml.device("default.qubit", wires=3))(circuit)
 
         assert np.allclose(qjit_fn(), qml_fn())
@@ -148,7 +148,7 @@ class TestBraketGates:
             qml.MultiRZ(np.pi / 2, wires=[0, 1, 2])
             return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
 
-        qjit_fn = qjit()(qml.qnode(device)(circuit))
+        qjit_fn = qjit(qml.qnode(device)(circuit))
 
         with pytest.raises(
             RuntimeError, match="The given QIR gate name is not supported by the OpenQASM builder."
@@ -181,7 +181,7 @@ class TestBraketGates:
 
             return qml.var(qml.PauliZ(0) @ qml.PauliZ(1) @ qml.PauliZ(2))
 
-        qjit_fn = qjit()(qml.qnode(device)(circuit))
+        qjit_fn = qjit(qml.qnode(device)(circuit))
         qml_fn = qml.qnode(qml.device("default.qubit", wires=3))(circuit)
 
         assert np.allclose(qjit_fn(3.14, 0.6), qml_fn(3.14, 0.6))

--- a/frontend/test/pytest/test_buffer_args.py
+++ b/frontend/test/pytest/test_buffer_args.py
@@ -70,13 +70,13 @@ class TestReturnValues:
             qml.SingleExcitation(params[1], wires=[0, 2])
             return qml.expval(qml.PauliZ(2))
 
-        @qjit()
+        @qjit
         def order1(params):
             diff = grad(circuit, argnums=0)
             h = diff(params)
             return h[0], params
 
-        @qjit()
+        @qjit
         def order2(params):
             diff = grad(circuit, argnums=0)
             h = diff(params)

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -748,7 +748,7 @@ class TestCondPredicateConversion:
     def test_conversion_integer(self):
         """Test entry predicate conversion from integer to bool."""
 
-        @qjit()
+        @qjit
         def workflow(x):
             n = 1
 
@@ -768,7 +768,7 @@ class TestCondPredicateConversion:
     def test_conversion_float(self):
         """Test entry predicate conversion from float to bool."""
 
-        @qjit()
+        @qjit
         def workflow(x):
             n = 2.0
 
@@ -788,7 +788,7 @@ class TestCondPredicateConversion:
     def test_jax_bool(self):
         """Test entry predicate with a JAX bool."""
 
-        @qjit()
+        @qjit
         def workflow(x):
             n = jnp.bool_(True)
 
@@ -808,7 +808,7 @@ class TestCondPredicateConversion:
     def test_else_if_conversion_integer(self):
         """Test else_if predicate conversion from integer to bool."""
 
-        @qjit()
+        @qjit
         def workflow(x):
             n = 1
 

--- a/frontend/test/pytest/test_contexts.py
+++ b/frontend/test/pytest/test_contexts.py
@@ -184,7 +184,7 @@ class TestTracing:
     def test_fixed_tracing(self, backend):
         """Test fixed tracing."""
 
-        @qjit()
+        @qjit
         @qml.qnode(qml.device(backend, wires=1))
         def circuit():
             m = measure(wires=0)
@@ -211,7 +211,7 @@ class TestTracing:
 
             return m
 
-        @qjit()
+        @qjit
         @qml.qnode(qml.device(backend, wires=3))
         def circuit(n):
             @while_loop(lambda i: i < n)
@@ -233,7 +233,7 @@ class TestTracing:
     def test_discarded_measurements(self, backend):
         """Test discarded measurements."""
 
-        @qjit()
+        @qjit
         @qml.qnode(qml.device(backend, wires=2))
         def circuit():
             qml.state()
@@ -244,7 +244,7 @@ class TestTracing:
     def test_mixed_result_types(self, backend):
         """Test mixed result types."""
 
-        @qjit()
+        @qjit
         @qml.qnode(qml.device(backend, wires=1))
         def circuit():
             @while_loop(lambda _, repeat: repeat)

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -445,7 +445,7 @@ def test_finite_diff(inp, backend):
         qml.RX(x, wires=0)
         return qml.expval(qml.PauliY(0))
 
-    @qjit()
+    @qjit
     def compiled_grad_default(x: float):
         g = qml.qnode(qml.device(backend, wires=1))(f)
         h = grad(g, method="fd")
@@ -468,7 +468,7 @@ def test_finite_diff_mul(inp, backend):
         qml.RX(3 * x, wires=0)
         return qml.expval(qml.PauliY(0))
 
-    @qjit()
+    @qjit
     def compiled_grad_default(x: float):
         g = qml.qnode(qml.device(backend, wires=1))(f)
         h = grad(g, method="fd")
@@ -518,7 +518,7 @@ def test_adj(inp, backend):
         qml.RX(x, wires=0)
         return qml.expval(qml.PauliY(0))
 
-    @qjit()
+    @qjit
     def compiled(x: float):
         g = qml.qnode(qml.device(backend, wires=1), diff_method="adjoint")(f)
         h = grad(g, method="auto")
@@ -541,7 +541,7 @@ def test_adj_mult(inp, backend):
         qml.RX(x * 2, wires=0)
         return qml.expval(qml.PauliY(0))
 
-    @qjit()
+    @qjit
     def compiled(x: float):
         g = qml.qnode(qml.device(backend, wires=1), diff_method="adjoint")(f)
         h = grad(g, method="auto")
@@ -565,7 +565,7 @@ def test_adj_in_loop(inp, backend):
         qml.RX(3 * x, wires=0)
         return qml.expval(qml.PauliY(0))
 
-    @qjit()
+    @qjit
     def compiled_grad_default(params, ntrials):
         diff = grad(f, argnums=0, method="auto")
 
@@ -591,7 +591,7 @@ def test_ps(inp, backend):
         qml.RX(x * 2, wires=0)
         return qml.expval(qml.PauliY(0))
 
-    @qjit()
+    @qjit
     def compiled(x: float):
         g = qml.qnode(qml.device(backend, wires=1), diff_method="parameter-shift")(f)
         h = grad(g, method="auto")
@@ -629,7 +629,7 @@ def test_ps_conditionals(inp, backend):
             qml.RX(x, wires=0)
         return qml.expval(qml.PauliY(0))
 
-    @qjit()
+    @qjit
     def compiled(x: float, y: float):
         g = qml.qnode(qml.device(backend, wires=1), diff_method="parameter-shift")(f_compiled)
         h = grad(g, method="auto", argnums=0)
@@ -662,7 +662,7 @@ def test_ps_for_loops(inp, backend):
             qml.RX(x * i * 1.5, wires=0)
         return qml.expval(qml.PauliY(0))
 
-    @qjit()
+    @qjit
     def compiled(x: float, y: int):
         g = qml.qnode(qml.device(backend, wires=1), diff_method="parameter-shift")(f_compiled)
         h = grad(g, method="auto", argnums=0)
@@ -704,7 +704,7 @@ def test_ps_for_loops_entangled(inp, backend):
             qml.CNOT(wires=[0, i])
         return qml.expval(qml.PauliY(z))
 
-    @qjit()
+    @qjit
     def compiled(x: float, y: int, z: int):
         g = qml.qnode(qml.device(backend, wires=3), diff_method="parameter-shift")(f_compiled)
         h = grad(g, method="auto", argnums=0)
@@ -762,7 +762,7 @@ def test_ps_qft(inp, backend):
 
         return qml.expval(qml.PauliZ(z))
 
-    @qjit()
+    @qjit
     def compiled(x: float, y: int, z: int):
         g = qml.qnode(qml.device(backend, wires=3), diff_method="parameter-shift")(qft_compiled)
         h = grad(g, method="auto", argnums=0)
@@ -825,7 +825,7 @@ def test_finite_diff_h(inp, backend):
         qml.RX(x, wires=0)
         return qml.expval(qml.PauliY(0))
 
-    @qjit()
+    @qjit
     def compiled_grad_h(x: float):
         g = qml.qnode(qml.device(backend, wires=1))(f)
         h = grad(g, method="fd", h=0.1)
@@ -848,7 +848,7 @@ def test_finite_diff_argnum(inp, backend):
         qml.RX(x**y, wires=0)
         return qml.expval(qml.PauliY(0))
 
-    @qjit()
+    @qjit
     def compiled_grad_argnum(x: float):
         g = qml.qnode(qml.device(backend, wires=1))(f2)
         h = grad(g, method="fd", argnums=1)
@@ -871,7 +871,7 @@ def test_finite_diff_argnum_list(inp, backend):
         qml.RX(x**y, wires=0)
         return qml.expval(qml.PauliY(0))
 
-    @qjit()
+    @qjit
     def compiled_grad_argnum_list(x: float):
         g = qml.qnode(qml.device(backend, wires=1))(f2)
         h = grad(g, method="fd", argnums=[1])
@@ -898,7 +898,7 @@ def test_finite_grad_range_change(inp, backend):
         qml.RX(x**y, wires=0)
         return qml.expval(qml.PauliY(0))
 
-    @qjit()
+    @qjit
     def compiled_grad_range_change(x: float):
         g = qml.qnode(qml.device(backend, wires=1))(f2)
         h = grad(g, method="fd", argnums=[0, 1])
@@ -921,7 +921,7 @@ def test_ps_grad_range_change(inp, backend):
         qml.RX(x**y, wires=0)
         return qml.expval(qml.PauliY(0))
 
-    @qjit()
+    @qjit
     def compiled_grad_range_change(x: float):
         g = qml.qnode(qml.device(backend, wires=1), diff_method="parameter-shift")(f2)
         h = grad(g, method="auto", argnums=[0, 1])
@@ -944,7 +944,7 @@ def test_ps_tensorinp(inp, backend):
         qml.RX(x[0] ** y, wires=0)
         return qml.expval(qml.PauliY(0))
 
-    @qjit()
+    @qjit
     def compiled(x: jax.core.ShapedArray([1], float)):
         g = qml.qnode(qml.device(backend, wires=1), diff_method="parameter-shift")(f2)
         h = grad(g, method="auto", argnums=[0, 1])
@@ -968,7 +968,7 @@ def test_adjoint_grad_range_change(inp, backend):
         qml.RX(x**y, wires=0)
         return qml.expval(qml.PauliY(0))
 
-    @qjit()
+    @qjit
     def compiled_grad_range_change(x: float):
         g = qml.qnode(qml.device(backend, wires=1), diff_method="adjoint")(f2)
         h = grad(g, method="auto", argnums=[0, 1])
@@ -993,7 +993,7 @@ def test_assert_no_higher_order_without_fd(method, backend):
 
     with pytest.raises(DifferentiableCompileError, match="higher order derivatives"):
 
-        @qjit()
+        @qjit
         def workflow(x: float):
             g = qml.qnode(qml.device(backend, wires=1), diff_method=method)(f)
             h = grad(g, method="auto")
@@ -1010,7 +1010,7 @@ def test_assert_invalid_diff_method():
 
     with pytest.raises(ValueError, match="Invalid differentiation method"):
 
-        @qjit()
+        @qjit
         def workflow(x: float):
             g = qml.qnode(qml.device("lightning.qubit", wires=1))(f)
             h = grad(g, method="non-existent method")
@@ -1026,7 +1026,7 @@ def test_assert_invalid_h_type():
 
     with pytest.raises(ValueError, match="Invalid h value"):
 
-        @qjit()
+        @qjit
         def workflow(x: float):
             g = qml.qnode(qml.device("lightning.qubit", wires=1))(f)
             h = grad(g, method="fd", h="non-integer")
@@ -1065,7 +1065,7 @@ def test_finite_diff_higher_order(inp, backend):
         qml.RX(x, wires=0)
         return qml.expval(qml.PauliY(0))
 
-    @qjit()
+    @qjit
     def compiled_grad2_default(x: float):
         g = qml.qnode(qml.device(backend, wires=1))(f)
         h = grad(g, method="fd")
@@ -1095,7 +1095,7 @@ def test_jax_consts(h_coeffs, g_method, backend):
         h_obs = [qml.PauliX(0) @ qml.PauliZ(1), qml.PauliZ(0) @ qml.Hadamard(2)]
         return qml.expval(qml.Hamiltonian(h_coeffs, h_obs))
 
-    @qjit()
+    @qjit
     def compile_grad(params):
         diff_method = "adjoint" if g_method == "auto" else "finite-diff"
         g = qml.qnode(qml.device(backend, wires=3), diff_method=diff_method)(circuit)
@@ -1168,7 +1168,7 @@ def test_finite_diff_multiple_devices(inp, diff_method, backend):
         qml.RX(3 * x, wires=0)
         return qml.expval(qml.PauliY(0))
 
-    @qjit()
+    @qjit
     def compiled_grad_default(params, ntrials):
         d_f = grad(f, argnums=0, method=diff_method)
 
@@ -1482,7 +1482,7 @@ def test_adj_qubitunitary(inp, backend):
         qml.QubitUnitary(U1, wires=0)
         return qml.expval(qml.PauliY(0))
 
-    @qjit()
+    @qjit
     def compiled(x: float):
         g = qml.qnode(qml.device(backend, wires=1), diff_method="adjoint")(f)
         h = grad(g, method="auto")

--- a/frontend/test/pytest/test_jax_dynamic_api.py
+++ b/frontend/test/pytest/test_jax_dynamic_api.py
@@ -405,7 +405,7 @@ def test_array_assignment():
 def test_qjit_forloop_identity():
     """Test simple for-loop primitive vs dynamic dimensions"""
 
-    @qjit()
+    @qjit
     def f(sz):
         a = jnp.ones([sz], dtype=float)
 
@@ -424,7 +424,7 @@ def test_qjit_forloop_identity():
 def test_qjit_forloop_capture():
     """Test simple for-loop primitive vs dynamic dimensions"""
 
-    @qjit()
+    @qjit
     def f(sz):
         x = jnp.ones([sz], dtype=float)
 
@@ -443,7 +443,7 @@ def test_qjit_forloop_capture():
 def test_qjit_forloop_shared_indbidx():
     """Test for-loops with shared dynamic input dimensions in classical tracing mode"""
 
-    @qjit()
+    @qjit
     def f(sz):
         a = jnp.ones([sz], dtype=float)
         b = jnp.ones([sz], dtype=float)
@@ -463,7 +463,7 @@ def test_qjit_forloop_shared_indbidx():
 def test_qjit_forloop_indbidx_outdbidx():
     """Test for-loops with shared dynamic output dimensions in classical tracing mode"""
 
-    @qjit()
+    @qjit
     def f(sz):
         a = jnp.ones([sz, 3], dtype=float)
         b = jnp.ones([sz, 3], dtype=float)
@@ -485,7 +485,7 @@ def test_qjit_forloop_indbidx_outdbidx():
 def test_qjit_forloop_index_indbidx():
     """Test for-loops referring loop return new dimension variable."""
 
-    @qjit()
+    @qjit
     def f(sz):
         a0 = jnp.ones([sz], dtype=float)
 
@@ -504,7 +504,7 @@ def test_qjit_forloop_index_indbidx():
 def test_qjit_forloop_indbidx_const():
     """Test for-loops preserve type information in the presence of a constant."""
 
-    @qjit()
+    @qjit
     def f(sz):
         a0 = jnp.ones([sz], dtype=float)
 
@@ -545,7 +545,7 @@ def test_qjit_forloop_shared_dimensions():
 def test_qnode_forloop_identity():
     """Test simple for-loops with dynamic dimensions while doing quantum tracing."""
 
-    @qjit()
+    @qjit
     @qml.qnode(qml.device("lightning.qubit", wires=4))
     def f(sz):
         a = jnp.ones([sz], dtype=float)
@@ -565,7 +565,7 @@ def test_qnode_forloop_identity():
 def test_qnode_forloop_capture():
     """Test simple for-loops with dynamic dimensions while doing quantum tracing."""
 
-    @qjit()
+    @qjit
     @qml.qnode(qml.device("lightning.qubit", wires=4))
     def f(sz):
         x = jnp.ones([sz], dtype=float)
@@ -585,7 +585,7 @@ def test_qnode_forloop_capture():
 def test_qnode_forloop_shared_indbidx():
     """Tests that for-loops preserve equality of output dynamic dimensions."""
 
-    @qjit()
+    @qjit
     @qml.qnode(qml.device("lightning.qubit", wires=4))
     def f(sz):
         a = jnp.ones([sz], dtype=float)
@@ -606,7 +606,7 @@ def test_qnode_forloop_shared_indbidx():
 def test_qnode_forloop_indbidx_outdbidx():
     """Test for-loops with mixed input and output dimension variables during the quantum tracing."""
 
-    @qjit()
+    @qjit
     @qml.qnode(qml.device("lightning.qubit", wires=4))
     def f(sz):
         a = jnp.ones([sz], dtype=float)
@@ -650,7 +650,7 @@ def test_qnode_forloop_abstracted_axes():
 def test_qnode_forloop_index_indbidx():
     """Test for-loops referring loop index as a dimension during the quantum tracing."""
 
-    @qjit()
+    @qjit
     @qml.qnode(qml.device("lightning.qubit", wires=4))
     def f(sz):
         a = jnp.ones([sz, 3], dtype=float)
@@ -670,7 +670,7 @@ def test_qnode_forloop_index_indbidx():
 def test_qnode_whileloop_1():
     """Test that catalyst tensor primitive is compatible with quantum while"""
 
-    @qjit()
+    @qjit
     @qml.qnode(qml.device("lightning.qubit", wires=4))
     def f(sz):
         a0 = jnp.ones([sz + 1], dtype=float)
@@ -691,7 +691,7 @@ def test_qnode_whileloop_1():
 def test_qnode_whileloop_2():
     """Test that catalyst tensor primitive is compatible with quantum while"""
 
-    @qjit()
+    @qjit
     @qml.qnode(qml.device("lightning.qubit", wires=4))
     def f(sz):
         a = jnp.ones([sz + 1], dtype=float)
@@ -713,7 +713,7 @@ def test_qnode_whileloop_2():
 def test_qnode_whileloop_capture():
     """Tests that while-loop primitive can capture variables from the outer scope"""
 
-    @qjit()
+    @qjit
     @qml.qnode(qml.device("lightning.qubit", wires=4))
     def f(sz):
         x = jnp.ones([sz], dtype=float)
@@ -755,7 +755,7 @@ def test_qnode_whileloop_abstracted_axes():
 def test_qnode_whileloop_shared_indbidx():
     """Test that catalyst tensor primitive is compatible with quantum while"""
 
-    @qjit()
+    @qjit
     @qml.qnode(qml.device("lightning.qubit", wires=4))
     def f(sz):
         a = jnp.ones([sz], dtype=float)
@@ -777,7 +777,7 @@ def test_qnode_whileloop_shared_indbidx():
 def test_qnode_whileloop_indbidx_outdbidx():
     """Test that catalyst tensor primitive is compatible with quantum while"""
 
-    @qjit()
+    @qjit
     @qml.qnode(qml.device("lightning.qubit", wires=4))
     def f(sz):
         a = jnp.ones([sz], dtype=float)
@@ -841,7 +841,7 @@ def test_qjit_whileloop_1():
 def test_qjit_whileloop_2():
     """Test that catalyst tensor primitive is compatible with quantum while"""
 
-    @qjit()
+    @qjit
     def f(sz):
         a = jnp.ones([sz + 1], dtype=float)
 
@@ -884,7 +884,7 @@ def test_qjit_whileloop_shared_dimensions():
 def test_qjit_whileloop_shared_indbidx():
     """Test that catalyst tensor primitive is compatible with quantum while"""
 
-    @qjit()
+    @qjit
     def f(sz):
         a = jnp.ones([sz], dtype=float)
         b = jnp.ones([sz], dtype=float)
@@ -905,7 +905,7 @@ def test_qjit_whileloop_shared_indbidx():
 def test_qjit_whileloop_indbidx_outdbidx():
     """Test that catalyst tensor primitive is compatible with quantum while"""
 
-    @qjit()
+    @qjit
     def f(sz):
         a0 = jnp.ones([sz], dtype=float)
         b0 = jnp.ones([sz], dtype=float)
@@ -947,7 +947,7 @@ def test_qjit_whileloop_outer():
 def test_qjit_whileloop_capture():
     """Tests that while-loop primitive can capture variables from the outer scope"""
 
-    @qjit()
+    @qjit
     def f(sz):
         x = jnp.ones([sz], dtype=float)
 

--- a/frontend/test/pytest/test_jnp_vs_np.py
+++ b/frontend/test/pytest/test_jnp_vs_np.py
@@ -33,8 +33,8 @@ def circuit_np():
 def test_variable_wires(backend):
     """Test variable wires."""
 
-    jitted_fn_jnp = qjit()(qml.qnode(qml.device(backend, wires=1))(circuit_jnp))
-    jitted_fn_np = qjit()(qml.qnode(qml.device(backend, wires=1))(circuit_np))
+    jitted_fn_jnp = qjit(qml.qnode(qml.device(backend, wires=1))(circuit_jnp))
+    jitted_fn_np = qjit(qml.qnode(qml.device(backend, wires=1))(circuit_np))
     assert np.isclose(jitted_fn_jnp(), jitted_fn_np())
 
 

--- a/frontend/test/pytest/test_keyword_arguments.py
+++ b/frontend/test/pytest/test_keyword_arguments.py
@@ -29,7 +29,7 @@ class TestKeywordArguments:
     def test_function_with_kwargs(self):
         """Test that a function works with keyword argeument."""
 
-        @qjit()
+        @qjit
         def f(x, y):
             return x * y
 
@@ -39,7 +39,7 @@ class TestKeywordArguments:
     def test_function_with_kwargs_partial(self):
         """Test that a function works with keyword argeument."""
 
-        @qjit()
+        @qjit
         def f(x, y):
             return x * y
 
@@ -50,7 +50,7 @@ class TestKeywordArguments:
         """Test that a qnode works with keyword argeument."""
         dev = qml.device(backend, wires=1)
 
-        @qjit()
+        @qjit
         @qml.qnode(dev)
         def circuit(x, c):
             qml.RY(c, 0)
@@ -63,7 +63,7 @@ class TestKeywordArguments:
         """Test that a qnode works with keyword argeument."""
         dev = qml.device(backend, wires=1)
 
-        @qjit()
+        @qjit
         @qml.qnode(dev)
         def circuit(x, c):
             qml.RX(x, wires=0)

--- a/frontend/test/pytest/test_loops.py
+++ b/frontend/test/pytest/test_loops.py
@@ -311,7 +311,7 @@ class TestForLoops:
     def test_dynamic_wires(self, backend):
         """Test for loops with iteration index-dependant wires."""
 
-        @qjit()
+        @qjit
         @qml.qnode(qml.device(backend, wires=6))
         def circuit(n: int):
             qml.Hadamard(wires=0)

--- a/frontend/test/pytest/test_operations.py
+++ b/frontend/test/pytest/test_operations.py
@@ -89,7 +89,7 @@ def test_no_parameters(backend):
 
         return qml.state()
 
-    qjit_fn = qjit()(qml.qnode(qml.device(backend, wires=4))(circuit))
+    qjit_fn = qjit(qml.qnode(qml.device(backend, wires=4))(circuit))
     qml_fn = qml.qnode(qml.device("default.qubit", wires=4))(circuit)
 
     assert np.allclose(qjit_fn(), qml_fn())
@@ -144,7 +144,7 @@ def test_param(backend):
 
         return qml.state()
 
-    qjit_fn = qjit()(qml.qnode(qml.device(backend, wires=4))(circuit))
+    qjit_fn = qjit(qml.qnode(qml.device(backend, wires=4))(circuit))
     qml_fn = qml.qnode(qml.device("default.qubit", wires=4))(circuit)
 
     assert np.allclose(qjit_fn(3.14, 0.6), qml_fn(3.14, 0.6))
@@ -197,7 +197,7 @@ def test_hybrid_op_repr(backend):
                 assert not has_nested_tapes(op)
         return qml.state()
 
-    qjit()(qml.qnode(qml.device(backend, wires=4))(circuit))(1)
+    qjit(qml.qnode(qml.device(backend, wires=4))(circuit))(1)
 
 
 @pytest.mark.parametrize("inp", [(1.0), (2.0), (3.0), (4.0)])
@@ -210,7 +210,7 @@ def test_qubitunitary_complex(inp, backend):
         qml.QubitUnitary(U1, wires=0)
         return qml.expval(qml.PauliY(0))
 
-    @qjit()
+    @qjit
     def compiled(x: float):
         g = qml.qnode(qml.device(backend, wires=1))(f)
         return g(x)

--- a/frontend/test/pytest/test_peephole_optimizations.py
+++ b/frontend/test/pytest/test_peephole_optimizations.py
@@ -188,7 +188,7 @@ def test_chained_passes():
     Test that chained passes are present in the transform passes.
     """
 
-    @qjit()
+    @qjit
     @merge_rotations
     @cancel_inverses
     @qml.qnode(qml.device("lightning.qubit", wires=2))
@@ -209,7 +209,7 @@ def test_disentangle_passes():
     and are applied correctly.
     """
 
-    @qjit()
+    @qjit
     @qml.qnode(qml.device("lightning.qubit", wires=2))
     def circuit_with_no_disentangle_passes():
         # first qubit in |1>
@@ -219,7 +219,7 @@ def test_disentangle_passes():
         qml.SWAP(wires=[0, 1])  # state after SWAP |11>
         return qml.state()
 
-    @qjit()
+    @qjit
     @disentangle_cnot
     @disentangle_swap
     @qml.qnode(qml.device("lightning.qubit", wires=2))

--- a/frontend/test/pytest/test_qnode.py
+++ b/frontend/test/pytest/test_qnode.py
@@ -27,7 +27,7 @@ from catalyst.device.qjit_device import QJITDevice
 def test_variable_capture(_in, _out):
     """Test closures (outer-scope variable capture) for quantum functions."""
 
-    @qjit()
+    @qjit
     def workflow(n: int):
         @qml.qnode(qml.device("lightning.qubit", wires=2))
         def f(x: float):
@@ -54,7 +54,7 @@ def test_variable_capture(_in, _out):
 def test_variable_capture_multiple_devices(_in, _out, backend):
     """Test variable capture using multiple backend devices."""
 
-    @qjit()
+    @qjit
     def workflow(n: int):
         @qml.qnode(qml.device("lightning.qubit", wires=2))
         def f(x: float):

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -434,7 +434,7 @@ class TestCatalystControlled:
             qml.ctrl(qml.PauliZ(wires=[0]), control=[1, 2, 3])
             return qml.state()
 
-        compiled = qjit()(native_controlled)
+        compiled = qjit(native_controlled)
         assert all(sign in compiled.mlir for sign in ["ctrls", "ctrlvals"])
         result = compiled()
         expected = native_controlled()
@@ -461,7 +461,7 @@ class TestCatalystControlled:
             )
             return qml.state()
 
-        compiled = qjit()(native_controlled)
+        compiled = qjit(native_controlled)
         result = compiled()
         expected = native_controlled()
         assert_allclose(result, expected, atol=1e-5, rtol=1e-5)

--- a/frontend/test/pytest/test_unsupported_argument_type.py
+++ b/frontend/test/pytest/test_unsupported_argument_type.py
@@ -23,7 +23,7 @@ def test_strings_aot(backend):
     """Test strings AOT."""
 
     # Due to limitations in the frontend, we can only test qjit with scalar floats.
-    @qjit()
+    @qjit
     @qml.qnode(qml.device(backend, wires=2))
     def foo(x: float, y: float):
         val = jax.numpy.arctan2(x, y)
@@ -38,7 +38,7 @@ def test_strings_jit(backend):
     """Test strings JIT."""
 
     # Due to limitations in the frontend, we can only test qjit with scalar floats.
-    @qjit()
+    @qjit
     @qml.qnode(qml.device(backend, wires=2))
     def bar(x, y):
         val = jax.numpy.arctan2(x, y)

--- a/frontend/test/pytest/test_variable_wires.py
+++ b/frontend/test/pytest/test_variable_wires.py
@@ -155,7 +155,7 @@ class TestControlFlow:
     def test_conditional(self, args, expected, backend):
         """Test conditional."""
 
-        @qjit()
+        @qjit
         @qml.qnode(qml.device(backend, wires=2))
         def circuit(x: int, y: int):
             @cond(x > 4)
@@ -177,7 +177,7 @@ class TestControlFlow:
     def test_while_loop_with_func_arg_wires(self, args, expected, backend):
         """Test while loop with func arg wires."""
 
-        @qjit()
+        @qjit
         @qml.qnode(qml.device(backend, wires=2))
         def circuit(n: int, m: int):
             @while_loop(lambda v: v[0] < v[1])
@@ -204,7 +204,7 @@ class TestControlFlow:
     def test_while_loop_with_loop_arg_wires(self, args, expected, backend):
         """Test while loop with loop arg wires."""
 
-        @qjit()
+        @qjit
         @qml.qnode(qml.device(backend, wires=5))
         def circuit(n: int, m: int):
             qml.RX(jnp.pi, wires=0)


### PR DESCRIPTION
When no kwargs are supplied, an additional function call with empty
parenthesis is not necessary and discouraged in all public use cases.

Non-functional change, docs and tests only. No changelog