### PR TITLE
Remove `qml.capture.disable()` from changelog code examples

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -33,8 +33,6 @@
           qml.CNOT(wires=[q[0], 2])   # |011> and |1>
 
       return qml.probs(wires=[0, 1, 2])
-
-  qml.capture.disable()
   ```
 
   ```pycon


### PR DESCRIPTION
**Context:**
The common usage of capture is to enable it for a session at the top and then use it throughout, so unless the user explicitly needs both modes we should not recommend the disable function.

**Description of the Change:**
Remove `qml.capture.disable()` from changelog code examples

