### PR TITLE
Catalyst docs - Changed URL to PBC from PPM

### DIFF
--- a/doc/releases/changelog-0.11.0.md
+++ b/doc/releases/changelog-0.11.0.md
@@ -62,7 +62,7 @@
   * :func:`catalyst.passes.ppr_to_ppm <~.passes.ppr_to_ppm>`: Absorb Clifford PPRs into terminal Pauli 
     product measurements (PPMs).
 
-  For more information on PPMs, please refer to our [PPM documentation page](https://pennylane.ai/compilation/pauli-based-computation).
+  For more information on PPMs, please refer to our [Pauli-based computation documentation page](https://pennylane.ai/compilation/pauli-based-computation).
 
 * Catalyst now supports qubit number-invariant compilation. That is, programs can be compiled without
   specifying the number of qubits to allocate ahead of time. Instead, the device can be supplied with

--- a/doc/releases/changelog-0.11.0.md
+++ b/doc/releases/changelog-0.11.0.md
@@ -62,7 +62,7 @@
   * :func:`catalyst.passes.ppr_to_ppm <~.passes.ppr_to_ppm>`: Absorb Clifford PPRs into terminal Pauli 
     product measurements (PPMs).
 
-  For more information on PPMs, please refer to our [PPM documentation page](https://pennylane.ai/compilation/pauli-product-measurement).
+  For more information on PPMs, please refer to our [PPM documentation page](https://pennylane.ai/compilation/pauli-based-computation).
 
 * Catalyst now supports qubit number-invariant compilation. That is, programs can be compiled without
   specifying the number of qubits to allocate ahead of time. Instead, the device can be supplied with

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -85,5 +85,5 @@ Sengthai Heng,
 Jeffrey Kam,
 Mudit Pandey,
 Andrija Paurevic,
-David D.W. Ren
+David D.W. Ren,
 Paul Haochen Wang.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -44,10 +44,14 @@
 * Updated the Unified Compiler Cookbook to be compatible with the latest versions of PennyLane and Catalyst.
   [(#2406)](https://github.com/PennyLaneAI/catalyst/pull/2406)
 
+* Updated the changelog and builtin_passes.py to link to https://pennylane.ai/compilation/pauli-based-computation instead.
+  [(#2409)](https://github.com/PennyLaneAI/catalyst/pull/2409)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
 Ali Asadi
 Sengthai Heng,
 Jeffrey Kam,
-Mudit Pandey.
+Mudit Pandey,
+David Ren.

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -643,7 +643,7 @@ def to_ppr(qnode):
     Non-Clifford gates are defined as :math:`\exp(-{iP\tfrac{\pi}{8}})`.
 
     For more information on the PPM compilation pass, check out the
-    `compilation hub <https://pennylane.ai/compilation/pauli-product-measurement>`__.
+    `compilation hub <https://pennylane.ai/compilation/pauli-based-computation>`__.
 
     .. note::
 
@@ -727,7 +727,7 @@ def commute_ppr(qnode=None, *, max_pauli_size=0):
         :func:`pennylane.specs`, please use :func:`pennylane.transforms.commute_ppr`.
 
     For more information on PPRs, check out the
-    `Compilation Hub <https://pennylane.ai/compilation/pauli-product-measurement>`_.
+    `Compilation Hub <https://pennylane.ai/compilation/pauli-based-computation>`_.
 
     .. note::
 
@@ -842,7 +842,7 @@ def merge_ppr_ppm(qnode=None, *, max_pauli_size=0):
         :func:`pennylane.specs`, please use :func:`pennylane.transforms.merge_ppr_ppm`.
 
     For more information on PPRs and PPMs, check out
-    the `Compilation Hub <https://pennylane.ai/compilation/pauli-product-measurement>`_.
+    the `Compilation Hub <https://pennylane.ai/compilation/pauli-based-computation>`_.
 
     Args:
         fn (QNode): QNode to apply the pass to
@@ -1045,7 +1045,7 @@ def ppm_compilation(
     :func:`~.passes.commute_ppr` and :func:`~.passes.merge_ppr_ppm` passes.
 
     For more information on PPRs and PPMs, check out
-    the `Compilation Hub <https://pennylane.ai/compilation/pauli-product-measurement>`_.
+    the `Compilation Hub <https://pennylane.ai/compilation/pauli-based-computation>`_.
 
     Args:
         qnode (QNode, optional): QNode to apply the pass to. If None, returns a decorator.

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -727,7 +727,7 @@ def commute_ppr(qnode=None, *, max_pauli_size=0):
         :func:`pennylane.specs`, please use :func:`pennylane.transforms.commute_ppr`.
 
     For more information on PPRs, check out the
-    `Compilation Hub <https://pennylane.ai/compilation/pauli-based-computation>`_.
+    `Compilation Hub <https://pennylane.ai/compilation/pauli-product-rotations>`_.
 
     .. note::
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new functions and code must be clearly commented and documented.

- [ ] Ensure that code is properly formatted by running `make format`.
      The latest version of black and `clang-format-20` are used in CI/CD to check formatting.

- [ ] All new features must include a unit test.
      Integration and frontend tests should be added to [`frontend/test`](../frontend/test/),
      Quantum dialect and MLIR tests should be added to [`mlir/test`](../mlir/test/), and
      Runtime tests should be added to [`runtime/tests`](../runtime/tests/).

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**
Korbinian requested that the Compilation Hub's "Pauli Product Measurement" page be changed to be called "Pauli-Based Computation" instead. Consequently, the website's URL must change. This URL change must be reflected across the Pennylane website. 

**Description of the Change:**
The URL has been updated to /pauli-based-computation instead of /pauli-product-measurement in all the places they exist. 

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
Do not merge until the cloud team has closed the following ticket that creates URL redirects. https://app.shortcut.com/xanaduai/story/108096/add-a-redirect-for-compilation-page-url-change