### PR TITLE
Fixing qml demo one shot issue

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -346,7 +346,8 @@
 * Fixed the Clifford PPR decomposition rule where using the Y measurement should take the inverse.
   [(#2043)](https://github.com/PennyLaneAI/catalyst/pull/2043)
 
-* Added new error handling to resolve a build failure in the QML repo due to the new Catalyst one-shot implementation.
+* `static_argnums` is now correctly passed to internally transformed kernel functions,
+for example the one-shot mid circuit measurement transform.
   [(#2056)](https://github.com/PennyLaneAI/catalyst/pull/2056)
 
 <h3>Internal changes ⚙️</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -213,6 +213,9 @@
 * Fixed the Clifford PPR decomposition rule where using the Y measurement should take the inverse.
   [(#2043)](https://github.com/PennyLaneAI/catalyst/pull/2043)
 
+* Added new error handling to resolve a build failure in the QML repo due to the new Catalyst one-shot implementation.
+  [(#2056)](https://github.com/PennyLaneAI/catalyst/pull/2056)
+
 <h3>Internal changes ⚙️</h3>
 
 * Updates use of `qml.transforms.dynamic_one_shot.parse_native_mid_circuit_measurements` to improved signature.

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -227,6 +227,7 @@ class Function:
     def __call__(self, *args, **kwargs):
         jaxpr, _, out_tree = make_jaxpr2(
             self.fn,
+            static_argnums=kwargs.pop("static_argnums", ()),
             debug_info=kwargs.pop("debug_info", jdb("Function", self.fn, args, kwargs)),
         )(*args, **kwargs)
 

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -51,6 +51,7 @@ from catalyst.utils.exceptions import CompileError
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
+
 @dataclass
 class OutputContext:
     """Context containing parameters needed for finalizing quantum function output."""

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -50,7 +50,7 @@ from catalyst.utils.exceptions import CompileError
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
-
+logging.basicConfig(filename='mylog.log', level=logging.DEBUG)
 
 @dataclass
 class OutputContext:
@@ -179,6 +179,7 @@ def configure_mcm_and_try_one_shot(qnode, args, kwargs):
 
                 # Fallback only if mcm was auto-determined
                 error_msg = str(e)
+                # TODO: handle the underlying reasons for the unsupported errors
                 unsupported_measurement_error = any(
                     pattern in error_msg
                     for pattern in [
@@ -192,7 +193,7 @@ def configure_mcm_and_try_one_shot(qnode, args, kwargs):
 
                 # Fallback if error is related to unsupported measurements
                 if unsupported_measurement_error:
-                    logger.debug("Fallback to single-branch-statistics: %s", e)
+                    logger.warning("Fallback to single-branch-statistics: %s", e)
                     mcm_config = replace(mcm_config, mcm_method="single-branch-statistics")
                 else:
                     raise

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -172,7 +172,6 @@ def configure_mcm_and_try_one_shot(qnode, args, kwargs):
             try:
                 return Function(dynamic_one_shot(qnode, mcm_config=mcm_config))(*args, **kwargs)
             except (TypeError, ValueError, CompileError, NotImplementedError) as e:
-
                 # If user specified mcm_method, we can't fallback to single-branch-statistics,
                 # reraise the original error
                 if user_specified_mcm_method is not None:
@@ -187,6 +186,7 @@ def configure_mcm_and_try_one_shot(qnode, args, kwargs):
                         "qml.var(obs) cannot be returned when `mcm_method='one-shot'`",
                         "empty wires is not supported with dynamic wires in one-shot mode",
                         "No need to run one-shot mode",
+                        "must be an int or convertable to atuple of ints",
                     ]
                 )
 

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -186,7 +186,7 @@ def configure_mcm_and_try_one_shot(qnode, args, kwargs):
                         "qml.var(obs) cannot be returned when `mcm_method='one-shot'`",
                         "empty wires is not supported with dynamic wires in one-shot mode",
                         "No need to run one-shot mode",
-                        "must be an int or convertable to atuple of ints",
+                        "The `static_argnums` argument to `qjit` must be an int",
                     ]
                 )
 

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -50,7 +50,6 @@ from catalyst.utils.exceptions import CompileError
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
-logging.basicConfig(filename='mylog.log', level=logging.DEBUG)
 
 @dataclass
 class OutputContext:
@@ -179,7 +178,6 @@ def configure_mcm_and_try_one_shot(qnode, args, kwargs):
 
                 # Fallback only if mcm was auto-determined
                 error_msg = str(e)
-                # TODO: handle the underlying reasons for the unsupported errors
                 unsupported_measurement_error = any(
                     pattern in error_msg
                     for pattern in [
@@ -187,7 +185,6 @@ def configure_mcm_and_try_one_shot(qnode, args, kwargs):
                         "qml.var(obs) cannot be returned when `mcm_method='one-shot'`",
                         "empty wires is not supported with dynamic wires in one-shot mode",
                         "No need to run one-shot mode",
-                        "The `static_argnums` argument to `qjit` must be an int",
                     ]
                 )
 

--- a/frontend/test/lit/test_mid_circuit_measurement.py
+++ b/frontend/test/lit/test_mid_circuit_measurement.py
@@ -31,8 +31,11 @@ def circuit(x: float):
 print(circuit.mlir)
 
 
-@qjit(static_argnums=(0))
+@qjit(static_argnums=0)
 def test_one_shot_with_static_argnums(N):
+    """
+    Test static argnums is passed correctly to the one shot qnodes.
+    """
     # CHECK: func.func public @jit_test_one_shot_with_static_argnums() -> tensor<1024xf64>
     # CHECK: {{%.+}} = call @one_shot_wrapper() : () -> tensor<1024xf64>
 

--- a/frontend/test/pytest/test_mid_circuit_measurement.py
+++ b/frontend/test/pytest/test_mid_circuit_measurement.py
@@ -424,6 +424,24 @@ class TestMidCircuitMeasurement:
 class TestDynamicOneShotIntegration:
     """Integration tests for QNodes using mcm_method="one-shot"/dynamic_one_shot."""
 
+    def test_dynamic_one_shot_static_argnums(self, backend):
+        """
+        Test static argnums is passed correctly to the one shot qnodes.
+        """
+
+        @qjit(static_argnums=(0))
+        def workflow(N):
+            dev = qml.device(backend, wires=N)
+
+            @qml.set_shots(N + 1)
+            @qml.qnode(dev, mcm_method="one-shot")
+            def circ():
+                return qml.probs()
+
+            return circ()
+
+        assert np.allclose(workflow(1), [1, 0])
+
     # pylint: disable=too-many-arguments
     @pytest.mark.parametrize(
         "postselect, reset, expected",

--- a/frontend/test/pytest/test_mid_circuit_measurement.py
+++ b/frontend/test/pytest/test_mid_circuit_measurement.py
@@ -429,7 +429,7 @@ class TestDynamicOneShotIntegration:
         Test static argnums is passed correctly to the one shot qnodes.
         """
 
-        @qjit(static_argnums=(0))
+        @qjit(static_argnums=0)
         def workflow(N):
             dev = qml.device(backend, wires=N)
 


### PR DESCRIPTION
**Context:** The recent one-shot implementaiton in Catalyst is causing a build [failure](https://github.com/PennyLaneAI/qml/actions/runs/17844479263/job/50741097686) in the QML demo repository, giving the error:

```
      ...

      File "/home/runner/work/qml/qml/.venv-build/lib/python3.11/site-packages/catalyst/qfunc.py", line 292, in __call__
        fn_result = configure_mcm_and_try_one_shot(self, args, kwargs)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/runner/work/qml/qml/.venv-build/lib/python3.11/site-packages/catalyst/qfunc.py", line 173, in configure_mcm_and_try_one_shot
        return Function(dynamic_one_shot(qnode, mcm_config=mcm_config))(*args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      ...

      File "/home/runner/work/qml/qml/.venv-build/lib/python3.11/site-packages/catalyst/qfunc.py", line 334, in __call__
        flattened_fun, _, _, out_tree_promise = deduce_avals(
                                                ^^^^^^^^^^^^^
      File "/home/runner/work/qml/qml/.venv-build/lib/python3.11/site-packages/catalyst/jax_extras/tracing.py", line 401, in deduce_avals
        verify_static_argnums_type(static_argnums)
      File "/home/runner/work/qml/qml/.venv-build/lib/python3.11/site-packages/catalyst/tracing/type_signatures.py", line 101, in verify_static_argnums_type
        raise TypeError(
    TypeError: The `static_argnums` argument to `qjit` must be an int or convertable to atuple of ints, but got value (Traced<~int64[]>with<DynamicJaxprTrace>,)
```

As a side note, the failure comes from the checks in`frontend/catalyst/tracing/type_signatures.py`.
```python
def verify_static_argnums_type(static_argnums):
    """Verify that static_argnums have correct type.

    Args:
        static_argnums (Iterable[int]): indices to verify

    Returns:
        None
    """
    is_tuple = isinstance(static_argnums, tuple)
    is_valid = is_tuple and all(isinstance(arg, int) for arg in static_argnums)
    if not is_valid:
        raise TypeError(
            "The `static_argnums` argument to `qjit` must be an int or convertable to a"
            f"tuple of ints, but got value {static_argnums}"
        )
    return None
```
When we ignore the verification, the aforementioned issue will be resolved as well. However, it doesn't make sense to remove this check as a solution, as it may lead to more issues down the line. 

**Description of the Change:** We solve this by passing `static_argnums` correctly to internally transformed kernel functions,
which includes the one-shot mid circuit measurement transform here.

**Benefits:** Resolve the build failure in the QML repo.
