### PR TITLE
Add miscellaneous fixes to `python_interface`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -24,7 +24,7 @@
 * `qml.vjp` can now be used with Catalyst and program capture.
   [(#2279)](https://github.com/PennyLaneAI/catalyst/pull/2279)
 
-* The `measurements_from_samples` pass no longer results in `nan`s and cryptic error messages when   
+* The `measurements_from_samples` pass no longer results in `nan`s and cryptic error messages when
   `shots` aren't set. Instead, an informative error message is raised.
   [(#2456)](https://github.com/PennyLaneAI/catalyst/pull/2456)
 
@@ -40,6 +40,10 @@
 <h3>Deprecations 👋</h3>
 
 <h3>Bug fixes 🐛</h3>
+
+* Fix a bug with the xDSL `ParitySynth` pass that caused failure when the QNode being transformed
+  contained operations with regions.
+  [(#2408)](https://github.com/PennyLaneAI/catalyst/pull/2408)
 
 * Fix `replace_ir` for certain stages when used with gradients.
   [(#2436)](https://github.com/PennyLaneAI/catalyst/pull/2436)

--- a/frontend/catalyst/python_interface/dialects/quantum/__init__.py
+++ b/frontend/catalyst/python_interface/dialects/quantum/__init__.py
@@ -107,6 +107,8 @@ Quantum = Dialect(
 )
 
 __all__ = [
+    # Main dialect
+    "Quantum",
     # Attributes
     "NamedObservable",
     "NamedObservableAttr",

--- a/frontend/test/pytest/python_interface/transforms/quantum/test_xdsl_combine_global_phases.py
+++ b/frontend/test/pytest/python_interface/transforms/quantum/test_xdsl_combine_global_phases.py
@@ -30,13 +30,14 @@ class TestCombineGlobalPhasesPass:
     def test_combinable_ops_without_control_flow(self, run_filecheck):
         """Test that combines global phases in a func without control flow."""
         program = """
-            func.func @test_func(%arg0: f64, %arg1: f64) {
+            // CHECK-LABEL: test_combine_global_phase
+            func.func @test_combine_global_phase(%arg0: f64, %arg1: f64) {
                 // CHECK: [[q0:%.+]] = "test.op"() : () -> !quantum.bit
                 %0 = "test.op"() : () -> !quantum.bit
                 // CHECK: [[phi_sum:%.+]] = arith.addf %arg1, %arg0 : f64
                 // CHECK: quantum.gphase([[phi_sum]])
-                quantum.gphase %arg0
-                quantum.gphase %arg1
+                quantum.gphase(%arg0) :
+                quantum.gphase(%arg1) :
                 // CHECK: [[q1:%.+]] = quantum.custom "PauliX"() [[q0]] : !quantum.bit
                 %2 = quantum.custom "PauliX"() %0 : !quantum.bit
                 return
@@ -49,21 +50,22 @@ class TestCombineGlobalPhasesPass:
     def test_combinable_ops_with_control_flow(self, run_filecheck):
         """Test that combines global phases in a func with control flow."""
         program = """
-            func.func @test_func(%cond: i32, %arg0: f64, %arg1: f64) {
+            // CHECK-LABEL: test_combine_global_phase
+            func.func @test_combine_global_phase(%cond: i1, %arg0: f64, %arg1: f64) {
                 // CHECK: [[q0:%.+]] = "test.op"() : () -> !quantum.bit
                 %0 = "test.op"() : () -> !quantum.bit
-                quantum.gphase %arg0
-                // CHECK: [[ret:%.+]] = scf.if %cond -> (f64) {
+                quantum.gphase(%arg0) :
+                // CHECK: [[ret:%.+]] = scf.if
                 %ret = scf.if %cond -> (f64) {
                     // CHECK: [[two:%.+]] = arith.constant {{2.+}} : f64
-                    %two = arith.constant 2 : f64
+                    %two = arith.constant 2.0 : f64
                     // CHECK: [[arg02:%.+]] = arith.mulf %arg0, [[two]] : f64
                     %arg0x2 = arith.mulf %arg0, %two : f64
                     // CHECK: scf.yield [[arg02]] : f64
                     scf.yield %arg0x2 : f64
                 } else {
                     // CHECK: [[two_1:%.+]] = arith.constant {{2.+}} : f64
-                    %two_1 = arith.constant 2 : f64
+                    %two_1 = arith.constant 2.0 : f64
                     // CHECK: [[arg12:%.+]] = arith.mulf %arg1, [[two_1]] : f64
                     %arg1x2 = arith.mulf %arg1, %two_1 : f64
                     // CHECK: scf.yield [[arg12:%.+]] : f64
@@ -71,7 +73,7 @@ class TestCombineGlobalPhasesPass:
                 }
                 // CHECK: [[phi_sum:%.+]] = arith.addf [[ret]], %arg0 : f64
                 // CHECK: quantum.gphase([[phi_sum]]) :
-                quantum.gphase %ret
+                quantum.gphase(%ret) :
                 // CHECK: quantum.custom "PauliX"() [[q0]] : !quantum.bit
                 %2 = quantum.custom "PauliX"() %0 : !quantum.bit
                 return
@@ -86,42 +88,42 @@ class TestCombineGlobalPhasesPass:
         Here the control flow is an `if` operation.
         """
         program = """
-            // CHECK: func.func @test_func(%cond : i32, [[arg0:%.+]] : f64, [[arg1:%.+]] : f64)
-            func.func @test_func(%cond : i32, %arg0 : f64, %arg1 : f64) {
+            // CHECK: func.func @test_combine_global_phase([[cond:%.+]] : i1, [[arg0:%.+]] : f64, [[arg1:%.+]] : f64)
+            func.func @test_combine_global_phase(%cond : i1, %arg0 : f64, %arg1 : f64) {
                 // CHECK: [[q0:%.+]] = "test.op"() : () -> !quantum.bit
                 %0 = "test.op"() : () -> !quantum.bit
-                // CHECK: [[ret:%.+]] = scf.if [[cond:%.+]] -> (f64) {
+                // CHECK: [[ret:%.+]] = scf.if [[cond]] -> (f64) {
                 %ret = scf.if %cond -> (f64) {
                     // CHECK: [[two0:%.+]] = arith.constant {{2.+}} : f64
-                    %two0 = arith.constant 2 : f64
+                    %two0 = arith.constant 2.0 : f64
                     // CHECK: [[arg02:%.+]] = arith.mulf [[arg0]], [[two0]] : f64
                     %arg02 = arith.mulf %arg0, %two0 : f64
                     // CHECK: [[t0:%.+]] = "test.op"() : () -> f64
                     %t0 = "test.op"() : () -> f64
                     // CHECK: [[phi_sum_0:%.+]] = arith.addf [[t0]], [[t0]] : f64
                     // CHECK: quantum.gphase([[phi_sum_0]])
-                    quantum.gphase %t0
-                    quantum.gphase %t0
+                    quantum.gphase(%t0) :
+                    quantum.gphase(%t0) :
                     // CHECK: scf.yield [[arg02]] : f64
                     scf.yield %arg02 : f64
                     // CHECK: } else {
                 } else {
                     // CHECK: [[two1:%.+]] = arith.constant {{2.+}} : f64
-                    %two1 = arith.constant 2 : f64
+                    %two1 = arith.constant 2.0 : f64
                     // CHECK: [[arg1x2:%.+]] = arith.mulf [[arg1]], [[two1]] : f64
                     %arg1x2 = arith.mulf %arg1, %two1 : f64
                     // CHECK: [[phi_sum_1:%.+]] = arith.addf [[arg1x2]], [[arg1x2]] : f64
                     // CHECK: quantum.gphase([[phi_sum_1]])
-                    quantum.gphase %arg1x2
-                    quantum.gphase %arg1x2
+                    quantum.gphase(%arg1x2) :
+                    quantum.gphase(%arg1x2) :
                     // CHECK: scf.yield [[arg1x2]] : f64
                     scf.yield %arg1x2 : f64
                     // CHECK: }
                 }
                 // CHECK: [[phi_sum_2:%.+]] = arith.addf [[arg1]], [[arg0]] : f64
                 // CHECK: quantum.gphase([[phi_sum_2:%.+]])
-                quantum.gphase %arg0
-                quantum.gphase %arg1
+                quantum.gphase(%arg0) :
+                quantum.gphase(%arg1) :
                 // CHECK: quantum.custom "PauliX"() [[q0]] : !quantum.bit
                 %2 = quantum.custom "PauliX"() %0 : !quantum.bit
                 return
@@ -136,30 +138,30 @@ class TestCombineGlobalPhasesPass:
         Here the control flow is a `for` operation.
         """
         program = """
-            // CHECK: func.func @test_func(%n : i32, [[arg0:%.+]] : f64, [[arg1:%.+]] : f64)
-            func.func @test_func(%n : i32, %arg0 : f64, %arg1 : f64) {
+            // CHECK: func.func @test_combine_global_phase(%n : index, [[arg0:%.+]] : f64, [[arg1:%.+]] : f64)
+            func.func @test_combine_global_phase(%n : index, %arg0 : f64, %arg1 : f64) {
                 // CHECK: [[q0:%.+]] = "test.op"() : () -> !quantum.bit
-                // CHECK: [[c0:%.+]] = arith.constant 0 : i32
-                // CHECK: [[c1:%.+]] = arith.constant 1 : i32
+                // CHECK: [[c0:%.+]] = arith.constant 0 : index
+                // CHECK: [[c1:%.+]] = arith.constant 1 : index
                 %0 = "test.op"() : () -> !quantum.bit
-                %c0 = arith.constant 0 : i32
-                %c1 = arith.constant 1 : i32
+                %c0 = arith.constant 0 : index
+                %c1 = arith.constant 1 : index
                 scf.for %i = %c0 to %n step %c1 {
                     // CHECK: [[two0:%.+]] = arith.constant {{2.+}} : f64
-                    %two0 = arith.constant 2 : f64
+                    %two0 = arith.constant 2.0 : f64
                     // CHECK: [[arg02:%.+]] = arith.mulf [[arg0]], [[two0]] : f64
                     %arg02 = arith.mulf %arg0, %two0 : f64
                     // CHECK: [[t0:%.+]] = "test.op"() : () -> f64
                     %t0 = "test.op"() : () -> f64
                     // CHECK: [[phi_sum_0:%.+]] = arith.addf [[t0]], [[t0]] : f64
                     // CHECK: quantum.gphase([[phi_sum_0]])
-                    quantum.gphase %t0
-                    quantum.gphase %t0
+                    quantum.gphase(%t0) :
+                    quantum.gphase(%t0) :
                 }
                 // CHECK: [[phi_sum_1:%.+]] = arith.addf [[arg1]], [[arg0]] : f64
                 // CHECK: quantum.gphase([[phi_sum_1]])
-                quantum.gphase %arg0
-                quantum.gphase %arg1
+                quantum.gphase(%arg0) :
+                quantum.gphase(%arg1) :
                 // CHECK: quantum.custom "PauliX"() [[q0]] : !quantum.bit
                 %2 = quantum.custom "PauliX"() %0 : !quantum.bit
                 return
@@ -174,34 +176,34 @@ class TestCombineGlobalPhasesPass:
         Here the control flow is a `while` operation.
         """
         program = """
-            // CHECK: func.func @test_func(%n : i32, [[arg0:%.+]] : f64, [[arg1:%.+]] : f64)
-            func.func @test_func(%n : i32, %arg0 : f64, %arg1 : f64) {
+            // CHECK: func.func @test_combine_global_phase(%n : i32, [[arg0:%.+]] : f64, [[arg1:%.+]] : f64)
+            func.func @test_combine_global_phase(%n : i32, %arg0 : f64, %arg1 : f64) {
                 // CHECK: [[q0:%.+]] = "test.op"() : () -> !quantum.bit
                 %0 = "test.op"() : () -> !quantum.bit
                 %c0 = arith.constant 0 : i32
                 %c1 = arith.constant 1 : i32
-                scf.while (%current_i = %n) : (i32) -> () {
+                scf.while (%current_i = %n) : (i32) -> (i32) {
                     %cond = arith.cmpi slt, %current_i, %n : i32
                     scf.condition(%cond) %current_i : i32
                 } do {
                 ^bb0(%i : i32):
                     %next_i = arith.addi %i, %c1 : i32
                     // CHECK: [[two0:%.+]] = arith.constant {{2.+}} : f64
-                    %two0 = arith.constant 2 : f64
+                    %two0 = arith.constant 2.0 : f64
                     // CHECK: [[arg02:%.+]] = arith.mulf [[arg0]], [[two0]] : f64
                     %arg02 = arith.mulf %arg0, %two0 : f64
                     // CHECK: [[t0:%.+]] = "test.op"() : () -> f64
                     %t0 = "test.op"() : () -> f64
                     // CHECK: [[phi_sum_0:%.+]] = arith.addf [[t0]], [[t0]] : f64
                     // CHECK: quantum.gphase([[phi_sum_0]])
-                    quantum.gphase %t0
-                    quantum.gphase %t0
+                    quantum.gphase(%t0) :
+                    quantum.gphase(%t0) :
                     scf.yield %next_i : i32
                 }
                 // CHECK: [[phi_sum_1:%.+]] = arith.addf [[arg1]], [[arg0]] : f64
                 // CHECK: quantum.gphase([[phi_sum_1]]) :
-                quantum.gphase %arg0
-                quantum.gphase %arg1
+                quantum.gphase(%arg0) :
+                quantum.gphase(%arg1) :
                 // CHECK: quantum.custom "PauliX"() [[q0]] : !quantum.bit
                 %2 = quantum.custom "PauliX"() %0 : !quantum.bit
                 return


### PR DESCRIPTION
* Add changelog entry for ParitySynth bugfix in #2408 
* Fix combine_global_phases filecheck tests. I'm not really sure how they were passing before
* Add `Quantum` dialect to the dialect's `__init__.py`'s `__all__`