### PR TITLE
Install RC PL and Lightning when on RC branch

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -30,7 +30,14 @@ matplotlib==3.10.0
 lxml_html_clean
 
 # Pre-install PL development wheels
---extra-index-url https://test.pypi.org/simple/
-pennylane-lightning-kokkos==0.44.0-dev26
-pennylane-lightning==0.44.0-dev26
-pennylane==0.44.0-dev72
+# --extra-index-url https://test.pypi.org/simple/
+# pennylane-lightning-kokkos==0.44.0-dev26
+# pennylane-lightning==0.44.0-dev26
+# pennylane==0.44.0-dev72
+
+# If targeting RC branch, we must install latest RC packages from TestPyPI
+# Revert when merging RC branch back to main, and uncomment the above regular requirements
+--pre --extra-index-url https://test.pypi.org/simple/
+pennylane-lightning-kokkos>=0.44.0rc0,<=0.44.0
+pennylane-lightning>=0.44.0rc0,<=0.44.0
+pennylane>=0.44.0rc0,<=0.44.0

--- a/setup.py
+++ b/setup.py
@@ -121,7 +121,7 @@ else:
     lightning_dep = f"pennylane-lightning>={lq_min_release}"
     kokkos_dep = ""
 
-# On if targeting RC branch, we must install latest RC packages from TestPyPI
+# If targeting RC branch, we must install latest RC packages from TestPyPI
 # Revert when merging RC branch back to main
 pennylane_dep = f"pennylane>=0.44.0rc0,<=0.44.0"
 lightning_dep = f"pennylane-lightning>=0.44.0rc0,<=0.44.0"


### PR DESCRIPTION
**Context:**
In `setup.py`, we install RC PL and Lightning packages. This only occurs for the rc branch.
For PRs targeting RC branch as base, locally `make frontend` will now automatically install RC PL and Lightning! 

Note that starting from the previous release, we sync all versioning from testpypi. There will be no more git-based installations.

Note that when merging rc branch back to main after the release, this PR must be reverted for .dep_versions to take back control of the versions.