### PR TITLE
Bump lightning version

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -14,4 +14,4 @@ pennylane=0.45.0-dev1
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'
-lightning=0.45.0-dev1
+lightning=0.45.0-dev2

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -31,6 +31,6 @@ lxml_html_clean
 
 # Pre-install PL development wheels
 --extra-index-url https://test.pypi.org/simple/
-pennylane-lightning-kokkos==0.45.0-dev1
-pennylane-lightning==0.45.0-dev1
+pennylane-lightning-kokkos==0.45.0-dev2
+pennylane-lightning==0.45.0-dev2
 pennylane==0.45.0-dev1


### PR DESCRIPTION
**Context:**
Lightning version v0.45.0-dev1 is missing from testpypi for python 3.14, because the upload action was cancelled by a unfortunately-timed subsequent commit to `master` in lightning repo

<img width="1153" height="137" alt="image" src="https://github.com/user-attachments/assets/ad0d70ec-6f46-4025-852a-e89cb88a98c7" />

**Description of the Change:**
Use dev2
