### PR TITLE
Set graph-based decomposition as the default with capture

### DIFF
--- a/frontend/test/pytest/conftest.py
+++ b/frontend/test/pytest/conftest.py
@@ -51,9 +51,15 @@ def disable_capture():
 def use_capture():
     """Enable capture before and disable capture after the test."""
     qml.capture.enable()
+    # FIXME: enable graph decomposition by default with capture
+    # this is temporary until we can properly test all cases
+    # where capture + graph decomposition is used
+    qml.decomposition.enable_graph()
     try:
         yield
     finally:
+        # FIXME: disable graph decomposition after the test
+        qml.decomposition.disable_graph()
         qml.capture.disable()
 
 


### PR DESCRIPTION
**Context:**
Set graph-based decomposition within the new Catalyst decomposition framework as the default with capture enabled.


**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
