### PR TITLE
Issue #1744: Some comments on Accelerate LAPACKE integration

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -75,7 +75,8 @@ add_subdirectory(tests)
 
 if(APPLE AND (${CMAKE_SYSTEM_PROCESSOR} STREQUAL arm64))
 # Don't rerun external project everytime we configure the runtime build.
-if(NOT EXISTS ${CMAKE_BINARY_DIR}/lib/liblapacke.3.dylib)
+find_package(LAPACKE CONFIG PATHS "${CMAKE_BINARY_DIR}/_lapacke-accelerate/install" NO_DEFAULT_PATH)
+if(NOT LAPACKE_FOUND)
     if(CMAKE_OSX_SYSROOT)
         get_filename_component(OSX_SDK_PATH ${CMAKE_OSX_SYSROOT} REALPATH)
     else()
@@ -106,11 +107,10 @@ if(NOT EXISTS ${CMAKE_BINARY_DIR}/lib/liblapacke.3.dylib)
                    "-DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/_lapacke-accelerate/install"
                    "-DCMAKE_OSX_SYSROOT=${OSX_SDK_PATH}"
         INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install
-        COMMAND cp ${CMAKE_BINARY_DIR}/_lapacke-accelerate/install/lib/liblapacke.3.dylib ${CMAKE_BINARY_DIR}/lib
         LOG_CONFIGURE ON
         LOG_INSTALL ON
         LOG_BUILD ON
     )
     add_dependencies(rt_capi lapacke-accelerate)  # automatically build with the runtime
-endif()
-endif()
+endif()  # if(NOT LAPACKE_FOUND)
+endif()  # if(APPLE AND (${CMAKE_SYSTEM_PROCESSOR} STREQUAL arm64))

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -101,7 +101,7 @@ if(NOT LAPACKE_FOUND)
 
     ExternalProject_Add(lapacke-accelerate
         GIT_REPOSITORY https://github.com/lepus2589/accelerate-lapacke.git
-        GIT_TAG 6cf628bd8c169fe3753555f593a8a1ddf0a124a1  # v2.0.0
+        GIT_TAG v2.0.0
         PREFIX _lapacke-accelerate
         CMAKE_ARGS "--preset accelerate-lapacke32"
                    "-DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/_lapacke-accelerate/install"

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -100,7 +100,7 @@ if(NOT EXISTS ${CMAKE_BINARY_DIR}/lib/liblapacke.3.dylib)
 
     ExternalProject_Add(lapacke-accelerate
         GIT_REPOSITORY https://github.com/lepus2589/accelerate-lapacke.git
-        GIT_TAG master
+        GIT_TAG 6cf628bd8c169fe3753555f593a8a1ddf0a124a1  # v2.0.0
         PREFIX _lapacke-accelerate
         CMAKE_ARGS "--preset accelerate-lapacke32"
                    "-DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/_lapacke-accelerate/install"

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -74,9 +74,6 @@ add_subdirectory(lib)
 add_subdirectory(tests)
 
 if(APPLE AND (${CMAKE_SYSTEM_PROCESSOR} STREQUAL arm64))
-# Don't rerun external project everytime we configure the runtime build.
-find_package(LAPACKE CONFIG PATHS "${CMAKE_BINARY_DIR}/_lapacke-accelerate/install" NO_DEFAULT_PATH)
-if(NOT LAPACKE_FOUND)
     if(CMAKE_OSX_SYSROOT)
         get_filename_component(OSX_SDK_PATH ${CMAKE_OSX_SYSROOT} REALPATH)
     else()
@@ -99,18 +96,21 @@ if(NOT LAPACKE_FOUND)
         endif()
     endif()
 
+    # Let CMake figure out, if rebuilding the external project is necessary
     ExternalProject_Add(lapacke-accelerate
         GIT_REPOSITORY https://github.com/lepus2589/accelerate-lapacke.git
         GIT_TAG v2.0.0
         PREFIX _lapacke-accelerate
-        CMAKE_ARGS "--preset accelerate-lapacke32"
-                   "-DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/_lapacke-accelerate/install"
+        INSTALL_DIR _lapacke-accelerate/install
+        CMAKE_ARGS "--preset" "accelerate-lapacke32"
+                   "-DCMAKE_STAGING_PREFIX=<INSTALL_DIR>"
+                   "-DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/lib"
                    "-DCMAKE_OSX_SYSROOT=${OSX_SDK_PATH}"
-        INSTALL_COMMAND ${CMAKE_COMMAND} --build . --target install
+        INSTALL_COMMAND "${CMAKE_COMMAND}" --build <BINARY_DIR> --target install
+        COMMAND "${CMAKE_COMMAND}" -E copy_if_different "<INSTALL_DIR>/lib/liblapacke.3.dylib" "${CMAKE_BINARY_DIR}/lib"
         LOG_CONFIGURE ON
         LOG_INSTALL ON
         LOG_BUILD ON
     )
     add_dependencies(rt_capi lapacke-accelerate)  # automatically build with the runtime
-endif()  # if(NOT LAPACKE_FOUND)
 endif()  # if(APPLE AND (${CMAKE_SYSTEM_PROCESSOR} STREQUAL arm64))


### PR DESCRIPTION
**Context:**
This PR addresses @lepus2589 [comments](https://github.com/PennyLaneAI/catalyst/issues/1744#issue-3062490330) from issue 1744.

**Description of the Change:**
Use `find_package(LAPACKE)`.
Use a tag (v2.0.0) instead of referencin the `master` branch.
Remove check for `EXISTS ${CMAKE_BINARY_DIR}/lib/liblapacke.3.dylib`
Remove copy of `liblapacke.3.dylib` to `${CMAKE_BINARY_DIR}/lib`.

**Benefits:**
Rely on `find_package` to check if LAPACKE library has to be downloaded.
Reference a stable LAPACKE library version.
Remove an unnecessary copy of a dynamic library.

**Possible Drawbacks:**
This PR has to be tested on Apple/ARM64, which I couldn't do.

**Related GitHub Issues:**
#1744