### PR TITLE
fix: Update tests to new queuing behaviour

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.238
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.45.0-dev22
+pennylane=0.45.0-dev23
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -54,6 +54,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fix a bug caused by a change in queuing behaviour in PennyLane in 
+  [PL #8131](https://github.com/PennyLaneAI/pennylane/pull/8131)
+  [(#2408)](https://github.com/PennyLaneAI/catalyst/pull/2408)
+
 * Fix a bug with the xDSL `ParitySynth` pass that caused failure when the QNode being transformed
   contained operations with regions.
   [(#2408)](https://github.com/PennyLaneAI/catalyst/pull/2408)
@@ -177,4 +181,5 @@ Mudit Pandey,
 Andrija Paurevic,
 David D.W. Ren,
 Paul Haochen Wang,
+David Wierichs,
 Jake Zaia.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -54,10 +54,6 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* Fix a bug caused by a change in queuing behaviour in PennyLane in 
-  [PL #8131](https://github.com/PennyLaneAI/pennylane/pull/8131)
-  [(#2408)](https://github.com/PennyLaneAI/catalyst/pull/2408)
-
 * Fix a bug with the xDSL `ParitySynth` pass that caused failure when the QNode being transformed
   contained operations with regions.
   [(#2408)](https://github.com/PennyLaneAI/catalyst/pull/2408)
@@ -181,5 +177,4 @@ Mudit Pandey,
 Andrija Paurevic,
 David D.W. Ren,
 Paul Haochen Wang,
-David Wierichs,
 Jake Zaia.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -34,4 +34,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.45.0-dev8
 pennylane-lightning==0.45.0-dev8
-pennylane==0.45.0-dev23
+pennylane==0.45.0-dev22

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -34,4 +34,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.45.0-dev8
 pennylane-lightning==0.45.0-dev8
-pennylane==0.45.0-dev22
+pennylane==0.45.0-dev23

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -885,11 +885,6 @@ class TestProperties:
         op = adjoint(qml.PauliX(0))
         assert op._queue_category == "_ops"  # pylint: disable=protected-access
 
-    def test_queue_category_None(self):
-        """Test that the queue category `None` for some observables carries over."""
-        op = adjoint(qml.Hermitian([[1, 0], [0, 1]], wires=0))
-        assert op._queue_category is None  # pylint: disable=protected-access
-
     @pytest.mark.parametrize("value", (True, False))
     def test_is_verified_hermitian(self, value):
         """Test `is_verified_hermitian` property mirrors that of the base."""
@@ -1394,7 +1389,7 @@ class TestAdjointConstructorPreconstructedOp:
         assert isinstance(out, Adjoint)
 
         qs = qml.tape.QuantumScript.from_queue(q)
-        assert len(qs) == 0
+        assert len(qs) == 1
 
 
 class TestAdjointConstructorDifferentCallableTypes:

--- a/frontend/test/pytest/test_measurements_results.py
+++ b/frontend/test/pytest/test_measurements_results.py
@@ -435,8 +435,8 @@ class TestExpval:
         )
         obs = qml.Hermitian(obs_matrix, wires=[0, 1])
         coeff = np.array([0.8, 0.2])
-        obs2 = qml.Hamiltonian(coeff, [obs, qml.Hamiltonian([1, 1], [qml.PauliX(0), qml.PauliZ(1)])])
-        obs3 = obs2 @ qml.PauliZ(2)
+        obs2 = qml.Hamiltonian(coeff, [obs, qml.Hamiltonian([1, 1], [qml.X(0), qml.Z(1)])])
+        obs3 = obs2 @ qml.Z(2)
 
         @qjit
         @qml.qnode(qml.device(backend, wires=3))

--- a/frontend/test/pytest/test_measurements_results.py
+++ b/frontend/test/pytest/test_measurements_results.py
@@ -425,30 +425,25 @@ class TestExpval:
 
     def test_hamiltonian_4(self, backend):
         """Test expval with TensorObs and nested Hamiltonian observables."""
+        obs_matrix = np.array(
+            [
+                [0.5, 1.0j, 0.0, -3j],
+                [-1.0j, -1.1, 0.0, -0.1],
+                [0.0, 0.0, -0.9, 12.0],
+                [3j, -0.1, 12.0, 0.0],
+            ]
+        )
+        obs = qml.Hermitian(obs_matrix, wires=[0, 1])
+        coeff = np.array([0.8, 0.2])
+        obs2 = qml.Hamiltonian(coeff, [obs, qml.Hamiltonian([1, 1], [qml.PauliX(0), qml.PauliZ(1)])])
+        obs3 = obs2 @ qml.PauliZ(2)
 
         @qjit
         @qml.qnode(qml.device(backend, wires=3))
         def expval(x: float):
             qml.RX(x, wires=0)
             qml.RX(x + 1.0, wires=2)
-
-            coeff = np.array([0.8, 0.2])
-            obs_matrix = np.array(
-                [
-                    [0.5, 1.0j, 0.0, -3j],
-                    [-1.0j, -1.1, 0.0, -0.1],
-                    [0.0, 0.0, -0.9, 12.0],
-                    [3j, -0.1, 12.0, 0.0],
-                ]
-            )
-
-            obs = qml.Hermitian(obs_matrix, wires=[0, 1])
-            return qml.expval(
-                qml.Hamiltonian(
-                    coeff, [obs, qml.Hamiltonian([1, 1], [qml.PauliX(0), qml.PauliZ(1)])]
-                )
-                @ qml.PauliZ(2)
-            )
+            return qml.expval(obs3)
 
         expected = np.array(-0.09284557)
         observed = expval(np.pi / 4)

--- a/frontend/test/pytest/test_measurements_results.py
+++ b/frontend/test/pytest/test_measurements_results.py
@@ -425,25 +425,30 @@ class TestExpval:
 
     def test_hamiltonian_4(self, backend):
         """Test expval with TensorObs and nested Hamiltonian observables."""
-        obs_matrix = np.array(
-            [
-                [0.5, 1.0j, 0.0, -3j],
-                [-1.0j, -1.1, 0.0, -0.1],
-                [0.0, 0.0, -0.9, 12.0],
-                [3j, -0.1, 12.0, 0.0],
-            ]
-        )
-        obs = qml.Hermitian(obs_matrix, wires=[0, 1])
-        coeff = np.array([0.8, 0.2])
-        obs2 = qml.Hamiltonian(coeff, [obs, qml.Hamiltonian([1, 1], [qml.X(0), qml.Z(1)])])
-        obs3 = obs2 @ qml.Z(2)
 
         @qjit
         @qml.qnode(qml.device(backend, wires=3))
         def expval(x: float):
             qml.RX(x, wires=0)
             qml.RX(x + 1.0, wires=2)
-            return qml.expval(obs3)
+
+            coeff = np.array([0.8, 0.2])
+            obs_matrix = np.array(
+                [
+                    [0.5, 1.0j, 0.0, -3j],
+                    [-1.0j, -1.1, 0.0, -0.1],
+                    [0.0, 0.0, -0.9, 12.0],
+                    [3j, -0.1, 12.0, 0.0],
+                ]
+            )
+
+            obs = qml.Hermitian(obs_matrix, wires=[0, 1])
+            return qml.expval(
+                qml.Hamiltonian(
+                    coeff, [obs, qml.Hamiltonian([1, 1], [qml.PauliX(0), qml.PauliZ(1)])]
+                )
+                @ qml.PauliZ(2)
+            )
 
         expected = np.array(-0.09284557)
         observed = expval(np.pi / 4)

--- a/frontend/test/pytest/test_measurements_results.py
+++ b/frontend/test/pytest/test_measurements_results.py
@@ -426,29 +426,26 @@ class TestExpval:
     def test_hamiltonian_4(self, backend):
         """Test expval with TensorObs and nested Hamiltonian observables."""
 
+        obs_matrix = np.array(
+            [
+                [0.5, 1.0j, 0.0, -3j],
+                [-1.0j, -1.1, 0.0, -0.1],
+                [0.0, 0.0, -0.9, 12.0],
+                [3j, -0.1, 12.0, 0.0],
+            ]
+        )
+        obs = qml.Hermitian(obs_matrix, wires=[0, 1])
+        coeff = np.array([0.8, 0.2])
+        obs2 = qml.Hamiltonian(coeff, [obs, qml.Hamiltonian([1, 1], [qml.X(0), qml.Z(1)])])
+        obs3 = obs2 @ qml.Z(2)
+
         @qjit
         @qml.qnode(qml.device(backend, wires=3))
         def expval(x: float):
             qml.RX(x, wires=0)
             qml.RX(x + 1.0, wires=2)
 
-            coeff = np.array([0.8, 0.2])
-            obs_matrix = np.array(
-                [
-                    [0.5, 1.0j, 0.0, -3j],
-                    [-1.0j, -1.1, 0.0, -0.1],
-                    [0.0, 0.0, -0.9, 12.0],
-                    [3j, -0.1, 12.0, 0.0],
-                ]
-            )
-
-            obs = qml.Hermitian(obs_matrix, wires=[0, 1])
-            return qml.expval(
-                qml.Hamiltonian(
-                    coeff, [obs, qml.Hamiltonian([1, 1], [qml.PauliX(0), qml.PauliZ(1)])]
-                )
-                @ qml.PauliZ(2)
-            )
+            return qml.expval(obs3)
 
         expected = np.array(-0.09284557)
         observed = expval(np.pi / 4)

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -803,7 +803,7 @@ class TestControlledProperties:
         op = C_ctrl(DummyOp(1), 0)
         assert op.has_diagonalizing_gates is value
 
-    @pytest.mark.parametrize("value", ("_ops", None))
+    @pytest.mark.parametrize("value", ("_ops", "_measurements"))
     def test_queue_cateogry(self, value):
         """Test that `catalyst.ctrl` defers `_queue_category` to base operator."""
 
@@ -1388,13 +1388,13 @@ class TestDecomposition:
         op = C_ctrl(qml.RZ(1.2, wires=0), (1, 2, 3, 4))
         decomp = op.decomposition()
 
-        assert qml.equal(decomp[0], qml.Toffoli(wires=(1, 2, 0)))
+        assert qml.equal(decomp[0], qml.MultiControlledX(wires=(1, 2, 0), work_wires=(3, 4)))
         assert isinstance(decomp[1], qml.QubitUnitary)
-        assert qml.equal(decomp[2], qml.Toffoli(wires=(3, 4, 0)))
+        assert qml.equal(decomp[2], qml.MultiControlledX(wires=(3, 4, 0), work_wires=(1, 2)))
         assert isinstance(decomp[3].base, qml.QubitUnitary)
-        assert qml.equal(decomp[4], qml.Toffoli(wires=(1, 2, 0)))
+        assert qml.equal(decomp[4], qml.MultiControlledX(wires=(1, 2, 0), work_wires=(3, 4)))
         assert isinstance(decomp[5], qml.QubitUnitary)
-        assert qml.equal(decomp[6], qml.Toffoli(wires=(3, 4, 0)))
+        assert qml.equal(decomp[6], qml.MultiControlledX(wires=(3, 4, 0), work_wires=(1, 2)))
         assert isinstance(decomp[7].base, qml.QubitUnitary)
 
         decomp_mat = qml.matrix(op.decomposition, wire_order=op.wires)()


### PR DESCRIPTION
**Context:**
In PennyLane PR [#8131](https://github.com/PennyLaneAI/pennylane/pull/8131), we changed queuing behaviour of some operators, in particular in operator math.
This breaks a small number of tests in the Catalyst frontend.

**Description of the Change:**
Update the tests to either expect the changed behaviour or to avoid the new queuing behaviour where it is unwanted (e.g. construct a static observable outside of a QNode, which can be considered the better practice imo).

Note that there is also a follow-up bugfix PR in PL itself:

**Benefits:**
Bug fix/compatibility.

**Possible Drawbacks:**

**Related GitHub Issues:**
