### PR TITLE
Remove pass that promotes heap allocs to stack in quantum function

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -29,6 +29,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixes an issue where a heap-to-stack allocation conversion pass was causing SIGSEGV issues 
+  during program execution at runtime.
+  [(#2172)](https://github.com/PennyLaneAI/catalyst/pull/2172)
+
 * Fixes the issue with capturing unutilized abstracted adjoint and controlled rules
   by the graph in the new decomposition framework.
   [(#2160)](https://github.com/PennyLaneAI/catalyst/pull/2160)
@@ -99,6 +103,7 @@ This release contains contributions from (in alphabetical order):
 Ali Asadi,
 Christina Lee,
 River McCubbin,
+Lee J. O'Riordan,
 Roberto Turrado,
 Paul Haochen Wang,
 Hongsheng Zheng.

--- a/frontend/catalyst/pipelines.py
+++ b/frontend/catalyst/pipelines.py
@@ -294,7 +294,7 @@ def get_bufferization_stage(options: CompileOptions) -> List[str]:
         "func.func(buffer-loop-hoisting)",
         # TODO: investigate re-adding this after new buffer dealloc pipeline
         #       removed due to high stack memory use in nested structures
-        #"func.func(promote-buffers-to-stack)",
+        # "func.func(promote-buffers-to-stack)",
         # TODO: migrate to new buffer deallocation "buffer-deallocation-pipeline"
         "func.func(buffer-deallocation)",
         "convert-arraylist-to-memref",


### PR DESCRIPTION
**Context:** The [`promote-buffers-to-stack`](https://mlir.llvm.org/docs/Passes/#-promote-buffers-to-stack) when used with quantum operators in deep nested structures has been observed to perform a large number of `alloca` calls whose lifetime is at the function scope. This has caused failures due to the limited stack size on given systems, resulting in catastrophic program failure during execution. This PR temporarily removes the pass from the given bufferization pipeline stage, which has been observed to remediate the issue.

**Description of the Change:** Remove `promote-buffers-to-stack` pass from Catalyst's pipeline

**Benefits:** Fixes issues with stack allocations resulting in SIGSEGV errrors.

**Possible Drawbacks:** Potential performance loss due to non-conversion of heap allocations.

**Related GitHub Issues:**
