### PR TITLE
Add a jax primitive for single qubit dealloc

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -56,11 +56,11 @@
   %0 = transform.apply_registered_pass "some-pass" with options = {"an-option" = true, "maxValue" = 1 : i64, "multi-word-option" = 1 : i64}
   ```
 
-*  Commuting Clifford Pauli Product Rotation (PPR) operations, past non-Clifford PPRs, now supports P(π/2) Cliffords in addition to P(π/4)
-   [(#1966)](https://github.com/PennyLaneAI/catalyst/pull/1966)
+* Commuting Clifford Pauli Product Rotation (PPR) operations, past non-Clifford PPRs, now supports P(π/2) Cliffords in addition to P(π/4)
+  [(#1966)](https://github.com/PennyLaneAI/catalyst/pull/1966)
 
-*  A new jax primitive `qdealloc_qb_p` is available for single qubit deallocations.
-   [(#2005)](https://github.com/PennyLaneAI/catalyst/pull/2005)
+* A new jax primitive `qdealloc_qb_p` is available for single qubit deallocations.
+  [(#2005)](https://github.com/PennyLaneAI/catalyst/pull/2005)
 
 
 <h3>Breaking changes 💔</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -53,8 +53,12 @@
   %0 = transform.apply_registered_pass "some-pass" with options = {"an-option" = true, "maxValue" = 1 : i64, "multi-word-option" = 1 : i64}
   ```
 
-*  `Commuting Clifford Pauli Product Rotation (PPR) operations, past non-Clifford PPRs, now supports P(π/2) Cliffords in addition to P(π/4)`
+*  Commuting Clifford Pauli Product Rotation (PPR) operations, past non-Clifford PPRs, now supports P(π/2) Cliffords in addition to P(π/4)
    [(#1966)](https://github.com/PennyLaneAI/catalyst/pull/1966)
+
+*  A new jax primitive `qdealloc_qb_p` is available for single qubit deallocations.
+   [(#2005)](https://github.com/PennyLaneAI/catalyst/pull/2005)
+
 
 <h3>Breaking changes 💔</h3>
 

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -76,6 +76,7 @@ from mlir_quantum.dialects.quantum import (
     CountsOp,
     CustomOp,
     DeallocOp,
+    DeallocQubitOp,
     DeviceInitOp,
     DeviceReleaseOp,
     ExpvalOp,
@@ -259,6 +260,8 @@ num_qubits_p = Primitive("num_qubits")
 qalloc_p = Primitive("qalloc")
 qdealloc_p = Primitive("qdealloc")
 qdealloc_p.multiple_results = True
+qdealloc_qb_p = Primitive("qdealloc_qb")
+qdealloc_qb_p.multiple_results = True
 qextract_p = Primitive("qextract")
 qinsert_p = Primitive("qinsert")
 gphase_p = Primitive("gphase")
@@ -1006,6 +1009,21 @@ def _qdealloc_lowering(jax_ctx: mlir.LoweringRuleContext, qreg):
     ctx = jax_ctx.module_context.context
     ctx.allow_unregistered_dialects = True
     DeallocOp(qreg)
+    return ()
+
+
+#
+# qdealloc_qb
+#
+@qdealloc_qb_p.def_abstract_eval
+def _qdealloc_qb_abstract_eval(qubit):
+    return ()
+
+
+def _qdealloc_qb_lowering(jax_ctx: mlir.LoweringRuleContext, qubit):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+    DeallocQubitOp(qubit)
     return ()
 
 
@@ -2460,6 +2478,7 @@ CUSTOM_LOWERING_RULES = (
     (device_release_p, _device_release_lowering),
     (qalloc_p, _qalloc_lowering),
     (qdealloc_p, _qdealloc_lowering),
+    (qdealloc_qb_p, _qdealloc_qb_lowering),
     (qextract_p, _qextract_lowering),
     (qinsert_p, _qinsert_lowering),
     (qinst_p, _qinst_lowering),

--- a/frontend/test/lit/test_dynamic_qubit_allocation.py
+++ b/frontend/test/lit/test_dynamic_qubit_allocation.py
@@ -1,0 +1,46 @@
+# Copyright 2025 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the dynamic qubit allocation.
+Note that this feature is only available under the plxpr pipeline.
+"""
+
+# RUN: %PYTHON %s | FileCheck %s
+
+import pennylane as qml
+
+from catalyst import qjit
+from catalyst.jax_primitives import qalloc_p, qdealloc_qb_p, qextract_p
+
+
+@qjit
+def test_single_qubit_dealloc():
+    """
+    Unit test for the single qubit dealloc primitive's lowerings.
+    """
+
+    # CHECK: [[qubit:.]]:AbstractQbit() = qextract {{.+}} 3
+    # CHECK: qdealloc_qb [[qubit]]
+
+    # CHECK: [[qubit:%.+]] = quantum.extract {{.+}} 3
+    # CHECK: quantum.dealloc_qb [[qubit]] : !quantum.bit
+
+    qreg = qalloc_p.bind(10)
+    qubit = qextract_p.bind(qreg, 3)
+    qdealloc_qb_p.bind(qubit)
+
+
+print(test_single_qubit_dealloc.jaxpr)
+print(test_single_qubit_dealloc.mlir)

--- a/frontend/test/lit/test_dynamic_qubit_allocation.py
+++ b/frontend/test/lit/test_dynamic_qubit_allocation.py
@@ -19,8 +19,6 @@ Note that this feature is only available under the plxpr pipeline.
 
 # RUN: %PYTHON %s | FileCheck %s
 
-import pennylane as qml
-
 from catalyst import qjit
 from catalyst.jax_primitives import qalloc_p, qdealloc_qb_p, qextract_p
 

--- a/frontend/test/lit/test_dynamic_qubit_allocation.py
+++ b/frontend/test/lit/test_dynamic_qubit_allocation.py
@@ -14,7 +14,6 @@
 
 """
 Unit tests for the dynamic qubit allocation.
-Note that this feature is only available under the plxpr pipeline.
 """
 
 # RUN: %PYTHON %s | FileCheck %s


### PR DESCRIPTION
**Context:**
There is an mlir op for the single qubit deallocation (which lowers to `__catalyst__rt__qubit_release`), but there is no frontend jax primitive for it.

**Description of the Change:**
Add a jax primitive for single qubit dealloc.

**Benefits:**
Things requiring single qubit deallocation like ftqc, decomposition, and dynamic allocation itself, can start doing so in plxpr conversion.
