### PR TITLE
Raise an error if shots=0 when using measurements_from_samples pass

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -20,6 +20,10 @@
 * `qml.vjp` can now be used with Catalyst and program capture.
   [(#2279)](https://github.com/PennyLaneAI/catalyst/pull/2279)
 
+* The `measurements_from_samples` pass no longer results in `nan`s and cryptic error messages when   
+  `shots` aren't set. Instead, an informative error message is raised.
+  [(#2456)](https://github.com/PennyLaneAI/catalyst/pull/2456)
+
 <h3>Breaking changes 💔</h3>
 
 * When an integer argnums is provided to `catalyst.vjp`, a singleton dimension is now squeezed
@@ -127,6 +131,7 @@ This release contains contributions from (in alphabetical order):
 Ali Asadi,
 Joey Carter,
 Yushao Chen,
+Lillian Frederiksen,
 Sengthai Heng,
 David Ittah,
 Jeffrey Kam,

--- a/frontend/catalyst/python_interface/transforms/quantum/measurements_from_samples.py
+++ b/frontend/catalyst/python_interface/transforms/quantum/measurements_from_samples.py
@@ -90,6 +90,8 @@ class MeasurementsFromSamplesPattern(RewritePattern):
         assert isinstance(
             shots, int
         ), f"Expected `shots` to be an integer value but got {type(shots).__name__}"
+        if shots == 0:
+            raise ValueError("The measurements_from_samples pass requires non-zero shots")
         self._shots = shots
 
     @abstractmethod

--- a/frontend/test/pytest/python_interface/transforms/quantum/test_xdsl_measurements_from_samples.py
+++ b/frontend/test/pytest/python_interface/transforms/quantum/test_xdsl_measurements_from_samples.py
@@ -451,15 +451,17 @@ class TestMeasurementsFromSamplesIntegration:
     def test_no_shots_raises_error(self):
         """Test that when no shots are provided, the pass raises an error"""
 
+        @qml.qjit
+        @measurements_from_samples_pass
         @qml.qnode(qml.device("lightning.qubit", wires=1))
-        def circuit_ref():
-            qml.X(0)
+        def circuit(x):
+            qml.RX(x, 0)
             return qml.expval(qml.Z(0))
 
         with pytest.raises(
             ValueError, match="measurements_from_samples pass requires non-zero shots"
         ):
-            qml.qjit(measurements_from_samples_pass(circuit_ref))
+            circuit(1.2)
 
     @pytest.mark.parametrize("shots", [1, 2])
     @pytest.mark.parametrize(

--- a/frontend/test/pytest/python_interface/transforms/quantum/test_xdsl_measurements_from_samples.py
+++ b/frontend/test/pytest/python_interface/transforms/quantum/test_xdsl_measurements_from_samples.py
@@ -31,6 +31,24 @@ pytestmark = pytest.mark.xdsl
 class TestMeasurementsFromSamplesPass:
     """Unit tests for the measurements-from-samples pass."""
 
+    def test_no_shots_raises_error(self, run_filecheck):
+        """Test that when no shots are provided, the pass raises an error"""
+
+        program = """
+        builtin.module @module_circuit {
+            // CHECK-LABEL: circuit
+            func.func public @circuit() -> (tensor<f64>) {
+                %0 = arith.constant 0 : i64
+                quantum.device shots(%0) ["", "", ""]
+            }
+        }
+        """
+
+        pipeline = (MeasurementsFromSamplesPass(),)
+
+        with pytest.raises(ValueError, match="measurements_from_samples pass requires non-zero shots"):
+            run_filecheck(program, pipeline)
+
     def test_1_wire_expval(self, run_filecheck):
         """Test the measurements-from-samples pass on a 1-wire circuit terminating with an expval(Z)
         measurement.
@@ -429,6 +447,18 @@ class TestMeasurementsFromSamplesIntegration:
     """Tests of the execution of simple workloads with the xDSL-based MeasurementsFromSamplesPass
     transform.
     """
+
+    def test_no_shots_raises_error(self):
+        """Test that when no shots are provided, the pass raises an error"""
+
+        @qml.qnode(qml.device("lightning.qubit", wires=1))
+        def circuit_ref():
+            qml.X(0)
+            return qml.expval(qml.Z(0))
+
+        with pytest.raises(ValueError, match="measurements_from_samples pass requires non-zero shots"):
+            qml.qjit(measurements_from_samples_pass(circuit_ref))
+
 
     @pytest.mark.parametrize("shots", [1, 2])
     @pytest.mark.parametrize(

--- a/frontend/test/pytest/python_interface/transforms/quantum/test_xdsl_measurements_from_samples.py
+++ b/frontend/test/pytest/python_interface/transforms/quantum/test_xdsl_measurements_from_samples.py
@@ -33,7 +33,6 @@ class TestMeasurementsFromSamplesPass:
 
     def test_no_shots_raises_error(self, run_filecheck):
         """Test that when no shots are provided, the pass raises an error"""
-
         program = """
         builtin.module @module_circuit {
             // CHECK-LABEL: circuit
@@ -45,8 +44,9 @@ class TestMeasurementsFromSamplesPass:
         """
 
         pipeline = (MeasurementsFromSamplesPass(),)
-
-        with pytest.raises(ValueError, match="measurements_from_samples pass requires non-zero shots"):
+        with pytest.raises(
+            ValueError, match="measurements_from_samples pass requires non-zero shots"
+        ):
             run_filecheck(program, pipeline)
 
     def test_1_wire_expval(self, run_filecheck):
@@ -456,9 +456,10 @@ class TestMeasurementsFromSamplesIntegration:
             qml.X(0)
             return qml.expval(qml.Z(0))
 
-        with pytest.raises(ValueError, match="measurements_from_samples pass requires non-zero shots"):
+        with pytest.raises(
+            ValueError, match="measurements_from_samples pass requires non-zero shots"
+        ):
             qml.qjit(measurements_from_samples_pass(circuit_ref))
-
 
     @pytest.mark.parametrize("shots", [1, 2])
     @pytest.mark.parametrize(


### PR DESCRIPTION
**Context:**
The `measurements_from_samples` pass returns `nan` on `lightning` if there are no shots provided, and raises a cryptic RuntimeError on `null.qubit`. In neither case is it obvious that the issue is related to shots or to the pass. This  has happened several times to various people, and takes a while to debug.

**Description of the Change:**
After we confirm that `shots` is an integer, we raise an error if it's 0.

**Benefits:**
Looking at the error traceback makes it immediately obvious what happened, so you don't spend 30+ minutes trying to debug things, just to realize you forgot to `set_shots` 🤦‍♀️

[sc-100896]
