### PR TITLE
Switch to using experimental_capture qjit kwarg instead of global `qml.capture.enabled()`

### DIFF
--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -77,6 +77,7 @@ def qjit(
     *,
     autograph=False,
     autograph_include=(),
+    experimental_capture=False,
     async_qnodes=False,
     target="binary",
     keep_intermediate=False,
@@ -698,7 +699,7 @@ class QJIT(CatalystCallable):
     def pre_compilation(self):
         """Perform pre-processing tasks on the Python function, such as AST transformations."""
         if self.compile_options.autograph:
-            if qml.capture.enabled():
+            if self.compile_options.experimental_capture:
                 if self.compile_options.autograph_include:
                     raise NotImplementedError(
                         "capture autograph does not yet support autograph_include."
@@ -731,7 +732,7 @@ class QJIT(CatalystCallable):
 
         dbg = debug_info("qjit_capture", self.user_function, args, kwargs)
 
-        if qml.capture.enabled():
+        if self.compile_options.experimental_capture:
             with Patcher(
                 (
                     jax._src.interpreters.partial_eval,  # pylint: disable=protected-access

--- a/frontend/catalyst/pipelines.py
+++ b/frontend/catalyst/pipelines.py
@@ -112,8 +112,12 @@ class CompileOptions:
             Default is ``None``.
         pass_plugins (Optional[Iterable[Path]]): List of paths to pass plugins.
         dialect_plugins (Optional[Iterable[Path]]): List of paths to dialect plugins.
+        experimental_capture (bool): If set to ``True``,
+            use PennyLane's experimental program capture capabilities
+            to capture the function for compilation.
     """
 
+    experimental_capture : bool = False
     verbose: Optional[bool] = False
     logfile: Optional[TextIOWrapper] = sys.stderr
     target: Optional[str] = "binary"

--- a/frontend/test/pytest.ini
+++ b/frontend/test/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
+markers = 
+    capture_only: marks tests for capture only
+    old_frontend: tests for capture off
 xfail_strict=true

--- a/frontend/test/pytest/conftest.py
+++ b/frontend/test/pytest/conftest.py
@@ -62,14 +62,16 @@ def use_capture():
 @pytest.fixture(scope="function")
 def use_capture_dgraph():
     """Enable capture and graph-decomposition before and disable them both after the test."""
-    qml.capture.enable()
     qml.decomposition.enable_graph()
     try:
         yield
     finally:
         qml.decomposition.disable_graph()
-        qml.capture.disable()
 
+
+@pytest.fixture(params=[True, False], scope="function")
+def experimental_capture(request):
+    yield request.param
 
 @pytest.fixture(params=["capture", "no_capture"], scope="function")
 def use_both_frontend(request):

--- a/frontend/test/pytest/from_plxpr/test_decompose_transform.py
+++ b/frontend/test/pytest/from_plxpr/test_decompose_transform.py
@@ -24,6 +24,8 @@ from pennylane.typing import TensorLike
 from pennylane.wires import WiresLike
 
 
+pytestmark = pytest.mark.capture_only
+
 class TestGraphDecomposition:
     """Test the new graph-based decomposition integration with from_plxpr."""
 
@@ -31,7 +33,7 @@ class TestGraphDecomposition:
     def test_with_multiple_decomps_transforms(self):
         """Test that a circuit with multiple decompositions and transforms can be converted."""
 
-        @qml.qjit(target="mlir")
+        @qml.qjit(target="mlir", experimental_capture=True)
         @partial(
             qml.transforms.decompose,
             gate_set={"RX", "RY"},
@@ -54,7 +56,7 @@ class TestGraphDecomposition:
     def test_fallback_warnings(self):
         """Test the fallback to legacy decomposition system with warnings."""
 
-        @qml.qjit
+        @qml.qjit(experimental_capture=True)
         @partial(qml.transforms.decompose, gate_set={qml.GlobalPhase})
         @qml.qnode(qml.device("lightning.qubit", wires=2))
         def circuit(x):
@@ -81,7 +83,7 @@ class TestGraphDecomposition:
             return qml.expval(qml.X(0))
 
         without_qjit = circuit()
-        with_qjit = qml.qjit(circuit)
+        with_qjit = qml.qjit(circuit, experimental_capture=True)
 
         assert qml.math.allclose(without_qjit, with_qjit())
 
@@ -110,7 +112,7 @@ class TestGraphDecomposition:
             qml.CNOT(wires=[0, 1])
             return qml.state()
 
-        qjited_circuit = qml.qjit(circuit)
+        qjited_circuit = qml.qjit(circuit, experimental_capture=True)
 
         expected = np.array([1, 0, 0, 1]) / np.sqrt(2)
         assert qml.math.allclose(qjited_circuit(), expected)
@@ -165,7 +167,7 @@ class TestGraphDecomposition:
             return qml.expval(qml.Z(0))
 
         without_qjit = circuit()
-        with_qjit = qml.qjit(circuit)
+        with_qjit = qml.qjit(circuit, experimental_capture=True)
 
         assert qml.math.allclose(without_qjit, with_qjit())
 
@@ -199,7 +201,7 @@ class TestGraphDecomposition:
         y = 0.3
 
         without_qjit = circuit(x, y)
-        with_qjit = qml.qjit(circuit)
+        with_qjit = qml.qjit(circuit, experimental_capture=True)
 
         assert qml.math.allclose(without_qjit, with_qjit(x, y))
         expected_resources = qml.specs(circuit, level="device")(x, y)["resources"].gate_types
@@ -221,7 +223,7 @@ class TestGraphDecomposition:
         z = 0.2
 
         without_qjit = circuit(x, y, z)
-        with_qjit = qml.qjit(circuit)
+        with_qjit = qml.qjit(circuit, experimental_capture=True)
 
         assert qml.math.allclose(without_qjit, with_qjit(x, y, z))
 
@@ -249,7 +251,7 @@ class TestGraphDecomposition:
             OSError,
             match="undefined symbol",  # ___catalyst__qis__RotXZX
         ):
-            qml.qjit(circuit)()
+            qml.qjit(circuit, experimental_capture=True)()
 
     @pytest.mark.usefixtures("use_capture_dgraph")
     def test_ftqc_rotxzx(self):
@@ -266,7 +268,7 @@ class TestGraphDecomposition:
             return qml.expval(qml.X(0))
 
         without_qjit = circuit()
-        with_qjit = qml.qjit(circuit)
+        with_qjit = qml.qjit(circuit, experimental_capture=True)
 
         assert qml.math.allclose(without_qjit, with_qjit())
 
@@ -293,7 +295,7 @@ class TestGraphDecomposition:
             return qml.expval(qml.X(0))
 
         without_qjit = circuit()
-        with_qjit = qml.qjit(circuit)
+        with_qjit = qml.qjit(circuit, experimental_capture=True)
 
         assert qml.math.allclose(without_qjit, with_qjit())
 
@@ -317,7 +319,7 @@ class TestGraphDecomposition:
             return qml.expval(qml.Z(0))
 
         without_qjit = circuit()
-        with_qjit = qml.qjit(circuit)
+        with_qjit = qml.qjit(circuit, experimental_capture=True)
 
         assert qml.math.allclose(without_qjit, with_qjit())
 
@@ -342,7 +344,7 @@ class TestGraphDecomposition:
             return qml.expval(qml.Z(0))
 
         without_qjit = circuit()
-        with_qjit = qml.qjit(circuit)
+        with_qjit = qml.qjit(circuit, experimental_capture=True)
         assert qml.math.allclose(without_qjit, with_qjit())
 
         expected_resources = qml.specs(circuit, level="device")()["resources"].gate_types
@@ -366,7 +368,7 @@ class TestGraphDecomposition:
             return qml.expval(qml.Z(0))
 
         without_qjit = circuit()
-        with_qjit = qml.qjit(circuit)
+        with_qjit = qml.qjit(circuit, experimental_capture=True)
 
         assert qml.math.allclose(without_qjit, with_qjit())
 
@@ -390,7 +392,7 @@ class TestGraphDecomposition:
             return qml.expval(qml.Z(0))
 
         without_qjit = circuit()
-        with_qjit = qml.qjit(circuit)
+        with_qjit = qml.qjit(circuit, experimental_capture=True)
 
         assert qml.math.allclose(without_qjit, with_qjit())
 
@@ -412,7 +414,7 @@ class TestGraphDecomposition:
             return qml.expval(qml.Z(0))
 
         without_qjit = circuit()
-        with_qjit = qml.qjit(circuit)
+        with_qjit = qml.qjit(circuit, experimental_capture=True)
 
         assert qml.math.allclose(without_qjit, with_qjit())
 
@@ -438,7 +440,7 @@ class TestGraphDecomposition:
             return qml.expval(qml.PauliX(0))
 
         without_qjit = circuit()
-        with_qjit = qml.qjit(circuit)
+        with_qjit = qml.qjit(circuit, experimental_capture=True)
 
         assert qml.math.allclose(without_qjit, with_qjit())
 
@@ -472,7 +474,7 @@ class TestGraphDecomposition:
         without_qjit = qml.transforms.decompose(circuit, gate_set={"RZ", "CNOT"})
         with_qjit = qml.qjit(
             qml.transforms.decompose(circuit, gate_set={"RZ", "CNOT"}), autograph=True
-        )
+        , experimental_capture=True)
 
         assert qml.math.allclose(without_qjit(), with_qjit())
 

--- a/frontend/test/pytest/from_plxpr/test_from_plxpr.py
+++ b/frontend/test/pytest/from_plxpr/test_from_plxpr.py
@@ -34,7 +34,7 @@ from catalyst.jax_primitives import (
     while_p,
 )
 
-pytestmark = pytest.mark.usefixtures("disable_capture")
+pytestmark = pytest.mark.capture_only
 
 
 def catalyst_execute_jaxpr(jaxpr):

--- a/frontend/test/pytest/from_plxpr/test_from_plxpr_qubit_handler.py
+++ b/frontend/test/pytest/from_plxpr/test_from_plxpr_qubit_handler.py
@@ -47,6 +47,8 @@ from catalyst.from_plxpr.qubit_handler import QubitHandler, QubitIndexRecorder
 from catalyst.jax_primitives import AbstractQbit, AbstractQreg, qalloc_p, qextract_p
 from catalyst.utils.exceptions import CompileError
 
+pytestmark = pytest.mark.capture_only
+
 
 @pytest.fixture(autouse=True)
 def launch_empty_jaxpr_interpreter():

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -705,8 +705,7 @@ class TestConditionals:
         assert circuit(3) == False
         assert circuit(6) == True
 
-    @pytest.mark.usefixtures("use_both_frontend")
-    def test_branch_return_mismatch(self, backend):
+    def test_branch_return_mismatch(self, backend, experimental_capture):
         """Test that an exception is raised when the true branch returns a value without an else
         branch.
         """
@@ -725,7 +724,7 @@ class TestConditionals:
         with pytest.raises(
             err_type, match="Some branches did not define a value for variable 'res'"
         ):
-            qjit(autograph=True)(qml.qnode(qml.device(backend, wires=1))(circuit))
+            qjit(autograph=True, experimental_capture=experimental_capture)(qml.qnode(qml.device(backend, wires=1))(circuit))
 
     def test_branch_no_multi_return_mismatch(self, backend):
         """Test that case when the return types of all branches do not match."""
@@ -816,11 +815,10 @@ class TestForLoops:
         assert isinstance(c_range._py_range, range)
         assert c_range[2] == 2
 
-    @pytest.mark.usefixtures("use_both_frontend")
-    def test_for_in_array(self):
+    def test_for_in_array(self, experimental_capture):
         """Test for loop over JAX array."""
 
-        @qjit(autograph=True)
+        @qjit(autograph=True, experimental_capture=experimental_capture)
         @qml.qnode(qml.device("lightning.qubit", wires=1))
         def f(params):
             for x in params:
@@ -830,11 +828,10 @@ class TestForLoops:
         result = f(jnp.array([0.0, 1 / 4 * jnp.pi, 2 / 4 * jnp.pi]))
         assert np.allclose(result, -jnp.sqrt(2) / 2)
 
-    @pytest.mark.usefixtures("use_both_frontend")
-    def test_for_in_array_unpack(self):
+    def test_for_in_array_unpack(self, experimental_capture):
         """Test for loop over a 2D JAX array unpacking the inner dimension."""
 
-        @qjit(autograph=True)
+        @qjit(autograph=True, experimental_capture=experimental_capture)
         @qml.qnode(qml.device("lightning.qubit", wires=1))
         def f(params):
             for x1, x2 in params:
@@ -845,11 +842,10 @@ class TestForLoops:
         result = f(jnp.array([[0.0, 1 / 4 * jnp.pi], [2 / 4 * jnp.pi, jnp.pi]]))
         assert np.allclose(result, jnp.sqrt(2) / 2)
 
-    @pytest.mark.usefixtures("use_both_frontend")
-    def test_for_in_numeric_list(self):
+    def test_for_in_numeric_list(self, experimental_capture):
         """Test for loop over a Python list that is convertible to an array."""
 
-        @qjit(autograph=True)
+        @qjit(autograph=True, experimental_capture=experimental_capture)
         @qml.qnode(qml.device("lightning.qubit", wires=1))
         def f():
             params = [0.0, 1 / 4 * jnp.pi, 2 / 4 * jnp.pi]
@@ -860,11 +856,10 @@ class TestForLoops:
         result = f()
         assert np.allclose(result, -jnp.sqrt(2) / 2)
 
-    @pytest.mark.usefixtures("use_both_frontend")
-    def test_for_in_numeric_list_of_list(self):
+    def test_for_in_numeric_list_of_list(self, experimental_capture):
         """Test for loop over a nested Python list that is convertible to an array."""
 
-        @qjit(autograph=True)
+        @qjit(autograph=True, experimental_capture=experimental_capture)
         @qml.qnode(qml.device("lightning.qubit", wires=1))
         def f():
             params = [[0.0, 1 / 4 * jnp.pi], [2 / 4 * jnp.pi, jnp.pi]]

--- a/frontend/test/pytest/test_dynamic_qubit_allocation.py
+++ b/frontend/test/pytest/test_dynamic_qubit_allocation.py
@@ -30,13 +30,13 @@ from catalyst.jax_primitives import subroutine
 from catalyst.utils.exceptions import CompileError
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 def test_basic_dynamic_wire_alloc_plain_API(backend):
     """
     Test basic qml.allocate and qml.deallocate.
     """
 
-    @qjit
+    @qjit(experimental_capture=True)
     @qml.qnode(qml.device(backend, wires=3))
     def circuit():
         qml.X(1)  # |010>
@@ -54,13 +54,13 @@ def test_basic_dynamic_wire_alloc_plain_API(backend):
     assert np.allclose(expected, observed)
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 def test_basic_dynamic_wire_alloc_ctx_API(backend):
     """
     Test basic qml.allocate with context manager API.
     """
 
-    @qjit
+    @qjit(experimental_capture=True)
     @qml.qnode(qml.device(backend, wires=3))
     def circuit():
         qml.X(1)
@@ -77,13 +77,13 @@ def test_basic_dynamic_wire_alloc_ctx_API(backend):
     assert np.allclose(expected, observed)
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 def test_measure(backend):
     """
     Test qml.allocate with qml.Measure ops.
     """
 
-    @qjit(autograph=True)
+    @qjit(autograph=True, experimental_capture=True)
     @qml.qnode(qml.device(backend, wires=1))
     def circuit():
         with qml.allocate(1) as q:
@@ -101,13 +101,13 @@ def test_measure(backend):
     assert np.allclose(expected, observed)
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 def test_measure_with_reset(backend):
     """
     Test qml.allocate with qml.Measure ops with resetting.
     """
 
-    @qjit(autograph=True)
+    @qjit(autograph=True, experimental_capture=True)
     @qml.qnode(qml.device(backend, wires=1))
     def circuit():
         with qml.allocate(1) as q:
@@ -131,14 +131,14 @@ def test_measure_with_reset(backend):
     assert np.allclose(expected, observed)
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 @pytest.mark.parametrize("ctrl_val, expected", [(False, [0, 1]), (True, [1, 0])])
 def test_qml_ctrl(ctrl_val, expected, backend):
     """
     Test qml.allocate with qml.ctrl ops.
     """
 
-    @qjit
+    @qjit(experimental_capture=True)
     @qml.qnode(qml.device(backend, wires=1))
     def circuit():
         with qml.allocate(1) as q:
@@ -150,13 +150,13 @@ def test_qml_ctrl(ctrl_val, expected, backend):
     assert np.allclose(expected, observed)
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 def test_QubitUnitary(backend):
     """
     Test qml.allocate with qml.QubitUnitary ops.
     """
 
-    @qjit
+    @qjit(experimental_capture=True)
     @qml.qnode(qml.device(backend, wires=1))
     def circuit():
         with qml.allocate(2) as qs:
@@ -169,13 +169,13 @@ def test_QubitUnitary(backend):
     assert np.allclose(expected, observed)
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 def test_StatePrep(backend):
     """
     Test qml.allocate with qml.StatePrep ops.
     """
 
-    @qjit
+    @qjit(experimental_capture=True)
     @qml.qnode(qml.device(backend, wires=1))
     def circuit():
         with qml.allocate(1) as q:
@@ -188,13 +188,13 @@ def test_StatePrep(backend):
     assert np.allclose(expected, observed)
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 def test_BasisState(backend):
     """
     Test qml.allocate with qml.BasisState ops.
     """
 
-    @qjit
+    @qjit(experimental_capture=True)
     @qml.qnode(qml.device(backend, wires=1))
     def circuit():
         with qml.allocate(1) as q:
@@ -207,14 +207,14 @@ def test_BasisState(backend):
     assert np.allclose(expected, observed)
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 @pytest.mark.parametrize("cond, expected", [(True, [0, 0, 1, 0]), (False, [0, 1, 0, 0])])
 def test_dynamic_wire_alloc_cond(cond, expected, backend):
     """
     Test qml.allocate and qml.deallocate inside cond.
     """
 
-    @qjit(autograph=True)
+    @qjit(autograph=True, experimental_capture=True)
     @qml.qnode(qml.device(backend, wires=2))
     def circuit(c):
         if c:
@@ -235,14 +235,14 @@ def test_dynamic_wire_alloc_cond(cond, expected, backend):
     assert np.allclose(expected, observed)
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 @pytest.mark.parametrize("cond, expected", [(True, [0, 1, 0, 0]), (False, [1, 0, 0, 0])])
 def test_dynamic_wire_alloc_cond_outside(cond, expected, backend):
     """
     Test passing dynamically allocated wires into a cond.
     """
 
-    @qjit(autograph=True)
+    @qjit(autograph=True, experimental_capture=True)
     @qml.qnode(qml.device(backend, wires=2))
     def circuit(c):
         with qml.allocate(1) as q1:
@@ -260,7 +260,7 @@ def test_dynamic_wire_alloc_cond_outside(cond, expected, backend):
     assert np.allclose(expected, observed)
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 @pytest.mark.parametrize(
     "num_iter, expected", [(3, [0, 0, 1, 0, 0, 0, 0, 0]), (4, [1, 0, 0, 0, 0, 0, 0, 0])]
 )
@@ -269,7 +269,7 @@ def test_dynamic_wire_alloc_forloop(num_iter, expected, backend):
     Test qml.allocate and qml.deallocate inside for loop.
     """
 
-    @qjit(autograph=True)
+    @qjit(autograph=True, experimental_capture=True)
     @qml.qnode(qml.device(backend, wires=3))
     def circuit(N):
         for _ in range(N):
@@ -285,13 +285,13 @@ def test_dynamic_wire_alloc_forloop(num_iter, expected, backend):
     assert np.allclose(expected, observed)
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 def test_dynamic_wire_alloc_forloop_outside(backend):
     """
     Test passing dynamically allocated wires into a for loop.
     """
 
-    @qjit(autograph=True)
+    @qjit(autograph=True, experimental_capture=True)
     @qml.qnode(qml.device(backend, wires=1))
     def circuit():
         with qml.allocate(1) as q:
@@ -307,13 +307,13 @@ def test_dynamic_wire_alloc_forloop_outside(backend):
     assert np.allclose(expected, observed)
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 def test_dynamic_wire_alloc_forloop_outside_multiple_regs(backend):
     """
     Test using multiple dynamically allocated registers from inside for loop.
     """
 
-    @qjit(autograph=True)
+    @qjit(autograph=True, experimental_capture=True)
     @qml.qnode(qml.device(backend, wires=1))
     def circuit():
         with qml.allocate(1) as q1:
@@ -330,7 +330,7 @@ def test_dynamic_wire_alloc_forloop_outside_multiple_regs(backend):
     assert np.allclose(expected, observed)
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 @pytest.mark.parametrize(
     "num_iter, expected", [(3, [0, 0, 1, 0, 0, 0, 0, 0]), (4, [1, 0, 0, 0, 0, 0, 0, 0])]
 )
@@ -339,7 +339,7 @@ def test_dynamic_wire_alloc_whileloop(num_iter, expected, backend):
     Test qml.allocate and qml.deallocate inside while loop.
     """
 
-    @qjit(autograph=True)
+    @qjit(autograph=True, experimental_capture=True)
     @qml.qnode(qml.device(backend, wires=3))
     def circuit(N):
         i = 0
@@ -357,14 +357,14 @@ def test_dynamic_wire_alloc_whileloop(num_iter, expected, backend):
     assert np.allclose(expected, observed)
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 @pytest.mark.parametrize("num_iter, expected", [(3, [0, 1, 0, 0]), (4, [1, 0, 0, 0])])
 def test_dynamic_wire_alloc_whileloop_outside(num_iter, expected, backend):
     """
     Test passing dynamically allocated wires into a while loop.
     """
 
-    @qjit(autograph=True)
+    @qjit(autograph=True, experimental_capture=True)
     @qml.qnode(qml.device(backend, wires=2))
     def circuit(N):
         i = 0
@@ -383,7 +383,7 @@ def test_dynamic_wire_alloc_whileloop_outside(num_iter, expected, backend):
     assert np.allclose(expected, observed)
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 @pytest.mark.parametrize("flip_again, expected", [(True, [1, 0]), (False, [0, 1])])
 def test_subroutine(flip_again, expected, backend):
     """
@@ -395,7 +395,7 @@ def test_subroutine(flip_again, expected, backend):
         qml.X(w)
         qml.CNOT(wires=[w, 0])
 
-    @qjit
+    @qjit(experimental_capture=True)
     @qml.qnode(qml.device(backend, wires=1))
     def circuit():
         with qml.allocate(1) as q1:
@@ -409,7 +409,7 @@ def test_subroutine(flip_again, expected, backend):
     assert np.allclose(expected, observed)
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 def test_subroutine_multiple_args(backend):
     """
     Test passing dynamically allocated wires into a subroutine with multiple arguments.
@@ -421,7 +421,7 @@ def test_subroutine_multiple_args(backend):
         qml.X(w2)
         qml.ctrl(qml.RX, (w1, w2))(theta, wires=0)
 
-    @qjit
+    @qjit(experimental_capture=True)
     @qml.qnode(qml.device(backend, wires=1))
     def circuit():
         with qml.allocate(1) as q1:
@@ -434,6 +434,7 @@ def test_subroutine_multiple_args(backend):
     assert np.allclose(expected, observed)
 
 
+@pytest.mark.old_frontend
 def test_no_capture(backend):
     """
     Test error message when used without capture.
@@ -443,7 +444,7 @@ def test_no_capture(backend):
         match=re.escape("qml.allocate() is only supported with program capture enabled."),
     ):
 
-        @qjit
+        @qjit(experimental_capture=False)
         @qml.qnode(qml.device(backend, wires=1))
         def circuit():
             with qml.allocate(1) as _:
@@ -451,7 +452,7 @@ def test_no_capture(backend):
             return qml.probs(wires=[0])
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 def test_use_after_free(backend):
     """
     Test error message when used after free.
@@ -462,7 +463,7 @@ def test_use_after_free(backend):
         match="Deallocated qubits cannot be used, but used in Hadamard.",
     ):
 
-        @qjit
+        @qjit(experimental_capture=True)
         @qml.qnode(qml.device(backend, wires=1))
         def circuit():
             with qml.allocate(1) as q:
@@ -471,7 +472,7 @@ def test_use_after_free(backend):
             return qml.probs(wires=[0])
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 def test_terminal_MP_all_wires(backend):
     """
     Test error message when used with terminal measurements on all wires.
@@ -487,7 +488,7 @@ def test_terminal_MP_all_wires(backend):
         ),
     ):
 
-        @qjit
+        @qjit(experimental_capture=True)
         @qml.qnode(qml.device(backend, wires=1))
         def circuit():
             with qml.allocate(1) as _:
@@ -495,7 +496,7 @@ def test_terminal_MP_all_wires(backend):
             return qml.probs()
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 def test_terminal_MP_dynamic_wires(backend):
     """
     Test error message when used with terminal measurements on dynamic wires.
@@ -511,14 +512,14 @@ def test_terminal_MP_dynamic_wires(backend):
         ),
     ):
 
-        @qjit
+        @qjit(experimental_capture=True)
         @qml.qnode(qml.device(backend, wires=1))
         def circuit():
             q = qml.allocate(1)
             return qml.probs(q)
 
 
-@pytest.mark.usefixtures("use_capture")
+@pytest.mark.capture_only
 def test_unsupported_adjoint(backend):
     """
     Test that an error is raised when a dynamically allocated wire is passed into a adjoint.
@@ -529,7 +530,7 @@ def test_unsupported_adjoint(backend):
         match="Dynamically allocated wires cannot be used in quantum adjoints yet.",
     ):
 
