### PR TITLE
Removing patches in decomposition tests involving PauliRot

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -72,9 +72,6 @@
 * The upstream MLIR `Test` dialect is now available via the `catalyst` command line tool.
   [(#2417)](https://github.com/PennyLaneAI/catalyst/pull/2417)
 
-* Removing patches previously made to decomposition tests before having PPR/PPM execution support
-  [(#2430)]https://github.com/PennyLaneAI/catalyst/pull/2430
-
 <h3>Documentation 📝</h3>
 
 * Updated the Unified Compiler Cookbook to be compatible with the latest versions of PennyLane and Catalyst.


### PR DESCRIPTION
**Context:**
Reverting patches made in https://github.com/PennyLaneAI/catalyst/pull/2365.

[[sc-107501]]
