### PR TITLE
Register xDSL op for new MCMObsOp in MLIR

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -534,6 +534,10 @@
   }
   ```
 
+  * A new MLIR op, `MCMObsOp`, is defined as a pseudo-observable of mid-circuit measurements for use in 
+    measurement processes. It is also registered in xDSL.
+    [(#2458)](https://github.com/PennyLaneAI/catalyst/pull/2458)
+    [(#2536)](https://github.com/PennyLaneAI/catalyst/pull/2536)
 
 <h3>Documentation 📝</h3>
 

--- a/frontend/catalyst/python_interface/dialects/quantum/__init__.py
+++ b/frontend/catalyst/python_interface/dialects/quantum/__init__.py
@@ -47,6 +47,7 @@ from .operations import (
     HermitianOp,
     InitializeOp,
     InsertOp,
+    MCMObsOp,
     MeasureOp,
     MultiRZOp,
     NamedObsOp,
@@ -87,6 +88,7 @@ Quantum = Dialect(
         HermitianOp,
         InitializeOp,
         InsertOp,
+        MCMObsOp,
         MeasureOp,
         MultiRZOp,
         NamedObsOp,
@@ -139,6 +141,7 @@ __all__ = [
     "ComputationalBasisOp",
     "HamiltonianOp",
     "HermitianOp",
+    "MCMObsOp",
     "NamedObsOp",
     "TensorOp",
     # Mid-circuit measurements

--- a/frontend/catalyst/python_interface/dialects/quantum/operations/__init__.py
+++ b/frontend/catalyst/python_interface/dialects/quantum/operations/__init__.py
@@ -51,6 +51,7 @@ from .observable_ops import (
     NamedObsOp,
     ObservableOp,
     TensorOp,
+    MCMObsOp,
 )
 from .qubit_ops import AllocOp, AllocQubitOp, DeallocOp, DeallocQubitOp, ExtractOp, InsertOp
 
@@ -75,6 +76,7 @@ __all__ = [
     "HermitianOp",
     "NamedObsOp",
     "TensorOp",
+    "MCMObsOp",
     # Mid-circuit measurements
     "MeasureOp",
     # Terminal measurements

--- a/frontend/catalyst/python_interface/dialects/quantum/operations/__init__.py
+++ b/frontend/catalyst/python_interface/dialects/quantum/operations/__init__.py
@@ -48,10 +48,10 @@ from .observable_ops import (
     ComputationalBasisOp,
     HamiltonianOp,
     HermitianOp,
+    MCMObsOp,
     NamedObsOp,
     ObservableOp,
     TensorOp,
-    MCMObsOp,
 )
 from .qubit_ops import AllocOp, AllocQubitOp, DeallocOp, DeallocQubitOp, ExtractOp, InsertOp
 

--- a/frontend/catalyst/python_interface/dialects/quantum/operations/observable_ops.py
+++ b/frontend/catalyst/python_interface/dialects/quantum/operations/observable_ops.py
@@ -15,7 +15,7 @@
 This file contains the definition of operations that represent observables
 in the Quantum dialect.
 """
-from xdsl.dialects.builtin import I1, ComplexType, Float64Type
+from xdsl.dialects.builtin import i1, ComplexType, Float64Type
 from xdsl.ir import Operation
 from xdsl.irdl import (
     AttrSizedOperandSegments,
@@ -140,4 +140,4 @@ class MCMObsOp(ObservableOp):
 
     assembly_format = "$mcms attr-dict `:` type(results)"
 
-    mcms = var_operand_def(I1)
+    mcms = var_operand_def(i1)

--- a/frontend/catalyst/python_interface/dialects/quantum/operations/observable_ops.py
+++ b/frontend/catalyst/python_interface/dialects/quantum/operations/observable_ops.py
@@ -15,7 +15,7 @@
 This file contains the definition of operations that represent observables
 in the Quantum dialect.
 """
-from xdsl.dialects.builtin import ComplexType, Float64Type, I1
+from xdsl.dialects.builtin import I1, ComplexType, Float64Type
 from xdsl.ir import Operation
 from xdsl.irdl import (
     AttrSizedOperandSegments,

--- a/frontend/catalyst/python_interface/dialects/quantum/operations/observable_ops.py
+++ b/frontend/catalyst/python_interface/dialects/quantum/operations/observable_ops.py
@@ -15,7 +15,7 @@
 This file contains the definition of operations that represent observables
 in the Quantum dialect.
 """
-from xdsl.dialects.builtin import i1, ComplexType, Float64Type
+from xdsl.dialects.builtin import ComplexType, Float64Type, i1
 from xdsl.ir import Operation
 from xdsl.irdl import (
     AttrSizedOperandSegments,

--- a/frontend/catalyst/python_interface/dialects/quantum/operations/observable_ops.py
+++ b/frontend/catalyst/python_interface/dialects/quantum/operations/observable_ops.py
@@ -15,7 +15,7 @@
 This file contains the definition of operations that represent observables
 in the Quantum dialect.
 """
-from xdsl.dialects.builtin import ComplexType, Float64Type
+from xdsl.dialects.builtin import ComplexType, Float64Type, I1
 from xdsl.ir import Operation
 from xdsl.irdl import (
     AttrSizedOperandSegments,
@@ -130,3 +130,14 @@ class TensorOp(ObservableOp):
     assembly_format = "$terms attr-dict `:` type(results)"
 
     terms = var_operand_def(ObservableType)
+
+
+@irdl_op_definition
+class MCMObsOp(ObservableOp):
+    """Define a pseudo-observable of mid-circuit measurements for use in measurements"""
+
+    name = "quantum.mcmobs"
+
+    assembly_format = "$mcms attr-dict `:` type(results)"
+
+    mcms = var_operand_def(I1)

--- a/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
@@ -178,7 +178,10 @@ expected_ops_init_kwargs = {
         {"in_qreg": qreg, "idx": int_attr, "qubit": q1},
         {"in_qreg": qreg, "idx": 0, "qubit": q1},
     ],
-    "MCMObsOp": [{"operands": (bool_ssa,), "result_types": (obs,)}],
+    "MCMObsOp": [
+        {"operands": (bool_ssa,), "result_types": (obs,)},
+        {"operands": ((bool_ssa, bool_ssa, bool_ssa),), "result_types": (obs,)}
+    ],
     "MeasureOp": [
         {"in_qubit": q0, "postselect": int_ssa},
         {"in_qubit": q0},

--- a/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
@@ -61,6 +61,7 @@ expected_ops_names = {
     "HermitianOp": "quantum.hermitian",
     "InitializeOp": "quantum.init",
     "InsertOp": "quantum.insert",
+    "MCMObsOp": "quantum.mcmobs",
     "MeasureOp": "quantum.measure",
     "MultiRZOp": "quantum.multirz",
     "NamedObsOp": "quantum.namedobs",
@@ -177,6 +178,7 @@ expected_ops_init_kwargs = {
         {"in_qreg": qreg, "idx": int_attr, "qubit": q1},
         {"in_qreg": qreg, "idx": 0, "qubit": q1},
     ],
+    "MCMObsOp": [{"operands": (bool_ssa,), "result_types": (obs,)}],
     "MeasureOp": [
         {"in_qubit": q0, "postselect": int_ssa},
         {"in_qubit": q0},

--- a/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
@@ -646,16 +646,15 @@ class TestAssemblyFormat:
         %cb_all = quantum.compbasis qreg %qreg : !quantum.obs
 
         //////////// **MCMObsOp** ////////////
-        // create mcms
+        // create booleans for the mcms
         // CHECK: [[MCM1:%.+]] = "test.op"() : () -> i1
         // CHECK: [[MCM2:%.+]] = "test.op"() : () -> i1
         %mcm1 = "test.op"() : () -> i1
         %mcm2 = "test.op"() : () -> i1
 
         // CHECK: {{%.+}} = quantum.mcmobs [[MCM1]] : !quantum.obs
-        %mcm_obs1 = quantum.mcmobs %mcm1 : !quantum.obs
-
         // CHECK: {{%.+}} = quantum.mcmobs [[MCM1]], [[MCM2]] : !quantum.obs
+        %mcm_obs1 = quantum.mcmobs %mcm1 : !quantum.obs
         %mcm_obs2 = quantum.mcmobs %mcm1, %mcm2 : !quantum.obs
         """
 

--- a/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
@@ -180,7 +180,7 @@ expected_ops_init_kwargs = {
     ],
     "MCMObsOp": [
         {"operands": (bool_ssa,), "result_types": (obs,)},
-        {"operands": ((bool_ssa, bool_ssa, bool_ssa),), "result_types": (obs,)}
+        {"operands": ((bool_ssa, bool_ssa, bool_ssa),), "result_types": (obs,)},
     ],
     "MeasureOp": [
         {"in_qubit": q0, "postselect": int_ssa},

--- a/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
@@ -644,6 +644,19 @@ class TestAssemblyFormat:
         // CHECK: {{%.+}} = quantum.compbasis qreg [[QREG]] : !quantum.obs
         %cb_01 = quantum.compbasis qubits %q0, %q1 : !quantum.obs
         %cb_all = quantum.compbasis qreg %qreg : !quantum.obs
+
+        //////////// **MCMObsOp** ////////////
+        // create mcms
+        // CHECK: [[MCM1:%.+]] = "test.op"() : () -> i1
+        // CHECK: [[MCM2:%.+]] = "test.op"() : () -> i1
+        %mcm1 = "test.op"() : () -> i1
+        %mcm2 = "test.op"() : () -> i1
+
+        // CHECK: {{%.+}} = quantum.mcmobs [[MCM1]] : !quantum.obs
+        %mcm_obs1 = quantum.mcmobs %mcm1 : !quantum.obs
+
+        // CHECK: {{%.+}} = quantum.mcmobs [[MCM1]], [[MCM2]] : !quantum.obs
+        %mcm_obs2 = quantum.mcmobs %mcm1, %mcm2 : !quantum.obs
         """
 
         run_filecheck(program, roundtrip=True, verify=True, pretty_print=pretty_print)


### PR DESCRIPTION
**Context:**
In #2458 we added a new MCMObsOp to the quantum dialect, but it isn't registered in xDSL yet.

**Description of the Change:**
Register the new observable op in xDSL.

**Benefits:**
We can use the new observable in xDSL passes instead of encountering an `UnregisteredOpWithNameOp`.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
N/A

[sc-112645]