### PR TITLE
Remove `format` header from Runtime CAPI

### DIFF
--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -16,7 +16,6 @@
 #include <cstdarg>
 #include <cstdlib>
 #include <ctime>
-#include <format>
 #include <memory>
 #include <ostream>
 #include <stdexcept>


### PR DESCRIPTION
We accidentally left in a stray

```cpp
#include <format>
```

in the runtime CAPI in #2000, but it is not being used. This PR removes it.