### PR TITLE
Fix a bug in `setup_dev_from_wheel` script

### DIFF
--- a/setup_dev_from_wheel.sh
+++ b/setup_dev_from_wheel.sh
@@ -53,8 +53,7 @@ checkout_nightly_build(){
 
     # Search for the commit corresponding to latest available Wheel at TestPyPI
     git log --grep="bump nightly version" | grep "commit" | cut -d " " -f 2 | while read -r NIGHTLY_BUMP; do
-        # The commit right before the nightly bump must have the same version as the Wheel
-        git checkout $NIGHTLY_BUMP^1; 
+        git checkout $NIGHTLY_BUMP; 
         export DIFF=$(diff $CATALYST_WHEEL/_version.py $CATALYST_FRONTEND_SRC/_version.py)
         if [ -z "${DIFF}" ]; then
             export CATALYST_WHEEL_COMMIT=$(git log -1 --format="%h")


### PR DESCRIPTION
**Context:**
`setup_dev_from_wheel` script aims to find the correct commit that corresponds to the latest PyPi release, however it checks out the parent commit of the nightly version bump commit which would have a lower version and hence fails to find the correct commit.  

**Description of the Change:**
changes the script to checkout the correct commit.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-104391]