### PR TITLE
Do not run a function to compile its executable

### DIFF
--- a/frontend/catalyst/debug/compiler_functions.py
+++ b/frontend/catalyst/debug/compiler_functions.py
@@ -237,7 +237,7 @@ def compile_executable(fn, *args):
 
     # if fn is not compiled, compile it first.
     if not fn.compiled_function:
-        fn(*args)
+        fn.jit_compile(args)
 
     f_name = str(fn.__name__)
     workspace = str(fn.workspace) if fn.compile_options.keep_intermediate else os.getcwd()


### PR DESCRIPTION
The debug functionality to compile a catalyst program to a standalone executable compiles the program by running the QJIT function. However, if the functionality is used for debugging programs with execution failures, the failure will prevent the executable from being generated. Compile the program by calling the dedicated compilation method instead.