### PR TITLE
Remove `mhlo` references from Catalyst

### DIFF
--- a/.github/workflows/check-jax-release.yaml
+++ b/.github/workflows/check-jax-release.yaml
@@ -70,7 +70,7 @@ jobs:
       run: |
         make llvm
 
-    - name: Build MHLO
+    - name: Build StableHLO
       run: |
         make stablehlo
 

--- a/doc/dev/installation.rst
+++ b/doc/dev/installation.rst
@@ -292,12 +292,12 @@ To make Enzyme libraries discoverable to the compiler:
 
   export ENZYME_LIB_DIR="$PWD/mlir/Enzyme/build/Enzyme"
 
-To make required tools in ``llvm-project/build``, ``mlir-hlo/mhlo-build``, and
+To make required tools in ``llvm-project/build``, ``stablehlo/build``, and
 ``mlir/build`` discoverable to the compiler:
 
 .. code-block:: console
 
-  export PATH="$PWD/mlir/llvm-project/build/bin:$PWD/mlir/mlir-hlo/mhlo-build/bin:$PWD/mlir/build/bin:$PATH"
+  export PATH="$PWD/mlir/llvm-project/build/bin:$PWD/mlir/stablehlo/build/bin:$PWD/mlir/build/bin:$PATH"
 
 Tests
 ^^^^^

--- a/frontend/catalyst/jax_extras/lowering.py
+++ b/frontend/catalyst/jax_extras/lowering.py
@@ -104,7 +104,7 @@ def custom_lower_jaxpr_to_module(
     arg_shardings=None,
     result_shardings=None,
 ):
-    """Lowers a top-level jaxpr to an MHLO module.
+    """Lowers a top-level jaxpr to an MLIR module.
 
     Handles the quirks of the argument/return value passing conventions of the
     runtime.


### PR DESCRIPTION
**Context:**
There are some references to mhlo remaining in the docs within the repo 

**Description of the Change:**
replace the references to mhlo with StableHLO
**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
