### PR TITLE
Supporting Stopping Condition with `qml.decompose`

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.238
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.45.0-dev33
+pennylane=0.45.0-dev34
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -179,6 +179,9 @@
   with the `decompose-lowering` pass and with `qp.transforms.decompose`.
   [(#2470)](https://github.com/PennyLaneAI/catalyst/pull/2470)
 
+* Added support for `stopping_condition` in user-defined `qml.decompose` when capture is enabled.
+  [(#2486)](https://github.com/PennyLaneAI/catalyst/pull/2486)
+
 <h3>Breaking changes 💔</h3>
 
 * `catalyst.jax_primitives.subroutine` has been moved to `qml.capture.subroutine`.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -179,7 +179,7 @@
   with the `decompose-lowering` pass and with `qp.transforms.decompose`.
   [(#2470)](https://github.com/PennyLaneAI/catalyst/pull/2470)
 
-* Added support for `stopping_condition` in user-defined `qml.decompose` when capture is enabled.
+* Added support for `stopping_condition` in user-defined `qp.decompose` when capture is enabled with both graph enabled and disabled.
   [(#2486)](https://github.com/PennyLaneAI/catalyst/pull/2486)
 
 <h3>Breaking changes 💔</h3>

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -34,4 +34,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.45.0-dev18
 pennylane-lightning==0.45.0-dev18
-pennylane==0.45.0-dev33
+pennylane==0.45.0-dev34

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -293,7 +293,7 @@ def handle_qnode(
             tgateset=list(self.decompose_tkwargs.get("gate_set", [])),
         )
 
-    if stopping_condition := self.decompose_tkwargs.get("stopping_condition"):        
+    if stopping_condition := self.decompose_tkwargs.get("stopping_condition"):
         # Use the plxpr decompose transform and ignore graph decomposition
         closed_jaxpr = _apply_compiler_decompose_to_plxpr(
             inner_jaxpr=qfunc_jaxpr,
@@ -459,11 +459,13 @@ def handle_transform(
         and qml.decomposition.enabled_graph()
     ):
         return _handle_decompose_transform(self, inner_jaxpr, consts, non_const_args, tkwargs)
-    elif hasattr(transform._plxpr_transform, "__name__") and transform._plxpr_transform.__name__ == "decompose_plxpr_to_plxpr":
+    elif (
+        hasattr(transform._plxpr_transform, "__name__")
+        and transform._plxpr_transform.__name__ == "decompose_plxpr_to_plxpr"
+    ):
         _set_decompose_lowering_state(self)
         # TODO: Might need to add self.decompose_tkwargs = tkwargs here.
 
-    
     catalyst_pass_name = transform.pass_name
     if catalyst_pass_name is None:
         catalyst_pass_name = transforms_to_passes.get(transform, (None,))[0]
@@ -577,7 +579,9 @@ def trace_from_pennylane(
     return jaxpr, out_type, out_treedef, sig
 
 
-def _apply_compiler_decompose_to_plxpr(inner_jaxpr, consts, ncargs, tgateset=None, tkwargs=None, stopping_condition=None):
+def _apply_compiler_decompose_to_plxpr(
+    inner_jaxpr, consts, ncargs, tgateset=None, tkwargs=None, stopping_condition=None
+):
     """Apply the compiler-specific decomposition for a given JAXPR.
 
     This function first disables the graph-based decomposition optimization
@@ -632,7 +636,7 @@ def _apply_compiler_decompose_to_plxpr(inner_jaxpr, consts, ncargs, tgateset=Non
 
     if graph_enabled:
         qml.decomposition.enable_graph()
-    
+
     return final_jaxpr
 
 

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -393,6 +393,7 @@ def _set_decompose_lowering_state(self):
     else:
         raise NotImplementedError("Multiple decomposition transforms are not yet supported.")
 
+
 # pylint: disable=too-many-positional-arguments
 def _handle_decompose_transform(self, inner_jaxpr, consts, non_const_args, tkwargs, use_graph=True):
     _set_decompose_lowering_state(self)

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -286,7 +286,6 @@ def handle_qnode(
 
     # Plxpr decomposition for templates
     if self.requires_decompose_lowering:
-        print("Performing template decomposition.")
         closed_jaxpr = _apply_compiler_decompose_to_plxpr(
             inner_jaxpr=qfunc_jaxpr,
             consts=consts,
@@ -296,7 +295,6 @@ def handle_qnode(
 
     if stopping_condition := self.decompose_tkwargs.get("stopping_condition"):        
         # Use the plxpr decompose transform and ignore graph decomposition
-        print("Plxpr decomposition for stopping condition.")
         closed_jaxpr = _apply_compiler_decompose_to_plxpr(
             inner_jaxpr=qfunc_jaxpr,
             consts=consts,
@@ -305,7 +303,7 @@ def handle_qnode(
             stopping_condition=stopping_condition,
         )
     elif not qml.decomposition.enabled_graph() and self.requires_decompose_lowering:
-        print("Performing plxpr decomposition.")
+        # Use the plxpr decompose transform when graph is disabled
         closed_jaxpr = _apply_compiler_decompose_to_plxpr(
             inner_jaxpr=qfunc_jaxpr,
             consts=consts,
@@ -313,7 +311,7 @@ def handle_qnode(
             tkwargs={"gate_set": self.decompose_tkwargs.get("gate_set", [])},
         )
     elif qml.decomposition.enabled_graph() and self.requires_decompose_lowering:
-        print("Performing graph decomposition.")
+        # Use the graph-based decomposition when graph is enabled
         closed_jaxpr, graph_succeeded = _collect_and_compile_graph_solutions(
             inner_jaxpr=closed_jaxpr.jaxpr,
             consts=closed_jaxpr.consts,
@@ -324,7 +322,6 @@ def handle_qnode(
         # Fallback to the legacy decomposition if the graph-based decomposition failed
         if not graph_succeeded:
             # Remove the decompose-lowering pass from the pipeline
-            print("Graph decomposition failed. Falling back to legacy decomposition.")
             self._pass_pipeline = [
                 p for p in self._pass_pipeline if p.pass_name != "decompose-lowering"
             ]

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -393,7 +393,7 @@ def _set_decompose_lowering_state(self):
     else:
         raise NotImplementedError("Multiple decomposition transforms are not yet supported.")
 
-
+# pylint: disable=too-many-positional-arguments
 def _handle_decompose_transform(self, inner_jaxpr, consts, non_const_args, tkwargs, use_graph=True):
     _set_decompose_lowering_state(self)
 
@@ -457,7 +457,9 @@ def handle_transform(
     transform_name = getattr(transform._plxpr_transform, "__name__", None)
     if transform_name == "decompose_plxpr_to_plxpr":
         use_graph = qml.decomposition.enabled_graph()
-        return _handle_decompose_transform(self, inner_jaxpr, consts, non_const_args, tkwargs, use_graph)
+        return _handle_decompose_transform(
+            self, inner_jaxpr, consts, non_const_args, tkwargs, use_graph
+        )
 
     catalyst_pass_name = transform.pass_name
     if catalyst_pass_name is None:

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -311,7 +311,6 @@ def handle_qnode(
             tkwargs={"gate_set": self.decompose_tkwargs.get("gate_set", [])},
         )
     elif qml.decomposition.enabled_graph() and self.requires_decompose_lowering:
-        # Use the graph-based decomposition when graph is enabled
         closed_jaxpr, graph_succeeded = _collect_and_compile_graph_solutions(
             inner_jaxpr=closed_jaxpr.jaxpr,
             consts=closed_jaxpr.consts,
@@ -464,7 +463,6 @@ def handle_transform(
         and transform._plxpr_transform.__name__ == "decompose_plxpr_to_plxpr"
     ):
         _set_decompose_lowering_state(self)
-        # TODO: Might need to add self.decompose_tkwargs = tkwargs here.
 
     catalyst_pass_name = transform.pass_name
     if catalyst_pass_name is None:

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -622,9 +622,6 @@ def _apply_compiler_decompose_to_plxpr(
         else tkwargs
     )
 
-    if kwargs is None:
-        kwargs = {}
-
     if stopping_condition:
         kwargs["stopping_condition"] = stopping_condition
 

--- a/frontend/test/pytest/from_plxpr/test_decompose_transform.py
+++ b/frontend/test/pytest/from_plxpr/test_decompose_transform.py
@@ -24,7 +24,9 @@ import pytest
 from pennylane.exceptions import DecompositionError, DecompositionWarning
 from pennylane.typing import TensorLike
 from pennylane.wires import WiresLike
-from pennylane_lightning.lightning_qubit.lightning_qubit import stopping_condition
+from pennylane_lightning.lightning_qubit.lightning_qubit import (
+    stopping_condition as lightning_stopping_condition,
+)
 
 
 @contextmanager
@@ -286,7 +288,7 @@ class TestGraphDecomposition:
         @partial(
             qml.transforms.decompose,
             gate_set=[qml.CNOT, qml.PauliZ],
-            stopping_condition=stopping_condition,
+            stopping_condition=lightning_stopping_condition,
         )
         @qml.qnode(device)
         def circuit(x):

--- a/frontend/test/pytest/from_plxpr/test_decompose_transform.py
+++ b/frontend/test/pytest/from_plxpr/test_decompose_transform.py
@@ -76,7 +76,9 @@ class TestGraphDecomposition:
             with pytest.warns(
                 DecompositionWarning, match="unable to find a decomposition for {'Hadamard'}"
             ):
-                circuit(0)
+                with pytest.warns(UserWarning, match="Operator RX does not define"):
+                    with pytest.warns(UserWarning, match="Operator RZ does not define"):
+                        circuit(0)
 
     @pytest.mark.usefixtures("use_capture_dgraph")
     def test_decompose_lowering_on_empty_circuit(self):

--- a/frontend/test/pytest/from_plxpr/test_decompose_transform.py
+++ b/frontend/test/pytest/from_plxpr/test_decompose_transform.py
@@ -24,6 +24,8 @@ import pytest
 from pennylane.exceptions import DecompositionError, DecompositionWarning
 from pennylane.typing import TensorLike
 from pennylane.wires import WiresLike
+from pennylane_lightning.lightning_qubit.lightning_qubit import stopping_condition
+
 
 @contextmanager
 def does_not_raise():
@@ -277,9 +279,7 @@ class TestGraphDecomposition:
 
     @pytest.mark.usefixtures("use_capture_dgraph")
     def test_decompose_with_lightning_stopping_condition(self):
-        """Test that decompose with stopping_condition using Lightning's stopping condition.
-        """
-        from pennylane_lightning.lightning_qubit.lightning_qubit import stopping_condition
+        """Test that decompose with stopping_condition using Lightning's stopping condition."""
 
         device = qml.device("lightning.qubit", wires=4)
 

--- a/frontend/test/pytest/from_plxpr/test_decompose_transform.py
+++ b/frontend/test/pytest/from_plxpr/test_decompose_transform.py
@@ -72,14 +72,12 @@ class TestGraphDecomposition:
             qml.Hadamard(x)
             return qml.state()
 
-        # TODO: RZ/RX warnings  should not be raised, remove (PL issue #8885)
+        # TODO: RZ/RX warnings should not be raised, remove (PL issue #8885)
         with pytest.warns(UserWarning, match="Falling back to the legacy decomposition system"):
             with pytest.warns(
                 DecompositionWarning, match="unable to find a decomposition for {'Hadamard'}"
             ):
-                with pytest.warns(UserWarning, match="Operator RX does not define"):
-                    with pytest.warns(UserWarning, match="Operator RZ does not define"):
-                        circuit(0)
+                circuit(0)
 
     @pytest.mark.usefixtures("use_capture_dgraph")
     def test_decompose_lowering_on_empty_circuit(self):

--- a/frontend/test/pytest/from_plxpr/test_decompose_transform.py
+++ b/frontend/test/pytest/from_plxpr/test_decompose_transform.py
@@ -240,6 +240,41 @@ class TestGraphDecomposition:
         resources = qml.specs(with_qjit, level="device")(x, y, z)["resources"].gate_types
         assert resources == expected_resources
 
+    @pytest.mark.usefixtures("use_capture_dgraph")
+    def test_decompose_with_stopping_condition(self):
+        """Test that decompose with stopping_condition uses plxpr decomposition correctly.
+
+        When stopping_condition is passed to qml.transforms.decompose, from_plxpr uses
+        the plxpr decompose path (no graph), passing stopping_condition to the transform.
+        This test ensures that path compiles and produces correct results.
+        """
+
+        def stopping_condition(op):
+            return op.name == "MultiRZ"
+
+        @partial(
+            qml.transforms.decompose,
+            gate_set=[qml.RX, qml.RY, qml.RZ],
+            stopping_condition=stopping_condition,
+        )
+        @qml.qnode(qml.device("lightning.qubit", wires=2))
+        def circuit(x, y, z):
+            qml.Rot(x, y, z, wires=0)
+            qml.MultiRZ(0.5, wires=[0, 1])
+            return qml.expval(qml.PauliZ(0))
+
+        x, y, z = 0.5, 0.3, 0.2
+        without_qjit = circuit(x, y, z)
+        with_qjit = qml.qjit(circuit)
+        assert qml.math.allclose(without_qjit, with_qjit(x, y, z))
+
+        expected_resources = qml.specs(circuit, level="device")(x, y, z)["resources"].gate_types
+        resources = qml.specs(with_qjit, level="device")(x, y, z)["resources"].gate_types
+        assert "MultiRZ" in resources
+        assert "MultiRZ" in expected_resources
+        assert resources == expected_resources
+
+
     @pytest.mark.skip(
         reason="inconsistent type and error msg across gcc/clang on arm/x86 for undefined symbols"
     )

--- a/frontend/test/pytest/from_plxpr/test_decompose_transform.py
+++ b/frontend/test/pytest/from_plxpr/test_decompose_transform.py
@@ -274,7 +274,6 @@ class TestGraphDecomposition:
         assert "MultiRZ" in expected_resources
         assert resources == expected_resources
 
-
     @pytest.mark.skip(
         reason="inconsistent type and error msg across gcc/clang on arm/x86 for undefined symbols"
     )

--- a/frontend/test/pytest/from_plxpr/test_from_plxpr_qubit_handler.py
+++ b/frontend/test/pytest/from_plxpr/test_from_plxpr_qubit_handler.py
@@ -348,7 +348,7 @@ class TestQubitValues:
             # So let's just check the string...
             # pytest context messes with jax's debug info, ignore warning
             with pytest.warns(DeprecationWarning, match="core.Jaxpr is missing a DebugInfo object"):
-                observed_jaxpr = str(trace.to_jaxpr([], None, None)[0])
+                observed_jaxpr = trace.to_jaxpr([], None, None)[0].pretty_print(use_color=False)
             expected = """\
             { lambda ; . let
                 a:AbstractQreg() = qalloc 42:i64[]
@@ -435,7 +435,7 @@ class TestQregAndQubit:
         with take_current_trace() as trace:
             # pytest context messes with jax's debug info, ignore warning
             with pytest.warns(DeprecationWarning, match="core.Jaxpr is missing a DebugInfo object"):
-                observed_jaxpr = str(trace.to_jaxpr([], None, None)[0])
+                observed_jaxpr = trace.to_jaxpr([], None, None)[0].pretty_print(use_color=False)
             expected = """\
             { lambda ; . let
                 a:AbstractQreg() = qalloc 42:i64[]

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -15,6 +15,7 @@
 
 from textwrap import dedent
 
+import re
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -71,11 +72,12 @@ class TestCondToJaxpr:
 
             out = cond_fn()
             return out
-
+        
         def asline(text):
-            return " ".join(map(lambda x: x.strip(), str(text).split("\n"))).strip()
+            return " ".join(map(lambda x: re.sub(r"\033\[[0-9;]*m", "", x).strip(), str(text).split("\n"))).strip()
 
-        assert asline(expected) == asline(circuit.jaxpr)
+        result = circuit.jaxpr
+        assert asline(expected) == asline(result)
 
 
 # pylint: disable=too-many-public-methods,too-many-lines

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 # pylint: disable=too-many-lines
 
+import re
 from textwrap import dedent
 
-import re
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -72,9 +72,11 @@ class TestCondToJaxpr:
 
             out = cond_fn()
             return out
-        
+
         def asline(text):
-            return " ".join(map(lambda x: re.sub(r"\033\[[0-9;]*m", "", x).strip(), str(text).split("\n"))).strip()
+            return " ".join(
+                map(lambda x: re.sub(r"\033\[[0-9;]*m", "", x).strip(), str(text).split("\n"))
+            ).strip()
 
         result = circuit.jaxpr
         assert asline(expected) == asline(result)

--- a/frontend/test/pytest/test_loops.py
+++ b/frontend/test/pytest/test_loops.py
@@ -58,7 +58,8 @@ class TestLoopToJaxpr:
 
             return loop((0, x))
 
-        assert expected.strip() == str(circuit.jaxpr).strip()
+        result = circuit.jaxpr.pretty_print(use_color=False).strip()
+        assert expected.strip() == result
 
     def test_for_loop(self):
         """Check the for loop JAXPR."""
@@ -87,7 +88,8 @@ class TestLoopToJaxpr:
 
             return loop((0, x))
 
-        assert expected.strip() == str(circuit.jaxpr).strip()
+        result = circuit.jaxpr.pretty_print(use_color=False).strip()
+        assert expected.strip() == result
 
 
 class TestWhileLoops:

--- a/frontend/test/pytest/test_pauli_rot_and_measure.py
+++ b/frontend/test/pytest/test_pauli_rot_and_measure.py
@@ -63,7 +63,7 @@ def test_pauli_rot_lowering_with_ctrl_qubits():
 
 @pytest.mark.usefixtures("use_capture")
 def test_pauli_rot_to_ppr():
-    """Test that Pauli rotation is converted to qec.ppr."""
+    """Test that Pauli rotation is converted to pbc.ppr."""
     pipe = [("pipe", ["quantum-compilation-stage"])]
 
     @qjit(pipelines=pipe, target="mlir")
@@ -78,7 +78,7 @@ def test_pauli_rot_to_ppr():
 
     optimized_ir = test_pauli_rot_to_ppr_workflow.mlir_opt
     print(optimized_ir)
-    assert "qec.ppr" in optimized_ir
+    assert "pbc.ppr" in optimized_ir
 
 
 @pytest.mark.usefixtures("use_capture")
@@ -97,7 +97,8 @@ def test_pauli_rot_with_arbitrary_angle_to_ppr():
         return f()
 
     optimized_ir = test_pauli_rot_with_arbitrary_angle_to_ppr_workflow.mlir_opt
-    assert "qec.ppr.arbitrary" in optimized_ir
+    print(optimized_ir)
+    assert "pbc.ppr.arbitrary" in optimized_ir
 
 
 @pytest.mark.usefixtures("use_capture")
@@ -116,12 +117,12 @@ def test_pauli_rot_with_dynamic_angle_to_ppr():
         return f(0.42)
 
     optimized_ir = test_pauli_rot_with_dynamic_angle_to_ppr_workflow.mlir_opt
-    assert "qec.ppr.arbitrary" in optimized_ir
+    assert "pbc.ppr.arbitrary" in optimized_ir
 
 
 @pytest.mark.usefixtures("use_capture")
 def test_pauli_measure_to_ppm():
-    """Test that Pauli measurement is converted to qec.ppm."""
+    """Test that Pauli measurement is converted to pbc.ppm."""
     pipe = [("pipe", ["quantum-compilation-stage"])]
 
     @qjit(pipelines=pipe, target="mlir")
@@ -135,7 +136,7 @@ def test_pauli_measure_to_ppm():
         return f()
 
     optimized_ir = test_pauli_measure_to_ppr_workflow.mlir_opt
-    assert "qec.ppm" in optimized_ir
+    assert "pbc.ppm" in optimized_ir
 
 
 @pytest.mark.usefixtures("use_capture")

--- a/frontend/test/pytest/test_pauli_rot_and_measure.py
+++ b/frontend/test/pytest/test_pauli_rot_and_measure.py
@@ -30,7 +30,7 @@ def test_pauli_rot_lowering():
     @qjit(pipelines=pipe, target="mlir")
     def test_pauli_rot_lowering_workflow():
 
-        @qml.qnode(qml.device("lightning.qubit", wires=1))
+        @qml.qnode(qml.device("null.qubit", wires=1))
         def f():
             qml.PauliRot(np.pi / 4, "X", wires=0)
 
@@ -50,7 +50,7 @@ def test_pauli_rot_lowering_with_ctrl_qubits():
     @qjit(pipelines=pipe, target="mlir")
     def test_pauli_rot_lowering_with_ctrl_qubits_workflow():
 
-        @qml.qnode(qml.device("lightning.qubit", wires=2))
+        @qml.qnode(qml.device("null.qubit", wires=2))
         def f():
             qml.ctrl(qml.PauliRot(np.pi / 4, "X", wires=0), control=1)
 
@@ -70,7 +70,7 @@ def test_pauli_rot_to_ppr():
     @to_ppr
     def test_pauli_rot_to_ppr_workflow():
 
-        @qml.qnode(qml.device("lightning.qubit", wires=1))
+        @qml.qnode(qml.device("null.qubit", wires=1))
         def f():
             qml.PauliRot(np.pi / 4, "X", wires=0)
 
@@ -90,7 +90,7 @@ def test_pauli_rot_with_arbitrary_angle_to_ppr():
     @to_ppr
     def test_pauli_rot_with_arbitrary_angle_to_ppr_workflow():
 
-        @qml.qnode(qml.device("lightning.qubit", wires=1))
+        @qml.qnode(qml.device("null.qubit", wires=1))
         def f():
             qml.PauliRot(0.42, "X", wires=0)
 
@@ -109,7 +109,7 @@ def test_pauli_rot_with_dynamic_angle_to_ppr():
     @to_ppr
     def test_pauli_rot_with_dynamic_angle_to_ppr_workflow():
 
-        @qml.qnode(qml.device("lightning.qubit", wires=1))
+        @qml.qnode(qml.device("null.qubit", wires=1))
         def f(x: float):
             qml.PauliRot(x, "X", wires=0)
 
@@ -128,7 +128,7 @@ def test_pauli_measure_to_ppm():
     @to_ppr
     def test_pauli_measure_to_ppr_workflow():
 
-        @qml.qnode(qml.device("lightning.qubit", wires=1))
+        @qml.qnode(qml.device("null.qubit", wires=1))
         def f():
             qml.pauli_measure("X", wires=0)
 
@@ -152,7 +152,7 @@ def test_pauli_rot_to_ppr_pauli_word_error():
         @qjit(pipelines=pipe, target="mlir")
         def test_pauli_rot_to_ppr_pauli_word_error_workflow():
 
-            @qml.qnode(qml.device("lightning.qubit", wires=1))
+            @qml.qnode(qml.device("null.qubit", wires=1))
             def f():
                 qml.PauliRot(np.pi / 4, "A", wires=0)
 
@@ -172,7 +172,7 @@ def test_pauli_measure_to_ppr_pauli_word_error():
         @qjit(pipelines=pipe, target="mlir")
         def test_pauli_measure_to_ppr_pauli_word_error_workflow():
 
-            @qml.qnode(qml.device("lightning.qubit", wires=1))
+            @qml.qnode(qml.device("null.qubit", wires=1))
             def f():
                 qml.pauli_measure("A", wires=0)
 

--- a/frontend/test/pytest/test_pauli_rot_and_measure.py
+++ b/frontend/test/pytest/test_pauli_rot_and_measure.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Xanadu Quantum Technologies Inc.
+# Copyright 2025-2026 Xanadu Quantum Technologies Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ def test_pauli_rot_lowering():
     @qjit(pipelines=pipe, target="mlir")
     def test_pauli_rot_lowering_workflow():
 
-        @qml.qnode(qml.device("null.qubit", wires=1))
+        @qml.qnode(qml.device("lightning.qubit", wires=1))
         def f():
             qml.PauliRot(np.pi / 4, "X", wires=0)
 
@@ -42,7 +42,7 @@ def test_pauli_rot_lowering():
 
 @pytest.mark.usefixtures("use_capture")
 def test_pauli_rot_lowering_with_ctrl_qubits():
-    """Test that Pauli rotation with control qubits is converted to pbc.ppr.
+    """Test that Pauli rotation with control qubits is converted to quantum.paulirot.
     Note that control PauliRot is currently not supported by the to_ppr pass.
     """
     pipe = [("pipe", ["quantum-compilation-stage"])]
@@ -50,7 +50,7 @@ def test_pauli_rot_lowering_with_ctrl_qubits():
     @qjit(pipelines=pipe, target="mlir")
     def test_pauli_rot_lowering_with_ctrl_qubits_workflow():
 
-        @qml.qnode(qml.device("null.qubit", wires=2))
+        @qml.qnode(qml.device("lightning.qubit", wires=2))
         def f():
             qml.ctrl(qml.PauliRot(np.pi / 4, "X", wires=0), control=1)
 
@@ -63,21 +63,22 @@ def test_pauli_rot_lowering_with_ctrl_qubits():
 
 @pytest.mark.usefixtures("use_capture")
 def test_pauli_rot_to_ppr():
-    """Test that Pauli rotation is converted to pbc.ppr."""
+    """Test that Pauli rotation is converted to qec.ppr."""
     pipe = [("pipe", ["quantum-compilation-stage"])]
 
     @qjit(pipelines=pipe, target="mlir")
     @to_ppr
     def test_pauli_rot_to_ppr_workflow():
 
-        @qml.qnode(qml.device("null.qubit", wires=1))
+        @qml.qnode(qml.device("lightning.qubit", wires=1))
         def f():
             qml.PauliRot(np.pi / 4, "X", wires=0)
 
         return f()
 
     optimized_ir = test_pauli_rot_to_ppr_workflow.mlir_opt
-    assert "pbc.ppr" in optimized_ir
+    print(optimized_ir)
+    assert "qec.ppr" in optimized_ir
 
 
 @pytest.mark.usefixtures("use_capture")
@@ -89,14 +90,14 @@ def test_pauli_rot_with_arbitrary_angle_to_ppr():
     @to_ppr
     def test_pauli_rot_with_arbitrary_angle_to_ppr_workflow():
 
-        @qml.qnode(qml.device("null.qubit", wires=1))
+        @qml.qnode(qml.device("lightning.qubit", wires=1))
         def f():
             qml.PauliRot(0.42, "X", wires=0)
 
         return f()
 
     optimized_ir = test_pauli_rot_with_arbitrary_angle_to_ppr_workflow.mlir_opt
-    assert "pbc.ppr.arbitrary" in optimized_ir
+    assert "qec.ppr.arbitrary" in optimized_ir
 
 
 @pytest.mark.usefixtures("use_capture")
@@ -108,33 +109,33 @@ def test_pauli_rot_with_dynamic_angle_to_ppr():
     @to_ppr
     def test_pauli_rot_with_dynamic_angle_to_ppr_workflow():
 
-        @qml.qnode(qml.device("null.qubit", wires=1))
+        @qml.qnode(qml.device("lightning.qubit", wires=1))
         def f(x: float):
             qml.PauliRot(x, "X", wires=0)
 
         return f(0.42)
 
     optimized_ir = test_pauli_rot_with_dynamic_angle_to_ppr_workflow.mlir_opt
-    assert "pbc.ppr.arbitrary" in optimized_ir
+    assert "qec.ppr.arbitrary" in optimized_ir
 
 
 @pytest.mark.usefixtures("use_capture")
 def test_pauli_measure_to_ppm():
-    """Test that Pauli measurement is converted to pbc.ppm."""
+    """Test that Pauli measurement is converted to qec.ppm."""
     pipe = [("pipe", ["quantum-compilation-stage"])]
 
     @qjit(pipelines=pipe, target="mlir")
     @to_ppr
     def test_pauli_measure_to_ppr_workflow():
 
-        @qml.qnode(qml.device("null.qubit", wires=1))
+        @qml.qnode(qml.device("lightning.qubit", wires=1))
         def f():
             qml.pauli_measure("X", wires=0)
 
         return f()
 
     optimized_ir = test_pauli_measure_to_ppr_workflow.mlir_opt
-    assert "pbc.ppm" in optimized_ir
+    assert "qec.ppm" in optimized_ir
 
 
 @pytest.mark.usefixtures("use_capture")
@@ -151,7 +152,7 @@ def test_pauli_rot_to_ppr_pauli_word_error():
         @qjit(pipelines=pipe, target="mlir")
         def test_pauli_rot_to_ppr_pauli_word_error_workflow():
 
-            @qml.qnode(qml.device("null.qubit", wires=1))
+            @qml.qnode(qml.device("lightning.qubit", wires=1))
             def f():
                 qml.PauliRot(np.pi / 4, "A", wires=0)
 
@@ -171,7 +172,7 @@ def test_pauli_measure_to_ppr_pauli_word_error():
         @qjit(pipelines=pipe, target="mlir")
         def test_pauli_measure_to_ppr_pauli_word_error_workflow():
 
-            @qml.qnode(qml.device("null.qubit", wires=1))
+            @qml.qnode(qml.device("lightning.qubit", wires=1))
             def f():
                 qml.pauli_measure("A", wires=0)
 

--- a/frontend/test/pytest/test_pauli_rot_and_measure.py
+++ b/frontend/test/pytest/test_pauli_rot_and_measure.py
@@ -77,7 +77,6 @@ def test_pauli_rot_to_ppr():
         return f()
 
     optimized_ir = test_pauli_rot_to_ppr_workflow.mlir_opt
-    print(optimized_ir)
     assert "pbc.ppr" in optimized_ir
 
 

--- a/frontend/test/pytest/test_pauli_rot_and_measure.py
+++ b/frontend/test/pytest/test_pauli_rot_and_measure.py
@@ -97,7 +97,6 @@ def test_pauli_rot_with_arbitrary_angle_to_ppr():
         return f()
 
     optimized_ir = test_pauli_rot_with_arbitrary_angle_to_ppr_workflow.mlir_opt
-    print(optimized_ir)
     assert "pbc.ppr.arbitrary" in optimized_ir
 
 

--- a/runtime/lib/backend/null_qubit/null_qubit.toml
+++ b/runtime/lib/backend/null_qubit/null_qubit.toml
@@ -42,6 +42,7 @@ IsingXY                = { properties = [ "invertible", "controllable", "differe
 IsingYY                = { properties = [ "invertible", "controllable", "differentiable" ] }
 IsingZZ                = { properties = [ "invertible", "controllable", "differentiable" ] }
 MultiRZ                = { properties = [ "invertible", "controllable", "differentiable" ] }
+PauliRot               = { properties = [ "invertible",                                  ] }
 PauliX                 = { properties = [ "invertible", "controllable", "differentiable" ] }
 PauliY                 = { properties = [ "invertible", "controllable", "differentiable" ] }
 PauliZ                 = { properties = [ "invertible", "controllable", "differentiable" ] }


### PR DESCRIPTION
Context: Supporting `stopping_condition` when user supplies it in `qml.decompose` with capture enabled. This will use the plxpr transform to handle the decomposition with stopping condition. 

This PR is a subset of https://github.com/PennyLaneAI/catalyst/pull/2472. See that PR for a more detailed discussion.

[[sc-110276]]