### PR TITLE
Migrate some more lit tests to `qml.set_shots`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -224,6 +224,7 @@ David Ittah,
 Christina Lee,
 Joseph Lee,
 Andrija Paurevic,
+Ritu Thombre,
 Roberto Turrado,
 Paul Haochen Wang,
 Jake Zaia.

--- a/frontend/test/lit/test_decomposition.py
+++ b/frontend/test/lit/test_decomposition.py
@@ -46,8 +46,8 @@ def get_custom_device_without(num_wires, discards=frozenset(), force_matrix=froz
 
         _to_matrix_ops = {}
 
-        def __init__(self, shots=None, wires=None):
-            super().__init__(wires=wires, shots=shots)
+        def __init__(self, wires=None):
+            super().__init__(wires=wires)
             self.qjit_capabilities = deepcopy(get_device_capabilities(self))
             for gate in discards:
                 self.qjit_capabilities.operations.pop(gate, None)

--- a/frontend/test/lit/test_device_api.py
+++ b/frontend/test/lit/test_device_api.py
@@ -39,8 +39,8 @@ class CustomDevice(Device):
 
     config_filepath = CONFIG_CUSTOM_DEVICE
 
-    def __init__(self, wires, shots=1024):
-        super().__init__(wires=wires, shots=shots)
+    def __init__(self, wires):
+        super().__init__(wires=wires)
 
     @staticmethod
     def get_c_interface():
@@ -73,9 +73,10 @@ def test_circuit():
 
     # CHECK:   [[shots:%.+]] = arith.constant 2048 : i64
     # CHECK:   quantum.device shots([[shots]]) ["[[PATH:.*]]librtd_null_qubit.{{so|dylib}}", "Custom", "{}"]
-    dev = CustomDevice(wires=2, shots=2048)
+    dev = CustomDevice(wires=2)
 
     @qjit(target="mlir")
+    @qml.set_shots(2048)
     @qml.qnode(device=dev)
     def circuit():
         # CHECK:   quantum.custom "Hadamard"
@@ -99,9 +100,10 @@ def test_preprocess():
 
     # CHECK:   [[shots:%.+]] = arith.constant 2048 : i64
     # CHECK:   quantum.device shots([[shots]]) ["[[PATH:.*]]librtd_null_qubit.{{so|dylib}}", "Custom", "{}"]
-    dev = CustomDevice(wires=2, shots=2048)
+    dev = CustomDevice(wires=2)
 
     @qjit(target="mlir")
+    @qml.set_shots(2048)
     @qml.qnode(device=dev)
     def circuit_split():
         qml.Hadamard(wires=0)

--- a/frontend/test/lit/test_mcmc.py
+++ b/frontend/test/lit/test_mcmc.py
@@ -23,6 +23,7 @@ from catalyst import qjit
 
 
 @qjit
+@qml.set_shots(1000)
 @qml.qnode(
     qml.device(
         "lightning.qubit",
@@ -30,7 +31,6 @@ from catalyst import qjit
         mcmc=True,
         num_burnin=200,
         kernel_name="NonZeroRandom",
-        shots=1000,
     )
 )
 def circuit():

--- a/frontend/test/lit/test_measurements.py
+++ b/frontend/test/lit/test_measurements.py
@@ -35,7 +35,8 @@ from catalyst.jax_primitives import compbasis_p, counts_p, sample_p
 try:
     # COM: CHECK-LABEL: public @sample1(
     @qjit(target="mlir")
-    @qml.qnode(qml.device("lightning.qubit", wires=2, shots=1000))
+    @qml.set_shots(1000)
+    @qml.qnode(qml.device("lightning.qubit", wires=2))
     def sample1(x: float, y: float):
         qml.RX(x, wires=0)
         qml.RY(y, wires=1)
@@ -50,7 +51,8 @@ try:
 
     # COM: CHECK-LABEL: public @sample2(
     @qjit(target="mlir")
-    @qml.qnode(qml.device("lightning.qubit", wires=2, shots=1000))
+    @qml.set_shots(1000)
+    @qml.qnode(qml.device("lightning.qubit", wires=2))
     def sample2(x: float, y: float):
         qml.RX(x, wires=0)
         # COM: CHECK: [[q1:%.+]] = quantum.custom "RY"
@@ -71,7 +73,8 @@ except CompileError:
 
 # CHECK-LABEL: public @sample3(
 @qjit(target="mlir")
-@qml.qnode(qml.device("lightning.qubit", wires=2, shots=1000))
+@qml.set_shots(1000)
+@qml.qnode(qml.device("lightning.qubit", wires=2))
 # CHECK: [[shots:%.+]] = arith.constant 1000 : i64
 # CHECK: quantum.device shots([[shots]]) [{{.+}}]
 def sample3(x: float, y: float):
@@ -111,18 +114,19 @@ def test_sample_static():
 print(test_sample_static.mlir)
 
 
-# TODO: convert the device to have a dynamic shots value when core PennyLane device supports it
-# CHECK-LABEL: public @test_sample_dynamic(
 @qjit
-@qml.qnode(
-    qml.device("null.qubit", wires=1)
-)  # SampleOp is only legal if there is a device in the same scope
 def test_sample_dynamic(shots: int):
     """Test that the sample primitive with dynamic shape can be correctly compiled to mlir."""
-    obs = compbasis_p.bind()
-    x = shots + 1
-    sample = sample_p.bind(obs, x, static_shape=(None, 0))
-    return sample + jax.numpy.zeros((x, 0))
+
+    @qml.set_shots(shots)
+    @qml.qnode(qml.device("null.qubit", wires=1))
+    def circ():
+        obs = compbasis_p.bind()
+        x = shots + 1
+        sample = sample_p.bind(obs, x, static_shape=(None, 0))
+        return sample + jax.numpy.zeros((x, 0))
+
+    circ()
 
 
 # CHECK: [[one:%.+]] = stablehlo.constant dense<1> : tensor<i64>
@@ -139,7 +143,8 @@ print(test_sample_dynamic.mlir)
 # CHECK-LABEL: @sample_dynamic_qubits
 @qjit(target="mlir")
 def sample_dynamic_qubits(num_qubits):
-    @qml.qnode(qml.device("lightning.qubit", wires=num_qubits, shots=37))
+    @qml.set_shots(37)
+    @qml.qnode(qml.device("lightning.qubit", wires=num_qubits))
     def circ():
         # CHECK: [[nqubits:%.+]] = quantum.num_qubits : i64
         # CHECK: quantum.compbasis
@@ -165,7 +170,8 @@ try:
 
     # COM: CHECK-LABEL: public @counts1(
     @qjit(target="mlir")
-    @qml.qnode(qml.device("lightning.qubit", wires=2, shots=1000))
+    @qml.set_shots(1000)
+    @qml.qnode(qml.device("lightning.qubit", wires=2))
     def counts1(x: float, y: float):
         qml.RX(x, wires=0)
         qml.RY(y, wires=1)
@@ -179,7 +185,8 @@ try:
     print(counts1.mlir)
 
     @qjit(target="mlir")
-    @qml.qnode(qml.device("lightning.qubit", wires=2, shots=1000))
+    @qml.set_shots(1000)
+    @qml.qnode(qml.device("lightning.qubit", wires=2))
     def counts2(x: float, y: float):
         qml.RX(x, wires=0)
         # COM: CHECK: [[q1:%.+]] = "quantum.custom"({{%.+}}, {{%.+}}) {gate_name = "RY"
@@ -200,7 +207,8 @@ except:
 
 # CHECK-LABEL: public @counts3(
 @qjit(target="mlir")
-@qml.qnode(qml.device("lightning.qubit", wires=2, shots=1000))
+@qml.set_shots(1000)
+@qml.qnode(qml.device("lightning.qubit", wires=2))
 # CHECK: [[shots:%.+]] = arith.constant 1000 : i64
 # CHECK: quantum.device shots([[shots]]) [{{.+}}]
 def counts3(x: float, y: float):
@@ -240,7 +248,8 @@ print(test_counts_static.mlir)
 # CHECK-LABEL: @counts_dynamic_qubits
 @qjit(target="mlir")
 def counts_dynamic_qubits(num_qubits):
-    @qml.qnode(qml.device("lightning.qubit", wires=num_qubits, shots=37))
+    @qml.set_shots(37)
+    @qml.qnode(qml.device("lightning.qubit", wires=num_qubits))
     def circ():
         # CHECK: [[one:%.+]] = stablehlo.constant dense<1> : tensor<i64>
         # CHECK: [[nqubits:%.+]] = quantum.num_qubits : i64

--- a/frontend/test/lit/test_multi_qubit_gates.py
+++ b/frontend/test/lit/test_multi_qubit_gates.py
@@ -87,8 +87,8 @@ def get_custom_qjit_device(num_wires, discards, additions):
         name = "lightning.qubit"
         config_filepath = CONFIG_CUSTOM_DEVICE
 
-        def __init__(self, shots=None, wires=None):
-            super().__init__(wires=wires, shots=shots)
+        def __init__(self, wires=None):
+            super().__init__(wires=wires)
             self.qjit_capabilities = get_device_capabilities(self)
             for gate in discards:
                 self.qjit_capabilities.operations.pop(gate, None)

--- a/frontend/test/lit/test_quantum_control.py
+++ b/frontend/test/lit/test_quantum_control.py
@@ -41,8 +41,8 @@ def get_custom_qjit_device(num_wires, discards, additions):
         name = "lightning.qubit"
         config_filepath = CONFIG_CUSTOM_DEVICE
 
-        def __init__(self, shots=None, wires=None):
-            super().__init__(wires=wires, shots=shots)
+        def __init__(self, wires=None):
+            super().__init__(wires=wires)
             self.qjit_capabilities = get_device_capabilities(self)
             for gate in discards:
                 self.qjit_capabilities.operations.pop(gate, None)

--- a/frontend/test/lit/test_snapshot_mlir.py
+++ b/frontend/test/lit/test_snapshot_mlir.py
@@ -76,7 +76,8 @@ print(single_qubit_circuit.mlir)
 
 # CHECK-LABEL: public @jit_two_qubit_circuit
 @qjit(target="mlir")
-@qml.qnode(qml.device("lightning.qubit", wires=2, shots=5))
+@qml.set_shots(5)
+@qml.qnode(qml.device("lightning.qubit", wires=2))
 def two_qubit_circuit():
     """Test MLIR output of qml.Snapshot on two qubits with shots"""
 


### PR DESCRIPTION
**Context:**
Some python lit tests have not been migrated to `qml.set_shots` and are still emitting deprecation warnings.

**Description of the Change:**
Use `qml.set_shots(...)` instead of `qml.device(shots=...)` in more python lit tests.

**Benefits:**
No warnings.

