### PR TITLE
Add a fixture to pass `capture` kwarg to qjit automatically

### DIFF
--- a/frontend/test/pytest/conftest.py
+++ b/frontend/test/pytest/conftest.py
@@ -107,7 +107,7 @@ def capture_mode(request):
         if "old_frontend" in request.keywords:
             pytest.skip("Test is specific to the old frontend and should not run with capture.")
         if "capture_todo" in request.keywords:
-            pytest.xfail("capture todo's do not yet work with program capture.")
+            pytest.xfail("Not expected to work yet with program capture.")
     return request.param
 
 


### PR DESCRIPTION
**Context:**
We are about to start the audit of tests. For convenience, a tiny nice fixture to automatically apply the two values of `capture` kwarg locally is good.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-111330]