### PR TITLE
Prepare for the next development cycle (v15)

### DIFF
--- a/.github/workflows/build-nightly-release-candidate.yaml
+++ b/.github/workflows/build-nightly-release-candidate.yaml
@@ -2,14 +2,14 @@ name: Build Release Branch Nightly for TestPyPI
 
 on:
   schedule:
-    # Run from October 7th to October 12th at 02:00 UTC (10:00 PM EDT)
-    - cron: "0 2 7-12 10 *"
+    # Run from Jan 6th to Jan 11th at 02:00 UTC (10:00 PM EDT)
+    - cron: "0 2 6-11 1 *"
   workflow_dispatch:
     inputs:
       branch:
         description: 'Branch to build from'
         required: true
-        default: 'v0.13.0-rc'
+        default: 'v0.14.0-rc'
 
 jobs:
   setup:
@@ -20,7 +20,7 @@ jobs:
     steps:
     - name: Set branch
       id: set_branch
-      run: echo "branch=${{ github.event.inputs.branch || 'v0.13.0-rc' }}" >> $GITHUB_OUTPUT
+      run: echo "branch=${{ github.event.inputs.branch || 'v0.14.0-rc' }}" >> $GITHUB_OUTPUT
 
     - name: Checkout Catalyst repo release branch
       uses: actions/checkout@v4

--- a/doc/dev/release_notes.rst
+++ b/doc/dev/release_notes.rst
@@ -3,6 +3,8 @@ Release notes
 
 This page contains the release notes for Catalyst.
 
+.. mdinclude:: ../releases/changelog-dev.md
+
 .. mdinclude:: ../releases/changelog-0.14.0.md
 
 .. mdinclude:: ../releases/changelog-0.13.0.md

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1,0 +1,19 @@
+# Release 0.15.0 (development release)
+
+<h3>New features since last release</h3>
+
+<h3>Improvements 🛠</h3>
+
+<h3>Breaking changes 💔</h3>
+
+<h3>Deprecations 👋</h3>
+
+<h3>Bug fixes 🐛</h3>
+
+<h3>Internal changes ⚙️</h3>
+
+<h3>Documentation 📝</h3>
+
+<h3>Contributors ✍️</h3>
+
+This release contains contributions from (in alphabetical order):

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.14.0"
+__version__ = "0.15.0-dev0"


### PR DESCRIPTION
Context: Setting up the repository for the next development cycle after v14 release.

Description of the Change:

- Add new changelog-dev.md file for v0.15.0
- Add changelog-dev reference to release_notes.rst
- Update version in _version.py to 0.15.0-dev0
- Update build-nightly-release-candidate.yaml's schedule for this release