### PR TITLE
fix device test

### DIFF
--- a/frontend/test/pytest/test_device_api.py
+++ b/frontend/test/pytest/test_device_api.py
@@ -43,8 +43,8 @@ def test_qjit_device():
         transform_program, _ = device_qjit.preprocess(ctx)
     assert transform_program
     assert len(transform_program) == 3
-    assert transform_program[-2]._transform.__name__ == "verify_operations"
-    assert transform_program[-1]._transform.__name__ == "validate_measurements"
+    assert transform_program[-2].transform.__name__ == "verify_operations"
+    assert transform_program[-1].transform.__name__ == "validate_measurements"
 
     # TODO: readd when we do not discard device preprocessing
     # t = transform_program[0].transform.__name__


### PR DESCRIPTION
**Context:**

Failure in L/L/L becuase `test_device_api.py` was testing against a private attribute that was renamed.

**Description of the Change:**

Now uses the public version of the attribute.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
