### PR TITLE
fix: improve testing of `setup_options` in our unified transforms API

### DIFF
--- a/frontend/test/pytest/test_transform_pass_name.py
+++ b/frontend/test/pytest/test_transform_pass_name.py
@@ -16,10 +16,10 @@
 from functools import partial
 from typing import Type
 
-from catalyst.compiler import CompileError
-
 import pennylane as qml
 import pytest
+
+from catalyst.compiler import CompileError
 
 
 @pytest.mark.parametrize(
@@ -54,9 +54,7 @@ def test_pass_with_options(options, expected_strings, backend):
     capture_mlir = captured_circuit.mlir
     assert 'transform.apply_registered_pass "my-pass"' in capture_mlir
     for expected_str in expected_strings:
-        assert expected_str in str(capture_mlir), (
-            f"Expected {expected_str} in MLIR: {capture_mlir}"
-        )
+        assert expected_str in str(capture_mlir), f"Expected {expected_str} in MLIR: {capture_mlir}"
 
 
 @pytest.mark.parametrize(
@@ -104,9 +102,7 @@ def test_pass_before_tape_transform(backend):
     def f(x):  # pylint: disable=unused-argument
         return qml.state()
 
-    with pytest.raises(
-        ValueError, match="without a tape definition occurs before tape transform"
-    ):
+    with pytest.raises(ValueError, match="without a tape definition occurs before tape transform"):
         f(0.5)
 
 
@@ -168,13 +164,9 @@ def test_xdsl_pass_with_qml_transform():
     assert op_has_attr(named_sequence_mod, "catalyst.uses_xdsl_passes")
     assert op_has_attr(named_sequence_mod, "transform.with_named_sequence")
 
-    named_sequence_op = next(
-        iter(named_sequence_mod.regions[0].blocks[0].operations), None
-    )
+    named_sequence_op = next(iter(named_sequence_mod.regions[0].blocks[0].operations), None)
     assert named_sequence_op is not None
-    first_transform_op = next(
-        iter(named_sequence_op.regions[0].blocks[0].operations), None
-    )
+    first_transform_op = next(iter(named_sequence_op.regions[0].blocks[0].operations), None)
     assert first_transform_op is not None
 
     assert op_has_attr(first_transform_op, "catalyst.xdsl_pass")

--- a/frontend/test/pytest/test_transform_pass_name.py
+++ b/frontend/test/pytest/test_transform_pass_name.py
@@ -12,29 +12,80 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Testing use of transforms with pass name integrating with qnodes."""
+
 from functools import partial
+from typing import Type
+
+from catalyst.compiler import CompileError
 
 import pennylane as qml
 import pytest
 
 
-def test_pass_with_options(backend):
+@pytest.mark.parametrize(
+    "options, expected_strings",
+    [
+        ({"my_string": "blah"}, ['"my-string" = "blah"']),
+        ({"on": True, "off": False}, ['"on" = true', '"off" = false']),
+        ({"num_iterations": 10}, ['"num-iterations" = 10']),
+        (
+            {"eps_dec": 0.001, "eps_sci": 1e-3},
+            ['"eps-dec" = 1.000000e-03', '"eps-sci" = 1.000000e-03'],
+        ),
+    ],
+    ids=[
+        "string",
+        "bool",
+        "integer",
+        "float",
+    ],
+)
+def test_pass_with_options(options, expected_strings, backend):
     """Test the integration for a circuit with a pass that takes in options."""
 
     my_pass = qml.transform(pass_name="my-pass")
 
     @qml.qjit(target="mlir")
-    @partial(my_pass, my_option="my_option_value", my_other_option=False)
+    @partial(my_pass, **options)
     @qml.qnode(qml.device(backend, wires=1))
     def captured_circuit():
         return qml.expval(qml.PauliZ(0))
 
     capture_mlir = captured_circuit.mlir
     assert 'transform.apply_registered_pass "my-pass"' in capture_mlir
-    assert (
-        'with options = {"my-option" = "my_option_value", "my-other-option" = false}'
-        in capture_mlir
+    for expected_str in expected_strings:
+        assert expected_str in str(capture_mlir), (
+            f"Expected {expected_str} in MLIR: {capture_mlir}"
+        )
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"option": [1, 2, 3]},
+        {"option": {"blah": "foo"}},
+        {"option": None},
+    ],
+    ids=["list", "dict", "None"],
+)
+def test_pass_with_unsupported_options(options, backend):
+    """Tests that unsupported option types raise a clear error."""
+
+    my_pass = qml.transform(pass_name="my-pass")
+
+    @partial(my_pass, **options)
+    @qml.qnode(qml.device(backend, wires=1))
+    def captured_circuit():
+        return qml.expval(qml.PauliZ(0))
+
+    expected_error = CompileError if options["option"] is None else TypeError
+    expected_msg = (
+        r"Cannot convert Python type <class 'NoneType'> to an MLIR attribute"
+        if options["option"] is None
+        else "unhashable type"
     )
+    with pytest.raises(expected_error, match=expected_msg):
+        qml.qjit(captured_circuit)
 
 
 def test_pass_before_tape_transform(backend):
@@ -53,7 +104,9 @@ def test_pass_before_tape_transform(backend):
     def f(x):  # pylint: disable=unused-argument
         return qml.state()
 
-    with pytest.raises(ValueError, match="without a tape definition occurs before tape transform"):
+    with pytest.raises(
+        ValueError, match="without a tape definition occurs before tape transform"
+    ):
         f(0.5)
 
 
@@ -115,9 +168,13 @@ def test_xdsl_pass_with_qml_transform():
     assert op_has_attr(named_sequence_mod, "catalyst.uses_xdsl_passes")
     assert op_has_attr(named_sequence_mod, "transform.with_named_sequence")
 
-    named_sequence_op = next(iter(named_sequence_mod.regions[0].blocks[0].operations), None)
+    named_sequence_op = next(
+        iter(named_sequence_mod.regions[0].blocks[0].operations), None
+    )
     assert named_sequence_op is not None
-    first_transform_op = next(iter(named_sequence_op.regions[0].blocks[0].operations), None)
+    first_transform_op = next(
+        iter(named_sequence_op.regions[0].blocks[0].operations), None
+    )
     assert first_transform_op is not None
 
     assert op_has_attr(first_transform_op, "catalyst.xdsl_pass")

--- a/frontend/test/pytest/test_transform_pass_name.py
+++ b/frontend/test/pytest/test_transform_pass_name.py
@@ -14,7 +14,6 @@
 """Testing use of transforms with pass name integrating with qnodes."""
 
 from functools import partial
-from typing import Type
 
 import pennylane as qml
 import pytest


### PR DESCRIPTION
**Context:**

I was investigating https://app.shortcut.com/xanaduai/story/104262/polish-up-handling-of-options-and-valued-options?vc_group_by=day&ct_workflow=all&cf_workflow=500000005 and noticed we can improve our testing a bit here.

**Description of the Change:**

Adds more coverage for different common set-up options for transforms.

**Benefits:**

Better testing.

[sc-112601]