### PR TITLE
Fix `qml.decompose` with `qml.templates.Subroutine`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -153,6 +153,7 @@
 * Catalyst with program capture can now be used with the new `qml.templates.Subroutine` class and the associated
   `qml.capture.subroutine` upstreamed from `catalyst.jax_primitives.subroutine`.
   [(#2396)](https://github.com/PennyLaneAI/catalyst/pull/2396)
+  [(#2493)](https://github.com/PennyLaneAI/catalyst/pull/2493)
 
 * The PPR/PPM lowering passes (`lower-pbc-init-ops`, `unroll-conditional-ppr-ppm`) are now run
   as part of the main quantum compilation pipeline. When using `to-ppr` and `ppr-to-ppm` transforms,

--- a/frontend/catalyst/from_plxpr/decompose.py
+++ b/frontend/catalyst/from_plxpr/decompose.py
@@ -148,6 +148,7 @@ class DecompRuleInterpreter(qml.capture.PlxprInterpreter):
         self._captured = False
         self._operations = set()
         self._decomp_graph_solution = {}
+        self.subroutine_cache = {}
 
     def interpret_operation(self, op: "qml.operation.Operator"):
         """Interpret a PennyLane operation instance.
@@ -227,7 +228,6 @@ class DecompRuleInterpreter(qml.capture.PlxprInterpreter):
                     num_wires = len(pauli_word)
                 elif num_wires == -1 and op_num_wires is not None:
                     num_wires = op_num_wires
-
                 _create_decomposition_rule(
                     rule,
                     op_name=op.op.name,

--- a/frontend/catalyst/from_plxpr/decompose.py
+++ b/frontend/catalyst/from_plxpr/decompose.py
@@ -150,6 +150,7 @@ class DecompRuleInterpreter(qml.capture.PlxprInterpreter):
         self._operations = set()
         self._decomp_graph_solution = {}
         self.subroutine_cache = {}
+        # This will be consumed by _quantum_subroutine inherited from PlxprInterpreter
 
     def interpret_operation(self, op: "qml.operation.Operator"):
         """Interpret a PennyLane operation instance.

--- a/frontend/catalyst/from_plxpr/decompose.py
+++ b/frontend/catalyst/from_plxpr/decompose.py
@@ -97,6 +97,7 @@ COMPILER_OPS_FOR_DECOMPOSITION: dict[str, tuple[int, int]] = {
 }
 
 
+# pylint: disable=too-many-instance-attributes
 class DecompRuleInterpreter(qml.capture.PlxprInterpreter):
     """Interpreter for getting the decomposition graph solution
     from a jaxpr when program capture is enabled.

--- a/frontend/test/lit/test_decomposition.py
+++ b/frontend/test/lit/test_decomposition.py
@@ -797,8 +797,8 @@ def test_decomposition_inside_subroutine():
         # CHECK-DAG [[SECOND_CONST:%.+]] = stablehlo.constant dense<1.200000e+00> : tensor<f64>
 
         # CHECK: [[QREG:%.+]] = quantum.alloc
-        # CHECK: [[QREG_1:%.+]] = call @f([[QREG]], {{FIRST_CONST}}, {{%.+}}) : (!quantum.reg, tensor<f64>, tensor<2xi64>) -> !quantum.reg
-        # CHECK: [[QREG_2:%.+]] = call @f([[QREG_1]], {{SECOND_CONST}, {{%.+}}) : (!quantum.reg, tensor<f64>, tensor<2xi64>) -> !quantum.reg
+        # CHECK: [[QREG_1:%.+]] = call @f([[QREG]], [[FIRST_CONST]], {{%.+}}) : (!quantum.reg, tensor<f64>, tensor<2xi64>) -> !quantum.reg
+        # CHECK: [[QREG_2:%.+]] = call @f([[QREG_1]], [[SECOND_CONST]], {{%.+}}) : (!quantum.reg, tensor<f64>, tensor<2xi64>) -> !quantum.reg
 
         f(0.5, (0, 1))
         f(1.2, (2, 3))

--- a/frontend/test/lit/test_decomposition.py
+++ b/frontend/test/lit/test_decomposition.py
@@ -793,8 +793,8 @@ def test_decomposition_inside_subroutine():
     @qml.qnode(qml.device("lightning.qubit", wires=5))
     # CHECK-DAG: %0 = transform.apply_registered_pass "decompose-lowering"
     def subroutine_circuit():
-        # CHECK-DAG [[FIRST_CONST:%.+]] = stablehlo.constant dense<5.000000e-01> : tensor<f64>
-        # CHECK-DAG [[SECOND_CONST:%.+]] = stablehlo.constant dense<1.200000e+00> : tensor<f64>
+        # CHECK-DAG: [[FIRST_CONST:%.+]] = stablehlo.constant dense<5.000000e-01> : tensor<f64>
+        # CHECK-DAG: [[SECOND_CONST:%.+]] = stablehlo.constant dense<1.200000e+00> : tensor<f64>
 
         # CHECK: [[QREG:%.+]] = quantum.alloc
         # CHECK: [[QREG_1:%.+]] = call @f([[QREG]], [[FIRST_CONST]], {{%.+}}) : (!quantum.reg, tensor<f64>, tensor<2xi64>) -> !quantum.reg

--- a/frontend/test/lit/test_decomposition.py
+++ b/frontend/test/lit/test_decomposition.py
@@ -793,9 +793,12 @@ def test_decomposition_inside_subroutine():
     @qml.qnode(qml.device("lightning.qubit", wires=5))
     # CHECK-DAG: %0 = transform.apply_registered_pass "decompose-lowering"
     def subroutine_circuit():
+        # CHECK-DAG [[FIRST_CONST:%.+]] = stablehlo.constant dense<5.000000e-01> : tensor<f64>
+        # CHECK-DAG [[SECOND_CONST:%.+]] = stablehlo.constant dense<1.200000e+00> : tensor<f64>
+
         # CHECK: [[QREG:%.+]] = quantum.alloc
-        # CHECK: [[QREG_1:%.+]] = call @f([[QREG]], %cst_1, %3) : (!quantum.reg, tensor<f64>, tensor<2xi64>) -> !quantum.reg
-        # CHECK: [[QREG_2:%.+]] = call @f([[QREG_1]], %cst, %7) : (!quantum.reg, tensor<f64>, tensor<2xi64>) -> !quantum.reg
+        # CHECK: [[QREG_1:%.+]] = call @f([[QREG]], {{FIRST_CONST}}, {{%.+}}) : (!quantum.reg, tensor<f64>, tensor<2xi64>) -> !quantum.reg
+        # CHECK: [[QREG_2:%.+]] = call @f([[QREG_1]], {{SECOND_CONST}, {{%.+}}) : (!quantum.reg, tensor<f64>, tensor<2xi64>) -> !quantum.reg
 
         f(0.5, (0, 1))
         f(1.2, (2, 3))

--- a/frontend/test/lit/test_decomposition.py
+++ b/frontend/test/lit/test_decomposition.py
@@ -790,23 +790,24 @@ def test_decomposition_inside_subroutine():
 
     @qml.qjit(capture=True, target="mlir")
     @qml.decompose(gate_set=qml.gate_sets.ROTATIONS_PLUS_CNOT)
-    @qml.qnode(qml.device('lightning.qubit', wires=5))
+    @qml.qnode(qml.device("lightning.qubit", wires=5))
     # CHECK-DAG: %0 = transform.apply_registered_pass "decompose-lowering"
     def subroutine_circuit():
         # CHECK: [[QREG:%.+]] = quantum.alloc
         # CHECK: [[QREG_1:%.+]] = call @f([[QREG]], %cst_1, %3) : (!quantum.reg, tensor<f64>, tensor<2xi64>) -> !quantum.reg
         # CHECK: [[QREG_2:%.+]] = call @f([[QREG_1]], %cst, %7) : (!quantum.reg, tensor<f64>, tensor<2xi64>) -> !quantum.reg
 
-        f(0.5, (0,1))
-        f(1.2, (2,3))
+        f(0.5, (0, 1))
+        f(1.2, (2, 3))
         return qml.probs(wires=0)
-
 
     # CHECK-DAG: func.func public @_isingxx_to_cnot_rx_cnot(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<2xi64>)
     print(subroutine_circuit.mlir)
     qml.decomposition.disable_graph()
 
+
 test_decomposition_inside_subroutine()
+
 
 def test_decomposition_rule_name_update_multi_qubits():
     """Test the name of the decomposition rule with multi-qubit gates."""

--- a/frontend/test/lit/test_decomposition.py
+++ b/frontend/test/lit/test_decomposition.py
@@ -779,6 +779,35 @@ def test_decomposition_rule_name_update():
 test_decomposition_rule_name_update()
 
 
+def test_decomposition_inside_subroutine():
+    """Test that operators inside subroutines can be decomposed."""
+
+    qml.decomposition.enable_graph()
+
+    @qml.templates.Subroutine
+    def f(x, wires):
+        qml.IsingXX(x, wires)
+
+    @qml.qjit(capture=True, target="mlir")
+    @qml.decompose(gate_set=qml.gate_sets.ROTATIONS_PLUS_CNOT)
+    @qml.qnode(qml.device('lightning.qubit', wires=5))
+    # CHECK-DAG: %0 = transform.apply_registered_pass "decompose-lowering"
+    def subroutine_circuit():
+        # CHECK: [[QREG:%.+]] = quantum.alloc
+        # CHECK: [[QREG_1:%.+]] = call @f([[QREG]], %cst_1, %3) : (!quantum.reg, tensor<f64>, tensor<2xi64>) -> !quantum.reg
+        # CHECK: [[QREG_2:%.+]] = call @f([[QREG_1]], %cst, %7) : (!quantum.reg, tensor<f64>, tensor<2xi64>) -> !quantum.reg
+
+        f(0.5, (0,1))
+        f(1.2, (2,3))
+        return qml.probs(wires=0)
+
+
+    # CHECK-DAG: func.func public @_isingxx_to_cnot_rx_cnot(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<2xi64>)
+    print(subroutine_circuit.mlir)
+    qml.decomposition.disable_graph()
+
+test_decomposition_inside_subroutine()
+
 def test_decomposition_rule_name_update_multi_qubits():
     """Test the name of the decomposition rule with multi-qubit gates."""
 

--- a/frontend/test/pytest/from_plxpr/test_decompose_transform.py
+++ b/frontend/test/pytest/from_plxpr/test_decompose_transform.py
@@ -536,10 +536,10 @@ class TestGraphDecomposition:
 
         @qml.qjit(capture=True)
         @qml.decompose(gate_set=qml.gate_sets.ROTATIONS_PLUS_CNOT)
-        @qml.qnode(qml.device('lightning.qubit', wires=5))
+        @qml.qnode(qml.device("lightning.qubit", wires=5))
         def c():
-            f(0.5, (0,1))
-            f(1.2, (2,3))
+            f(0.5, (0, 1))
+            f(1.2, (2, 3))
             return qml.expval(qml.Z(0)), qml.expval(qml.Z(2))
 
         resources = qml.specs(c, level="device")().resources.gate_types
@@ -550,6 +550,7 @@ class TestGraphDecomposition:
         assert qml.math.allclose(r2, np.cos(1.2))
 
         qml.decomposition.disable_graph()
+
 
 if __name__ == "__main__":
     pytest.main(["-x", __file__])


### PR DESCRIPTION
**Context:**

Small bug prevented the use of subroutines with `qml.decompose` with capture turned on.

**Description of the Change:**

Add a `subroutine_cache` property at initialization and adds tests.

**Benefits:**

FTQC workflow will hopefully finally work.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-112062]