### PR TITLE
fix: Update deprecated code to fix LLL

### DIFF
--- a/frontend/test/async_tests/test_async.py
+++ b/frontend/test/async_tests/test_async.py
@@ -83,7 +83,7 @@ def test_gradient(inp, diff_methods, backend):
     def interpreted(x):
         device = qml.device("default.qubit", wires=1)
         g = qml.QNode(f, device, diff_method="backprop")
-        h = qml.grad(g, argnum=0)
+        h = qml.grad(g, argnums=0)
         return h(x)
 
     assert "async_execute_fn" in compiled.qir


### PR DESCRIPTION
Fixes LLL by using the updated "argnums" argument rather than the deprecated "argnum" argument.

Testing here: https://github.com/PennyLaneAI/catalyst/actions/runs/21070356834