### PR TITLE
Add MLIR parsing and pretty-printing to round-trip tests

### DIFF
--- a/frontend/catalyst/python_interface/dialects/quantum.py
+++ b/frontend/catalyst/python_interface/dialects/quantum.py
@@ -491,11 +491,11 @@ class GlobalPhaseOp(IRDLOperation):
     name = "quantum.gphase"
 
     assembly_format = """
-        `(` $params `)` 
-        attr-dict 
-        ( `ctrls` `(` $in_ctrl_qubits^ `)` )?  
-        ( `ctrlvals` `(` $in_ctrl_values^ `)` )? 
-        `:` type(results)
+        `(` $params `)`
+        attr-dict
+        ( `ctrls` `(` $in_ctrl_qubits^ `)` )?
+        ( `ctrlvals` `(` $in_ctrl_values^ `)` )?
+        `:` (`ctrls` type($out_ctrl_qubits)^ )?
     """
 
     irdl_options = (AttrSizedOperandSegments(as_property=True), ParsePropInAttrDict())

--- a/frontend/test/pytest/python_interface/conftest.py
+++ b/frontend/test/pytest/python_interface/conftest.py
@@ -38,6 +38,7 @@ except (ImportError, ModuleNotFoundError):
     deps_available = False
 
 
+# pylint: disable=too-many-positional-arguments,too-many-arguments
 def _run_filecheck_impl(
     program_str: str,
     pipeline: tuple[ModulePass, ...] = (),

--- a/frontend/test/pytest/python_interface/conftest.py
+++ b/frontend/test/pytest/python_interface/conftest.py
@@ -55,9 +55,11 @@ def _run_filecheck_impl(
     xdsl_module = QuantumParser(ctx, program_str, extra_dialects=(test.Test,)).parse_module()
 
     if roundtrip:
-        # Print -> parse to MLIR -> print -> parse to xDSL
+        # Print -> parse to xDSL
         # If `pretty_print == True`, the assembly format (or other custom printing logic)
         # will be used
+        # If `to_mlir == True`, the printed program will be parsed to MLIR and printed back
+        # before parsing to xDSL
         stream = StringIO()
         Printer(stream=stream, print_generic_format=not pretty_print).print_op(xdsl_module)
         mod_str = stream.getvalue()

--- a/frontend/test/pytest/python_interface/conftest.py
+++ b/frontend/test/pytest/python_interface/conftest.py
@@ -109,12 +109,13 @@ def run_filecheck():
         verify (bool): Whether or not to verify the IR after parsing and transforming.
             ``False`` by default.
         roundtrip (bool): Whether or not to use round-trip testing. This is useful for dialect
-            tests to verify that xDSL both parses and prints the IR correctly. If ``True``, we parse
-            the program string into an xDSL module, print it, parse the printed module into an MLIR module,
-            print it again, and then parse this back to an xDSL module. ``False`` by default.
-        pretty_print (bool): Whether to pretty print the program when round-trip testing is performed.
-            If ``False``, the program will be printed in generic format. If ``roundtrip == False``,
-            this argument does nothing. ``False`` by default.
+            tests to verify that xDSL both parses and prints the IR correctly. If ``True``, we
+            parse the program string into an xDSL module, print it, parse the printed module
+            into an MLIR module, print it again, and then parse this back to an xDSL module.
+            ``False`` by default.
+        pretty_print (bool): Whether to pretty print the program when round-trip testing is
+            performed. If ``False``, the program will be printed in generic format. If
+            ``roundtrip == False``, this argument does nothing. ``False`` by default.
     """
     if not deps_available:
         pytest.skip("Cannot run xDSL lit tests without the Python 'filecheck' package.")

--- a/frontend/test/pytest/python_interface/dialects/test_catalyst_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_catalyst_dialect.py
@@ -108,4 +108,4 @@ def test_assembly_format(run_filecheck):
     %callback_result = catalyst.callback_call @test_func(%tensor_val) : (tensor<1xf64>) -> f64
     """
 
-    run_filecheck(program, roundtrip=True)
+    run_filecheck(program, roundtrip=True, verify=True)

--- a/frontend/test/pytest/python_interface/dialects/test_catalyst_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_catalyst_dialect.py
@@ -68,7 +68,18 @@ def test_all_attributes_names(attr):
     assert attr.name == expected_name
 
 
-def test_assembly_format(run_filecheck):
+@pytest.mark.parametrize(
+    "pretty_print",
+    [
+        pytest.param(
+            True,
+            id="pretty_print",
+            marks=pytest.mark.xfail(reason="No assembly format for arraylist"),
+        ),
+        pytest.param(False, id="generic_print"),
+    ],
+)
+def test_assembly_format(run_filecheck, pretty_print):
     """Test the assembly format of the catalyst ops."""
     program = """
     // Function to set up symbols for call-like operations
@@ -108,4 +119,4 @@ def test_assembly_format(run_filecheck):
     %callback_result = catalyst.callback_call @test_func(%tensor_val) : (tensor<1xf64>) -> f64
     """
 
-    run_filecheck(program, roundtrip=True, verify=True)
+    run_filecheck(program, roundtrip=True, verify=True, pretty_print=pretty_print)

--- a/frontend/test/pytest/python_interface/dialects/test_mbqc_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_mbqc_dialect.py
@@ -94,7 +94,7 @@ def test_assembly_format(run_filecheck):
     %graph_reg = mbqc.graph_state_prep (%adj_matrix : tensor<6xi1>) [init "Hadamard", entangle "CZ"] : !quantum.reg
     """
 
-    run_filecheck(program, roundtrip=True)
+    run_filecheck(program, roundtrip=True, verify=True)
 
 
 class TestMeasureInBasisOp:

--- a/frontend/test/pytest/python_interface/dialects/test_mbqc_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_mbqc_dialect.py
@@ -60,7 +60,10 @@ def test_all_attributes_names(attr):
     assert attr.name == expected_name
 
 
-def test_assembly_format(run_filecheck):
+@pytest.mark.parametrize(
+    "pretty_print", [pytest.param(True, id="pretty_print"), pytest.param(False, id="generic_print")]
+)
+def test_assembly_format(run_filecheck, pretty_print):
     """Test the assembly format of the mbqc ops."""
     program = r"""
     // CHECK: [[angle:%.+]] = "test.op"() : () -> f64
@@ -94,7 +97,7 @@ def test_assembly_format(run_filecheck):
     %graph_reg = mbqc.graph_state_prep (%adj_matrix : tensor<6xi1>) [init "Hadamard", entangle "CZ"] : !quantum.reg
     """
 
-    run_filecheck(program, roundtrip=True, verify=True)
+    run_filecheck(program, roundtrip=True, verify=True, pretty_print=pretty_print)
 
 
 class TestMeasureInBasisOp:

--- a/frontend/test/pytest/python_interface/dialects/test_qec_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_qec_dialect.py
@@ -61,7 +61,10 @@ def test_all_attributes_names(attr):
     assert attr.name == expected_name
 
 
-def test_assembly_format(run_filecheck):
+@pytest.mark.parametrize(
+    "pretty_print", [pytest.param(True, id="pretty_print"), pytest.param(False, id="generic_print")]
+)
+def test_assembly_format(run_filecheck, pretty_print):
     """Test the assembly format of the qec ops."""
     program = """
     // CHECK: [[Q0:%.+]], [[Q1:%.+]], [[Q2:%.+]] = "test.op"() : () -> (!quantum.bit
@@ -96,4 +99,4 @@ def test_assembly_format(run_filecheck):
 
     """
 
-    run_filecheck(program, roundtrip=True, verify=True)
+    run_filecheck(program, roundtrip=True, verify=True, pretty_print=pretty_print)

--- a/frontend/test/pytest/python_interface/dialects/test_qec_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_qec_dialect.py
@@ -64,8 +64,8 @@ def test_all_attributes_names(attr):
 def test_assembly_format(run_filecheck):
     """Test the assembly format of the qec ops."""
     program = """
-    // CHECK: [[QUBIT:%.+]] = "test.op"() : () -> !quantum.bit
-    %qubit = "test.op"() : () -> !quantum.bit
+    // CHECK: [[Q0:%.+]], [[Q1:%.+]], [[Q2:%.+]] = "test.op"() : () -> (!quantum.bit
+    %q0, %q1, %q2 = "test.op"() : () -> (!quantum.bit, !quantum.bit, !quantum.bit)
 
     // CHECK: [[PARAM:%.+]] = "test.op"() : () -> f64
     %param = "test.op"() : () -> f64
@@ -73,27 +73,27 @@ def test_assembly_format(run_filecheck):
     // CHECK: [[COND:%.+]] = "test.op"() : () -> i1
     %cond = "test.op"() : () -> i1
 
-    // CHECK: [[FABRICATED:%.+]] = qec.fabricate magic : !quantum.bit
+    // CHECK: {{%.+}} = qec.fabricate magic : !quantum.bit
     %fabricated = qec.fabricate magic : !quantum.bit
 
-    // CHECK: [[PREPARED:%.+]] = qec.prepare zero [[QUBIT]] : !quantum.bit
-    %prepared = qec.prepare zero %qubit : !quantum.bit
+    // CHECK: {{%.+}} = qec.prepare zero [[Q0]] : !quantum.bit
+    %prepared = qec.prepare zero %q0 : !quantum.bit
 
-    // CHECK: [[ROTATED_ARB:%.+]] = qec.ppr.arbitrary ["X", "Y", "Z"]([[PARAM]]) [[QUBIT]] : !quantum.bit
-    %rotated_arb = qec.ppr.arbitrary ["X", "Y", "Z"](%param) %qubit : !quantum.bit
+    // CHECK: {{%.+}}, {{%.+}} = qec.ppr.arbitrary ["X", "Y"]([[PARAM]]) [[Q0]], [[Q1]] : !quantum.bit,
+    %arb0, %arb1 = qec.ppr.arbitrary ["X", "Y"](%param) %q0, %q1 : !quantum.bit, !quantum.bit
 
-    // CHECK: [[ROTATED:%.+]] = qec.ppr ["X", "I", "Z"](4) [[QUBIT]] : !quantum.bit
-    %rotated = qec.ppr ["X", "I", "Z"](4) %qubit : !quantum.bit
+    // CHECK: {{%.+}}, {{%.+}} = qec.ppr ["X", "I"](4) [[Q0]], [[Q1]] : !quantum.bit,
+    %r0, %r1 = qec.ppr ["X", "I"](4) %q0, %q1 : !quantum.bit, !quantum.bit
 
-    // CHECK: [[MEASURED:%.+]], [[OUT_QUBITS:%.+]] = qec.ppm ["X", "I", "Z"] [[QUBIT]] : i1, !quantum.bit
-    %measured, %out_qubits = qec.ppm ["X", "I", "Z"] %qubit : i1, !quantum.bit
+    // CHECK: {{%.+}}, {{%.+}}, {{%.+}} = qec.ppm ["X", "Z"] [[Q0]], [[Q1]] : i1, !quantum.bit,
+    %measured, %m0, %m1 = qec.ppm ["X", "Z"] %q0, %q1 : i1, !quantum.bit, !quantum.bit
 
-    // CHECK: [[MEASURED_COND:%.+]], [[OUT_QUBITS_COND:%.+]] = qec.ppm ["X", "I", "Z"] [[QUBIT]] cond([[COND]]) : i1, !quantum.bit
-    %measured_cond, %out_qubits_cond = qec.ppm ["X", "I", "Z"] %qubit cond(%cond) : i1, !quantum.bit
+    // CHECK: {{%.+}}, {{%.+}}, {{%.+}} = qec.ppm ["I", "Z"] [[Q0]], [[Q1]] cond([[COND]]) : i1, !quantum.bit,
+    %measured_cond, %c0, %c1 = qec.ppm ["I", "Z"] %q0, %q1 cond(%cond) : i1, !quantum.bit, !quantum.bit
 
-    // CHECK: [[SELECT_MEASURED:%.+]], [[SELECT_OUT:%.+]] = qec.select.ppm([[COND]], ["X"], ["Z"]) [[QUBIT]] : i1, !quantum.bit
-    %select_measured, %select_out = qec.select.ppm (%cond, ["X"], ["Z"]) %qubit : i1, !quantum.bit
+    // CHECK: {{%.+}}, {{%.+}} = qec.select.ppm([[COND]], ["X"], ["Z"]) [[Q0]] : i1, !quantum.bit
+    %select_measured, %select_out = qec.select.ppm (%cond, ["X"], ["Z"]) %q0 : i1, !quantum.bit
 
     """
 
-    run_filecheck(program)
+    run_filecheck(program, roundtrip=True, verify=True)

--- a/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
@@ -268,11 +268,14 @@ class TestCustomVerifiers:
             op.verify()
 
 
+@pytest.mark.parametrize(
+    "pretty_print", [pytest.param(True, id="pretty_print"), pytest.param(False, id="generic_print")]
+)
 class TestAssemblyFormat:
     """Lit tests for assembly format of operations/attributes in the Quantum
     dialect."""
 
-    def test_qubit_qreg_operations(self, run_filecheck):
+    def test_qubit_qreg_operations(self, run_filecheck, pretty_print):
         """Test that the assembly format for operations for allocation/deallocation of
         qubits/quantum registers works correctly."""
 
@@ -330,9 +333,9 @@ class TestAssemblyFormat:
         %qreg2 = quantum.insert %qreg1[%dyn_index], %dyn_qubit1 : !quantum.reg, !quantum.bit
         """
 
-        run_filecheck(program, roundtrip=True, verify=True)
+        run_filecheck(program, roundtrip=True, verify=True, pretty_print=pretty_print)
 
-    def test_quantum_ops(self, run_filecheck):
+    def test_quantum_ops(self, run_filecheck, pretty_print):
         """Test that the assembly format for quantum non-terminal operations works correctly."""
 
         # Tests for CustomOp, GlobalPhaseOp, MeasureOp, MultiRZOp, QubitUnitaryOp
@@ -393,12 +396,12 @@ class TestAssemblyFormat:
         quantum.gphase(%param1) :
 
         // Control wires and values
-        // CHECK: {{%.+}}, {{%.+}} = quantum.gphase([[PARAM1]]) ctrls([[Q0]], [[Q1]]) ctrlvals([[FALSE_CST]], [[TRUE_CST]]) : !quantum.bit, !quantum.bit
-        %qg1, %qg2 = quantum.gphase(%param1) ctrls(%q0, %q1) ctrlvals(%false_cst, %true_cst) : !quantum.bit, !quantum.bit
+        // CHECK: {{%.+}}, {{%.+}} = quantum.gphase([[PARAM1]]) ctrls([[Q0]], [[Q1]]) ctrlvals([[FALSE_CST]], [[TRUE_CST]]) : ctrls !quantum.bit, !quantum.bit
+        %qg1, %qg2 = quantum.gphase(%param1) ctrls(%q0, %q1) ctrlvals(%false_cst, %true_cst) : ctrls !quantum.bit, !quantum.bit
 
         // Adjoint
-        // CHECK: {{%.+}} = quantum.gphase([[PARAM1]]) {adjoint} ctrls([[Q0]]) ctrlvals([[TRUE_CST]]) : !quantum.bit
-        %qg3 = quantum.gphase(%param1) {adjoint} ctrls(%q0) ctrlvals(%true_cst) : !quantum.bit
+        // CHECK: {{%.+}} = quantum.gphase([[PARAM1]]) {adjoint} ctrls([[Q0]]) ctrlvals([[TRUE_CST]]) : ctrls !quantum.bit
+        %qg3 = quantum.gphase(%param1) {adjoint} ctrls(%q0) ctrlvals(%true_cst) : ctrls !quantum.bit
 
         ////////////////// **MultiRZOp tests** //////////////////
         // No control wires
@@ -468,9 +471,9 @@ class TestAssemblyFormat:
         %mres3, %mqubit3 = quantum.measure %q2 postselect 1 : i1, !quantum.bit
         """
 
-        run_filecheck(program, roundtrip=True, verify=True)
+        run_filecheck(program, roundtrip=True, verify=True, pretty_print=pretty_print)
 
-    def test_state_prep(self, run_filecheck):
+    def test_state_prep(self, run_filecheck, pretty_print):
         """Test that the assembly format for state prep operations works correctly."""
 
         # Tests for SetBasisStateOp, SetStateOp
@@ -510,9 +513,9 @@ class TestAssemblyFormat:
         %q8, %q9 = quantum.set_state(%state_memref) %q6, %q7 : (memref<4xcomplex<f64>>, !quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
         """
 
-        run_filecheck(program, roundtrip=True, verify=True)
+        run_filecheck(program, roundtrip=True, verify=True, pretty_print=pretty_print)
 
-    def test_observables(self, run_filecheck):
+    def test_observables(self, run_filecheck, pretty_print):
         """Test that the assembly format for observable operations works correctly."""
 
         # Tests for observables: ComputationalBasisOp, HamiltonianOp, HermitianOp,
@@ -588,9 +591,9 @@ class TestAssemblyFormat:
         %cb_all = quantum.compbasis qreg %qreg : !quantum.obs
         """
 
-        run_filecheck(program, roundtrip=True, verify=True)
+        run_filecheck(program, roundtrip=True, verify=True, pretty_print=pretty_print)
 
-    def test_measurements(self, run_filecheck):
+    def test_measurements(self, run_filecheck, pretty_print):
         """Test that the assembly format for measurement operations works correctly."""
 
         # Tests for measurements: CountsOp, ExpvalOp, MeasureOp, ProbsOp, SampleOp,
@@ -699,9 +702,9 @@ class TestAssemblyFormat:
         quantum.sample %c_obs in(%samples_in : memref<7x3xf64>)
         """
 
-        run_filecheck(program, roundtrip=True, verify=True)
+        run_filecheck(program, roundtrip=True, verify=True, pretty_print=pretty_print)
 
-    def test_miscellaneous_operations(self, run_filecheck):
+    def test_miscellaneous_operations(self, run_filecheck, pretty_print):
         """Test that the assembly format for miscelleneous operations
         works correctly."""
 
@@ -754,7 +757,7 @@ class TestAssemblyFormat:
         %nqubits = quantum.num_qubits : i64
         """
 
-        run_filecheck(program, roundtrip=True, verify=True)
+        run_filecheck(program, roundtrip=True, verify=True, pretty_print=pretty_print)
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/python_interface/dialects/test_stablehlo_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_stablehlo_dialect.py
@@ -24,75 +24,75 @@ def test_all_unary_operations(run_filecheck):
     program = r"""
     // CHECK: %[[tf32:.*]] = "test.op"() : () -> tensor<f32>
     %tf32 = "test.op"() : () -> tensor<f32>
-    
+
     // CHECK: %[[tf64:.*]] = "test.op"() : () -> tensor<f64>
     %tf64 = "test.op"() : () -> tensor<f64>
-    
+
     // CHECK: %[[tcomplex:.*]] = "test.op"() : () -> tensor<complex<f32>>
     %tcomplex = "test.op"() : () -> tensor<complex<f32>>
-    
+
     // CHECK: %convert = "stablehlo.convert"(%[[tf32]]) : (tensor<f32>) -> tensor<f64>
     %convert = "stablehlo.convert"(%tf32) : (tensor<f32>) -> tensor<f64>
-    
+
     // CHECK: %cos = "stablehlo.cosine"(%[[tf32]]) : (tensor<f32>) -> tensor<f32>
     %cos = "stablehlo.cosine"(%tf32) : (tensor<f32>) -> tensor<f32>
-    
+
     // CHECK: %exp = "stablehlo.exponential"(%[[tf32]]) : (tensor<f32>) -> tensor<f32>
     %exp = "stablehlo.exponential"(%tf32) : (tensor<f32>) -> tensor<f32>
-    
+
     // CHECK: %exponential_minus_one = "stablehlo.exponential_minus_one"(%[[tf32]]) : (tensor<f32>) -> tensor<f32>
     %exponential_minus_one = "stablehlo.exponential_minus_one"(%tf32) : (tensor<f32>) -> tensor<f32>
-    
+
     // CHECK: %floor = "stablehlo.floor"(%[[tf64]]) : (tensor<f64>) -> tensor<f64>
     %floor = "stablehlo.floor"(%tf64) : (tensor<f64>) -> tensor<f64>
-    
+
     // CHECK: %imag = "stablehlo.imag"(%[[tcomplex]]) : (tensor<complex<f32>>) -> tensor<f32>
     %imag = "stablehlo.imag"(%tcomplex) : (tensor<complex<f32>>) -> tensor<f32>
-    
+
     // CHECK: %is_finite = "stablehlo.is_finite"(%[[tf32]]) : (tensor<f32>) -> tensor<i1>
     %is_finite = "stablehlo.is_finite"(%tf32) : (tensor<f32>) -> tensor<i1>
-    
+
     // CHECK: %log = "stablehlo.log"(%[[tf32]]) : (tensor<f32>) -> tensor<f32>
     %log = "stablehlo.log"(%tf32) : (tensor<f32>) -> tensor<f32>
-    
+
     // CHECK: %log_plus_one = "stablehlo.log_plus_one"(%[[tf64]]) : (tensor<f64>) -> tensor<f64>
     %log_plus_one = "stablehlo.log_plus_one"(%tf64) : (tensor<f64>) -> tensor<f64>
-    
+
     // CHECK: %logistic = "stablehlo.logistic"(%[[tf32]]) : (tensor<f32>) -> tensor<f32>
     %logistic = "stablehlo.logistic"(%tf32) : (tensor<f32>) -> tensor<f32>
-    
+
     // CHECK: %negate = "stablehlo.negate"(%[[tf32]]) : (tensor<f32>) -> tensor<f32>
     %negate = "stablehlo.negate"(%tf32) : (tensor<f32>) -> tensor<f32>
-    
+
     // CHECK: %real = "stablehlo.real"(%[[tcomplex]]) : (tensor<complex<f32>>) -> tensor<f32>
     %real = "stablehlo.real"(%tcomplex) : (tensor<complex<f32>>) -> tensor<f32>
-    
+
     // CHECK: %round_afz = "stablehlo.round_nearest_afz"(%[[tf64]]) : (tensor<f64>) -> tensor<f64>
     %round_afz = "stablehlo.round_nearest_afz"(%tf64) : (tensor<f64>) -> tensor<f64>
-    
+
     // CHECK: %round_even = "stablehlo.round_nearest_even"(%[[tf64]]) : (tensor<f64>) -> tensor<f64>
     %round_even = "stablehlo.round_nearest_even"(%tf64) : (tensor<f64>) -> tensor<f64>
-    
+
     // CHECK: %rsqrt = "stablehlo.rsqrt"(%[[tf32]]) : (tensor<f32>) -> tensor<f32>
     %rsqrt = "stablehlo.rsqrt"(%tf32) : (tensor<f32>) -> tensor<f32>
-    
+
     // CHECK: %sign = "stablehlo.sign"(%[[tf32]]) : (tensor<f32>) -> tensor<f32>
     %sign = "stablehlo.sign"(%tf32) : (tensor<f32>) -> tensor<f32>
-    
+
     // CHECK: %sin = "stablehlo.sine"(%[[tf32]]) : (tensor<f32>) -> tensor<f32>
     %sin = "stablehlo.sine"(%tf32) : (tensor<f32>) -> tensor<f32>
-    
+
     // CHECK: %sqrt = "stablehlo.sqrt"(%[[tf32]]) : (tensor<f32>) -> tensor<f32>
     %sqrt = "stablehlo.sqrt"(%tf32) : (tensor<f32>) -> tensor<f32>
-    
+
     // CHECK: %tan = "stablehlo.tan"(%[[tf64]]) : (tensor<f64>) -> tensor<f64>
     %tan = "stablehlo.tan"(%tf64) : (tensor<f64>) -> tensor<f64>
-    
+
     // CHECK: %tanh = "stablehlo.tanh"(%[[tf32]]) : (tensor<f32>) -> tensor<f32>
     %tanh = "stablehlo.tanh"(%tf32) : (tensor<f32>) -> tensor<f32>
     """
 
-    run_filecheck(program, roundtrip=True, verify=True)
+    run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_all_binary_operations(run_filecheck):
@@ -100,36 +100,36 @@ def test_all_binary_operations(run_filecheck):
     program = r"""
     // CHECK: %[[tf32_1:.*]] = "test.op"() : () -> tensor<f32>
     %tf32_1 = "test.op"() : () -> tensor<f32>
-    
+
     // CHECK: %[[tf32_2:.*]] = "test.op"() : () -> tensor<f32>
     %tf32_2 = "test.op"() : () -> tensor<f32>
-    
+
     // CHECK: %[[tf64_1:.*]] = "test.op"() : () -> tensor<f64>
     %tf64_1 = "test.op"() : () -> tensor<f64>
-    
+
     // CHECK: %[[tf64_2:.*]] = "test.op"() : () -> tensor<f64>
     %tf64_2 = "test.op"() : () -> tensor<f64>
 
     // CHECK: %complex = "stablehlo.complex"(%[[tf32_1]], %[[tf32_2]]) : (tensor<f32>, tensor<f32>) -> tensor<complex<f32>>
     %complex = "stablehlo.complex"(%tf32_1, %tf32_2) : (tensor<f32>, tensor<f32>) -> tensor<complex<f32>>
-    
+
     // CHECK: %divide = "stablehlo.divide"(%[[tf32_1]], %[[tf32_2]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     %divide = "stablehlo.divide"(%tf32_1, %tf32_2) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-    
+
     // CHECK: %maximum = "stablehlo.maximum"(%[[tf32_1]], %[[tf32_2]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     %maximum = "stablehlo.maximum"(%tf32_1, %tf32_2) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-    
+
     // CHECK: %minimum = "stablehlo.minimum"(%[[tf32_1]], %[[tf32_2]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     %minimum = "stablehlo.minimum"(%tf32_1, %tf32_2) : (tensor<f32>, tensor<f32>) -> tensor<f32>
-    
+
     // CHECK: %power = "stablehlo.power"(%[[tf64_1]], %[[tf64_2]]) : (tensor<f64>, tensor<f64>) -> tensor<f64>
     %power = "stablehlo.power"(%tf64_1, %tf64_2) : (tensor<f64>, tensor<f64>) -> tensor<f64>
-    
+
     // CHECK: %remainder = "stablehlo.remainder"(%[[tf32_1]], %[[tf32_2]]) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     %remainder = "stablehlo.remainder"(%tf32_1, %tf32_2) : (tensor<f32>, tensor<f32>) -> tensor<f32>
     """
 
-    run_filecheck(program, roundtrip=True, verify=True)
+    run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_all_other_operations(run_filecheck):
@@ -146,10 +146,10 @@ def test_all_other_operations(run_filecheck):
 
     // CHECK: %clamp = "stablehlo.clamp"(%[[tf32]], %[[tf32]], %[[tf32]]) : (tensor<f32>, tensor<f32>, tensor<f32>) -> tensor<f32>
     %clamp = "stablehlo.clamp"(%tf32, %tf32, %tf32) : (tensor<f32>, tensor<f32>, tensor<f32>) -> tensor<f32>
-    
+
     // CHECK: %compare = stablehlo.compare EQ, %[[tf32]], %[[tf32]] : (tensor<f32>, tensor<f32>) -> tensor<i1>
     %compare = "stablehlo.compare"(%tf32, %tf32) {comparison_direction = #stablehlo<comparison_direction EQ>} : (tensor<f32>, tensor<f32>) -> tensor<i1>
-    
+
     // CHECK: %map = "stablehlo.map"(%[[tf32]], %[[tf32]]) ({
     // CHECK:   ^[[bb0:.*]](%arg0 : tensor<f32>, %arg1 : tensor<f32>):
     // CHECK:     %0 = "stablehlo.multiply"(%arg0, %arg1) : (tensor<f32>, tensor<f32>) -> tensor<f32>
@@ -162,10 +162,10 @@ def test_all_other_operations(run_filecheck):
     }) {
       dimensions = array<i64: 0, 1>
     } : (tensor<f32>, tensor<f32>) -> tensor<f32>
-    
+
     // CHECK: %reduce_precision = "stablehlo.reduce_precision"(%[[tf64]]) {exponent_bits = 5 : i32, mantissa_bits = 10 : i32} : (tensor<f64>) -> tensor<f64>
     %reduce_precision = "stablehlo.reduce_precision"(%tf64) {exponent_bits = 5 : i32, mantissa_bits = 10 : i32} : (tensor<f64>) -> tensor<f64>
-    
+
     // CHECK: %select = "stablehlo.select"(%[[ti1]], %[[tf32]], %[[tf32]]) : (tensor<i1>, tensor<f32>, tensor<f32>) -> tensor<f32>
     %select = "stablehlo.select"(%ti1, %tf32, %tf32) : (tensor<i1>, tensor<f32>, tensor<f32>) -> tensor<f32>
 
@@ -173,7 +173,7 @@ def test_all_other_operations(run_filecheck):
     %constant1 = "stablehlo.constant"() <{value = dense<[[0.0, 1.0], [2.0, 3.0]]> : tensor<2x2xf32>}> : () -> tensor<2x2xf32>
     """
 
-    run_filecheck(program, roundtrip=True, verify=True)
+    run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_invalid_ir_shape_mismatch(run_filecheck):
@@ -181,7 +181,7 @@ def test_invalid_ir_shape_mismatch(run_filecheck):
     program = r"""
     %tf32_2x3 = "test.op"() : () -> tensor<2x3xf32>
     %tf64_3x2 = "test.op"() : () -> tensor<3x2xf64>
-    
+
     // This should fail verification due to shape mismatch
     %convert = "stablehlo.convert"(%tf32_2x3) : (tensor<2x3xf32>) -> tensor<3x2xf64>
     """
@@ -189,20 +189,20 @@ def test_invalid_ir_shape_mismatch(run_filecheck):
     with pytest.raises(
         Exception, match="all non-scalar operands/results must have the same shape and base type"
     ):
-        run_filecheck(program, roundtrip=True, verify=True)
+        run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_invalid_ir_type_mismatch(run_filecheck):
     """Test that operations with type mismatches are properly rejected."""
     program = r"""
     %ti32 = "test.op"() : () -> tensor<2x3xi32>
-    
+
     // This should fail verification due to type mismatch (cosine expects float/complex)
     %cos = "stablehlo.cosine"(%ti32) : (tensor<2x3xi32>) -> tensor<2x3xi32>
     """
 
     with pytest.raises(Exception, match="'operand' at position 0 does not verify"):
-        run_filecheck(program, roundtrip=True, verify=True)
+        run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_invalid_ir_missing_operands(run_filecheck):
@@ -212,7 +212,7 @@ def test_invalid_ir_missing_operands(run_filecheck):
     """
 
     with pytest.raises(Exception, match="Expected 1 operand"):
-        run_filecheck(program, roundtrip=True, verify=True)
+        run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_invalid_ir_trait_verification_failure(run_filecheck):
@@ -220,20 +220,20 @@ def test_invalid_ir_trait_verification_failure(run_filecheck):
     program = r"""
     %tf32_2x3 = "test.op"() : () -> tensor<2x3xf32>
     %tf64_3x2 = "test.op"() : () -> tensor<3x2xf64>
-    
+
     // This should fail verification due to shape mismatch between operands
     %complex = "stablehlo.complex"(%tf32_2x3, %tf64_3x2) : (tensor<2x3xf32>, tensor<3x2xf64>) -> tensor<2x3xcomplex<f32>>
     """
 
     with pytest.raises(Exception, match="requires the same shape"):
-        run_filecheck(program, roundtrip=True, verify=True)
+        run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_invalid_ir_operand_result_shape_mismatch(run_filecheck):
     """Test that operations with operand vs result shape mismatches are properly rejected."""
     program = r"""
     %tf32_2x3 = "test.op"() : () -> tensor<2x3xf32>
-    
+
     // This should fail verification due to shape mismatch between operand and result
     %convert = "stablehlo.convert"(%tf32_2x3) : (tensor<2x3xf32>) -> tensor<3x2xf64>
     """
@@ -241,17 +241,17 @@ def test_invalid_ir_operand_result_shape_mismatch(run_filecheck):
     with pytest.raises(
         Exception, match="all non-scalar operands/results must have the same shape and base type"
     ):
-        run_filecheck(program, roundtrip=True, verify=True)
+        run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_control_flow_operations(run_filecheck):
     """Test the IfOp operation."""
     program = r"""
     // Test IfOp:
-    
+
     // CHECK:   %[[pred:.*]] = "test.op"() : () -> tensor<i1>
     %pred = "test.op"() : () -> tensor<i1>
-    
+
     // CHECK:   %[[result:.*]] = "stablehlo.if"(%[[pred]]) ({
     // CHECK:     "stablehlo.return"(%[[pred]]) : (tensor<i1>) -> ()
     // CHECK:   }, {
@@ -262,21 +262,21 @@ def test_control_flow_operations(run_filecheck):
     }, {
         "stablehlo.return"(%pred) : (tensor<i1>) -> ()
     }) : (tensor<i1>) -> tensor<i1>
