### PR TITLE
un-xfail `BasisRotation` tests

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.238
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.45.0-dev56
+pennylane=0.45.0-dev57
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.238
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.45.0-dev55
+pennylane=0.45.0-dev56
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -34,4 +34,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.45.0-dev21
 pennylane-lightning==0.45.0-dev21
-pennylane==0.45.0-dev56
+pennylane==0.45.0-dev57

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -34,4 +34,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.45.0-dev21
 pennylane-lightning==0.45.0-dev21
-pennylane==0.45.0-dev55
+pennylane==0.45.0-dev56

--- a/frontend/test/pytest/test_template.py
+++ b/frontend/test/pytest/test_template.py
@@ -1126,7 +1126,6 @@ def test_qutrit_basis_state_preparation(backend):
     assert np.allclose(interpreted_fn(basis_state, obs), jitted_fn(basis_state, obs))
 
 
-@pytest.mark.xfail(reason="givens issue under investigation")
 def test_basis_rotation(backend):
     """Test BasisRotation"""
 


### PR DESCRIPTION
**Context:**
https://github.com/PennyLaneAI/pennylane/pull/9155/ fixes `BasisRotation`, so that we can remove an `xfail` in the frontend tests.

**Description of the Change:**
remove `xfail`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
