### PR TITLE
Patch JAX's implicitly added return outvar for dynamic shapes

### DIFF
--- a/frontend/catalyst/jax_extras/tracing.py
+++ b/frontend/catalyst/jax_extras/tracing.py
@@ -62,7 +62,7 @@ from jax.lax import convert_element_type
 from jax.tree_util import PyTreeDef, tree_flatten, tree_structure, tree_unflatten, treedef_is_leaf
 from jaxlib._jax.pytree import PyTreeRegistry
 
-from catalyst.jax_extras.patches import gather2_p, get_aval2
+from catalyst.jax_extras.patches import gather2_p, get_aval2, patched_add_implicit_outputs
 from catalyst.logging import debug_logger
 from catalyst.tracing.type_signatures import verify_static_argnums_type
 from catalyst.utils.exceptions import CompileError
@@ -498,6 +498,11 @@ def make_jaxpr2(
         # TODO: re-use `deduce_avals` here.
         with Patcher(
             (jax._src.interpreters.partial_eval, "get_aval", get_aval2),
+            (
+                jax._src.interpreters.partial_eval,
+                "_add_implicit_outputs",
+                patched_add_implicit_outputs,
+            ),
             (jax._src.lax.slicing, "gather_p", gather2_p),
         ), ExitStack():
             f = wrap_init(fun, debug_info=debug_info)

--- a/frontend/test/pytest/test_measurement_dynamic_shapes.py
+++ b/frontend/test/pytest/test_measurement_dynamic_shapes.py
@@ -394,5 +394,27 @@ def test_dynamic_shots_and_wires(capfd):
     assert out.count("compiling...") == 1
 
 
+@pytest.mark.usefixtures("use_capture")
+def test_dynamic_shots_with_sample_and_pass_on_capture(backend):
+    """
+    Test that dynamic number of shots with qml.sample() can be used when a pass is applied.
+    """
+
+    @catalyst.qjit
+    def workflow(shots: int):
+        @qml.transform(pass_name="cancel-inverses")
+        @qml.qnode(qml.device(backend, wires=2), shots=shots)
+        def aloha():
+            return qml.sample()
+
+        return aloha()
+
+    res = workflow(1000)
+    assert res.shape == (1000, 2)
+
+    res = workflow(500)
+    assert res.shape == (500, 2)
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])


### PR DESCRIPTION
**Context:**
There was a mysterious failure when all of the following conditions are met: 
- use capture
- apply a pass
- returns `qml.sample()` from a qnode
- use dynamic number of shots

When these conditions are met, JAX leaks an argument from the inner jaxpr of the pennylane transform primitive out into the returned outvar of the top level jaxpr, as the dynamically-shaped shot dimension for the samples.

See https://xanaduhq.slack.com/archives/C06CNPQLK2T/p1770325357111409   

```python
qml.capture.enable()
dev = qml.device("lightning.qubit", wires=2)

@qjit
def workflow(shots:int):
    @qml.transform(pass_name="cancel-inverses")
    @qml.qnode(dev, shots=shots)
    def aloha():
        qml.Hadamard(wires=0)
        return qml.sample()

    return aloha()

x = workflow(5)
print(x)
```

```
File "/home/paul.wang/catalyst_new/catalyst/frontend/catalyst/jit.py", line 735, in capture
    return trace_from_pennylane(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/paul.wang/catalyst_new/catalyst/frontend/catalyst/from_plxpr/from_plxpr.py", line 536, in trace_from_pennylane
    jaxpr = from_plxpr(plxpr)(*plxpr.in_avals)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/paul.wang/catalyst_new/catalyst/frontend/catalyst/from_plxpr/from_plxpr.py", line 204, in wrapped_fn
    return jax.make_jaxpr(original_fn)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/paul.wang/catalyst_new/catalyst/cat_env/lib/python3.12/site-packages/pennylane/capture/base_interpreter.py", line 389, in eval
    outval = self.read(var)
             ^^^^^^^^^^^^^^
  File "/home/paul.wang/catalyst_new/catalyst/cat_env/lib/python3.12/site-packages/pennylane/capture/base_interpreter.py", line 267, in read
    return var.val if isinstance(var, jax.extend.core.Literal) else self._env[var]
                                                                    ~~~~~~~~~^^^^^
KeyError: Var(id=134741294431552):int64[]
```

**Description of the Change:**
In jax/_src/interpreters/partial_eval.py/_add_implicit_outputs, the vars for the dynamic dimensions of a returned jaxpr value are added to the jaxpr outvars.
Starting from v0.7.1, the dynamic dimension is actually no longer necessary to return, judging from the test suite we have (including those that deal with dynamic shapes).
We just patch this method to not add any implicit outputs.

**Benefits:**
Things work.

**Possible Drawbacks:**
Might trainwreck dynamic shapes in the future, but even JAX itself kinda stopped caring about dynamic shapes.
