### PR TITLE
Register upstream MLIR `Test` dialect in `catalyst` CLI tool

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -43,6 +43,9 @@
   into normal PPR and PPMs with SCF dialect to support runtime execution.
   [(#2390)](https://github.com/PennyLaneAI/catalyst/pull/2390)
 
+* The upstream MLIR `Test` dialect is now available via the `catalyst` command line tool.
+  [(#2417)](https://github.com/PennyLaneAI/catalyst/pull/2417)
+
 <h3>Documentation 📝</h3>
 
 * Updated the Unified Compiler Cookbook to be compatible with the latest versions of PennyLane and Catalyst.

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -331,6 +331,13 @@ struct CatalystPassInstrumentation : public PassInstrumentation {
 
 } // namespace
 
+/// The upstream MLIR Test dialect does not have a header we can include
+/// We must declare the registration function, and link to the corresponding upstream target
+/// in CMake.
+namespace test {
+void registerTestDialect(mlir::DialectRegistry &);
+} // namespace test
+
 namespace {
 /// Parse an MLIR module given in textual ASM representation. Any errors during parsing will be
 /// output to diagnosticStream.
@@ -368,6 +375,7 @@ void registerAllCatalystDialects(DialectRegistry &registry)
     // MLIR Core dialects
     registerAllDialects(registry);
     registerAllExtensions(registry);
+    ::test::registerTestDialect(registry);
 
     // HLO
     stablehlo::registerAllDialects(registry);

--- a/mlir/test/cli/TestDialect.mlir
+++ b/mlir/test/cli/TestDialect.mlir
@@ -1,0 +1,21 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RUN: catalyst --tool=opt %s --catalyst-pipeline="pipeline(quantum-compilation-stage)"
+
+func.func @foo() {
+    // CHECK: "test.op"() : () -> !quantum.bit
+    %0 = "test.op"() : () -> !quantum.bit
+    return
+}

--- a/mlir/tools/catalyst-cli/CMakeLists.txt
+++ b/mlir/tools/catalyst-cli/CMakeLists.txt
@@ -46,6 +46,7 @@ set(LIBS
     MLIRCatalystTest
     ${ENZYME_LIB}
     CatalystCompilerDriver
+    MLIRTestDialect
 )
 
 add_mlir_tool(catalyst-cli catalyst-cli.cpp SUPPORT_PLUGINS)


### PR DESCRIPTION
**Context:**
The upstream MLIR dialect `Test` was included into the `quantum-opt` tool in #1147 . The motivation was to use mocked test ops to produce values of arbitrary types, cutting down the necessity to include extra dialects just for tests.

We registered this `Test` dialect into `quantum-opt` but not into the `catalyst` CLI (possibly because the catalyst CLI didn't exist yet).

This was causing some issues for xdsl tests, since the python entry point `_quantum_opt()` calls the `catalyst` CLI, not the `quantum-opt` CLI. https://github.com/PennyLaneAI/catalyst/blob/9f2aaa97b0c78924ea78215a3ea8a65196a62bdc/frontend/catalyst/compiler.py#L302

**Description of the Change:**
Register the upstream MLIR `Test` dialect into `catalyst` CLI.

**Benefits:**
- xdsl tests can use them
- agreement between the two tools
