### PR TITLE
[Decomposition] Update default fallback message following changes in PL

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -5,9 +5,13 @@
 * A new experimental decomposition system is introduced in Catalyst enabling the
   PennyLane's graph-based decomposition and MLIR-based lowering of decomposition rules.
   This feature is integrated with PennyLane program capture and graph-based decomposition
-  including support for custom decomposition rules and operators.
-  [(#2001)](https://github.com/PennyLaneAI/catalyst/pull/2001)
+  including support for custom decomposition rules and operators via ``qml.transforms.decompose``.
+  Similar to PennyLane's behaviour, this experimental feature will fall back to the old system
+  whenever the graph cannot find decomposition rules for all unsupported operators in the program,
+  and a ``UserWarning`` is raised.
+  [(#2091)](https://github.com/PennyLaneAI/catalyst/pull/2091)
   [(#2029)](https://github.com/PennyLaneAI/catalyst/pull/2029)
+  [(#2001)](https://github.com/PennyLaneAI/catalyst/pull/2001)
 
 * Catalyst now supports dynamic wire allocation with ``qml.allocate()`` and
   ``qml.deallocate()`` when program capture is enabled.

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.13.0-dev66"
+__version__ = "0.13.0-dev67"

--- a/frontend/catalyst/from_plxpr/decompose.py
+++ b/frontend/catalyst/from_plxpr/decompose.py
@@ -374,7 +374,7 @@ def _solve_decomposition_graph(operations, gate_set, fixed_decomps, alt_decomps)
 
         # TODO: use a custom warning class for this in PennyLane to remove this
         # string matching and make it more robust.
-        if "The graph-based decomposition system is unable" in str(wi.message):
+        if "The graph-based decomposition system is unable" in str(wi.message): # pragma: no cover
             graph_failed = True
 
     if graph_failed:

--- a/frontend/catalyst/from_plxpr/decompose.py
+++ b/frontend/catalyst/from_plxpr/decompose.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import functools
 import inspect
 import types
+import warnings
 from collections.abc import Callable
 from typing import get_type_hints
 
@@ -358,8 +359,34 @@ def _solve_decomposition_graph(operations, gate_set, fixed_decomps, alt_decomps)
         alt_decomps=alt_decomps,
     )
 
-    # Find the efficient pathways to the target gate set
-    solutions = decomp_graph.solve()
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        warnings.simplefilter("always", UserWarning)
+        solutions = decomp_graph.solve()
+
+    # Check if the graph-based decomposition failed for any operation
+    # We shall do the check after the context manager of warnings.catch_warnings
+    # to be able to check and re-emit the warnings to the user.
+    graph_failed = False
+
+    for wi in captured_warnings:
+        # Re-emit all captured warnings to the user
+        warnings.showwarning(wi.message, wi.category, wi.filename, wi.lineno)
+
+        # TODO: use a custom warning class for this in PennyLane to remove this
+        # string matching and make it more robust.
+        if "The graph-based decomposition system is unable" in str(wi.message):
+            graph_failed = True
+
+    if graph_failed:
+        # Note that this warning is already issued in the DecompositionGraph.solve()
+        # method, but we capture it here to make it more visible to the user
+        # that we are falling back to the standard PennyLane decomposition.
+        # This is important because we cannot use `op.decomposition()` in the
+        # Catalyst MLIR decomposition pass, as it may introduce new unsupported ops
+        # so we need to inform the user that if some operations could not be
+        # decomposed to the target gate set using the graph-based approach,
+        # we need to fallback to the legacy approach without MLIR decomposition.
+        return {}
 
     def is_solved_for(op):
         return (

--- a/frontend/catalyst/from_plxpr/decompose.py
+++ b/frontend/catalyst/from_plxpr/decompose.py
@@ -374,7 +374,7 @@ def _solve_decomposition_graph(operations, gate_set, fixed_decomps, alt_decomps)
 
         # TODO: use a custom warning class for this in PennyLane to remove this
         # string matching and make it more robust.
-        if "The graph-based decomposition system is unable" in str(wi.message): # pragma: no cover
+        if "The graph-based decomposition system is unable" in str(wi.message):  # pragma: no cover
             graph_failed = True
 
     if graph_failed:

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -1025,7 +1025,7 @@ def _collect_and_compile_graph_solutions(inner_jaxpr, consts, tkwargs, ncargs):
         warnings.showwarning(w.message, w.category, w.filename, w.lineno)
         # TODO: use a custom warning class for this in PennyLane to remove this
         # string matching and make it more robust.
-        if "The graph-based decomposition system is unable" in str(w.message):
+        if "The graph-based decomposition system is unable" in str(w.message): # pragma: no cover
             graph_succeeded = False
             warnings.warn(
                 "Falling back to the legacy decomposition system.",

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -17,6 +17,7 @@ This submodule defines a utility for converting plxpr into Catalyst jaxpr.
 # pylint: disable=protected-access
 # pylint: disable=too-many-lines
 
+import warnings
 from copy import copy
 from functools import partial
 from typing import Callable
@@ -219,13 +220,25 @@ def handle_qnode(
         )
     )
 
+    graph_succeeded = False
     if self.requires_decompose_lowering:
-        closed_jaxpr = _collect_and_compile_graph_solutions(
+        closed_jaxpr, graph_succeeded = _collect_and_compile_graph_solutions(
             inner_jaxpr=closed_jaxpr.jaxpr,
             consts=closed_jaxpr.consts,
             tkwargs=self.decompose_tkwargs,
             ncargs=non_const_args,
         )
+
+        # Fallback to the legacy decomposition if the graph-based decomposition failed
+        if not graph_succeeded:
+            # Remove the decompose-lowering pass from the pipeline
+            self._pass_pipeline = [p for p in self._pass_pipeline if p.name != "decompose-lowering"]
+            closed_jaxpr = _apply_compiler_decompose_to_plxpr(
+                inner_jaxpr=closed_jaxpr.jaxpr,
+                consts=closed_jaxpr.consts,
+                ncargs=non_const_args,
+                tkwargs=self.decompose_tkwargs,
+            )
 
     def calling_convention(*args):
         device_init_p.bind(
@@ -244,7 +257,7 @@ def handle_qnode(
         device_release_p.bind()
         return retvals
 
-    if self.requires_decompose_lowering:
+    if self.requires_decompose_lowering and graph_succeeded:
         # Add gate_set attribute to the quantum kernel primitive
         # decompose_gatesets is treated as a queue of gatesets to be used
         # but we only support a single gateset for now in from_plxpr
@@ -929,15 +942,26 @@ def trace_from_pennylane(
     return jaxpr, out_type, out_treedef, sig
 
 
-def _apply_compiler_decompose_to_plxpr(inner_jaxpr, consts, tgateset, ncargs):
+def _apply_compiler_decompose_to_plxpr(inner_jaxpr, consts, ncargs, tgateset=None, tkwargs=None):
     """Apply the compiler-specific decomposition for a given JAXPR.
+
+    This function first disables the graph-based decomposition optimization
+    to ensure that only high-level gates and templates with a single decomposition
+    are decomposed. It then performs the pre-mlir decomposition using PennyLane's
+    `plxpr_transform` function.
+
+    `tgateset` is a list of target gateset for decomposition.
+    If provided, it will be combined with the default compiler ops for decomposition.
+    If not provided, `tkwargs` will be used as the keyword arguments for the
+    decomposition transform. This is to ensure compatibility with the existing
+    PennyLane decomposition transform as well as providing a fallback mechanism.
 
     Args:
         inner_jaxpr (Jaxpr): The input JAXPR to be decomposed.
         consts (list): The constants used in the JAXPR.
-        tgateset (list): A list of target gateset for decomposition.
         ncargs (list): Non-constant arguments for the JAXPR.
-        qargs (list): All arguments including constants and non-constants.
+        tgateset (list): A list of target gateset for decomposition. Defaults to None.
+        tkwargs (list): The keyword arguments of the decompose transform. Defaults to None.
 
     Returns:
         ClosedJaxpr: The decomposed JAXPR.
@@ -951,17 +975,15 @@ def _apply_compiler_decompose_to_plxpr(inner_jaxpr, consts, tgateset, ncargs):
     # based on the graph solution.
     # Besides, the graph-based decomposition is not supported
     # yet in from_plxpr for most gates and templates.
-
     # TODO: Enable the graph-based decomposition
     qml.decomposition.disable_graph()
 
-    # First perform the pre-mlir decomposition to simplify the jaxpr
-    # by decomposing high-level gates and templates
-    gate_set = set(COMPILER_OPS_FOR_DECOMPOSITION.keys()).union(tgateset)
-
-    final_jaxpr = qml.transforms.decompose.plxpr_transform(
-        inner_jaxpr, consts, (), {"gate_set": gate_set}, *ncargs
+    kwargs = (
+        {"gate_set": set(COMPILER_OPS_FOR_DECOMPOSITION.keys()).union(tgateset)}
+        if tgateset
+        else tkwargs
     )
+    final_jaxpr = qml.transforms.decompose.plxpr_transform(inner_jaxpr, consts, (), kwargs, *ncargs)
 
     qml.decomposition.enable_graph()
 
@@ -986,15 +1008,31 @@ def _collect_and_compile_graph_solutions(inner_jaxpr, consts, tkwargs, ncargs):
 
     Returns:
         ClosedJaxpr: The decomposed JAXPR.
+        bool: A flag indicating whether the graph-based decomposition was successful.
     """
     gds_interpreter = DecompRuleInterpreter(**tkwargs)
 
     def gds_wrapper(*args):
         return gds_interpreter.eval(inner_jaxpr, consts, *args)
 
-    final_jaxpr = jax.make_jaxpr(gds_wrapper)(*ncargs)
+    graph_succeeded = True
 
-    return final_jaxpr
+    with warnings.catch_warnings(record=True) as captured_warnings:
+        warnings.simplefilter("always", UserWarning)
+        final_jaxpr = jax.make_jaxpr(gds_wrapper)(*ncargs)
+
+    for w in captured_warnings:
+        warnings.showwarning(w.message, w.category, w.filename, w.lineno)
+        # TODO: use a custom warning class for this in PennyLane to remove this
+        # string matching and make it more robust.
+        if "The graph-based decomposition system is unable" in str(w.message):
+            graph_succeeded = False
+            warnings.warn(
+                "Falling back to the legacy decomposition system.",
+                UserWarning,
+            )
+
+    return final_jaxpr, graph_succeeded
 
 
 def _get_operator_name(op):

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -1025,7 +1025,7 @@ def _collect_and_compile_graph_solutions(inner_jaxpr, consts, tkwargs, ncargs):
         warnings.showwarning(w.message, w.category, w.filename, w.lineno)
         # TODO: use a custom warning class for this in PennyLane to remove this
         # string matching and make it more robust.
-        if "The graph-based decomposition system is unable" in str(w.message): # pragma: no cover
+        if "The graph-based decomposition system is unable" in str(w.message):  # pragma: no cover
             graph_succeeded = False
             warnings.warn(
                 "Falling back to the legacy decomposition system.",

--- a/frontend/test/pytest/from_plxpr/test_from_plxpr.py
+++ b/frontend/test/pytest/from_plxpr/test_from_plxpr.py
@@ -1000,6 +1000,27 @@ class TestGraphDecomposition:
 
         assert qml.decomposition.enabled_graph() is False
 
+    def test_decompose_fallback_warnings(self):
+        """Test the fallback to legacy decomposition system with warnings."""
+        qml.capture.enable()
+        qml.decomposition.enable_graph()
+
+        @qml.qjit
+        @partial(qml.transforms.decompose, gate_set={qml.RX, qml.RZ})
+        @qml.qnode(qml.device("lightning.qubit", wires=2))
+        def circuit(x):
+            qml.Hadamard(x)
+            return qml.state()
+
+        with pytest.warns(
+            UserWarning,
+            match="The graph-based decomposition system is unable to find a decomposition for",
+        ):
+            circuit(0)
+
+        qml.decomposition.disable_graph()
+        qml.capture.disable()
+
 
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/from_plxpr/test_from_plxpr.py
+++ b/frontend/test/pytest/from_plxpr/test_from_plxpr.py
@@ -15,6 +15,8 @@
 This module tests the from_plxpr conversion function.
 """
 
+# pylint: disable=too-many-lines
+
 from functools import partial
 
 import jax

--- a/frontend/test/pytest/from_plxpr/test_from_plxpr.py
+++ b/frontend/test/pytest/from_plxpr/test_from_plxpr.py
@@ -1006,7 +1006,7 @@ class TestGraphDecomposition:
         qml.decomposition.enable_graph()
 
         @qml.qjit
-        @partial(qml.transforms.decompose, gate_set={qml.RX, qml.RZ})
+        @partial(qml.transforms.decompose, gate_set={qml.GlobalPhase})
         @qml.qnode(qml.device("lightning.qubit", wires=2))
         def circuit(x):
             qml.Hadamard(x)
@@ -1014,7 +1014,8 @@ class TestGraphDecomposition:
 
         with pytest.warns(
             UserWarning,
-            match="The graph-based decomposition system is unable to find a decomposition for",
+            match="The graph-based decomposition system is unable to find a decomposition"
+            " for {'Hadamard'} to the target gate set {'GlobalPhase'}.",
         ):
             circuit(0)
 


### PR DESCRIPTION
**Context:**
Update the default fallback message and behaviour so that the system always falls back to the legacy implementation when PL’s decomposition graph fails to solve. This ensures consistency with PL `UserWarning`s and allows us to continue compiling and executing the circuit end-to-end.

**Description of the Change:**
- Capture warnings and raise a `UserWarning` in `from_plxpr` when graph fails.
- Consistency with the behaviour of PL when the graph-decomposition fails to find rules

**Benefits:**
- Clearer user warnings/errors (consistent with PL warnings/errors) using `qml.transforms.decompose`

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-100399]