### PR TITLE
Fix `replace_ir` with gradients

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -26,6 +26,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fix `replace_ir` for certain stages when used with gradients.
+  [(#2436)](https://github.com/PennyLaneAI/catalyst/pull/2436)
+
 * Restore the ability to differentiate multiple (expectation value) QNode results with the
   adjoint-differentiation method.
   [(#2428)](https://github.com/PennyLaneAI/catalyst/pull/2428)

--- a/frontend/test/pytest/test_debug.py
+++ b/frontend/test/pytest/test_debug.py
@@ -410,7 +410,19 @@ class TestCProgramGeneration:
         shutil.rmtree(str(jit_f.workspace), ignore_errors=True)
         assert old_result * data == new_result
 
-    @pytest.mark.parametrize("pass_name", ["HLOLoweringStage", "O2Opt", "Enzyme"])
+    @pytest.mark.parametrize(
+        "pass_name",
+        [
+            "QuantumCompilationStage",
+            "HLOLoweringStage",
+            "GradientLoweringStage",
+            "BufferizationStage",
+            "MLIRToLLVMDialectConversion",
+            "LLVMIRTranslation",
+            "O2Opt",
+            "Enzyme",
+        ],
+    )
     def test_modify_ir_file_generation(self, pass_name):
         """Test if recompilation rerun the same pass."""
 
@@ -429,7 +441,7 @@ class TestCProgramGeneration:
         replace_ir(jit_grad_f, pass_name, ir)
         jit_grad_f(3.0)
         file_list = os.listdir(str(jit_grad_f.workspace))
-        res = [i for i in file_list if pass_name in i]
+        res = [file_name for file_name in file_list if pass_name in file_name]
 
         shutil.rmtree(old_workspace, ignore_errors=True)
         shutil.rmtree(str(jit_grad_f.workspace), ignore_errors=True)

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -68,6 +68,7 @@
 #include "Driver/Support.h"
 #include "Gradient/IR/GradientDialect.h"
 #include "Gradient/IR/GradientInterfaces.h"
+#include "Gradient/IR/GradientOps.h"
 #include "Gradient/Transforms/BufferizableOpInterfaceImpl.h"
 #include "Ion/IR/IonDialect.h"
 #include "MBQC/IR/MBQCDialect.h"
@@ -353,9 +354,12 @@ OwningOpRef<ModuleOp> parseMLIRSource(MLIRContext *ctx, const llvm::SourceMgr &s
 bool containsGradients(mlir::ModuleOp moduleOp)
 {
     bool contain = false;
-    moduleOp.walk([&](catalyst::gradient::GradientOpInterface op) {
-        contain = true;
-        return WalkResult::interrupt();
+    moduleOp.walk([&](Operation *op) {
+        if (isa<gradient::GradientOpInterface>(op) || isa<gradient::BackpropOp>(op)) {
+            contain = true;
+            return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
     });
     return contain;
 }

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -44,6 +44,7 @@
 #include "llvm/Transforms/Coroutines/CoroSplit.h"
 #include "llvm/Transforms/IPO/GlobalDCE.h"
 
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllExtensions.h"
@@ -350,18 +351,16 @@ OwningOpRef<ModuleOp> parseMLIRSource(MLIRContext *ctx, const llvm::SourceMgr &s
     return parseSourceFile<ModuleOp>(sourceMgr, parserConfig);
 }
 
-/// From the MLIR module it checks if gradients operations are in the program.
-bool containsGradients(mlir::ModuleOp moduleOp)
+/// Detect whether Enzyme differentiation is needed for the module.
+bool containsGradients(const llvm::Module &llvmModule)
 {
-    bool contain = false;
-    moduleOp.walk([&](Operation *op) {
-        if (isa<gradient::GradientOpInterface>(op) || isa<gradient::BackpropOp>(op)) {
-            contain = true;
-            return WalkResult::interrupt();
+    // This will match both declarations and definitions
+    for (const llvm::Function &func : llvmModule.functions()) {
+        if (func.getName().starts_with("__enzyme_autodiff")) {
+            return true;
         }
-        return WalkResult::advance();
-    });
-    return contain;
+    }
+    return false;
 }
 
 /// Parse an LLVM module given in textual representation. Any parse errors will be output to
@@ -762,10 +761,6 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
     }
     parserTiming.stop();
 
-    // Enzyme always happens after O2Opt. If the checkpoint is O2Opt, enzymeRun must be set to
-    // true so that the enzyme pass can be executed.
-    bool enzymeRun = options.checkpointStage == "O2Opt";
-
     bool runAll = (options.loweringAction == Action::All);
     bool runOpt = (options.loweringAction == Action::OPT) || runAll;
     bool runTranslate = (options.loweringAction == Action::Translate) || runAll;
@@ -773,10 +768,6 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
 
     if (runOpt && (inType == InputType::MLIR)) {
         TimingScope optTiming = timing.nest("Optimization");
-        // TODO: The enzymeRun flag will not travel correctly in the case where different
-        // stages of compilation are executed independently via the Catalyst CLI.
-        // Ideally, It should be added to the IR via an attribute.
-        enzymeRun = containsGradients(*mlirModule);
         if (failed(runLowering(options, &ctx, *mlirModule, output, optTiming))) {
             CO_MSG(options, Verbosity::Urgent, "Failed to lower MLIR module\n");
             return failure();
@@ -849,6 +840,7 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
             catalyst::utils::LinesCount::Module(*llvmModule.get());
         }
 
+        bool enzymeRun = containsGradients(*llvmModule);
         if (enzymeRun) {
             TimingScope o2PassesTiming = llcTiming.nest("LLVM O2 passes");
             if (failed(timer::timer(runO2LLVMPasses, "runO2LLVMPasses", /* add_endl */ false,


### PR DESCRIPTION
Fixes #2432 

The problem was the detection of whether or not to run the enzyme passes. Right now we only look for high-level diff ops, so any stage after the gradient lowering wouldn't work as an entry point.

Solution: detect presence `__enzyme_autodiff` directly in the llvmir before running enzyme passes, instead of proxy detections in the mlir.

Old summary:
- `mlir`, `QuantumCompilationStage`, `HLOLoweringStage`: handled via high-level `GradientOpInterface`
- `GradientLoweringStage` and `BufferizationStage`: can be detected via the `BackpropOp` (new)
- `MLIRToLLVMDialectConversion`: ~??~ can be detected via `__enzyme_autodiff` function declaration
- `LLVMIRTranslation` and `CoroOpt`: ~??~ same as above, but on the llvmir <--- use this as the sole universal detection
- `O2Opt`: automatically handled because we always run enzyme with O2
- `Enzyme`: already ran relevant passes

[sc-109451]