### PR TITLE
Fix typos in Gradient and Quantum dialect docs

### DIFF
--- a/mlir/include/Gradient/IR/GradientOps.td
+++ b/mlir/include/Gradient/IR/GradientOps.td
@@ -37,7 +37,7 @@ def GradOp : Gradient_Op<"grad", [
         using the finite difference method.
 
         This operation acts much like the `func.call` operation, taking a
-        symbol reference and arguments to the original functionan as input.
+        symbol reference and arguments to the original function as input.
         However, instead of the function result, the gradient of the function
         is returned.
 
@@ -245,7 +245,7 @@ def VJPOp : Gradient_Op<"vjp", [
 def ForwardOp : Gradient_Op<"forward",
     [FunctionOpInterface, IsolatedFromAbove]> {
 
-  let summary = "Operation denoting the forwrad pass that is registered with Enzyme.";
+  let summary = "Operation denoting the forward pass that is registered with Enzyme.";
 
   let description = [{
     Wrapper around the concrete function. This wrapper ensures calling convention.

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -725,7 +725,7 @@ class Observable_Op<string mnemonic, list<Trait> traits = []> :
         Quantum_Op<mnemonic, traits # [Pure]>;
 
 def ComputationalBasisOp : Observable_Op<"compbasis", [AttrSizedOperandSegments]> {
-    let summary = "Define a pseudo-obeservable of the computational basis for use in measurements";
+    let summary = "Define a pseudo-observable of the computational basis for use in measurements";
     let description = [{
         The `quantum.compbasis` operation defines a quantum observable to be used by other
         operations such as measurement processes. The specific observable defined here is a
@@ -929,7 +929,7 @@ def SampleOp : Measurement_Op<"sample", [AttrSizedOperandSegments]> {
 
         Note that the return value type depends on the type of observable provided. Computational
         basis samples are returned as a 2D array of shape (shot number, number of qubits), with all
-        other obversables the output is a 1D array of lenth equal to the shot number.
+        other observables the output is a 1D array of length equal to the shot number.
 
         Example:
 
@@ -951,7 +951,7 @@ def SampleOp : Measurement_Op<"sample", [AttrSizedOperandSegments]> {
 
             The return value type depends on the type of observable provided. Computational
             basis samples are returned as a 2D array of shape (shot number, number of qubits), with all
-            other obversables the output is a 1D array of lenth equal to the shot number.
+            other observables the output is a 1D array of length equal to the shot number.
 
         .. note::
 


### PR DESCRIPTION
Fixes a few stray typos in the Gradient and Quantum dialect documentation.

**Benefits:** Placate our IDE spell checkers.