-    
+
     // Test WhileOp:
 
     // CHECK:   %[[init_i:.*]] = "test.op"() : () -> tensor<i64>
     %init_i = "test.op"() : () -> tensor<i64>
-    
+
     // CHECK:   %[[init_sum:.*]] = "test.op"() : () -> tensor<i64>
     %init_sum = "test.op"() : () -> tensor<i64>
-    
+
     // CHECK:   %[[ten:.*]] = "test.op"() : () -> tensor<i64>
     %ten = "test.op"() : () -> tensor<i64>
-    
+
     // CHECK:   %[[one:.*]] = "test.op"() : () -> tensor<i64>
     %one = "test.op"() : () -> tensor<i64>
-    
+
     // CHECK:   %[[results:.*]], %[[results_1:.*]] = "stablehlo.while"(%[[init_i]], %[[init_sum]]) ({
     // CHECK:   ^{{.*}}(%[[arg0:.*]] : tensor<i64>, %[[arg1:.*]] : tensor<i64>):
     // CHECK:     %[[cond:.*]] = stablehlo.compare LT, %[[arg0]], %[[ten]] : (tensor<i64>, tensor<i64>) -> tensor<i1>
@@ -297,17 +297,17 @@ def test_control_flow_operations(run_filecheck):
       %new_i = "stablehlo.add"(%arg0, %one) : (tensor<i64>, tensor<i64>) -> tensor<i64>
       "stablehlo.return"(%new_i, %new_sum) : (tensor<i64>, tensor<i64>) -> ()
     }) : (tensor<i64>, tensor<i64>) -> (tensor<i64>, tensor<i64>)
