### PR TITLE
Modify RC CI to install RC branches from PL and Lightning

### DIFF
--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -478,13 +478,13 @@ jobs:
     - name: Install PennyLane release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@0.43.0-rc0
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.43.0-rc0
     - name: Checkout PennyLane-Lightning release branch
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       uses: actions/checkout@v4
       with:
         repository: PennyLaneAI/pennylane-lightning
-        ref: 0.43.0_rc
+        ref: v0.43.0_rc
         path: lightning_build
         fetch-depth: 0
 
@@ -581,13 +581,13 @@ jobs:
     - name: Install PennyLane release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@0.43.0-rc0
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.43.0-rc0
     - name: Checkout PennyLane-Lightning release branch
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       uses: actions/checkout@v4
       with:
         repository: PennyLaneAI/pennylane-lightning
-        ref: 0.43.0_rc
+        ref: v0.43.0_rc
         path: lightning_build
         fetch-depth: 0
 
@@ -665,7 +665,7 @@ jobs:
     - name: Install PennyLane release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@0.43.0-rc0
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.43.0-rc0
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -483,7 +483,7 @@ jobs:
     - name: Install PennyLane-Lightning release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        pip install --extra-index-url https://test.pypi.org/simple/ --no-deps --pre -U pennylane-lightning'<=0.43.0'
+        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane-lightning'<=0.43.0'
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build
@@ -576,7 +576,7 @@ jobs:
     - name: Install PennyLane-Lightning-Kokkos release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        pip install --extra-index-url https://test.pypi.org/simple/ --no-deps --pre -U pennylane-lightning-kokkos'<=0.43.0'
+        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane-lightning-kokkos'<=0.43.0'
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -476,11 +476,11 @@ jobs:
         make frontend
 
     - name: Install PennyLane release candidate
-      if: github.event.pull_request.base.ref == '0.13.0-rc'
+      if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
         pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@0.43.0-rc0
     - name: Checkout PennyLane-Lightning release branch
-      if: github.event.pull_request.base.ref == '0.13.0-rc'
+      if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       uses: actions/checkout@v4
       with:
         repository: PennyLaneAI/pennylane-lightning
@@ -489,7 +489,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install PennyLane-Lightning release candidate
-      if: github.event.pull_request.base.ref == '0.13.0-rc'
+      if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
         cd lightning_build
         pip install -r requirements.txt
@@ -579,11 +579,11 @@ jobs:
         make frontend
 
     - name: Install PennyLane release candidate
-      if: github.event.pull_request.base.ref == '0.13.0-rc'
+      if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
         pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@0.43.0-rc0
     - name: Checkout PennyLane-Lightning release branch
-      if: github.event.pull_request.base.ref == '0.13.0-rc'
+      if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       uses: actions/checkout@v4
       with:
         repository: PennyLaneAI/pennylane-lightning
@@ -592,7 +592,7 @@ jobs:
         fetch-depth: 0
 
     - name: Install PennyLane-Lightning release candidate
-      if: github.event.pull_request.base.ref == '0.13.0-rc'
+      if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
         # Lightning-Kokkos can no longer be installed with pip from git
         cd lightning_build
@@ -663,7 +663,7 @@ jobs:
         make frontend
 
     - name: Install PennyLane release candidate
-      if: github.event.pull_request.base.ref == '0.13.0-rc'
+      if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
         pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@0.43.0-rc0
 

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -475,6 +475,26 @@ jobs:
         python3 -m pip install oqc-qcaas-client
         make frontend
 
+    - name: Install PennyLane release candidate
+      if: github.event.pull_request.base.ref == '0.13.0-rc'
+      run: |
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@0.43.0-rc0
+    - name: Checkout PennyLane-Lightning release branch
+      if: github.event.pull_request.base.ref == '0.13.0-rc'
+      uses: actions/checkout@v4
+      with:
+        repository: PennyLaneAI/pennylane-lightning
+        ref: 0.43.0_rc
+        path: lightning_build
+        fetch-depth: 0
+
+    - name: Install PennyLane-Lightning release candidate
+      if: github.event.pull_request.base.ref == '0.13.0-rc'
+      run: |
+        cd lightning_build
+        pip install -r requirements.txt
+        pip install --no-deps --force .
+
     - name: Get Cached LLVM Build
       id: cache-llvm-build
       uses: actions/cache@v4
@@ -558,6 +578,28 @@ jobs:
         python3 -m pip install -r requirements.txt
         make frontend
 
+    - name: Install PennyLane release candidate
+      if: github.event.pull_request.base.ref == '0.13.0-rc'
+      run: |
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@0.43.0-rc0
+    - name: Checkout PennyLane-Lightning release branch
+      if: github.event.pull_request.base.ref == '0.13.0-rc'
+      uses: actions/checkout@v4
+      with:
+        repository: PennyLaneAI/pennylane-lightning
+        ref: 0.43.0_rc
+        path: lightning_build
+        fetch-depth: 0
+
+    - name: Install PennyLane-Lightning release candidate
+      if: github.event.pull_request.base.ref == '0.13.0-rc'
+      run: |
+        # Lightning-Kokkos can no longer be installed with pip from git
+        cd lightning_build
+        pip install -r requirements.txt
+        PL_BACKEND=lightning_kokkos python scripts/configure_pyproject_toml.py
+        pip install --no-deps --force .
+
     - name: Get Cached LLVM Build
       id: cache-llvm-build
       uses: actions/cache@v4
@@ -619,6 +661,11 @@ jobs:
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
         make frontend
