### PR TITLE
Selective unitary decomposition fallback to fix IR blow-up

### DIFF
--- a/doc/releases/changelog-0.13.0.md
+++ b/doc/releases/changelog-0.13.0.md
@@ -175,6 +175,14 @@
 
 <h3>Improvements 🛠</h3>
 
+* `QubitUnitary` is no longer favoured in the decomposition of controlled operators when the
+  operator is not natively supported by the device, and the device supports `QubitUnitary`. Instead,
+  conversion to `QubitUnitary` only happens if the operator does not define another decomposition.
+  The previous behaviour was the cause of performance issues when dealing with large controlled
+  operators, as their matrix representation could be embedded as dense constant data into the
+  program. The performance difference can span multiple orders of magnitude depending on regime.
+  [(#2100)](https://github.com/PennyLaneAI/catalyst/pull/2100)
+
 * Catalyst conditional operators, such as :func:`~.cond` or :func:`pennylane.cond`, now allow the
   target / branch functions to use arguments in their call signature. Previously, one had to supply
   all values via closure, but this is now done automatically under the hood.

--- a/frontend/catalyst/device/decomposition.py
+++ b/frontend/catalyst/device/decomposition.py
@@ -16,6 +16,7 @@
 This module contains the decomposition functions to pre-process tapes for
 compilation & execution on devices.
 """
+
 import copy
 import logging
 from functools import partial
@@ -79,11 +80,9 @@ def catalyst_decomposer(op, capabilities: DeviceCapabilities):
     if op.name in getattr(capabilities, "to_matrix_ops", {}):
         return _decompose_to_matrix(op)
 
-    if op.has_matrix and isinstance(op, qml.ops.Controlled):
-
+    if not op.has_decomposition and op.has_matrix and "QubitUnitary" in capabilities.operations:
         # If the device supports unitary matrices, apply the fallback.
-        if "QubitUnitary" in capabilities.operations:
-            return _decompose_to_matrix(op)
+        return _decompose_to_matrix(op)
 
     return op.decomposition()
 


### PR DESCRIPTION
Do not fallback to QubitUnitary unless operator provides no decomposition. Previously, a QubitUnitary would be constructed for any Controlled operator not natively supported by the device. While this can have some advantages, e.g. better performance on simulators for gates up to a certain size (which was never the intention of the fallback), it can also cause issues like overly large constant matrices embedded into the IR, and can also be unexpected to users since they might expect a decomposition to elementary gates.

The proposed update should be more robust in that it still uses the QubitUnitary fallback for gates that don't implement a decomposition, but otherwise makes use of the provided one.

closes #2077