### PR TITLE
Slightly change `CompilerError` message for `qml.allocate()` + disabled capture to include qjit context

### DIFF
--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -1508,7 +1508,7 @@ def _trace_classical_phase(
         # with an extra computational cost
 
         if any(isinstance(wire, qml.wires.DynamicWire) for wire in quantum_tape.wires):
-            msg = "qml.allocate() is only supported with program capture enabled."
+            msg = "qml.allocate() with qjit is only supported with program capture enabled."
             raise CompileError(msg)
 
         # 1. Recompute the original return

--- a/frontend/test/pytest/test_dynamic_qubit_allocation.py
+++ b/frontend/test/pytest/test_dynamic_qubit_allocation.py
@@ -515,7 +515,7 @@ def test_no_capture(backend):
     """
     with pytest.raises(
         CompileError,
-        match=re.escape("qml.allocate() is only supported with program capture enabled."),
+        match=re.escape("qml.allocate() with qjit is only supported with program capture enabled."),
     ):
 
         @qjit


### PR DESCRIPTION
**Context:**
It is a bit confusing to obtain the error message
`CompileError: qml.allocate() is only supported with program capture enabled.`
when actually `allocate` without capture is fine without `qjit`. So we should explicitly mention that `qjit` being in the mix leads to an unsupported configuration.

**Description of the Change:**
Mention `qjit` in the error message.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