-    
+
     // Test OptimizationBarrierOp:
 
     // CHECK:   %[[operand:.*]] = "test.op"() : () -> tensor<i1>
     %operand = "test.op"() : () -> tensor<i1>
-    
+
     // CHECK:   %[[result2:.*]] = "stablehlo.optimization_barrier"(%[[operand]]) : (tensor<i1>) -> tensor<i1>
     %result2 = "stablehlo.optimization_barrier"(%operand) : (tensor<i1>) -> tensor<i1>
     """
 
-    run_filecheck(program, roundtrip=True, verify=True)
+    run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_data_movement_operations(run_filecheck):
@@ -316,40 +316,40 @@ def test_data_movement_operations(run_filecheck):
     ////////////////// Setup test operations //////////////////
     // CHECK: %[[input1:.*]] = "test.op"() : () -> tensor<3x2xi64>
     %input1 = "test.op"() : () -> tensor<3x2xi64>
-    
+
     // CHECK: %[[input2:.*]] = "test.op"() : () -> tensor<1x2xi64>
     %input2 = "test.op"() : () -> tensor<1x2xi64>
-    
+
     // CHECK: %[[operand:.*]] = "test.op"() : () -> tensor<2x3x4x2xi32>
     %operand = "test.op"() : () -> tensor<2x3x4x2xi32>
-    
+
     // CHECK: %[[start_indices:.*]] = "test.op"() : () -> tensor<2x2x3x2xi64>
     %start_indices = "test.op"() : () -> tensor<2x2x3x2xi64>
-    
+
     // CHECK: %[[reshape_input:.*]] = "test.op"() : () -> tensor<2xf32>
     %reshape_input = "test.op"() : () -> tensor<2xf32>
-    
+
     // CHECK: %[[scatter_input:.*]] = "test.op"() : () -> tensor<2x3x4x2xi64>
     %scatter_input = "test.op"() : () -> tensor<2x3x4x2xi64>
-    
+
     // CHECK: %[[scatter_indices:.*]] = "test.op"() : () -> tensor<2x2x3x2xi64>
     %scatter_indices = "test.op"() : () -> tensor<2x2x3x2xi64>
-    
+
     // CHECK: %[[scatter_updates:.*]] = "test.op"() : () -> tensor<2x2x3x2x2xi64>
     %scatter_updates = "test.op"() : () -> tensor<2x2x3x2x2xi64>
-    
+
     // CHECK: %[[slice_input:.*]] = "test.op"() : () -> tensor<3x4xi64>
     %slice_input = "test.op"() : () -> tensor<3x4xi64>
-    
+
     // CHECK: %[[broadcast_input:.*]] = "test.op"() : () -> tensor<1x3xi32>
     %broadcast_input = "test.op"() : () -> tensor<1x3xi32>
-    
+
     ////////////////// Test ConcatenateOp //////////////////
     // CHECK: %concatenate = "stablehlo.concatenate"(%[[input1]], %[[input2]]) <{dimension = 0 : i64}> : (tensor<3x2xi64>, tensor<1x2xi64>) -> tensor<4x2xi64>
     %concatenate = "stablehlo.concatenate"(%input1, %input2) {dimension = 0 : i64} : (tensor<3x2xi64>, tensor<1x2xi64>) -> tensor<4x2xi64>
-    
+
     ////////////////// Test GatherOp //////////////////
-    // CHECK: %gather = "stablehlo.gather"(%[[operand]], %[[start_indices]]) 
+    // CHECK: %gather = "stablehlo.gather"(%[[operand]], %[[start_indices]])
     // CHECK-SAME: dimension_numbers = #stablehlo.gather<
     // CHECK-NEXT:   offset_dims = [3, 4],
     // CHECK-NEXT:   collapsed_slice_dims = [1],
@@ -369,13 +369,13 @@ def test_data_movement_operations(run_filecheck):
       slice_sizes = array<i64: 1, 1, 2, 2>,
       indices_are_sorted = false
     } : (tensor<2x3x4x2xi32>, tensor<2x2x3x2xi64>) -> tensor<2x2x3x2x2xi32>
-    
+
     ////////////////// Test ReshapeOp //////////////////
     // CHECK: %reshape = stablehlo.reshape %[[reshape_input]] : (tensor<2xf32>) -> tensor<1x2xf32>
     %reshape = "stablehlo.reshape"(%reshape_input) : (tensor<2xf32>) -> tensor<1x2xf32>
-    
+
     ////////////////// Test ScatterOp //////////////////
-    // CHECK: %scatter = "stablehlo.scatter"(%[[scatter_input]], %[[scatter_indices]], %[[scatter_updates]]) 
+    // CHECK: %scatter = "stablehlo.scatter"(%[[scatter_input]], %[[scatter_indices]], %[[scatter_updates]])
     // CHECK-SAME: scatter_dimension_numbers = #stablehlo.scatter<
     // CHECK-NEXT:   update_window_dims = [3, 4],
     // CHECK-NEXT:   inserted_window_dims = [1],
@@ -402,7 +402,7 @@ def test_data_movement_operations(run_filecheck):
       indices_are_sorted = false,
       unique_indices = false
     } : (tensor<2x3x4x2xi64>, tensor<2x2x3x2xi64>, tensor<2x2x3x2x2xi64>) -> tensor<2x3x4x2xi64>
-    
+
     ////////////////// Test SliceOp //////////////////
     // CHECK: %slice = "stablehlo.slice"(%[[slice_input]])
     // CHECK-SAME:   start_indices = array<i64: 1, 2>,
@@ -414,7 +414,7 @@ def test_data_movement_operations(run_filecheck):
       limit_indices = array<i64: 3, 4>,
       strides = array<i64: 1, 1>
     } : (tensor<3x4xi64>) -> tensor<2x2xi64>
-    
+
     ////////////////// Test BroadcastInDimOp //////////////////
     // CHECK: %broadcast = stablehlo.broadcast_in_dim %[[broadcast_input]], dims = [2, 1] : (tensor<1x3xi32>) -> tensor<2x3x2xi32>
     %broadcast = "stablehlo.broadcast_in_dim"(%broadcast_input) {broadcast_dimensions = array<i64: 2, 1>} : (tensor<1x3xi32>) -> tensor<2x3x2xi32>
@@ -437,7 +437,7 @@ def test_data_movement_operations(run_filecheck):
     } : (tensor<4x4xi32>, tensor<i64>, tensor<i64>) -> tensor<2x3xi32>
     """
 