-        @qjit
+        @qjit(experimental_capture=True)
         @qml.qnode(qml.device(backend, wires=2))
         def circuit():
             with qml.allocate(1) as q:

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -901,13 +901,14 @@ class TestDefaultAvailableIR:
         assert g.mlir_opt
         assert "__catalyst__qis" in g.mlir_opt
 
-    @pytest.mark.usefixtures("use_capture", "requires_xdsl")
+    @pytest.mark.capture_only
+    @pytest.mark.usefixtures("requires_xdsl")
     def test_mlir_opt_using_xdsl_passes(self, backend):
         """Test mlir opt using xDSL passes."""
         # pylint: disable-next=import-outside-toplevel
         from pennylane.compiler.python_compiler.transforms import iterative_cancel_inverses_pass
 
-        @qjit
+        @qjit(experimental_capture=True)
         @iterative_cancel_inverses_pass
         @qml.qnode(qml.device(backend, wires=1))
         def f():


### PR DESCRIPTION
**Context:**

This PR is basically just to revert #1657 .... 

We are currently using the global `qml.capture.enabled()` kwarg to figure out if we are using the new frontend.

The problem is that the global toggle controls both catalyst's frontend and how pennylane executes. But executing normal qnodes when capture is enabled is an unmaintained experimental feature.  So we need to separate out using the program capture frontend in catalyst and executing with program capture in PennyLane.

**Description of the Change:**

Adds the `experimental_capture` kwarg back onto `QJIT`.

Updates tests. So many tests.

**Benefits:**

We can turn program capture on with catalyst with also turning it on in pennylane executions.

**Possible Drawbacks:**

So many tests... Also just reverting something we had earlier 🤦‍♀️ 

**Related GitHub Issues:**
