### PR TITLE
`clean-dialect-docs` should remove the entire dialect docs build

### DIFF
--- a/mlir/Makefile
+++ b/mlir/Makefile
@@ -247,7 +247,7 @@ clean-plugin:
 
 clean-dialect-docs:
 	@echo "clean dialect docs"
-	rm -rf $(DIALECTS_DOCS_BUILD_DIR)/docs
+	rm -rf $(DIALECTS_DOCS_BUILD_DIR)
 
 .PHONY: format
 format:


### PR DESCRIPTION
**Context:**
`make clean-dialect-docs` should remove the entire dialect docs build directory, instead of just a subdirectory inside.

**Benefits:**
Cleaning works.
Otherwise, the cmake files from the previous builds are still in the build directory.