-    run_filecheck(program, roundtrip=True, verify=True)
+    run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_invalid_slice_operations(run_filecheck):
@@ -459,7 +459,7 @@ def test_invalid_slice_operations(run_filecheck):
         Exception,
         match="all of \\{start_indices, limit_indices, strides\\} must have the same size: got sizes 2, 3, 2",
     ):
-        run_filecheck(program_slice_mismatch, roundtrip=True, verify=True)
+        run_filecheck(program_slice_mismatch, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_invalid_slice_element_type_mismatch(run_filecheck):
@@ -479,7 +479,7 @@ def test_invalid_slice_element_type_mismatch(run_filecheck):
     with pytest.raises(
         Exception, match="requires the same element type for all operands and results"
     ):
-        run_filecheck(program, roundtrip=True, verify=True)
+        run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_invalid_gather_element_type_mismatch(run_filecheck):
@@ -506,7 +506,7 @@ def test_invalid_gather_element_type_mismatch(run_filecheck):
     with pytest.raises(
         Exception, match=r"all of \{operand, result\} must have the same element type"
     ):
-        run_filecheck(program, roundtrip=True, verify=True)
+        run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_invalid_reshape_operations(run_filecheck):
@@ -519,7 +519,7 @@ def test_invalid_reshape_operations(run_filecheck):
     """
 
     with pytest.raises(Exception, match="number of output elements"):
-        run_filecheck(program_reshape_mismatch, roundtrip=True, verify=True)
+        run_filecheck(program_reshape_mismatch, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_invalid_broadcast_in_dim_operations(run_filecheck):
@@ -533,7 +533,9 @@ def test_invalid_broadcast_in_dim_operations(run_filecheck):
     """
 
     with pytest.raises(Exception, match="broadcast_dimensions size .* does not match operand rank"):
-        run_filecheck(program_broadcast_dims_size_mismatch, roundtrip=True, verify=True)
+        run_filecheck(
+            program_broadcast_dims_size_mismatch, roundtrip=True, to_mlir=False, verify=True
+        )
 
     # Test duplicate dims.
     program_broadcast_duplicate_dims = r"""
@@ -544,7 +546,7 @@ def test_invalid_broadcast_in_dim_operations(run_filecheck):
     """
 
     with pytest.raises(Exception, match="broadcast_dimensions should not have duplicates"):
-        run_filecheck(program_broadcast_duplicate_dims, roundtrip=True, verify=True)
+        run_filecheck(program_broadcast_duplicate_dims, roundtrip=True, to_mlir=False, verify=True)
 
     # Test dim index out of bounds.
     program_broadcast_dim_oob = r"""
@@ -555,7 +557,7 @@ def test_invalid_broadcast_in_dim_operations(run_filecheck):
     """
 
     with pytest.raises(Exception, match="broadcast_dimensions contains invalid value"):
-        run_filecheck(program_broadcast_dim_oob, roundtrip=True, verify=True)
+        run_filecheck(program_broadcast_dim_oob, roundtrip=True, to_mlir=False, verify=True)
 
     # Test operand dim not 1 and not equal to result dim.
     program_broadcast_dim_mismatch = r"""
@@ -569,7 +571,7 @@ def test_invalid_broadcast_in_dim_operations(run_filecheck):
         Exception,
         match="size of operand dimension .* is not equal to 1 or size of result dimension",
     ):
-        run_filecheck(program_broadcast_dim_mismatch, roundtrip=True, verify=True)
+        run_filecheck(program_broadcast_dim_mismatch, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_dynamism_operations(run_filecheck):
@@ -589,7 +591,7 @@ def test_dynamism_operations(run_filecheck):
     } : (tensor<1x3xi64>, tensor<3xi64>) -> tensor<2x3x2xi64>
     """
 
-    run_filecheck(program, roundtrip=True, verify=True)
+    run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_reduction_operations(run_filecheck):
@@ -615,7 +617,7 @@ def test_reduction_operations(run_filecheck):
     }) {dimensions = array<i64: 1>} : (tensor<1x6xi64>, tensor<i64>) -> tensor<1xi64>
     """
 
-    run_filecheck(program, roundtrip=True, verify=True)
+    run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_invalid_reduction_operations(run_filecheck):
@@ -634,7 +636,7 @@ def test_invalid_reduction_operations(run_filecheck):
     """
 
     with pytest.raises(Exception, match=r"dimensions should not have duplicates"):
