### PR TITLE
 Add a `graph_state_prep` operation to the MBQC dialect

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -128,7 +128,7 @@
 * The `mbqc.graph_state_prep` operation has been added to the MBQC dialect. This operation prepares
   a graph state with arbitrary qubit connectivity, specified by an input adjacency-matrix operand,
   for use in MBQC workloads.
-  [(#TODO)](https://github.com/PennyLaneAI/catalyst/pull/TODO)
+  [(#1965)](https://github.com/PennyLaneAI/catalyst/pull/1965)
 
 * `catalyst.accelerate`, `catalyst.debug.callback`, and `catalyst.pure_callback`, `catalyst.debug.print`, and `catalyst.debug.print_memref` now work when capture is enabled.
   [(#1902)](https://github.com/PennyLaneAI/catalyst/pull/1902)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -10,7 +10,7 @@
 *  Displays Catalyst version in `quantum-opt --version` output.
   [(#1922)](https://github.com/PennyLaneAI/catalyst/pull/1922)
 
-* Snakecased keyword arguments to :func:`catalyst.passes.apply_pass()` are now correctly parsed 
+* Snakecased keyword arguments to :func:`catalyst.passes.apply_pass()` are now correctly parsed
   to kebab-case pass options [(#1954)](https://github.com/PennyLaneAI/catalyst/pull/1954).
   For example:
 
@@ -124,6 +124,11 @@
   def workload():
       ...
   ```
+
+* The `mbqc.graph_state_prep` operation has been added to the MBQC dialect. This operation prepares
+  a graph state with arbitrary qubit connectivity, specified by an input adjacency-matrix operand,
+  for use in MBQC workloads.
+  [(#TODO)](https://github.com/PennyLaneAI/catalyst/pull/TODO)
 
 * `catalyst.accelerate`, `catalyst.debug.callback`, and `catalyst.pure_callback`, `catalyst.debug.print`, and `catalyst.debug.print_memref` now work when capture is enabled.
   [(#1902)](https://github.com/PennyLaneAI/catalyst/pull/1902)

--- a/mlir/include/MBQC/IR/MBQCOps.td
+++ b/mlir/include/MBQC/IR/MBQCOps.td
@@ -92,9 +92,53 @@ def MeasureInBasisOp : MBQC_Op<"measure_in_basis"> {
 }
 
 def GraphStatePrepOp : MBQC_Op<"graph_state_prep"> {
-    let summary = "TODO";
+    let summary = "Allocate resources for a new graph state.";
     let description = [{
-        TODO
+        This operation allocates the resources for a new quantum *graph state* for use in MBQC
+        workloads. A graph state is a highly entangled group of qubits arranged according to an
+        arbitrary graph structure, where each qubit is represented by a vertex of the graph and
+        where there is an edge between every interacting pair of neighbouring qubits.
+
+        A graph state requires three parameters to be fully expressed:
+
+        1. A graph representing the qubit connectivity.
+        2. The qubit initial state. All qubits in the graph state are assumed to be initialized
+           to the same state. This parameter is expressed as the name of the one-qubit gate that
+           would have to be applied to the :math:`|0\rangle` state to realize the desired state.
+        3. The type of entangling interaction along each edge. All interactions between
+           neighbouring qubits are assumed to be the same. This parameter is expressed as the name
+           of the two-qubit gate that would have to be applied to the pairs of neighbouring qubits
+           to realize the desired entangled state.
+
+        A *densely packed adjacency matrix* is used to represent the graph structure. This
+        representations is a more compact form of the familiar adjacency matrix graph
+        representation, where only the lower-triangular part of the matrix is stored (since the
+        graph is undirected) and where the diagonal elements are excluded (since there are no qubit
+        self-interactions). The matrix values are then packed into a flat array. For example, the
+        following graph structure,
+
+        .. code-block::
+
+            0 -- 1 -- 2 -- 3
+
+        has the adjacency matrix representation (with row and column indices shown for reference):
+
+        .. code-block::
+
+                 0  1  2  3
+
+            0    0  1  0  0
+            1    1  0  1  0
+            2    0  1  0  1
+            3    0  0  1  0
+
+        The equivalent densely packed adjacency matrix has the lower-triangular part of the above
+        matrix packed into a flat array using row-major order as follows (with extra space added
+        between sequences of values to indicate the rows of the matrix):
+
+        .. code-block::
+
+            [1,   0, 1,   0, 0, 1]
     }];
 
     let arguments = (ins

--- a/mlir/include/MBQC/IR/MBQCOps.td
+++ b/mlir/include/MBQC/IR/MBQCOps.td
@@ -91,4 +91,27 @@ def MeasureInBasisOp : MBQC_Op<"measure_in_basis"> {
     }];
 }
 
+def GraphStatePrepOp : MBQC_Op<"graph_state_prep"> {
+    let summary = "TODO";
+    let description = [{
+        TODO
+    }];
+
+    let arguments = (ins
+        AnyTypeOf<[
+            1DTensorOf<[I1]>, MemRefRankOf<[I1], [1]>
+        ]>:$adj_matrix,
+        StrAttr:$init_op,
+        StrAttr:$entangle_op
+    );
+
+    let results = (outs
+        QuregType:$qreg
+    );
+
+    let assemblyFormat = [{
+        `(` $adj_matrix `:` type($adj_matrix) `)` `[` `init` $init_op `,` `entangle` $entangle_op `]` attr-dict `:` type(results)
+    }];
+}
+
 #endif // MBQC_OPS

--- a/mlir/include/MBQC/IR/MBQCOps.td
+++ b/mlir/include/MBQC/IR/MBQCOps.td
@@ -139,6 +139,19 @@ def GraphStatePrepOp : MBQC_Op<"graph_state_prep"> {
         .. code-block::
 
             [1,   0, 1,   0, 0, 1]
+
+        In this representation, the number of vertices, :math:`N`, in the graph is related to the
+        number of elements, :math:`m`, in the densely packed adjacency matrix via
+
+        .. math::
+
+            m = N(N - 1) / 2,
+
+        or inversely,
+
+        .. math::
+
+            N = (1 + \sqrt{1 + 8m}) / 2.
     }];
 
     let arguments = (ins

--- a/mlir/test/MBQC/DialectTest.mlir
+++ b/mlir/test/MBQC/DialectTest.mlir
@@ -14,7 +14,7 @@
 
 // RUN: quantum-opt --split-input-file --verify-diagnostics %s
 
-func.func @testXY(%q1 : !quantum.bit) {
+func.func @test_measure_in_basis_XY(%q1 : !quantum.bit) {
     %angle = arith.constant 3.141592653589793 : f64
     %res, %new_q = mbqc.measure_in_basis [XY, %angle] %q1 : i1, !quantum.bit
     func.return
@@ -22,7 +22,7 @@ func.func @testXY(%q1 : !quantum.bit) {
 
 // -----
 
-func.func @testYZ(%q1 : !quantum.bit) {
+func.func @test_measure_in_basis_YZ(%q1 : !quantum.bit) {
     %angle = arith.constant 3.141592653589793 : f64
     %res, %new_q = mbqc.measure_in_basis [YZ, %angle] %q1 : i1, !quantum.bit
     func.return
@@ -30,7 +30,7 @@ func.func @testYZ(%q1 : !quantum.bit) {
 
 // -----
 
-func.func @testZX(%q1 : !quantum.bit) {
+func.func @test_measure_in_basis_ZX(%q1 : !quantum.bit) {
     %angle = arith.constant 3.141592653589793 : f64
     %res, %new_q = mbqc.measure_in_basis [ZX, %angle] %q1 : i1, !quantum.bit
     func.return
@@ -38,7 +38,7 @@ func.func @testZX(%q1 : !quantum.bit) {
 
 // -----
 
-func.func @testDynamicAngle(%q1 : !quantum.bit, %arg0: tensor<f64>) {
+func.func @test_measure_in_basis_dynamic_angle(%q1 : !quantum.bit, %arg0: tensor<f64>) {
     %1 = stablehlo.convert %arg0 : tensor<f64>
     %angle = tensor.extract %1[] : tensor<f64>
     %res, %new_q = mbqc.measure_in_basis [XY, %angle] %q1 : i1, !quantum.bit
@@ -47,7 +47,7 @@ func.func @testDynamicAngle(%q1 : !quantum.bit, %arg0: tensor<f64>) {
 
 // -----
 
-func.func @testInvalid(%q1 : !quantum.bit) {
+func.func @test_measure_in_basis_invalid_plane(%q1 : !quantum.bit) {
     %angle = arith.constant 3.141592653589793 : f64
     // expected-error@below {{expected catalyst::mbqc::MeasurementPlane to be one of: XY, YZ, ZX}}
     // expected-error@below {{failed to parse MeasurementPlaneAttr parameter}}
@@ -57,7 +57,7 @@ func.func @testInvalid(%q1 : !quantum.bit) {
 
 // -----
 
-func.func @testPostSelect0(%q1 : !quantum.bit) {
+func.func @test_measure_in_basis_postselect_0(%q1 : !quantum.bit) {
     %angle = arith.constant 3.141592653589793 : f64
     %res, %new_q = mbqc.measure_in_basis [XY, %angle] %q1 postselect 0 : i1, !quantum.bit
     func.return
@@ -65,7 +65,7 @@ func.func @testPostSelect0(%q1 : !quantum.bit) {
 
 // -----
 
-func.func @testPostSelect1(%q1 : !quantum.bit) {
+func.func @test_measure_in_basis_postselect_1(%q1 : !quantum.bit) {
     %angle = arith.constant 3.141592653589793 : f64
     %res, %new_q = mbqc.measure_in_basis [XY, %angle] %q1 postselect 1 : i1, !quantum.bit
     func.return
@@ -73,7 +73,7 @@ func.func @testPostSelect1(%q1 : !quantum.bit) {
 
 // -----
 
-func.func @testPostSelectInvalid(%q1 : !quantum.bit) {
+func.func @test_measure_in_basis_postselect_invalid(%q1 : !quantum.bit) {
     %angle = arith.constant 3.141592653589793 : f64
     // expected-error@below {{op attribute 'postselect' failed to satisfy constraint}}
     %res, %new_q = mbqc.measure_in_basis [XY, %angle] %q1 postselect -1 : i1, !quantum.bit
@@ -82,9 +82,17 @@ func.func @testPostSelectInvalid(%q1 : !quantum.bit) {
 
 // -----
 
-func.func @testPostSelectInvalid(%q1 : !quantum.bit) {
+func.func @test_measure_in_basis_postselect_invalid(%q1 : !quantum.bit) {
     %angle = arith.constant 3.141592653589793 : f64
     // expected-error@below {{op attribute 'postselect' failed to satisfy constraint}}
     %res, %new_q = mbqc.measure_in_basis [XY, %angle] %q1 postselect 2 : i1, !quantum.bit
+    func.return
+}
+
+// -----
+
+func.func @test_graph_state_prep() {
+    %adj_matrix = arith.constant dense<[1, 0, 1, 0, 0, 1]> : tensor<6xi1>
+    %graph_reg = mbqc.graph_state_prep (%adj_matrix : tensor<6xi1>) [init "Hadamard", entangle "CZ"] : !quantum.reg
     func.return
 }


### PR DESCRIPTION
**Context:** We require a more compact way to express graph states in the IR for MBQC workloads, and one that is more akin to eventual hardware-native instructions for allocating resources for a new graph state.

**Description of the Change:** Adds a new operation to the MBQC dialect called `mbqc.graph_state_prep`, which logically is equivalent to the PennyLane operation [`qml.ftqc.GraphStatePrep`](https://docs.pennylane.ai/en/stable/code/api/pennylane.ftqc.GraphStatePrep.html), except that it only expresses the desired form of the graph state in the IR without decomposing it to its equivalent set of quantum gate operations (such a decomposition can be added in the future as a compilation pass). For more details on this new operation, please refer to the documentation included in the op definition.

Some unit tests for other MBQC-dialect ops have also been renamed for better code organization.

**Example**

```mlir
%adj_matrix = arith.constant dense<[1, 0, 1, 0, 0, 1]> : tensor<6xi1>
%graph_reg = mbqc.graph_state_prep (%adj_matrix : tensor<6xi1>) [init "Hadamard", entangle "CZ"] : !quantum.reg
```

[sc-97319]