### PR TITLE
No longer absorb initial StatePrep for null.qubit

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -4,6 +4,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* ``null.qubit`` no longer skips initial `qml.StatePrep` operations.
+  [(#2195)](https://github.com/PennyLaneAI/catalyst/pull/2195)
+
 * The new graph-based decomposition framework has Autograph feature parity with PennyLane
   when capture enabled. When compiling with `qml.qjit(autograph=True)`, the decomposition rules
   returned by the graph-based framework are now correctly compiled using Autograph.

--- a/runtime/lib/backend/null_qubit/null_qubit.toml
+++ b/runtime/lib/backend/null_qubit/null_qubit.toml
@@ -102,4 +102,4 @@ dynamic_qubit_management = false
 # in a single execution
 non_commuting_observables = true
 # Whether the device supports (arbitrary) initial state preparation.
-initial_state_prep = true
+initial_state_prep = false


### PR DESCRIPTION
**Context:**
The `null.qubit` device currently removes `StatePrep` operations that happen at the beginning of the circuit. This is intended as a feature to speed up simulators, but `null.qubit` doesn't actually simulate any gates. This can cause issues where the IRs do not match the expected value.

**Description of the Change:**
Updates `null.qubit` to no longer skip initial state preps.

**Benefits:**
`null.qubit` behaves in a more straightforward and expected way.

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-104048]