### PR TITLE
Rename `t_layer_reduction` to `reduce_t_depth` pass

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -92,19 +92,20 @@
   [A Game of Surface Codes](https://arXiv:1808.02892v3).
   [(#1975)](https://github.com/PennyLaneAI/catalyst/pull/1975)
   [(#2048)](https://github.com/PennyLaneAI/catalyst/pull/2048)
+  [(#2084)](https://github.com/PennyLaneAI/catalyst/pull/2084)
 
   Consider the following circuit.
 
   ```python
   import pennylane as qml
   from catalyst import qjit, measure
-  from catalyst.passes import to_ppr, commute_ppr, t_layer_reduction, merge_ppr_ppm
+  from catalyst.passes import to_ppr, commute_ppr, reduce_t_depth, merge_ppr_ppm
 
   pips = [("pipe", ["enforce-runtime-invariants-pipeline"])]
 
 
   @qjit(pipelines=pips, target="mlir")
-  @t_layer_reduction
+  @reduce_t_depth
   @merge_ppr_ppm
   @commute_ppr
   @to_ppr
@@ -123,7 +124,7 @@
 
   After performing the ``catalyst.passes.to_ppr`` and ``catalyst.passes.merge_ppr_ppm``
   passes, the circuit contains a depth of four of non-Clifford PPRs. Subsequently applying the
-  ``t_layer_reduction`` pass will move PPRs around via commutation, resulting in a circuit with a
+  ``reduce_t_depth`` pass will move PPRs around via commutation, resulting in a circuit with a
   smaller PPR depth of three.
 
   ```pycon

--- a/frontend/catalyst/passes/__init__.py
+++ b/frontend/catalyst/passes/__init__.py
@@ -45,7 +45,7 @@ from catalyst.passes.builtin_passes import (
     ppm_specs,
     ppr_to_mbqc,
     ppr_to_ppm,
-    t_layer_reduction,
+    reduce_t_depth,
     to_ppr,
 )
 from catalyst.passes.pass_api import Pass, PassPlugin, apply_pass, apply_pass_plugin
@@ -66,6 +66,6 @@ __all__ = (
     "merge_ppr_ppm",
     "ppr_to_ppm",
     "ppm_compilation",
-    "t_layer_reduction",
+    "reduce_t_depth",
     "ppr_to_mbqc",
 )

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -1112,7 +1112,7 @@ def ppm_specs(fn):
         raise NotImplementedError("PPM passes only support AOT (Ahead-Of-Time) compilation mode.")
 
 
-def t_layer_reduction(qnode):
+def reduce_t_depth(qnode):
     R"""
     An MLIR compiler pass that reduces the depth and count of non-Clifford PPRs (e.g., ``T`` gates) by
     commuting PPRs in adjacent layers and merging compatible ones (a layer comprises a set of PPRs
@@ -1129,7 +1129,7 @@ def t_layer_reduction(qnode):
 
     In the example below, after performing the :func:`catalyst.passes.to_ppr` and
     :func:`catalyst.passes.merge_ppr_ppm` passes, the circuit contains a depth of four of
-    non-Clifford PPRs. Subsequently applying the ``t_layer_reduction`` pass will move PPRs around via
+    non-Clifford PPRs. Subsequently applying the ``reduce_t_depth`` pass will move PPRs around via
     commutation, resulting in a circuit with a smaller PPR depth. Specifically, in the circuit
     below, the Pauli-:math:`X` PPR (:math:`\exp(iX\tfrac{\pi}{8})`) on qubit Q1 will be moved to the
     first layer, which results in a depth of three non-Clifford PPRs.
@@ -1138,13 +1138,13 @@ def t_layer_reduction(qnode):
 
         import pennylane as qml
         from catalyst import qjit, measure
-        from catalyst.passes import to_ppr, commute_ppr, t_layer_reduction, merge_ppr_ppm
+        from catalyst.passes import to_ppr, commute_ppr, reduce_t_depth, merge_ppr_ppm
 
         pips = [("pipe", ["enforce-runtime-invariants-pipeline"])]
 
 
         @qjit(pipelines=pips, target="mlir")
-        @t_layer_reduction
+        @reduce_t_depth
         @merge_ppr_ppm
         @commute_ppr
         @to_ppr
@@ -1187,7 +1187,7 @@ def t_layer_reduction(qnode):
 
     """
 
-    return PassPipelineWrapper(qnode, "t-layer-reduction")
+    return PassPipelineWrapper(qnode, "reduce-t-depth")
 
 
 def ppr_to_mbqc(qnode):

--- a/frontend/catalyst/passes/pass_api.py
+++ b/frontend/catalyst/passes/pass_api.py
@@ -385,6 +385,6 @@ def _API_name_to_pass_name():
         "decompose_non_clifford_ppr": "decompose-non-clifford-ppr",
         "decompose_clifford_ppr": "decompose-clifford-ppr",
         "ppm_compilation": "ppm-compilation",
-        "t_layer_reduction": "t-layer-reduction",
+        "reduce_t_depth": "reduce-t-depth",
         "ppr_to_mbqc": "ppr-to-mbqc",
     }

--- a/frontend/test/lit/test_ppr_ppm.py
+++ b/frontend/test/lit/test_ppr_ppm.py
@@ -27,7 +27,7 @@ from catalyst.passes import (
     ppm_compilation,
     ppr_to_mbqc,
     ppr_to_ppm,
-    t_layer_reduction,
+    reduce_t_depth,
     to_ppr,
 )
 
@@ -353,20 +353,20 @@ def test_clifford_to_ppm():
 test_clifford_to_ppm()
 
 
-def test_t_layer_reduction():
+def test_reduce_t_depth():
     """
-    Test the `t_layer_reduction` pass.
+    Test the `reduce_t_depth` pass.
     """
 
     pipe = [("pipe", ["enforce-runtime-invariants-pipeline"])]
 
     @qjit(pipelines=pipe, target="mlir")
-    @t_layer_reduction
+    @reduce_t_depth
     @merge_ppr_ppm
     @commute_ppr
     @to_ppr
     @qml.qnode(qml.device("null.qubit", wires=3))
-    def test_t_layer_reduction_workflow():
+    def test_reduce_t_depth_workflow():
         n = 3
         for i in range(n):
             qml.H(wires=i)
@@ -378,7 +378,7 @@ def test_t_layer_reduction():
 
         return [measure(wires=i) for i in range(n)]
 
-    print(test_t_layer_reduction_workflow.mlir_opt)
+    print(test_reduce_t_depth_workflow.mlir_opt)
 
 
 # CHECK: qec.ppr ["X"](8)
@@ -387,7 +387,7 @@ def test_t_layer_reduction():
 # CHECK: qec.ppr ["X"](8)
 # CHECK: qec.ppr ["X", "Y", "X"](8)
 # CHECK: qec.ppr ["X", "X", "Y"](8)
-test_t_layer_reduction()
+test_reduce_t_depth()
 
 
 def test_ppr_to_mbqc():

--- a/mlir/include/QEC/Transforms/Passes.td
+++ b/mlir/include/QEC/Transforms/Passes.td
@@ -141,7 +141,7 @@ def PartitionLayersPass : Pass<"partition-layers"> {
     let constructor = "catalyst::createPartitionLayersPass()";
 }
 
-def TLayerReductionPass : Pass<"t-layer-reduction"> {
+def TLayerReductionPass : Pass<"reduce-t-depth"> {
     let summary = "Reduce T layers to PPR operations.";
     
     let constructor = "catalyst::createTLayerReductionPass()";

--- a/mlir/lib/QEC/Transforms/TLayerReduction.cpp
+++ b/mlir/lib/QEC/Transforms/TLayerReduction.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#define DEBUG_TYPE "t-layer-reduction"
+#define DEBUG_TYPE "reduce-t-depth"
 
 #include <vector>
 

--- a/mlir/test/QEC/TLayerReduction.mlir
+++ b/mlir/test/QEC/TLayerReduction.mlir
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// RUN: quantum-opt --t-layer-reduction --split-input-file --verify-diagnostics %s | FileCheck %s
+// RUN: quantum-opt --reduce-t-depth --split-input-file --verify-diagnostics %s | FileCheck %s
 
 // From example in GoSC paper
 func.func @test_t_layer_opt_GoSC(%qr0 : !quantum.bit, %qr1 : !quantum.bit, %qr2 : !quantum.bit, %qr3 : !quantum.bit) {


### PR DESCRIPTION
Rename the`t_layer_reduction` transform  to `reduce_t_depth` for more user-friendly

[[sc-99454]]