### PR TITLE
Add missing backticks to changelog

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -175,6 +175,7 @@
       return qp.expval(qp.X(0))
 
   circuit()
+  ```
 
 * Added a pass to compute resource metrics of functions marked with the `target_gate` attribute,
   effectively filtering for decomposition rules in the MLIR-native decomposition framework.


### PR DESCRIPTION
Without this triple backtick to close the python env the entire changelog afterwards will be regarded as Python env
<img width="985" height="1100" alt="image" src="https://github.com/user-attachments/assets/15fb96d4-ba1f-478b-96cb-e90574c918ce" />
