### PR TITLE
update does_not_raise context to pass flaky tests

### DIFF
--- a/frontend/test/pytest/from_plxpr/test_decompose_transform.py
+++ b/frontend/test/pytest/from_plxpr/test_decompose_transform.py
@@ -15,7 +15,7 @@
 This module tests the decompose transformation.
 """
 
-from contextlib import contextmanager
+from contextlib import nullcontext as does_not_raise
 from functools import partial
 
 import numpy as np
@@ -24,15 +24,6 @@ import pytest
 from pennylane.exceptions import DecompositionError, DecompositionWarning
 from pennylane.typing import TensorLike
 from pennylane.wires import WiresLike
-
-
-@contextmanager
-def does_not_raise():
-    """
-    define a context manager for tests that do not fail, for use with `parametrize`.
-    See https://github.com/pytest-dev/pytest/pull/4682/changes for details.
-    """
-    yield
 
 
 class TestGraphDecomposition:


### PR DESCRIPTION
**Context:**
[Flaky tests fail](https://github.com/PennyLaneAI/catalyst/actions/runs/22266652194/job/64414088584) on [decomposition work wires tests](https://github.com/PennyLaneAI/catalyst/blob/f050b9f28c23911acfebac56cca433829dd4502f/frontend/test/pytest/from_plxpr/test_decompose_transform.py#L476).

Reproducible with 

```python
python -m pytest frontend/test/pytest/from_plxpr/test_decompose_transform.py -k work_wires --tb=native --backend="lightning.qubit" --runbraket=NONE -n auto  --force-flaky --max-runs=5 --min-passes=5
```

**Description of the Change:**
Update the `does_not_raise()` context manager from a manual implementation to the newer `nullcontext` from contextlib.

**Benefits:**
Flaky tests pass.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A