### PR TITLE
Remove support for using QNodes as input to inspection tools

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -150,9 +150,13 @@
 
 <h3>Improvements 🛠</h3>
 
+* `catalyst.python_interface.utils.get_constant_from_ssa` can now extract constant values cast using
+  `arith.index_cast`.
+  [(#2542)](https://github.com/PennyLaneAI/catalyst/pull/2542)
+
 * The tape transform :func:`~.device.decomposition.catalyst_decompose` now accepts the optional
   keyword arguments ``target_gates``, ``num_work_wires``, ``fixed_decomps``, and ``alt_decomps``,
-  which all are passed to the used PennyLane decomposition function 
+  which all are passed to the used PennyLane decomposition function
   ``qml.devices.preprocess.decompose`` and used if the graph-based decomposition system is enabled.
   [(#2501)](https://github.com/PennyLaneAI/catalyst/pull/2501)
 
@@ -200,6 +204,10 @@
   [(#2486)](https://github.com/PennyLaneAI/catalyst/pull/2486)
 
 <h3>Breaking changes 💔</h3>
+
+* `catalyst.python_interface.inspection.draw` and `catalyst.python_interface.inspection.generate_mlir_graph` no longer
+  accept QNodes as the input. Now, the input must always be a :class:`~.QJIT` object.
+  [(#2542)](https://github.com/PennyLaneAI/catalyst/pull/2542)
 
 * `catalyst.from_plxpr.register_transforms` as a way to access MLIR passes from Python has been removed in favour of the new unified transforms API. MLIR passes can be accessed from Python using `qml.transform(pass_name="some-pass-name")`.
   [(#2509)](https://github.com/PennyLaneAI/catalyst/pull/2509)
@@ -549,7 +557,7 @@
   }
   ```
 
-  * A new MLIR op, `MCMObsOp`, is defined as a pseudo-observable of mid-circuit measurements for use in 
+  * A new MLIR op, `MCMObsOp`, is defined as a pseudo-observable of mid-circuit measurements for use in
     measurement processes. It is also registered in xDSL.
     [(#2458)](https://github.com/PennyLaneAI/catalyst/pull/2458)
     [(#2536)](https://github.com/PennyLaneAI/catalyst/pull/2536)

--- a/frontend/catalyst/python_interface/inspection/mlir_graph.py
+++ b/frontend/catalyst/python_interface/inspection/mlir_graph.py
@@ -31,7 +31,7 @@ from catalyst.python_interface.compiler import Compiler
 from .xdsl_conversion import get_mlir_module
 
 if TYPE_CHECKING:  # pragma: no cover
-    from pennylane import QNode
+    from catalyst.jit import QJIT
 
 try:
     from graphviz import Source as GraphSource
@@ -82,19 +82,18 @@ def _mlir_graph_callback(previous_pass, module, next_pass, pass_level=0):
         f.write(graph.pipe(format="svg"))
 
 
-def generate_mlir_graph(qnode: QNode) -> Callable:
+def generate_mlir_graph(qnode: QJIT) -> Callable:
     """
     Generate an MLIR graph for the given QNode and saves it to a file.
 
     This function uses the callback mechanism of the unified compiler framework to generate
     the MLIR graph in between compilation passes. The provided QNode is assumed to be decorated
-    with xDSL compilation passes. The ``qjit`` decorator is used to recompile the QNode with the
-    passes and the provided arguments.
+    with xDSL compilation passes.
 
     If no passes are applied, the original QNode is visualized.
 
     Args:
-        qnode (.QNode): the input QNode that is to be visualized.
+        qnode (.QJIT): the input QNode that is to be visualized.
 
 
     Returns:

--- a/frontend/catalyst/python_interface/inspection/xdsl_conversion.py
+++ b/frontend/catalyst/python_interface/inspection/xdsl_conversion.py
@@ -217,9 +217,6 @@ def resolve_constant_params(ssa: SSAValue) -> float | int | str:
         case "arith.constant":
             return op.value.value.data  # Catalyst
 
-        case "arith.index_cast":
-            return resolve_constant_params(op.input)
-
         case "stablehlo.add":
             x, y = (
                 resolve_constant_params(op.operands[0]),

--- a/frontend/catalyst/python_interface/inspection/xdsl_conversion.py
+++ b/frontend/catalyst/python_interface/inspection/xdsl_conversion.py
@@ -77,19 +77,19 @@ def conditional_pause(pause):
     return dont_do_anything()
 
 
-def get_mlir_module(qnode: QNode | QJIT, args, kwargs) -> Module:
-    """Ensure the QNode is compiled and return its MLIR module."""
-    if hasattr(qnode, "mlir_module") and qnode.mlir_module is not None:
-        return qnode.mlir_module
+def get_mlir_module(workflow: QJIT, args, kwargs) -> Module:
+    """Ensure the workflow is compiled and return its MLIR module."""
+    if not isinstance(workflow, QJIT):
+        raise TypeError(f"Cannot generate MLIR module for non-QJIT objects. Got {workflow}.")
 
-    if isinstance(qnode, QJIT):
-        # Deep copy as to not mutate compile_options
-        compile_options = deepcopy(qnode.compile_options)
-        compile_options.autograph = False  # Autograph has already been applied for `user_function`
+    if (mlir_module := getattr(workflow, "mlir_module", None)) is not None:
+        return mlir_module
 
-        jitted_qnode = QJIT(qnode.user_function, compile_options)
-    else:
-        jitted_qnode = qjit(qnode)
+    # Deep copy as to not mutate compile_options
+    compile_options = deepcopy(workflow.compile_options)
+    compile_options.autograph = False  # Autograph has already been applied for `user_function`
+
+    jitted_qnode = QJIT(workflow.user_function, compile_options)
 
     jitted_qnode.jit_compile(args, **kwargs)
     return jitted_qnode.mlir_module

--- a/frontend/catalyst/python_interface/inspection/xdsl_conversion.py
+++ b/frontend/catalyst/python_interface/inspection/xdsl_conversion.py
@@ -34,7 +34,7 @@ from xdsl.dialects.scf import ForOp
 from xdsl.dialects.tensor import ExtractOp as TensorExtractOp
 from xdsl.ir import Block, SSAValue
 
-from catalyst.jit import QJIT, qjit
+from catalyst.jit import QJIT
 from catalyst.python_interface.dialects.pbc import (
     PPMeasurementOp,
     PPRotationArbitraryOp,

--- a/frontend/catalyst/python_interface/utils.py
+++ b/frontend/catalyst/python_interface/utils.py
@@ -18,6 +18,7 @@ from numbers import Number
 from typing import Any
 
 from xdsl.dialects.arith import ConstantOp as arithConstantOp
+from xdsl.dialects.arith import IndexCastOp
 from xdsl.dialects.builtin import (
     ArrayAttr,
     ComplexType,
@@ -83,6 +84,9 @@ def get_constant_from_ssa(value: SSAValue) -> Number | None:
                     val = val[0] + 1j * val[1]
 
                 return val
+
+        if isinstance(owner, IndexCastOp):
+            return get_constant_from_ssa(owner.operands[0])
 
     return None
 

--- a/frontend/test/pytest/python_interface/inspection/test_draw_unified_compiler.py
+++ b/frontend/test/pytest/python_interface/inspection/test_draw_unified_compiler.py
@@ -71,7 +71,6 @@ class TestDraw:
 
         return circ
 
-    @pytest.mark.parametrize("qjit", [True, False])
     @pytest.mark.parametrize(
         "level, expected",
         [
@@ -92,20 +91,16 @@ class TestDraw:
             (50, "0: ──RX──RZ─┤  State\n1: ──RY─────┤  State\n2: ──RZ─────┤  State"),
         ],
     )
-    def test_multiple_levels_xdsl(self, transforms_circuit, level, qjit, expected):
+    def test_multiple_levels_xdsl(self, transforms_circuit, level, expected):
         """Test that multiple levels of transformation are applied correctly with xDSL
         compilation passes."""
 
-        transforms_circuit = iterative_cancel_inverses_pass(
-            merge_rotations_pass(transforms_circuit)
+        transforms_circuit = qml.qjit(
+            iterative_cancel_inverses_pass(merge_rotations_pass(transforms_circuit))
         )
-
-        if qjit:
-            transforms_circuit = qml.qjit(transforms_circuit)
 
         assert draw(transforms_circuit, level=level)() == expected
 
-    @pytest.mark.parametrize("qjit", [True, False])
     @pytest.mark.parametrize(
         "level, expected",
         [
@@ -126,20 +121,16 @@ class TestDraw:
             (50, "0: ──RX──RZ─┤  State\n1: ──RY─────┤  State\n2: ──RZ─────┤  State"),
         ],
     )
-    def test_multiple_levels_catalyst(self, transforms_circuit, level, qjit, expected):
+    def test_multiple_levels_catalyst(self, transforms_circuit, level, expected):
         """Test that multiple levels of transformation are applied correctly with Catalyst
         compilation passes."""
 
-        transforms_circuit = qml.transforms.cancel_inverses(
-            qml.transforms.merge_rotations(transforms_circuit)
+        transforms_circuit = qml.qjit(
+            qml.transforms.cancel_inverses(qml.transforms.merge_rotations(transforms_circuit))
         )
-
-        if qjit:
-            transforms_circuit = qml.qjit(transforms_circuit)
 
         assert draw(transforms_circuit, level=level)() == expected
 
-    @pytest.mark.parametrize("qjit", [True, False])
     @pytest.mark.parametrize(
         "level, expected",
         [
@@ -160,19 +151,16 @@ class TestDraw:
             (50, "0: ──RX──RZ─┤  State\n1: ──RY─────┤  State\n2: ──RZ─────┤  State"),
         ],
     )
-    def test_multiple_levels_xdsl_catalyst(self, transforms_circuit, level, qjit, expected):
+    def test_multiple_levels_xdsl_catalyst(self, transforms_circuit, level, expected):
         """Test that multiple levels of transformation are applied correctly with xDSL and
         Catalyst compilation passes."""
 
-        transforms_circuit = iterative_cancel_inverses_pass(
-            qml.transforms.merge_rotations(transforms_circuit)
+        transforms_circuit = qml.qjit(
+            iterative_cancel_inverses_pass(qml.transforms.merge_rotations(transforms_circuit))
         )
-        if qjit:
-            transforms_circuit = qml.qjit(transforms_circuit)
 
         assert draw(transforms_circuit, level=level)() == expected
 
-    @pytest.mark.parametrize("qjit", [True, False])
     @pytest.mark.parametrize(
         "level, expected",
         [
@@ -208,11 +196,9 @@ class TestDraw:
             ),
         ],
     )
-    def test_no_passes(self, transforms_circuit, level, qjit, expected):
+    def test_no_passes(self, transforms_circuit, level, expected):
         """Test that if no passes are applied, the circuit is still visualized."""
-
-        if qjit:
-            transforms_circuit = qml.qjit(transforms_circuit)
+        transforms_circuit = qml.qjit(transforms_circuit)
 
         assert draw(transforms_circuit, level=level)() == expected
 
@@ -242,6 +228,7 @@ class TestDraw:
         Test the visualization of control and adjoint variants.
         """
 
+        @qml.qjit
         @qml.qnode(qml.device("lightning.qubit", wires=3))
         def circuit():
             op()
@@ -254,6 +241,7 @@ class TestDraw:
         Test the visualization of control operations before custom ops.
         """
 
+        @qml.qjit
         @qml.qnode(qml.device("lightning.qubit", wires=3))
         def circuit():
             qml.ctrl(qml.X(3), control=[0, 1, 2], control_values=[1, 0, 1])
@@ -330,22 +318,26 @@ class TestDraw:
         """
         Test the visualization of measurements.
         """
+        shots = (
+            10
+            if isinstance(measurement(), (qml.measurements.SampleMP, qml.measurements.CountsMP))
+            else None
+        )
 
-        @qml.qnode(qml.device("lightning.qubit", wires=3))
+        @qml.qjit
+        @qml.qnode(qml.device("lightning.qubit", wires=3), shots=shots)
         def circuit():
             qml.RX(0.1, 0)
             qml.RY(0.2, 1)
             qml.RZ(0.3, 2)
             return measurement()
 
-        if isinstance(measurement(), qml.measurements.SampleMP):
-            circuit = qml.set_shots(10)(circuit)
-
         assert draw(circuit)() == expected
 
     def test_global_phase(self):
         """Test the visualization of global phase shifts."""
 
+        @qml.qjit
         @qml.qnode(qml.device("lightning.qubit", wires=3))
         def circuit():
             qml.H(0)
@@ -371,6 +363,7 @@ class TestDraw:
     def test_draw_mid_circuit_measurement_postselect(self, postselect, mid_measure_label):
         """Test that mid-circuit measurements are drawn correctly."""
 
+        @qml.qjit
         @qml.qnode(qml.device("lightning.qubit", wires=2))
         def circuit():
             qml.Hadamard(0)
@@ -453,6 +446,7 @@ class TestDraw:
         Test the visualization of the quantum operations defined in the unified compiler dialect.
         """
 
+        @qml.qjit
         @qml.qnode(qml.device("lightning.qubit", wires=3))
         def circuit():
             for op, param, wires in ops:
@@ -468,6 +462,7 @@ class TestDraw:
         two_dim = jax.numpy.array([[0, 1], [1, 0]])
         eight_dim = jax.numpy.zeros((8, 8))
 
+        @qml.qjit
         @qml.qnode(qml.device("lightning.qubit", wires=2))
         def circuit():
             qml.RX(one_dim[0], wires=0)
@@ -486,6 +481,7 @@ class TestDraw:
         """Test that a warning is raised when dynamic arguments are used."""
 
         # pylint: disable=unused-argument
+        @qml.qjit
         @qml.qnode(qml.device("lightning.qubit", wires=3))
         def circ(arg):
             qml.RX(0.1, wires=0)

--- a/frontend/test/pytest/python_interface/inspection/test_draw_unified_compiler.py
+++ b/frontend/test/pytest/python_interface/inspection/test_draw_unified_compiler.py
@@ -71,6 +71,22 @@ class TestDraw:
 
         return circ
 
+    def test_no_qjit_error(self):
+        """Test that an error is raised if trying to use anything other than QJIT as
+        an input."""
+
+        @qml.qnode(qml.device("lightning.qubit", wires=3))
+        def f():
+            qml.RX(0.1, 0)
+            qml.RX(2.0, 0)
+            qml.CNOT([0, 2])
+            qml.CNOT([0, 2])
+            return qml.state()
+
+        gen = draw(f)
+        with pytest.raises(TypeError, match="Cannot generate MLIR module"):
+            gen()
+
     @pytest.mark.parametrize(
         "level, expected",
         [

--- a/frontend/test/pytest/python_interface/inspection/test_mlir_graph.py
+++ b/frontend/test/pytest/python_interface/inspection/test_mlir_graph.py
@@ -55,6 +55,22 @@ def assert_files(tmp_path: Path, expected: set[str]):
 class TestMLIRGraph:
     """Test the MLIR graph generation"""
 
+    def test_no_qjit_error(self):
+        """Test that an error is raised if trying to use anything other than QJIT as
+        an input."""
+
+        @qml.qnode(qml.device("lightning.qubit", wires=3))
+        def f():
+            qml.RX(0.1, 0)
+            qml.RX(2.0, 0)
+            qml.CNOT([0, 2])
+            qml.CNOT([0, 2])
+            return qml.state()
+
+        gen = generate_mlir_graph(f)
+        with pytest.raises(TypeError, match="Cannot generate MLIR module"):
+            gen()
+
     def test_no_transforms(self, tmp_path: Path):
         """Test the MLIR graph is still generated when no transforms are applied"""
 

--- a/frontend/test/pytest/python_interface/inspection/test_mlir_graph.py
+++ b/frontend/test/pytest/python_interface/inspection/test_mlir_graph.py
@@ -55,42 +55,36 @@ def assert_files(tmp_path: Path, expected: set[str]):
 class TestMLIRGraph:
     """Test the MLIR graph generation"""
 
-    @pytest.mark.parametrize("qjit", [True, False])
-    def test_no_transforms(self, tmp_path: Path, qjit: bool):
+    def test_no_transforms(self, tmp_path: Path):
         """Test the MLIR graph is still generated when no transforms are applied"""
 
+        @qml.qjit
         @qml.qnode(qml.device("lightning.qubit", wires=3))
-        def _():
+        def f():
             qml.RX(0.1, 0)
             qml.RX(2.0, 0)
             qml.CNOT([0, 2])
             qml.CNOT([0, 2])
             return qml.state()
 
-        if qjit:
-            _ = qml.qjit(_)
-
-        generate_mlir_graph(_)()
+        generate_mlir_graph(f)()
         assert collect_files(tmp_path) == {"QNode_level_0_no_transforms.svg"}
 
-    @pytest.mark.parametrize("qjit", [True, False])
-    def test_xdsl_transforms_no_args(self, tmp_path: Path, qjit: bool):
+    def test_xdsl_transforms_no_args(self, tmp_path: Path):
         """Test the MLIR graph generation with no arguments to the QNode with and without qjit"""
 
+        @qml.qjit
         @merge_rotations_pass
         @iterative_cancel_inverses_pass
         @qml.qnode(qml.device("lightning.qubit", wires=3))
-        def _():
+        def f():
             qml.RX(0.1, 0)
             qml.RX(2.0, 0)
             qml.CNOT([0, 2])
             qml.CNOT([0, 2])
             return qml.state()
 
-        if qjit:
-            _ = qml.qjit(_)
-
-        generate_mlir_graph(_)()
+        generate_mlir_graph(f)()
         assert_files(
             tmp_path,
             {
@@ -100,22 +94,19 @@ class TestMLIRGraph:
             },
         )
 
-    @pytest.mark.parametrize("qjit", [True, False])
-    def test_xdsl_transforms_args(self, tmp_path: Path, qjit: bool):
+    def test_xdsl_transforms_args(self, tmp_path: Path):
         """Test the MLIR graph generation with arguments to the QNode for xDSL transforms"""
 
+        @qml.qjit
         @merge_rotations_pass
         @iterative_cancel_inverses_pass
         @qml.qnode(qml.device("lightning.qubit", wires=3))
-        def _(x, y, w1, w2):
+        def f(x, y, w1, w2):
             qml.RX(x, w1)
             qml.RX(y, w2)
             return qml.state()
 
-        if qjit:
-            _ = qml.qjit(_)
-
-        generate_mlir_graph(_)(0.1, 0.2, 0, 1)
+        generate_mlir_graph(f)(0.1, 0.2, 0, 1)
         assert_files(
             tmp_path,
             {
@@ -125,22 +116,19 @@ class TestMLIRGraph:
             },
         )
 
-    @pytest.mark.parametrize("qjit", [True, False])
-    def test_catalyst_transforms_args(self, tmp_path: Path, qjit: bool):
+    def test_catalyst_transforms_args(self, tmp_path: Path):
         """Test the MLIR graph generation with arguments to the QNode for catalyst transforms"""
 
+        @qml.qjit
         @qml.transforms.merge_rotations
         @qml.transforms.cancel_inverses
         @qml.qnode(qml.device("lightning.qubit", wires=3))
-        def _(x, y, w1, w2):
+        def f(x, y, w1, w2):
             qml.RX(x, w1)
             qml.RX(y, w2)
             return qml.state()
 
-        if qjit:
-            _ = qml.qjit(_)
-
-        generate_mlir_graph(_)(0.1, 0.2, 0, 1)
+        generate_mlir_graph(f)(0.1, 0.2, 0, 1)
         assert_files(
             tmp_path,
             {
@@ -150,23 +138,20 @@ class TestMLIRGraph:
             },
         )
 
-    @pytest.mark.parametrize("qjit", [True, False])
-    def test_catalyst_xdsl_transforms_args(self, tmp_path: Path, qjit: bool):
+    def test_catalyst_xdsl_transforms_args(self, tmp_path: Path):
         """Test the MLIR graph generation with arguments to the QNode for catalyst and xDSL
         transforms"""
 
+        @qml.qjit
         @qml.transforms.merge_rotations
         @iterative_cancel_inverses_pass
         @qml.qnode(qml.device("lightning.qubit", wires=3))
-        def _(x, y, w1, w2):
+        def f(x, y, w1, w2):
             qml.RX(x, w1)
             qml.RX(y, w2)
             return qml.state()
 
-        if qjit:
-            _ = qml.qjit(_)
-
-        generate_mlir_graph(_)(0.1, 0.2, 0, 1)
+        generate_mlir_graph(f)(0.1, 0.2, 0, 1)
         assert_files(
             tmp_path,
             {
@@ -179,9 +164,10 @@ class TestMLIRGraph:
     def test_cond(self, tmp_path: Path):
         """Test the MLIR graph generation for a conditional"""
 
+        @qml.qjit
         @merge_rotations_pass
         @qml.qnode(qml.device("lightning.qubit", wires=3))
-        def _(pred, arg1, arg2):
+        def f(pred, arg1, arg2):
             """Quantum circuit with conditional branches."""
 
             qml.RX(0.10, wires=0)
@@ -199,7 +185,7 @@ class TestMLIRGraph:
             qml.RX(0.10, wires=0)
             return qml.expval(qml.Z(wires=0))
 
-        generate_mlir_graph(_)(0.5, 0.1, 0.2)
+        generate_mlir_graph(f)(0.5, 0.1, 0.2)
         assert_files(
             tmp_path,
             {
@@ -217,9 +203,10 @@ class TestMLIRGraph:
         def false_fn(arg):
             qml.RY(3 * arg, 0)
 
+        @qml.qjit
         @merge_rotations_pass
         @qml.qnode(qml.device("lightning.qubit", wires=3))
-        def _(x, y):
+        def f(x, y):
             """Quantum circuit with conditional branches."""
 
             qml.RX(x, 0)
@@ -228,7 +215,7 @@ class TestMLIRGraph:
             qml.cond(m, true_fn, false_fn)(y)
             return qml.expval(qml.Z(0))
 
-        generate_mlir_graph(_)(0.5, 0.1)
+        generate_mlir_graph(f)(0.5, 0.1)
         assert_files(
             tmp_path,
             {
@@ -240,9 +227,10 @@ class TestMLIRGraph:
     def test_for_loop(self, tmp_path: Path):
         """Test the MLIR graph generation for a for loop"""
 
+        @qml.qjit
         @merge_rotations_pass
         @qml.qnode(qml.device("lightning.qubit", wires=3))
-        def _():
+        def f():
             @qml.for_loop(0, 100)
             def loop(_):
                 qml.RX(0.1, 0)
@@ -252,7 +240,7 @@ class TestMLIRGraph:
             loop()
             return qml.state()
 
-        generate_mlir_graph(_)()
+        generate_mlir_graph(f)()
         assert_files(
             tmp_path,
             {
@@ -264,9 +252,10 @@ class TestMLIRGraph:
     def test_while_loop(self, tmp_path: Path):
         """Test the MLIR graph generation for a while loop"""
 
+        @qml.qjit
         @merge_rotations_pass
         @qml.qnode(qml.device("lightning.qubit", wires=3))
-        def _(x):
+        def f(x):
             def cond_fn(x):
                 return x < 2
 
@@ -277,7 +266,7 @@ class TestMLIRGraph:
             loop(x)
             return qml.expval(qml.PauliZ(0))
 
-        generate_mlir_graph(_)(0.5)
+        generate_mlir_graph(f)(0.5)
         assert_files(
             tmp_path,
             {

--- a/frontend/test/pytest/python_interface/test_xdsl_utils.py
+++ b/frontend/test/pytest/python_interface/test_xdsl_utils.py
@@ -129,6 +129,23 @@ class TestGetConstantFromSSA:
 
         assert get_constant_from_ssa(val) is None
 
+    @pytest.mark.parametrize(
+        "const, attr_type, dtype",
+        [
+            (11, builtin.IntegerAttr, builtin.IntegerType(64)),
+            (5, builtin.IntegerAttr, builtin.IndexType()),
+            (2.5, builtin.FloatAttr, builtin.Float64Type()),
+        ],
+    )
+    def test_index_cast(self, const, attr_type, dtype):
+        """Test that a constant value cast into an IndexType using arith.index_cast can be
+        extracted."""
+        const_attr = attr_type(const, dtype)
+        val = arith.ConstantOp(value=const_attr).results[0]
+        cast_val = arith.IndexCastOp(val, builtin.IndexType()).results[0]
+
+        assert get_constant_from_ssa(cast_val) == const
+
 
 class TestGetPyvalFromXdslAttr:
     """Unit tests for ``get_pyval_from_xdsl_attr``."""


### PR DESCRIPTION
`catalyst.python_interface.draw` and `catalyst.python_interface.generate_mlir_graph` allowed using QNodes as input. Both these functions are supposed to only work with QJIT (and in fact they wrap the input QNode in QJIT before anything else). Supporting QNode inputs for MLIR-level functionality does not make sense, and is also causing issues with #2496 .

Also sneaking in a change to support getting the value of constants cast using `index_cast` in `get_constant_from_ssa`

[sc-113126] [sc-113127]