### PR TITLE
Pin mac wheels CI runner to MacOS 14

### DIFF
--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -387,7 +387,9 @@ jobs:
         sudo xcode-select --switch /Library/Developer/CommandLineTools
         cmake -S mlir -B $GITHUB_WORKSPACE/quantum-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_OSX_SYSROOT=$(xcrun --show-sdk-path) \
               -DLLVM_ENABLE_ASSERTIONS=ON \
+              -DLLVM_USE_SANITIZER=OFF \
               -DQUANTUM_ENABLE_BINDINGS_PYTHON=ON \
               -DPython3_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -DPython3_NumPy_INCLUDE_DIRS=$(python${{ matrix.python_version }} -c "import numpy as np; print(np.get_include())") \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -367,8 +367,8 @@ jobs:
     # Build Quantum and Gradient Dialects
     - name: Build MLIR Dialects
       run: |
-        # TODO: turn off spotlight when upgrading to macos 15 and xcode 16 in github mac runners
-        # sudo mdutil -i off /Users
+        # xcode 16 builds very slow if we don't turn off spotlight
+        sudo mdutil -i off /Users
         cmake -S mlir -B $GITHUB_WORKSPACE/quantum-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DLLVM_ENABLE_ASSERTIONS=ON \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -400,7 +400,10 @@ jobs:
               -DLLVM_ENABLE_LLD=OFF \
               -DLLVM_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm"
 
-        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli
+        # xcode >= 16 turns on verifier after building every translation unit
+        # This will verify all llvm builds and take a huge amount of time
+        # To turn it off, we need to set ENABLE_MODULE_VERIFIER
+        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli -- -sdk macosx ENABLE_MODULE_VERIFIER=NO
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -384,6 +384,7 @@ jobs:
     # Build Quantum and Gradient Dialects
     - name: Build MLIR Dialects
       run: |
+        sudo mdutil -i off /Users
         sudo xcode-select --switch /Library/Developer/CommandLineTools
         cmake -S mlir -B $GITHUB_WORKSPACE/quantum-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
@@ -405,7 +406,7 @@ jobs:
         # xcode >= 16 turns on verifier after building every translation unit
         # This will verify all llvm builds and take a huge amount of time
         # To turn it off, we need to set ENABLE_MODULE_VERIFIER
-        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli -- -j 4
+        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli -- -j 1
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -328,6 +328,8 @@ jobs:
     - name: Setup Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
+        # On GH images, MacOS is current 15.5
+        # This macos works with xcode 16.4
         xcode-version: '16.4.0'
 
     # Build Catalyst-Runtime
@@ -336,22 +338,7 @@ jobs:
       run: |
         # On GH images, gfortran is only available as a specific version.
         export FC=gfortran-14
-
-        # On GH images, MacOS is current 15.5
-        # This macos works with xcode 16.4
         sudo xcode-select --switch /Library/Developer/CommandLineTools
-
-        # Starting xcode 16, the xcode version is no longer appended to the MacOSX<version>.sdk filename
-        # but instead is appened to the upper directory as Xcode_16.4.app
-        # This breaks the version parsing inside lapack: they still get the version from the .sdk's filename
-        #   https://github.com/lepus2589/accelerate-lapack/blob/5b1a99ae8c4c682a90d4318ae5bb7b465e9dbb66/CMakeLists.txt#L75
-        # To resolve this, we manually make a .sdk file with the version
-        # We need to `find` instead of `xcrun` because `xcrun` returns the symbolic path
-        # export MAC_SDK_FILE=$(find $MD_APPLE_SDK_ROOT -name "MacOSX.sdk" 2>/dev/null)
-        # export MAC_SDK_PATH=$(dirname $MAC_SDK_FILE)
-        # sudo mv $MAC_SDK_FILE $MAC_SDK_PATH/MacOSX16.4.sdk
-        # sudo ln -sn $MAC_SDK_PATH/MacOSX16.4.sdk $MAC_SDK_FILE
-
         cmake -S runtime -B $GITHUB_WORKSPACE/runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY="$GITHUB_WORKSPACE/runtime-build/lib" \
