### PR TITLE
Unified Compiler: Fix a bug where the initial pass triggers the callback twice

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -232,6 +232,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a bug where the unified compiler would trigger a passed callback function 1 extra time for the initial pass level.
+  [(#2528)](https://github.com/PennyLaneAI/catalyst/pull/2528)
+
 * Fix a bug in the bind call function for `PCPhase` where the signature did not match what was
   expected in `jax_primitives`. `ctrl_qubits` was missing from positional arguments in previous signature.
   [(#2467)](https://github.com/PennyLaneAI/catalyst/pull/2467)

--- a/frontend/catalyst/python_interface/pass_api/transform_interpreter.py
+++ b/frontend/catalyst/python_interface/pass_api/transform_interpreter.py
@@ -142,7 +142,8 @@ class TransformInterpreterPass(ModulePass):
         interpreter = Interpreter(op)
         interpreter.register_implementations(TransformFunctionsExt(ctx, self.passes, self.callback))
         schedule.parent_op().detach()
-        if self.callback:
+        if self.callback and len(schedule.body.ops) == 1:
+            # If there are no passes to apply, we still want to call the callback once with the original module
             self.callback(None, op, None, pass_level=0)
         interpreter.call_op(schedule, (op,))
 

--- a/frontend/test/pytest/python_interface/pass_api/test_transform_interpreter.py
+++ b/frontend/test/pytest/python_interface/pass_api/test_transform_interpreter.py
@@ -325,12 +325,12 @@ class TestTransformInterpreterPass:
         # We check that there is a space after the pass name to check that no options were specified
         assert "--mlir-pass2 " in captured_cmds[1]
 
-    def test_callback_count(self, mocker, capsys):
+    def test_callback_count(self):
         """Test that the apply function calls the callback the correct number of times."""
 
         num_calls = 0
 
-        def callback(previous_pass, module, next_pass, pass_level=None):
+        def callback(previous_pass, module, next_pass, pass_level=None): # pylint: disable=unused-argument
             """Mock implementation of the callback function"""
             nonlocal num_calls
             num_calls += 1

--- a/frontend/test/pytest/python_interface/pass_api/test_transform_interpreter.py
+++ b/frontend/test/pytest/python_interface/pass_api/test_transform_interpreter.py
@@ -330,7 +330,9 @@ class TestTransformInterpreterPass:
 
         num_calls = 0
 
-        def callback(previous_pass, module, next_pass, pass_level=None): # pylint: disable=unused-argument
+        def callback(
+            previous_pass, module, next_pass, pass_level=None
+        ):  # pylint: disable=unused-argument
             """Mock implementation of the callback function"""
             nonlocal num_calls
             num_calls += 1

--- a/frontend/test/pytest/python_interface/pass_api/test_transform_interpreter.py
+++ b/frontend/test/pytest/python_interface/pass_api/test_transform_interpreter.py
@@ -325,6 +325,45 @@ class TestTransformInterpreterPass:
         # We check that there is a space after the pass name to check that no options were specified
         assert "--mlir-pass2 " in captured_cmds[1]
 
+    def test_callback_count(self, mocker, capsys):
+        """Test that the apply function calls the callback the correct number of times."""
+
+        num_calls = 0
+
+        def callback(previous_pass, module, next_pass, pass_level=None):
+            """Mock implementation of the callback function"""
+            nonlocal num_calls
+            num_calls += 1
+
+        pass_names = ["options-pass"]
+        mod_non_blank = create_test_module(pass_names, [{}])
+
+        _pass = TransformInterpreterPass(
+            passes={"options-pass": lambda: OptionsPass}, callback=callback
+        )
+        ctx = Context()
+        ctx.load_dialect(builtin.Builtin)
+        ctx.load_dialect(transform.Transform)
+        _pass.apply(ctx, mod_non_blank)
+
+        # Should be 2 calls, 1 for init pass, 1 for "options-pass"
+        assert num_calls == 2
+
+        num_calls = 0  # Reset
+
+        mod_blank = create_test_module([], [])
+
+        _pass = TransformInterpreterPass(
+            passes={"options-pass": lambda: OptionsPass}, callback=callback
+        )
+        ctx = Context()
+        ctx.load_dialect(builtin.Builtin)
+        ctx.load_dialect(transform.Transform)
+        _pass.apply(ctx, mod_blank)
+
+        # Should be 1 call, for the init pass, since there are no passes to apply
+        assert num_calls == 1
+
     @pytest.mark.usefixtures("use_both_frontend")
     def test_qjit_with_passes_interpreted_correctly(self):
         """Test that applying the TransformInterpreter to a qjitted qnode's


### PR DESCRIPTION
**Context:**
Currently, the unified compiler actually triggers the passed callback to `Compiler.run` twice for the pass at level 0. This does not affect the correctness of any code, but results in performance degradation whereby the same pass may be processed by a callback function multiple times.

**Description of the Change:**
Adds a clause to the line which triggers the initial pass an extra time to ensure it is not extraneously called.

**Benefits:**
Features which make use of the unified compiler callback function (such as `specs` or `draw_graph`) will no longer be triggered twice on the initial pass, improving overall performance.

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-112748]