### PR TITLE
Install xdsl-jax dependency from pypi instead of github

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,4 @@ nbmake
 pennylane-lightning-kokkos
 amazon-braket-pennylane-plugin>1.27.1
 xdsl
-xdsl-jax @ git+https://github.com/xdslproject/xdsl-jax.git@main
+xdsl-jax


### PR DESCRIPTION
**Context:**
Install xdsl-jax dependency from pypi instead of github
