### PR TITLE
rcrcrc action use rc PennyLane from testpypi instead of git

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -141,23 +141,11 @@ jobs:
         path: lightning_build
         fetch-depth: 0
 
-    - name: Download PennyLane-Lightning (release-candidate)
+    - name: Install PennyLane-Lightning (release-candidate)
       if: ${{ inputs.lightning == 'release-candidate' }}
-      uses: actions/checkout@v4
-      with:
-        repository: PennyLaneAI/pennylane-lightning
-        ref: v0.43.0_rc
-        path: lightning_build
-        fetch-depth: 0
-
-    - name: Install PennyLane-Lightning (latest/release-candidate)
-      if: ${{ inputs.lightning != 'stable' }}
       run: |
-        # Lightning-Kokkos can no longer be installed with pip from git
-        cd lightning_build
-        pip install --no-deps --force .
-        PL_BACKEND=lightning_kokkos python scripts/configure_pyproject_toml.py
-        pip install --no-deps --force .
+        pip install --no-deps --pre -U --index-url https://test.pypi.org/simple/ pennylane-lightning'<=0.43.0'
+        pip install --no-deps --pre -U --index-url https://test.pypi.org/simple/ pennylane-lightning-kokkos'<=0.43.0'
 
     # PennyLane doesn't update its dev version number on every commit like Lightning, so we need to
     # force the package to be re-installed. First, handle potential dependency changes, then force
@@ -175,7 +163,7 @@ jobs:
     - name: Install PennyLane (release-candidate)
       if: ${{ inputs.pennylane == 'release-candidate' }}
       run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@v0.43.0-rc0
+        pip install --no-deps --pre -U --index-url https://test.pypi.org/simple/ pennylane'<=0.43.0'
 
     - name: Add Frontend Dependencies to PATH
       if: ${{ inputs.catalyst != 'stable' }}


### PR DESCRIPTION
**Context:**
rcrcrc action use rc PennyLane from testpypi instead of git

Note that this needs to be updated on main, not rc branch, since the rcrcrc action is triggered from main.