-        run_filecheck(program_dup_dims, roundtrip=True, verify=True)
+        run_filecheck(program_dup_dims, roundtrip=True, to_mlir=False, verify=True)
 
     # Dimension out of range
     program_dim_oob = r"""
@@ -649,7 +651,7 @@ def test_invalid_reduction_operations(run_filecheck):
     """
 
     with pytest.raises(Exception, match=r"dimensions contains an invalid value"):
-        run_filecheck(program_dim_oob, roundtrip=True, verify=True)
+        run_filecheck(program_dim_oob, roundtrip=True, to_mlir=False, verify=True)
 
     # Input/init element type mismatch
     program_elem_mismatch = r"""
@@ -664,7 +666,7 @@ def test_invalid_reduction_operations(run_filecheck):
     """
 
     with pytest.raises(Exception, match=r"input and init_value must have the same element type"):
-        run_filecheck(program_elem_mismatch, roundtrip=True, verify=True)
+        run_filecheck(program_elem_mismatch, roundtrip=True, to_mlir=False, verify=True)
 
     # Reducer wrong arity (expects 2 args per input; give 1)
     program_wrong_arity = r"""
@@ -678,7 +680,7 @@ def test_invalid_reduction_operations(run_filecheck):
     """
 
     with pytest.raises(Exception, match=r"reducer must take 2 arguments, got 1"):
