### PR TITLE
Stop casting transform kwargs from tuple to list

### DIFF
--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -446,7 +446,7 @@ def handle_transform(
     consts = args[_tuple_to_slice(consts_slice)]
     non_const_args = args[_tuple_to_slice(args_slice)]
     targs = args[_tuple_to_slice(targs_slice)]
-    tkwargs = _tuple_to_dict(tkwargs)
+    pl_tkwargs = _tuple_to_dict(tkwargs)
 
     # If the transform is a decomposition transform
     # and the graph-based decomposition is enabled
@@ -454,7 +454,7 @@ def handle_transform(
     if transform_name == "decompose_plxpr_to_plxpr":
         use_graph = qml.decomposition.enabled_graph()
         return _handle_decompose_transform(
-            self, inner_jaxpr, consts, non_const_args, tkwargs, use_graph
+            self, inner_jaxpr, consts, non_const_args, pl_tkwargs, use_graph
         )
 
     catalyst_pass_name = transform.pass_name
@@ -470,11 +470,11 @@ def handle_transform(
 
         unravelled_jaxpr = jax.make_jaxpr(wrapper)(*non_const_args)
         final_jaxpr = transform._plxpr_transform(
-            unravelled_jaxpr.jaxpr, unravelled_jaxpr.consts, targs, tkwargs, *non_const_args
+            unravelled_jaxpr.jaxpr, unravelled_jaxpr.consts, targs, pl_tkwargs, *non_const_args
         )
         if transforms_to_passes[transform][1]:
             final_jaxpr = pl_decompose._plxpr_transform(
-                final_jaxpr.jaxpr, final_jaxpr.consts, targs, tkwargs, *non_const_args
+                final_jaxpr.jaxpr, final_jaxpr.consts, targs, pl_tkwargs, *non_const_args
             )
 
         return copy(self).eval(final_jaxpr.jaxpr, final_jaxpr.consts, *non_const_args)
@@ -482,7 +482,7 @@ def handle_transform(
     # Apply the corresponding Catalyst pass counterpart
     next_eval = copy(self)
     t = qml.transform(pass_name=catalyst_pass_name)
-    bound_pass = qml.transforms.core.TransformContainer(t, args=targs, kwargs=tkwargs)
+    bound_pass = qml.transforms.core.TransformContainer(t, args=targs, kwargs=dict(tkwargs))
     next_eval._pass_pipeline.insert(0, bound_pass)
     return next_eval.eval(inner_jaxpr, consts, *non_const_args)
 


### PR DESCRIPTION
**Context:**
Current conversion turns tuples into lists, and then doesn't turn them back. It's preventing us from passing a tuple to an xDSL transform through the PL/capture frontend.

**Description of the Change:**
We only modify the transform arguments to make them lists where its used for the old plxpr infrastructure, instead of also doing it for `tkwarg`s passed to the MLIR/xDSL passes.

**Benefits:**
We don't need special handling to cast things back to tuples for passes that have some `kwarg=tuple(1, 2, 3..)` argument

