### PR TITLE
Enhance `ppm_specs` function to prevent duplicate pass addition

### DIFF
--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -1060,7 +1060,9 @@ def ppm_specs(fn):
 
         # add ppm-spec pass at the end to existing pipeline
         _, pass_list = new_options.pipelines[0]  # first pipeline runs the user passes
-        pass_list.append("ppm-specs")
+        # check if ppm-specs is already in the pass list
+        if "ppm-specs" not in pass_list:  # pragma: nocover
+            pass_list.append("ppm-specs")
 
         new_options = _options_to_cli_flags(new_options)
         raw_result = _quantum_opt(*new_options, [], stdin=str(fn.mlir_module))
@@ -1072,7 +1074,7 @@ def ppm_specs(fn):
         except Exception as e:  # pragma: nocover
             raise CompileError(
                 "Invalid json format encountered in ppm_specs. "
-                f" but got {raw_result[: raw_result.index('module')]}"
+                f"Expected valid JSON but got {raw_result[: raw_result.index('module')]}"
             ) from e
 
     else:


### PR DESCRIPTION
Enhance ppm_specs function to prevent duplicate pass addition

**Description of the Change:**
Added a check to ensure "ppm-specs" is not already in the pass list before appending it. This prevents unnecessary duplication in the pipeline configuration.