### PR TITLE
On-board catalyst to using new large runner

### DIFF
--- a/.github/workflows/determine-workflow-runner.yml
+++ b/.github/workflows/determine-workflow-runner.yml
@@ -13,7 +13,7 @@ on:
         value: ${{ jobs.determine_workflow_runner.outputs.runner_group || inputs.default_runner }}
 
 env:
-  LARGE_RUNNER_GROUP_NAME: pl-4-core-large-runner
+  LARGE_RUNNER_GROUP_NAME: blacksmith-4vcpu-ubuntu-2404
 
 jobs:
   determine_workflow_runner:
@@ -22,7 +22,7 @@ jobs:
         (
           github.event_name == 'pull_request'
           && contains(github.event.pull_request.labels.*.name, 'urgent')
-        ) && 'pl-4-core-large-runner' || 'ubuntu-24.04'
+        ) && 'blacksmith-4vcpu-ubuntu-2404' || 'ubuntu-24.04'
       }}
 
     outputs:


### PR DESCRIPTION
**Context:**
Change the large runners that catalyst uses.

This would swap any instance of GitHub based large runners to the same large runners offered by a third-part vendor [blacksmith](https://blacksmith.sh).

**Description of the Change:**
This pull request changes the name of the runner returned when a large runner is requested.

Which affects:
- All tests run on `master` branch
- All tests run on PRs that have the `urgent` label

**Benefits:**

- Lower costs, blacksmith offers identical environment setup to GitHub large runners but at half the price per minute. So even without performance benefits, we slash monthly costs for CI in half.
- Faster vcpu clock cycle and higher single thread performance. From my coarse testing, the entire test suite has had a 30% speed-up. Tests that were running in the 18-20 min range ran in 10-12 min. Tests that ran in 12-15min ran in 6-9 min. 
- Faster runner boot up. A substantial speed up for urgent PRs waiting for a runner.
- They also offer a dashboard for all jobs run on their runners. More details regarding this coming soon.

**Possible Drawbacks:**

The new large runners should be a complete drop-in replacement for the existing GitHub large runner.

On the pennylane side, one test had to be updated. See PennyLaneAI/pennylane#8134 for details.

The issue on the pennylane side did seem to be instability in the test itself. It failed on higher versions of python across all runner variants. Reducing the tolerance did fix it across the board.


**Related GitHub Issues:**
None.