### PR TITLE
bump PL to dev34

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -10,7 +10,7 @@ enzyme=v0.0.186
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.43.0.dev30
+pennylane=0.43.0.dev34
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -33,4 +33,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.43.0.dev15
 pennylane-lightning==0.43.0.dev15
-pennylane==0.43.0.dev30
+pennylane==0.43.0.dev34


### PR DESCRIPTION
**Context:**
`autoray` release broke PennyLane. This will be fixed at dev34 (should be available Aug21)

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
