### PR TITLE
Refactor quantum dialect type declarations

### DIFF
--- a/mlir/include/MBQC/IR/MBQCOps.td
+++ b/mlir/include/MBQC/IR/MBQCOps.td
@@ -19,6 +19,7 @@ include "mlir/IR/AttrTypeBase.td"
 include "mlir/IR/EnumAttr.td"
 
 include "Quantum/IR/QuantumDialect.td"
+include "Quantum/IR/QuantumTypes.td"
 
 include "MBQC/IR/MBQCDialect.td"
 

--- a/mlir/include/PauliFrame/IR/PauliFrameOps.td
+++ b/mlir/include/PauliFrame/IR/PauliFrameOps.td
@@ -18,6 +18,7 @@
 include "mlir/IR/EnumAttr.td"
 
 include "Quantum/IR/QuantumDialect.td"
+include "Quantum/IR/QuantumTypes.td"
 include "PauliFrame/IR/PauliFrameDialect.td"
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/QEC/IR/QECOps.td
+++ b/mlir/include/QEC/IR/QECOps.td
@@ -20,6 +20,7 @@ include "mlir/Interfaces/ControlFlowInterfaces.td"  // for ReturnLike
 include "mlir/Interfaces/SideEffectInterfaces.td" // for Pure
 
 include "Quantum/IR/QuantumDialect.td"
+include "Quantum/IR/QuantumTypes.td"
 include "QEC/IR/QECDialect.td"
 include "QEC/IR/QECOpInterfaces.td"
 

--- a/mlir/include/Quantum/IR/CMakeLists.txt
+++ b/mlir/include/Quantum/IR/CMakeLists.txt
@@ -4,6 +4,11 @@ add_mlir_doc(QuantumDialect QuantumDialect Quantum/ -gen-dialect-doc)
 add_mlir_doc(QuantumOps QuantumOps Quantum/ -gen-op-doc)
 add_mlir_doc(QuantumInterfaces QuantumInterfaces Quantum/ -gen-op-interface-docs)
 
+set(LLVM_TARGET_DEFINITIONS QuantumTypes.td)
+mlir_tablegen(QuantumTypes.h.inc -gen-typedef-decls)
+mlir_tablegen(QuantumTypes.cpp.inc -gen-typedef-defs)
+add_public_tablegen_target(MLIRQuantumTypesIncGen)
+
 set(LLVM_TARGET_DEFINITIONS QuantumOps.td)
 mlir_tablegen(QuantumEnums.h.inc -gen-enum-decls)
 mlir_tablegen(QuantumEnums.cpp.inc -gen-enum-defs)

--- a/mlir/include/Quantum/IR/QuantumDialect.td
+++ b/mlir/include/Quantum/IR/QuantumDialect.td
@@ -16,7 +16,6 @@
 #define QUANTUM_DIALECT
 
 include "mlir/IR/DialectBase.td"
-include "mlir/IR/AttrTypeBase.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 //===----------------------------------------------------------------------===//
@@ -49,28 +48,6 @@ def QuantumDialect : Dialect {
     /// Use the default type printing/parsing hooks, otherwise we would explicitly define them.
     let useDefaultTypePrinterParser = 1;
     let useDefaultAttributePrinterParser = 1;
-}
-
-//===----------------------------------------------------------------------===//
-// Quantum dialect types.
-//===----------------------------------------------------------------------===//
-
-class Quantum_Type<string name, string typeMnemonic, list<Trait> traits = []>
-        : TypeDef<QuantumDialect, name, traits> {
-    let mnemonic = typeMnemonic;
-}
-
-def QubitType : Quantum_Type<"Qubit", "bit"> {
-    let summary = "A value-semantic qubit (state).";
-}
-def QuregType : Quantum_Type<"Qureg", "reg"> {
-    let summary = "An array of value-semantic qubits (i.e. quantum register).";
-}
-def ObservableType : Quantum_Type<"Observable", "obs"> {
-    let summary = "A quantum observable for use in measurements.";
-}
-def ResultType : Quantum_Type<"Result", "res"> {
-    let summary = "A quantum measurement result.";
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -22,6 +22,7 @@ include "mlir/Interfaces/ControlFlowInterfaces.td"
 
 include "Quantum/IR/QuantumDialect.td"
 include "Quantum/IR/QuantumInterfaces.td"
+include "Quantum/IR/QuantumTypes.td"
 
 //===----------------------------------------------------------------------===//
 // Quantum dialect enums.

--- a/mlir/include/Quantum/IR/QuantumTypes.h
+++ b/mlir/include/Quantum/IR/QuantumTypes.h
@@ -1,0 +1,24 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+//===----------------------------------------------------------------------===//
+// Quantum type declarations.
+//===----------------------------------------------------------------------===//
+
+#include "mlir/IR/Types.h"
+
+#define GET_TYPEDEF_CLASSES
+#include "Quantum/IR/QuantumTypes.h.inc"

--- a/mlir/include/Quantum/IR/QuantumTypes.td
+++ b/mlir/include/Quantum/IR/QuantumTypes.td
@@ -1,0 +1,39 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+include "mlir/IR/AttrTypeBase.td"
+
+include "Quantum/IR/QuantumDialect.td"
+
+//===----------------------------------------------------------------------===//
+// Quantum dialect types.
+//===----------------------------------------------------------------------===//
+
+class Quantum_Type<string name, string typeMnemonic, list<Trait> traits = []>
+        : TypeDef<QuantumDialect, name, traits> {
+    let mnemonic = typeMnemonic;
+}
+
+def QubitType : Quantum_Type<"Qubit", "bit"> {
+    let summary = "A value-semantic qubit (state).";
+}
+def QuregType : Quantum_Type<"Qureg", "reg"> {
+    let summary = "An array of value-semantic qubits (i.e. quantum register).";
+}
+def ObservableType : Quantum_Type<"Observable", "obs"> {
+    let summary = "A quantum observable for use in measurements.";
+}
+def ResultType : Quantum_Type<"Result", "res"> {
+    let summary = "A quantum measurement result.";
+}


### PR DESCRIPTION
**Context:** Currently, the quantum dialect types are declared in TableGen in the same file scope as the dialect itself. It would simplify development when adding new types to have a more modular file structure with all quantum dialect types declared in a separate TableGen file (and corresponding header file).

**Description of the Change:** Moves the types defined in `Quantum/IR/QuantumDialect.td` to `Quantum/IR/QuantumTypes.td`. The build system and dialects that depend on these types have also been updated.

**Benefits:** More modular source code structure.

**Possible Drawbacks:** None.

[sc-107669]