### PR TITLE
Merge rotation fix

### DIFF
--- a/mlir/lib/Quantum/Transforms/MergeRotationsPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/MergeRotationsPatterns.cpp
@@ -343,9 +343,10 @@ struct MergePPRRewritePattern : public OpRewritePattern<PPRotationOp> {
         }
 
         // verify that prevOp agrees on all qubits, not just the first
-        ValueRange outQubits = prevOp.getOutQubits();
-        if (outQubits != inQubits) {
-            return failure();
+        for (auto qubit : inQubits) {
+            if (qubit.getDefiningOp() != prevOp) {
+                return failure();
+            }
         }
 
         // check same pauli strings


### PR DESCRIPTION
**Context:**
Previous PR had comparison of mismatched types which errored on wheel build.

**Description of the Change:**
This explicitly types for valid comparison.
