### PR TITLE
Remove xfail on a seeded non-flaky test

### DIFF
--- a/frontend/test/pytest/test_mid_circuit_measurement.py
+++ b/frontend/test/pytest/test_mid_circuit_measurement.py
@@ -548,9 +548,6 @@ class TestDynamicOneShotIntegration:
         assert result.shape == (shots,)
         assert jnp.allclose(result, expected)
 
-    @pytest.mark.xfail(
-        reason="Midcircuit measurements with sampling is unseeded and hence this test is flaky"
-    )
     @pytest.mark.parametrize("shots", [10000])
     @pytest.mark.parametrize("postselect", [None, 0, 1])
     @pytest.mark.parametrize("measure_f", [qml.counts, qml.expval, qml.probs, qml.sample, qml.var])


### PR DESCRIPTION
**Context:**
A test marked xfail with the reason being flaky is not actually flaky. We probably just forgot to remove the xfail?

**Description of the Change:**
Remove the xfail mark on the test.

**Benefits:**
One less xfail.
