### PR TITLE
[LLVM update] Fix CI segfaults in the xfailed grad+vmap tests

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -19,6 +19,7 @@
   [(#2415)](https://github.com/PennyLaneAI/catalyst/pull/2415)
   [(#2416)](https://github.com/PennyLaneAI/catalyst/pull/2416)
   [(#2444)](https://github.com/PennyLaneAI/catalyst/pull/2444)
+  [(#2445)](https://github.com/PennyLaneAI/catalyst/pull/2445)
 
   - The StableHLO version has been updated to
   [v1.13.7](https://github.com/openxla/stablehlo/tree/v1.13.7).

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1704,6 +1704,7 @@ def test_ellipsis_differentiation(backend, diff_method):
 
 def test_vmap_worflow_derivation(backend):
     """Check the gradient of a vmap workflow"""
+    pytest.xfail("Avoid segfault in CI: vmap differentiation not stable yet.")
     n_wires = 5
     data = jnp.sin(jnp.mgrid[-2:2:0.2].reshape(n_wires, -1)) ** 3
 
@@ -1759,6 +1760,7 @@ def test_vmap_worflow_derivation(backend):
 
 def test_forloop_vmap_worflow_derivation(backend):
     """Test a forloop vmap."""
+    pytest.xfail("Avoid segfault in CI: vmap differentiation not stable yet.")
     n_wires = 5
     data = jnp.sin(jnp.mgrid[-2:2:0.2].reshape(n_wires, -1)) ** 3
     weights = jnp.ones([n_wires, 3])

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -1623,7 +1623,6 @@ def test_adj_qubitunitary(inp, backend):
     assert np.allclose(compiled(inp), interpreted(inp))
 
 
-@pytest.mark.xfail(reason="Need PR 332.")
 @pytest.mark.parametrize("inp", [(1.0), (2.0), (3.0), (4.0)])
 def test_preprocessing_outside_qnode(inp, backend):
     """Test the preprocessing outside qnode."""
@@ -1703,7 +1702,6 @@ def test_ellipsis_differentiation(backend, diff_method):
     assert np.allclose(cat_res, jax_res)
 
 
-@pytest.mark.xfail(reason="First need #332, then Vmap yields wrong results when differentiated")
 def test_vmap_worflow_derivation(backend):
     """Check the gradient of a vmap workflow"""
     n_wires = 5
@@ -1759,7 +1757,6 @@ def test_vmap_worflow_derivation(backend):
     assert jnp.allclose(data_cat[1], data_jax[1])
 
 
-@pytest.mark.xfail(reason="First need #332, then Vmap yields wrong results when differentiated")
 def test_forloop_vmap_worflow_derivation(backend):
     """Test a forloop vmap."""
     n_wires = 5


### PR DESCRIPTION
**Context:**
There has been a old issue with using grad + vmap captured by https://github.com/PennyLaneAI/catalyst/issues/1912 that seems to be partially resolved as we updated LLVM + Enzyme. This most likely related to the update from enzyme. As a result of this three of the tests previously marked  as xfail now have changed status. One passes and the other two segfault (yikes!). Turns out that the example discussed in https://github.com/PennyLaneAI/catalyst/issues/1912 which is the floowing:
```python
@vmap
@qml.qnode(qml.device("lightning.qubit", wires=1))
def circuit(x):
    qml.RX(x, wires=0)
    return qml.expval(qml.PauliZ(0))

@qjit
@grad
def loss(x):
    return jnp.sum(circuit(x))

print(loss(jnp.array([0.1, 0.2, 0.3])))
```
now runs with no compilation error. However a case like below segfaults at runtime:

```python 
@vmap
@qml.qnode(qml.device("lightning.qubit", wires=1))
def circuit(x, data):
    qml.RX(x, wires=0)
    qml.RX(data, wires=0)
    return qml.expval(qml.PauliZ(0))

@qjit
@grad
def loss(x, data):
    return jnp.sum(circuit(x, data))

print(loss(jnp.array([0.1, 0.2, 0.3]), jnp.array([0.1, 0.2, 0.3])))
```
the main difference is the addition of `data` as the second argument.

**Description of the Change:**
Remove the xfail for the passed test and move the other two xfails inside the test to avoid their execution and hence the segmentation fault.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
