### PR TITLE
Prepare for Catalyst RC v0.13.0

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -10,8 +10,8 @@ enzyme=v0.0.186
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.43.0.dev65
+pennylane=0.43.0.dev71
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'
-lightning=0.43.0.dev36
+lightning=0.43.0.dev40

--- a/doc/dev/release_notes.rst
+++ b/doc/dev/release_notes.rst
@@ -3,7 +3,7 @@ Release notes
 
 This page contains the release notes for Catalyst.
 
-.. mdinclude:: ../releases/changelog-dev.md
+.. mdinclude:: ../releases/changelog-0.13.0.md
 
 .. mdinclude:: ../releases/changelog-0.12.0.md
 

--- a/doc/releases/changelog-0.12.0.md
+++ b/doc/releases/changelog-0.12.0.md
@@ -1,4 +1,4 @@
-# Release 0.12.0 (current release)
+# Release 0.12.0
 
 <h3>New features since last release</h3>
 

--- a/doc/releases/changelog-0.13.0.md
+++ b/doc/releases/changelog-0.13.0.md
@@ -1,4 +1,4 @@
-# Release 0.13.0 (development release)
+# Release 0.13.0 (current release)
 
 <h3>New features since last release</h3>
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -31,6 +31,6 @@ lxml_html_clean
 
 # Pre-install PL development wheels
 --extra-index-url https://test.pypi.org/simple/
-pennylane-lightning-kokkos==0.43.0.dev36
-pennylane-lightning==0.43.0.dev36
-pennylane==0.43.0.dev65
+pennylane-lightning-kokkos==0.43.0.dev40
+pennylane-lightning==0.43.0.dev40
+pennylane==0.43.0.dev71

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.13.0-dev71"
+__version__ = "0.13.0"


### PR DESCRIPTION
Context: Preparing for the Catalyst v0.13.0 release candidate (RC).

Description of the Change:
- Update versions in release notes and _version.py.
- Updated the changelogs