### PR TITLE
Fix a clang-tidy warning on main

### DIFF
--- a/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
@@ -87,7 +87,11 @@ class OpSignatureAnalyzer {
                                 .inCtrlQubits = op.getCtrlQubitOperands(),
                                 .inCtrlValues = op.getCtrlValueOperands(),
                                 .outQubits = op.getNonCtrlQubitResults(),
-                                .outCtrlQubits = op.getCtrlQubitResults()})
+                                .outCtrlQubits = op.getCtrlQubitResults(),
+                                .inWireIndices = {},
+                                .inCtrlWireIndices = {},
+                                .outQubitIndices = {},
+                                .outCtrlQubitIndices = {}})
     {
         if (!enableQregMode)
             return;


### PR DESCRIPTION
**Context:**
A clang-tidy warning on main branch is blocking benchmark runs. 

We do have `-Wall` turned on by default, but we might have slightly different configs than the benchmark suite? 
But anyway, this is the needed fix.

**Description of the Change:**
A class is instantiated with some fields missing initial values. 
We provide the empty init values.

**Benefits:**
Benchmark suite runs.