-        run_filecheck(program_wrong_arity, roundtrip=True, verify=True)
+        run_filecheck(program_wrong_arity, roundtrip=True, to_mlir=False, verify=True)
 
     # Reducer arg wrong rank (should be 0D)
     program_arg_rank = r"""
@@ -693,7 +695,7 @@ def test_invalid_reduction_operations(run_filecheck):
     """
 
     with pytest.raises(Exception, match=r"reducer arguments must be rank-0 tensors"):
-        run_filecheck(program_arg_rank, roundtrip=True, verify=True)
+        run_filecheck(program_arg_rank, roundtrip=True, to_mlir=False, verify=True)
 
     # Reducer return wrong count
     program_return_count = r"""
@@ -707,7 +709,7 @@ def test_invalid_reduction_operations(run_filecheck):
     """
 
     with pytest.raises(Exception, match=r"reducer must return exactly one value per input"):
-        run_filecheck(program_return_count, roundtrip=True, verify=True)
+        run_filecheck(program_return_count, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_custom_call_basic(run_filecheck):
@@ -726,7 +728,7 @@ def test_custom_call_basic(run_filecheck):
     } : (tensor<2x3xi32>) -> tensor<2x3xi32>
     """
 
-    run_filecheck(program, roundtrip=True, verify=True)
+    run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_custom_call_with_layouts(run_filecheck):
@@ -747,7 +749,7 @@ def test_custom_call_with_layouts(run_filecheck):
     } : (tensor<2x3xi32>) -> tensor<2x3xi32>
     """
 
