### PR TITLE
fix: Provide better name for variable names debug option

### DIFF
--- a/doc/releases/changelog-0.14.0.md
+++ b/doc/releases/changelog-0.14.0.md
@@ -346,7 +346,7 @@
   now counted as a single pass instead of potentially many passes.
   [(#1978)](https://github.com/PennyLaneAI/catalyst/pull/1978)
 
-* A new option called ``use_nameloc`` has been added to :func:`~.qjit` that embeds variable names
+* A new option called ``embed_var_names`` has been added to :func:`~.qjit` that embeds variable names
   from Python into the compiler IR, which can make it easier to read when debugging programs.
   [(#2054)](https://github.com/PennyLaneAI/catalyst/pull/2054)
 

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -319,7 +319,7 @@ def canonicalize(*args, stdin=None, options: Optional[CompileOptions] = None):
     Returns stdout string
     """
     opts = ["--pass-pipeline", "builtin.module(canonicalize)"]
-    if options and options.use_nameloc:
+    if options and options.embed_var_names:
         opts.append("--use-nameloc-as-prefix")
 
     return _quantum_opt(*opts, *args, stdin=stdin)
@@ -359,7 +359,7 @@ def _options_to_cli_flags(options):
         case _:
             pass
 
-    if options.use_nameloc:
+    if options.embed_var_names:
         extra_args += ["--use-nameloc-as-prefix"]
 
     if options.verbose:

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -82,7 +82,7 @@ def qjit(
     async_qnodes=False,
     target="binary",
     keep_intermediate=False,
-    use_nameloc=False,
+    embed_var_names=False,
     verbose=False,
     logfile=None,
     pipelines=None,
@@ -129,7 +129,7 @@ def qjit(
             - :attr:`~.QJIT.mlir`: MLIR representation after canonicalization
             - :attr:`~.QJIT.mlir_opt`: MLIR representation after optimization
             - :attr:`~.QJIT.llvmir`: LLVM IR representation
-        use_nameloc (bool): If ``True``, function parameter names are added to the IR as name
+        embed_var_names (bool): If ``True``, function parameter names are added to the IR as name
             locations.
         verbose (bool): If ``True``, the tools and flags used by Catalyst behind the scenes are
             printed out.
@@ -612,7 +612,7 @@ class QJIT(CatalystCallable):
             return None
 
         stdin = self.mlir_module.operation.get_asm(
-            enable_debug_info=self.compile_options.use_nameloc
+            enable_debug_info=self.compile_options.embed_var_names
         )
         return canonicalize(stdin=stdin, options=self.compile_options)
 
@@ -624,7 +624,7 @@ class QJIT(CatalystCallable):
         using_python_compiler = self.compiler.is_using_python_compiler(self.mlir_module)
         stdin = self.mlir_module.operation.get_asm(
             print_generic_op_form=using_python_compiler,
-            enable_debug_info=self.compile_options.use_nameloc,
+            enable_debug_info=self.compile_options.embed_var_names,
         )
         return to_mlir_opt(
             stdin=stdin, options=self.compile_options, using_python_compiler=using_python_compiler

--- a/frontend/catalyst/pipelines.py
+++ b/frontend/catalyst/pipelines.py
@@ -89,7 +89,7 @@ class CompileOptions:
             - ``True`` or ``1`` or ``"pipeline"``: Intermediate files are saved after each pipeline.
             - ``2`` or ``"changed"``: Intermediate files are saved after each pass only if changed.
             - ``3`` or ``"pass"``: Intermediate files are saved after each pass, even if unchanged.
-        use_nameloc (Optional[bool]): If ``True``, add function parameter names to the IR as name
+        embed_var_names (Optional[bool]): If ``True``, add function parameter names to the IR as name
             locations.
         pipelines (Optional[List[Tuple[str,List[str]]]]): A list of tuples. The first entry of the
             tuple corresponds to the name of a pipeline. The second entry of the tuple corresponds
@@ -128,7 +128,7 @@ class CompileOptions:
     target: Optional[str] = "binary"
     link: Optional[bool] = True
     keep_intermediate: Optional[Union[str, int, bool, KeepIntermediateLevel]] = False
-    use_nameloc: Optional[bool] = False
+    embed_var_names: Optional[bool] = False
     pipelines: Optional[List[Any]] = None
     autograph: Optional[bool] = False
     autograph_include: Optional[Iterable[str]] = ()

--- a/frontend/test/lit/test_option_embed_var_names.py
+++ b/frontend/test/lit/test_option_embed_var_names.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for use name location option."""
+"""Unit tests for embed variable names option."""
 
 # RUN: %PYTHON %s | FileCheck %s
 
@@ -22,7 +22,7 @@ from catalyst import qjit
 
 
 # CHECK-LABEL: @jit_f
-@qjit(use_nameloc=True)
+@qjit(embed_var_names=True)
 def f(x: float, y: float):
     """Check that MLIR module contains name location information, and MLIR code uses that name
     location information.
@@ -38,7 +38,7 @@ print_mlir(f, 0.3, 0.4)
 
 
 # CHECK-LABEL: @jit_f_opt
-@qjit(use_nameloc=True)
+@qjit(embed_var_names=True)
 def f_opt(x: float, y: float):
     """Check that MLIR module contains name location information, and MLIR code uses that name
     location information.

--- a/frontend/test/pytest/test_debug.py
+++ b/frontend/test/pytest/test_debug.py
@@ -574,10 +574,10 @@ class TestOptionsToCliFlags:
         assert ("--load-dialect-plugin", path) in flags
         assert isinstance(options.dialect_plugins, set)
 
-    def test_option_use_nameloc(self):
-        """Test use name location option"""
+    def test_option_embed_var_names(self):
+        """Test embed variable names option"""
 
-        options = CompileOptions(use_nameloc=True)
+        options = CompileOptions(embed_var_names=True)
         flags = _options_to_cli_flags(options)
         assert "--use-nameloc-as-prefix" in flags
 


### PR DESCRIPTION
**Context:**

The debug option `use_nameloc` has been renamed to `embed_var_names` to provide a clearer and more descriptive name that better reflects its purpose: embedding variable names from Python into the compiler IR for easier debugging.

**Description of the Change:**

All occurrences of the `use_nameloc` parameter have been renamed to `embed_var_names` throughout the codebase, including function signatures, documentation, tests, and the changelog.

**Benefits:**

The new name `embed_var_names` is more intuitive and self-descriptive, making it clearer to users what the option does without needing to refer to documentation.

**Possible Drawbacks:**

This is a breaking change for any code that currently uses the `use_nameloc` parameter. Users will need to update their code to use `embed_var_names` instead.

**Related GitHub Issues:**

Closes #2376