### PR TITLE
allow MLIR spinal case in python pass_api

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -10,9 +10,30 @@
 *  Displays Catalyst version in `quantum-opt --version` output.
   [(#1922)](https://github.com/PennyLaneAI/catalyst/pull/1922)
 
-* :func:`~.passes.apply_pass` can now take in `valued_options` whose names consist of multiple words as
-  snake_case post-processed to hyphens `-` when passing to MLIR pass.
-  [(#1954)](https://github.com/PennyLaneAI/catalyst/pull/1954)
+* Snakecased keyword arguments to :func:`catalyst.passes.apply_pass()` are now correctly parsed 
+  to kebab-case pass options [(#1954)](https://github.com/PennyLaneAI/catalyst/pull/1954).
+  For example:
+
+  ```python
+  @qjit(target="mlir")
+  @catalyst.passes.apply_pass("some-pass", "an-option", maxValue=1, multi_word_option=1)
+  @qml.qnode(qml.device("null.qubit", wires=1))
+  def example():
+      return qml.state()
+  ```
+
+  which looks like the following line in the MLIR:
+
+  ```pycon
+  module attributes {transform.with_named_sequence} {
+      transform.named_sequence @__transform_main(%arg0: !transform.op<"builtin.module">) {
+        %0 = transform.apply_registered_pass "some-pass" with options = {"an-option" = true, "maxValue" = 1 : i64, "multi-word-option" = 1 : i64} to %arg0 : (!transform.op<"builtin.module">) -> !transform.op<"builtin.module">
+        transform.yield 
+      }
+    }
+  ```
+
+For example, ...
 
 <h3>Breaking changes 💔</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -25,15 +25,8 @@
   which looks like the following line in the MLIR:
 
   ```pycon
-  module attributes {transform.with_named_sequence} {
-      transform.named_sequence @__transform_main(%arg0: !transform.op<"builtin.module">) {
-        %0 = transform.apply_registered_pass "some-pass" with options = {"an-option" = true, "maxValue" = 1 : i64, "multi-word-option" = 1 : i64} to %arg0 : (!transform.op<"builtin.module">) -> !transform.op<"builtin.module">
-        transform.yield 
-      }
-    }
+  %0 = transform.apply_registered_pass "some-pass" with options = {"an-option" = true, "maxValue" = 1 : i64, "multi-word-option" = 1 : i64}
   ```
-
-For example, ...
 
 <h3>Breaking changes 💔</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -10,6 +10,10 @@
 *  Displays Catalyst version in `quantum-opt --version` output.
   [(#1922)](https://github.com/PennyLaneAI/catalyst/pull/1922)
 
+* `~.passes.apply_pass` can now take in `valued_options` whose names consist of multiple words as
+  snake_case post-processed to hyphens `-` when passing to MLIR pass.
+  [(#1954)](https://github.com/PennyLaneAI/catalyst/pull/1954)
+
 <h3>Breaking changes 💔</h3>
 
 * The JAX version used by Catalyst is updated to 0.6.2.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -10,7 +10,7 @@
 *  Displays Catalyst version in `quantum-opt --version` output.
   [(#1922)](https://github.com/PennyLaneAI/catalyst/pull/1922)
 
-* `~.passes.apply_pass` can now take in `valued_options` whose names consist of multiple words as
+* :func:`~.passes.apply_pass` can now take in `valued_options` whose names consist of multiple words as
   snake_case post-processed to hyphens `-` when passing to MLIR pass.
   [(#1954)](https://github.com/PennyLaneAI/catalyst/pull/1954)
 

--- a/frontend/catalyst/passes/pass_api.py
+++ b/frontend/catalyst/passes/pass_api.py
@@ -296,9 +296,9 @@ class Pass:
             options_dict[str(option)] = get_mlir_attribute_from_pyval(True)
 
         for option, value in self.valued_options.items():
-            # MLIR options are either CamelCase 
+            # MLIR options are either CamelCase
             # or spinal-case (kebab-case) which is not allowed in python
-            mlir_option = str(option).replace("_","-") 
+            mlir_option = str(option).replace("_", "-")
             options_dict[mlir_option] = get_mlir_attribute_from_pyval(value)
 
         return options_dict

--- a/frontend/catalyst/passes/pass_api.py
+++ b/frontend/catalyst/passes/pass_api.py
@@ -296,7 +296,10 @@ class Pass:
             options_dict[str(option)] = get_mlir_attribute_from_pyval(True)
 
         for option, value in self.valued_options.items():
-            options_dict[str(option)] = get_mlir_attribute_from_pyval(value)
+            # MLIR options are either CamelCase 
+            # or spinal-case (kebab-case) which is not allowed in python
+            mlir_option = str(option).replace("_","-") 
+            options_dict[mlir_option] = get_mlir_attribute_from_pyval(value)
 
         return options_dict
 

--- a/frontend/test/lit/test_mlir_plugin.py
+++ b/frontend/test/lit/test_mlir_plugin.py
@@ -107,7 +107,7 @@ def test_pass_options():
 
     @qjit(target="mlir")
     # CHECK: options = {"an-option" = true, "maxValue" = 1 : i64, "mlir-option" = 1 : i64}
-    @catalyst.passes.apply_pass("some-pass", "an-option", maxValue=1, mlir_option = 1)
+    @catalyst.passes.apply_pass("some-pass", "an-option", maxValue=1, mlir_option=1)
     @qml.qnode(qml.device("null.qubit", wires=1))
     def example():
         return qml.state()

--- a/frontend/test/lit/test_mlir_plugin.py
+++ b/frontend/test/lit/test_mlir_plugin.py
@@ -106,8 +106,8 @@ def test_pass_options():
     """Is the option in the generated MLIR?"""
 
     @qjit(target="mlir")
-    # CHECK: options = {"an-option" = true, "maxValue" = 1 : i64, "mlir-option" = 1 : i64}
-    @catalyst.passes.apply_pass("some-pass", "an-option", maxValue=1, mlir_option=1)
+    # CHECK: options = {"an-option" = true, "maxValue" = 1 : i64, "multi-word-option" = 1 : i64}
+    @catalyst.passes.apply_pass("some-pass", "an-option", maxValue=1, multi_word_option=1)
     @qml.qnode(qml.device("null.qubit", wires=1))
     def example():
         return qml.state()

--- a/frontend/test/lit/test_mlir_plugin.py
+++ b/frontend/test/lit/test_mlir_plugin.py
@@ -106,8 +106,8 @@ def test_pass_options():
     """Is the option in the generated MLIR?"""
 
     @qjit(target="mlir")
-    # CHECK: options = {"an-option" = true, "maxValue" = 1 : i64}
-    @catalyst.passes.apply_pass("some-pass", "an-option", maxValue=1)
+    # CHECK: options = {"an-option" = true, "maxValue" = 1 : i64, "mlir-option" = 1 : i64}
+    @catalyst.passes.apply_pass("some-pass", "an-option", maxValue=1, mlir_option = 1)
     @qml.qnode(qml.device("null.qubit", wires=1))
     def example():
         return qml.state()


### PR DESCRIPTION
**Context:**

**Description of the Change:**

- MLIR options are either written in `CamelCase` or `spinal-case`
- [pass_api](https://docs.pennylane.ai/projects/catalyst/en/latest/code/api/catalyst.passes.apply_pass.html) can be used to directly call Catalyst MLIR passes from Python
- But variables in Python cannot be written in `spinal-case`
- This PR allows writing those options using `_` (underscores) in Python and post-process them to `spinal-case` in `frontend/catalyst/passes/pass_api.py`

E.g. 

```python
@qjit(target="mlir")
# CHECK: options = {"an-option" = true, "maxValue" = 1 : i64, "mlir-option" = 1 : i64}
@catalyst.passes.apply_pass("some-pass", "an-option", maxValue=1, mlir_option = 1)
@qml.qnode(qml.device("null.qubit", wires=1))
def example():
    return qml.state()

print(example.mlir)
```

**Benefits:** Support `spinal-case` in Python 

**Possible Drawbacks:** If MLIR options do have underscore (_) in them, it will be post-processed to `-` 
