### PR TITLE
Add explicit boundary marker between tape and MLIR levels to a CompilePipeline when qjiting

### DIFF
--- a/frontend/catalyst/qfunc.py
+++ b/frontend/catalyst/qfunc.py
@@ -649,4 +649,8 @@ def _extract_passes(transform_program):
             raise ValueError(
                 f"{t} without a tape definition occurs before tape transform {tape_transforms[-1]}."
             )
+
+    # Add boundary marker between tapes and MLIR to compile pipeline
+    transform_program.add_marker("mlir_boundary", i)
+
     return qml.CompilePipeline(tape_transforms), tuple(pass_pipeline)


### PR DESCRIPTION
**Context:**
Currently, there is no way for an end user to easily see where in the `CompilePipeline` transforms stop being tape transforms and begin being MLIR passes.

**Description of the Change:**
Adds an "mlir_boundary" marker to the CompilePipeline at qjit time so that the boundary between tapes and MLIR is more apparent

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
