### PR TITLE
Renaming `python_compiler` into `unified_compiler`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -23,6 +23,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* The `qml.compiler.python_compiler` module in PennyLane has been renamed `qml.compiler.unified_compiler`.
+  [(#1997)](https://github.com/PennyLaneAI/pennylane/pull/1997)
+
 * Adjoint differentiation is used by default when executing on lightning devices, significantly reduces gradient computation time.
   [(#1961)](https://github.com/PennyLaneAI/catalyst/pull/1961)
 

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -471,7 +471,7 @@ class Compiler:
         return output_object_name, out_IR
 
     @debug_logger
-    def is_using_python_compiler(self):
+    def is_using_unified_compiler(self):
         """Returns true if we detect that there is an xdsl plugin in use.
 
         Will also modify self.options.pass_plugins and self.options.dialect_plugins to remove
@@ -509,13 +509,13 @@ class Compiler:
             (str): filename of shared object
         """
 
-        if self.is_using_python_compiler():
+        if self.is_using_unified_compiler():
             # We keep this module here to keep xDSL requirement optional
             # Only move this is it has been decided that xDSL is no longer optional.
             # pylint: disable-next=import-outside-toplevel
-            from pennylane.compiler.python_compiler import Compiler as PythonCompiler
+            from pennylane.compiler.unified_compiler import Compiler as UnifiedCompiler
 
-            compiler = PythonCompiler()
+            compiler = UnifiedCompiler()
             mlir_module = compiler.run(mlir_module)
 
         return self.run_from_ir(


### PR DESCRIPTION
Context: This PR changes name from python.compiler into unified.compiler and updates all the entries in the source code.

Description of the Change: As above.

Benefits: Better name.

Possible Drawbacks: None that I can think of. Notice that a similar PR should be opened in catalyst.

Related GitHub Issues: None.

[sc-98172]