### PR TITLE
chore: remove unnecessary `deepcopy` for `config.device_options`

### DIFF
--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -26,7 +26,6 @@ from dataclasses import dataclass
 from typing import Any, Dict
 
 import pennylane as qml
-
 from jax.interpreters.partial_eval import DynamicJaxprTracer
 from pennylane.devices.capabilities import DeviceCapabilities, OperatorProperties
 from pennylane.devices.execution_config import ExecutionConfig

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -335,7 +335,7 @@ class QJITDevice(qml.devices.Device):
         self,
         ctx,
         execution_config: ExecutionConfig | None = None,
-    ) -> TransformProgram, ExecutionConfig:
+    ) -> tuple[TransformProgram, ExecutionConfig]:
         """This function defines the device transform program to be applied and an updated device
         configuration. The transform program will be created and applied to the tape before
         compilation, in order to modify the operations and measurements to meet device

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -22,14 +22,14 @@ import pathlib
 import platform
 import re
 from copy import deepcopy
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Any, Dict
 
 import pennylane as qml
-from pennylane.devices.execution_config import ExecutionConfig
 
 from jax.interpreters.partial_eval import DynamicJaxprTracer
 from pennylane.devices.capabilities import DeviceCapabilities, OperatorProperties
+from pennylane.devices.execution_config import ExecutionConfig
 from pennylane.transforms import (
     diagonalize_measurements,
     split_non_commuting,


### PR DESCRIPTION
**Context:**

https://github.com/PennyLaneAI/pennylane/pull/8046 fully freezes the `ExecutionConfig` to be totally immutable. This `deepcopy` stage is no longer needed.

[sc-96529]
