### PR TITLE
Quantum execution for structured qnode repr is added to the Catalyst

### DIFF
--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -17,6 +17,7 @@
 
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpBase.td"
+include "mlir/IR/SymbolInterfaces.td"
 include "mlir/Dialect/Bufferization/IR/AllocationOpInterface.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
 
@@ -1272,6 +1273,89 @@ def StateOp : Measurement_Op<"state", [AttrSizedOperandSegments]> {
     }];
 
     let hasVerifier = 1;
+}
+
+// -----
+
+def ExecutionOp : Quantum_Op<"execution", [
+    NoMemoryEffect,
+    SingleBlockImplicitTerminator<"ExecYieldOp">,
+    Symbol
+]> {
+    let summary = "Define a quantum execution as a top-level symbol";
+    let description = [{
+        The `quantum.execution` operation defines a quantum program execution with four
+        distinct phases as a top-level symbol that can be called by `quantum.call_execution`.
+        It acts like a function definition that can be invoked multiple times.
+
+        The four phases are:
+        1. **Init region**: Device initialization and quantum register allocation
+        2. **Evolution region**: Quantum state evolution
+        3. **Measurement region**: Observables and measurements
+        4. **Teardown region**: Resource cleanup
+
+        Each region can accept unlimited operands through block arguments and pass data
+        to subsequent regions via `quantum.exec_yield` operations.
+    }];
+
+    let arguments = (ins
+        SymbolNameAttr:$sym_name,
+        TypeAttr:$function_type
+    );
+
+    let results = (outs);
+
+    let regions = (region
+        SizedRegion<1>:$init_region,
+        SizedRegion<1>:$state_evolution_region,
+        SizedRegion<1>:$measurement_region,
+        SizedRegion<1>:$teardown_region
+    );
+
+    let assemblyFormat = [{
+        `(` `)` attr-dict
+        `(` `init` $init_region `,` `evolution` $state_evolution_region `,` `measurement` $measurement_region `,` `teardown` $teardown_region `)`
+    }];
+}
+
+def CallExecutionOp : Quantum_Op<"call_execution", [NoMemoryEffect]> {
+    let summary = "Call a quantum execution symbol";
+    let description = [{
+        The `quantum.call_execution` operation invokes a previously defined `quantum.execution`
+        symbol by name, passing the specified arguments and returning the computed results.
+
+        This operation actually performs the quantum computation defined by the
+        execution symbol, similar to how func.call invokes func.func.
+    }];
+
+    let arguments = (ins
+        FlatSymbolRefAttr:$callee,
+        Variadic<AnyType>:$operands
+    );
+
+    let results = (outs
+        Variadic<AnyType>:$results
+    );
+
+    let assemblyFormat = [{
+        `(` $operands `)` attr-dict `:` functional-type($operands, $results)
+    }];
+}
+
+def ExecYieldOp : Quantum_Op<"exec_yield", [Pure, ReturnLike, Terminator, ParentOneOf<["ExecutionOp"]>]> {
+    let summary = "Return results from quantum execution regions";
+
+    let arguments = (ins
+        Variadic<AnyType>:$retvals
+    );
+
+    let assemblyFormat = [{
+        attr-dict ($retvals ^ `:` type($retvals))?
+    }];
+
+    let builders = [
+        OpBuilder<(ins), [{ /* nothing to do */ }]>
+    ];
 }
 
 


### PR DESCRIPTION
**Context:**

Hackweek project

**Description of the Change:**

```mlir
builtin.module {
  func.func @qnode_main(%shots : i64, %num_qubits : i64, %angle : f64) -> tensor<4xf64> {
    %result = quantum.call_execution(%shots, %num_qubits, %angle) {callee = @execution_1} : (i64, i64, f64) -> tensor<4xf64>
    func.return %result : tensor<4xf64>
  }

  quantum.execution() {function_type = (i64, i64, f64) -> tensor<4xf64>, sym_name = "execution_1"} (
    init {
    ^bb0(%shots : i64, %num_qubits : i64, %angle : f64):
      quantum.device shots(%shots) [
          "...dylib",
          "LightningSimulator",
          "{'mcmc': False, 'num_burnin': 0, 'kernel_name': None}"
      ]
      %qreg = quantum.alloc(%num_qubits) : !quantum.reg
      quantum.exec_yield %qreg, %angle : !quantum.reg, f64
    },
    evolution {
    ^bb1(%qreg_in : !quantum.reg, %rx_angle : f64):
      %q0 = quantum.extract %qreg_in[0] : !quantum.reg -> !quantum.bit
      %q0_rx = quantum.custom "RX"(%rx_angle) %q0 : !quantum.bit
      %qreg_evolved = quantum.insert %qreg_in[0], %q0_rx : !quantum.reg, !quantum.bit
      quantum.exec_yield %qreg_evolved : !quantum.reg
    },
    measurement {
    ^bb2(%qreg_meas : !quantum.reg):
      %obs = quantum.compbasis qreg %qreg_meas : !quantum.obs
      %probs = quantum.probs %obs : tensor<4xf64>
      quantum.exec_yield %qreg_meas, %probs : !quantum.reg, tensor<4xf64>
    },
    teardown {
    ^bb3(%qreg_cleanup : !quantum.reg, %final_result : tensor<4xf64>):
      quantum.dealloc %qreg_cleanup : !quantum.reg
      quantum.device_release
      quantum.exec_yield %final_result : tensor<4xf64>
    }
  )
}
```

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
