### PR TITLE
Workflow: master -> main

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -153,7 +153,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: PennyLaneAI/pennylane-lightning
-        ref: main
+        ref: master
         path: lightning_build
         fetch-depth: 0
 

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -153,7 +153,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: PennyLaneAI/pennylane-lightning
-        ref: master
+        ref: main
         path: lightning_build
         fetch-depth: 0
 
@@ -170,7 +170,7 @@ jobs:
     - name: Install PennyLane (latest)
       if: ${{ inputs.pennylane == 'latest' }}
       run: |
-        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@master
+        pip install --no-deps --force git+https://github.com/PennyLaneAI/pennylane@main
 
     - name: Install PennyLane (stable)
       if: ${{ inputs.pennylane == 'stable' }}


### PR DESCRIPTION
We started to rename `master` to `main` recently:
https://github.com/PennyLaneAI/pennylane/commit/3c2ff8afa518171011b97e380dc50d1daf78437c
https://github.com/PennyLaneAI/pennylane-lightning/commit/c12077636280d3fe099390ceec45d2bb30738c1d

As a result, the LLL workflow should also target `main` of Pennylane