### PR TITLE
fix SSS: Install `graphviz` for `stable` Catalyst

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -115,6 +115,7 @@ jobs:
     - name: Install Catalyst (stable)
       if: ${{ inputs.catalyst == 'stable' }}
       run: |
+        sudo apt-get install -y graphviz
         pip install pennylane-catalyst
 
     - name: Install Catalyst (latest)


### PR DESCRIPTION
Fixes S/S/S as `graphviz` installation was added to both `latest` and `rc` checks but `stable` was missed.

Tested here: github.com/PennyLaneAI/catalyst/actions/runs/20969778272 💚 