### PR TITLE
Add clean-dialect-docs to clean-all

### DIFF
--- a/mlir/Makefile
+++ b/mlir/Makefile
@@ -215,7 +215,7 @@ test:
 	cmake --build $(DIALECTS_BUILD_DIR) --target check-dialects
 
 .PHONY: clean clean-dialects clean-enzyme clean-stablehlo clean-plugin clean-dialect-docs
-clean: clean-dialects clean-llvm clean-stablehlo clean-enzyme clean-plugin
+clean: clean-dialects clean-llvm clean-stablehlo clean-enzyme clean-plugin clean-dialect-docs
 
 clean-dialects:
 	@echo "clean catalyst dialect build files"


### PR DESCRIPTION
**Context:**
`make clean-all` does not clean dialect doc build. 
This causes hiccups during `make all`.

