### PR TITLE
Emit global phase operations in the `to-ppr` pass

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -43,6 +43,11 @@
   into normal PPR and PPMs with SCF dialect to support runtime execution.
   [(#2390)](https://github.com/PennyLaneAI/catalyst/pull/2390)
 
+* Added global phase tracking to the `to-ppr` compiler pass. When converting quantum gates to
+  Pauli Product Rotations (PPR), the pass now emits `quantum.gphase` operations to preserve
+  global phase correctness.
+  [(#XXXX)](https://github.com/PennyLaneAI/catalyst/pull/XXXX)
+
 <h3>Documentation 📝</h3>
 
 * Updated the Unified Compiler Cookbook to be compatible with the latest versions of PennyLane and Catalyst.

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.15.0-dev10"
+__version__ = "0.15.0-dev11"

--- a/frontend/test/pytest/python_interface/inspection/test_mlir_specs.py
+++ b/frontend/test/pytest/python_interface/inspection/test_mlir_specs.py
@@ -604,7 +604,12 @@ class TestMLIRSpecs:
             qml.PauliRot(0.1234, pauli_word="Z", wires=0)
 
         expected = make_static_resources(
-            operations={"PPR-pi/4": {1: 3}, "PPR-pi/8": {1: 1}, "PPR-Phi": {1: 1}},
+            operations={
+                "GlobalPhase": {0: 2},
+                "PPR-pi/4": {1: 3},
+                "PPR-pi/8": {1: 1},
+                "PPR-Phi": {1: 1},
+            },
             measurements={},
             num_allocs=2,
         )

--- a/frontend/test/pytest/test_specs.py
+++ b/frontend/test/pytest/test_specs.py
@@ -510,8 +510,8 @@ class TestPassByPassSpecs:
             shots=Shots(None),
             level=2,
             resources=SpecsResources(
-                gate_types={"PPR-pi/4": 3, "PPR-pi/8": 1},
-                gate_sizes={1: 4},
+                gate_types={"GlobalPhase": 2, "PPR-pi/4": 3, "PPR-pi/8": 1},
+                gate_sizes={0: 2, 1: 4},
                 measurements={},
                 num_allocs=2,
             ),

--- a/mlir/lib/QEC/Transforms/ToPPR.cpp
+++ b/mlir/lib/QEC/Transforms/ToPPR.cpp
@@ -350,7 +350,6 @@ struct QECOpLowering : public ConversionPattern {
     LogicalResult matchAndRewrite(Operation *op, ArrayRef<Value> operands,
                                   ConversionPatternRewriter &rewriter) const final
     {
-        const auto PI = llvm::numbers::pi;
         // cast to OriginOp
         if (auto originOp = dyn_cast_or_null<CustomOp>(op)) {
             switch (hashGate(originOp)) {

--- a/mlir/lib/QEC/Transforms/ToPPR.cpp
+++ b/mlir/lib/QEC/Transforms/ToPPR.cpp
@@ -275,10 +275,6 @@ LogicalResult convertPauliRotGate(PauliRotOp op, ConversionPatternRewriter &rewr
 
     auto angleOpt = resolveConstantValue(angleValue);
 
-    Value c2 = rewriter.create<arith::ConstantOp>(loc, rewriter.getF64FloatAttr(2.0));
-    Value halfAngle = rewriter.create<arith::DivFOp>(loc, op.getAngle(), c2);
-    applyGlobalPhase(loc, halfAngle, rewriter);
-
     if (angleOpt.has_value()) {
         constexpr double PI = llvm::numbers::pi;
         constexpr double SPECIFIC_ANGLES[6] = {PI / 2, PI / 4, PI / 8, -PI / 8, -PI / 4, -PI / 2};

--- a/mlir/lib/QEC/Transforms/ppm_compilation.cpp
+++ b/mlir/lib/QEC/Transforms/ppm_compilation.cpp
@@ -14,6 +14,7 @@
 
 #define DEBUG_TYPE "ppm-compilation"
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -52,6 +53,8 @@ struct PPMCompilationPass : public impl::PPMCompilationPassBase<PPMCompilationPa
 
             // Conversion target is QECDialect
             target.addLegalDialect<qec::QECDialect>();
+            target.addLegalDialect<mlir::arith::ArithDialect>();
+            target.addLegalOp<quantum::GlobalPhaseOp>();
 
             RewritePatternSet patterns(ctx);
             populateToPPRPatterns(patterns);

--- a/mlir/lib/QEC/Transforms/to_ppr.cpp
+++ b/mlir/lib/QEC/Transforms/to_ppr.cpp
@@ -50,6 +50,7 @@ struct ToPPRPass : impl::ToPPRPassBase<ToPPRPass> {
         // Conversion target is QECDialect
         target.addLegalDialect<qec::QECDialect>();
         target.addLegalDialect<mlir::arith::ArithDialect>();
+        target.addLegalOp<GlobalPhaseOp>();
 
         RewritePatternSet patterns(ctx);
         populateToPPRPatterns(patterns);

--- a/mlir/test/QEC/ToPPRTest.mlir
+++ b/mlir/test/QEC/ToPPRTest.mlir
@@ -135,6 +135,7 @@ func.func @test_dynamic_pauli_rot_to_ppr(%q1 : !quantum.bit, %arg0 : tensor<f64>
 
     // CHECK: [[cst:%.+]] = arith.constant 2.000000e+00 : f64
     // CHECK: [[extracted:%.+]] = tensor.extract
+    // CHECK: quantum.gphase
     // CHECK: [[div:%.+]] = arith.divf [[extracted]], [[cst]] : f64
     // CHECK: [[q0:%.+]] = qec.ppr.arbitrary ["Z"]([[div]])
 }

--- a/mlir/test/QEC/ToPPRTest.mlir
+++ b/mlir/test/QEC/ToPPRTest.mlir
@@ -19,11 +19,18 @@ func.func @test_clifford_t_to_ppr(%q1 : !quantum.bit, %q2 : !quantum.bit){
     // pi / 8 = 826990
     // CHECK-NOT: quantum.custom
     // CHECK: ([[q1:%.+]]: !quantum.bit, [[q2:%.+]]: !quantum.bit)
+    // CHECK: [[C:%.+]] = arith.constant -0.392
+    // CHECK: [[C0:%.+]] = arith.constant -0.785
+    // CHECK: [[C1:%.+]] = arith.constant -1.570
+    // CHECK: quantum.gphase([[C1]])
     // CHECK: [[q1_0_0:%.+]] = qec.ppr ["Z"](4) [[q1]]
     // CHECK: [[q1_0_1:%.+]] = qec.ppr ["X"](4) [[q1_0_0]]
     // CHECK: [[q1_0_2:%.+]] = qec.ppr ["Z"](4) [[q1_0_1]]
+    // CHECK: quantum.gphase([[C0]])
     // CHECK: [[q1_1:%.+]] = qec.ppr ["Z"](4) [[q1_0_2]]
+    // CHECK: quantum.gphase([[C]])
     // CHECK: [[q1_2:%.+]] = qec.ppr ["Z"](8) [[q1_1]]
+    // CHECK: quantum.gphase([[C0]])
     // CHECK: [[q1_3:%.+]]:2 = qec.ppr ["Z", "X"](4) [[q1_2]], [[q2]]
     %q1_0 = quantum.custom "H"() %q1 : !quantum.bit
     %q1_1 = quantum.custom "S"() %q1_0 : !quantum.bit
@@ -39,20 +46,27 @@ func.func @test_clifford_t_to_ppr(%q1 : !quantum.bit, %q2 : !quantum.bit){
 // -----
 
 func.func public @test_clifford_t_to_ppr_1() -> (tensor<i1>, tensor<i1>) {
+    // CHECK: [[C:%.+]] = arith.constant -0.392
+    // CHECK: [[C0:%.+]] = arith.constant -1.570
+    // CHECK: [[C1:%.+]] = arith.constant -0.785
     // CHECK: [[q0:%.+]] = quantum.alloc( 2) : !quantum.reg
     %0 = quantum.alloc( 2) : !quantum.reg
     // CHECK: [[q1_0:%.+]] = quantum.extract [[q0]][ 1]
     %1 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+    // CHECK: quantum.gphase([[C1]])
     // CHECK: [[q1_1:%.+]] = qec.ppr ["Z"](4) [[q1_0]]
     %out_qubits = quantum.custom "S"() %1 : !quantum.bit
     // CHECK: [[q0_0:%.+]] = quantum.extract [[q0]][ 0]
     %2 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+    // CHECK: quantum.gphase([[C0]])
     // CHECK: [[q0_1_0:%.+]] = qec.ppr ["Z"](4) [[q0_0]]
     // CHECK: [[q0_1_1:%.+]] = qec.ppr ["X"](4) [[q0_1_0]]
     // CHECK: [[q0_1_2:%.+]] = qec.ppr ["Z"](4) [[q0_1_1]]
     %out_qubits_0 = quantum.custom "Hadamard"() %2 : !quantum.bit
+    // CHECK: quantum.gphase([[C]])
     // CHECK: [[q0_2:%.+]] = qec.ppr ["Z"](8) [[q0_1_2]]
     %out_qubits_1 = quantum.custom "T"() %out_qubits_0 : !quantum.bit
+    // CHECK: quantum.gphase([[C1]])
     // CHECK: [[q_3:%.+]]:2 = qec.ppr ["Z", "X"](4) [[q0_2]], [[q1_1]]
     // CHECK: [[q_4:%.+]] = qec.ppr ["Z"](-4) [[q_3]]#0
     // CHECK: [[q_5:%.+]] = qec.ppr ["X"](-4) [[q_3]]#1
@@ -110,7 +124,7 @@ func.func @test_standard_pauli_rot_to_ppr(%q1 : !quantum.bit){
     %extracted = tensor.extract %cst[] : tensor<f64>
     %out_qubits = quantum.paulirot ["Z"](%extracted) %q1 : !quantum.bit
     func.return
-
+    // CHECK-NOT: quantum.gphase
     // CHECK: qec.ppr ["Z"](2)
 }
 
@@ -135,7 +149,6 @@ func.func @test_dynamic_pauli_rot_to_ppr(%q1 : !quantum.bit, %arg0 : tensor<f64>
 
     // CHECK: [[cst:%.+]] = arith.constant 2.000000e+00 : f64
     // CHECK: [[extracted:%.+]] = tensor.extract
-    // CHECK: quantum.gphase
     // CHECK: [[div:%.+]] = arith.divf [[extracted]], [[cst]] : f64
     // CHECK: [[q0:%.+]] = qec.ppr.arbitrary ["Z"]([[div]])
 }


### PR DESCRIPTION
**Context:**

When converting quantum gates to Pauli Product Rotations (PPR), the transformation changes the global phase of the circuit. Here we emit global phases when lowering to PPR.

**Description of the Change:**

This PR adds global phase compensation to the `to-ppr` compiler pass by emitting `quantum.gphase` operations during gate conversion:

- **H gate**: -π/2
- **S gate**: -π/4
- **T gate**: -π/8
- **X, Y, Z gates**: -π/2
- **CNOT gate**: +π/4

[[sc-98156]]
