### PR TITLE
fix: demote get_device_capabilities to a test util

### DIFF
--- a/frontend/catalyst/device/__init__.py
+++ b/frontend/catalyst/device/__init__.py
@@ -20,12 +20,10 @@ from catalyst.device.qjit_device import (
     BackendInfo,
     QJITDevice,
     extract_backend_info,
-    get_device_capabilities,
 )
 
 __all__ = (
     "QJITDevice",
     "BackendInfo",
     "extract_backend_info",
-    "get_device_capabilities",
 )

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -574,28 +574,6 @@ def filter_device_capabilities_with_shots(
     return device_capabilities
 
 
-def get_device_capabilities(device, shots=False) -> DeviceCapabilities:
-    """
-    Get the capabilities from the device.
-
-    TODO: this function is not actually used in the codebase, but is just used by the
-    tests that want custom device capabilities.
-
-    These tests piggy-back off the lightning device (which has "full capabilities") by
-    calling this get_device_capabilities() on lightning, and manually delete some capabilities.
-
-    We leave this function in for now, just for the tests.
-    However, these tests should construct their capabilities properly, instead of piggy-back off
-    lightning.
-    """
-
-    assert not isinstance(device, QJITDevice)
-
-    return filter_device_capabilities_with_shots(
-        _load_device_capabilities(device), bool(shots), getattr(device, "_to_matrix_ops", None)
-    )
-
-
 def is_dynamic_wires(wires: qml.wires.Wires):
     """
     Checks if a pennylane Wires object corresponds to a concrete number

--- a/frontend/test/lit/test_decomposition.py
+++ b/frontend/test/lit/test_decomposition.py
@@ -14,8 +14,9 @@ from pennylane.wires import WiresLike
 
 from catalyst import measure, qjit
 from catalyst.compiler import get_lib_path
-from catalyst.device import get_device_capabilities
 from catalyst.jax_primitives import decomposition_rule
+
+from ..test_utils import get_device_capabilities
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/frontend/test/lit/utils.py
+++ b/frontend/test/lit/utils.py
@@ -24,7 +24,8 @@ import platform
 import pennylane as qml
 
 from catalyst.compiler import get_lib_path
-from catalyst.device import get_device_capabilities
+
+from ..test_utils import get_device_capabilities
 
 TEST_PATH = os.path.dirname(__file__)
 CONFIG_CUSTOM_DEVICE = pathlib.Path(f"{TEST_PATH}/../custom_device/custom_device.toml")

--- a/frontend/test/pytest/test_device_api.py
+++ b/frontend/test/pytest/test_device_api.py
@@ -18,8 +18,10 @@ from pennylane.devices import NullQubit
 from pennylane.devices.capabilities import DeviceCapabilities, ExecutionCondition
 
 from catalyst import qjit
-from catalyst.device import QJITDevice, get_device_capabilities, qjit_device
+from catalyst.device import QJITDevice, qjit_device
 from catalyst.tracing.contexts import EvaluationContext, EvaluationMode
+
+from ..test_utils import get_device_capabilities
 
 # pylint:disable = protected-access,attribute-defined-outside-init
 

--- a/frontend/test/pytest/test_measurement_transforms.py
+++ b/frontend/test/pytest/test_measurement_transforms.py
@@ -31,10 +31,12 @@ from utils import CONFIG_CUSTOM_DEVICE
 
 from catalyst import qjit
 from catalyst.compiler import get_lib_path
-from catalyst.device import QJITDevice, get_device_capabilities
+from catalyst.device import QJITDevice
 from catalyst.device.decomposition import measurements_from_counts, measurements_from_samples
 from catalyst.tracing.contexts import EvaluationContext, EvaluationMode
 from catalyst.utils.exceptions import CompileError
+
+from ..test_utils import get_device_capabilities
 
 # pylint: disable=attribute-defined-outside-init
 

--- a/frontend/test/pytest/test_measurements_results.py
+++ b/frontend/test/pytest/test_measurements_results.py
@@ -22,8 +22,9 @@ from jax import numpy as jnp
 from utils import CONFIG_CUSTOM_DEVICE
 
 from catalyst import CompileError, qjit
-from catalyst.device import get_device_capabilities
 from catalyst.utils.runtime_environment import get_lib_path
+
+from ..test_utils import get_device_capabilities
 
 # pylint: disable=too-many-lines
 

--- a/frontend/test/pytest/test_verification.py
+++ b/frontend/test/pytest/test_verification.py
@@ -36,9 +36,10 @@ from catalyst import (
 )
 from catalyst.api_extensions import HybridAdjoint, HybridCtrl
 from catalyst.compiler import get_lib_path
-from catalyst.device import get_device_capabilities
 from catalyst.device.qjit_device import RUNTIME_OPERATIONS, get_qjit_device_capabilities
 from catalyst.device.verification import validate_measurements
+
+from ..test_utils import get_device_capabilities
 
 # pylint: disable = unused-argument, unnecessary-lambda-assignment, unnecessary-lambda
 

--- a/frontend/test/pytest/utils.py
+++ b/frontend/test/pytest/utils.py
@@ -22,7 +22,8 @@ import platform
 import pennylane as qml
 
 from catalyst.compiler import get_lib_path
-from catalyst.device import get_device_capabilities
+
+from ..test_utils import get_device_capabilities
 
 TEST_PATH = os.path.dirname(__file__)
 CONFIG_CUSTOM_DEVICE = pathlib.Path(f"{TEST_PATH}/../custom_device/custom_device.toml")

--- a/frontend/test/test_utils.py
+++ b/frontend/test/test_utils.py
@@ -1,0 +1,58 @@
+# Copyright 2024-2025 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test utilities for device capabilities management.
+
+This module provides helper functions for tests that need to construct custom device
+capabilities. The function `get_device_capabilities` was moved here from the main codebase
+as it is only used by tests.
+"""
+
+from pennylane.devices.capabilities import DeviceCapabilities
+
+from catalyst.device.qjit_device import (
+    QJITDevice,
+    _load_device_capabilities,
+    filter_device_capabilities_with_shots,
+)
+
+
+def get_device_capabilities(device, shots=False) -> DeviceCapabilities:
+    """
+    Get the capabilities from a device for testing purposes.
+
+    This function is a test utility that allows tests to create custom device capabilities
+    by loading capabilities from a base device (typically lightning.qubit) and then modifying
+    them as needed for the specific test case.
+
+    Args:
+        device: A PennyLane device (should not be a QJITDevice instance)
+        shots: Whether shots are present in the program (default: False)
+
+    Returns:
+        DeviceCapabilities: The device capabilities filtered based on whether shots are present
+
+    Note:
+        Tests typically use this function by calling it on a lightning device and then manually
+        modifying the resulting capabilities (e.g., removing or adding operations) to create
+        custom test scenarios. This approach piggy-backs off lightning's "full capabilities".
+        In the future, tests should ideally construct their capabilities directly instead.
+    """
+
+    assert not isinstance(device, QJITDevice)
+
+    return filter_device_capabilities_with_shots(
+        _load_device_capabilities(device), bool(shots), getattr(device, "_to_matrix_ops", None)
+    )


### PR DESCRIPTION
**Context:**

The `get_device_capabilities` function was previously part of the main codebase in `catalyst.device.qjit_device`, but it was not actually used in production code. The function was only being used by test files to create custom device capabilities by piggy-backing off the lightning device's "full capabilities" and then manually modifying them. As noted in issue #2089, this function should be demoted to a test utility and decoupled from the actual codebase.

**Description of the Change:**

Moved the `get_device_capabilities` function from the main codebase to a dedicated test utilities module. Created `frontend/test/test_utils.py` to house test-specific device utility functions. Updated all test files that were importing this function from `catalyst.device` to import from the new test utilities module instead. Removed the function from `catalyst/device/qjit_device.py` and its export from `catalyst/device/__init__.py`.

**Benefits:**

- Clearer separation between production code and test utilities
- Reduces confusion about which functions are part of the public API versus test helpers
- Makes the codebase more maintainable by clearly identifying test-only functionality
- Addresses technical debt identified in issue #2089

**Possible Drawbacks:**

None. This is purely a code organization improvement that moves test-only code to an appropriate test utilities module. No functionality changes were made.

**Related GitHub Issues:**

Closes  #2114
