### PR TITLE
Fix conversion target rule in `to_ppr` and `ppm_compilation` pass

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -136,7 +136,7 @@
 * Added support to avoid Y-basis measurements in `pauli-corrected` PPR decomposition.
   [(#2047)](https://github.com/PennyLaneAI/catalyst/pull/2047)
 
-* Update conversion targets and refactor `to_ppr` and `ppm_compilation` passes to handle gate `I`.
+* Update conversion targets and refactor `to_ppr` and `ppm_compilation` passes and handle gate `I`.
   [(#2058)](https://github.com/PennyLaneAI/catalyst/pull/2058)
 
 <h3>Breaking changes 💔</h3>

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -136,6 +136,9 @@
 * Added support to avoid Y-basis measurements in `pauli-corrected` PPR decomposition.
   [(#2047)](https://github.com/PennyLaneAI/catalyst/pull/2047)
 
+* Update conversion targets and refactor `to_ppr` and `ppm_compilation` passes to handle gate `I`.
+  [(#2058)](https://github.com/PennyLaneAI/catalyst/pull/2058)
+
 <h3>Breaking changes 💔</h3>
 
 * (Device implementers only) The `ReleaseAllQubits` device interface function

--- a/mlir/lib/QEC/Transforms/CliffordTToPPR.cpp
+++ b/mlir/lib/QEC/Transforms/CliffordTToPPR.cpp
@@ -81,7 +81,7 @@ void applyAdjointIfNeeded(GateConversion &gateConversion, CustomOp op)
 //===----------------------------------------------------------------------===//
 
 // C(P) = G(Angle)
-void applySingleQubitConversion(CustomOp op, SmallVector<GateConversion> gateConversions,
+void applySingleQubitConversion(CustomOp op, const SmallVector<GateConversion> &gateConversions,
                                 ConversionPatternRewriter &rewriter)
 {
     auto loc = op->getLoc();

--- a/mlir/lib/QEC/Transforms/CliffordTToPPR.cpp
+++ b/mlir/lib/QEC/Transforms/CliffordTToPPR.cpp
@@ -81,12 +81,12 @@ void applyAdjointIfNeeded(GateConversion &gateConversion, CustomOp op)
 //===----------------------------------------------------------------------===//
 
 // C(P) = G(Angle)
-void applySingleQubitConversion(CustomOp op, const SmallVector<GateConversion> &gateConversions,
+void applySingleQubitConversion(CustomOp op, const ArrayRef<GateConversion> &gateConversions,
                                 ConversionPatternRewriter &rewriter)
 {
     auto loc = op->getLoc();
     auto types = op.getOutQubits().getType();
-    SmallVector<Value> inQubits = op.getInQubits();
+    ValueRange inQubits = op.getInQubits();
     PPRotationOp pprOp;
 
     for (auto gateConversion : gateConversions) {
@@ -156,7 +156,6 @@ LogicalResult convertHGate(CustomOp op, ConversionPatternRewriter &rewriter)
     auto Z0 = GateConversion({"Z"}, 4);
     auto X1 = GateConversion({"X"}, 4);
     auto Z2 = GateConversion({"Z"}, 4);
-
     applySingleQubitConversion(op, {Z0, X1, Z2}, rewriter);
     return success();
 }

--- a/mlir/lib/QEC/Transforms/clifford_t_to_ppr.cpp
+++ b/mlir/lib/QEC/Transforms/clifford_t_to_ppr.cpp
@@ -40,12 +40,11 @@ struct CliffordTToPPRPass : impl::CliffordTToPPRPassBase<CliffordTToPPRPass> {
         auto ctx = &getContext();
         ConversionTarget target(*ctx);
 
-        target.addIllegalDialect<quantum::QuantumDialect>();
+        // Convert MeasureOp and CustomOp
+        target.addIllegalOp<quantum::MeasureOp>();
+        target.addIllegalOp<quantum::CustomOp>();
 
-        target.addLegalOp<quantum::InitializeOp, quantum::FinalizeOp>();
-        target.addLegalOp<quantum::DeviceInitOp, quantum::DeviceReleaseOp>();
-        target.addLegalOp<quantum::AllocOp, quantum::DeallocOp>();
-        target.addLegalOp<quantum::InsertOp, quantum::ExtractOp>();
+        // Conversion target is QECDialect
         target.addLegalDialect<qec::QECDialect>();
 
         RewritePatternSet patterns(ctx);

--- a/mlir/lib/QEC/Transforms/ppm_compilation.cpp
+++ b/mlir/lib/QEC/Transforms/ppm_compilation.cpp
@@ -45,11 +45,12 @@ struct PPMCompilationPass : public impl::PPMCompilationPassBase<PPMCompilationPa
         // Phase 1: Convert Clifford+T to PPR representation
         {
             ConversionTarget target(*ctx);
-            target.addIllegalDialect<quantum::QuantumDialect>();
-            target.addLegalOp<quantum::InitializeOp, quantum::FinalizeOp>();
-            target.addLegalOp<quantum::DeviceInitOp, quantum::DeviceReleaseOp>();
-            target.addLegalOp<quantum::AllocOp, quantum::DeallocOp>();
-            target.addLegalOp<quantum::InsertOp, quantum::ExtractOp>();
+
+            // Convert MeasureOp and CustomOp to PPR
+            target.addIllegalOp<quantum::MeasureOp>();
+            target.addIllegalOp<quantum::CustomOp>();
+
+            // Conversion target is QECDialect
             target.addLegalDialect<qec::QECDialect>();
 
             RewritePatternSet patterns(ctx);

--- a/mlir/test/QEC/CliffordTToPPRTest.mlir
+++ b/mlir/test/QEC/CliffordTToPPRTest.mlir
@@ -79,7 +79,7 @@ func.func public @test_clifford_t_to_ppr_1() -> (tensor<i1>, tensor<i1>) {
 
 func.func @test_clifford_t_to_ppr_2(%q1 : !quantum.bit, %q2 : !quantum.bit) {
     // expected-error @+1 {{failed to legalize operation 'quantum.custom' that was explicitly marked illegal}}
-    %0 = quantum.custom "SOME_UNKNOWN_GATE"() %q1 : !quantum.bit // expected-error @+0 {{Unsupported gate. Supported gates: H, S, T, X, Y, Z, S†, T†, and CNOT}}
+    %0 = quantum.custom "SOME_UNKNOWN_GATE"() %q1 : !quantum.bit // expected-error @+0 {{Unsupported gate. Supported gates: H, S, T, X, Y, Z, S†, T†, I, and CNOT}}
     %1 = quantum.custom "S"() %0 : !quantum.bit
     %2 = quantum.custom "T"() %1 : !quantum.bit
     %3:2 = quantum.custom "CNOT"() %2, %q2 : !quantum.bit, !quantum.bit


### PR DESCRIPTION
**Context:**
Updates the quantum gate conversion logic to add support for the identity gate (`I`) in the Clifford+T to PPR decomposition passes, and refactors the conversion targets. The main changes include extending gate handling to cover `I`, updating conversion targets to list both illegal and legal operations explicitly, and improving error messages.