### PR TITLE
Target decomposition rules via `decomposition_rule` attribute

### DIFF
--- a/frontend/catalyst/from_plxpr/decompose.py
+++ b/frontend/catalyst/from_plxpr/decompose.py
@@ -345,6 +345,7 @@ def _create_decomposition_rule(
     # Set custom attributes for the decomposition rule
     # These attributes are used in the MLIR decomposition pass
     # to identify the target gate and the number of wires
+    setattr(func_cp, "decomposition_rule", True)
     setattr(func_cp, "target_gate", op_name)
     setattr(func_cp, "num_wires", num_wires)
 

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -438,6 +438,9 @@ def decomposition_rule(func=None, *, is_qreg=True, num_params=0, pauli_word=None
         if getattr(func, "target_gate", None) is None:
             setattr(func, "target_gate", op_type)
 
+        if getattr(func, "decomposition_rule", None) is None:
+            setattr(func, "decomposition_rule", True)
+
         if pauli_word is not None:
             jaxpr = jax.make_jaxpr(func)(theta=args[0], wires=args[1], **kwargs)
         else:

--- a/frontend/catalyst/jax_primitives_utils.py
+++ b/frontend/catalyst/jax_primitives_utils.py
@@ -196,8 +196,10 @@ def lower_callable_to_funcop(ctx, callable_, call_jaxpr, public=False):
         if gateset := getattr(callable_, "decompose_gatesets", []):
             func_op.attributes["decompose_gatesets"] = get_mlir_attribute_from_pyval(gateset)
 
-    # Extract the target gate and number of wires from decomposition rules
+    # Extract the decomposition_rule, target gate and number of wires from decomposition rules
     # and set them as attributes on the FuncOp for use in the MLIR decomposition pass
+    if decomposition_rule := getattr(callable_, "decomposition_rule", None):
+        func_op.attributes["decomposition_rule"] = get_mlir_attribute_from_pyval(decomposition_rule)
     if target_gate := getattr(callable_, "target_gate", None):
         func_op.attributes["target_gate"] = get_mlir_attribute_from_pyval(target_gate)
     if num_wires := getattr(callable_, "num_wires", None):

--- a/frontend/test/lit/test_decomposition.py
+++ b/frontend/test/lit/test_decomposition.py
@@ -833,13 +833,13 @@ def test_decomposition_rule_name_update_multi_qubits():
         qml.DoubleExcitation(0.5, wires=[0, 1, 2, 3])
         return qml.expval(qml.Z(0))
 
-    # CHECK-DAG: func.func public @_cry(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<2xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 2 : i64, target_gate = "CRY"}
-    # CHECK-DAG: func.func public @_s_phaseshift(%arg0: !quantum.reg, %arg1: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "S"}
-    # CHECK-DAG: func.func public @_phaseshift_to_rz_gp(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "PhaseShift"}
-    # CHECK-DAG: func.func public @_rz_to_ry_rx(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "RZ"}
-    # CHECK-DAG: func.func public @_rot_to_rz_ry_rz(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>, %arg4: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Rot"}
-    # CHECK-DAG: func.func public @_doublexcit(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<4xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 4 : i64, target_gate = "DoubleExcitation"}
-    # CHECK-DAG: func.func public @_single_excitation_decomp(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<2xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 2 : i64, target_gate = "SingleExcitation"}
+    # CHECK-DAG: func.func public @_cry(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<2xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 2 : i64, target_gate = "CRY"}
+    # CHECK-DAG: func.func public @_s_phaseshift(%arg0: !quantum.reg, %arg1: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "S"}
+    # CHECK-DAG: func.func public @_phaseshift_to_rz_gp(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "PhaseShift"}
+    # CHECK-DAG: func.func public @_rz_to_ry_rx(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "RZ"}
+    # CHECK-DAG: func.func public @_rot_to_rz_ry_rz(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>, %arg4: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Rot"}
+    # CHECK-DAG: func.func public @_doublexcit(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<4xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 4 : i64, target_gate = "DoubleExcitation"}
+    # CHECK-DAG: func.func public @_single_excitation_decomp(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<2xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 2 : i64, target_gate = "SingleExcitation"}
     print(circuit_15.mlir)
 
     qml.decomposition.disable_graph()
@@ -874,11 +874,11 @@ def test_decomposition_rule_name_adjoint():
         qml.adjoint(qml.SingleExcitation(x, wires=[0, 1]))
         return qml.expval(qml.Z(0))
 
-    # CHECK-DAG: func.func public @_single_excitation_decomp(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<2xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 2 : i64, target_gate = "SingleExcitation"}
-    # CHECK-DAG: func.func public @_hadamard_to_rz_ry(%arg0: !quantum.reg, %arg1: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Hadamard"}
-    # CHECK-DAG: func.func public @_rz_to_ry_rx(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "RZ"}
-    # CHECK-DAG: func.func public @_rot_to_rz_ry_rz(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>, %arg4: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Rot"}
-    # CHECK-DAG: func.func public @_cnot_to_cz_h(%arg0: !quantum.reg, %arg1: tensor<2xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 2 : i64, target_gate = "CNOT"}
+    # CHECK-DAG: func.func public @_single_excitation_decomp(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<2xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 2 : i64, target_gate = "SingleExcitation"}
+    # CHECK-DAG: func.func public @_hadamard_to_rz_ry(%arg0: !quantum.reg, %arg1: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Hadamard"}
+    # CHECK-DAG: func.func public @_rz_to_ry_rx(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "RZ"}
+    # CHECK-DAG: func.func public @_rot_to_rz_ry_rz(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>, %arg4: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Rot"}
+    # CHECK-DAG: func.func public @_cnot_to_cz_h(%arg0: !quantum.reg, %arg1: tensor<2xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 2 : i64, target_gate = "CNOT"}
     print(circuit_16.mlir)
 
     qml.decomposition.disable_graph()
@@ -910,10 +910,10 @@ def test_decomposition_rule_name_ctrl():
         qml.ctrl(qml.PauliX, control=0)(1)
         return qml.expval(qml.Z(0))
 
-    # SKIP-CHECK-DAG: func.func public @_cnot_to_cz_h(%arg0: !quantum.reg, %arg1: tensor<2xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 2 : i64, target_gate = "CNOT"}
-    # SKIP-CHECK-DAG: func.func public @_cry(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<2xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 2 : i64, target_gate = "CRY"}
-    # SKIP-CHECK-DAG: func.func public @_ry_to_rz_rx(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "RY"}
-    # SKIP-CHECK-DAG: func.func public @_rot_to_rz_ry_rz(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>, %arg4: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Rot"}
+    # SKIP-CHECK-DAG: func.func public @_cnot_to_cz_h(%arg0: !quantum.reg, %arg1: tensor<2xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 2 : i64, target_gate = "CNOT"}
+    # SKIP-CHECK-DAG: func.func public @_cry(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<2xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 2 : i64, target_gate = "CRY"}
+    # SKIP-CHECK-DAG: func.func public @_ry_to_rz_rx(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "RY"}
+    # SKIP-CHECK-DAG: func.func public @_rot_to_rz_ry_rz(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>, %arg4: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Rot"}
     # print(circuit_17.mlir)
 
     qml.decomposition.disable_graph()
@@ -945,11 +945,11 @@ def test_qft_decomposition():
         qml.QFT(wires=[0, 1, 2, 3])
         return qml.expval(qml.Z(0))
 
-    # SKIP-CHECK-DAG: func.func public @ag___cphase_to_rz_cnot(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<2xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 2 : i64, target_gate = "ControlledPhaseShift"}
-    # SKIP-CHECK-DAG: func.func public @ag___rz_to_ry_rx(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "RZ"}
-    # SKIP-CHECK-DAG: func.func public @ag___rot_to_rz_ry_rz(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>, %arg4: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Rot"}
-    # SKIP-CHECK-DAG: func.func public @ag___swap_to_cnot(%arg0: !quantum.reg, %arg1: tensor<2xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 2 : i64, target_gate = "SWAP"}
-    # SKIP-CHECK-DAG: func.func public @ag___hadamard_to_rz_ry(%arg0: !quantum.reg, %arg1: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Hadamard"}
+    # SKIP-CHECK-DAG: func.func public @ag___cphase_to_rz_cnot(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<2xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 2 : i64, target_gate = "ControlledPhaseShift"}
+    # SKIP-CHECK-DAG: func.func public @ag___rz_to_ry_rx(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "RZ"}
+    # SKIP-CHECK-DAG: func.func public @ag___rot_to_rz_ry_rz(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>, %arg4: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Rot"}
+    # SKIP-CHECK-DAG: func.func public @ag___swap_to_cnot(%arg0: !quantum.reg, %arg1: tensor<2xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 2 : i64, target_gate = "SWAP"}
+    # SKIP-CHECK-DAG: func.func public @ag___hadamard_to_rz_ry(%arg0: !quantum.reg, %arg1: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Hadamard"}
     # print(circuit_18.mlir)
 
     qml.decomposition.disable_graph()
@@ -992,8 +992,8 @@ def test_decompose_lowering_with_other_passes():
         qml.RX(-0.1, wires=0)
         return qml.expval(qml.PauliX(0))
 
-    # CHECK-DAG: func.func public @_paulix_to_rx(%arg0: !quantum.reg, %arg1: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "PauliX"}
-    # CHECK-DAG: func.func public @_rx_to_rz_ry(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "RX"}
+    # CHECK-DAG: func.func public @_paulix_to_rx(%arg0: !quantum.reg, %arg1: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "PauliX"}
+    # CHECK-DAG: func.func public @_rx_to_rz_ry(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "RX"}
     print(circuit_19.mlir)
 
     qml.decomposition.disable_graph()
@@ -1030,9 +1030,9 @@ def test_decompose_lowering_multirz():
         qml.MultiRZ(x, wires=[1, 0, 2])
         return qml.expval(qml.PauliX(0))
 
-    # CHECK-DAG: func.func public @_multi_rz_decomposition_wires_1(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "MultiRZ"}
-    # CHECK-DAG: func.func public @_multi_rz_decomposition_wires_2(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<2xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 2 : i64, target_gate = "MultiRZ"}
-    # CHECK-DAG: func.func public @_multi_rz_decomposition_wires_3(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<3xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 3 : i64, target_gate = "MultiRZ"}
+    # CHECK-DAG: func.func public @_multi_rz_decomposition_wires_1(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "MultiRZ"}
+    # CHECK-DAG: func.func public @_multi_rz_decomposition_wires_2(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<2xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 2 : i64, target_gate = "MultiRZ"}
+    # CHECK-DAG: func.func public @_multi_rz_decomposition_wires_3(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<3xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 3 : i64, target_gate = "MultiRZ"}
     # CHECK-DAG: %0 = scf.for %arg3 = %c0 to %c2 step %c1 iter_args(%arg4 = %arg0) -> (!quantum.reg)
     # CHECK-DAG:   %5 = scf.for %arg3 = %c1 to %c3 step %c1 iter_args(%arg4 = %4) -> (!quantum.reg)
     print(circuit_20.mlir)
@@ -1079,9 +1079,9 @@ def test_decompose_lowering_with_ordered_passes():
         qml.RX(-x, wires=0)
         return qml.expval(qml.PauliX(0))
 
-    # CHECK-DAG: func.func public @_paulix_to_rx(%arg0: !quantum.reg, %arg1: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "PauliX"}
-    # CHECK-DAG: func.func public @_rx_to_rz_ry(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "RX"}
-    # CHECK-DAG: func.func public @_rot_to_rz_ry_rz(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>, %arg4: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Rot"}
+    # CHECK-DAG: func.func public @_paulix_to_rx(%arg0: !quantum.reg, %arg1: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "PauliX"}
+    # CHECK-DAG: func.func public @_rx_to_rz_ry(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "RX"}
+    # CHECK-DAG: func.func public @_rot_to_rz_ry_rz(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>, %arg4: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Rot"}
     print(circuit_21.mlir)
 
     qml.decomposition.disable_graph()
@@ -1114,8 +1114,8 @@ def test_decompose_lowering_with_gphase():
         qml.ctrl(qml.GlobalPhase, control=0)(phi=0.3, wires=[1, 2])
         return qml.expval(qml.PauliX(0))
 
-    # CHECK-DAG: func.func public @_phaseshift_to_rz_gp(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "PhaseShift"}
-    # CHECK-DAG: func.func public @_rz_to_ry_rx(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "RZ"}
+    # CHECK-DAG: func.func public @_phaseshift_to_rz_gp(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "PhaseShift"}
+    # CHECK-DAG: func.func public @_rz_to_ry_rx(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "RZ"}
     print(circuit_22.mlir)
 
     qml.decomposition.disable_graph()
@@ -1146,7 +1146,7 @@ def test_decompose_lowering_alt_decomps():
         qml.Rot(x, y, x + y, wires=1)
         return qml.expval(qml.PauliZ(0))
 
-    # CHECK-DAG: func.func public @custom_rot_cheap(%arg0: !quantum.reg, %arg1: tensor<3xf64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Rot"}
+    # CHECK-DAG: func.func public @custom_rot_cheap(%arg0: !quantum.reg, %arg1: tensor<3xf64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Rot"}
     print(circuit_23.mlir)
 
     qml.decomposition.disable_graph()
@@ -1189,9 +1189,9 @@ def test_decompose_lowering_with_tensorlike():
         qml.MultiRZ(x + y, wires=[0, 1, 2])
         return qml.expval(qml.PauliZ(0))
 
-    # CHECK-DAG: func.func public @custom_multirz_wires_3(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<3xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 3 : i64, target_gate = "MultiRZ"}
-    # CHECK-DAG: func.func public @_rz_to_ry_rx(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "RZ"}
-    # CHECK-DAG: func.func public @custom_rot(%arg0: !quantum.reg, %arg1: tensor<3xf64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Rot"}
+    # CHECK-DAG: func.func public @custom_multirz_wires_3(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<3xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 3 : i64, target_gate = "MultiRZ"}
+    # CHECK-DAG: func.func public @_rz_to_ry_rx(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "RZ"}
+    # CHECK-DAG: func.func public @custom_rot(%arg0: !quantum.reg, %arg1: tensor<3xf64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Rot"}
     print(circuit_24.mlir)
 
     qml.decomposition.disable_graph()
@@ -1241,7 +1241,7 @@ def test_decompose_lowering_params_ordering():
         qml.Rot(x, y, z, wires=0)
         return qml.expval(qml.PauliZ(0))
 
-    # CHECK: func.func public @_rot_to_rz_ry_rz(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>, %arg4: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Rot"}
+    # CHECK: func.func public @_rot_to_rz_ry_rz(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<f64>, %arg3: tensor<f64>, %arg4: tensor<1xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Rot"}
     # CHECK:  [[EXTRACTED_0:%.+]] = tensor.extract %arg1[] : tensor<f64>
     # CHECK-NEXT:  [[OUT_QUBITS:%.+]] = quantum.custom "RZ"([[EXTRACTED_0]]) {{%.+}} : !quantum.bit
     # CHECK:  [[EXTRACTED_3:%.+]] = tensor.extract %arg2[] : tensor<f64>
@@ -1335,7 +1335,7 @@ def test_decompose_autograph_multi_blocks():
 
         return qml.expval(qml.Z(0))
 
-    # CHECK: func.func public @ag___multi_rz_decomposition_wires_5(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<5xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 5 : i64, target_gate = "MultiRZ"}
+    # CHECK: func.func public @ag___multi_rz_decomposition_wires_5(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<5xi64>) -> !quantum.reg attributes {decomposition_rule = true, llvm.linkage = #llvm.linkage<internal>, num_wires = 5 : i64, target_gate = "MultiRZ"}
     # CHECK: {{%.+}} = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg4 = %arg0) -> (!quantum.reg)
     # CHECK: {{%.+}} = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg4 = %4) -> (!quantum.reg)
     print(circuit_29.mlir)
@@ -1372,7 +1372,7 @@ def test_decompose_work_wires_context_manager():
         return qml.probs()
 
     # check that decomp arrives properly
-    # CHECK: func.func public @my_decomp({{.*}}) -> !quantum.reg attributes {{{.*}} target_gate = "PauliZ"}
+    # CHECK: func.func public @my_decomp({{.*}}) -> !quantum.reg attributes {{{.*}} target_gate = "PauliZ"{{.*}}}
     print(my_circuit.mlir)
 
     # check that decomp is applied properly
@@ -1423,7 +1423,7 @@ def test_decompose_work_wires_alloc_dealloc():
         return qml.probs()
 
     # check that decomp arrives properly
-    # CHECK: func.func public @my_decomp({{.*}}) -> !quantum.reg attributes {{{.*}} target_gate = "RY"}
+    # CHECK: func.func public @my_decomp({{.*}}) -> !quantum.reg attributes {{{.*}} target_gate = "RY"{{.*}}}
     print(my_circuit.mlir)
 
     # check that the decomposition applies properly
@@ -1483,7 +1483,7 @@ def test_decompose_work_wires_control_flow():
         return qml.state()
 
     # target_gate attribute is correctly applied
-    # CHECK: my_decomp([[args:.*]]) -> !quantum.reg attributes {[[other_attributes:.*]] target_gate = "CRX"}
+    # CHECK: my_decomp([[args:.*]]) -> !quantum.reg attributes {[[other_attributes:.*]] target_gate = "CRX"{{.*}}}
     print(circuit.mlir)
 
     # test that the decomposition is applied correctly
@@ -1674,3 +1674,28 @@ def test_default_decomps():
 
 
 test_default_decomps()
+
+
+def test_decomposition_rule_attribute():
+    """Test that the decomposition rule attribute is set correctly."""
+
+    qml.capture.enable()
+
+    @decomposition_rule(is_qreg=False)
+    def Hadamard0(wire):
+        qml.Hadamard(wire)
+
+    @qml.qjit
+    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    def circuit(_: float):
+        Hadamard0(int)
+        return qml.probs()
+
+    # CHECK: func.func public @Hadamard0([[QBIT:%.+]]: !quantum.bit) -> !quantum.bit attributes {{{.*}}decomposition_rule = true{{.*}}}
+
+    print(circuit.mlir)
+
+    qml.capture.disable()
+
+
+test_decomposition_rule_attribute()

--- a/mlir/lib/Quantum/IR/QuantumDialect.cpp
+++ b/mlir/lib/Quantum/IR/QuantumDialect.cpp
@@ -34,7 +34,7 @@ namespace {
 struct QuantumInlinerInterface : public DialectInlinerInterface {
     using DialectInlinerInterface::DialectInlinerInterface;
 
-    static constexpr StringRef decompAttr = "target_gate";
+    static constexpr StringRef decompAttr = "decomposition_rule";
 
     /// Returns true if the given operation 'callable' can be inlined into the
     /// position given by the 'call'. Currently, we always inline quantum

--- a/mlir/lib/Quantum/Transforms/decompose_lowering.cpp
+++ b/mlir/lib/Quantum/Transforms/decompose_lowering.cpp
@@ -48,6 +48,7 @@ namespace quantum {
 
 namespace DecompUtils {
 
+static constexpr StringRef decomposition_rule_attr_name = "decomposition_rule";
 static constexpr StringRef target_gate_attr_name = "target_gate";
 static constexpr StringRef decomp_gateset_attr_name = "decomp_gateset";
 
@@ -56,7 +57,10 @@ static constexpr StringRef decomp_gateset_attr_name = "decomp_gateset";
 // `catalyst.decomposition.target_op` And this attribute is set by the `markDecompositionAttributes`
 // functionq The decomposition attribute are used to determine if a function is a decomposition
 // function, and target_op is that the decomposition function want to replace
-bool isDecompositionFunction(func::FuncOp func) { return func->hasAttr(target_gate_attr_name); }
+bool isDecompositionFunction(func::FuncOp func)
+{
+    return func->hasAttr(decomposition_rule_attr_name);
+}
 
 StringRef getTargetGateName(func::FuncOp func)
 {

--- a/mlir/test/Quantum/DecomposeLoweringTest.mlir
+++ b/mlir/test/Quantum/DecomposeLoweringTest.mlir
@@ -43,7 +43,7 @@ module @two_hadamards {
 
   // Decomposition function should be applied and removed from the module
   // CHECK-NOT: func.func private @Hadamard_to_RY_decomp
-  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
+  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {decomposition_rule = "True", target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
     %cst = arith.constant 3.1415926535897931 : f64
     %cst_0 = arith.constant 1.5707963267948966 : f64
     %out_qubits = quantum.custom "RZ"(%cst) %arg0 : !quantum.bit
@@ -75,7 +75,7 @@ module @single_hadamard {
 
   // Decomposition function should be applied and removed from the module
   // CHECK-NOT: func.func private @Hadamard_to_RY_decomp
-  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
+  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {decomposition_rule = "True", target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
       %cst = arith.constant 3.1415926535897931 : f64
       %cst_0 = arith.constant 1.5707963267948966 : f64
       %out_qubits = quantum.custom "RZ"(%cst) %arg0 : !quantum.bit
@@ -114,14 +114,14 @@ module @recursive {
 
   // Decomposition function should be applied and removed from the module
   // CHECK-NOT: func.func private @Hadamard_to_RY_decomp
-  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
+  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {decomposition_rule = "True", target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
     %out_qubits_0 = quantum.custom "RZRY"() %arg0 : !quantum.bit
     return %out_qubits_0 : !quantum.bit
   }
 
   // Decomposition function should be applied and removed from the module
   // CHECK-NOT: func.func private @RZRY_decomp
-  func.func private @RZRY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "RZRY", llvm.linkage = #llvm.linkage<internal>} {
+  func.func private @RZRY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {decomposition_rule = "True", target_gate = "RZRY", llvm.linkage = #llvm.linkage<internal>} {
     %cst = arith.constant 3.1415926535897931 : f64
     %cst_0 = arith.constant 1.5707963267948966 : f64
     %out_qubits_1 = quantum.custom "RZ"(%cst) %arg0 : !quantum.bit
@@ -160,14 +160,14 @@ module @recursive {
 
   // Decomposition function should be applied and removed from the module
   // CHECK-NOT: func.func private @Hadamard_to_RY_decomp
-  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
+  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {decomposition_rule = "True", target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
     %out_qubits_0 = quantum.custom "RZRY"() %arg0 : !quantum.bit
     return %out_qubits_0 : !quantum.bit
   }
 
   // Decomposition function should be applied and removed from the module
   // CHECK-NOT: func.func private @RZRY_decomp
-  func.func private @RZRY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "RZRY", llvm.linkage = #llvm.linkage<internal>} {
+  func.func private @RZRY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {decomposition_rule = "True", target_gate = "RZRY", llvm.linkage = #llvm.linkage<internal>} {
     %cst = arith.constant 3.1415926535897931 : f64
     %cst_0 = arith.constant 1.5707963267948966 : f64
     %out_qubits_1 = quantum.custom "RZ"(%cst) %arg0 : !quantum.bit
@@ -211,7 +211,7 @@ module @param_rxry {
   // Decomposition function expects tensor<f64> while operation provides f64
   // CHECK-NOT: func.func private @ParametrizedRX_decomp
   func.func private @ParametrizedRXRY_decomp(%arg0: tensor<f64>, %arg1: !quantum.bit) -> !quantum.bit
-      attributes {target_gate = "ParametrizedRXRY", llvm.linkage = #llvm.linkage<internal>} {
+      attributes {decomposition_rule = "True", target_gate = "ParametrizedRXRY", llvm.linkage = #llvm.linkage<internal>} {
     %extracted = tensor.extract %arg0[] : tensor<f64>
     %out_qubits = quantum.custom "RX"(%extracted) %arg1 : !quantum.bit
     %extracted_0 = tensor.extract %arg0[] : tensor<f64>
@@ -257,7 +257,7 @@ module @param_rxry_2 {
   // Decomposition function expects tensor<f64> while operation provides f64
   // CHECK-NOT: func.func private @ParametrizedRX_decomp
   func.func private @ParametrizedRXRY_decomp(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: !quantum.bit) -> !quantum.bit
-      attributes {target_gate = "ParametrizedRXRY", llvm.linkage = #llvm.linkage<internal>} {
+      attributes {decomposition_rule = "True", target_gate = "ParametrizedRXRY", llvm.linkage = #llvm.linkage<internal>} {
     %extracted_param_0 = tensor.extract %arg0[] : tensor<f64>
     %out_qubits = quantum.custom "RX"(%extracted_param_0) %arg2 : !quantum.bit
     %extracted_param_1 = tensor.extract %arg1[] : tensor<f64>
@@ -321,7 +321,7 @@ module @qreg_base_circuit {
     // Decomposition function should be applied and removed from the module
     // CHECK-NOT: func.func private @Test_rule_1
     func.func private @Test_rule_1(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg
-        attributes {target_gate = "Test", llvm.linkage = #llvm.linkage<internal>} {
+        attributes {decomposition_rule = "True", target_gate = "Test", llvm.linkage = #llvm.linkage<internal>} {
       %cst = stablehlo.constant dense<0.000000e+00> : tensor<f64>
       %10 = quantum.extract %arg0[ 0] : !quantum.reg -> !quantum.bit
       %mres, %out_qubit = quantum.measure %10 : i1, !quantum.bit
@@ -355,7 +355,7 @@ module @qreg_base_circuit {
     // Decomposition function should be applied and removed from the module
     // CHECK-NOT: func.func private @RzDecomp_rule_1
     func.func private @RzDecomp_rule_1(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg
-        attributes {target_gate = "RzDecomp", llvm.linkage = #llvm.linkage<internal>} {
+        attributes {decomposition_rule = "True", target_gate = "RzDecomp", llvm.linkage = #llvm.linkage<internal>} {
       %0 = stablehlo.slice %arg2 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
       %1 = stablehlo.reshape %0 : (tensor<1xi64>) -> tensor<i64>
       %extracted = tensor.extract %1[] : tensor<i64>
@@ -412,7 +412,7 @@ module @multi_wire_cnot_decomposition {
 
   // Decomposition function should be applied and removed from the module
   // CHECK-NOT: func.func private @CNOT_rule_cz_rz_ry
-  func.func private @CNOT_rule_cz_rz_ry(%arg0: !quantum.reg, %arg1: tensor<2xi64>) -> !quantum.reg attributes {target_gate = "CNOT", llvm.linkage = #llvm.linkage<internal>} {
+  func.func private @CNOT_rule_cz_rz_ry(%arg0: !quantum.reg, %arg1: tensor<2xi64>) -> !quantum.reg attributes {decomposition_rule = "True", target_gate = "CNOT", llvm.linkage = #llvm.linkage<internal>} {
     // CNOT decomposition: CNOT = (I ⊗ H) * CZ * (I ⊗ H)
     %cst = arith.constant 1.5707963267948966 : f64
     %cst_0 = arith.constant 3.1415926535897931 : f64
@@ -487,7 +487,7 @@ module @cnot_alternative_decomposition {
 
   // Decomposition function should be applied and removed from the module
   // CHECK-NOT: func.func private @CNOT_rule_h_cnot_h
-  func.func private @CNOT_rule_h_cnot_h(%arg0: !quantum.bit, %arg1: !quantum.bit) -> (!quantum.bit, !quantum.bit) attributes {target_gate = "CNOT", llvm.linkage = #llvm.linkage<internal>} {
+  func.func private @CNOT_rule_h_cnot_h(%arg0: !quantum.bit, %arg1: !quantum.bit) -> (!quantum.bit, !quantum.bit) attributes {decomposition_rule = "True", target_gate = "CNOT", llvm.linkage = #llvm.linkage<internal>} {
     // CNOT decomposition: CNOT = (I ⊗ H) * CZ * (I ⊗ H)
     %cst = arith.constant 1.5707963267948966 : f64
     %cst_0 = arith.constant 3.1415926535897931 : f64
@@ -532,7 +532,7 @@ module @mcm_example {
 
   // Decomposition function should be applied and removed from the module
   // CHECK-NOT: func.func public @rz_ry
-  func.func public @rz_ry(%arg0: !quantum.reg, %arg1: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Hadamard"} {
+  func.func public @rz_ry(%arg0: !quantum.reg, %arg1: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, decomposition_rule = "True", target_gate = "Hadamard"} {
     %cst = arith.constant 3.1415926535897931 : f64
     %cst_0 = arith.constant 1.5707963267948966 : f64
     %0 = stablehlo.slice %arg1 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
@@ -585,7 +585,7 @@ module @circuit_with_multirz {
   }
 
   // CHECK-NOT: func.func private @Hadamard_to_RY_decomp
-  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
+  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {decomposition_rule = "True", target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
     %cst = arith.constant 3.1415926535897931 : f64
     %cst_0 = arith.constant 1.5707963267948966 : f64
     %out_qubits = quantum.custom "RZ"(%cst) %arg0 : !quantum.bit
@@ -594,7 +594,7 @@ module @circuit_with_multirz {
   }
 
   // CHECK-NOT: func.func private @_multi_rz_decomposition_wires_1
-  func.func public @_multi_rz_decomposition_wires_1(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "MultiRZ"} {
+  func.func public @_multi_rz_decomposition_wires_1(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, decomposition_rule = "True", target_gate = "MultiRZ"} {
     %0 = stablehlo.slice %arg2 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
     %1 = stablehlo.reshape %0 : (tensor<1xi64>) -> tensor<i64>
     %extracted = tensor.extract %1[] : tensor<i64>


### PR DESCRIPTION
**Context:**
Currently, graph decomposition rules are targeted by finding the `target_gate` attribute. This name is very generic, and may want to be re-used by other systems in the future. 

**Description of the Change:**
The `decomposition_rule` attribute is set to `True` (python) and `true` (mlir). There is no change to the `target_gate` attribute (it is still present on decomposition rules and is used exactly the same as before).

**Benefits:**
- Explicit decomposition rule detection.
- Removes the potential for detecting other systems functions with the `target_gate` attribute.
- Unambiguous attribute names

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A

[sc-112459]