@@ -400,12 +387,8 @@ jobs:
               -DLLVM_ENABLE_ZLIB=FORCE_ON \
               -DLLVM_ENABLE_ZSTD=OFF \
               -DLLVM_ENABLE_LLD=OFF \
-              -DLLVM_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm" \
-              -DENABLE_MODULE_VERIFIER=NO
+              -DLLVM_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm"
 
-        # xcode >= 16 turns on verifier after building every translation unit
-        # This will verify all llvm builds and take a huge amount of time
-        # To turn it off, we need to set ENABLE_MODULE_VERIFIER
         cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli -- -j 1
 
     - name: Build Plugin wheel

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -397,9 +397,8 @@ jobs:
               -DENZYME_SRC_DIR="$GITHUB_WORKSPACE/mlir/Enzyme" \
               -DLLVM_ENABLE_ZLIB=FORCE_ON \
               -DLLVM_ENABLE_ZSTD=OFF \
-              -DLLVM_ENABLE_LLD=OFF \
-              -DLLVM_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm" \
-              -DCMAKE_CXX_FLAGS="-Xclang -fno-modules-validate-system-headers"
+              -DLLVM_ENABLE_LLD=ON \
+              -DLLVM_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm"
 
         # xcode >= 16 turns on verifier after building every translation unit
         # This will verify all llvm builds and take a huge amount of time

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -386,9 +386,8 @@ jobs:
               -DLLVM_ENABLE_LLD=OFF \
               -DLLVM_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm"
 
