### PR TITLE
Add changelog for bugfix release 0.14.1

### DIFF
--- a/doc/dev/release_notes.rst
+++ b/doc/dev/release_notes.rst
@@ -5,6 +5,8 @@ This page contains the release notes for Catalyst.
 
 .. mdinclude:: ../releases/changelog-dev.md
 
+.. mdinclude:: ../releases/changelog-0.14.1.md
+
 .. mdinclude:: ../releases/changelog-0.14.0.md
 
 .. mdinclude:: ../releases/changelog-0.13.0.md

--- a/doc/releases/changelog-0.14.0.md
+++ b/doc/releases/changelog-0.14.0.md
@@ -1,4 +1,4 @@
-# Release 0.14.0 (current release)
+# Release 0.14.0
 
 <h3>New features since last release</h3>
 

--- a/doc/releases/changelog-0.14.1.md
+++ b/doc/releases/changelog-0.14.1.md
@@ -1,0 +1,15 @@
+# Release 0.14.1 (current release)
+
+<h3>Bug fixes</h3>
+
+* The ``gast`` package is now an explicit dependency in Catalyst. The ``gast`` package was previously
+  pulled in transitively by ``diastatic-malt``, but ``diastatic-malt==2.15.3`` dropped ``gast`` as
+  a dependency, which caused an error when importing Catalyst.
+  [#2565](https://github.com/PennyLaneAI/catalyst/pull/2565)
+
+<h3>Contributors</h3>
+
+This release contains contributions from (in alphabetical order):
+
+David Ittah,
+Haochen Paul Wang.


### PR DESCRIPTION
**Context:**
To release v0.14.1, we need to add the corresponding changelog entries.
