### PR TITLE
Bump PL dep to latest for ftqc

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -10,7 +10,7 @@ enzyme=v0.0.186
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.43.0.dev60
+pennylane=0.43.0.dev65
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -33,4 +33,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.43.0.dev36
 pennylane-lightning==0.43.0.dev36
-pennylane==0.43.0.dev60
+pennylane==0.43.0.dev65


### PR DESCRIPTION
**Context:**
Bump pennylane dep to latest (0.43.0-dev65) for ftqc fixes

**Related GitHub Issues:**
closes #2059 

[sc-99801]