### PR TITLE
Fix two tests that are still using the deprecated `is_hermitian` property

### DIFF
--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -866,15 +866,18 @@ class TestProperties:
 
     @pytest.mark.parametrize("value", (True, False))
     def test_is_hermitian(self, value):
-        """Test `is_hermitian` property mirrors that of the base."""
+        """Test `is_verified_hermitian` property mirrors that of the base."""
 
         # pylint: disable=too-few-public-methods
         class DummyOp(qml.operation.Operator):
             num_wires = 1
-            is_hermitian = value
+            
+            @property
+            def is_verified_hermitian(self):
+                return value
 
         op = adjoint(DummyOp(0))
-        assert op.is_hermitian == value
+        assert op.is_verified_hermitian == value
 
     def test_batching_properties(self):
         """Test the batching properties and methods."""


### PR DESCRIPTION
**Context:**
A recent PennyLane [commit](https://github.com/PennyLaneAI/pennylane/pull/8494) deprecated `is_hermitian` and replaced it with a new `is_verified_hermitian`. Therefore some tests of Catalyst need adjustment as well 

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
