### PR TITLE
chore: remove autograph kwarg from qnode

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -10,7 +10,7 @@ enzyme=v0.0.186
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.43.0.dev39
+pennylane=0.43.0.dev42
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/.dep-versions
+++ b/.dep-versions
@@ -10,7 +10,7 @@ enzyme=v0.0.186
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.43.0.dev42
+pennylane=0.43.0.dev43
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -33,4 +33,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.43.0.dev15
 pennylane-lightning==0.43.0.dev15
-pennylane==0.43.0.dev42
+pennylane==0.43.0.dev43

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -33,4 +33,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.43.0.dev15
 pennylane-lightning==0.43.0.dev15
-pennylane==0.43.0.dev39
+pennylane==0.43.0.dev42

--- a/frontend/test/lit/test_decomposition.py
+++ b/frontend/test/lit/test_decomposition.py
@@ -446,7 +446,7 @@ def test_decomposition_rule_with_cond():
         qml.cond(param != 0.0, true_path, false_path)()
 
     @qml.qjit(autograph=False)
-    @qml.qnode(qml.device("lightning.qubit", wires=1), autograph=False)
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
     def circuit_6():
         # CHECK: module @circuit_6
         cond_RX(float, jax.core.ShapedArray((1,), int))
@@ -492,7 +492,7 @@ def test_decomposition_rule_caller():
         Op2_decomp(param, wires)
 
     @qml.qjit(autograph=False)
-    @qml.qnode(qml.device("lightning.qubit", wires=1), autograph=False)
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
     # CHECK: module @circuit_7
     def circuit_7():
         # CHECK: [[QREG:%.+]] = quantum.alloc

--- a/frontend/test/lit/test_quantum_subroutine.py
+++ b/frontend/test/lit/test_quantum_subroutine.py
@@ -196,7 +196,7 @@ def test_quantum_subroutine_with_control_flow():
         qml.cond(param != 0.0, true_path, false_path)()
 
     @qml.qjit(autograph=False)
-    @qml.qnode(qml.device("lightning.qubit", wires=1), autograph=False)
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
     # CHECK: module @subroutine_test_3
     def subroutine_test_3():
         # CHECK-DAG: [[CST:%.+]] = stablehlo.constant dense<3.140000e+00>
@@ -240,7 +240,7 @@ def test_nested_subroutine_call():
         Hadamard_subroutine()
 
     @qml.qjit(autograph=False)
-    @qml.qnode(qml.device("lightning.qubit", wires=1), autograph=False)
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
     # CHECK: module @subroutine_test_4
     def subroutine_test_4():
         # CHECK: [[QREG:%.+]] = quantum.alloc
@@ -298,7 +298,7 @@ def test_two_callsites_quantum():
     def identity(): ...
 
     @qml.qjit(autograph=False)
-    @qml.qnode(qml.device("lightning.qubit", wires=1), autograph=False)
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
     # CHECK: module @subroutine_test_6
     def subroutine_test_6():
         # CHECK: [[QREG:%.+]] = quantum.alloc
@@ -326,7 +326,7 @@ def test_two_qnodes_one_subroutine():
 
     # CHECK: module @main
 
-    @qml.qnode(qml.device("lightning.qubit", wires=1), autograph=False)
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
     def subroutine_test_7():
         # CHECK: [[QREG:%.+]] = quantum.alloc
         # CHECK: [[QREG_1:%.+]] = call @identity([[QREG]]) : (!quantum.reg) -> !quantum.reg
@@ -336,7 +336,7 @@ def test_two_qnodes_one_subroutine():
 
         # CHECK: func.func private @identity
 
-    @qml.qnode(qml.device("null.qubit", wires=1), autograph=False)
+    @qml.qnode(qml.device("null.qubit", wires=1))
     def subroutine_test_8():
         # CHECK: [[QREG:%.+]] = quantum.alloc
         # CHECK: [[QREG_1:%.+]] = call @identity_0([[QREG]]) : (!quantum.reg) -> !quantum.reg
