### PR TITLE
Add runtime capi to resolve dynamic wire labels

### DIFF
--- a/runtime/include/RuntimeCAPI.h
+++ b/runtime/include/RuntimeCAPI.h
@@ -34,6 +34,7 @@ void __catalyst__rt__print_tensor(OpaqueMemRefT *, bool);
 void __catalyst__rt__print_string(char *);
 void __catalyst__rt__assert_bool(bool, char *);
 int64_t __catalyst__rt__array_get_size_1d(QirArray *);
+int64_t __catalyst__rt__resolve_dynamic_wire_index();
 int8_t *__catalyst__rt__array_get_element_ptr_1d(QirArray *, int64_t);
 
 QUBIT *__catalyst__rt__qubit_allocate();

--- a/runtime/lib/capi/ExecutionContext.hpp
+++ b/runtime/lib/capi/ExecutionContext.hpp
@@ -18,6 +18,7 @@
 
 #include <cstdio>
 #include <functional>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <random>
@@ -168,6 +169,11 @@ class RTDevice {
     std::string rtd_kwargs;
     bool auto_qubit_management;
 
+    // Each device instance carries a map from the user wire labels to the indices
+    // that will be sent into  __catalyst__rt__array_get_element_ptr_1d(idx)
+    // This is to be used for runtime resolution of dynamic wire labels.
+    std::map<int64_t, int64_t> wire_labels_map = {{37,42}, {100,69}};
+
     std::unique_ptr<SharedLibraryManager> rtd_dylib{nullptr};
     std::unique_ptr<QuantumDevice> rtd_qdevice{nullptr};
 
@@ -264,6 +270,10 @@ class RTDevice {
     void setDeviceStatus(RTDeviceStatus new_status) noexcept { status = new_status; }
 
     bool getQubitManagementMode() { return auto_qubit_management; }
+
+    std::map<int64_t, int64_t>& getWireLabelsMap() {
+        return wire_labels_map;
+    }
 
     [[nodiscard]] auto getDeviceStatus() const -> RTDeviceStatus { return status; }
 

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -1076,6 +1076,16 @@ int64_t __catalyst__rt__array_get_size_1d(QirArray *ptr)
     return qubit_vector_ptr->size();
 }
 
+int64_t __catalyst__rt__resolve_dynamic_wire_index(){
+    std::cout << "__catalyst__rt__resolve_dynamic_wire_index, welcome\n";
+    std::cout << "current map: \n";
+    for (const auto& pair : RTD_PTR->getWireLabelsMap()) {
+        std::cout << "Key: " << pair.first << ", Value: " << pair.second << std::endl;
+    }
+
+    return 0;
+}
+
 int8_t *__catalyst__rt__array_get_element_ptr_1d(QirArray *ptr, int64_t idx)
 {
     std::vector<QubitIdType> *qubit_vector_ptr = reinterpret_cast<std::vector<QubitIdType> *>(ptr);

--- a/runtime/tests/Test_NullQubit.cpp
+++ b/runtime/tests/Test_NullQubit.cpp
@@ -748,6 +748,37 @@ TEST_CASE("Test NullQubit device shots methods", "[NullQubit]")
     }
 }
 
+TEST_CASE("Test runtime dynamic wire label resolution", "[NullQubit]")
+{
+    constexpr size_t shots = 10;
+    const auto [rtd_lib, rtd_name, rtd_kwargs] =
+        std::array<std::string, 3>{"null.qubit", "null_qubit", ""};
+    __catalyst__rt__initialize(nullptr);
+    __catalyst__rt__device_init((int8_t *)rtd_lib.c_str(), (int8_t *)rtd_name.c_str(),
+                                (int8_t *)rtd_kwargs.c_str(), shots,
+                                /*auto_qubit_management=*/false);
+
+    QirArray *qs = __catalyst__rt__qubit_allocate_array(37);
+
+    std::cout << __catalyst__rt__resolve_dynamic_wire_index() << " hiii! \n";
+    // QUBIT **target = (QUBIT **)__catalyst__rt__array_get_element_ptr_1d(qs, 2);
+
+    // __catalyst__qis__Hadamard(*target, NO_MODIFIERS);
+
+    // size_t n = __catalyst__rt__num_qubits();
+    // CHECK(n == 3);
+
+    // std::vector<double> buffer(shots * n);
+    // MemRefT_double_2d result = {buffer.data(), buffer.data(), 0, {shots, n}, {n, 1}};
+
+    // __catalyst__qis__Sample(&result, n);
+
+    __catalyst__rt__qubit_release_array(qs);
+
+    __catalyst__rt__device_release();
+    __catalyst__rt__finalize();
+}
+
 TEST_CASE("Test NullQubit device resource tracking", "[NullQubit]")
 {
     // The name of the file where the resource usage data is stored


### PR DESCRIPTION
**Context:**
After many discussions, we decided on the following behavior: `x = qml.allocate(...)` does not create new qubits. `x` is a(n array of) wire index/label(s) that will be dynamically resolved at runtime among the existing capacity qubits on the device.

This means `qml.allocate` will correspond to extract ops in catalyst, not alloc ops.

A runtime function needs to be added to query and return currently available wire labels for the extract indices.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
