### PR TITLE
[BUG] Fix measure from sample shot vector condition

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -57,6 +57,7 @@
 <h3>Bug fixes 🐛</h3>
 
 * Fix wrong handling of partitioned shots in the decomposition pass of `measurements_from_samples`.
+  [(#1981)](https://github.com/PennyLaneAI/catalyst/pull/1981)
 
 * Fix errors in AutoGraph transformed functions when `qml.prod` is used together with other operator
   transforms (e.g. `qml.adjoint`).

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -56,6 +56,8 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fix wrong handling of partitioned shots in the decomposition pass of `measurements_from_samples`.
+
 * Fix errors in AutoGraph transformed functions when `qml.prod` is used together with other operator
   transforms (e.g. `qml.adjoint`).
   [(#1910)](https://github.com/PennyLaneAI/catalyst/pull/1910)

--- a/frontend/catalyst/device/decomposition.py
+++ b/frontend/catalyst/device/decomposition.py
@@ -348,7 +348,7 @@ def measurements_from_samples(tape, device_wires):
         results_processed = []
         for m in tape.measurements:
             if isinstance(m, (ExpectationMP, VarianceMP, ProbabilityMP, SampleMP)):
-                if len(tape.shots.shot_vector) > 1:
+                if tape.shots.has_partitioned_shots:
                     res = tuple(m.process_samples(s, measured_wires) for s in samples)
                 else:
                     res = m.process_samples(samples, measured_wires)

--- a/frontend/test/pytest/test_measurement_transforms.py
+++ b/frontend/test/pytest/test_measurement_transforms.py
@@ -478,7 +478,7 @@ class TestMeasurementTransforms:
             ),
         ],
     )
-    @pytest.mark.parametrize("shots", [3000, (3000, 4000), (3000, 3500, 4000)])
+    @pytest.mark.parametrize("shots", [3000, (3000, 3000), (3000, 4000), (3000, 3500, 4000)])
     def test_measurement_from_samples_single_measurement_analytic(
         self,
         input_measurement,


### PR DESCRIPTION
**Context:**
With the new `shots` param added to the test `test_measurement_from_samples_single_measurement_analytic`, it fails immediately. The root cause has been discussed in a [PennyLane discussion](https://github.com/PennyLaneAI/pennylane/pull/7317#discussion_r2068721834).

**Description of the Change:**
Use `shots.has_partitioned_shots` instead of `len(shots.shot_vector) > 1`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-91172]