-    run_filecheck(program, roundtrip=True, verify=True)
+    run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_custom_call_missing_result_layouts(run_filecheck):
@@ -767,7 +769,7 @@ def test_custom_call_missing_result_layouts(run_filecheck):
         Exception,
         match=r"either both operands and results or none",
     ):
-        run_filecheck(program, roundtrip=True, verify=True)
+        run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_custom_call_layouts_mismatch(run_filecheck):
@@ -788,7 +790,7 @@ def test_custom_call_layouts_mismatch(run_filecheck):
     with pytest.raises(
         Exception, match=r"Number of operands must match the number of operand layouts"
     ):
-        run_filecheck(program, roundtrip=True, verify=True)
+        run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_custom_call_incorrect_layout_perm(run_filecheck):
@@ -806,7 +808,7 @@ def test_custom_call_incorrect_layout_perm(run_filecheck):
     """
 
     with pytest.raises(Exception, match=r"layout must be a permutation of \[0, 2\)"):
-        run_filecheck(program, roundtrip=True, verify=True)
+        run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_custom_call_single_tuple_result_with_element_layouts(run_filecheck):
@@ -830,7 +832,7 @@ def test_custom_call_single_tuple_result_with_element_layouts(run_filecheck):
       output_operand_aliases = []
     } : (tensor<2x3xi32>) -> tuple<tensor<2x3xi32>, tensor<1xi32>>
     """
