### PR TITLE
Fix uninitialized int in RTIO dialect for building wheel

### DIFF
--- a/mlir/lib/RTIO/IR/RTIODialect.cpp
+++ b/mlir/lib/RTIO/IR/RTIODialect.cpp
@@ -73,7 +73,7 @@ static ParseResult parseChannelTypeBody(AsmParser &parser, std::string &kind, Ar
         return success();
     }
 
-    int64_t id;
+    int64_t id = -1;
     if (failed(parser.parseInteger(id))) {
         return failure();
     }


### PR DESCRIPTION
**Context:**

**Description of the Change:**

`int64_t id; ` to `int64_t id = -1;`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