@@ -372,7 +372,7 @@ def test_with_constant():
     qml.capture.enable()
 
     @qml.qjit(autograph=False)
-    @qml.qnode(qml.device("null.qubit", wires=2), autograph=False)
+    @qml.qnode(qml.device("null.qubit", wires=2))
     def circ():
         Hadamard_plus_1(0)
         return qml.probs()

--- a/frontend/test/pytest/from_plxpr/test_capture_integration.py
+++ b/frontend/test/pytest/from_plxpr/test_capture_integration.py
@@ -1647,7 +1647,7 @@ def test_ctrl_transform_integration(separate_funcs):
         qml.RX(2 * x, wires=3)
 
     @qml.qjit
-    @qml.qnode(qml.device("lightning.qubit", wires=4), autograph=False)
+    @qml.qnode(qml.device("lightning.qubit", wires=4))
     def c(x, y):
         qml.X(1)
         if separate_funcs:

--- a/frontend/test/pytest/from_plxpr/test_from_plxpr.py
+++ b/frontend/test/pytest/from_plxpr/test_from_plxpr.py
@@ -578,7 +578,7 @@ class TestAdjointCtrl:
         """Test the conversion of a simple adjoint op."""
         qml.capture.enable()
 
-        @qml.qnode(qml.device("lightning.qubit", wires=4), autograph=False)
+        @qml.qnode(qml.device("lightning.qubit", wires=4))
         def c():
             op = qml.S(0)
             for _ in range(num_adjoints):
@@ -606,7 +606,7 @@ class TestAdjointCtrl:
 
         qml.capture.enable()
 
-        @qml.qnode(qml.device("lightning.qubit", wires=4), autograph=False)
+        @qml.qnode(qml.device("lightning.qubit", wires=4))
         def c(x, wire3):
             op = qml.RX(x, 0)
             if inner_adjoint:
@@ -643,7 +643,7 @@ class TestAdjointCtrl:
 
         qml.capture.enable()
 
-        @qml.qnode(qml.device("lightning.qubit", wires=3), autograph=False)
+        @qml.qnode(qml.device("lightning.qubit", wires=3))
         def c():
             if as_qfunc:
                 qml.ctrl(qml.ctrl(qml.S, 1), 2, control_values=[False])(0)
@@ -682,7 +682,7 @@ class TestAdjointCtrl:
             if with_return:
                 return op
 
-        @qml.qnode(qml.device("lightning.qubit", wires=2), autograph=False)
+        @qml.qnode(qml.device("lightning.qubit", wires=2))
         def c(x):
             qml.X(0)
             qml.adjoint(f)(x)
@@ -724,7 +724,7 @@ class TestAdjointCtrl:
 
         qml.capture.enable()
 