-    run_filecheck(program, roundtrip=True, verify=True)
+    run_filecheck(program, roundtrip=True, to_mlir=False, verify=True)
 
 
 def test_invalid_dynamic_broadcast_in_dim_operations(run_filecheck):
@@ -849,7 +851,7 @@ def test_invalid_dynamic_broadcast_in_dim_operations(run_filecheck):
     with pytest.raises(
         Exception, match=r"broadcast_dimensions size \(1\) does not match operand rank \(2\)"
     ):
-        run_filecheck(program_dims_size_mismatch, roundtrip=True, verify=True)
+        run_filecheck(program_dims_size_mismatch, roundtrip=True, to_mlir=False, verify=True)
 
     # result rank < operand rank (c3)
     program_result_rank_too_small = r"""
@@ -862,7 +864,7 @@ def test_invalid_dynamic_broadcast_in_dim_operations(run_filecheck):
     """
 
     with pytest.raises(Exception, match=r"result rank \(1\) is less than operand rank \(2\)"):
-        run_filecheck(program_result_rank_too_small, roundtrip=True, verify=True)
+        run_filecheck(program_result_rank_too_small, roundtrip=True, to_mlir=False, verify=True)
 
     # duplicate dims (c4)
     program_duplicate_dims = r"""
@@ -875,7 +877,7 @@ def test_invalid_dynamic_broadcast_in_dim_operations(run_filecheck):
     """
 
     with pytest.raises(Exception, match=r"broadcast_dimensions should not have duplicates"):
-        run_filecheck(program_duplicate_dims, roundtrip=True, verify=True)
+        run_filecheck(program_duplicate_dims, roundtrip=True, to_mlir=False, verify=True)
 
     # dim index out of bounds (c5 bounds)
     program_dim_oob = r"""
@@ -890,7 +892,7 @@ def test_invalid_dynamic_broadcast_in_dim_operations(run_filecheck):
     with pytest.raises(
         Exception, match=r"broadcast_dimensions contains invalid value 2 for result with rank 2"
     ):
-        run_filecheck(program_dim_oob, roundtrip=True, verify=True)
+        run_filecheck(program_dim_oob, roundtrip=True, to_mlir=False, verify=True)
 
     # per-dimension size compatibility (c5 compatibility)
     program_dim_incompatible = r"""
@@ -906,7 +908,7 @@ def test_invalid_dynamic_broadcast_in_dim_operations(run_filecheck):
         Exception,
         match=r"size of operand dimension 0 \(2\) is not compatible with size of result dimension 0 \(4\)",
     ):
-        run_filecheck(program_dim_incompatible, roundtrip=True, verify=True)
+        run_filecheck(program_dim_incompatible, roundtrip=True, to_mlir=False, verify=True)
 
     # output_dimensions length incompatible with result rank when static (c7)
     program_outlen_mismatch = r"""
@@ -922,7 +924,7 @@ def test_invalid_dynamic_broadcast_in_dim_operations(run_filecheck):
         Exception,
         match=r"length of output_dimensions \(2\) is not compatible with result rank \(3\)",
     ):
-        run_filecheck(program_outlen_mismatch, roundtrip=True, verify=True)
+        run_filecheck(program_outlen_mismatch, roundtrip=True, to_mlir=False, verify=True)
 
     # duplicate expansion hints across both lists (c8)
     program_dup_hints = r"""
@@ -939,7 +941,7 @@ def test_invalid_dynamic_broadcast_in_dim_operations(run_filecheck):
     with pytest.raises(
         Exception, match=r"duplicate expansion hint for at least one operand dimension"
     ):
-        run_filecheck(program_dup_hints, roundtrip=True, verify=True)
+        run_filecheck(program_dup_hints, roundtrip=True, to_mlir=False, verify=True)
 
     # hint refers to invalid operand dimension (c9/c10)
     program_hint_oob = r"""
@@ -956,4 +958,4 @@ def test_invalid_dynamic_broadcast_in_dim_operations(run_filecheck):
         Exception,
         match=r"hint for expanding dimension 5 does not refer to a valid operand dimension",
     ):
-        run_filecheck(program_hint_oob, roundtrip=True, verify=True)
+        run_filecheck(program_hint_oob, roundtrip=True, to_mlir=False, verify=True)


### PR DESCRIPTION
**Context:**
This PR updates the round trip testing strategy to also send the printed program to MLIR before parsing it back to xDSL. This improves verification of xDSL-MLIR parity as well.

**Description of the Change:**
* Added 2 new arguments to `run_filecheck`:
  * `to_mlir`: Whether to parse to MLIR when `roundtrip=True`. `True` by default.
  * `pretty_print`: If `True`, when `roundtrip=True`, the program will be pretty printed during the round trip
* This change caught an issue in the quantum dialect: `GlobalPhaseOp`'s `assembly_format` was incorrect, which is updated in this PR.
* Lit tests for all dialects were updated based on issues found with the updated round-trip testing. These issues came up because parsing MLIR with `quantum-opt` automatically runs verification on the module, which was failing for some of the tests
* Parametrized all lit tests to do the round trip with both pretty printing and generic printing
  * This caused the lit test for the Catalyst dialect to fail because xDSL doesn't support assembly formats for attributes. This test was xfailed.
* StableHLO lit tests set `to_mlir` to False because it doesn't work perfectly. This is fine in my opinion because StableHLO is being migrated to `xdsl-jax` anyway.

**Benefits:**
Better validation of parity between xDSL and MLIR dialects

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-98396] [sc-99388]