### PR TITLE
Allow arguments in conditional functions

### DIFF
--- a/doc/releases/changelog-0.13.0.md
+++ b/doc/releases/changelog-0.13.0.md
@@ -18,7 +18,7 @@
   [(#2002)](https://github.com/PennyLaneAI/catalyst/pull/2002)
 
   Two new functions, ``qml.allocate()`` and ``qml.deallocate()``, [have been added to
-  PennyLane](https://docs.pennylane.ai/en/stable/development/release_notes.html#release-0-43-0) 
+  PennyLane](https://docs.pennylane.ai/en/stable/development/release_notes.html#release-0-43-0)
   to support dynamic wire allocation. With Catalyst, these features can be accessed on
    ``lightning.qubit``, ``lightning.kokkos``, and ``lightning.gpu``.
 
@@ -45,13 +45,13 @@
   ```
 
   In the above program, 2 qubits are allocated during device initialization, and 1
-  additional qubit is allocated inside the circuit with ``qml.allocate(1)``. 
+  additional qubit is allocated inside the circuit with ``qml.allocate(1)``.
 
   For more information on what ``qml.allocate`` and ``qml.deallocate`` do, please consult the
   [PennyLane v0.43 release notes](https://docs.pennylane.ai/en/stable/development/release_notes.html#release-0-43-0).
 
   However, there are some notable differences between the behaviour of these features
-  with ``qjit`` versus without. For details, please see the relevant sections in the 
+  with ``qjit`` versus without. For details, please see the relevant sections in the
   [Catalyst sharp bits page](https://docs.pennylane.ai/projects/catalyst/en/stable/dev/sharp_bits.html#functionality-differences-from-pennylane).
 
 * A new quantum compilation pass that reduces the depth and count of non-Clifford Pauli product
@@ -98,7 +98,7 @@
               qml.H(wires=i)
               qml.T(wires=i)
 
-          return [measure(wires=i) for i in range(n)] 
+          return [measure(wires=i) for i in range(n)]
 
       print(ppm_specs(circuit))
   ```
@@ -108,7 +108,7 @@
   {'circuit_0': {'depth_pi8_ppr': 4, 'depth_ppm': 1, 'logical_qubits': 3, 'max_weight_pi8': 3, 'num_of_ppm': 3, 'pi8_ppr': 6}}
   ```
 
-  After performing the :func:`~.passes.to_ppr`, :func:`~.passes.commute_ppr`, and :func:`~.passes.merge_ppr_ppm`, 
+  After performing the :func:`~.passes.to_ppr`, :func:`~.passes.commute_ppr`, and :func:`~.passes.merge_ppr_ppm`,
   passes, the circuit contains a depth of four of non-Clifford PPRs (`depth_pi8_ppr`). Subsequently applying the
   :func:`~.passes.t_layer_reduction` pass will move PPRs around via commutation, resulting in a circuit with a
   smaller PPR depth of three.
@@ -166,6 +166,11 @@
   [[#2019]](https://github.com/PennyLaneAI/catalyst/pull/2019)
 
 <h3>Improvements 🛠</h3>
+
+* Catalyst conditional operators, such as :func:`~.cond` or :func:`pennylane.cond`, now allow the
+  target / branch functions to use arguments in their call signature. Previously, one had to supply
+  all values via closure, but this is now done automatically under the hood.
+  [(#2096)](https://github.com/PennyLaneAI/catalyst/pull/2096)
 
 * Significantly improved resource tracking with `null.qubit`.
   The new tracking has better integration with PennyLane (e.g. for passing the filename to write out), cleaner documentation, and its own wrapper class.
@@ -453,7 +458,7 @@ for example the one-shot mid circuit measurement transform.
   [(#2057)](https://github.com/PennyLaneAI/catalyst/pull/2057)
 
   This pass is part of a bottom-of-stack MBQC execution pathway, with a thin shim between the
-  PPR/PPM layer and MBQC to enable end-to-end compilation on a mocked backend.  Also, in an MBQC gate 
+  PPR/PPM layer and MBQC to enable end-to-end compilation on a mocked backend.  Also, in an MBQC gate
   set, one of the gate `RotXZX` cannot yet be executed on available backends.
 
   ```python
@@ -477,8 +482,8 @@ for example the one-shot mid circuit measurement transform.
 
 <h3>Documentation 📝</h3>
 
-* Typos were fixed and supplemental information was added to the 
-  docstrings for ``ppm_compilaion``, ``to_ppr``, ``commute_ppr``, 
+* Typos were fixed and supplemental information was added to the
+  docstrings for ``ppm_compilaion``, ``to_ppr``, ``commute_ppr``,
   ``ppr_to_ppm``, ``merge_ppr_ppm``, and ``ppm_specs``.
   [(#2050)](https://github.com/PennyLaneAI/catalyst/pull/2050)
 

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -810,9 +810,9 @@ class CondCallable:
             # use this familiar PL pattern, e.g. `qml.cond(p, qml.RY)(0.1, 0)`.
             if isinstance(fn, type) and issubclass(fn, qml.operation.Operation):
                 fn(*args, **kwargs)
-                # swallow return value to avoid mismatched pytrees across branches
-            else:
-                return fn(*args, **kwargs)
+                return None  # swallow return value to avoid mismatched pytrees across branches
+
+            return fn(*args, **kwargs)
 
         return argless_fn
 

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -19,7 +19,6 @@ with control flow, including conditionals, for loops, and while loops.
 
 # pylint: disable=too-many-lines
 
-import inspect
 from functools import partial
 from typing import Any, Callable, List
 
@@ -101,9 +100,6 @@ def cond(pred: DynamicJaxprTracer):
     Returns:
         A callable decorator that wraps the first 'if' branch of the conditional.
 
-    Raises:
-        AssertionError: Branch functions cannot have arguments.
-
     **Example**
 
     .. code-block:: python
@@ -181,7 +177,7 @@ def cond(pred: DynamicJaxprTracer):
         :title: Usage details
         :href: usage-details
 
-        There are various constraints and restrictions that should be kept in mind
+        There are some constraints and restrictions that should be kept in mind
         when working with conditionals in Catalyst.
 
         The return values of all branches of :func:`~.cond` must be the same shape.
@@ -256,17 +252,6 @@ def cond(pred: DynamicJaxprTracer):
         raise PlxprCaptureCFCompatibilityError("cond")
 
     def _decorator(true_fn: Callable):
-
-        if len(inspect.signature(true_fn).parameters):
-            if isinstance(true_fn, type) and issubclass(true_fn, qml.operation.Operation):
-                # Special treatment if conditional function body is a single pennylane gate
-                # The qml.operation.Operation base class represents things that
-                # can reasonably be considered as a gate,
-                # e.g. qml.Hadamard, qml.RX, etc.
-                return CondCallableSingleGateHandler(pred, true_fn)
-            else:
-                raise TypeError("Conditional 'True' function is not allowed to have any arguments")
-
         return CondCallable(pred, true_fn)
 
     return _decorator
@@ -576,14 +561,14 @@ def while_loop(cond_fn, allow_array_resizing: bool = False):
 
 ## IMPL ##
 class CondCallable:
-    """User-facing wrapper provoding "else_if" and "otherwise" public methods.
+    """User-facing wrapper providing "else_if" and "otherwise" public methods.
     Some code in this class has been adapted from the cond implementation in the JAX project at
     https://github.com/google/jax/blob/jax-v0.4.1/jax/_src/lax/control_flow/conditionals.py
     released under the Apache License, Version 2.0, with the following copyright notice:
 
     Copyright 2021 The JAX Authors.
 
-    Also provides access to the underlying "Cond" operation object.
+    Also provides access to the underlying "Cond" pennylane.Operation object.
 
     **Example**
 
@@ -630,18 +615,9 @@ class CondCallable:
     def __init__(self, pred, true_fn):
         self.preds = [self._convert_predicate_to_bool(pred)]
         self.branch_fns = [true_fn]
-        self.otherwise_fn = lambda: None
+        self.otherwise_fn = lambda *args, **kwargs: None
         self._operation = None
         self.expansion_strategy = cond_expansion_strategy()
-
-    def set_otherwise_fn(self, otherwise_fn):  # pylint:disable=missing-function-docstring
-        self.otherwise_fn = otherwise_fn
-
-    def add_pred(self, _pred):  # pylint:disable=missing-function-docstring
-        self.preds.append(self._convert_predicate_to_bool(_pred))
-
-    def add_branch_fn(self, _branch_fn):  # pylint:disable=missing-function-docstring
-        self.branch_fns.append(_branch_fn)
 
     @property
     def operation(self):
@@ -671,10 +647,6 @@ class CondCallable:
         """
 
         def decorator(branch_fn):
-            if len(inspect.signature(branch_fn).parameters):
-                raise TypeError(
-                    "Conditional 'else if' function is not allowed to have any arguments"
-                )
             self.preds.append(self._convert_predicate_to_bool(pred))
             self.branch_fns.append(branch_fn)
             return self
@@ -690,8 +662,6 @@ class CondCallable:
         Returns:
             self
         """
-        if len(inspect.signature(otherwise_fn).parameters):
-            raise TypeError("Conditional 'False' function is not allowed to have any arguments")
         self.otherwise_fn = otherwise_fn
         return self
 
@@ -830,7 +800,26 @@ class CondCallable:
                 return branch_fn()
         return self.otherwise_fn()
 
-    def __call__(self):
+    @staticmethod
+    def _make_argless_function(fn, args, kwargs):
+        """Wrap a user function into a function without arguments to satisfy the IR representation
+        of conditionals, which always accesses values via closure (besides the predicate)."""
+
+        def argless_fn():
+            # Special case for single gates supplied to cond. We'd would like users to be able to
+            # use this familiar PL pattern, e.g. `qml.cond(p, qml.RY)(0.1, 0)`.
+            if isinstance(fn, type) and issubclass(fn, qml.operation.Operation):
+                fn(*args, **kwargs)
+                # swallow return value to avoid mismatched pytrees across branches
+            else:
+                return fn(*args, **kwargs)
+
+        return argless_fn
+
+    def __call__(self, *args, **kwargs):
+        self.branch_fns = [self._make_argless_function(fn, args, kwargs) for fn in self.branch_fns]
+        self.otherwise_fn = self._make_argless_function(self.otherwise_fn, args, kwargs)
+
         mode = EvaluationContext.get_evaluation_mode()
         if mode == EvaluationMode.QUANTUM_COMPILATION:
             return self._call_with_quantum_ctx()
@@ -839,78 +828,6 @@ class CondCallable:
         else:
             assert mode == EvaluationMode.INTERPRETATION, f"Unsupported evaluation mode {mode}"
             return self._call_during_interpretation()
-
-
-class CondCallableSingleGateHandler(CondCallable):
-    """
-    Special CondCallable when the conditional body function is a single pennylane gate.
-
-    A usual pennylane conditional call for a gate looks like
-    `qml.cond(x == 42, qml.RX)(theta, wires=0)`
-
-    Since gates are guaranteed to take in arguments (at the very least the wire argument),
-    the usual CondCallable class, which expects the conditional body function to have no arguments,
-    cannot be used.
-    This class inherits from base CondCallable, but wraps the gate in a function with no arguments,
-    and sends that function to CondCallable.
-    This allows us to perform the conditional branch gate function with arguments.
-    """
-
-    def __init__(self, pred, true_fn):  # pylint:disable=super-init-not-called
-        self.sgh_preds = [pred]
-        self.sgh_branch_fns = [true_fn]
-        self.sgh_otherwise_fn = None
-
-    def __call__(self, *args, **kwargs):
-        def argless_true_fn():
-            self.sgh_branch_fns[0](*args, **kwargs)
-
-        super().__init__(self.sgh_preds[0], argless_true_fn)
-
-        if self.sgh_otherwise_fn is not None:
-
-            def argless_otherwise_fn():
-                self.sgh_otherwise_fn(*args, **kwargs)
-
-            super().set_otherwise_fn(argless_otherwise_fn)
-
-        for i in range(1, len(self.sgh_branch_fns)):
-
-            def argless_elseif_fn(i=i):  # i=i to work around late binding
-                self.sgh_branch_fns[i](*args, **kwargs)
-
-            super().add_pred(self.sgh_preds[i])
-            super().add_branch_fn(argless_elseif_fn)
-
-        return super().__call__()
-
-    def else_if(self, _pred):
-        """
-        Override the "can't have arguments" check in the original CondCallable's `else_if`
-        """
-
-        def decorator(branch_fn):
-            if isinstance(branch_fn, type) and issubclass(branch_fn, qml.operation.Operation):
-                self.sgh_preds.append(_pred)
-                self.sgh_branch_fns.append(branch_fn)
-                return self
-            else:  # pylint:disable=line-too-long
-                raise TypeError(
-                    "Conditional 'else if' function can have arguments only if it is a PennyLane gate."
-                )
-
-        return decorator
-
-    def otherwise(self, otherwise_fn):
-        """
-        Override the "can't have arguments" check in the original CondCallable's `otherwise`
-        """
-        if isinstance(otherwise_fn, type) and issubclass(otherwise_fn, qml.operation.Operation):
-            self.sgh_otherwise_fn = otherwise_fn
-        else:
-            raise TypeError(
-                "Conditional 'False' function can have arguments only if it is a PennyLane gate."
-            )
 
 
 class ForLoopCallable:

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -23,9 +23,10 @@ import pytest
 from pennylane import cond
 
 import catalyst
-from catalyst import api_extensions, qjit
+from catalyst import api_extensions
 from catalyst import cond as catalyst_cond
 from catalyst import measure as catalyst_measure
+from catalyst import qjit
 from catalyst.utils.exceptions import PlxprCaptureCFCompatibilityError
 
 # pylint: disable=missing-function-docstring

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -484,13 +484,12 @@ class TestCond:
             ):
                 f(True, 3)
 
-    @pytest.mark.xfail(
-        reason="Inability to apply Jax transformations before the quantum traing is complete"
-    )
     def test_branch_multi_return_type_unification_qnode_2(self, backend):
-        """Test that unification happens before the results of the cond primitve is available.
+        """Test that unification happens before the results of the cond primitive is available.
         See the FIXME in the ``CondCallable._call_with_quantum_ctx`` function.
         """
+        if qml.capture.enabled():
+            pytest.xfail(reason="unification not working with capture")
 
         @qjit
         @qml.qnode(qml.device(backend, wires=1))


### PR DESCRIPTION
The implementation simply wraps user provided functions in
parameter-less wrappers that propagate user-provided arguments
via closure.

A special case is maintained from a earlier bugfix in https://github.com/PennyLaneAI/catalyst/pull/1232 that allowed
"standard" usage of qml.cond with gate constructor without matching
the return types across branches, by dropping the return value in the
single operator case.

closes #2086
supersedes #1531 and #1232