### PR TITLE
Fixing GlobalPhase issue in Gridsynth when using PPR basis

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -34,6 +34,10 @@
 * Fixing incorrect lowering of PPM into CAPI calls when the PPM is in the negative basis.
   [(#2422)](https://github.com/PennyLaneAI/catalyst/pull/2422)
 
+* Fixed the GlobalPhase discrepancies when executing gridsynth in the PPR basis.
+  [(#2433)](https://github.com/PennyLaneAI/catalyst/pull/2433)
+
+
 <h3>Internal changes ⚙️</h3>
 
 * Autograph is no longer applied to decomposition rules based on whether it's applied to the workflow itself.

--- a/frontend/test/pytest/test_gridsynth.py
+++ b/frontend/test/pytest/test_gridsynth.py
@@ -14,9 +14,9 @@
 
 """Test cases for the gridsynth discretization/decomposition pass."""
 
+import numpy as np
 import pennylane as qml
 import pytest
-import numpy as np
 
 
 @pytest.mark.usefixtures("use_capture")

--- a/frontend/test/pytest/test_gridsynth.py
+++ b/frontend/test/pytest/test_gridsynth.py
@@ -16,8 +16,10 @@
 
 import pennylane as qml
 import pytest
+import numpy as np
 
 
+@pytest.mark.usefixtures("use_capture")
 @pytest.mark.parametrize(
     "param",
     [-11.1, -7.7, -4.4, -2.2, -1.1, -0.3, -0.2, -0.1, 0.0, 0.1, 0.2, 0.3, 1.1, 2.2, 4.4, 7.7, 11.1],
@@ -26,8 +28,6 @@ import pytest
 @pytest.mark.parametrize("eps", [1e-3, 1e-4, 1e-5, 1e-6, 1e-7])
 def test_PhaseShift_gridsynth(param, op, eps):
     """Test that PhaseShift gates are correctly decomposed using the gridsynth pass."""
-
-    qml.capture.enable()
 
     dev = qml.device("lightning.qubit", wires=1)
 
@@ -41,6 +41,30 @@ def test_PhaseShift_gridsynth(param, op, eps):
     gridsynthed_circuit = qml.transforms.gridsynth(circuit, epsilon=eps)
     qjitted_circuit = qml.qjit(gridsynthed_circuit)
     result = qjitted_circuit(param)
-    qml.capture.disable()
 
     assert qml.math.allclose(result, expected, atol=eps)
+
+
+@pytest.mark.usefixtures("use_capture")
+@pytest.mark.parametrize(
+    "param",
+    [-7.7, -2.2, -0.1, 0.0, 0.1, 2.2, 7.7],
+)
+@pytest.mark.parametrize("eps", [1e-6])
+def test_gridsynth_ppr_basis(param, eps):
+    """Test that gridsynth with ppr_basis is consistent with the default gridsynth."""
+
+    dev = qml.device("lightning.qubit", wires=1)
+
+    @qml.qnode(dev)
+    def circuit(x: float):
+        qml.RZ(x, wires=0)
+        return qml.state()
+
+    gridsynthed_circuit = qml.transforms.gridsynth(circuit, epsilon=eps)
+    gridsynthed_circuit_ppr = qml.transforms.gridsynth(circuit, epsilon=eps, ppr_basis=True)
+    qjitted_circuit = qml.qjit(gridsynthed_circuit)
+    qjitted_circuit_with_ppr = qml.qjit(gridsynthed_circuit_ppr)
+    result = qjitted_circuit(param)
+    result_with_ppr = qjitted_circuit_with_ppr(param)
+    assert np.allclose(result, result_with_ppr, atol=eps)

--- a/frontend/test/pytest/test_pauli_rot_and_measure.py
+++ b/frontend/test/pytest/test_pauli_rot_and_measure.py
@@ -191,4 +191,3 @@ def test_pauli_rot_and_measure_execution():
     expected = []
 
     assert np.allclose(qjit_gosc_circuit, expected)
-    

--- a/frontend/test/pytest/test_pauli_rot_and_measure.py
+++ b/frontend/test/pytest/test_pauli_rot_and_measure.py
@@ -176,3 +176,19 @@ def test_pauli_measure_to_ppr_pauli_word_error():
                 qml.pauli_measure("A", wires=0)
 
             return f()
+
+
+@pytest.mark.usefixtures("use_capture")
+def test_pauli_rot_and_measure_execution():
+    """Test that PauliRot and PauliMeasure are executed correctly."""
+
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    def gosc_circuit():
+        qml.PauliRot(np.pi / 4, "X", wires=0)
+        qml.pauli_measure("X", wires=0)
+
+    qjit_gosc_circuit = qjit(gosc_circuit)
+    expected = []
+
+    assert np.allclose(qjit_gosc_circuit, expected)
+    

--- a/frontend/test/pytest/test_pauli_rot_and_measure.py
+++ b/frontend/test/pytest/test_pauli_rot_and_measure.py
@@ -176,18 +176,3 @@ def test_pauli_measure_to_ppr_pauli_word_error():
                 qml.pauli_measure("A", wires=0)
 
             return f()
-
-
-@pytest.mark.usefixtures("use_capture")
-def test_pauli_rot_and_measure_execution():
-    """Test that PauliRot and PauliMeasure are executed correctly."""
-
-    @qml.qnode(qml.device("lightning.qubit", wires=1))
-    def gosc_circuit():
-        qml.PauliRot(np.pi / 4, "X", wires=0)
-        qml.pauli_measure("X", wires=0)
-
-    qjit_gosc_circuit = qjit(gosc_circuit)
-    expected = []
-
-    assert np.allclose(qjit_gosc_circuit, expected)

--- a/runtime/lib/RSDecompRuntime/RSDecomp.cpp
+++ b/runtime/lib/RSDecompRuntime/RSDecomp.cpp
@@ -210,7 +210,7 @@ std::pair<bool, double> try_append_pair_expansion(std::vector<PPRGateType> &out,
 }
 
 /**
- * @brief Convert single gate for HST_to_PPR
+ * @brief Convert single gate for HST_to_PPR and return the global phase update.
  */
 double append_single_gate_expansion(std::vector<PPRGateType> &out, GateType gate)
 {

--- a/runtime/lib/RSDecompRuntime/RSDecomp.cpp
+++ b/runtime/lib/RSDecompRuntime/RSDecomp.cpp
@@ -161,9 +161,9 @@ std::pair<std::vector<PPRGateType>, double> eval_ross_algorithm_ppr(double angle
 
     auto [gates, phase] = compute_clifford_T_decomposition(angle, epsilon);
 
-    std::vector<PPRGateType> ppr_gates = HST_to_PPR(gates);
+    auto [ppr_gates, ppr_phase_update] = HST_to_PPR(gates);
 
-    PPRCacheValue result = {std::move(ppr_gates), phase};
+    PPRCacheValue result = {std::move(ppr_gates), phase + ppr_phase_update};
 
     ross_cache_ppr.put(key, result);
     return result;
@@ -171,81 +171,83 @@ std::pair<std::vector<PPRGateType>, double> eval_ross_algorithm_ppr(double angle
 
 /**
  * @brief Try to convert a pair of gates for HST_to_PPR
- * @return true if a pair rule matched and was appended; false otherwise.
+ * @return std::pair<bool, double> true if a pair rule matched and was appended; false otherwise.
+ * and the global phase update.
  */
-bool try_append_pair_expansion(std::vector<PPRGateType> &out, GateType current, GateType next)
+std::pair<bool, double> try_append_pair_expansion(std::vector<PPRGateType> &out, GateType current,
+                                                  GateType next)
 {
     // We only care if the first gate is HT or SHT
     if (current != GateType::HT && current != GateType::SHT) {
-        return false;
+        return {false, 0.0};
     }
 
     // Rule: HT, HT -> X8, Z8
     if (current == GateType::HT && next == GateType::HT) {
         out.insert(out.end(), {PPRGateType::X8, PPRGateType::Z8});
-        return true;
+        return {true, -M_PI / 4.0};
     }
 
     // Rule: HT, SHT -> X4, X8, Z8
     if (current == GateType::HT && next == GateType::SHT) {
         out.insert(out.end(), {PPRGateType::X4, PPRGateType::X8, PPRGateType::Z8});
-        return true;
+        return {true, -M_PI / 2.0};
     }
 
     // Rule: SHT, HT -> Z4, X8, Z8
     if (current == GateType::SHT && next == GateType::HT) {
         out.insert(out.end(), {PPRGateType::Z4, PPRGateType::X8, PPRGateType::Z8});
-        return true;
+        return {true, -M_PI / 2.0};
     }
 
     // Rule: SHT, SHT -> Z4, X4, X8, Z8
     if (current == GateType::SHT && next == GateType::SHT) {
         out.insert(out.end(), {PPRGateType::Z4, PPRGateType::X4, PPRGateType::X8, PPRGateType::Z8});
-        return true;
+        return {true, -3 * M_PI / 4.0};
     }
 
-    return false;
+    return {false, 0.0};
 }
 
 /**
  * @brief Convert single gate for HST_to_PPR
  */
-void append_single_gate_expansion(std::vector<PPRGateType> &out, GateType gate)
+double append_single_gate_expansion(std::vector<PPRGateType> &out, GateType gate)
 {
     switch (gate) {
     case GateType::T:
         out.emplace_back(PPRGateType::Z8);
-        break;
+        return -M_PI / 8.0;
     case GateType::I:
         out.emplace_back(PPRGateType::I);
-        break;
+        return 0.0;
     case GateType::X:
         out.emplace_back(PPRGateType::X2);
-        break;
+        return -M_PI / 2.0;
     case GateType::Y:
         out.emplace_back(PPRGateType::Y2);
-        break;
+        return -M_PI / 2.0;
     case GateType::Z:
         out.emplace_back(PPRGateType::Z2);
-        break;
+        return -M_PI / 2.0;
     case GateType::H:
         out.insert(out.end(), {PPRGateType::Z4, PPRGateType::X4, PPRGateType::Z4});
-        break;
+        return -M_PI / 2.0;
     case GateType::S:
         out.emplace_back(PPRGateType::Z4);
-        break;
+        return -M_PI / 4.0;
     case GateType::Sd:
         out.emplace_back(PPRGateType::adjZ4);
-        break;
+        return M_PI / 4.0;
     case GateType::HT:
         // Applied commutation rules via PPR playground
         out.insert(out.end(), {PPRGateType::X8, PPRGateType::Z4, PPRGateType::X4, PPRGateType::Z4});
-        break;
+        return -5 * M_PI / 8.0;
     case GateType::SHT:
         // Applied commutation rules via PPR playground
         out.insert(out.end(),
                    {PPRGateType::adjY8, PPRGateType::adjX4, PPRGateType::Z4, PPRGateType::Z2});
-        break;
+        return -7 * M_PI / 8.0;
     default:
         RT_FAIL("Unknown GateType encountered.");
     }
@@ -255,29 +257,34 @@ void append_single_gate_expansion(std::vector<PPRGateType> &out, GateType gate)
  * @brief Converts a sequence of GateType in Clifford+T basis to PPR basis
  * using predefined conversion rules.
  * @param input_gates The input vector of GateType representing the Clifford+T sequence.
- * @return std::vector<PPRGateType> The converted vector of PPRGateType
+ * @return std::pair<std::vector<PPRGateType>, double> The converted vector of PPRGateType and
+ * the global phase update.
  */
-std::vector<PPRGateType> HST_to_PPR(const std::vector<GateType> &input_gates)
+std::pair<std::vector<PPRGateType>, double> HST_to_PPR(const std::vector<GateType> &input_gates)
 {
     std::vector<PPRGateType> output_gates;
     output_gates.reserve(input_gates.size() * 2);
+    double phase_update = 0;
 
     size_t i = 0;
     while (i < input_gates.size()) {
         // Try to consume a pair
         if (i + 1 < input_gates.size()) {
-            if (try_append_pair_expansion(output_gates, input_gates[i], input_gates[i + 1])) {
+            if (auto [success, phase] =
+                    try_append_pair_expansion(output_gates, input_gates[i], input_gates[i + 1]);
+                success) {
+                phase_update += phase;
                 i += 2; // Consumed two gates
                 continue;
             }
         }
 
         // Fallback to consuming a single gate
-        append_single_gate_expansion(output_gates, input_gates[i]);
+        phase_update += append_single_gate_expansion(output_gates, input_gates[i]);
         i += 1; // Consumed one gate
     }
 
-    return output_gates;
+    return {output_gates, phase_update};
 }
 
 // Extern C implementation

--- a/runtime/lib/RSDecompRuntime/RSDecomp.hpp
+++ b/runtime/lib/RSDecompRuntime/RSDecomp.hpp
@@ -21,7 +21,7 @@ using namespace RSDecomp::Rings;
 using namespace RSDecomp::CliffordData;
 std::pair<std::vector<GateType>, double> eval_ross_algorithm(double angle, double epsilon);
 std::pair<std::vector<PPRGateType>, double> eval_ross_algorithm_ppr(double angle, double epsilon);
-std::vector<PPRGateType> HST_to_PPR(const std::vector<GateType> &vector);
+std::pair<std::vector<PPRGateType>, double> HST_to_PPR(const std::vector<GateType> &vector);
 
 extern "C" {
 

--- a/runtime/tests/Test_RSDecomp.cpp
+++ b/runtime/tests/Test_RSDecomp.cpp
@@ -176,36 +176,47 @@ TEST_CASE("Test Zero Angle (Identity)", "[RSDecomp][Ross Selinger]")
 TEST_CASE("Test HST_to_PPR Conversion Rules", "[RSDecomp][Ross Selinger]")
 {
     // Rule: HT, HT -> X8, Z8
-    CHECK(HST_to_PPR({GateType::HT, GateType::HT}) ==
+    CHECK(HST_to_PPR({GateType::HT, GateType::HT}).first ==
           std::vector<PPRGateType>{PPRGateType::X8, PPRGateType::Z8});
+    CHECK(HST_to_PPR({GateType::HT, GateType::HT}).second == -M_PI / 4.0);
 
     // Rule: HT, SHT -> X4, X8, Z8
-    CHECK(HST_to_PPR({GateType::HT, GateType::SHT}) ==
+    CHECK(HST_to_PPR({GateType::HT, GateType::SHT}).first ==
           std::vector<PPRGateType>{PPRGateType::X4, PPRGateType::X8, PPRGateType::Z8});
+    CHECK(HST_to_PPR({GateType::HT, GateType::SHT}).second == -M_PI / 2.0);
 
     // Rule: SHT, HT -> Z4, X8, Z8
-    CHECK(HST_to_PPR({GateType::SHT, GateType::HT}) ==
+    CHECK(HST_to_PPR({GateType::SHT, GateType::HT}).first ==
           std::vector<PPRGateType>{PPRGateType::Z4, PPRGateType::X8, PPRGateType::Z8});
+    CHECK(HST_to_PPR({GateType::SHT, GateType::HT}).second == -M_PI / 2.0);
 
     // Rule: SHT, SHT -> Z4, X4, X8, Z8
-    CHECK(HST_to_PPR({GateType::SHT, GateType::SHT}) ==
+    CHECK(HST_to_PPR({GateType::SHT, GateType::SHT}).first ==
           std::vector<PPRGateType>{PPRGateType::Z4, PPRGateType::X4, PPRGateType::X8,
                                    PPRGateType::Z8});
+    CHECK(HST_to_PPR({GateType::SHT, GateType::SHT}).second == -3 * M_PI / 4.0);
 
     // Test Single Gate Mappings (Standard)
-    CHECK(HST_to_PPR({GateType::T}) == std::vector<PPRGateType>{PPRGateType::Z8});
-    CHECK(HST_to_PPR({GateType::S}) == std::vector<PPRGateType>{PPRGateType::Z4});
-    CHECK(HST_to_PPR({GateType::Z}) == std::vector<PPRGateType>{PPRGateType::Z2});
+    CHECK(HST_to_PPR({GateType::T}).first == std::vector<PPRGateType>{PPRGateType::Z8});
+    CHECK(HST_to_PPR({GateType::S}).first == std::vector<PPRGateType>{PPRGateType::Z4});
+    CHECK(HST_to_PPR({GateType::Z}).first == std::vector<PPRGateType>{PPRGateType::Z2});
+
+    CHECK(HST_to_PPR({GateType::T}).second == -M_PI / 8.0);
+    CHECK(HST_to_PPR({GateType::S}).second == -M_PI / 4.0);
+    CHECK(HST_to_PPR({GateType::Z}).second == -M_PI / 2.0);
 
     // H -> Z4, X4, Z4
-    CHECK(HST_to_PPR({GateType::H}) ==
+    CHECK(HST_to_PPR({GateType::H}).first ==
           std::vector<PPRGateType>{PPRGateType::Z4, PPRGateType::X4, PPRGateType::Z4});
+    CHECK(HST_to_PPR({GateType::H}).second == -M_PI / 2.0);
 
     // Test Edge Cases for Pair Lookahead
     // Case: HT at the very end of the vector (no next gate to pair with)
     // Should fallback to single HT expansion: X8, Z4, X4, Z4
-    CHECK(HST_to_PPR({GateType::HT}) == std::vector<PPRGateType>{PPRGateType::X8, PPRGateType::Z4,
-                                                                 PPRGateType::X4, PPRGateType::Z4});
+    CHECK(HST_to_PPR({GateType::HT}).first ==
+          std::vector<PPRGateType>{PPRGateType::X8, PPRGateType::Z4, PPRGateType::X4,
+                                   PPRGateType::Z4});
+    CHECK(HST_to_PPR({GateType::HT}).second == -5 * M_PI / 8.0);
 
     // Case: HT followed by a gate that doesn't form a pair (e.g. T)
     std::vector<GateType> input_mixed = {GateType::HT, GateType::T};
@@ -213,7 +224,8 @@ TEST_CASE("Test HST_to_PPR Conversion Rules", "[RSDecomp][Ross Selinger]")
         PPRGateType::X8, PPRGateType::Z4, PPRGateType::X4, PPRGateType::Z4, // HT
         PPRGateType::Z8                                                     // T
     };
-    CHECK(HST_to_PPR(input_mixed) == expected_mixed);
+    CHECK(HST_to_PPR(input_mixed).first == expected_mixed);
+    CHECK(HST_to_PPR(input_mixed).second == -3 * M_PI / 4.0);
 }
 
 TEST_CASE("Test C-API Wrapper (Memref Interface)", "[RSDecomp][Ross Selinger]")


### PR DESCRIPTION
**Context:** The current implementation of the gridsynth algorithm allows for two modes of output: one in the usual HST basis, and another in the PPR basis. When trying to compare the execution results between these two modes, we found that they sometimes differ by a global phase. This PR aims to address that and adds relevant test cases for gridsynth in the PPR basis.

[[sc-98156]]