### PR TITLE
Add a fixture that checks and skip tests if xdsl is not installed 

### DIFF
--- a/frontend/test/pytest/conftest.py
+++ b/frontend/test/pytest/conftest.py
@@ -70,3 +70,9 @@ def use_both_frontend(request):
             qml.capture.disable()
     else:
         yield
+
+
+@pytest.fixture(scope="function")
+def requires_xdsl():
+    """Fixture that ensures xdsl is available. It skips the test if xdsl is not installed."""
+    pytest.importorskip("xdsl", reason="xdsl is not installed, skipping test")

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -901,14 +901,11 @@ class TestDefaultAvailableIR:
         assert g.mlir_opt
         assert "__catalyst__qis" in g.mlir_opt
 
-    @pytest.mark.usefixtures("use_capture")
+    @pytest.mark.usefixtures("use_capture", "requires_xdsl")
     def test_mlir_opt_using_xdsl_passes(self, backend):
         """Test mlir opt using xDSL passes."""
-        try:
-            # pylint: disable-next=import-outside-toplevel
-            from pennylane.compiler.python_compiler.transforms import iterative_cancel_inverses_pass
-        except ModuleNotFoundError:
-            pytest.skip("xdsl is not installed, skipping test")
+        # pylint: disable-next=import-outside-toplevel
+        from pennylane.compiler.python_compiler.transforms import iterative_cancel_inverses_pass
 
         @qjit
         @iterative_cancel_inverses_pass


### PR DESCRIPTION
**Context:**
Pytest tests that use the python compiler should skip if xdsl is not installed since xdsl is not a hard dependency for Catalyst. 
 
**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
