### PR TITLE
Add a new pass to lower QEC initialization ops

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -72,7 +72,7 @@
   to Quantum dialect operations. This pass converts `qec.prepare` to `quantum.set_state` and
   `qec.fabricate` to `quantum.alloc_qb` + `quantum.set_state`, enabling runtime execution of
   QEC state preparation operations.
-  [(#XXXX)](https://github.com/PennyLaneAI/catalyst/pull/XXXX)
+  [(#2424)](https://github.com/PennyLaneAI/catalyst/pull/2424)
 
 <h3>Documentation 📝</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -68,6 +68,12 @@
 * The upstream MLIR `Test` dialect is now available via the `catalyst` command line tool.
   [(#2417)](https://github.com/PennyLaneAI/catalyst/pull/2417)
 
+* A new compiler pass `lower-qec-init-ops` has been added to lower QEC initialization operations
+  to Quantum dialect operations. This pass converts `qec.prepare` to `quantum.set_state` and
+  `qec.fabricate` to `quantum.alloc_qb` + `quantum.set_state`, enabling runtime execution of
+  QEC state preparation operations.
+  [(#XXXX)](https://github.com/PennyLaneAI/catalyst/pull/XXXX)
+
 <h3>Documentation 📝</h3>
 
 * Updated the Unified Compiler Cookbook to be compatible with the latest versions of PennyLane and Catalyst.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -69,8 +69,8 @@
   [(#2417)](https://github.com/PennyLaneAI/catalyst/pull/2417)
 
 * A new compiler pass `lower-qec-init-ops` has been added to lower QEC initialization operations
-  to Quantum dialect operations. This pass converts `qec.prepare` to `quantum.set_state` and
-  `qec.fabricate` to `quantum.alloc_qb` + `quantum.set_state`, enabling runtime execution of
+  to Quantum dialect operations. This pass converts `qec.prepare` to `quantum.custom` and
+  `qec.fabricate` to `quantum.alloc_qb` + `quantum.custom`, enabling runtime execution of
   QEC state preparation operations.
   [(#2424)](https://github.com/PennyLaneAI/catalyst/pull/2424)
 

--- a/mlir/include/QEC/Transforms/Passes.td
+++ b/mlir/include/QEC/Transforms/Passes.td
@@ -152,7 +152,7 @@ def UnrollConditionalPPRPPMPass : Pass<"unroll-conditional-ppr-ppm"> {
 }
 
 def LowerQECInitOpsPass : Pass<"lower-qec-init-ops"> {
-    let summary = "Lower QEC initialization ops (prepare, fabricate) to quantum dialect ops (set_state, set_basis_state).";
+    let summary = "Lower QEC initialization ops (prepare, fabricate) to quantum dialect op (set_basis_state).";
     
     let dependentDialects = [ "catalyst::qec::QECDialect"];
 }

--- a/mlir/include/QEC/Transforms/Passes.td
+++ b/mlir/include/QEC/Transforms/Passes.td
@@ -151,4 +151,10 @@ def UnrollConditionalPPRPPMPass : Pass<"unroll-conditional-ppr-ppm"> {
     let dependentDialects = [ "catalyst::qec::QECDialect", "scf::SCFDialect" ];
 }
 
+def LowerQECInitOpsPass : Pass<"lower-qec-init-ops"> {
+    let summary = "Lower QEC initialization ops (prepare, fabricate) to quantum dialect ops (set_state, set_basis_state).";
+    
+    let dependentDialects = [ "catalyst::qec::QECDialect"];
+}
+
 #endif // QEC_PASSES

--- a/mlir/include/QEC/Transforms/Patterns.h
+++ b/mlir/include/QEC/Transforms/Patterns.h
@@ -34,5 +34,6 @@ void populateDecomposeCliffordPPRPatterns(mlir::RewritePatternSet &, bool avoidY
 void populatePPRToMBQCPatterns(mlir::RewritePatternSet &);
 void populateDecomposeArbitraryPPRPatterns(mlir::RewritePatternSet &);
 void populateUnrollConditionalPPRPPMPatterns(mlir::RewritePatternSet &);
+void populateLowerQECInitOpsPatterns(mlir::RewritePatternSet &);
 } // namespace qec
 } // namespace catalyst

--- a/mlir/lib/QEC/Transforms/CMakeLists.txt
+++ b/mlir/lib/QEC/Transforms/CMakeLists.txt
@@ -24,6 +24,8 @@ file(GLOB SRC
     PPRToMBQC.cpp
     decompose_arbitrary_ppr.cpp
     DecomposeArbitraryPPR.cpp
+    lower_qec_init_ops.cpp
+    LowerQECInitOps.cpp
 )
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)

--- a/mlir/lib/QEC/Transforms/LowerQECInitOps.cpp
+++ b/mlir/lib/QEC/Transforms/LowerQECInitOps.cpp
@@ -14,10 +14,6 @@
 
 #define DEBUG_TYPE "lower-qec-init-ops"
 
-#include <type_traits>
-
-#include "llvm/Support/MathExtras.h"
-
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Builders.h"
 

--- a/mlir/lib/QEC/Transforms/LowerQECInitOps.cpp
+++ b/mlir/lib/QEC/Transforms/LowerQECInitOps.cpp
@@ -1,0 +1,128 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define DEBUG_TYPE "lower-qec-init-ops"
+
+#include <type_traits>
+
+#include "llvm/Support/MathExtras.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Builders.h"
+
+#include "QEC/IR/QECOps.h"
+#include "QEC/Transforms/Patterns.h"
+#include "Quantum/IR/QuantumOps.h"
+
+using namespace mlir;
+using namespace catalyst::qec;
+using namespace catalyst::quantum;
+
+namespace {
+
+/// Get the state vector values for a given LogicalInitKind
+/// Returns {re0, im0, re1, im1} for a single qubit state
+std::tuple<double, double, double, double> getStateVectorValues(LogicalInitKind initState)
+{
+    constexpr double sqrt2_inv = 1.0 / llvm::numbers::sqrt2; // 1/√2
+
+    switch (initState) {
+    case LogicalInitKind::zero:
+        return {1.0, 0.0, 0.0, 0.0};
+    case LogicalInitKind::one:
+        return {0.0, 0.0, 1.0, 0.0};
+    case LogicalInitKind::plus:
+        return {sqrt2_inv, 0.0, sqrt2_inv, 0.0};
+    case LogicalInitKind::minus:
+        return {sqrt2_inv, 0.0, -sqrt2_inv, 0.0};
+    case LogicalInitKind::plus_i:
+        return {sqrt2_inv, 0.0, 0.0, sqrt2_inv};
+    case LogicalInitKind::minus_i:
+        return {sqrt2_inv, 0.0, 0.0, -sqrt2_inv};
+    case LogicalInitKind::magic: // T gate
+        // |m⟩ = (|0⟩ + e^{iπ/4}|1⟩) / √2 = [1/√2, (1+i)/(2)]
+        return {sqrt2_inv, 0.0, 0.5, 0.5};
+    case LogicalInitKind::magic_conj: // T† gate
+        // |m̅⟩ = (|0⟩ + e^{-iπ/4}|1⟩) / √2 = [1/√2, (1-i)/(2)]
+        return {sqrt2_inv, 0.0, 0.5, -0.5};
+    }
+    llvm_unreachable("Unknown LogicalInitKind");
+}
+
+/// Create a dense tensor constant for a single qubit state vector
+Value createStateVectorTensor(Location loc, PatternRewriter &rewriter, LogicalInitKind initState)
+{
+    auto ctx = rewriter.getContext();
+    auto f64Type = Float64Type::get(ctx);
+    auto complexType = ComplexType::get(f64Type);
+    auto tensorType = RankedTensorType::get({2}, complexType);
+
+    auto [re0, im0, re1, im1] = getStateVectorValues(initState);
+
+    auto denseAttr = DenseElementsAttr::get(
+        tensorType, ArrayRef<std::complex<double>>{std::complex<double>(re0, im0),
+                                                   std::complex<double>(re1, im1)});
+
+    return rewriter.create<arith::ConstantOp>(loc, denseAttr);
+}
+
+/// Template pattern to lower QEC init ops (PrepareStateOp, FabricateOp) to SetStateOp
+/// - PrepareStateOp: uses existing input qubits
+/// - FabricateOp: allocates new qubits via AllocQubitOp
+template <typename OpType> struct LowerQECInitOpPattern : public OpRewritePattern<OpType> {
+    using OpRewritePattern<OpType>::OpRewritePattern;
+
+    LogicalResult matchAndRewrite(OpType op, PatternRewriter &rewriter) const override
+    {
+        Location loc = op.getLoc();
+        auto initState = op.getInitState();
+
+        SmallVector<Value> resultQubits;
+
+        size_t numQubits = op.getOutQubits().size();
+        for (size_t i = 0; i < numQubits; ++i) {
+            Value qubit;
+            if constexpr (std::is_same_v<OpType, PrepareStateOp>) {
+                // PrepareStateOp: use existing input qubits
+                qubit = op.getInQubits()[i];
+            }
+            else {
+                // FabricateOp: allocate a new qubit
+                auto allocOp = rewriter.create<AllocQubitOp>(loc);
+                qubit = allocOp.getResult();
+            }
+
+            Value stateVector = createStateVectorTensor(loc, rewriter, initState);
+            auto setStateOp = rewriter.create<SetStateOp>(loc, qubit.getType(), stateVector, qubit);
+            resultQubits.push_back(setStateOp.getOutQubits().front());
+        }
+
+        rewriter.replaceOp(op, resultQubits);
+        return success();
+    }
+};
+
+} // namespace
+
+namespace catalyst {
+namespace qec {
+
+void populateLowerQECInitOpsPatterns(RewritePatternSet &patterns)
+{
+    patterns.add<LowerQECInitOpPattern<PrepareStateOp>>(patterns.getContext());
+    patterns.add<LowerQECInitOpPattern<FabricateOp>>(patterns.getContext());
+}
+
+} // namespace qec
+} // namespace catalyst

--- a/mlir/lib/QEC/Transforms/lower_qec_init_ops.cpp
+++ b/mlir/lib/QEC/Transforms/lower_qec_init_ops.cpp
@@ -1,0 +1,51 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define DEBUG_TYPE "lower-qec-init-ops"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "QEC/Transforms/Patterns.h"
+
+using namespace llvm;
+using namespace mlir;
+using namespace catalyst;
+using namespace catalyst::qec;
+
+namespace catalyst {
+namespace qec {
+
+#define GEN_PASS_DECL_LOWERQECINITOPSPASS
+#define GEN_PASS_DEF_LOWERQECINITOPSPASS
+#include "QEC/Transforms/Passes.h.inc"
+
+struct LowerQECInitOpsPass : public impl::LowerQECInitOpsPassBase<LowerQECInitOpsPass> {
+    using LowerQECInitOpsPassBase::LowerQECInitOpsPassBase;
+
+    void runOnOperation() final
+    {
+        RewritePatternSet patterns(&getContext());
+
+        populateLowerQECInitOpsPatterns(patterns);
+
+        if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+            return signalPassFailure();
+        }
+    }
+};
+
+} // namespace qec
+} // namespace catalyst

--- a/mlir/test/QEC/LowerQECInitOps.mlir
+++ b/mlir/test/QEC/LowerQECInitOps.mlir
@@ -1,0 +1,161 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RUN: quantum-opt --lower-qec-init-ops --split-input-file --verify-diagnostics %s | FileCheck %s
+
+// Test lowering qec.prepare zero to quantum.set_state
+func.func @test_prepare_zero(%q : !quantum.bit) -> !quantum.bit {
+    %0 = qec.prepare zero %q : !quantum.bit
+    return %0 : !quantum.bit
+
+    // CHECK-LABEL: func.func @test_prepare_zero
+    // CHECK: [[STATE:%.+]] = arith.constant dense<[(1.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00)]> : tensor<2xcomplex<f64>>
+    // CHECK: [[OUT:%.+]] = quantum.set_state([[STATE]]) {{.*}} : (tensor<2xcomplex<f64>>, !quantum.bit) -> !quantum.bit
+    // CHECK: return [[OUT]]
+}
+
+// -----
+
+// Test lowering qec.prepare one to quantum.set_state
+func.func @test_prepare_one(%q : !quantum.bit) -> !quantum.bit {
+    %0 = qec.prepare one %q : !quantum.bit
+    return %0 : !quantum.bit
+
+    // CHECK-LABEL: func.func @test_prepare_one
+    // CHECK: [[STATE:%.+]] = arith.constant dense<[(0.000000e+00,0.000000e+00), (1.000000e+00,0.000000e+00)]> : tensor<2xcomplex<f64>>
+    // CHECK: [[OUT:%.+]] = quantum.set_state([[STATE]]) {{.*}} : (tensor<2xcomplex<f64>>, !quantum.bit) -> !quantum.bit
+    // CHECK: return [[OUT]]
+}
+
+// -----
+
+// Test lowering qec.prepare plus to quantum.set_state
+func.func @test_prepare_plus(%q : !quantum.bit) -> !quantum.bit {
+    %0 = qec.prepare plus %q : !quantum.bit
+    return %0 : !quantum.bit
+
+    // CHECK-LABEL: func.func @test_prepare_plus
+    // CHECK: [[STATE:%.+]] = arith.constant dense<(0.707{{.*}},0.000000e+00)> : tensor<2xcomplex<f64>>
+    // CHECK: [[OUT:%.+]] = quantum.set_state([[STATE]]) {{.*}} : (tensor<2xcomplex<f64>>, !quantum.bit) -> !quantum.bit
+    // CHECK: return [[OUT]]
+}
+
+// -----
+
+// Test lowering qec.prepare minus to quantum.set_state
+func.func @test_prepare_minus(%q : !quantum.bit) -> !quantum.bit {
+    %0 = qec.prepare minus %q : !quantum.bit
+    return %0 : !quantum.bit
+
+    // CHECK-LABEL: func.func @test_prepare_minus
+    // CHECK: [[STATE:%.+]] = arith.constant dense<[(0.707{{.*}},0.000000e+00), (-0.707{{.*}},0.000000e+00)]> : tensor<2xcomplex<f64>>
+    // CHECK: [[OUT:%.+]] = quantum.set_state([[STATE]]) {{.*}} : (tensor<2xcomplex<f64>>, !quantum.bit) -> !quantum.bit
+    // CHECK: return [[OUT]]
+}
+
+// -----
+
+// Test lowering qec.prepare plus_i to quantum.set_state
+func.func @test_prepare_plus_i(%q : !quantum.bit) -> !quantum.bit {
+    %0 = qec.prepare plus_i %q : !quantum.bit
+    return %0 : !quantum.bit
+
+    // CHECK-LABEL: func.func @test_prepare_plus_i
+    // CHECK: [[STATE:%.+]] = arith.constant dense<[(0.707{{.*}},0.000000e+00), (0.000000e+00,0.707{{.*}})]> : tensor<2xcomplex<f64>>
+    // CHECK: [[OUT:%.+]] = quantum.set_state([[STATE]]) {{.*}} : (tensor<2xcomplex<f64>>, !quantum.bit) -> !quantum.bit
+    // CHECK: return [[OUT]]
+}
+
+// -----
+
+// Test lowering qec.prepare minus_i to quantum.set_state
+func.func @test_prepare_minus_i(%q : !quantum.bit) -> !quantum.bit {
+    %0 = qec.prepare minus_i %q : !quantum.bit
+    return %0 : !quantum.bit
+
+    // CHECK-LABEL: func.func @test_prepare_minus_i
+    // CHECK: [[STATE:%.+]] = arith.constant dense<[(0.707{{.*}},0.000000e+00), (0.000000e+00,-0.707{{.*}})]> : tensor<2xcomplex<f64>>
+    // CHECK: [[OUT:%.+]] = quantum.set_state([[STATE]]) {{.*}} : (tensor<2xcomplex<f64>>, !quantum.bit) -> !quantum.bit
+    // CHECK: return [[OUT]]
+}
+
+// -----
+
+// Test lowering qec.fabricate magic to quantum.alloc_qb + quantum.set_state
+func.func @test_fabricate_magic() -> !quantum.bit {
+    %0 = qec.fabricate magic : !quantum.bit
+    return %0 : !quantum.bit
+
+    // CHECK-LABEL: func.func @test_fabricate_magic
+    // CHECK: [[STATE:%.+]] = arith.constant dense<[(0.707{{.*}},0.000000e+00), (5.000000e-01,5.000000e-01)]> : tensor<2xcomplex<f64>>
+    // CHECK: [[Q:%.+]] = quantum.alloc_qb : !quantum.bit
+    // CHECK: [[OUT:%.+]] = quantum.set_state([[STATE]]) [[Q]] : (tensor<2xcomplex<f64>>, !quantum.bit) -> !quantum.bit
+    // CHECK: return [[OUT]]
+}
+
+// -----
+
+// Test lowering qec.fabricate magic_conj to quantum.alloc_qb + quantum.set_state
+func.func @test_fabricate_magic_conj() -> !quantum.bit {
+    %0 = qec.fabricate magic_conj : !quantum.bit
+    return %0 : !quantum.bit
+
+    // CHECK-LABEL: func.func @test_fabricate_magic_conj
+    // CHECK: [[STATE:%.+]] = arith.constant dense<[(0.707{{.*}},0.000000e+00), (5.000000e-01,-5.000000e-01)]> : tensor<2xcomplex<f64>>
+    // CHECK: [[Q:%.+]] = quantum.alloc_qb : !quantum.bit
+    // CHECK: [[OUT:%.+]] = quantum.set_state([[STATE]]) [[Q]] : (tensor<2xcomplex<f64>>, !quantum.bit) -> !quantum.bit
+    // CHECK: return [[OUT]]
+}
+
+// -----
+
+// Test lowering qec.fabricate plus_i to quantum.alloc_qb + quantum.set_state
+func.func @test_fabricate_plus_i() -> !quantum.bit {
+    %0 = qec.fabricate plus_i : !quantum.bit
+    return %0 : !quantum.bit
+
+    // CHECK-LABEL: func.func @test_fabricate_plus_i
+    // CHECK: [[STATE:%.+]] = arith.constant dense<[(0.707{{.*}},0.000000e+00), (0.000000e+00,0.707{{.*}})]> : tensor<2xcomplex<f64>>
+    // CHECK: [[Q:%.+]] = quantum.alloc_qb : !quantum.bit
+    // CHECK: [[OUT:%.+]] = quantum.set_state([[STATE]]) [[Q]] : (tensor<2xcomplex<f64>>, !quantum.bit) -> !quantum.bit
+    // CHECK: return [[OUT]]
+}
+
+// -----
+
+// Test lowering qec.prepare with multiple qubits
+func.func @test_prepare_multiple_qubits(%q1 : !quantum.bit, %q2 : !quantum.bit) -> (!quantum.bit, !quantum.bit) {
+    %0, %1 = qec.prepare zero %q1, %q2 : !quantum.bit, !quantum.bit
+    return %0, %1 : !quantum.bit, !quantum.bit
+
+    // CHECK-LABEL: func.func @test_prepare_multiple_qubits
+    // CHECK: [[STATE:%.+]] = arith.constant dense<[(1.000000e+00,0.000000e+00), (0.000000e+00,0.000000e+00)]> : tensor<2xcomplex<f64>>
+    // CHECK: [[OUT1:%.+]] = quantum.set_state([[STATE]]) {{.*}} : (tensor<2xcomplex<f64>>, !quantum.bit) -> !quantum.bit
+    // CHECK: [[OUT2:%.+]] = quantum.set_state([[STATE]]) {{.*}} : (tensor<2xcomplex<f64>>, !quantum.bit) -> !quantum.bit
+    // CHECK: return [[OUT1]], [[OUT2]]
+}
+
+// -----
+
+// Test lowering qec.fabricate with multiple qubits
+func.func @test_fabricate_multiple_qubits() -> (!quantum.bit, !quantum.bit) {
+    %0, %1 = qec.fabricate magic : !quantum.bit, !quantum.bit
+    return %0, %1 : !quantum.bit, !quantum.bit
+
+    // CHECK-LABEL: func.func @test_fabricate_multiple_qubits
+    // CHECK: [[STATE:%.+]] = arith.constant dense<[(0.707{{.*}},0.000000e+00), (5.000000e-01,5.000000e-01)]> : tensor<2xcomplex<f64>>
+    // CHECK: [[OUT1:%.+]] = quantum.set_state([[STATE]]) {{.*}} : (tensor<2xcomplex<f64>>, !quantum.bit) -> !quantum.bit
+    // CHECK: [[OUT2:%.+]] = quantum.set_state([[STATE]]) {{.*}} : (tensor<2xcomplex<f64>>, !quantum.bit) -> !quantum.bit
+    // CHECK: return [[OUT1]], [[OUT2]]
+}

--- a/mlir/test/QEC/LowerQECInitOps.mlir
+++ b/mlir/test/QEC/LowerQECInitOps.mlir
@@ -83,7 +83,7 @@ func.func @test_prepare_minus_i(%q : !quantum.bit) -> !quantum.bit {
 
     // CHECK-LABEL: func.func @test_prepare_minus_i
     // CHECK: [[H:%.+]] = quantum.custom "Hadamard"() {{.*}} : !quantum.bit
-    // CHECK: [[OUT:%.+]] = quantum.custom "S"() [[H]] {adjoint} : !quantum.bit
+    // CHECK: [[OUT:%.+]] = quantum.custom "S"() [[H]] adj : !quantum.bit
     // CHECK: return [[OUT]]
 }
 
@@ -111,7 +111,7 @@ func.func @test_fabricate_magic_conj() -> !quantum.bit {
     // CHECK-LABEL: func.func @test_fabricate_magic_conj
     // CHECK: [[Q:%.+]] = quantum.alloc_qb : !quantum.bit
     // CHECK: [[H:%.+]] = quantum.custom "Hadamard"() [[Q]] : !quantum.bit
-    // CHECK: [[OUT:%.+]] = quantum.custom "T"() [[H]] {adjoint} : !quantum.bit
+    // CHECK: [[OUT:%.+]] = quantum.custom "T"() [[H]] adj : !quantum.bit
     // CHECK: return [[OUT]]
 }
 


### PR DESCRIPTION
**Context:**
- Add a new MLIR compiler pass `lower-qec-init-ops` that lowers QEC initialization operations to Quantum dialect operations
- `qec.prepare` is lowered to `quantum.customOp` with the appropriate state vector
- `qec.fabricate` is lowered to `quantum.alloc_qb` + `quantum.customOp`


[[sc-109079]]
