### PR TITLE
Add `SingleExcitation` and `DoubleExcitation` to RuntimeCAPI.

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -69,7 +69,7 @@
 
 <h3>Internal changes ⚙️</h3>
 
-* Add `__catalyst__qis__SingleExcitation` to RuntimeCAPI.
+* Add `SingleExcitation` and `DoubleExcitation` to native `RUNTIME_OPERATIONS` and `RuntimeCAPI`.
   [(#1980)](https://github.com/PennyLaneAI/catalyst/pull/1980)
 
 * Updates use of `qml.transforms.dynamic_one_shot.parse_native_mid_circuit_measurements` to improved signature.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -67,7 +67,7 @@
 <h3>Internal changes ⚙️</h3>
 
 * Add `__catalyst__qis__SingleExcitation` to RuntimeCAPI.
-  [(#19XX)](https://github.com/PennyLaneAI/catalyst/pull/19XX)
+  [(#1980)](https://github.com/PennyLaneAI/catalyst/pull/1980)
 
 * Updates use of `qml.transforms.dynamic_one_shot.parse_native_mid_circuit_measurements` to improved signature.
   [(#1953)](https://github.com/PennyLaneAI/catalyst/pull/1953)
@@ -165,6 +165,7 @@ Joey Carter,
 Sengthai Heng,
 David Ittah,
 Christina Lee,
+Joseph Lee,
 Andrija Paurevic,
 Roberto Turrado,
 Paul Haochen Wang.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -66,6 +66,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Add `__catalyst__qis__SingleExcitation` to RuntimeCAPI.
+  [(#19XX)](https://github.com/PennyLaneAI/catalyst/pull/19XX)
+
 * Updates use of `qml.transforms.dynamic_one_shot.parse_native_mid_circuit_measurements` to improved signature.
   [(#1953)](https://github.com/PennyLaneAI/catalyst/pull/1953)
 

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -72,6 +72,7 @@ RUNTIME_OPERATIONS = [
     "IsingYY",
     "IsingZZ",
     "SingleExcitation",
+    "DoubleExcitation",
     "ISWAP",
     "MultiRZ",
     "PauliX",

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -71,6 +71,7 @@ RUNTIME_OPERATIONS = [
     "IsingXY",
     "IsingYY",
     "IsingZZ",
+    "SingleExcitation",
     "ISWAP",
     "MultiRZ",
     "PauliX",

--- a/frontend/test/lit/test_decomposition.py
+++ b/frontend/test/lit/test_decomposition.py
@@ -169,6 +169,48 @@ def test_decompose_qubitunitary():
 test_decompose_qubitunitary()
 
 
+def test_decompose_singleexcitation():
+    """
+    Test that single excitation is not decomposed.
+    """
+    dev = get_custom_device_without(2)
+
+    @qjit(target="mlir")
+    @qml.qnode(dev)
+    # CHECK-LABEL: public @jit_decompose_singleexcitation
+    def decompose_singleexcitation(theta: float):
+        # CHECK: quantum.custom "SingleExcitation"
+
+        qml.SingleExcitation(theta, wires=[0, 1])
+        return measure(wires=0)
+
+    print(decompose_singleexcitation.mlir)
+
+
+test_decompose_singleexcitation()
+
+
+def test_decompose_doubleexcitation():
+    """
+    Test that Double excitation is not decomposed.
+    """
+    dev = get_custom_device_without(4)
+
+    @qjit(target="mlir")
+    @qml.qnode(dev)
+    # CHECK-LABEL: public @jit_decompose_doubleexcitation
+    def decompose_doubleexcitation(theta: float):
+        # CHECK: quantum.custom "DoubleExcitation"
+
+        qml.DoubleExcitation(theta, wires=[0, 1, 2, 3])
+        return measure(wires=0)
+
+    print(decompose_doubleexcitation.mlir)
+
+
+test_decompose_doubleexcitation()
+
+
 def test_decompose_singleexcitationplus():
     """
     Test decomposition of single excitation plus.

--- a/frontend/test/pytest/test_operations.py
+++ b/frontend/test/pytest/test_operations.py
@@ -262,7 +262,7 @@ def test_singleexcitation():
 
     assert np.allclose(circuit(0.1), circuit.original_function(0.1))
     assert "SingleExcitation" in str(circuit.jaxpr)
-    assert "SingleExcitation" in circuit.mlir
+    assert 'quantum.custom "SingleExcitation"' in circuit.mlir
 
 
 def test_doubleexcitation():
@@ -278,7 +278,7 @@ def test_doubleexcitation():
 
     assert np.allclose(circuit(0.1), circuit.original_function(0.1))
     assert "DoubleExcitation" in str(circuit.jaxpr)
-    assert "DoubleExcitation" in circuit.mlir
+    assert "quantum.custom "DoubleExcitation"" in circuit.mlir
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_operations.py
+++ b/frontend/test/pytest/test_operations.py
@@ -127,6 +127,9 @@ def test_param(backend):
         qml.SingleExcitation(x, wires=[0, 1])
         qml.SingleExcitation(y, wires=[1, 2])
 
+        qml.DoubleExcitation(x, wires=[0, 1, 2, 3])
+        qml.DoubleExcitation(y, wires=[2, 3, 0, 1])
+
         qml.CRX(x, wires=[0, 1])
         qml.CRY(x, wires=[0, 1])
         qml.CRZ(x, wires=[0, 1])

--- a/frontend/test/pytest/test_operations.py
+++ b/frontend/test/pytest/test_operations.py
@@ -278,7 +278,7 @@ def test_doubleexcitation():
 
     assert np.allclose(circuit(0.1), circuit.original_function(0.1))
     assert "DoubleExcitation" in str(circuit.jaxpr)
-    assert "quantum.custom "DoubleExcitation"" in circuit.mlir
+    assert 'quantum.custom "DoubleExcitation"' in circuit.mlir
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_operations.py
+++ b/frontend/test/pytest/test_operations.py
@@ -124,6 +124,9 @@ def test_param(backend):
         qml.IsingZZ(x, wires=[0, 1])
         qml.IsingZZ(y, wires=[1, 2])
 
+        qml.SingleExcitation(x, wires=[0, 1])
+        qml.SingleExcitation(y, wires=[1, 2])
+
         qml.CRX(x, wires=[0, 1])
         qml.CRY(x, wires=[0, 1])
         qml.CRZ(x, wires=[0, 1])

--- a/frontend/test/pytest/test_operations.py
+++ b/frontend/test/pytest/test_operations.py
@@ -249,37 +249,5 @@ def test_multicontrolledx_via_paulix():
     assert np.allclose(circuit(), circuit.original_function())
 
 
-def test_singleexcitation():
-    """Test that Single Excitation is not decomposed."""
-
-    dev = qml.device("lightning.qubit", wires=2)
-
-    @qjit
-    @qml.qnode(dev)
-    def circuit(phi):
-        qml.SingleExcitation(phi, wires=[0, 1])
-        return qml.expval(qml.PauliZ(0))
-
-    assert np.allclose(circuit(0.1), circuit.original_function(0.1))
-    assert "SingleExcitation" in str(circuit.jaxpr)
-    assert 'quantum.custom "SingleExcitation"' in circuit.mlir
-
-
-def test_doubleexcitation():
-    """Test that Double Excitation is not decomposed."""
-
-    dev = qml.device("lightning.qubit", wires=4)
-
-    @qjit
-    @qml.qnode(dev)
-    def circuit(phi):
-        qml.DoubleExcitation(phi, wires=[0, 1, 2, 3])
-        return qml.expval(qml.PauliZ(0))
-
-    assert np.allclose(circuit(0.1), circuit.original_function(0.1))
-    assert "DoubleExcitation" in str(circuit.jaxpr)
-    assert 'quantum.custom "DoubleExcitation"' in circuit.mlir
-
-
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_operations.py
+++ b/frontend/test/pytest/test_operations.py
@@ -249,5 +249,37 @@ def test_multicontrolledx_via_paulix():
     assert np.allclose(circuit(), circuit.original_function())
 
 
+def test_singleexcitation():
+    """Test that Single Excitation is not decomposed."""
+
+    dev = qml.device("lightning.qubit", wires=2)
+
+    @qjit
+    @qml.qnode(dev)
+    def circuit(phi):
+        qml.SingleExcitation(phi, wires=[0, 1])
+        return qml.expval(qml.PauliZ(0))
+
+    assert np.allclose(circuit(0.1), circuit.original_function(0.1))
+    assert "SingleExcitation" in str(circuit.jaxpr)
+    assert "SingleExcitation" in circuit.mlir
+
+
+def test_doubleexcitation():
+    """Test that Double Excitation is not decomposed."""
+
+    dev = qml.device("lightning.qubit", wires=4)
+
+    @qjit
+    @qml.qnode(dev)
+    def circuit(phi):
+        qml.DoubleExcitation(phi, wires=[0, 1, 2, 3])
+        return qml.expval(qml.PauliZ(0))
+
+    assert np.allclose(circuit(0.1), circuit.original_function(0.1))
+    assert "DoubleExcitation" in str(circuit.jaxpr)
+    assert "DoubleExcitation" in circuit.mlir
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/runtime/include/RuntimeCAPI.h
+++ b/runtime/include/RuntimeCAPI.h
@@ -70,6 +70,7 @@ void __catalyst__qis__IsingXX(double, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__IsingYY(double, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__IsingXY(double, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__IsingZZ(double, QUBIT *, QUBIT *, const Modifiers *);
+void __catalyst__qis__SingleExcitation(double, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__ControlledPhaseShift(double, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__CRX(double, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__CRY(double, QUBIT *, QUBIT *, const Modifiers *);

--- a/runtime/include/RuntimeCAPI.h
+++ b/runtime/include/RuntimeCAPI.h
@@ -71,6 +71,8 @@ void __catalyst__qis__IsingYY(double, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__IsingXY(double, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__IsingZZ(double, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__SingleExcitation(double, QUBIT *, QUBIT *, const Modifiers *);
+void __catalyst__qis__DoubleExcitation(double, QUBIT *, QUBIT *, QUBIT *, QUBIT *,
+                                       const Modifiers *);
 void __catalyst__qis__ControlledPhaseShift(double, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__CRX(double, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__CRY(double, QUBIT *, QUBIT *, const Modifiers *);

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -678,6 +678,15 @@ void __catalyst__qis__IsingZZ(double theta, QUBIT *control, QUBIT *target,
                                           /* modifiers */ MODIFIERS_ARGS(modifiers));
 }
 
+void __catalyst__qis__SingleExcitation(double phi, QUBIT *wire0, QUBIT *wire1,
+                                       const Modifiers *modifiers)
+{
+    getQuantumDevicePtr()->NamedOperation(
+        "SingleExcitation", {phi},
+        {reinterpret_cast<QubitIdType>(wire0), reinterpret_cast<QubitIdType>(wire1)},
+        MODIFIERS_ARGS(modifiers));
+}
+
 void __catalyst__qis__ControlledPhaseShift(double theta, QUBIT *control, QUBIT *target,
                                            const Modifiers *modifiers)
 {

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -687,6 +687,16 @@ void __catalyst__qis__SingleExcitation(double phi, QUBIT *wire0, QUBIT *wire1,
         MODIFIERS_ARGS(modifiers));
 }
 
+void __catalyst__qis__DoubleExcitation(double phi, QUBIT *wire0, QUBIT *wire1, QUBIT *wire2,
+                                       QUBIT *wire3, const Modifiers *modifiers)
+{
+    getQuantumDevicePtr()->NamedOperation(
+        "DoubleExcitation", {phi},
+        {reinterpret_cast<QubitIdType>(wire0), reinterpret_cast<QubitIdType>(wire1),
+         reinterpret_cast<QubitIdType>(wire2), reinterpret_cast<QubitIdType>(wire3)},
+        MODIFIERS_ARGS(modifiers));
+}
+
 void __catalyst__qis__ControlledPhaseShift(double theta, QUBIT *control, QUBIT *target,
                                            const Modifiers *modifiers)
 {


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new functions and code must be clearly commented and documented.

- [ ] Ensure that code is properly formatted by running `make format`.
      The latest version of black and `clang-format-20` are used in CI/CD to check formatting.

- [ ] All new features must include a unit test.
      Integration and frontend tests should be added to [`frontend/test`](../frontend/test/),
      Quantum dialect and MLIR tests should be added to [`mlir/test`](../mlir/test/), and
      Runtime tests should be added to [`runtime/tests`](../runtime/tests/).

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Lightning Devices support SingleExcitation and DoubleExcitation, and with the corresponding qis we will be able to target it directly in the runtime, without further decomposing.

**Description of the Change:**
Add SingleExcitation and DoubleExcitation to RuntimeCAPI

**Benefits:**
Reduce need to decompose SingleExcitation and accelerate XAS benchmark with capture enabled + qjit.

**Possible Drawbacks:**

**Related GitHub Issues:**

