### PR TITLE
fix: update import location of `Transform` (formerly known as `TransformDispatcher`)

### DIFF
--- a/frontend/catalyst/python_interface/pass_api/compiler_transform.py
+++ b/frontend/catalyst/python_interface/pass_api/compiler_transform.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Core API for registering xDSL transforms for use with PennyLane and Catalyst."""
 
-from pennylane.transforms.core import Transform 
+from pennylane.transforms.core import Transform
 from xdsl.passes import ModulePass
 
 from .apply_transform_sequence import register_pass


### PR DESCRIPTION
Importing from this specific file is making it annoying to rename the file here: https://github.com/PennyLaneAI/pennylane/pull/8906.

Minor update to how we are importing `Transform` (formerly known as `TransformDispatcher`).

[sc-105439]