### PR TITLE
Restore adjoint differentiation wrt to multiple QNode results

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -26,6 +26,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Restore the ability to differentiate multiple (expectation value) QNode results with the
+  adjoint-differentiation method.
+  [(#2428)](https://github.com/PennyLaneAI/catalyst/pull/2428)
+
 * Fixed the angle conversion when lowering `qec.ppr` and `qec.ppr.arbitrary` operations to
   `__catalyst__qis__PauliRot` runtime calls. The PPR rotation angle is now correctly multiplied
   by 2 to match the PauliRot convention (`PauliRot(φ) == PPR(φ/2)`).
@@ -59,7 +63,7 @@
   Pauli Product Rotations (PPR), the pass now emits `quantum.gphase` operations to preserve
   global phase correctness.
   [(#2419)](https://github.com/PennyLaneAI/catalyst/pull/2419)
-  
+
 * New qubit-type specializations have been added to Catalyst's MLIR type system. These new qubit
   types include `!quantum.bit<logical>`, `!quantum.bit<qec>` and `!quantum.bit<physical>`. The
   original `!quantum.bit` type continues to be supported and used as the default qubit type.
@@ -79,6 +83,7 @@ This release contains contributions from (in alphabetical order):
 Ali Asadi,
 Joey Carter,
 Sengthai Heng,
+David Ittah,
 Jeffrey Kam,
 Mudit Pandey,
 Andrija Paurevic,

--- a/frontend/test/lit/test_decomposition.py
+++ b/frontend/test/lit/test_decomposition.py
@@ -1177,7 +1177,7 @@ def test_decompose_lowering_fallback():
     @qml.qjit(target="mlir")
     @partial(qml.transforms.decompose, gate_set={qml.RX, qml.RZ})
     @qml.qnode(qml.device("lightning.qubit", wires=2))
-    # CHECK: func.func public @circuit_25() -> tensor<4xcomplex<f64>> attributes {diff_method = "adjoint", llvm.linkage = #llvm.linkage<internal>, qnode}
+    # CHECK-LABEL: func.func public @circuit_25()
     def circuit_25():
         # CHECK: [[OUT_QUBIT:%.+]] = quantum.custom "RZ"(%cst) {{%.+}} : !quantum.bit
         # CHECK-NEXT: [[OUT_QUBIT_0:%.+]] = quantum.custom "RX"(%cst) [[OUT_QUBIT]] : !quantum.bit

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1502,8 +1502,7 @@ def test_pytrees_return_classical_function(backend, diff_method):
     phi = 0.2
 
     if diff_method == "adjoint" and qml.capture.enabled():
-        if qml.capture.enabled():
-            pytest.xfail("TODO")
+        pytest.xfail("TODO")
     else:
         result = qjit(qml.jacobian(circuit, argnums=[0, 1]))(psi, phi)
 

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1501,14 +1501,9 @@ def test_pytrees_return_classical_function(backend, diff_method):
     psi = 0.1
     phi = 0.2
 
-    if diff_method == "adjoint":
-        # Adjoint method does not support multiple return values
+    if diff_method == "adjoint" and qml.capture.enabled():
         if qml.capture.enabled():
             pytest.xfail("TODO")
-        # TODO: specify error message and/or fix, currently MLIR Assertion error
-        #       "invalid qfunc symbol in adjoint op" which doesn't seem right
-        with pytest.raises(CompileError):
-            qjit(qml.jacobian(circuit, argnums=[0, 1]))(psi, phi)
     else:
         result = qjit(qml.jacobian(circuit, argnums=[0, 1]))(psi, phi)
 

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -2512,8 +2512,8 @@ def test_best_diff_method_multi_expval():
     qjit_jacobian = qjit(jacobian(circuit, argnums=[0, 1]))
     _ = qjit_jacobian(0.1, 0.2)
 
-    assert "parameter-shift" in qjit_jacobian.mlir
-    assert "adjoint" not in qjit_jacobian.mlir
+    assert "parameter-shift" not in qjit_jacobian.mlir
+    assert "adjoint" in qjit_jacobian.mlir
 
 
 @pytest.mark.usefixtures("use_both_frontend")

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -2433,44 +2433,6 @@ def test_closure_variable_value_and_grad(diff_method):
     assert np.allclose(expected, observed)
 
 
-@pytest.mark.parametrize("diff_method", ["parameter-shift", "adjoint"])
-def test_closure_variable_value_and_grad(diff_method):
-    """Test that value and grad can take closure variables"""
-
-    @qml.qjit
-    def workflow_closure(x, y):
-
-        dev = qml.device("lightning.qubit", wires=1)
-
-        @qml.qnode(dev, diff_method=diff_method)
-        def circuit(x):
-            qml.RX(jnp.pi * x, wires=0)
-            qml.RX(jnp.pi * y, wires=0)
-            return qml.expval(qml.PauliY(0))
-
-        g = value_and_grad(circuit)
-        return g(x)
-
-    @qml.qjit
-    def workflow_no_closure(x, y):
-
-        dev = qml.device("lightning.qubit", wires=1)
-
-        @qml.qnode(dev, diff_method=diff_method)
-        def circuit(x, y):
-            qml.RX(jnp.pi * x, wires=0)
-            qml.RX(jnp.pi * y, wires=0)
-            return qml.expval(qml.PauliY(0))
-
-        g = value_and_grad(circuit)
-        return g(x, y)
-
-    x, y = 1.0, 0.25
-    expected = workflow_no_closure(x, y)
-    observed = workflow_closure(x, y)
-    assert np.allclose(expected, observed)
-
-
 def test_bufferization_inside_tensor_generate(backend):
     """This tests specifically for an bug already
     filed in LLVM: https://github.com/llvm/llvm-project/issues/141667

--- a/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
@@ -219,10 +219,10 @@ struct AdjointOpPattern : public ConvertOpToLLVMPattern<AdjointOp> {
                 return op.emitOpError("adjoint can only return MemRef<?xf64> or tuple thereof");
         }
 
-        // The callee of the adjoint op must return 2 results: the quantum register and the expval.
+        // The callee of the adjoint op must return as a single result the quantum register.
         func::FuncOp callee =
             SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(op, op.getCalleeAttr());
-        assert(callee && callee.getNumResults() == 2 && "invalid qfunc symbol in adjoint op");
+        assert(callee && callee.getNumResults() == 1 && "adjoint: nodealloc must return only qreg");
 
         StringRef cacheFnName = "__catalyst__rt__toggle_recorder";
         StringRef gradFnName = "__catalyst__qis__Gradient";

--- a/mlir/lib/Gradient/Transforms/GradMethods/Adjoint.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/Adjoint.cpp
@@ -55,14 +55,8 @@ func::FuncOp AdjointLowering::discardAndReturnReg(PatternRewriter &rewriter, Loc
     assert(callee.getBody().hasOneBlock() &&
            "Gradients with unstructured control flow are not supported");
 
-    // Since the return value is guaranteed to be discarded, then let's change the return type
-    // to be only the quantum register and the expval.
-    //
-    // We also need to return the expval to avoid dead code elimination downstream from
-    // removing the expval op in the body.
-    // TODO: we only support grad on expval op for now
+    // Check some prerequisites & assumptions
     SmallVector<quantum::DeallocOp> deallocs;
-    SmallVector<quantum::ExpvalOp> expvalOps;
     SmallVector<quantum::DeviceReleaseOp> deviceReleaseOps;
     for (Operation &op : callee.getBody().getOps()) {
         if (isa<quantum::DeallocOp>(op)) {
@@ -71,7 +65,6 @@ func::FuncOp AdjointLowering::discardAndReturnReg(PatternRewriter &rewriter, Loc
         }
         else if (isa<quantum::MeasurementProcess>(op)) {
             if (isa<quantum::ExpvalOp>(op)) {
-                expvalOps.push_back(cast<quantum::ExpvalOp>(op));
                 continue;
             }
             else {
@@ -100,14 +93,12 @@ func::FuncOp AdjointLowering::discardAndReturnReg(PatternRewriter &rewriter, Loc
         return callee;
     }
 
-    // Create clone, return type is qreg and float for the expvals
+    // Since the MP results are not returned directly in the adjoint method, change the return type
+    // to be only the quantum register.
+    // Create clone, return type is qreg
     std::string fnName = callee.getName().str() + ".nodealloc";
     Type qregType = quantum::QuregType::get(rewriter.getContext());
-    Type f64Type = rewriter.getF64Type();
-    SmallVector<Type> retTypes{qregType};
-    std::for_each(expvalOps.begin(), expvalOps.end(),
-                  [&](const quantum::ExpvalOp &) { retTypes.push_back(f64Type); });
-    FunctionType fnType = rewriter.getFunctionType(callee.getArgumentTypes(), retTypes);
+    FunctionType fnType = rewriter.getFunctionType(callee.getArgumentTypes(), qregType);
     StringAttr visibility = rewriter.getStringAttr("private");
 
     func::FuncOp unallocFn =
@@ -124,12 +115,9 @@ func::FuncOp AdjointLowering::discardAndReturnReg(PatternRewriter &rewriter, Loc
         rewriter.cloneRegionBefore(callee.getBody(), unallocFn.getBody(), unallocFn.end(), mapper);
         rewriter.setInsertionPointToStart(&unallocFn.getBody().front());
 
-        // Let's return the qreg+expval and erase the device release.
-        // Fine for now: only one block in body so only one dealloc and one expval
+        // Let's return the qreg and erase the device release.
+        // Fine for now: only one block in body so only one dealloc
         SmallVector<Value> returnVals{mapper.lookup(deallocs[0])->getOperand(0)};
-        std::for_each(expvalOps.begin(), expvalOps.end(), [&](const quantum::ExpvalOp &expval) {
-            returnVals.push_back(mapper.lookup(expval));
-        });
 
         // Create the return
         // Again, assume just one block for now

--- a/mlir/lib/Gradient/Transforms/GradMethods/Adjoint.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/Adjoint.cpp
@@ -64,10 +64,7 @@ func::FuncOp AdjointLowering::discardAndReturnReg(PatternRewriter &rewriter, Loc
             continue;
         }
         else if (isa<quantum::MeasurementProcess>(op)) {
-            if (isa<quantum::ExpvalOp>(op)) {
-                continue;
-            }
-            else {
+            if (!isa<quantum::ExpvalOp>(op)) {
                 callee.emitOpError() << "Adjoint gradient is only supported on expval measurements";
                 return callee;
             }

--- a/mlir/test/Gradient/ConversionTest.mlir
+++ b/mlir/test/Gradient/ConversionTest.mlir
@@ -18,7 +18,7 @@
 // Native Gradients //
 //////////////////////
 
-func.func private @circuit.nodealloc(%arg0: f32) -> (!quantum.reg, f64)
+func.func private @circuit.nodealloc(%arg0: f32) -> (!quantum.reg)
 
 // CHECK-DAG:   llvm.func @__catalyst__rt__toggle_recorder(i1)
 // CHECK-DAG:   llvm.func @__catalyst__qis__Gradient(i64, ...)
@@ -29,7 +29,7 @@ func.func @adjoint(%arg0: f32, %arg1 : index) -> (memref<?xf64>, memref<?xf64>) 
     // CHECK-DAG:   [[F:%.+]] = llvm.mlir.constant(false) : i1
 
     // CHECK:       llvm.call @__catalyst__rt__toggle_recorder([[T]]) : (i1) -> ()
-    // CHECK:       [[QREG_and_expval:%.+]]:2 = call @circuit.nodealloc(%arg0)
+    // CHECK:       [[QREG:%.+]] = call @circuit.nodealloc(%arg0)
     // CHECK:       llvm.call @__catalyst__rt__toggle_recorder([[F]])
 
     // CHECK-DAG:   [[C1:%.+]] = llvm.mlir.constant(1 : i64) : i64
@@ -38,7 +38,7 @@ func.func @adjoint(%arg0: f32, %arg1 : index) -> (memref<?xf64>, memref<?xf64>) 
     // CHECK:       [[GRAD2:%.+]] = llvm.alloca [[C1]] x !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
 
     // CHECK:       llvm.call @__catalyst__qis__Gradient([[C2]], [[GRAD1]], [[GRAD2]])
-    // CHECK:       quantum.dealloc [[QREG_and_expval]]#0
+    // CHECK:       quantum.dealloc [[QREG]]
     %alloc0 = memref.alloc(%arg1) : memref<?xf64>
     %alloc1 = memref.alloc(%arg1) : memref<?xf64>
     gradient.adjoint @circuit.nodealloc(%arg0) size(%arg1) in(%alloc0, %alloc1 : memref<?xf64>, memref<?xf64>) : (f32) -> ()


### PR DESCRIPTION
fixes #2420 but will produce incorrectly arranged results in multi-arg/multi-result scenarios due to https://github.com/PennyLaneAI/pennylane-lightning/issues/1335

The assertion visible to the user has been reverted and should no longer be raised. The default diff_method is also adjusted to `adjoint` on lightning as long as the results are only expvals (rather than when there is only a single expval result).

[sc-109024]