### PR TITLE
Fix path to the catalyst CLI tool installation directory in the docs

### DIFF
--- a/doc/catalyst-cli/catalyst-cli.rst
+++ b/doc/catalyst-cli/catalyst-cli.rst
@@ -36,7 +36,7 @@ ability to run each stage individually. For example:
     the ``mlir/build/bin/`` directory relative to the root of your Catalyst source directory.
 
     If Catalyst is installed via pip or from wheels, the executable will be located
-    in the ``catalyst/bin/`` directory relative to the environment's installation directory.
+    in the ``bin/`` directory relative to the environment's installation directory.
 
 Usage
 -----

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -234,6 +234,12 @@
 
 <h3>Documentation 📝</h3>
 
+* The Catalyst Command Line Interface documentation incorrectly stated that the `catalyst`
+  executable is available in the `catalyst/bin/` directory relative to the environment's
+  installation directory when installed via pip. The documentation has been updated to point to the
+  correct location, which is the `bin/` directory relative to the environment's installation
+  directory.
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):


### PR DESCRIPTION
The Catalyst Command Line Interface documentation incorrectly stated that the `catalyst` executable is available in the `catalyst/bin/` directory relative to the environment's installation directory when installed via pip. The documentation has been updated to point to the correct location, which is the `bin/` directory relative to the environment's installation directory.