+
+    - name: Install PennyLane release candidate
+      if: github.event.pull_request.base.ref == '0.13.0-rc'
+      run: |
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@0.43.0-rc0
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -478,22 +478,12 @@ jobs:
     - name: Install PennyLane release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.43.0-rc0
-    - name: Checkout PennyLane-Lightning release branch
-      if: github.event.pull_request.base.ref == 'v0.13.0-rc'
-      uses: actions/checkout@v4
-      with:
-        repository: PennyLaneAI/pennylane-lightning
-        ref: v0.43.0_rc
-        path: lightning_build
-        fetch-depth: 0
+        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane
 
     - name: Install PennyLane-Lightning release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        cd lightning_build
-        pip install -r requirements.txt
-        pip install --no-deps --force .
+        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane-lightning
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build
@@ -581,24 +571,12 @@ jobs:
     - name: Install PennyLane release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.43.0-rc0
-    - name: Checkout PennyLane-Lightning release branch
-      if: github.event.pull_request.base.ref == 'v0.13.0-rc'
-      uses: actions/checkout@v4
-      with:
-        repository: PennyLaneAI/pennylane-lightning
-        ref: v0.43.0_rc
-        path: lightning_build
-        fetch-depth: 0
+        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane
 
-    - name: Install PennyLane-Lightning release candidate
+    - name: Install PennyLane-Lightning-Kokkos release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        # Lightning-Kokkos can no longer be installed with pip from git
-        cd lightning_build
-        pip install -r requirements.txt
-        PL_BACKEND=lightning_kokkos python scripts/configure_pyproject_toml.py
-        pip install --no-deps --force .
+        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane-lightning-kokkos
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build
@@ -665,7 +643,7 @@ jobs:
     - name: Install PennyLane release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.43.0-rc0
+        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -483,15 +483,7 @@ jobs:
     - name: Install PennyLane-Lightning release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        LIGHTNING_RC_VER=$( \
-        pip index versions --extra-index-url https://test.pypi.org/simple/ PennyLane-Lightning --pre | \
-        grep "Available versions:" | \
-        sed 's/Available versions: //g' | \
-        tr ',' '\n' | \
-        grep "0.43.0rc" | \
-        head -n 1 | \
-        tr -d '[:space:]' )
-        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane-lightning==$LIGHTNING_RC_VER
+        pip install --extra-index-url https://test.pypi.org/simple/ --no-deps --pre -U pennylane-lightning'<=0.43.0'
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build
@@ -584,15 +576,7 @@ jobs:
     - name: Install PennyLane-Lightning-Kokkos release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        LIGHTNING_KOKKOS_RC_VER=$( \
-        pip index versions --extra-index-url https://test.pypi.org/simple/ pennylane-lightning-kokkos --pre | \
-        grep "Available versions:" | \
-        sed 's/Available versions: //g' | \
-        tr ',' '\n' | \
-        grep "0.43.0rc" | \
-        head -n 1 | \
-        tr -d '[:space:]' )
-        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane-lightning-kokkos==$LIGHTNING_KOKKOS_RC_VER
+        pip install --extra-index-url https://test.pypi.org/simple/ --no-deps --pre -U pennylane-lightning-kokkos'<=0.43.0'
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -478,7 +478,7 @@ jobs:
     - name: Install PennyLane release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.43.0-rc0
 
     - name: Install PennyLane-Lightning release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
@@ -571,7 +571,7 @@ jobs:
     - name: Install PennyLane release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.43.0-rc0
 
     - name: Install PennyLane-Lightning-Kokkos release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
@@ -643,7 +643,7 @@ jobs:
     - name: Install PennyLane release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.43.0-rc0
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -483,7 +483,15 @@ jobs:
     - name: Install PennyLane-Lightning release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane-lightning>=0.43.0rc0
+        LIGHTNING_RC_VER=$( \
+        pip index versions --extra-index-url https://test.pypi.org/simple/ PennyLane-Lightning --pre | \
+        grep "Available versions:" | \
+        sed 's/Available versions: //g' | \
+        tr ',' '\n' | \
+        grep "0.43.0rc" | \
+        head -n 1 | \
+        tr -d '[:space:]' )
+        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane-lightning==$LIGHTNING_RC_VER
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build
@@ -576,7 +584,15 @@ jobs:
     - name: Install PennyLane-Lightning-Kokkos release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane-lightning-kokkos>=0.43.0rc0
+        LIGHTNING_KOKKOS_RC_VER=$( \
+        pip index versions --extra-index-url https://test.pypi.org/simple/ pennylane-lightning-kokkos --pre | \
+        grep "Available versions:" | \
+        sed 's/Available versions: //g' | \
+        tr ',' '\n' | \
+        grep "0.43.0rc" | \
+        head -n 1 | \
+        tr -d '[:space:]' )
+        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane-lightning-kokkos==$LIGHTNING_KOKKOS_RC_VER
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -483,7 +483,7 @@ jobs:
     - name: Install PennyLane-Lightning release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane-lightning
+        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane-lightning>=0.43.0rc0
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build
@@ -576,7 +576,7 @@ jobs:
     - name: Install PennyLane-Lightning-Kokkos release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane-lightning-kokkos
+        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane-lightning-kokkos>=0.43.0rc0
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build


### PR DESCRIPTION
**Context:**
PRs targeting `v0.13.0-rc` should be tested with the release candidate branches of PL and Lightning as well.
We manually overwrite the CI to install these directly after `make frontend` (which gets the version from `.dep_versions`).

Note that when merging rc branch back to main after the release, this PR must be reverted for `.dep_versions` to take back control of the versions. 
