### PR TITLE
Update rcrcrc action to point to the 0.14/0.44 versions

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -44,7 +44,7 @@ jobs:
         # was built and uploaded to TestPyPI, so that the tests are the compatible ones
         # to be run with the latest rc/rc/rc packges on TestPyPI.
         # This would be the last autobump-and-upload commit made on the rc branch.
-        git checkout v0.13.0-rc
+        git checkout v0.14.0-rc
         git checkout "$(git log -1 --author="ringo-but-quantum" --pretty=format:%H)"
 
     - name: Set up Python
@@ -139,7 +139,7 @@ jobs:
         # Thus this one shouldn't have no-deps: it needs to pull in all PL dependencies
         jax_version=$(grep jax .dep-versions | awk -F '=' '{ print $2 }')
         pip install jax==$jax_version
-        pip install --pre -U --index-url https://test.pypi.org/simple/ pennylane-catalyst'<=0.13.0'
+        pip install --pre -U --index-url https://test.pypi.org/simple/ pennylane-catalyst'<=0.14.0'
 
     - name: Install PennyLane-Lightning (stable)
       if: ${{ inputs.lightning == 'stable' }}
@@ -159,8 +159,8 @@ jobs:
     - name: Install PennyLane-Lightning (release-candidate)
       if: ${{ inputs.lightning == 'release-candidate' }}
       run: |
-        pip install --no-deps --pre -U --index-url https://test.pypi.org/simple/ pennylane-lightning'<=0.43.0'
-        pip install --no-deps --pre -U --index-url https://test.pypi.org/simple/ pennylane-lightning-kokkos'<=0.43.0'
+        pip install --no-deps --pre -U --index-url https://test.pypi.org/simple/ pennylane-lightning'<=0.44.0'
+        pip install --no-deps --pre -U --index-url https://test.pypi.org/simple/ pennylane-lightning-kokkos'<=0.44.0'
 
     # PennyLane doesn't update its dev version number on every commit like Lightning, so we need to
     # force the package to be re-installed. First, handle potential dependency changes, then force
@@ -178,7 +178,7 @@ jobs:
     - name: Install PennyLane (release-candidate)
       if: ${{ inputs.pennylane == 'release-candidate' }}
       run: |
-        pip install --no-deps --pre -U --index-url https://test.pypi.org/simple/ pennylane'<=0.43.0'
+        pip install --no-deps --pre -U --index-url https://test.pypi.org/simple/ pennylane'<=0.44.0'
 
     - name: Add Frontend Dependencies to PATH
       if: ${{ inputs.catalyst == 'latest' }}


### PR DESCRIPTION
**Context:**
In preparation for the Catalyst v0.14.0-rc release candidate (RC), the GitHub action must point to the corresponding RC branches of Catalyst, Pennylane, and Lightning.

**Description of the Change:**
Update the Catalyst RC branch v0.13.0-rc -> v0.14.0-rc, as well as the corresponding RC packages for Lightning and PennyLane from v0.43 versions to v0.44 versions.