### PR TITLE
Fix the PauliRot decompose-lowering flaky tests

### DIFF
--- a/frontend/test/pytest/from_plxpr/test_decompose_transform.py
+++ b/frontend/test/pytest/from_plxpr/test_decompose_transform.py
@@ -257,7 +257,7 @@ class TestGraphDecomposition:
 
         @partial(
             qml.transforms.decompose,
-            gate_set={qml.CNOT, qml.GlobalPhase, qml.RX, qml.RZ},
+            gate_set={qml.CNOT: 1, qml.GlobalPhase: 1, qml.RX: 1, qml.RZ: 1, "PauliRot": 100},
         )
         @qml.qnode(qml.device("lightning.qubit", wires=2))
         def circuit():
@@ -375,16 +375,13 @@ class TestGraphDecomposition:
         resources = qml.specs(with_qjit, level="device")()["resources"].gate_types
         assert resources == expected_resources
 
-    @pytest.mark.skip(
-        reason="Graph decomp might hit PauliRot, which doesn't have a runtime stub yet."
-    )
     @pytest.mark.usefixtures("use_capture_dgraph")
     def test_ctrl(self):
         """Test the decompose lowering pass with controlled operations."""
 
         @partial(
             qml.transforms.decompose,
-            gate_set={"RX", "RZ", "H", "CZ"},
+            gate_set={"RX": 1, "RZ": 1, "H": 1, "CZ": 1, "PauliRot": 100},
         )
         @qml.qnode(qml.device("lightning.qubit", wires=2))
         def circuit():
@@ -402,16 +399,13 @@ class TestGraphDecomposition:
         resources = qml.specs(with_qjit, level="device")()["resources"].gate_types
         assert resources == expected_resources
 
-    @pytest.mark.skip(
-        reason="Graph decomp might hit PauliRot, which doesn't have a runtime stub yet."
-    )
     @pytest.mark.usefixtures("use_capture_dgraph")
     def test_template_qft(self):
         """Test the decompose lowering pass with the QFT template."""
 
         @partial(
             qml.transforms.decompose,
-            gate_set={"RX", "RY", "CNOT", "GlobalPhase"},
+            gate_set={"RX": 1, "RY": 1, "CNOT": 1, "GlobalPhase": 1, "PauliRot": 100},
         )
         @qml.qnode(qml.device("lightning.qubit", wires=4))
         def circuit():


### PR DESCRIPTION
**Context:**
Fix the PauliRot decompose-lowering flaky tests by adding a higher cost for `PauliRot` in the target geteset. This will avoid decomposition-rules with `PauliRot` to be picked by the graph as the optimal pathway for decomposition. We have to revert this after adding LLVM lowering for `quantum.paulirot` (sc-107501).

**Description of the Change:**

**Benefits:**
- Battle dynamism in the graph decomposition for pathways with `PauliRot`

**Possible Drawbacks:**
- YABA (Yet another band-aid) :crying_cat_face: 

**Related GitHub Issues:**

[sc-107498]