-        # xcode >=16 builds significantly slower when multithreaded
-        # TODO: force single-thread build (-- -j 1) when updating to MacOS 15 in the github runner images
-        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli
+        # xcode builds significantly slower when multithreaded
+        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli -- -j 1
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -325,14 +325,8 @@ jobs:
         key: ${{ runner.os }}-${{ runner.arch }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-wheel-build
         fail-on-cache-miss: True
 
-    - name: Setup Xcode version
-      #uses: maxim-lobanov/setup-xcode@v1
-      #with:
-        # On GH images, MacOS is current 15.5
-        # This macos works with xcode 16.4
-        # xcode-version: '16.4.0'
+    - name: Setup Xcode
       run:
-        #sudo xcode-select -s /Applications/Xcode_16.4.app
         sudo xcode-select --switch /Library/Developer/CommandLineTools
 
     # Build Catalyst-Runtime
@@ -341,7 +335,6 @@ jobs:
       run: |
         # On GH images, gfortran is only available as a specific version.
         export FC=gfortran-14
-        #sudo xcode-select --switch /Library/Developer/CommandLineTools
         cmake -S runtime -B $GITHUB_WORKSPACE/runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY="$GITHUB_WORKSPACE/runtime-build/lib" \
@@ -375,7 +368,6 @@ jobs:
     - name: Build MLIR Dialects
       run: |
         sudo mdutil -i off /Users
-        #sudo xcode-select --switch /Library/Developer/CommandLineTools
         cmake -S mlir -B $GITHUB_WORKSPACE/quantum-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DLLVM_ENABLE_ASSERTIONS=ON \
@@ -392,6 +384,8 @@ jobs:
               -DLLVM_ENABLE_LLD=OFF \
               -DLLVM_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm"
 
+        # xcode >=16 builds significantly slower when multithreaded
+        # So we force single-thread build
         cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli -- -j 1
 
     - name: Build Plugin wheel

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -385,10 +385,9 @@ jobs:
               -DLLVM_ENABLE_LLD=OFF \
               -DLLVM_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm"
 
-        # TODO: xcode >=16 builds significantly slower when multithreaded
+        # xcode >=16 builds significantly slower when multithreaded
         # So we force single-thread build
-        # cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli -- -j 1
-        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli
+        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli -- -j 1
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -347,7 +347,7 @@ jobs:
         #   https://github.com/lepus2589/accelerate-lapack/blob/5b1a99ae8c4c682a90d4318ae5bb7b465e9dbb66/CMakeLists.txt#L75
         # To resolve this, we manually make a .sdk file with the version
         # We need to `find` instead of `xcrun` because `xcrun` returns the symbolic path
-        export MAC_SDK_FILE=$(find / -name "MacOSX.sdk" 2>/dev/null)
+        export MAC_SDK_FILE=$(find $MD_APPLE_SDK_ROOT -name "MacOSX.sdk" 2>/dev/null)
         export MAC_SDK_PATH=$(dirname $MAC_SDK_FILE)
         sudo mv $MAC_SDK_FILE $MAC_SDK_PATH/MacOSX16.4.sdk
         sudo ln -sn $MAC_SDK_PATH/MacOSX16.4.sdk $MAC_SDK_FILE

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -387,9 +387,7 @@ jobs:
         sudo xcode-select --switch /Library/Developer/CommandLineTools
         cmake -S mlir -B $GITHUB_WORKSPACE/quantum-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_OSX_SYSROOT=$(xcrun --show-sdk-path) \
               -DLLVM_ENABLE_ASSERTIONS=ON \
-              -DLLVM_USE_SANITIZER=OFF \
               -DQUANTUM_ENABLE_BINDINGS_PYTHON=ON \
               -DPython3_EXECUTABLE=$(which python${{ matrix.python_version }}) \
               -DPython3_NumPy_INCLUDE_DIRS=$(python${{ matrix.python_version }} -c "import numpy as np; print(np.get_include())") \
@@ -407,7 +405,7 @@ jobs:
         # xcode >= 16 turns on verifier after building every translation unit
         # This will verify all llvm builds and take a huge amount of time
         # To turn it off, we need to set ENABLE_MODULE_VERIFIER
-        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli
+        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli -- -j 4
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -387,7 +387,7 @@ jobs:
               -DLLVM_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm"
 
         # xcode builds significantly slower when multithreaded
-        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli -- -j 1
+        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli -- -j1
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -339,7 +339,8 @@ jobs:
         sw_vers
         #softwareupdate --install "Command Line Tools for Xcode 16.4"
         sudo xcode-select --switch /Applications/Xcode_16.4.app
-        sudo ln -sf /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX16.4.sdk
+        sudo mv /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX16.4.sdk
+        sudo ln -sn /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX16.4.sdk /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
         cmake -S runtime -B $GITHUB_WORKSPACE/runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY="$GITHUB_WORKSPACE/runtime-build/lib" \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -332,6 +332,7 @@ jobs:
         # On GH images, gfortran is only available as a specific version.
         export FC=gfortran-14
         sw_vers
+        xcode-select intsall
         cmake -S runtime -B $GITHUB_WORKSPACE/runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY="$GITHUB_WORKSPACE/runtime-build/lib" \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -325,6 +325,11 @@ jobs:
         key: ${{ runner.os }}-${{ runner.arch }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-wheel-build
         fail-on-cache-miss: True
 
+    - name: Setup Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: latest-stable
+
     # Build Catalyst-Runtime
     - name: Build Catalyst-Runtime
       id: runtime-build
@@ -332,7 +337,8 @@ jobs:
         # On GH images, gfortran is only available as a specific version.
         export FC=gfortran-14
         sw_vers
-        softwareupdate --install "Command Line Tools for Xcode 16.4"
+        #softwareupdate --install "Command Line Tools for Xcode 16.4"
+        xcode-select --switch /Applications/Xcode_16.4.app
         cmake -S runtime -B $GITHUB_WORKSPACE/runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY="$GITHUB_WORKSPACE/runtime-build/lib" \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -399,7 +399,7 @@ jobs:
               -DLLVM_ENABLE_ZSTD=OFF \
               -DLLVM_ENABLE_LLD=OFF \
               -DLLVM_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm" \
-              -DCMAKE_CXX_FLAGS="-Xclang -fno-module-validate-system-headers"
+              -DCMAKE_CXX_FLAGS="-Xclang -fno-modules-validate-system-headers"
 
         # xcode >= 16 turns on verifier after building every translation unit
         # This will verify all llvm builds and take a huge amount of time

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -398,12 +398,13 @@ jobs:
               -DLLVM_ENABLE_ZLIB=FORCE_ON \
               -DLLVM_ENABLE_ZSTD=OFF \
               -DLLVM_ENABLE_LLD=OFF \
-              -DLLVM_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm"
+              -DLLVM_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm" \
+              -DCMAKE_CXX_FLAGS="-Xclang -fno-module-validate-system-headers"
 
         # xcode >= 16 turns on verifier after building every translation unit
         # This will verify all llvm builds and take a huge amount of time
         # To turn it off, we need to set ENABLE_MODULE_VERIFIER
-        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli -- -sdk macosx ENABLE_MODULE_VERIFIER=NO
+        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -37,7 +37,7 @@ on:
         type: string
 
 env:
-  MACOSX_DEPLOYMENT_TARGET: 15.5
+  MACOSX_DEPLOYMENT_TARGET: 15.0
 
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -338,7 +338,7 @@ jobs:
         export FC=gfortran-14
         sw_vers
         #softwareupdate --install "Command Line Tools for Xcode 16.4"
-        xcode-select --switch /Applications/Xcode_16.4.app
+        sudo xcode-select --switch /Applications/Xcode_16.4.app
         cmake -S runtime -B $GITHUB_WORKSPACE/runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY="$GITHUB_WORKSPACE/runtime-build/lib" \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -325,9 +325,10 @@ jobs:
         key: ${{ runner.os }}-${{ runner.arch }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-wheel-build
         fail-on-cache-miss: True
 
-    - name: Setup Xcode
-      run:
-        sudo xcode-select --switch /Library/Developer/CommandLineTools
+    # TODO: uncomment the setup xcode action when updating to MacOS 15 in the github runner images
+    # - name: Setup Xcode
+    #   run:
+    #     sudo xcode-select --switch /Library/Developer/CommandLineTools
 
     # Build Catalyst-Runtime
     - name: Build Catalyst-Runtime
@@ -368,7 +369,8 @@ jobs:
     - name: Build MLIR Dialects
       run: |
         # xcode 16 builds very slow if we don't turn off spotlight
-        sudo mdutil -i off /Users
+        # TODO: uncomment the below when updating to MacOS 15 in the github runner images
+        # sudo mdutil -i off /Users
         cmake -S mlir -B $GITHUB_WORKSPACE/quantum-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DLLVM_ENABLE_ASSERTIONS=ON \
@@ -386,8 +388,8 @@ jobs:
               -DLLVM_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm"
 
         # xcode >=16 builds significantly slower when multithreaded
-        # So we force single-thread build
-        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli -- -j 1
+        # TODO: force single-thread build (-- -j 1) when updating to MacOS 15 in the github runner images
+        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -368,9 +368,8 @@ jobs:
     # Build Quantum and Gradient Dialects
     - name: Build MLIR Dialects
       run: |
-        # xcode 16 builds very slow if we don't turn off spotlight
-        # TODO: uncomment the below when updating to MacOS 15 in the github runner images
-        # sudo mdutil -i off /Users
+        # xcode builds very slow if we don't turn off spotlight
+        sudo mdutil -i off /Users
         cmake -S mlir -B $GITHUB_WORKSPACE/quantum-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DLLVM_ENABLE_ASSERTIONS=ON \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -325,12 +325,14 @@ jobs:
         key: ${{ runner.os }}-${{ runner.arch }}-enzyme-${{ needs.constants.outputs.llvm_version }}-${{ needs.constants.outputs.enzyme_version }}-wheel-build
         fail-on-cache-miss: True
 
-    - name: Setup Xcode
-      uses: maxim-lobanov/setup-xcode@v1
-      with:
+    - name: Setup Xcode version
+      #uses: maxim-lobanov/setup-xcode@v1
+      #with:
         # On GH images, MacOS is current 15.5
         # This macos works with xcode 16.4
-        xcode-version: '16.4.0'
+        # xcode-version: '16.4.0'
+      run:
+        sudo xcode-select -s /Applications/Xcode_16.4.app
 
     # Build Catalyst-Runtime
     - name: Build Catalyst-Runtime

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -332,7 +332,8 @@ jobs:
         # This macos works with xcode 16.4
         # xcode-version: '16.4.0'
       run:
-        sudo xcode-select -s /Applications/Xcode_16.4.app
+        #sudo xcode-select -s /Applications/Xcode_16.4.app
+        sudo xcode-select --switch /Library/Developer/CommandLineTools
 
     # Build Catalyst-Runtime
     - name: Build Catalyst-Runtime
@@ -340,7 +341,7 @@ jobs:
       run: |
         # On GH images, gfortran is only available as a specific version.
         export FC=gfortran-14
-        sudo xcode-select --switch /Library/Developer/CommandLineTools
+        #sudo xcode-select --switch /Library/Developer/CommandLineTools
         cmake -S runtime -B $GITHUB_WORKSPACE/runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY="$GITHUB_WORKSPACE/runtime-build/lib" \
@@ -374,7 +375,7 @@ jobs:
     - name: Build MLIR Dialects
       run: |
         sudo mdutil -i off /Users
-        sudo xcode-select --switch /Library/Developer/CommandLineTools
+        #sudo xcode-select --switch /Library/Developer/CommandLineTools
         cmake -S mlir -B $GITHUB_WORKSPACE/quantum-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DLLVM_ENABLE_ASSERTIONS=ON \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -384,7 +384,6 @@ jobs:
     # Build Quantum and Gradient Dialects
     - name: Build MLIR Dialects
       run: |
-        sudo mdutil -i off /Users
         sudo xcode-select --switch /Library/Developer/CommandLineTools
         cmake -S mlir -B $GITHUB_WORKSPACE/quantum-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
@@ -406,7 +405,7 @@ jobs:
         # xcode >= 16 turns on verifier after building every translation unit
         # This will verify all llvm builds and take a huge amount of time
         # To turn it off, we need to set ENABLE_MODULE_VERIFIER
-        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli
+        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli -- -j 1
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -331,6 +331,7 @@ jobs:
       run: |
         # On GH images, gfortran is only available as a specific version.
         export FC=gfortran-14
+        sw_vers
         cmake -S runtime -B $GITHUB_WORKSPACE/runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY="$GITHUB_WORKSPACE/runtime-build/lib" \
@@ -344,7 +345,7 @@ jobs:
     - name: Error log on failure
       if: failure() && steps.runtime-build.outcome == 'failure'
       run: |
-        cat $GITHUB_WORKSPACE/runtime-build/_lapacke-accelerate/src/lapacke-accelerate-stamp/*-err.log 2>/dev/null || True
+        cat $GITHUB_WORKSPACE/runtime-build/_lapacke-accelerate/src/lapacke-accelerate-stamp/*-err.log || True
 
     - name: Test Catalyst-Runtime
       run: |

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -37,7 +37,7 @@ on:
         type: string
 
 env:
-  MACOSX_DEPLOYMENT_TARGET: 15.0
+  MACOSX_DEPLOYMENT_TARGET: 14.0
 
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
@@ -68,7 +68,7 @@ jobs:
         python_version: ${{ fromJson(format('["{0}"]', needs.constants.outputs.primary_python_version)) }}
 
     name: Build Dependencies (Python ${{ matrix.python_version }})
-    runs-on: macos-latest
+    runs-on: macos-14
 
     if: needs.check_if_wheel_build_required.outputs.build-wheels == 'true'
 
@@ -252,7 +252,7 @@ jobs:
         python_version: ${{ fromJson(needs.constants.outputs.python_versions) }}
 
     name: Build Wheels (Python ${{ matrix.python_version }})
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
     - name: Checkout Catalyst repo
@@ -367,7 +367,8 @@ jobs:
     # Build Quantum and Gradient Dialects
     - name: Build MLIR Dialects
       run: |
-        sudo mdutil -i off /Users
+        # TODO: turn off spotlight when upgrading to macos 15 and xcode 16 in github mac runners
+        # sudo mdutil -i off /Users
         cmake -S mlir -B $GITHUB_WORKSPACE/quantum-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DLLVM_ENABLE_ASSERTIONS=ON \
@@ -384,9 +385,10 @@ jobs:
               -DLLVM_ENABLE_LLD=OFF \
               -DLLVM_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm"
 
-        # xcode >=16 builds significantly slower when multithreaded
+        # TODO: xcode >=16 builds significantly slower when multithreaded
         # So we force single-thread build
-        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli -- -j 1
+        # cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli -- -j 1
+        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time
@@ -437,7 +439,7 @@ jobs:
 
     # To check all wheels for supported python3 versions
     name: Test Wheels (Python ${{ matrix.python_version }}) on Mac arm64
-    runs-on: macos-latest
+    runs-on: macos-14
 
     steps:
     - name: Checkout Catalyst repo

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -406,7 +406,7 @@ jobs:
         # xcode >= 16 turns on verifier after building every translation unit
         # This will verify all llvm builds and take a huge amount of time
         # To turn it off, we need to set ENABLE_MODULE_VERIFIER
-        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli -- -j 1
+        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -37,7 +37,7 @@ on:
         type: string
 
 env:
-  MACOSX_DEPLOYMENT_TARGET: 14.0
+  MACOSX_DEPLOYMENT_TARGET: 15.5
 
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.
@@ -336,11 +336,22 @@ jobs:
       run: |
         # On GH images, gfortran is only available as a specific version.
         export FC=gfortran-14
-        sw_vers
-        #softwareupdate --install "Command Line Tools for Xcode 16.4"
+
+        # On GH images, MacOS is current 15.5
+        # This macos works with xcode 16.4
         sudo xcode-select --switch /Applications/Xcode_16.4.app
-        sudo mv /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX16.4.sdk
-        sudo ln -sn /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX16.4.sdk /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
+
+        # Starting xcode 16, the xcode version is no longer appended to the MacOSX<version>.sdk filename
+        # but instead is appened to the upper directory as Xcode_16.4.app
+        # This breaks the version parsing inside lapack: they still get the version from the .sdk's filename
+        #   https://github.com/lepus2589/accelerate-lapack/blob/5b1a99ae8c4c682a90d4318ae5bb7b465e9dbb66/CMakeLists.txt#L75
+        # To resolve this, we manually make a .sdk file with the version
+        # We need to `find` instead of `xcrun` because `xcrun` returns the symbolic path
+        export MAC_SDK_FILE=$(find / -name "MacOSX.sdk" 2>/dev/null)
+        export MAC_SDK_PATH=$(dirname $MAC_SDK_FILE)
+        sudo mv $MAC_SDK_FILE $MAC_SDK_PATH/MacOSX16.4.sdk
+        sudo ln -sn $MAC_SDK_PATH/MacOSX16.4.sdk $MAC_SDK_FILE
+
         cmake -S runtime -B $GITHUB_WORKSPACE/runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY="$GITHUB_WORKSPACE/runtime-build/lib" \
@@ -354,7 +365,7 @@ jobs:
     - name: Error log on failure
       if: failure() && steps.runtime-build.outcome == 'failure'
       run: |
-        cat $GITHUB_WORKSPACE/runtime-build/_lapacke-accelerate/src/lapacke-accelerate-stamp/*-err.log || True
+        cat $GITHUB_WORKSPACE/runtime-build/_lapacke-accelerate/src/lapacke-accelerate-stamp/*-err.log 2>/dev/null || True
 
     - name: Test Catalyst-Runtime
       run: |

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -387,7 +387,7 @@ jobs:
               -DLLVM_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm"
 
         # xcode builds significantly slower when multithreaded
-        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli -- -j1
+        cmake --build $GITHUB_WORKSPACE/quantum-build --target check-dialects catalyst-cli -- -j 1
 
     - name: Build Plugin wheel
       # Run only on Thursday at the given time

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -332,7 +332,7 @@ jobs:
         # On GH images, gfortran is only available as a specific version.
         export FC=gfortran-14
         sw_vers
-        xcode-select intsall
+        xcode-select --install
         cmake -S runtime -B $GITHUB_WORKSPACE/runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY="$GITHUB_WORKSPACE/runtime-build/lib" \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -339,6 +339,7 @@ jobs:
         sw_vers
         #softwareupdate --install "Command Line Tools for Xcode 16.4"
         sudo xcode-select --switch /Applications/Xcode_16.4.app
+        sudo ln -sf /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX16.4.sdk
         cmake -S runtime -B $GITHUB_WORKSPACE/runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY="$GITHUB_WORKSPACE/runtime-build/lib" \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -339,7 +339,7 @@ jobs:
 
         # On GH images, MacOS is current 15.5
         # This macos works with xcode 16.4
-        sudo xcode-select --switch /Applications/Xcode_16.4.app
+        sudo xcode-select --switch /Applications/Xcode_15.5.app
 
         # Starting xcode 16, the xcode version is no longer appended to the MacOSX<version>.sdk filename
         # but instead is appened to the upper directory as Xcode_16.4.app
@@ -349,8 +349,8 @@ jobs:
         # We need to `find` instead of `xcrun` because `xcrun` returns the symbolic path
         export MAC_SDK_FILE=$(find $MD_APPLE_SDK_ROOT -name "MacOSX.sdk" 2>/dev/null)
         export MAC_SDK_PATH=$(dirname $MAC_SDK_FILE)
-        sudo mv $MAC_SDK_FILE $MAC_SDK_PATH/MacOSX16.4.sdk
-        sudo ln -sn $MAC_SDK_PATH/MacOSX16.4.sdk $MAC_SDK_FILE
+        sudo mv $MAC_SDK_FILE $MAC_SDK_PATH/MacOSX15.5.sdk
+        sudo ln -sn $MAC_SDK_PATH/MacOSX15.5.sdk $MAC_SDK_FILE
 
         cmake -S runtime -B $GITHUB_WORKSPACE/runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -332,7 +332,7 @@ jobs:
         # On GH images, gfortran is only available as a specific version.
         export FC=gfortran-14
         sw_vers
-        softwareupdate --install "Command Line Tools for Xcode-16.4"
+        softwareupdate --install "Command Line Tools for Xcode 16.4"
         cmake -S runtime -B $GITHUB_WORKSPACE/runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY="$GITHUB_WORKSPACE/runtime-build/lib" \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -328,7 +328,7 @@ jobs:
     - name: Setup Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '15.5'
+        xcode-version: '16.4.0'
 
     # Build Catalyst-Runtime
     - name: Build Catalyst-Runtime
@@ -339,7 +339,7 @@ jobs:
 
         # On GH images, MacOS is current 15.5
         # This macos works with xcode 16.4
-        sudo xcode-select --switch /Applications/Xcode_15.5.app
+        sudo xcode-select --switch /Applications/Xcode_16.4.app
 
         # Starting xcode 16, the xcode version is no longer appended to the MacOSX<version>.sdk filename
         # but instead is appened to the upper directory as Xcode_16.4.app
@@ -349,8 +349,8 @@ jobs:
         # We need to `find` instead of `xcrun` because `xcrun` returns the symbolic path
         export MAC_SDK_FILE=$(find $MD_APPLE_SDK_ROOT -name "MacOSX.sdk" 2>/dev/null)
         export MAC_SDK_PATH=$(dirname $MAC_SDK_FILE)
-        sudo mv $MAC_SDK_FILE $MAC_SDK_PATH/MacOSX15.5.sdk
-        sudo ln -sn $MAC_SDK_PATH/MacOSX15.5.sdk $MAC_SDK_FILE
+        sudo mv $MAC_SDK_FILE $MAC_SDK_PATH/MacOSX16.4.sdk
+        sudo ln -sn $MAC_SDK_PATH/MacOSX16.4.sdk $MAC_SDK_FILE
 
         cmake -S runtime -B $GITHUB_WORKSPACE/runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -384,6 +384,7 @@ jobs:
     # Build Quantum and Gradient Dialects
     - name: Build MLIR Dialects
       run: |
+        sudo mdutil -i off /Users
         sudo xcode-select --switch /Library/Developer/CommandLineTools
         cmake -S mlir -B $GITHUB_WORKSPACE/quantum-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -332,7 +332,7 @@ jobs:
         # On GH images, gfortran is only available as a specific version.
         export FC=gfortran-14
         sw_vers
-        xcode-select --install
+        softwareupdate --install "Command Line Tools for Xcode-16.4"
         cmake -S runtime -B $GITHUB_WORKSPACE/runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_LIBRARY_OUTPUT_DIRECTORY="$GITHUB_WORKSPACE/runtime-build/lib" \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -339,7 +339,7 @@ jobs:
 
         # On GH images, MacOS is current 15.5
         # This macos works with xcode 16.4
-        sudo xcode-select --switch /Applications/Xcode_16.4.app
+        sudo xcode-select --switch /Library/Developer/CommandLineTools
 
         # Starting xcode 16, the xcode version is no longer appended to the MacOSX<version>.sdk filename
         # but instead is appened to the upper directory as Xcode_16.4.app
@@ -347,10 +347,10 @@ jobs:
         #   https://github.com/lepus2589/accelerate-lapack/blob/5b1a99ae8c4c682a90d4318ae5bb7b465e9dbb66/CMakeLists.txt#L75
         # To resolve this, we manually make a .sdk file with the version
         # We need to `find` instead of `xcrun` because `xcrun` returns the symbolic path
-        export MAC_SDK_FILE=$(find $MD_APPLE_SDK_ROOT -name "MacOSX.sdk" 2>/dev/null)
-        export MAC_SDK_PATH=$(dirname $MAC_SDK_FILE)
-        sudo mv $MAC_SDK_FILE $MAC_SDK_PATH/MacOSX16.4.sdk
-        sudo ln -sn $MAC_SDK_PATH/MacOSX16.4.sdk $MAC_SDK_FILE
+        # export MAC_SDK_FILE=$(find $MD_APPLE_SDK_ROOT -name "MacOSX.sdk" 2>/dev/null)
+        # export MAC_SDK_PATH=$(dirname $MAC_SDK_FILE)
+        # sudo mv $MAC_SDK_FILE $MAC_SDK_PATH/MacOSX16.4.sdk
+        # sudo ln -sn $MAC_SDK_PATH/MacOSX16.4.sdk $MAC_SDK_FILE
 
         cmake -S runtime -B $GITHUB_WORKSPACE/runtime-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
@@ -384,6 +384,7 @@ jobs:
     # Build Quantum and Gradient Dialects
     - name: Build MLIR Dialects
       run: |
+        sudo xcode-select --switch /Library/Developer/CommandLineTools
         cmake -S mlir -B $GITHUB_WORKSPACE/quantum-build -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DLLVM_ENABLE_ASSERTIONS=ON \

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -328,7 +328,7 @@ jobs:
     - name: Setup Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: latest-stable
+        xcode-version: '15.5'
 
     # Build Catalyst-Runtime
     - name: Build Catalyst-Runtime

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -397,8 +397,9 @@ jobs:
               -DENZYME_SRC_DIR="$GITHUB_WORKSPACE/mlir/Enzyme" \
               -DLLVM_ENABLE_ZLIB=FORCE_ON \
               -DLLVM_ENABLE_ZSTD=OFF \
-              -DLLVM_ENABLE_LLD=ON \
-              -DLLVM_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm"
+              -DLLVM_ENABLE_LLD=OFF \
+              -DLLVM_DIR="$GITHUB_WORKSPACE/llvm-build/lib/cmake/llvm" \
+              -DENABLE_MODULE_VERIFIER=NO
 
         # xcode >= 16 turns on verifier after building every translation unit
         # This will verify all llvm builds and take a huge amount of time


### PR DESCRIPTION
**Context:**
Github recently updated MacOS in CI images to 15.5. This macos works with xcode 16.4.
https://github.com/actions/runner-images/issues/12541
https://github.com/actions/runner-images/issues/12520

New xcode registers the sdk file a bit differently, which broke the macos/xcode version parsing in lapacke.

**Description of the Change:**
Pin macos version in mac wheels CI to `macos-14`

**Benefits:**
Mac wheels no longer fail.

**Possible Drawbacks:**
xcode 16 seems painfully slow. Forcing single threaded build and disabling macos spotlight/OS indexing fixes this.
