### PR TITLE
Actions use rc PennyLane from testpypi instead of git

### DIFF
--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -478,7 +478,7 @@ jobs:
     - name: Install PennyLane release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.43.0-rc0
+        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane'<=0.43.0'
 
     - name: Install PennyLane-Lightning release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
@@ -571,7 +571,7 @@ jobs:
     - name: Install PennyLane release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.43.0-rc0
+        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane'<=0.43.0'
 
     - name: Install PennyLane-Lightning-Kokkos release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
@@ -643,7 +643,7 @@ jobs:
     - name: Install PennyLane release candidate
       if: github.event.pull_request.base.ref == 'v0.13.0-rc'
       run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.43.0-rc0
+        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane'<=0.43.0'
 
     - name: Get Cached LLVM Build
       id: cache-llvm-build

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -141,23 +141,11 @@ jobs:
         path: lightning_build
         fetch-depth: 0
 
-    - name: Download PennyLane-Lightning (release-candidate)
+    - name: Install PennyLane-Lightning (release-candidate)
       if: ${{ inputs.lightning == 'release-candidate' }}
-      uses: actions/checkout@v4
-      with:
-        repository: PennyLaneAI/pennylane-lightning
-        ref: v0.43.0_rc
-        path: lightning_build
-        fetch-depth: 0
-
-    - name: Install PennyLane-Lightning (latest/release-candidate)
-      if: ${{ inputs.lightning != 'stable' }}
       run: |
-        # Lightning-Kokkos can no longer be installed with pip from git
-        cd lightning_build
-        pip install --no-deps --force .
-        PL_BACKEND=lightning_kokkos python scripts/configure_pyproject_toml.py
-        pip install --no-deps --force .
+        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane-lightning'<=0.43.0'
+        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane-lightning-kokkos'<=0.43.0'
 
     # PennyLane doesn't update its dev version number on every commit like Lightning, so we need to
     # force the package to be re-installed. First, handle potential dependency changes, then force
@@ -175,7 +163,7 @@ jobs:
     - name: Install PennyLane (release-candidate)
       if: ${{ inputs.pennylane == 'release-candidate' }}
       run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.43.0-rc0
+        pip install --no-deps --pre -U --extra-index-url https://test.pypi.org/simple/ pennylane'<=0.43.0'
 
     - name: Add Frontend Dependencies to PATH
       if: ${{ inputs.catalyst != 'stable' }}


### PR DESCRIPTION
**Context:**
Change two actions to use rc PennyLane from testpypi instead of git:
- check-catalyst (CI on PRs in catalyst repo targeting the rc branch)
- check-pl-compat (the rcrcrc check CI)
