### PR TITLE
Remove unnecessary capabilities arg in `extract_backend_info`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,6 +4,8 @@
 
 <h3>Improvements 🛠</h3>
 
+* QJitDevice helper `extract_backend_info` removed its redundant `capabilities` argument.
+
 * Workflows `for_loop`, `while_loop` and `cond` now error out if `qml.capture` is enabled.
   [(#1945)](https://github.com/PennyLaneAI/catalyst/pull/1945)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,9 +4,6 @@
 
 <h3>Improvements 🛠</h3>
 
-* QJitDevice helper `extract_backend_info` removed its redundant `capabilities` argument.
-  [(#1956)](https://github.com/PennyLaneAI/catalyst/pull/1956)
-
 * Workflows `for_loop`, `while_loop` and `cond` now error out if `qml.capture` is enabled.
   [(#1945)](https://github.com/PennyLaneAI/catalyst/pull/1945)
 
@@ -59,6 +56,9 @@
   [(#1926)](https://github.com/PennyLaneAI/catalyst/pull/1926)
 
 <h3>Internal changes ⚙️</h3>
+
+* QJitDevice helper `extract_backend_info` removed its redundant `capabilities` argument.
+  [(#1956)](https://github.com/PennyLaneAI/catalyst/pull/1956)
 
 * Raise warning when subroutines are used without capture enabled.
   [(#1930)](https://github.com/PennyLaneAI/catalyst/pull/1930)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -5,6 +5,7 @@
 <h3>Improvements 🛠</h3>
 
 * QJitDevice helper `extract_backend_info` removed its redundant `capabilities` argument.
+  [(#1956)](https://github.com/PennyLaneAI/catalyst/pull/1956)
 
 * Workflows `for_loop`, `while_loop` and `cond` now error out if `qml.capture` is enabled.
   [(#1945)](https://github.com/PennyLaneAI/catalyst/pull/1945)

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -140,8 +140,7 @@ class BackendInfo:
 # pylint: disable=too-many-branches
 @debug_logger
 def extract_backend_info(
-    device: qml.devices.QubitDevice, capabilities: DeviceCapabilities
-) -> BackendInfo:
+    device: qml.devices.QubitDevice) -> BackendInfo:
     """Extract the backend info from a quantum device. The device is expected to carry a reference
     to a valid TOML config file."""
 
@@ -295,9 +294,9 @@ class QJITDevice(qml.devices.Device):
 
     @staticmethod
     @debug_logger
-    def extract_backend_info(device, capabilities: DeviceCapabilities) -> BackendInfo:
+    def extract_backend_info(device) -> BackendInfo:
         """Wrapper around extract_backend_info in the runtime module."""
-        return extract_backend_info(device, capabilities)
+        return extract_backend_info(device)
 
     @debug_logger_init
     def __init__(self, original_device):
@@ -323,7 +322,7 @@ class QJITDevice(qml.devices.Device):
                     "The device that specifies to_matrix_ops must support QubitUnitary."
                 )
 
-        backend = QJITDevice.extract_backend_info(original_device, device_capabilities)
+        backend = QJITDevice.extract_backend_info(original_device)
 
         self.backend_name = backend.c_interface_name
         self.backend_lib = backend.lpath

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -139,8 +139,7 @@ class BackendInfo:
 
 # pylint: disable=too-many-branches
 @debug_logger
-def extract_backend_info(
-    device: qml.devices.QubitDevice) -> BackendInfo:
+def extract_backend_info(device: qml.devices.QubitDevice) -> BackendInfo:
     """Extract the backend info from a quantum device. The device is expected to carry a reference
     to a valid TOML config file."""
 

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -88,7 +88,6 @@ measurement_map = {
 
 def _get_device_kwargs(device) -> dict:
     """Calulcate the params for a device equation."""
-    capabilities = get_device_capabilities(device)
     info = extract_backend_info(device)
     # Note that the value of rtd_kwargs is a string version of
     # the info kwargs, not the info kwargs itself

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -89,7 +89,7 @@ measurement_map = {
 def _get_device_kwargs(device) -> dict:
     """Calulcate the params for a device equation."""
     capabilities = get_device_capabilities(device)
-    info = extract_backend_info(device, capabilities)
+    info = extract_backend_info(device)
     # Note that the value of rtd_kwargs is a string version of
     # the info kwargs, not the info kwargs itself
     # this is due to ease of serialization to MLIR

--- a/frontend/catalyst/third_party/cuda/catalyst_to_cuda_interpreter.py
+++ b/frontend/catalyst/third_party/cuda/catalyst_to_cuda_interpreter.py
@@ -808,7 +808,7 @@ class QJIT_CUDAQ:
             an MLIR module
         """
 
-        def cudaq_backend_info(device, _capabilities) -> BackendInfo:
+        def cudaq_backend_info(device) -> BackendInfo:
             """The extract_backend_info should not be run by the cuda compiler as it is
             catalyst-specific. We need to make this API a bit nicer for third-party compilers.
             """

--- a/frontend/test/pytest/test_custom_devices.py
+++ b/frontend/test/pytest/test_custom_devices.py
@@ -20,7 +20,7 @@ from conftest import CONFIG_CUSTOM_DEVICE
 
 from catalyst import measure, qjit
 from catalyst.compiler import get_lib_path
-from catalyst.device import QJITDevice, extract_backend_info, get_device_capabilities
+from catalyst.device import QJITDevice, extract_backend_info
 from catalyst.utils.exceptions import CompileError
 
 RUNTIME_LIB_PATH = get_lib_path("runtime", "RUNTIME_LIB_DIR")
@@ -62,8 +62,7 @@ def test_custom_device_load():
             raise NotImplementedError
 
     device = CustomDevice(wires=1)
-    capabilities = get_device_capabilities(device)
-    backend_info = extract_backend_info(device, capabilities)
+    backend_info = extract_backend_info(device)
     assert backend_info.kwargs["option1"] == 42
     assert backend_info.kwargs["option2"] == 38
 

--- a/frontend/test/pytest/test_device_api.py
+++ b/frontend/test/pytest/test_device_api.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Test for the device API."""
-import platform
-
 import pennylane as qml
 import pytest
 from pennylane.devices import NullQubit
@@ -129,12 +127,12 @@ def test_simple_circuit():
 def test_track_resources():
     """Test that resource tracking settings get passed to the device."""
     dev = NullQubit(wires=2)
-    assert "track_resources" in QJITDevice.extract_backend_info(dev, dev.capabilities).kwargs
-    assert QJITDevice.extract_backend_info(dev, dev.capabilities).kwargs["track_resources"] is False
+    assert "track_resources" in QJITDevice.extract_backend_info(dev).kwargs
+    assert QJITDevice.extract_backend_info(dev).kwargs["track_resources"] is False
 
     dev = NullQubit(wires=2, track_resources=True)
-    assert "track_resources" in QJITDevice.extract_backend_info(dev, dev.capabilities).kwargs
-    assert QJITDevice.extract_backend_info(dev, dev.capabilities).kwargs["track_resources"] is True
+    assert "track_resources" in QJITDevice.extract_backend_info(dev).kwargs
+    assert QJITDevice.extract_backend_info(dev).kwargs["track_resources"] is True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Context:**
House cleaning. Somehow this redundancy was never caught by CodeFactor or pylint.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-96916]