### PR TITLE
Cast result of measure_p back to int during plxpr interpreting

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -322,7 +322,7 @@
   were updated in-place. Entry-point arguments are now treated as non-writable during bufferization,
   preserving the expected immutability of user inputs.
   [(#2562)](https://github.com/PennyLaneAI/catalyst/pull/2562)
-  
+
 * Fixed a bug in the `split-non-commuting` pass where dead `NamedObsOp`s were left behind after
   erasing composite obs (`TensorOp`, `HamiltonianOp`).
   [(#2567)](https://github.com/PennyLaneAI/catalyst/pull/2567)
@@ -375,11 +375,16 @@
 * Fixed incorrect global phase when lowering CNOT gates into PPR/PPM operations.
   [(#2459)](https://github.com/PennyLaneAI/catalyst/pull/2459)
 
+* Fixed a bug where the Catalyst measurement primitive was incorrectly returning a boolean type
+  as the measurement result, when replacing the PennyLane measurement primitive, whose measurement
+  result is integer type.
+  [(#2582)](https://github.com/PennyLaneAI/catalyst/pull/2582)
+
 <h3>Internal changes ⚙️</h3>
 
 * Catalyst internally uses the new unified transforms API rather than `PassPipelineWrapper`.
-  [(#2525)](https://github.com/PennyLaneAI/catalyst/pull/2525)  
-  
+  [(#2525)](https://github.com/PennyLaneAI/catalyst/pull/2525)
+
 * Added an `EmptyPass` MLIR pass that does not transform the program for debugging and standing in for
   unimplemented transforms.
   [(#2575)](https://github.com/PennyLaneAI/catalyst/pull/2575)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -375,9 +375,9 @@
 * Fixed incorrect global phase when lowering CNOT gates into PPR/PPM operations.
   [(#2459)](https://github.com/PennyLaneAI/catalyst/pull/2459)
 
-* Fixed a bug where the Catalyst measurement primitive was incorrectly returning a boolean type
-  as the measurement result, when replacing the PennyLane measurement primitive, whose measurement
-  result is integer type.
+* Fixed a bug where the Catalyst measurement primitive returning a boolean type as the measurement
+  result was incorrectly replacing the PennyLane measurement primitive, whose measurement
+  result is integer type, during the PLxPR conversion.
   [(#2582)](https://github.com/PennyLaneAI/catalyst/pull/2582)
 
 <h3>Internal changes ⚙️</h3>

--- a/frontend/catalyst/from_plxpr/qfunc_interpreter.py
+++ b/frontend/catalyst/from_plxpr/qfunc_interpreter.py
@@ -710,7 +710,11 @@ def handle_measure(self, wire, reset, postselect):
             ]
         )
         out_wire = cond_p.bind(
-            result, out_wire, out_wire, branch_jaxprs=correction, num_implicit_outputs=None
+            jnp.bool(result),
+            out_wire,
+            out_wire,
+            branch_jaxprs=correction,
+            num_implicit_outputs=None,
         )[0]
 
     in_qreg[in_qreg.global_index_to_local_index(wire)] = out_wire

--- a/frontend/catalyst/from_plxpr/qfunc_interpreter.py
+++ b/frontend/catalyst/from_plxpr/qfunc_interpreter.py
@@ -699,6 +699,7 @@ def handle_measure(self, wire, reset, postselect):
         _[0] for _ in get_in_qubit_values([wire], self.qubit_index_recorder, self.init_qreg)
     )
     result, out_wire = measure_p.bind(in_wire, postselect=postselect)
+    result = jnp.astype(result, int)
 
     if reset:
         # Constants need to be passed as input values for some reason I forgot about.

--- a/frontend/catalyst/from_plxpr/qfunc_interpreter.py
+++ b/frontend/catalyst/from_plxpr/qfunc_interpreter.py
@@ -699,7 +699,6 @@ def handle_measure(self, wire, reset, postselect):
         _[0] for _ in get_in_qubit_values([wire], self.qubit_index_recorder, self.init_qreg)
     )
     result, out_wire = measure_p.bind(in_wire, postselect=postselect)
-    result = jnp.astype(result, int)
 
     if reset:
         # Constants need to be passed as input values for some reason I forgot about.
@@ -710,7 +709,7 @@ def handle_measure(self, wire, reset, postselect):
             ]
         )
         out_wire = cond_p.bind(
-            jnp.bool(result),
+            result,
             out_wire,
             out_wire,
             branch_jaxprs=correction,
@@ -718,6 +717,7 @@ def handle_measure(self, wire, reset, postselect):
         )[0]
 
     in_qreg[in_qreg.global_index_to_local_index(wire)] = out_wire
+    result = jnp.astype(result, int)
     return result
 
 

--- a/frontend/catalyst/from_plxpr/qfunc_interpreter.py
+++ b/frontend/catalyst/from_plxpr/qfunc_interpreter.py
@@ -653,6 +653,7 @@ def handle_pauli_measure(self, *invals, pauli_word, **params):
     result, *out_qubits = outvals  # First element is the measurement result
     for in_qreg, w, new_wire in zip(in_qregs, invals, out_qubits):
         in_qreg[in_qreg.global_index_to_local_index(w)] = new_wire
+    result = jnp.astype(result, int)
     return result
 
 

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1835,7 +1835,14 @@ def _mcmobs_abstract_eval(*mcms):
 def _mcm_obs_lowering(jax_ctx: mlir.LoweringRuleContext, *mcms: list[ir.Value]):
     ctx = jax_ctx.module_context.context
     result_type = ir.OpaqueType.get("quantum", "obs", ctx)
-    extracted = [extract_scalar(mcm, "mcmobs") for mcm in mcms]
+    i1type = ir.IntegerType.get_signless(1)
+
+    extracted = []
+    for mcm in mcms:
+        shape = mcm.type.shape
+        tensor_i1_type = ir.RankedTensorType.get(shape, i1type)
+        convert_op = StableHLOConvertOp(tensor_i1_type, mcm)
+        extracted.append(extract_scalar(convert_op.result, "mcmobs"))
     return MCMObsOp(result_type, extracted).results
 
 

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1835,12 +1835,10 @@ def _mcmobs_abstract_eval(*mcms):
 def _mcm_obs_lowering(jax_ctx: mlir.LoweringRuleContext, *mcms: list[ir.Value]):
     ctx = jax_ctx.module_context.context
     result_type = ir.OpaqueType.get("quantum", "obs", ctx)
-    i1type = ir.IntegerType.get_signless(1)
+    tensor_i1_type = ir.RankedTensorType.get([], ir.IntegerType.get_signless(1))
 
     extracted = []
     for mcm in mcms:
-        shape = mcm.type.shape
-        tensor_i1_type = ir.RankedTensorType.get(shape, i1type)
         convert_op = StableHLOConvertOp(tensor_i1_type, mcm)
         extracted.append(extract_scalar(convert_op.result, "mcmobs"))
     return MCMObsOp(result_type, extracted).results

--- a/frontend/test/lit/test_dynamic_qubit_allocation.py
+++ b/frontend/test/lit/test_dynamic_qubit_allocation.py
@@ -102,12 +102,20 @@ def test_measure_with_reset():
     Test qml.allocate with qml.measure with a reset.
     """
 
+    # CHECK: [[zero:%.+]] = stablehlo.constant dense<0> : tensor<i64>
+
     # CHECK: [[device_init_qreg:%.+]] = quantum.alloc( 3)
 
     # CHECK: [[dyn_qreg:%.+]] = quantum.alloc( 1)
     # CHECK: [[dyn_qubit:%.+]] = quantum.extract [[dyn_qreg]][ 0]
     # CHECK: [[mres:%.+]], [[mout_qubit:%.+]] = quantum.measure [[dyn_qubit]] postselect 1
-    # CHECK: [[reset_qubit:%.+]] = scf.if [[mres]] -> (!quantum.bit) {
+    # CHECK: [[tensor_i1_mres:%.+]] = tensor.from_elements [[mres]] : tensor<i1>
+    # CHECK: [[tensor_i64_mres:%.+]] = stablehlo.convert [[tensor_i1_mres]] : (tensor<i1>) -> tensor<i64>
+    # CHECK: [[all_zeros:%.+]] = stablehlo.broadcast_in_dim [[zero]], dims = [] : (tensor<i64>) -> tensor<i64>
+    # CHECK: [[cmp_tensor:%.+]] = stablehlo.compare  NE, [[tensor_i64_mres]], [[all_zeros]],  SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
+    # CHECK: [[convert:%.+]] = stablehlo.convert [[cmp_tensor]] : tensor<i1>
+    # CHECK: [[extracted_cmp:%.+]] = tensor.extract [[convert]][] : tensor<i1>
+    # CHECK: [[reset_qubit:%.+]] = scf.if [[extracted_cmp]] -> (!quantum.bit) {
     # CHECK:    [[x_out_qubit:%.+]] = quantum.custom "PauliX"() [[mout_qubit]]
     # CHECK:    scf.yield [[x_out_qubit]] : !quantum.bit
     # CHECK:  } else {

--- a/frontend/test/lit/test_dynamic_qubit_allocation.py
+++ b/frontend/test/lit/test_dynamic_qubit_allocation.py
@@ -23,6 +23,8 @@ import pennylane as qml
 from catalyst import qjit
 from catalyst.jax_primitives import qalloc_p, qdealloc_qb_p, qextract_p
 
+# pylint: disable=line-too-long
+
 
 @qjit(target="mlir")
 def test_single_qubit_dealloc():

--- a/frontend/test/lit/test_dynamic_qubit_allocation.py
+++ b/frontend/test/lit/test_dynamic_qubit_allocation.py
@@ -23,8 +23,6 @@ import pennylane as qml
 from catalyst import qjit
 from catalyst.jax_primitives import qalloc_p, qdealloc_qb_p, qextract_p
 
-# pylint: disable=line-too-long
-
 
 @qjit(target="mlir")
 def test_single_qubit_dealloc():
@@ -104,20 +102,12 @@ def test_measure_with_reset():
     Test qml.allocate with qml.measure with a reset.
     """
 
-    # CHECK: [[zero:%.+]] = stablehlo.constant dense<0> : tensor<i64>
-
     # CHECK: [[device_init_qreg:%.+]] = quantum.alloc( 3)
 
     # CHECK: [[dyn_qreg:%.+]] = quantum.alloc( 1)
     # CHECK: [[dyn_qubit:%.+]] = quantum.extract [[dyn_qreg]][ 0]
     # CHECK: [[mres:%.+]], [[mout_qubit:%.+]] = quantum.measure [[dyn_qubit]] postselect 1
-    # CHECK: [[tensor_i1_mres:%.+]] = tensor.from_elements [[mres]] : tensor<i1>
-    # CHECK: [[tensor_i64_mres:%.+]] = stablehlo.convert [[tensor_i1_mres]] : (tensor<i1>) -> tensor<i64>
-    # CHECK: [[all_zeros:%.+]] = stablehlo.broadcast_in_dim [[zero]], dims = [] : (tensor<i64>) -> tensor<i64>
-    # CHECK: [[cmp_tensor:%.+]] = stablehlo.compare  NE, [[tensor_i64_mres]], [[all_zeros]],  SIGNED : (tensor<i64>, tensor<i64>) -> tensor<i1>
-    # CHECK: [[convert:%.+]] = stablehlo.convert [[cmp_tensor]] : tensor<i1>
-    # CHECK: [[extracted_cmp:%.+]] = tensor.extract [[convert]][] : tensor<i1>
-    # CHECK: [[reset_qubit:%.+]] = scf.if [[extracted_cmp]] -> (!quantum.bit) {
+    # CHECK: [[reset_qubit:%.+]] = scf.if [[mres]] -> (!quantum.bit) {
     # CHECK:    [[x_out_qubit:%.+]] = quantum.custom "PauliX"() [[mout_qubit]]
     # CHECK:    scf.yield [[x_out_qubit]] : !quantum.bit
     # CHECK:  } else {

--- a/frontend/test/lit/test_mid_circuit_measurement.py
+++ b/frontend/test/lit/test_mid_circuit_measurement.py
@@ -100,20 +100,46 @@ print(test_one_shot_with_passes.mlir)
 @qjit(capture=True, target="mlir")
 def test_mcm_obs():
     """
-    Test generation of mcm observale operation.
+    Test generation of mcm observable operation.
     """
 
     # CHECK:  [[m0:%.+]], {{%.+}} = quantum.measure
+    # CHECK:  [[m0_tensor_i1:%.+]] = tensor.from_elements [[m0]] : tensor<i1>
+    # CHECK:  [[m0_tensor_i64:%.+]] = stablehlo.convert [[m0_tensor_i1]] : (tensor<i1>) -> tensor<i64>
+
     # CHECK:  [[m1:%.+]], {{%.+}} = quantum.measure
-    # CHECK:  [[expvalObs:%.+]] = quantum.mcmobs [[m0]] : !quantum.obs
+    # CHECK:  [[m1_tensor_i1:%.+]] = tensor.from_elements [[m1]] : tensor<i1>
+    # CHECK:  [[m1_tensor_i64:%.+]] = stablehlo.convert [[m1_tensor_i1]] : (tensor<i1>) -> tensor<i64>
+
+    # CHECK:  [[m0_tensor_i1:%.+]] = stablehlo.convert [[m0_tensor_i64]] : (tensor<i64>) -> tensor<i1>
+    # CHECK:  [[m0_i1:%.+]] = tensor.extract [[m0_tensor_i1]][] : tensor<i1>
+    # CHECK:  [[expvalObs:%.+]] = quantum.mcmobs [[m0_i1]] : !quantum.obs
     # CHECK:  [[expval:%.+]] = quantum.expval [[expvalObs]] : f64
-    # CHECK:  [[sampleObs:%.+]] = quantum.mcmobs [[m0]], [[m1]] : !quantum.obs
+
+    # CHECK:  [[m0_tensor_i1:%.+]] = stablehlo.convert [[m0_tensor_i64]] : (tensor<i64>) -> tensor<i1>
+    # CHECK:  [[m0_i1:%.+]] = tensor.extract [[m0_tensor_i1]][] : tensor<i1>
+    # CHECK:  [[m1_tensor_i1:%.+]] = stablehlo.convert [[m1_tensor_i64]] : (tensor<i64>) -> tensor<i1>
+    # CHECK:  [[m1_i1:%.+]] = tensor.extract [[m1_tensor_i1]][] : tensor<i1>
+    # CHECK:  [[sampleObs:%.+]] = quantum.mcmobs [[m0_i1]], [[m1_i1]] : !quantum.obs
     # CHECK:  [[sample:%.+]] = quantum.sample [[sampleObs]] : tensor<1000x2xf64>
-    # CHECK:  [[probsObs:%.+]] = quantum.mcmobs [[m0]], [[m1]] : !quantum.obs
+
+    # CHECK:  [[m0_tensor_i1:%.+]] = stablehlo.convert [[m0_tensor_i64]] : (tensor<i64>) -> tensor<i1>
+    # CHECK:  [[m0_i1:%.+]] = tensor.extract [[m0_tensor_i1]][] : tensor<i1>
+    # CHECK:  [[m1_tensor_i1:%.+]] = stablehlo.convert [[m1_tensor_i64]] : (tensor<i64>) -> tensor<i1>
+    # CHECK:  [[m1_i1:%.+]] = tensor.extract [[m1_tensor_i1]][] : tensor<i1>
+    # CHECK:  [[probsObs:%.+]] = quantum.mcmobs [[m0_i1]], [[m1_i1]] : !quantum.obs
     # CHECK:  [[probs:%.+]] = quantum.probs [[probsObs]] : tensor<4xf64>
-    # CHECK:  [[varObs:%.+]] = quantum.mcmobs [[m0]] : !quantum.obs
+
+    # CHECK:  [[m0_tensor_i1:%.+]] = stablehlo.convert [[m0_tensor_i64]] : (tensor<i64>) -> tensor<i1>
+    # CHECK:  [[m0_i1:%.+]] = tensor.extract [[m0_tensor_i1]][] : tensor<i1>
+    # CHECK:  [[varObs:%.+]] = quantum.mcmobs [[m0_i1]] : !quantum.obs
     # CHECK:  [[var:%.+]] = quantum.var [[varObs]] : f64
-    # CHECK:  [[countsObs:%.+]] = quantum.mcmobs [[m0]], [[m1]] : !quantum.obs
+
+    # CHECK:  [[m0_tensor_i1:%.+]] = stablehlo.convert [[m0_tensor_i64]] : (tensor<i64>) -> tensor<i1>
+    # CHECK:  [[m0_i1:%.+]] = tensor.extract [[m0_tensor_i1]][] : tensor<i1>
+    # CHECK:  [[m1_tensor_i1:%.+]] = stablehlo.convert [[m1_tensor_i64]] : (tensor<i64>) -> tensor<i1>
+    # CHECK:  [[m1_i1:%.+]] = tensor.extract [[m1_tensor_i1]][] : tensor<i1>
+    # CHECK:  [[countsObs:%.+]] = quantum.mcmobs [[m0_i1]], [[m1_i1]] : !quantum.obs
     # CHECK:  [[counts:%.+]] = quantum.counts [[countsObs]] : tensor<4xf64>, tensor<4xi64>
 
     dev = qml.device("lightning.qubit", wires=2)

--- a/frontend/test/lit/test_mid_circuit_measurement.py
+++ b/frontend/test/lit/test_mid_circuit_measurement.py
@@ -19,6 +19,8 @@ import pennylane as qml
 from catalyst import measure, qjit
 from catalyst.passes import merge_rotations
 
+# pylint: disable=line-too-long
+
 
 @qjit(target="mlir")
 @qml.qnode(qml.device("lightning.qubit", wires=1))

--- a/frontend/test/pytest/from_plxpr/test_capture_integration.py
+++ b/frontend/test/pytest/from_plxpr/test_capture_integration.py
@@ -427,6 +427,29 @@ class TestCapture:
 
         assert jnp.allclose(capture_result, expected_result)
 
+    @pytest.mark.parametrize("pred", [False, 0.0, 0])
+    def test_measure_as_condition(self, backend, pred):
+        """Test the integration for a circuit with a mid-circuit measurement used as a conditional
+        predicate.
+        """
+        device = qml.device(backend, wires=1)
+
+        qml.capture.enable()
+
+        @qjit(autograph=True)
+        @qml.qnode(device)
+        def captured_circuit():
+            m = qml.measure(wires=0)
+            if m == pred:
+                qml.X(0)
+            return qml.expval(qml.Z(0))
+
+        capture_result = captured_circuit()
+
+        qml.capture.disable()
+
+        assert jnp.allclose(capture_result, -1)
+
     @pytest.mark.parametrize("theta", (jnp.pi, 0.1, 0.0))
     def test_forloop(self, backend, theta):
         """Test the integration for a circuit with a for loop."""


### PR DESCRIPTION
**Context:**
The plxpr measure primitive returns an int type, but the catalyst meaure_p primitive returns a bool type.

When interpreting the plxpr (to convert to catalyst jaxpr), the result of `measure_p.bind()` is therefore a bool type, but the plxpr being interpreted would expect the replacement equation for the plxpr measure equation to also return an int type!

This was never exposed by our tests, and we encountered it when we tried to use a mcm result as a conditional predicate. When users explicitly request
```python
m = qml.measure(0)
if m == 0:
   ...
```

The arithmetic comparisons from the input plxpr are all on int types. The plxpr for the above scenario looks like 
```
          h:i64[] = measure[postselect=None reset=False] 0:i64[]
          i:bool[] = eq h 0:i64[]
          cond[
            # ... cond body ...
          ] i
```  

The `eq` equation is a comparison between int types, as that's what the plxpr measure primitive returns. The binded catalyst measure_p returns a bool, which is not accepted by the `eq` equation (which stays unchanged and still expects an int: the plxpr conversion interpreter doesn't have any interpretation rules for classical primitives), leading to an error like 

```
TypeError: lax.eq requires arguments to have the same dtypes, got bool, int64. (Tip: jnp.equal is a similar function that does automatic type promotion on inputs).
```

**Description of the Change:**
When interpreting plxpr's measurement primitive, after binding the catalyst measure primitive (which returns bool), cast the result to int type.

**Benefits:**
Types match: during interpretation, the new equation (catalyst measure) and the replaced equation (plxpr measure) must return the same types. 


**Related GitHub Issues:**
closes #2579 
[sc-113905], [sc-112370]