### PR TITLE
Add support of MCM for decompose pass

### DIFF
--- a/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
@@ -346,6 +346,9 @@ class OpSignatureAnalyzer {
                 }
                 qubit = customOp.getQubitOperands()[0];
             }
+            else if (auto measureOp = dyn_cast_or_null<quantum::MeasureOp>(qubit.getDefiningOp())) {
+                qubit = measureOp.getInQubit();
+            }
         }
 
         return nullptr;
@@ -376,6 +379,9 @@ class OpSignatureAnalyzer {
                         continue;
                     }
                 }
+            }
+            else if (auto measureOp = dyn_cast_or_null<quantum::MeasureOp>(qubit.getDefiningOp())) {
+                qubit = measureOp.getInQubit();
             }
 
             break;


### PR DESCRIPTION
**Context:**

**Description of the Change:**
Added traversal logic of mcm. For an example, finding the `qreg` and index of `qb3` in the following case, it needs to traverse the def-use chain through the ops.

```
qb0 = extract(...)
...
meas_result, qb2 = qml.measure(qb1, 0)
...
qb4 = op(qb3, ...) 
```


**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-100311]
