### PR TITLE
[WIP] Trying to fix adjoint with Subroutine

### DIFF
--- a/frontend/catalyst/from_plxpr/qfunc_interpreter.py
+++ b/frontend/catalyst/from_plxpr/qfunc_interpreter.py
@@ -457,14 +457,12 @@ def _subroutine_kernel(
     wire_label_arg_to_tracer_arg_index=(),
     wire_to_owner_qreg=(),
 ):
-
     *dynqregs_plus_args, global_qreg = args_plus_qregs
     num_dynamic_alloced_qregs = len(outer_dynqreg_handlers)
     dynalloced_qregs, args = (
         dynqregs_plus_args[:num_dynamic_alloced_qregs],
         dynqregs_plus_args[num_dynamic_alloced_qregs:],
     )
-
     # Launch a new interpreter for the body region
     # A new interpreter's root qreg value needs a new recorder
     converter = copy(interpreter)
@@ -500,7 +498,6 @@ def _subroutine_kernel(
             converter.qubit_index_recorder[arg] = arg_to_qreg[arg]
 
     retvals = converter(jaxpr, *args)
-
     init_qreg.insert_all_dangling_qubits()
 
     # Return all registers
@@ -550,7 +547,7 @@ def handle_subroutine(self, *args, **kwargs):
             wire_to_owner_qreg=wire_to_owner_qreg,
         )
         converted_closed_jaxpr_branch = jax.make_jaxpr(f)(
-            self.init_qreg.get(), *[dyn_qreg.get() for dyn_qreg in dynalloced_qregs], *args
+            *args, *[dyn_qreg.get() for dyn_qreg in dynalloced_qregs], self.init_qreg.get()
         )
         self.subroutine_cache[plxpr] = converted_closed_jaxpr_branch
     else:
@@ -795,7 +792,6 @@ def handle_adjoint_transform(
         return *retvals, converter.init_qreg.get()
 
     converted_jaxpr_branch = jax.make_jaxpr(calling_convention)(*args, qreg)
-
     converted_closed_jaxpr_branch = ClosedJaxpr(
         convert_constvars_jaxpr(converted_jaxpr_branch.jaxpr), ()
     )


### PR DESCRIPTION
**Context:**

Trying to get the adjoint of a subroutine to work:
```
@qml.templates.Subroutine
def f(x, wires):
    qml.RX(x, wires)

@qml.qjit(capture=True)
@qml.qnode(qml.device('lightning.qubit', wires=1))
def c():
    qml.adjoint(f)(0.5, 0)
    return qml.probs(0)
```

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-111989]