-        @qml.qnode(qml.device("lightning.qubit", wires=4), autograph=False)
+        @qml.qnode(qml.device("lightning.qubit", wires=4)
         def c(wire):
             qml.CNOT((0, wire))
             if as_qfunc:
@@ -764,7 +764,7 @@ class TestAdjointCtrl:
         def g(i):
             qml.X(i)
 
-        @qml.qnode(qml.device("lightning.qubit", wires=4), autograph=False)
+        @qml.qnode(qml.device("lightning.qubit", wires=4))
         def c():
             qml.ctrl(g, [4, 5])()
             return qml.state()

--- a/frontend/test/pytest/from_plxpr/test_from_plxpr.py
+++ b/frontend/test/pytest/from_plxpr/test_from_plxpr.py
@@ -724,7 +724,7 @@ class TestAdjointCtrl:
 
         qml.capture.enable()
 
-        @qml.qnode(qml.device("lightning.qubit", wires=4)
+        @qml.qnode(qml.device("lightning.qubit", wires=4))
         def c(wire):
             qml.CNOT((0, wire))
             if as_qfunc:

--- a/frontend/test/pytest/from_plxpr/test_observables.py
+++ b/frontend/test/pytest/from_plxpr/test_observables.py
@@ -129,7 +129,7 @@ def test_sum(as_linear_combination):
     """Test the conversion of a Sum class."""
     qml.capture.enable()
 
-    @qml.qnode(qml.device("lightning.qubit", wires=4), autograph=False)
+    @qml.qnode(qml.device("lightning.qubit", wires=4))
     def c():
         if as_linear_combination:
             # Note that we should investigate improving the capture of hamiltonian

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -992,6 +992,7 @@ class TestForLoops:
     def test_for_in_dynamic_range_indexing_array(self):
         """Test for loop over a Python range with dynamic bounds that is used to index an array."""
 
+        @qjit(autograph=True)
         @qml.qnode(qml.device("lightning.qubit", wires=1))
         def f(n: int):
             params = jnp.array([0.0, 1 / 4 * jnp.pi, 2 / 4 * jnp.pi])

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -255,7 +255,7 @@ class TestCond:
             with pytest.raises(
                 ValueError, match="false branch must be provided if the true branch"
             ):
-                qjit(qml.qnode(qml.device(backend, wires=1), autograph=False)(circuit))
+                qjit(qml.qnode(qml.device(backend, wires=1))(circuit))
         else:
 
             with pytest.raises(
@@ -314,7 +314,7 @@ class TestCond:
                 ValueError,
                 match="Mismatch in output abstract values in false branch",
             ):
-                qjit(qml.qnode(qml.device(backend, wires=1), autograph=False)(circuit))
+                qjit(qml.qnode(qml.device(backend, wires=1))(circuit))
         else:
             m = "Conditional requires a consistent array shape per result across all branches"
             with pytest.raises(
@@ -331,7 +331,7 @@ class TestCond:
             pytest.xfail("capture does not allow returning mcm's or classical values")
 
         @qjit
-        @qml.qnode(qml.device(backend, wires=1), autograph=False)
+        @qml.qnode(qml.device(backend, wires=1))
         def circuit():
             @cond(True)
             def cond_fn():
@@ -577,7 +577,7 @@ class TestCond:
         with pytest.raises(
             TypeError, match="Conditional 'else if' function is not allowed to have any arguments"
         ):
-            qjit(qml.qnode(qml.device("lightning.qubit", wires=1), autograph=False)(circuit))
+            qjit(qml.qnode(qml.device("lightning.qubit", wires=1))(circuit))
 
     def test_identical_branch_names(self, backend):
         """Test that branches of the conditional can carry the same function name."""
@@ -586,7 +586,7 @@ class TestCond:
             pytest.xfail("capture does not allow returning mcms")
 
         @qjit
-        @qml.qnode(qml.device(backend, wires=1), autograph=False)
+        @qml.qnode(qml.device(backend, wires=1))
         def circuit(pred: bool):
             @cond(pred)
             def conditional_flip():
@@ -864,7 +864,7 @@ class TestCondOperatorAccess:
         """Test Cond operation access in quantum context."""
 
         @qjit
-        @qml.qnode(qml.device(backend, wires=1), autograph=False)
+        @qml.qnode(qml.device(backend, wires=1))
         def circuit(n):
             @cond(n > 4)
             def cond_fn():

--- a/frontend/test/pytest/test_quantum_subroutine.py
+++ b/frontend/test/pytest/test_quantum_subroutine.py
@@ -116,7 +116,7 @@ def test_quantum_subroutine_conditional():
     qml.capture.enable()
 
     @qml.qjit(autograph=False)
-    @qml.qnode(qml.device("lightning.qubit", wires=1), autograph=False)
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
     def subroutine_test(c: int):
         Hadamard0(c)
         return qml.state()


### PR DESCRIPTION
**Context:**

We are removing the `autograph` kwarg at the QNode level in favour of `disable_autograph` / `run_autograph` + `qjit` (see PL PR https://github.com/PennyLaneAI/pennylane/pull/8104).

~~⚠️ Tests are failing but that is expected and should be fixed once the PL PR merges as autograph will be off by default.~~

[sc-92903]
