### PR TITLE
Checks if all control and targets in multi-qubit operations at runtime are different

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -56,6 +56,9 @@
   %0 = transform.apply_registered_pass "some-pass" with options = {"an-option" = true, "maxValue" = 1 : i64, "multi-word-option" = 1 : i64}
   ```
 
+* Added checks to make sure all the operands in all the multi-qubit gates in `RuntimeCAPI.cpp` are distinct. 
+  [(#2006)](https://github.com/PennyLaneAI/catalyst/pull/2006).
+
 *  `Commuting Clifford Pauli Product Rotation (PPR) operations, past non-Clifford PPRs, now supports P(π/2) Cliffords in addition to P(π/4)`
    [(#1966)](https://github.com/PennyLaneAI/catalyst/pull/1966)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -56,7 +56,7 @@
   %0 = transform.apply_registered_pass "some-pass" with options = {"an-option" = true, "maxValue" = 1 : i64, "multi-word-option" = 1 : i64}
   ```
 
-* Added checks to make sure all the operands in all the multi-qubit gates in `RuntimeCAPI.cpp` are distinct. 
+* Added checks to raise an error when the input qubits to the multi-qubit gates in the runtime CAPI are not all distinct. 
   [(#2006)](https://github.com/PennyLaneAI/catalyst/pull/2006).
 
 *  `Commuting Clifford Pauli Product Rotation (PPR) operations, past non-Clifford PPRs, now supports P(π/2) Cliffords in addition to P(π/4)`

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -815,7 +815,7 @@ void __catalyst__qis__CSWAP(QUBIT *control, QUBIT *aswap, QUBIT *bswap, const Mo
 void __catalyst__qis__Toffoli(QUBIT *wire0, QUBIT *wire1, QUBIT *wire2, const Modifiers *modifiers)
 {
     RT_FAIL_IF((wire0 == wire1 || wire1 == wire2 || wire0 == wire2),
-               "Invalid input for Toffoli gate. All three qubit operands must be distinct..");
+               "Invalid input for Toffoli gate. All three qubit operands must be distinct.");
     getQuantumDevicePtr()->NamedOperation("Toffoli", {},
                                           {reinterpret_cast<QubitIdType>(wire0),
                                            reinterpret_cast<QubitIdType>(wire1),

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -638,6 +638,8 @@ void __catalyst__qis__CNOT(QUBIT *control, QUBIT *target, const Modifiers *modif
 
 void __catalyst__qis__CY(QUBIT *control, QUBIT *target, const Modifiers *modifiers)
 {
+    RT_FAIL_IF(control == target,
+               "Invalid input for CY gate. Control and target qubit operands must be distinct.");
     getQuantumDevicePtr()->NamedOperation("CY", {},
                                           {/* control = */ reinterpret_cast<QubitIdType>(control),
                                            /* target = */ reinterpret_cast<QubitIdType>(target)},
@@ -646,6 +648,8 @@ void __catalyst__qis__CY(QUBIT *control, QUBIT *target, const Modifiers *modifie
 
 void __catalyst__qis__CZ(QUBIT *control, QUBIT *target, const Modifiers *modifiers)
 {
+    RT_FAIL_IF(control == target,
+               "Invalid input for CZ gate. Control and target qubit operands must be distinct.");
     getQuantumDevicePtr()->NamedOperation("CZ", {},
                                           {/* control = */ reinterpret_cast<QubitIdType>(control),
                                            /* target = */ reinterpret_cast<QubitIdType>(target)},
@@ -654,6 +658,8 @@ void __catalyst__qis__CZ(QUBIT *control, QUBIT *target, const Modifiers *modifie
 
 void __catalyst__qis__SWAP(QUBIT *control, QUBIT *target, const Modifiers *modifiers)
 {
+    RT_FAIL_IF(control == target,
+               "Invalid input for SWAP gate. Control and target qubit operands must be distinct.");
     getQuantumDevicePtr()->NamedOperation("SWAP", {},
                                           {/* control = */ reinterpret_cast<QubitIdType>(control),
                                            /* target = */ reinterpret_cast<QubitIdType>(target)},
@@ -663,6 +669,9 @@ void __catalyst__qis__SWAP(QUBIT *control, QUBIT *target, const Modifiers *modif
 void __catalyst__qis__IsingXX(double theta, QUBIT *control, QUBIT *target,
                               const Modifiers *modifiers)
 {
+    RT_FAIL_IF(
+        control == target,
+        "Invalid input for IsingXX gate. Control and target qubit operands must be distinct.");
     getQuantumDevicePtr()->NamedOperation("IsingXX", {theta},
                                           {/* control = */ reinterpret_cast<QubitIdType>(control),
                                            /* target = */ reinterpret_cast<QubitIdType>(target)},
@@ -672,6 +681,9 @@ void __catalyst__qis__IsingXX(double theta, QUBIT *control, QUBIT *target,
 void __catalyst__qis__IsingYY(double theta, QUBIT *control, QUBIT *target,
                               const Modifiers *modifiers)
 {
+    RT_FAIL_IF(
+        control == target,
+        "Invalid input for IsingYY gate. Control and target qubit operands must be distinct.");
     getQuantumDevicePtr()->NamedOperation("IsingYY", {theta},
                                           {/* control = */ reinterpret_cast<QubitIdType>(control),
                                            /* target = */ reinterpret_cast<QubitIdType>(target)},
@@ -681,6 +693,9 @@ void __catalyst__qis__IsingYY(double theta, QUBIT *control, QUBIT *target,
 void __catalyst__qis__IsingXY(double theta, QUBIT *control, QUBIT *target,
                               const Modifiers *modifiers)
 {
+    RT_FAIL_IF(
+        control == target,
+        "Invalid input for IsingXY gate. Control and target qubit operands must be distinct.");
     getQuantumDevicePtr()->NamedOperation("IsingXY", {theta},
                                           {/* control = */ reinterpret_cast<QubitIdType>(control),
                                            /* target = */ reinterpret_cast<QubitIdType>(target)},
@@ -690,6 +705,9 @@ void __catalyst__qis__IsingXY(double theta, QUBIT *control, QUBIT *target,
 void __catalyst__qis__IsingZZ(double theta, QUBIT *control, QUBIT *target,
                               const Modifiers *modifiers)
 {
+    RT_FAIL_IF(
+        control == target,
+        "Invalid input for IsingZZ gate. Control and target qubit operands must be distinct.");
     getQuantumDevicePtr()->NamedOperation("IsingZZ", {theta},
                                           {/* control = */ reinterpret_cast<QubitIdType>(control),
                                            /* target = */ reinterpret_cast<QubitIdType>(target)},
@@ -699,6 +717,8 @@ void __catalyst__qis__IsingZZ(double theta, QUBIT *control, QUBIT *target,
 void __catalyst__qis__SingleExcitation(double phi, QUBIT *wire0, QUBIT *wire1,
                                        const Modifiers *modifiers)
 {
+    RT_FAIL_IF(wire0 == wire1,
+               "Invalid input for SingleExcitation gate. All two qubit operands must be distinct.");
     getQuantumDevicePtr()->NamedOperation(
         "SingleExcitation", {phi},
         {reinterpret_cast<QubitIdType>(wire0), reinterpret_cast<QubitIdType>(wire1)},
@@ -708,6 +728,10 @@ void __catalyst__qis__SingleExcitation(double phi, QUBIT *wire0, QUBIT *wire1,
 void __catalyst__qis__DoubleExcitation(double phi, QUBIT *wire0, QUBIT *wire1, QUBIT *wire2,
                                        QUBIT *wire3, const Modifiers *modifiers)
 {
+    RT_FAIL_IF(
+        (wire0 == wire1 || wire0 == wire2 || wire0 == wire3 || wire1 == wire2 || wire1 == wire3 ||
+         wire2 == wire3),
+        "Invalid input for DoubleExcitation gate. All four qubit operands must be distinct.");
     getQuantumDevicePtr()->NamedOperation(
         "DoubleExcitation", {phi},
         {reinterpret_cast<QubitIdType>(wire0), reinterpret_cast<QubitIdType>(wire1),
@@ -718,6 +742,8 @@ void __catalyst__qis__DoubleExcitation(double phi, QUBIT *wire0, QUBIT *wire1, Q
 void __catalyst__qis__ControlledPhaseShift(double theta, QUBIT *control, QUBIT *target,
                                            const Modifiers *modifiers)
 {
+    RT_FAIL_IF(control == target, "Invalid input for ControlledPhaseShift gate. Control and target "
+                                  "qubit operands must be distinct.");
     getQuantumDevicePtr()->NamedOperation("ControlledPhaseShift", {theta},
                                           {/* control = */ reinterpret_cast<QubitIdType>(control),
                                            /* target = */ reinterpret_cast<QubitIdType>(target)},
@@ -726,6 +752,8 @@ void __catalyst__qis__ControlledPhaseShift(double theta, QUBIT *control, QUBIT *
 
 void __catalyst__qis__CRX(double theta, QUBIT *control, QUBIT *target, const Modifiers *modifiers)
 {
+    RT_FAIL_IF(control == target,
+               "Invalid input for CRX gate. Control and target qubit operands must be distinct.");
     getQuantumDevicePtr()->NamedOperation("CRX", {theta},
                                           {/* control = */ reinterpret_cast<QubitIdType>(control),
                                            /* target = */ reinterpret_cast<QubitIdType>(target)},
@@ -734,6 +762,8 @@ void __catalyst__qis__CRX(double theta, QUBIT *control, QUBIT *target, const Mod
 
 void __catalyst__qis__CRY(double theta, QUBIT *control, QUBIT *target, const Modifiers *modifiers)
 {
+    RT_FAIL_IF(control == target,
+               "Invalid input for CRY gate. Control and target qubit operands must be distinct.");
     getQuantumDevicePtr()->NamedOperation("CRY", {theta},
                                           {/* control = */ reinterpret_cast<QubitIdType>(control),
                                            /* target = */ reinterpret_cast<QubitIdType>(target)},
@@ -742,6 +772,8 @@ void __catalyst__qis__CRY(double theta, QUBIT *control, QUBIT *target, const Mod
 
 void __catalyst__qis__CRZ(double theta, QUBIT *control, QUBIT *target, const Modifiers *modifiers)
 {
+    RT_FAIL_IF(control == target,
+               "Invalid input for CRZ gate. Control and target qubit operands must be distinct.");
     getQuantumDevicePtr()->NamedOperation("CRZ", {theta},
                                           {/* control = */ reinterpret_cast<QubitIdType>(control),
                                            /* target = */ reinterpret_cast<QubitIdType>(target)},
@@ -750,6 +782,8 @@ void __catalyst__qis__CRZ(double theta, QUBIT *control, QUBIT *target, const Mod
 
 void __catalyst__qis__MS(double theta, QUBIT *control, QUBIT *target, const Modifiers *modifiers)
 {
+    RT_FAIL_IF(control == target,
+               "Invalid input for MS gate. Control and target qubit operands must be distinct.");
     getQuantumDevicePtr()->NamedOperation("MS", {theta},
                                           {/* control = */ reinterpret_cast<QubitIdType>(control),
                                            /* target = */ reinterpret_cast<QubitIdType>(target)},
@@ -759,6 +793,8 @@ void __catalyst__qis__MS(double theta, QUBIT *control, QUBIT *target, const Modi
 void __catalyst__qis__CRot(double phi, double theta, double omega, QUBIT *control, QUBIT *target,
                            const Modifiers *modifiers)
 {
+    RT_FAIL_IF(control == target,
+               "Invalid input for CRot gate. Control and target qubit operands must be distinct.");
     getQuantumDevicePtr()->NamedOperation("CRot", {phi, theta, omega},
                                           {/* control = */ reinterpret_cast<QubitIdType>(control),
                                            /* target = */ reinterpret_cast<QubitIdType>(target)},
@@ -767,6 +803,8 @@ void __catalyst__qis__CRot(double phi, double theta, double omega, QUBIT *contro
 
 void __catalyst__qis__CSWAP(QUBIT *control, QUBIT *aswap, QUBIT *bswap, const Modifiers *modifiers)
 {
+    RT_FAIL_IF((control == aswap || aswap == bswap || control == bswap),
+               "Invalid input for CSWAP gate. Control and target qubit operands must be distinct.");
     getQuantumDevicePtr()->NamedOperation("CSWAP", {},
                                           {reinterpret_cast<QubitIdType>(control),
                                            reinterpret_cast<QubitIdType>(aswap),
@@ -776,6 +814,8 @@ void __catalyst__qis__CSWAP(QUBIT *control, QUBIT *aswap, QUBIT *bswap, const Mo
 
 void __catalyst__qis__Toffoli(QUBIT *wire0, QUBIT *wire1, QUBIT *wire2, const Modifiers *modifiers)
 {
+    RT_FAIL_IF((wire0 == wire1 || wire1 == wire2 || wire0 == wire2),
+               "Invalid input for Toffoli gate. All three qubit operands must be distinct..");
     getQuantumDevicePtr()->NamedOperation("Toffoli", {},
                                           {reinterpret_cast<QubitIdType>(wire0),
                                            reinterpret_cast<QubitIdType>(wire1),
@@ -801,6 +841,8 @@ void __catalyst__qis__MultiRZ(double theta, const Modifiers *modifiers, int64_t 
 
 void __catalyst__qis__ISWAP(QUBIT *wire0, QUBIT *wire1, const Modifiers *modifiers)
 {
+    RT_FAIL_IF(wire0 == wire1,
+               "Invalid input for ISWAP gate. Control and target qubit operands must be distinct.");
     getQuantumDevicePtr()->NamedOperation(
         "ISWAP", {}, {reinterpret_cast<QubitIdType>(wire0), reinterpret_cast<QubitIdType>(wire1)},
         MODIFIERS_ARGS(modifiers));
@@ -808,6 +850,8 @@ void __catalyst__qis__ISWAP(QUBIT *wire0, QUBIT *wire1, const Modifiers *modifie
 
 void __catalyst__qis__PSWAP(double phi, QUBIT *wire0, QUBIT *wire1, const Modifiers *modifiers)
 {
+    RT_FAIL_IF(wire0 == wire1,
+               "Invalid input for PSWAP gate. Control and target qubit operands must be distinct.");
     getQuantumDevicePtr()->NamedOperation(
         "PSWAP", {phi},
         {reinterpret_cast<QubitIdType>(wire0), reinterpret_cast<QubitIdType>(wire1)},


### PR DESCRIPTION
**Context:**
RuntimeCAPI.cpp checks if control and target qubit operand for CNOT gate `__catalyst__qis__CNOT` are different.
But the same checks are missing in other multi-qubit gates like CRY, CRZ, CRot, Toffoli, CSWAP etc.


```python
import pennylane as qml
import numpy as np
dev = qml.device("lightning.qubit")
@qml.qjit(autograph=True)
@qml.qnode(dev)
def circuit(x):
    qml.Hadamard(0)
    qml.CRY(0.5, [x,1])
    return qml.state()
print(circuit(1))
```
prints the following (printed NamedOperation from NullQubit)

```pycon
Name: Hadamard
Wires : 0,
Name: CRY
Wires : 1,1,
[1.+0.j 0.+0.j 0.+0.j 0.+0.j]
```
The code still executes and produces state when executed with lightning qubit:

```python
import pennylane as qml
import numpy as np
dev = qml.device("lightning.qubit")=
@qml.qjit(autograph=True)
@qml.qnode(dev)
def circuit(x):
    qml.Hadamard(0)
    qml.CRY(0.5, [x,1])
    return qml.state()
print(circuit(1))
```

which prints 
```pycon
[0.70710678+0.j 0.        +0.j 0.70710678+0.j 0.        +0.j]
``` 

i.e. $\frac{1}{2}(|0\rangle + |1\rangle)|0\rangle$. The state produced is as if only first Hadamard gate was applied. This could have been hard to debug with printing all the operations using null qubit

**Description of the Change:**
Added checks to make sure all the operands in all the multi-qubit gates at runtime are distinct.


**Related GitHub Issues:**
