### PR TITLE
Use `tape_transform` to deprecate `BoundTransform.transform`.

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -56,6 +56,7 @@
 
 * The private helper `_extract_passes` of `qfunc.py` uses `BoundTransform.tape_transform`
   instead of the deprecated `BoundTransform.transform`.
+  `jax_tracer.py` and `tracing.py` also updated accordingly.
   [(#2440)](https://github.com/PennyLaneAI/catalyst/pull/2440)
 
 * Autograph is no longer applied to decomposition rules based on whether it's applied to the workflow itself.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -54,6 +54,10 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* The private helper `_extract_passes` of `qfunc.py` uses `BoundTransform.tape_transform`
+  instead of the deprecated `BoundTransform.transform`.
+  [(#2440)](https://github.com/PennyLaneAI/catalyst/pull/2440)
+
 * Autograph is no longer applied to decomposition rules based on whether it's applied to the workflow itself.
   Operator developers now need to manually apply autograph to decomposition rules when needed.
   [(#2421)](https://github.com/PennyLaneAI/catalyst/pull/2421)
@@ -112,6 +116,7 @@
 This release contains contributions from (in alphabetical order):
 Ali Asadi,
 Joey Carter,
+Yushao Chen,
 Sengthai Heng,
 David Ittah,
 Jeffrey Kam,

--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -1005,6 +1005,6 @@ def uses_transform(qnode, transform_name):
               False otherwise
     """
     compile_pipeline = getattr(qnode, "compile_pipeline", [])
-    transform_funcs = [bound_transform.transform for bound_transform in compile_pipeline]
+    transform_funcs = [bound_transform.tape_transform for bound_transform in compile_pipeline]
 
     return any(transform_name in func.__name__ for func in transform_funcs)

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -1312,7 +1312,8 @@ def apply_transforms(
         tracing_mode = TracingMode.TRANSFORM
     elif len(qnode_program) or have_measurements_changed(tape, tapes[0]):
         with_measurement_from_counts_or_samples = any(
-            "measurements_from_counts" in (transform_str := str(getattr(qnode, "tape_transform", "")))
+            "measurements_from_counts"
+            in (transform_str := str(getattr(qnode, "tape_transform", "")))
             or "measurements_from_samples" in transform_str
             for qnode in qnode_program
         )

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -1312,7 +1312,7 @@ def apply_transforms(
         tracing_mode = TracingMode.TRANSFORM
     elif len(qnode_program) or have_measurements_changed(tape, tapes[0]):
         with_measurement_from_counts_or_samples = any(
-            "measurements_from_counts" in (transform_str := str(getattr(qnode, "transform", "")))
+            "measurements_from_counts" in (transform_str := str(getattr(qnode, "tape_transform", "")))
             or "measurements_from_samples" in transform_str
             for qnode in qnode_program
         )

--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -645,7 +645,7 @@ def _extract_passes(transform_program):
     pass_pipeline = transform_program[i:]
     tape_transforms = transform_program[:i]
     for t in tape_transforms:
-        if t.transform is None:
+        if t.tape_transform is None:
             raise ValueError(
                 f"{t} without a tape definition occurs before tape transform {tape_transforms[-1]}."
             )


### PR DESCRIPTION
Context: in frontend, the private helper `qfunc.py::_extract_passes` integrates the `CompilePipeline` extraction defined on Pennylane side. Same usage also exists for tracing system.

But `BoundTransform.transform` is about to [deprecate](https://github.com/PennyLaneAI/pennylane/pull/8985) sooon
The `tape_transform` is basically doing the same thing.

[sc-105882]