### PR TITLE
Allow quantum adjoint op to take in arbitrary arguments

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -232,7 +232,7 @@
 
 <h3>Improvements 🛠</h3>
 
-* The `quantum.adjoint` and `qref.adjoint` operations can now take in multiple quantum values, allowing
+* The `quantum.adjoint` operation can now take in multiple quantum values, allowing
   both qubits and registers, as opposed to constraining the operand to be a single quantum register.
   [(#2590)](https://github.com/PennyLaneAI/catalyst/pull/2590)
 
@@ -448,6 +448,7 @@
 * A new dialect `QRef` was created. This dialect is very similar to the existing `Quantum` dialect,
   but it is in reference semantics, whereas the existing `Quantum` dialect is in value semantics.
   [(#2320)](https://github.com/PennyLaneAI/catalyst/pull/2320)
+  [(#2590)](https://github.com/PennyLaneAI/catalyst/pull/2590)
 
   Unlike qubit (or qreg) SSA values in the `Quantum` dialect, a qubit (or qreg) reference SSA value
   in the `QRef` dialect is allowed to be used multiple times. The operands of gates and observables

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -232,6 +232,10 @@
 
 <h3>Improvements 🛠</h3>
 
+* The `quantum.adjoint` and `qref.adjoint` operations can now take in multiple quantum values, allowing
+  both qubits and registers, as opposed to constraining the operand to be a single quantum register.
+  [(#2590)](https://github.com/PennyLaneAI/catalyst/pull/2590)
+
 * Catalyst with program capture now supports device preprocessing. Currently, preprocessing transforms
   that do not have native MLIR or xDSL implementations will be replaced with empty transforms.
   [(#2557)](https://github.com/PennyLaneAI/catalyst/pull/2557)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -341,6 +341,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Quantum adjoint can now be used on subroutines with classical arguments.
+  [(#2590)](https://github.com/PennyLaneAI/catalyst/pull/2590)
+
 * Fixed a bug where input array arguments could be mutated during execution when copied inputs
   were updated in-place. Entry-point arguments are now treated as non-writable during bufferization,
   preserving the expected immutability of user inputs.

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -2765,7 +2765,7 @@ def _adjoint_lowering(
     ), f"Expected a single result of quantum.register type, got: {output_types}"
 
     # Build an adjoint operation with a single-block region.
-    op = AdjointOp(output_types[0], qargs[0])
+    op = AdjointOp(output_types, qargs)
     adjoint_block = op.regions[0].blocks.append(*[mlir.aval_to_ir_types(a)[0] for a in aqargs])
     with ir.InsertionPoint(adjoint_block):
         source_info_util.extend_name_stack("adjoint")

--- a/frontend/catalyst/python_interface/dialects/quantum/operations/miscellaneous_ops.py
+++ b/frontend/catalyst/python_interface/dialects/quantum/operations/miscellaneous_ops.py
@@ -28,7 +28,6 @@ from xdsl.irdl import (
     ParsePropInAttrDict,
     irdl_op_definition,
     lazy_traits_def,
-    operand_def,
     opt_operand_def,
     opt_prop_def,
     prop_def,

--- a/frontend/catalyst/python_interface/dialects/quantum/operations/miscellaneous_ops.py
+++ b/frontend/catalyst/python_interface/dialects/quantum/operations/miscellaneous_ops.py
@@ -16,6 +16,7 @@ This file contains the definition of miscellaneous operations in the
 Quantum dialect.
 """
 from collections.abc import Sequence
+from typing import ClassVar
 
 from xdsl.dialects.builtin import (
     StringAttr,
@@ -24,8 +25,10 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.ir import Block, Operation, Region
 from xdsl.irdl import (
+    AnyOf,
     IRDLOperation,
     ParsePropInAttrDict,
+    VarConstraint,
     irdl_op_definition,
     lazy_traits_def,
     opt_operand_def,
@@ -53,15 +56,17 @@ from ..attributes import QubitSSAValue, QubitType, QuregSSAValue, QuregType
 class AdjointOp(IRDLOperation):
     """Calculate the adjoint of the enclosed operations"""
 
+    T: ClassVar = VarConstraint("T", AnyOf([QubitType, QuregType]))
+
     name = "quantum.adjoint"
 
     assembly_format = """
-        `(` $args `)` attr-dict `:` type($args) `->` type($outs) $region
+        `(` $args `)` attr-dict `:` type($outs) $region
     """
 
-    args = var_operand_def(QuregType | QubitType)
+    args = var_operand_def(T)
 
-    outs = var_result_def(QuregType | QubitType)
+    outs = var_result_def(T)
 
     region = region_def("single_block")
 
@@ -74,19 +79,6 @@ class AdjointOp(IRDLOperation):
     ):
         result_types = tuple(arg.type for arg in args)
         super().__init__(operands=(args,), result_types=(result_types,), regions=(region,))
-
-
-@irdl_op_definition
-class YieldOp(IRDLOperation):
-    """Return results from quantum program regions"""
-
-    name = "quantum.yield"
-
-    assembly_format = "attr-dict ($retvals^ `:` type($retvals))?"
-
-    retvals = var_operand_def(QuregType | QubitType)
-
-    traits = traits_def(HasParent(AdjointOp), IsTerminator(), Pure(), ReturnLike())
 
 
 @irdl_op_definition
@@ -150,3 +142,16 @@ class NumQubitsOp(IRDLOperation):
     """
 
     num_qubits = result_def(i64)
+
+
+@irdl_op_definition
+class YieldOp(IRDLOperation):
+    """Return results from quantum program regions"""
+
+    name = "quantum.yield"
+
+    assembly_format = "attr-dict ($retvals^ `:` type($retvals))?"
+
+    retvals = var_operand_def(QuregType | QubitType)
+
+    traits = traits_def(HasParent(AdjointOp), IsTerminator(), Pure(), ReturnLike())

--- a/frontend/catalyst/python_interface/dialects/quantum/operations/miscellaneous_ops.py
+++ b/frontend/catalyst/python_interface/dialects/quantum/operations/miscellaneous_ops.py
@@ -36,6 +36,7 @@ from xdsl.irdl import (
     result_def,
     traits_def,
     var_operand_def,
+    var_result_def,
 )
 from xdsl.traits import (
     HasParent,
@@ -46,7 +47,7 @@ from xdsl.traits import (
     SingleBlockImplicitTerminator,
 )
 
-from ..attributes import QuregSSAValue, QuregType
+from ..attributes import QubitSSAValue, QubitType, QuregSSAValue, QuregType
 
 
 @irdl_op_definition
@@ -56,12 +57,12 @@ class AdjointOp(IRDLOperation):
     name = "quantum.adjoint"
 
     assembly_format = """
-        `(` $qreg `)` attr-dict `:` type(operands) $region
+        `(` $args `)` attr-dict `:` type($args) `->` type($outs) $region
     """
 
-    qreg = operand_def(QuregType)
+    args = var_operand_def(QuregType | QubitType)
 
-    out_qreg = result_def(QuregType)
+    outs = var_result_def(QuregType | QubitType)
 
     region = region_def("single_block")
 
@@ -69,10 +70,24 @@ class AdjointOp(IRDLOperation):
 
     def __init__(
         self,
-        qreg: QuregSSAValue | Operation,
+        args: Sequence[QuregSSAValue | QubitSSAValue] | Operation,
         region: Region | Sequence[Operation] | Sequence[Block],
     ):
-        super().__init__(operands=(qreg,), result_types=(QuregType(),), regions=(region,))
+        result_types = tuple(arg.type for arg in args)
+        super().__init__(operands=(args,), result_types=(result_types,), regions=(region,))
+
+
+@irdl_op_definition
+class YieldOp(IRDLOperation):
+    """Return results from quantum program regions"""
+
+    name = "quantum.yield"
+
+    assembly_format = "attr-dict ($retvals^ `:` type($retvals))?"
+
+    retvals = var_operand_def(QuregType | QubitType)
+
+    traits = traits_def(HasParent(AdjointOp), IsTerminator(), Pure(), ReturnLike())
 
 
 @irdl_op_definition
@@ -136,16 +151,3 @@ class NumQubitsOp(IRDLOperation):
     """
 
     num_qubits = result_def(i64)
-
-
-@irdl_op_definition
-class YieldOp(IRDLOperation):
-    """Return results from quantum program regions"""
-
-    name = "quantum.yield"
-
-    assembly_format = "attr-dict ($retvals^ `:` type($retvals))?"
-
-    retvals = var_operand_def(QuregType)
-
-    traits = traits_def(HasParent(AdjointOp), IsTerminator(), Pure(), ReturnLike())

--- a/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
@@ -786,18 +786,16 @@ class TestAssemblyFormat:
         //////////// Quantum register ////////////
         //////////////////////////////////////////
         // CHECK: [[QREG:%.+]] = "test.op"() : () -> !quantum.reg
-        // CHECK: [[QUBIT:%.+]] = "test.op"() : () -> !quantum.bit
         %qreg = "test.op"() : () -> !quantum.reg
-        %qubit = "test.op"() : () -> !quantum.bit
 
         //////////// **AdjointOp and YieldOp tests** ////////////
-        // CHECK:      quantum.adjoint([[QREG]], [[QUBIT]]) : !quantum.reg, !quantum.bit -> !quantum.reg, !quantum.bit {
-        // CHECK-NEXT: ^bb0([[ARG_QREG:%.+]] : !quantum.reg, [[ARG_QUBIT:%.+]] : !quantum.bit):
-        // CHECK-NEXT:   quantum.yield [[ARG_QREG]], [[ARG_QUBIT]] : !quantum.reg, !quantum.bit
+        // CHECK:      quantum.adjoint([[QREG]]) : !quantum.reg {
+        // CHECK-NEXT: ^bb0([[ARG_QREG:%.+]] : !quantum.reg):
+        // CHECK-NEXT:   quantum.yield [[ARG_QREG]] : !quantum.reg
         // CHECK-NEXT: }
-        %qreg1, %qubit1 = quantum.adjoint(%qreg, %qubit) : !quantum.reg, !quantum.bit -> !quantum.reg, !quantum.bit {
-        ^bb0(%arg_qreg: !quantum.reg, %arg_qubit: !quantum.bit):
-          quantum.yield %arg_qreg, %arg_qubit : !quantum.reg, !quantum.bit
+        %qreg1 = quantum.adjoint(%qreg) : !quantum.reg {
+        ^bb0(%arg_qreg: !quantum.reg):
+          quantum.yield %arg_qreg : !quantum.reg
         }
 
         //////////// **DeviceInitOp tests** ////////////

--- a/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
@@ -120,7 +120,7 @@ int_attr = IntegerAttr(0, 32)
 expected_ops_init_kwargs = {
     "AdjointOp": [
         {
-            "qreg": qreg,
+            "args": (qreg, q0, q1),
             "region": Region(Block((CustomOp(gate_name="CNOT", in_qubits=(q0, q1)),))),
         }
     ],
@@ -786,16 +786,18 @@ class TestAssemblyFormat:
         //////////// Quantum register ////////////
         //////////////////////////////////////////
         // CHECK: [[QREG:%.+]] = "test.op"() : () -> !quantum.reg
+        // CHECK: [[QUBIT:%.+]] = "test.op"() : () -> !quantum.bit
         %qreg = "test.op"() : () -> !quantum.reg
+        %qubit = "test.op"() : () -> !quantum.bit
 
         //////////// **AdjointOp and YieldOp tests** ////////////
-        // CHECK:      quantum.adjoint([[QREG]]) : !quantum.reg {
-        // CHECK-NEXT: ^bb0([[ARG_QREG:%.+]] : !quantum.reg):
-        // CHECK-NEXT:   quantum.yield [[ARG_QREG]] : !quantum.reg
+        // CHECK:      quantum.adjoint([[QREG]], [[QUBIT]]) : !quantum.reg, !quantum.bit -> !quantum.reg, !quantum.bit {
+        // CHECK-NEXT: ^bb0([[ARG_QREG:%.+]] : !quantum.reg, [[ARG_QUBIT:%.+]] : !quantum.bit):
+        // CHECK-NEXT:   quantum.yield [[ARG_QREG]], [[ARG_QUBIT]] : !quantum.reg, !quantum.bit
         // CHECK-NEXT: }
-        %qreg1 = quantum.adjoint(%qreg) : !quantum.reg {
-        ^bb0(%arg_qreg: !quantum.reg):
-          quantum.yield %arg_qreg : !quantum.reg
+        %qreg1, %qubit1 = quantum.adjoint(%qreg, %qubit) : !quantum.reg, !quantum.bit -> !quantum.reg, !quantum.bit {
+        ^bb0(%arg_qreg: !quantum.reg, %arg_qubit: !quantum.bit):
+          quantum.yield %arg_qreg, %arg_qubit : !quantum.reg, !quantum.bit
         }
 
         //////////// **DeviceInitOp tests** ////////////

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -590,6 +590,25 @@ class TestCatalyst:
         observed = qjit(circuit)()
         assert_allclose(expected, observed)
 
+    @pytest.mark.usefixtures("use_both_frontend")
+    def test_adjoint_subroutine_with_classical_args(self, backend):
+        """Test an adjoint on a subroutine, with classical arguments"""
+
+        @qml.templates.Subroutine
+        def f(x, wires):
+            qml.IsingXX(x, wires)
+
+        dev = qml.device(backend, wires=4)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.adjoint(f)(0.5, (0, 1))
+            return qml.probs(wires=0)
+
+        expected = circuit()
+        observed = qjit(circuit)()
+        assert_allclose(expected, observed)
+
     def test_adjoint_outside_qjit(self, backend):
         """Test that the hybrid adjoint can be used from outside qjit & qnode."""
 

--- a/mlir/include/QRef/IR/QRefInterfaces.td
+++ b/mlir/include/QRef/IR/QRefInterfaces.td
@@ -17,34 +17,6 @@
 
 include "mlir/IR/OpBase.td"
 
-def QuantumRegion : OpInterface<"QuantumRegion"> {
-    let description = [{
-        This interface provides a generic way to interact with instructions that are
-        considered quantum regions. These are characterized by operating on a single
-        qubit register reference.
-    }];
-
-    let cppNamespace = "::catalyst::qref";
-
-    let methods = [
-        InterfaceMethod<
-            "Return the quantum register operand.",
-            "mlir::Value", "getRegisterOperand", (ins), /*methodBody=*/[{
-                return $_op->getOperand(0);
-            }]
-        >
-    ];
-
-    let verify = [{
-
-        if ($_op->getNumOperands() != 1) {
-            return $_op->emitOpError("must have exactly one operand (a quantum register)");
-        }
-
-        return mlir::success();
-    }];
-}
-
 def QuantumOperation : OpInterface<"QuantumOperation"> {
     let description = [{
         A base class for all quantum operations that can be considered actions on qubits.

--- a/mlir/include/QRef/IR/QRefOps.td
+++ b/mlir/include/QRef/IR/QRefOps.td
@@ -525,17 +525,17 @@ def QubitUnitaryOp : UnitaryGate_Op<"unitary", [ParametrizedGate, AttrSizedOpera
 class Region_Op<string mnemonic, list<Trait> traits = []> :
         QRef_Op<mnemonic, traits # []>;
 
-def AdjointOp : Region_Op<"adjoint", [QuantumRegion, NoTerminator]> {
+def AdjointOp : Region_Op<"adjoint", [NoTerminator]> {
     let summary = "Calculate the adjoint of the enclosed operations";
 
     let regions = (region SizedRegion<1>:$region);
 
     let arguments = (ins
-        QuregRefType:$qreg
+        Variadic<AnyTypeOf<[QuregRefType, QubitRefType]>>:$args
     );
 
     let assemblyFormat = [{
-        `(` $qreg `)` attr-dict `:` type(operands) $region
+        `(` $args `)` attr-dict `:` type(operands) $region
     }];
 
     let hasVerifier = 1;

--- a/mlir/include/QRef/IR/QRefOps.td
+++ b/mlir/include/QRef/IR/QRefOps.td
@@ -530,12 +530,8 @@ def AdjointOp : Region_Op<"adjoint", [NoTerminator]> {
 
     let regions = (region SizedRegion<1>:$region);
 
-    let arguments = (ins
-        Variadic<AnyTypeOf<[QuregRefType, QubitRefType]>>:$args
-    );
-
     let assemblyFormat = [{
-        `(` $args `)` attr-dict `:` type(operands) $region
+        attr-dict-with-keyword $region
     }];
 
     let hasVerifier = 1;

--- a/mlir/include/Quantum/IR/QuantumInterfaces.td
+++ b/mlir/include/Quantum/IR/QuantumInterfaces.td
@@ -17,42 +17,6 @@
 
 include "mlir/IR/OpBase.td"
 
-def QuantumRegion : OpInterface<"QuantumRegion"> {
-    let description = [{
-        This interface provides a generic way to interact with instructions that are
-        considered quantum regions. These are characterized by operating on a single
-        qubit register, and returning a new register value.
-    }];
-
-    let cppNamespace = "::catalyst::quantum";
-
-    let methods = [
-        InterfaceMethod<
-            "Return the quantum register operand.",
-            "mlir::Value", "getRegisterOperand", (ins), /*methodBody=*/[{
-                return $_op->getOperand(0);
-            }]
-        >,
-        InterfaceMethod<
-            "Return the quantum register result.",
-            "mlir::Value", "getRegisterResult", (ins), /*methodBody=*/[{
-                return $_op->getResult(0);
-            }]
-        >,
-    ];
-
-    let verify = [{
-
-        if ($_op->getNumOperands() != 1)
-            return $_op->emitOpError("must have exactly one operand (quantum register)");
-
-        if ($_op->getNumResults() != 1)
-            return $_op->emitOpError("must have exactly one result (quantum register)");
-
-        return mlir::success();
-    }];
-}
-
 def QuantumOperation : OpInterface<"QuantumOperation"> {
     let description = [{
         This interface provides a generic way to interact with instructions that are

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -766,7 +766,7 @@ def YieldOp : Quantum_Op<"yield", [Pure, ReturnLike, Terminator, ParentOneOf<["A
     let summary = "Return results from quantum program regions";
 
     let arguments = (ins
-        Variadic<QuregType>:$retvals
+        Variadic<AnyTypeOf<[QuregType, QubitType]>>:$retvals
     );
 
     let assemblyFormat = [{

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -742,7 +742,7 @@ def QubitUnitaryOp : UnitaryGate_Op<"unitary", [ParametrizedGate, NoMemoryEffect
 class Region_Op<string mnemonic, list<Trait> traits = []> :
         Quantum_Op<mnemonic, traits # [NoMemoryEffect]>;
 
-def AdjointOp : Region_Op<"adjoint", [SingleBlockImplicitTerminator<"YieldOp">]> {
+def AdjointOp : Region_Op<"adjoint", [SingleBlockImplicitTerminator<"YieldOp">, AllTypesMatch<["args", "results"]>]> {
     let summary = "Calculate the adjoint of the enclosed operations";
 
     let regions = (region SizedRegion<1>:$region);
@@ -756,7 +756,7 @@ def AdjointOp : Region_Op<"adjoint", [SingleBlockImplicitTerminator<"YieldOp">]>
     );
 
     let assemblyFormat = [{
-        `(` $args `)` attr-dict `:` type(operands) `->` type(results) $region
+        `(` $args `)` attr-dict `:` type($results) $region
     }];
 
     let hasVerifier = 1;

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -742,21 +742,21 @@ def QubitUnitaryOp : UnitaryGate_Op<"unitary", [ParametrizedGate, NoMemoryEffect
 class Region_Op<string mnemonic, list<Trait> traits = []> :
         Quantum_Op<mnemonic, traits # [NoMemoryEffect]>;
 
-def AdjointOp : Region_Op<"adjoint", [QuantumRegion, SingleBlockImplicitTerminator<"YieldOp">]> {
+def AdjointOp : Region_Op<"adjoint", [SingleBlockImplicitTerminator<"YieldOp">]> {
     let summary = "Calculate the adjoint of the enclosed operations";
 
     let regions = (region SizedRegion<1>:$region);
 
     let arguments = (ins
-        QuregType:$qreg
+        Variadic<AnyTypeOf<[QuregType, QubitType]>>:$args
     );
 
     let results = (outs
-        QuregType:$out_qreg
+        Variadic<AnyTypeOf<[QuregType, QubitType]>>:$results
     );
 
     let assemblyFormat = [{
-        `(` $qreg `)` attr-dict `:` type(operands) $region
+        `(` $args `)` attr-dict `:` type(operands) `->` type(results) $region
     }];
 
     let hasVerifier = 1;

--- a/mlir/lib/Gradient/Transforms/GradMethods/ClassicalJacobian.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/ClassicalJacobian.cpp
@@ -95,8 +95,8 @@ func::FuncOp genParamCountFunction(PatternRewriter &rewriter, Location loc, func
             else if (auto gate = dyn_cast<quantum::QuantumOperation>(op)) {
                 rewriter.replaceOp(op, gate.getQubitOperands());
             }
-            else if (auto region = dyn_cast<quantum::QuantumRegion>(op)) {
-                rewriter.replaceOp(op, region.getRegisterOperand());
+            else if (auto adjointOp = dyn_cast<quantum::AdjointOp>(op)) {
+                rewriter.replaceOp(op, adjointOp.getArgs());
             }
             else if (isa<quantum::DeallocOp>(op)) {
                 rewriter.eraseOp(op);
@@ -185,8 +185,8 @@ func::FuncOp genSplitPreprocessed(PatternRewriter &rewriter, Location loc, func:
             else if (auto gate = dyn_cast<quantum::QuantumOperation>(op)) {
                 rewriter.replaceOp(op, gate.getQubitOperands());
             }
-            else if (auto region = dyn_cast<quantum::QuantumRegion>(op)) {
-                rewriter.replaceOp(op, region.getRegisterOperand());
+            else if (auto adjointOp = dyn_cast<quantum::AdjointOp>(op)) {
+                rewriter.replaceOp(op, adjointOp.getArgs());
             }
             else if (isa<quantum::DeallocOp>(op)) {
                 rewriter.eraseOp(op);

--- a/mlir/lib/Gradient/Transforms/GradMethods/PS_QuantumGradient.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/PS_QuantumGradient.cpp
@@ -306,8 +306,8 @@ func::FuncOp ParameterShiftLowering::genQGradFunction(PatternRewriter &rewriter,
                 // so that we can safely delete it (all quantum ops must be eliminated).
                 rewriter.replaceOp(gate, gate.getQubitOperands());
             }
-            else if (auto region = dyn_cast<quantum::QuantumRegion>(op)) {
-                rewriter.replaceOp(op, region.getRegisterOperand());
+            else if (auto adjointOp = dyn_cast<quantum::AdjointOp>(op)) {
+                rewriter.replaceOp(op, adjointOp.getArgs());
             }
             else if (isa<quantum::DeallocOp>(op)) {
                 rewriter.eraseOp(op);

--- a/mlir/lib/Mitigation/Transforms/MitigationMethods/Zne.cpp
+++ b/mlir/lib/Mitigation/Transforms/MitigationMethods/Zne.cpp
@@ -290,7 +290,7 @@ FlatSymbolRefAttr globalFolding(Location loc, PatternRewriter &rewriter, std::st
                         .getResult(0);
                 quantum::YieldOp::create(builder, loc, fnWithoutMeasurementsAdjointQreg);
                 builder.setInsertionPointAfter(adjointOp);
-                scf::YieldOp::create(builder, loc, adjointOp.getResult());
+                scf::YieldOp::create(builder, loc, adjointOp.getResults());
             })
             .getResult(0);
     std::vector<Value> argsAndRegMeasurement(fnFoldedOp.getArguments().begin(),

--- a/mlir/lib/QRef/IR/QRefOps.cpp
+++ b/mlir/lib/QRef/IR/QRefOps.cpp
@@ -211,13 +211,15 @@ LogicalResult AdjointOp::verify()
     }
 
     Block &b = this->getRegion().front();
-    if (b.getNumArguments() != this->getArgs().size()){
-        return emitOpError("Adjoint op number of operands must be the same as the number of arguments on its block");
+    if (b.getNumArguments() != this->getArgs().size()) {
+        return emitOpError("Adjoint op number of operands must be the same as the number of "
+                           "arguments on its block");
     }
 
-    for (auto [operand, bbArg] : llvm::zip_equal(this->getArgs(), b.getArguments())){
-        if (operand.getType() != bbArg.getType()){
-            return emitOpError("Adjoint op operand types must be the same as the argument types on its block");
+    for (auto [operand, bbArg] : llvm::zip_equal(this->getArgs(), b.getArguments())) {
+        if (operand.getType() != bbArg.getType()) {
+            return emitOpError(
+                "Adjoint op operand types must be the same as the argument types on its block");
         }
     }
 

--- a/mlir/lib/QRef/IR/QRefOps.cpp
+++ b/mlir/lib/QRef/IR/QRefOps.cpp
@@ -211,16 +211,8 @@ LogicalResult AdjointOp::verify()
     }
 
     Block &b = this->getRegion().front();
-    if (b.getNumArguments() != this->getArgs().size()) {
-        return emitOpError("Adjoint op number of operands must be the same as the number of "
-                           "arguments on its block");
-    }
-
-    for (auto [operand, bbArg] : llvm::zip_equal(this->getArgs(), b.getArguments())) {
-        if (operand.getType() != bbArg.getType()) {
-            return emitOpError(
-                "Adjoint op operand types must be the same as the argument types on its block");
-        }
+    if (b.getNumArguments() != 0) {
+        return emitOpError("qref.adjoint op must have no arguments on its block");
     }
 
     return success();

--- a/mlir/lib/QRef/IR/QRefOps.cpp
+++ b/mlir/lib/QRef/IR/QRefOps.cpp
@@ -210,6 +210,17 @@ LogicalResult AdjointOp::verify()
         return emitOpError("quantum measurements are not allowed in the adjoint regions");
     }
 
+    Block &b = this->getRegion().front();
+    if (b.getNumArguments() != this->getArgs().size()){
+        return emitOpError("Adjoint op number of operands must be the same as the number of arguments on its block");
+    }
+
+    for (auto [operand, bbArg] : llvm::zip_equal(this->getArgs(), b.getArguments())){
+        if (operand.getType() != bbArg.getType()){
+            return emitOpError("Adjoint op operand types must be the same as the argument types on its block");
+        }
+    }
+
     return success();
 }
 

--- a/mlir/lib/Quantum/IR/QuantumOps.cpp
+++ b/mlir/lib/Quantum/IR/QuantumOps.cpp
@@ -560,9 +560,5 @@ LogicalResult AdjointOp::verify()
         }
     }
 
-    if (this->getOperandTypes() != this->getResultTypes()) {
-        return emitOpError("Adjoint op operand types and result types must be the same");
-    }
-
     return success();
 }

--- a/mlir/lib/Quantum/IR/QuantumOps.cpp
+++ b/mlir/lib/Quantum/IR/QuantumOps.cpp
@@ -548,13 +548,15 @@ LogicalResult AdjointOp::verify()
     }
 
     Block &b = this->getRegion().front();
-    if (b.getNumArguments() != this->getArgs().size()){
-        return emitOpError("Adjoint op number of operands must be the same as the number of arguments on its block");
+    if (b.getNumArguments() != this->getArgs().size()) {
+        return emitOpError("Adjoint op number of operands must be the same as the number of "
+                           "arguments on its block");
     }
 
-    for (auto [operand, bbArg] : llvm::zip_equal(this->getArgs(), b.getArguments())){
-        if (operand.getType() != bbArg.getType()){
-            return emitOpError("Adjoint op operand types must be the same as the argument types on its block");
+    for (auto [operand, bbArg] : llvm::zip_equal(this->getArgs(), b.getArguments())) {
+        if (operand.getType() != bbArg.getType()) {
+            return emitOpError(
+                "Adjoint op operand types must be the same as the argument types on its block");
         }
     }
 

--- a/mlir/lib/Quantum/IR/QuantumOps.cpp
+++ b/mlir/lib/Quantum/IR/QuantumOps.cpp
@@ -560,5 +560,9 @@ LogicalResult AdjointOp::verify()
         }
     }
 
+    if (this->getOperandTypes() != this->getResultTypes()) {
+        return emitOpError("Adjoint op operand types and result types must be the same");
+    }
+
     return success();
 }

--- a/mlir/lib/Quantum/IR/QuantumOps.cpp
+++ b/mlir/lib/Quantum/IR/QuantumOps.cpp
@@ -547,5 +547,16 @@ LogicalResult AdjointOp::verify()
         return emitOpError("quantum measurements are not allowed in the adjoint regions");
     }
 
+    Block &b = this->getRegion().front();
+    if (b.getNumArguments() != this->getArgs().size()){
+        return emitOpError("Adjoint op number of operands must be the same as the number of arguments on its block");
+    }
+
+    for (auto [operand, bbArg] : llvm::zip_equal(this->getArgs(), b.getArguments())){
+        if (operand.getType() != bbArg.getType()){
+            return emitOpError("Adjoint op operand types must be the same as the argument types on its block");
+        }
+    }
+
     return success();
 }

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <mlir/IR/Block.h>
+#include <mlir/IR/Value.h>
 #define DEBUG_TYPE "adjoint"
 
 #include <algorithm>
@@ -401,10 +403,17 @@ class AdjointGenerator {
         }
         for (size_t i = 0; i < args.size(); i++) {
             if (!isa<QuregType, QubitType>(args[i].getType())) {
-                continue;
+                if (!isa<BlockArgument>(args[i]) &&
+                    args[i].getDefiningOp()->getParentRegion() == callOp->getParentRegion()) {
+                    // Encountered a classical call operand from within the adjoint region
+                    // Must use the clone outside
+                    args[i] = remappedValues.lookup(args[i]);
+                }
             }
-            args[i] = reversedResults.front();
-            reversedResults.pop();
+            else {
+                args[i] = reversedResults.front();
+                reversedResults.pop();
+            }
         }
 
         // Call the adjoint func op

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -306,6 +306,32 @@ class AdjointGenerator {
         }
     }
 
+    void getAdjointCallOpArgs(func::CallOp callOp, std::vector<Value> &args)
+    {
+        // Get the reversed results
+        args = {callOp.getArgOperands().begin(), callOp.getArgOperands().end()};
+        std::queue<Value> reversedResults;
+        for (Value callResult : callOp.getResults()) {
+            if (!isa<QuregType, QubitType>(callResult.getType())) {
+                continue;
+            }
+            reversedResults.push(remappedValues.lookup(callResult));
+        }
+        for (size_t i = 0; i < args.size(); i++) {
+            if (!isa<QuregType, QubitType>(args[i].getType())) {
+                if (!isa<BlockArgument>(args[i]) &&
+                    args[i].getDefiningOp()->getParentRegion() == callOp->getParentRegion()) {
+                    // Encountered a classical call operand from within the adjoint region
+                    // Must use the clone outside
+                    args[i] = remappedValues.lookup(args[i]);
+                }
+            }
+            else {
+                args[i] = reversedResults.front();
+                reversedResults.pop();
+            }
+        }
+    }
     void visitOperation(func::CallOp callOp, OpBuilder &builder)
     {
         // Get the the original function
@@ -392,29 +418,8 @@ class AdjointGenerator {
         // Leave the adjoint func op to go back at the saved insertion
         builder.restoreInsertionPoint(insertionSaved);
 
-        // Get the reversed results
-        std::vector<Value> args = {callOp.getArgOperands().begin(), callOp.getArgOperands().end()};
-        std::queue<Value> reversedResults;
-        for (Value callResult : callOp.getResults()) {
-            if (!isa<QuregType, QubitType>(callResult.getType())) {
-                continue;
-            }
-            reversedResults.push(remappedValues.lookup(callResult));
-        }
-        for (size_t i = 0; i < args.size(); i++) {
-            if (!isa<QuregType, QubitType>(args[i].getType())) {
-                if (!isa<BlockArgument>(args[i]) &&
-                    args[i].getDefiningOp()->getParentRegion() == callOp->getParentRegion()) {
-                    // Encountered a classical call operand from within the adjoint region
-                    // Must use the clone outside
-                    args[i] = remappedValues.lookup(args[i]);
-                }
-            }
-            else {
-                args[i] = reversedResults.front();
-                reversedResults.pop();
-            }
-        }
+        std::vector<Value> args;
+        getAdjointCallOpArgs(callOp, args);
 
         // Call the adjoint func op
         auto adjointCallOp = func::CallOp::create(builder, loc, adjointFnOp, args);

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -57,7 +57,6 @@ void cloneAdjointRegion(AdjointOp op, OpBuilder &builder, IRMapping &mapping,
         builder.clone(op, mapping);
     }
     auto yieldOp = cast<quantum::YieldOp>(block.getTerminator());
-    // return mapping.lookupOrDefault(yieldOp.getOperand(0));
     for (Value yieldVal : yieldOp->getOperands()) {
         reversedResults.push_back(mapping.lookupOrDefault(yieldVal));
     }
@@ -125,15 +124,12 @@ class AdjointGenerator {
                 visitOperation(ppr, builder);
             }
             else if (auto adjointOp = dyn_cast<quantum::AdjointOp>(&op)) {
-                // BlockArgument regionArg = adjointOp.getRegion().getArgument(0);
-                // Value result = adjointOp.getResult();
                 for (auto [regionArg, result] : llvm::zip_equal(
                          adjointOp.getRegion().getArguments(), adjointOp.getResults())) {
                     remappedValues.map(regionArg, remappedValues.lookup(result));
                 }
                 SmallVector<Value> reversedResults;
                 cloneAdjointRegion(adjointOp, builder, remappedValues, reversedResults);
-                // remappedValues.map(adjointOp.getQreg(), reversedResult);
                 for (auto [operand, reversedResult] :
                      llvm::zip_equal(adjointOp.getArgs(), reversedResults)) {
                     remappedValues.map(operand, reversedResult);

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <queue>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -391,32 +392,33 @@ class AdjointGenerator {
 
         // Get the reversed results
         std::vector<Value> args = {callOp.getArgOperands().begin(), callOp.getArgOperands().end()};
-        SmallVector<Value> reversedResults;
+        std::queue<Value> reversedResults;
         for (Value callResult : callOp.getResults()) {
             if (!isa<QuregType, QubitType>(callResult.getType())) {
                 continue;
             }
-            reversedResults.push_back(remappedValues.lookup(callResult));
+            reversedResults.push(remappedValues.lookup(callResult));
         }
-
-        size_t current_reversed_result = 0;
         for (size_t i = 0; i < args.size(); i++) {
             if (!isa<QuregType, QubitType>(args[i].getType())) {
                 continue;
             }
-            args[i] = reversedResults[current_reversed_result];
-            current_reversed_result++;
+            args[i] = reversedResults.front();
+            reversedResults.pop();
         }
 
         // Call the adjoint func op
         auto adjointCallOp = func::CallOp::create(builder, loc, adjointFnOp, args);
-        size_t i = 0;
+        std::queue<Value> adjointCallOpResults;
+        for (Value adjointCallResult : adjointCallOp->getResults()) {
+            adjointCallOpResults.push(adjointCallResult);
+        }
         for (auto callOperand : callOp.getArgOperands()) {
             if (!isa<QuregType, QubitType>(callOperand.getType())) {
                 continue;
             }
-            remappedValues.map(callOperand, adjointCallOp.getResult(i));
-            i++;
+            remappedValues.map(callOperand, adjointCallOpResults.front());
+            adjointCallOpResults.pop();
         }
     }
 

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -49,14 +49,17 @@ namespace {
 
 /// Clone the region of the adjoint operation `op` to the insertion point specified by the
 /// `builder`. Build and return the value mapping `mapping`.
-Value cloneAdjointRegion(AdjointOp op, OpBuilder &builder, IRMapping &mapping)
+void cloneAdjointRegion(AdjointOp op, OpBuilder &builder, IRMapping &mapping, SmallVector<Value> &reversedResults)
 {
     Block &block = op.getRegion().front();
     for (Operation &op : block.without_terminator()) {
         builder.clone(op, mapping);
     }
     auto yieldOp = cast<quantum::YieldOp>(block.getTerminator());
-    return mapping.lookupOrDefault(yieldOp.getOperand(0));
+    //return mapping.lookupOrDefault(yieldOp.getOperand(0));
+    for (Value yieldVal : yieldOp->getOperands()){
+        reversedResults.push_back(mapping.lookupOrDefault(yieldVal));
+    }
 }
 
 /// A class that generates the quantum "backwards pass" of the adjoint operation using the stored
@@ -121,11 +124,17 @@ class AdjointGenerator {
                 visitOperation(ppr, builder);
             }
             else if (auto adjointOp = dyn_cast<quantum::AdjointOp>(&op)) {
-                BlockArgument regionArg = adjointOp.getRegion().getArgument(0);
-                Value result = adjointOp.getResult();
-                remappedValues.map(regionArg, remappedValues.lookup(result));
-                Value reversedResult = cloneAdjointRegion(adjointOp, builder, remappedValues);
-                remappedValues.map(adjointOp.getQreg(), reversedResult);
+                // BlockArgument regionArg = adjointOp.getRegion().getArgument(0);
+                // Value result = adjointOp.getResult();
+                for (auto [regionArg, result] : llvm::zip_equal(adjointOp.getRegion().getArguments(), adjointOp.getResults())){
+                    remappedValues.map(regionArg, remappedValues.lookup(result));
+                }
+                SmallVector<Value> reversedResults;
+                cloneAdjointRegion(adjointOp, builder, remappedValues, reversedResults);
+                //remappedValues.map(adjointOp.getQreg(), reversedResult);
+                for (auto [operand, reversedResult] : llvm::zip_equal(adjointOp.getArgs(), reversedResults)){
+                    remappedValues.map(operand, reversedResult);
+                }
             }
             else if (isa<QuantumDialect>(op.getDialect())) {
                 op.emitError("Unhandled operation in adjoint region");
@@ -374,7 +383,7 @@ class AdjointGenerator {
         IRRewriter rewriter(builder);
         rewriter.eraseOp(terminator);
         builder.setInsertionPointAfter(adjointOp);
-        func::ReturnOp::create(builder, loc, adjointOp.getResult());
+        func::ReturnOp::create(builder, loc, adjointOp.getResults());
 
         // Leave the adjoint func op to go back at the saved insertion
         builder.restoreInsertionPoint(insertionSaved);
@@ -528,7 +537,9 @@ struct AdjointSingleOpRewritePattern : public OpRewritePattern<AdjointOp> {
         // Initialize the backward pass with the operand of the quantum.yield
         auto yieldOp = cast<quantum::YieldOp>(adjoint.getRegion().front().getTerminator());
         assert(yieldOp.getNumOperands() == 1 && "Expected quantum.yield to have one operand");
-        oldToCloned.map(yieldOp.getOperands().front(), adjoint.getQreg());
+        for (auto [yieldVal, adjointOperand] : llvm::zip_equal(yieldOp.getOperands(), adjoint.getArgs())){
+            oldToCloned.map(yieldVal, adjointOperand);
+        }
 
         // Emit the adjoint quantum operations and reversed control flow, using cached values.
         AdjointGenerator adjointGenerator{oldToCloned, cache};

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -49,15 +49,16 @@ namespace {
 
 /// Clone the region of the adjoint operation `op` to the insertion point specified by the
 /// `builder`. Build and return the value mapping `mapping`.
-void cloneAdjointRegion(AdjointOp op, OpBuilder &builder, IRMapping &mapping, SmallVector<Value> &reversedResults)
+void cloneAdjointRegion(AdjointOp op, OpBuilder &builder, IRMapping &mapping,
+                        SmallVector<Value> &reversedResults)
 {
     Block &block = op.getRegion().front();
     for (Operation &op : block.without_terminator()) {
         builder.clone(op, mapping);
     }
     auto yieldOp = cast<quantum::YieldOp>(block.getTerminator());
-    //return mapping.lookupOrDefault(yieldOp.getOperand(0));
-    for (Value yieldVal : yieldOp->getOperands()){
+    // return mapping.lookupOrDefault(yieldOp.getOperand(0));
+    for (Value yieldVal : yieldOp->getOperands()) {
         reversedResults.push_back(mapping.lookupOrDefault(yieldVal));
     }
 }
@@ -126,13 +127,15 @@ class AdjointGenerator {
             else if (auto adjointOp = dyn_cast<quantum::AdjointOp>(&op)) {
                 // BlockArgument regionArg = adjointOp.getRegion().getArgument(0);
                 // Value result = adjointOp.getResult();
-                for (auto [regionArg, result] : llvm::zip_equal(adjointOp.getRegion().getArguments(), adjointOp.getResults())){
+                for (auto [regionArg, result] : llvm::zip_equal(
+                         adjointOp.getRegion().getArguments(), adjointOp.getResults())) {
                     remappedValues.map(regionArg, remappedValues.lookup(result));
                 }
                 SmallVector<Value> reversedResults;
                 cloneAdjointRegion(adjointOp, builder, remappedValues, reversedResults);
-                //remappedValues.map(adjointOp.getQreg(), reversedResult);
-                for (auto [operand, reversedResult] : llvm::zip_equal(adjointOp.getArgs(), reversedResults)){
+                // remappedValues.map(adjointOp.getQreg(), reversedResult);
+                for (auto [operand, reversedResult] :
+                     llvm::zip_equal(adjointOp.getArgs(), reversedResults)) {
                     remappedValues.map(operand, reversedResult);
                 }
             }
@@ -536,8 +539,8 @@ struct AdjointSingleOpRewritePattern : public OpRewritePattern<AdjointOp> {
 
         // Initialize the backward pass with the operand of the quantum.yield
         auto yieldOp = cast<quantum::YieldOp>(adjoint.getRegion().front().getTerminator());
-        assert(yieldOp.getNumOperands() == 1 && "Expected quantum.yield to have one operand");
-        for (auto [yieldVal, adjointOperand] : llvm::zip_equal(yieldOp.getOperands(), adjoint.getArgs())){
+        for (auto [yieldVal, adjointOperand] :
+             llvm::zip_equal(yieldOp.getOperands(), adjoint.getArgs())) {
             oldToCloned.map(yieldVal, adjointOperand);
         }
 

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <mlir/IR/Block.h>
-#include <mlir/IR/Value.h>
 #define DEBUG_TYPE "adjoint"
 
 #include <algorithm>

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -37,6 +37,7 @@
 #include "PBC/IR/PBCOps.h"
 #include "Quantum/IR/QuantumInterfaces.h"
 #include "Quantum/IR/QuantumOps.h"
+#include "Quantum/IR/QuantumTypes.h"
 #include "Quantum/Transforms/Patterns.h"
 #include "Quantum/Utils/QuantumSplitting.h"
 
@@ -311,13 +312,10 @@ class AdjointGenerator {
         assert(funcOp != nullptr && "The funcOp is null and therefore not supported.");
 
         auto resultTypes = funcOp.getResultTypes();
-        bool multiReturns = resultTypes.size() > 1;
 
-        bool quantum = std::any_of(resultTypes.begin(), resultTypes.end(),
-                                   [](const auto &value) { return isa<QuregType>(value); });
-        assert(!(quantum && multiReturns) && "Adjoint does not support functions with multiple "
-                                             "returns that contain a quantum register.");
-
+        bool quantum = std::any_of(resultTypes.begin(), resultTypes.end(), [](const auto &value) {
+            return isa<QuregType, QubitType>(value);
+        });
         if (!quantum) {
             // This operation is purely classical
             return;
@@ -348,23 +346,27 @@ class AdjointGenerator {
         // Create the block of the adjoint function
         Block *adjointFnBlock = adjointFnOp.addEntryBlock();
         builder.setInsertionPointToStart(adjointFnBlock);
-        Type qregType = quantum::QuregType::get(builder.getContext());
-        auto argumentsSize = adjointFnOp.getArguments().size();
 
-        // The last argument is the quantum register
-        Value lastArg = adjointFnOp.getArgument(argumentsSize - 1);
-        assert(isa<QuregType>(lastArg.getType()) &&
-               "The last argument of the function must be the quantum register.");
-        quantum::AdjointOp adjointOp = quantum::AdjointOp::create(builder, loc, qregType, lastArg);
+        SmallVector<Value> quantumArgs;
+        for (auto adjointFnArg : adjointFnBlock->getArguments()) {
+            if (isa<QuregType, QubitType>(adjointFnArg.getType())) {
+                quantumArgs.push_back(adjointFnArg);
+            }
+        }
+        quantum::AdjointOp adjointOp =
+            quantum::AdjointOp::create(builder, loc, TypeRange(quantumArgs), quantumArgs);
 
         Region *adjointRegion = &adjointOp.getRegion();
         Region &originalRegion = funcOp.getRegion();
 
         // Map the arguments with the original function
         IRMapping map;
-        for (size_t i = 0; i < funcOp.getArguments().size() - 1; i++) {
+        for (size_t i = 0; i < funcOp.getArguments().size(); i++) {
             Value arg = adjointFnOp.front().getArgument(i);
             Value argBlock = originalRegion.front().getArgument(i);
+            if (isa<QuregType, QubitType>(argBlock.getType())) {
+                continue;
+            }
             map.map(argBlock, arg);
         }
 
@@ -387,16 +389,35 @@ class AdjointGenerator {
         // Leave the adjoint func op to go back at the saved insertion
         builder.restoreInsertionPoint(insertionSaved);
 
-        // Get the reversed result
-        Value reversedResult = remappedValues.lookup(getQuantumReg(callOp.getResults()).value());
+        // Get the reversed results
         std::vector<Value> args = {callOp.getArgOperands().begin(), callOp.getArgOperands().end()};
-        args.pop_back();
-        args.push_back(reversedResult);
+        SmallVector<Value> reversedResults;
+        for (Value callResult : callOp.getResults()) {
+            if (!isa<QuregType, QubitType>(callResult.getType())) {
+                continue;
+            }
+            reversedResults.push_back(remappedValues.lookup(callResult));
+        }
+
+        size_t current_reversed_result = 0;
+        for (size_t i = 0; i < args.size(); i++) {
+            if (!isa<QuregType, QubitType>(args[i].getType())) {
+                continue;
+            }
+            args[i] = reversedResults[current_reversed_result];
+            current_reversed_result++;
+        }
+
         // Call the adjoint func op
         auto adjointCallOp = func::CallOp::create(builder, loc, adjointFnOp, args);
-        ValueRange initQreg = callOp.getArgOperands();
-        // Map the initial quantum register with the adjoint result
-        remappedValues.map(getQuantumReg(initQreg).value(), adjointCallOp.getResult(0));
+        size_t i = 0;
+        for (auto callOperand : callOp.getArgOperands()) {
+            if (!isa<QuregType, QubitType>(callOperand.getType())) {
+                continue;
+            }
+            remappedValues.map(callOperand, adjointCallOp.getResult(i));
+            i++;
+        }
     }
 
     void visitOperation(scf::ForOp forOp, OpBuilder &builder)
@@ -548,7 +569,7 @@ struct AdjointSingleOpRewritePattern : public OpRewritePattern<AdjointOp> {
 
         // Explicitly free the memory of the caches.
         cache.emitDealloc(rewriter, adjoint.getLoc());
-        // The final register is the re-mapped region argument of the original adjoint op.
+        // The final quantum values are the re-mapped region arguments of the original adjoint op.
         SmallVector<Value> reversedOutputs;
         for (BlockArgument arg : adjoint.getRegion().getArguments()) {
             reversedOutputs.push_back(oldToCloned.lookup(arg));

--- a/mlir/lib/Quantum/Utils/QuantumSplitting.cpp
+++ b/mlir/lib/Quantum/Utils/QuantumSplitting.cpp
@@ -224,19 +224,14 @@ void AugmentedCircuitGenerator::generate(Region &region, OpBuilder &builder)
         }
         else if (auto callOp = dyn_cast<func::CallOp>(op)) {
             auto results = callOp.getResultTypes();
-
-            bool multiReturns = results.size() > 1;
-
-            bool quantum = std::any_of(results.begin(), results.end(),
-                                       [](const auto &value) { return isa<QuregType>(value); });
+            bool quantum = std::any_of(results.begin(), results.end(), [](const auto &value) {
+                return isa<QuregType, QubitType>(value);
+            });
 
             // Classical call operations are cloned for the backward pass
             if (!quantum) {
                 builder.clone(op, oldToCloned);
             }
-
-            assert(!(quantum && multiReturns) && "Adjoint does not support functions with multiple "
-                                                 "returns that contain a quantum register.");
         }
         else {
             // Purely classical ops are deeply cloned as-is.

--- a/mlir/test/Gradient/AdjointTest.mlir
+++ b/mlir/test/Gradient/AdjointTest.mlir
@@ -17,7 +17,9 @@
 // Check scalar to scalar function
 func.func private @funcScalarScalar(%arg0: f64) -> f64 attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    %1 = quantum.adjoint(%0) : !quantum.reg {}  // prevent folding of dealloc into alloc
+    %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
+    ^bb0(%arg1: !quantum.reg):
+    }  // prevent folding of dealloc into alloc
     quantum.dealloc %1 : !quantum.reg
     return %arg0 : f64
 }
@@ -43,7 +45,9 @@ func.func @gradCallScalarScalar(%arg0: f64) -> f64 {
 // Check scalar to tensor function
 func.func private @funcScalarTensor(%arg0: f64) -> tensor<2x3xf64> attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    %1 = quantum.adjoint(%0) : !quantum.reg {}  // prevent folding of dealloc into alloc
+    %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
+    ^bb0(%arg1: !quantum.reg):
+    }  // prevent folding of dealloc into alloc
     quantum.dealloc %1 : !quantum.reg
     %c0 = arith.constant 0.0 : f64
     %res = tensor.from_elements %c0, %c0, %c0, %c0, %c0, %c0 : tensor<2x3xf64>
@@ -70,7 +74,9 @@ func.func @gradCallScalarTensor(%arg0: f64) -> tensor<2x3xf64> {
 // Check tensor to scalar
 func.func private @funcTensorScalar(%arg0: tensor<3xf64>) -> f64 attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    %1 = quantum.adjoint(%0) : !quantum.reg {}  // prevent folding of dealloc into alloc
+    %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
+    ^bb0(%arg1: !quantum.reg):
+    }  // prevent folding of dealloc into alloc
     quantum.dealloc %1 : !quantum.reg
     %res = arith.constant 0.0 : f64
     return %res : f64
@@ -97,7 +103,9 @@ func.func @gradCallTensorScalar(%arg0: tensor<3xf64>) -> tensor<3xf64> {
 // Check tensor to tensor case
 func.func private @funcTensorTensor(%arg0: tensor<7x3x2x1xf64>) -> tensor<2xf64> attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    %1 = quantum.adjoint(%0) : !quantum.reg {}  // prevent folding of dealloc into alloc
+    %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
+    ^bb0(%arg1: !quantum.reg):
+    }  // prevent folding of dealloc into alloc
     quantum.dealloc %1 : !quantum.reg
     %c0 = arith.constant 0.0 : f64
     %res = tensor.from_elements %c0, %c0 : tensor<2xf64>
@@ -124,7 +132,9 @@ func.func @gradCallTensorTensor(%arg0: tensor<7x3x2x1xf64>) -> tensor<2x7x3x2x1x
 // Check the multiple results case
 func.func @funcMultiRes(%arg0: f64) -> (f64, tensor<2xf64>) attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    %1 = quantum.adjoint(%0) : !quantum.reg {}  // prevent folding of dealloc into alloc
+    %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
+    ^bb0(%arg1: !quantum.reg):
+    }  // prevent folding of dealloc into alloc
     quantum.dealloc %1 : !quantum.reg
     %res = tensor.from_elements %arg0, %arg0 : tensor<2xf64>
     func.return %arg0, %res : f64, tensor<2xf64>
@@ -151,7 +161,9 @@ func.func @gradCallMultiRes(%arg0: f64) -> (f64, tensor<2xf64>)  {
 // Check the case with multiple grad invocations with varying diffArgIndices
 func.func @funcMultiArg(%arg0: f64, %arg1: tensor<2xf64>) -> f64 attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    %1 = quantum.adjoint(%0) : !quantum.reg {}  // prevent folding of dealloc into alloc
+    %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
+    ^bb0(%arg2: !quantum.reg):
+    }  // prevent folding of dealloc into alloc
     quantum.dealloc %1 : !quantum.reg
     func.return %arg0 : f64
 }
@@ -179,7 +191,9 @@ func.func @gradCallMultiArg(%arg0: f64, %arg1: tensor<2xf64>) -> (f64, tensor<2x
 // Check multiple grad calls to same function with the same diffArgIndices
 func.func private @funcMultiCall(%arg0: f64) -> f64 attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    %1 = quantum.adjoint(%0) : !quantum.reg {}  // prevent folding of dealloc into alloc
+    %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
+    ^bb0(%arg1: !quantum.reg):
+    }  // prevent folding of dealloc into alloc
     quantum.dealloc %1 : !quantum.reg
     func.return %arg0 : f64
 }

--- a/mlir/test/Gradient/AdjointTest.mlir
+++ b/mlir/test/Gradient/AdjointTest.mlir
@@ -17,7 +17,7 @@
 // Check scalar to scalar function
 func.func private @funcScalarScalar(%arg0: f64) -> f64 attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
+    %1 = quantum.adjoint(%0) : !quantum.reg {
     ^bb0(%arg1: !quantum.reg):
     }  // prevent folding of dealloc into alloc
     quantum.dealloc %1 : !quantum.reg
@@ -45,7 +45,7 @@ func.func @gradCallScalarScalar(%arg0: f64) -> f64 {
 // Check scalar to tensor function
 func.func private @funcScalarTensor(%arg0: f64) -> tensor<2x3xf64> attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
+    %1 = quantum.adjoint(%0) : !quantum.reg {
     ^bb0(%arg1: !quantum.reg):
     }  // prevent folding of dealloc into alloc
     quantum.dealloc %1 : !quantum.reg
@@ -74,7 +74,7 @@ func.func @gradCallScalarTensor(%arg0: f64) -> tensor<2x3xf64> {
 // Check tensor to scalar
 func.func private @funcTensorScalar(%arg0: tensor<3xf64>) -> f64 attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
+    %1 = quantum.adjoint(%0) : !quantum.reg {
     ^bb0(%arg1: !quantum.reg):
     }  // prevent folding of dealloc into alloc
     quantum.dealloc %1 : !quantum.reg
@@ -103,7 +103,7 @@ func.func @gradCallTensorScalar(%arg0: tensor<3xf64>) -> tensor<3xf64> {
 // Check tensor to tensor case
 func.func private @funcTensorTensor(%arg0: tensor<7x3x2x1xf64>) -> tensor<2xf64> attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
+    %1 = quantum.adjoint(%0) : !quantum.reg {
     ^bb0(%arg1: !quantum.reg):
     }  // prevent folding of dealloc into alloc
     quantum.dealloc %1 : !quantum.reg
@@ -132,7 +132,7 @@ func.func @gradCallTensorTensor(%arg0: tensor<7x3x2x1xf64>) -> tensor<2x7x3x2x1x
 // Check the multiple results case
 func.func @funcMultiRes(%arg0: f64) -> (f64, tensor<2xf64>) attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
+    %1 = quantum.adjoint(%0) : !quantum.reg {
     ^bb0(%arg1: !quantum.reg):
     }  // prevent folding of dealloc into alloc
     quantum.dealloc %1 : !quantum.reg
@@ -161,7 +161,7 @@ func.func @gradCallMultiRes(%arg0: f64) -> (f64, tensor<2xf64>)  {
 // Check the case with multiple grad invocations with varying diffArgIndices
 func.func @funcMultiArg(%arg0: f64, %arg1: tensor<2xf64>) -> f64 attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
+    %1 = quantum.adjoint(%0) : !quantum.reg {
     ^bb0(%arg2: !quantum.reg):
     }  // prevent folding of dealloc into alloc
     quantum.dealloc %1 : !quantum.reg
@@ -191,7 +191,7 @@ func.func @gradCallMultiArg(%arg0: f64, %arg1: tensor<2xf64>) -> (f64, tensor<2x
 // Check multiple grad calls to same function with the same diffArgIndices
 func.func private @funcMultiCall(%arg0: f64) -> f64 attributes {qnode, diff_method = "adjoint"} {
     %0 = quantum.alloc(1) : !quantum.reg
-    %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
+    %1 = quantum.adjoint(%0) : !quantum.reg {
     ^bb0(%arg1: !quantum.reg):
     }  // prevent folding of dealloc into alloc
     quantum.dealloc %1 : !quantum.reg

--- a/mlir/test/Mitigation/ZneFoldingGlobalTest.mlir
+++ b/mlir/test/Mitigation/ZneFoldingGlobalTest.mlir
@@ -23,7 +23,7 @@
     // CHECK:      [[qReg:%.+]] = call @simpleCircuit.quantumAlloc([[nQubits]]) : (i64) -> !quantum.reg
     // CHECK:      [[outQregFor:%.+]]  = scf.for %arg2 = [[c0]] to %arg1 step [[c1]] iter_args([[inQreg:%.+]] = [[qReg]]) -> (!quantum.reg) {
         // CHECK:      [[outQreg1:%.+]] = func.call @simpleCircuit.withoutMeasurements(%arg0, [[inQreg]]) : (tensor<3xf64>, !quantum.reg) -> !quantum.reg
-        // CHECK:      [[outQreg2:%.+]] = quantum.adjoint([[outQreg1]]) : !quantum.reg {
+        // CHECK:      [[outQreg2:%.+]] = quantum.adjoint([[outQreg1]]) : !quantum.reg -> !quantum.reg {
         // CHECK:      ^bb0(%arg4: !quantum.reg):
             // CHECK:      [[callWithoutMeasurements:%.+]] = func.call @simpleCircuit.withoutMeasurements(%arg0, %arg4) : (tensor<3xf64>, !quantum.reg) -> !quantum.reg
             // CHECK:      quantum.yield [[callWithoutMeasurements]] : !quantum.reg

--- a/mlir/test/Mitigation/ZneFoldingGlobalTest.mlir
+++ b/mlir/test/Mitigation/ZneFoldingGlobalTest.mlir
@@ -23,7 +23,7 @@
     // CHECK:      [[qReg:%.+]] = call @simpleCircuit.quantumAlloc([[nQubits]]) : (i64) -> !quantum.reg
     // CHECK:      [[outQregFor:%.+]]  = scf.for %arg2 = [[c0]] to %arg1 step [[c1]] iter_args([[inQreg:%.+]] = [[qReg]]) -> (!quantum.reg) {
         // CHECK:      [[outQreg1:%.+]] = func.call @simpleCircuit.withoutMeasurements(%arg0, [[inQreg]]) : (tensor<3xf64>, !quantum.reg) -> !quantum.reg
-        // CHECK:      [[outQreg2:%.+]] = quantum.adjoint([[outQreg1]]) : !quantum.reg -> !quantum.reg {
+        // CHECK:      [[outQreg2:%.+]] = quantum.adjoint([[outQreg1]]) : !quantum.reg {
         // CHECK:      ^bb0(%arg4: !quantum.reg):
             // CHECK:      [[callWithoutMeasurements:%.+]] = func.call @simpleCircuit.withoutMeasurements(%arg0, %arg4) : (tensor<3xf64>, !quantum.reg) -> !quantum.reg
             // CHECK:      quantum.yield [[callWithoutMeasurements]] : !quantum.reg

--- a/mlir/test/PBC/AdjointTest.mlir
+++ b/mlir/test/PBC/AdjointTest.mlir
@@ -17,7 +17,7 @@
 // CHECK-LABEL:      @workflow
 func.func private @workflow(%r: !quantum.reg) -> !quantum.reg attributes {} {
   // CHECK-NOT: quantum.adjoint
-  %r_out = quantum.adjoint(%r) : !quantum.reg {
+  %r_out = quantum.adjoint(%r) : !quantum.reg -> !quantum.reg {
   ^bb0(%arg0: !quantum.reg):
     %0 = quantum.extract %arg0[0] : !quantum.reg -> !quantum.bit
 

--- a/mlir/test/PBC/AdjointTest.mlir
+++ b/mlir/test/PBC/AdjointTest.mlir
@@ -17,7 +17,7 @@
 // CHECK-LABEL:      @workflow
 func.func private @workflow(%r: !quantum.reg) -> !quantum.reg attributes {} {
   // CHECK-NOT: quantum.adjoint
-  %r_out = quantum.adjoint(%r) : !quantum.reg -> !quantum.reg {
+  %r_out = quantum.adjoint(%r) : !quantum.reg {
   ^bb0(%arg0: !quantum.reg):
     %0 = quantum.extract %arg0[0] : !quantum.reg -> !quantum.bit
 

--- a/mlir/test/QRef/CanonicalizationTest.mlir
+++ b/mlir/test/QRef/CanonicalizationTest.mlir
@@ -165,9 +165,9 @@ func.func @test_canonicalize_no_dce(%arg0: tensor<2xcomplex<f64>>, %arg1 : tenso
     // CHECK: qref.adjoint
     // CHECK:   qref.get
     // CHECK:   qref.custom "Hadamard"
-    qref.adjoint(%r) : !qref.reg<2> {
-    ^bb0(%r0: !qref.reg<2>):
-        %q = qref.get %r0[0] : !qref.reg<2> -> !qref.bit
+    qref.adjoint {
+    ^bb0():
+        %q = qref.get %r[0] : !qref.reg<2> -> !qref.bit
         qref.custom "Hadamard"() %q : !qref.bit
     }
 

--- a/mlir/test/QRef/UnitTests.mlir
+++ b/mlir/test/QRef/UnitTests.mlir
@@ -240,6 +240,19 @@ func.func @test_adjoint_op(%r: !qref.reg<2>)
 
 // -----
 
+func.func @test_adjoint_multiple_args(%r: !qref.reg<2>, %q: !qref.bit)
+{
+    qref.adjoint(%r, %q) : !qref.reg<2>, !qref.bit {
+    ^bb0(%arg0: !qref.reg<2>, %arg1: !qref.bit):
+        %q1 = qref.get %arg0[1] : !qref.reg<2> -> !qref.bit
+        qref.custom "Hadamard"() %arg1 : !qref.bit
+        qref.custom "CNOT"() %arg1, %q1 : !qref.bit, !qref.bit
+    }
+    return
+}
+
+// -----
+
 func.func @test_computational_basis_op(%q0: !qref.bit, %q1: !qref.bit, %r: !qref.reg<5>)
 {
     %obs_q = qref.compbasis qubits %q0, %q1 : !quantum.obs

--- a/mlir/test/QRef/UnitTests.mlir
+++ b/mlir/test/QRef/UnitTests.mlir
@@ -228,10 +228,10 @@ func.func @test_qubit_unitary(%q0: !qref.bit, %q1: !qref.bit,
 
 func.func @test_adjoint_op(%r: !qref.reg<2>)
 {
-    qref.adjoint(%r) : !qref.reg<2> {
-    ^bb0(%arg0: !qref.reg<2>):
-        %q0 = qref.get %arg0[0] : !qref.reg<2> -> !qref.bit
-        %q1 = qref.get %arg0[1] : !qref.reg<2> -> !qref.bit
+    qref.adjoint {
+    ^bb0():
+        %q0 = qref.get %r[0] : !qref.reg<2> -> !qref.bit
+        %q1 = qref.get %r[1] : !qref.reg<2> -> !qref.bit
         qref.custom "Hadamard"() %q0 : !qref.bit
         qref.custom "CNOT"() %q0, %q1 : !qref.bit, !qref.bit
     }
@@ -242,11 +242,11 @@ func.func @test_adjoint_op(%r: !qref.reg<2>)
 
 func.func @test_adjoint_multiple_args(%r: !qref.reg<2>, %q: !qref.bit)
 {
-    qref.adjoint(%r, %q) : !qref.reg<2>, !qref.bit {
-    ^bb0(%arg0: !qref.reg<2>, %arg1: !qref.bit):
-        %q1 = qref.get %arg0[1] : !qref.reg<2> -> !qref.bit
-        qref.custom "Hadamard"() %arg1 : !qref.bit
-        qref.custom "CNOT"() %arg1, %q1 : !qref.bit, !qref.bit
+    qref.adjoint {
+    ^bb0():
+        %q1 = qref.get %r[1] : !qref.reg<2> -> !qref.bit
+        qref.custom "Hadamard"() %q : !qref.bit
+        qref.custom "CNOT"() %q, %q1 : !qref.bit, !qref.bit
     }
     return
 }

--- a/mlir/test/QRef/VerifierTests.mlir
+++ b/mlir/test/QRef/VerifierTests.mlir
@@ -204,6 +204,31 @@ func.func @test_adjoint_op_no_MP(%r: !qref.reg<2>)
 
 // -----
 
+func.func @test_adjoint_same_num_args(%r: !qref.reg<2>, %q: !qref.bit)
+{
+    // expected-error@+1 {{Adjoint op number of operands must be the same as the number of arguments on its block}}
+    qref.adjoint(%r, %q) : !qref.reg<2>, !qref.bit {
+    ^bb0(%arg0: !qref.reg<2>):
+        %q1 = qref.get %arg0[1] : !qref.reg<2> -> !qref.bit
+        qref.custom "Hadamard"() %q1 : !qref.bit
+    }
+    return
+}
+
+// -----
+
+func.func @test_adjoint_same_arg_type(%r: !qref.reg<2>, %q: !qref.bit)
+{
+    // expected-error@+1 {{Adjoint op operand types must be the same as the argument types on its block}}
+    qref.adjoint(%r, %q) : !qref.reg<2>, !qref.bit {
+    ^bb0(%arg0: !qref.bit, %arg1: !qref.bit):
+        qref.custom "CNOT"() %arg0, %arg1 : !qref.bit, !qref.bit
+    }
+    return
+}
+
+// -----
+
 func.func @test_hermitian_bad_matrix_shape(%q0: !qref.bit, %matrix: tensor<20x20xcomplex<f64>>) {
     // expected-error@+1 {{The Hermitian matrix must be of size 2^(num_qubits) * 2^(num_qubits)}}
     %obs = qref.hermitian(%matrix : tensor<20x20xcomplex<f64>>) %q0 : !quantum.obs

--- a/mlir/test/QRef/VerifierTests.mlir
+++ b/mlir/test/QRef/VerifierTests.mlir
@@ -193,9 +193,9 @@ func.func @test_alloc_bad_static_size() {
 func.func @test_adjoint_op_no_MP(%r: !qref.reg<2>)
 {
     // expected-error@+1 {{quantum measurements are not allowed in the adjoint regions}}
-    qref.adjoint(%r) : !qref.reg<2> {
-    ^bb0(%arg0: !qref.reg<2>):
-        %q1 = qref.get %arg0[1] : !qref.reg<2> -> !qref.bit
+    qref.adjoint {
+    ^bb0():
+        %q1 = qref.get %r[1] : !qref.reg<2> -> !qref.bit
         %obs = qref.namedobs %q1 [ PauliX] : !quantum.obs
         %expval = quantum.expval %obs : f64
     }
@@ -204,25 +204,13 @@ func.func @test_adjoint_op_no_MP(%r: !qref.reg<2>)
 
 // -----
 
-func.func @test_adjoint_same_num_args(%r: !qref.reg<2>, %q: !qref.bit)
+func.func @test_adjoint_with_args(%r: !qref.reg<2>, %q: !qref.bit)
 {
-    // expected-error@+1 {{Adjoint op number of operands must be the same as the number of arguments on its block}}
-    qref.adjoint(%r, %q) : !qref.reg<2>, !qref.bit {
+    // expected-error@+1 {{qref.adjoint op must have no arguments on its block}}
+    qref.adjoint {
     ^bb0(%arg0: !qref.reg<2>):
         %q1 = qref.get %arg0[1] : !qref.reg<2> -> !qref.bit
         qref.custom "Hadamard"() %q1 : !qref.bit
-    }
-    return
-}
-
-// -----
-
-func.func @test_adjoint_same_arg_type(%r: !qref.reg<2>, %q: !qref.bit)
-{
-    // expected-error@+1 {{Adjoint op operand types must be the same as the argument types on its block}}
-    qref.adjoint(%r, %q) : !qref.reg<2>, !qref.bit {
-    ^bb0(%arg0: !qref.bit, %arg1: !qref.bit):
-        qref.custom "CNOT"() %arg0, %arg1 : !qref.bit, !qref.bit
     }
     return
 }

--- a/mlir/test/Quantum/AdjointTest.mlir
+++ b/mlir/test/Quantum/AdjointTest.mlir
@@ -25,7 +25,7 @@ func.func private @workflow_plain() -> tensor<4xcomplex<f64>> attributes {} {
   // CHECK:        RX
   %2 = quantum.custom "RX"(%cst) %1 : !quantum.bit
   %3 = quantum.insert %0[%c0_i64], %2 : !quantum.reg, !quantum.bit
-  %4 = quantum.adjoint(%3) : !quantum.reg {
+  %4 = quantum.adjoint(%3) : !quantum.reg -> !quantum.reg {
   // CHECK:        PauliZ
   // CHECK-SAME:          adj
   // CHECK:        PauliY
@@ -69,19 +69,19 @@ func.func private @workflow_nested() -> tensor<4xcomplex<f64>> attributes {} {
   %c0_i64 = arith.constant 0 : i64
   quantum.device ["rtd_lightning.so", "LightningQubit", "{shots: 0}"]
   %0 = quantum.alloc( 2) : !quantum.reg
-  %1 = quantum.adjoint(%0) : !quantum.reg {
+  %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
   ^bb0(%arg0: !quantum.reg):
     %6 = quantum.extract %arg0[%c1_i64] : !quantum.reg -> !quantum.bit
     %7 = quantum.custom "OpA"() %6 : !quantum.bit
     %8 = quantum.custom "OpB"() %7 : !quantum.bit
     %9 = quantum.insert %arg0[%c1_i64], %8 : !quantum.reg, !quantum.bit
-    %10 = quantum.adjoint(%9) : !quantum.reg {
+    %10 = quantum.adjoint(%9) : !quantum.reg -> !quantum.reg {
     ^bb0(%arg1: !quantum.reg):
       %11 = quantum.extract %arg1[%c1_i64] : !quantum.reg -> !quantum.bit
       %12 = quantum.custom "OpC"() %11 : !quantum.bit
       %13 = quantum.custom "OpD"() %12 : !quantum.bit
       %14 = quantum.insert %arg1[%c1_i64], %13 : !quantum.reg, !quantum.bit
-      %15 = quantum.adjoint(%14) : !quantum.reg {
+      %15 = quantum.adjoint(%14) : !quantum.reg -> !quantum.reg {
       ^bb0(%arg2: !quantum.reg):
         %16 = quantum.extract %arg2[%c1_i64] : !quantum.reg -> !quantum.bit
         %17 = quantum.custom "OpE"() %16 : !quantum.bit
@@ -105,7 +105,7 @@ func.func private @workflow_nested() -> tensor<4xcomplex<f64>> attributes {} {
 
 func.func @workflow_unhandled() {
   %0 = quantum.alloc(1) : !quantum.reg
-  %1 = quantum.adjoint (%0) : !quantum.reg {
+  %1 = quantum.adjoint (%0) : !quantum.reg -> !quantum.reg {
   ^bb0(%arg0: !quantum.reg):
     %qb = quantum.extract %arg0[0] : !quantum.reg -> !quantum.bit
     // expected-error@+1 {{Unhandled operation in adjoint region}}
@@ -122,7 +122,7 @@ func.func @workflow_unhandled() {
 func.func private @qubit_unitary_test(%arg0: tensor<4x4xcomplex<f64>>) -> tensor<4xcomplex<f64>> {
     quantum.device ["rtd_lightning.so", "LightningQubit", "{shots: 0}"]
     %0 = quantum.alloc( 2) : !quantum.reg
-    %1 = quantum.adjoint(%0) : !quantum.reg {
+    %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
     ^bb0(%arg1: !quantum.reg):
       %6 = quantum.extract %arg1[ 0] : !quantum.reg -> !quantum.bit
       %7 = quantum.extract %arg1[ 1] : !quantum.reg -> !quantum.bit
@@ -204,7 +204,7 @@ func.func private @workflow_adjoint(%arg0: f64) -> tensor<4xcomplex<f64>> attrib
   %1 = quantum.extract %0[%c0_i64] : !quantum.reg -> !quantum.bit
   %2 = quantum.custom "RX"(%cst) %1 : !quantum.bit
   %3 = quantum.insert %0[%c0_i64], %2 : !quantum.reg, !quantum.bit
-  %4 = quantum.adjoint(%3) : !quantum.reg {
+  %4 = quantum.adjoint(%3) : !quantum.reg -> !quantum.reg {
     ^bb0(%arg1: !quantum.reg):
       %5 = quantum.extract %arg1[%c0_i64] : !quantum.reg -> !quantum.bit
       %6 = quantum.custom "PauliX"() %5 : !quantum.bit
@@ -242,7 +242,7 @@ func.func private @param_ordering(%0: !quantum.reg) -> !quantum.reg {
   // CHECK:     catalyst.list_push [[C3]]
 
   // CHECK-NOT: quantum.adjoint
-  %1 = quantum.adjoint(%0) : !quantum.reg {
+  %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
   ^bb0(%r0: !quantum.reg):
     %q0 = quantum.extract %r0[ 0] : !quantum.reg -> !quantum.bit
 

--- a/mlir/test/Quantum/AdjointTest.mlir
+++ b/mlir/test/Quantum/AdjointTest.mlir
@@ -25,7 +25,7 @@ func.func private @workflow_plain() -> tensor<4xcomplex<f64>> attributes {} {
   // CHECK:        RX
   %2 = quantum.custom "RX"(%cst) %1 : !quantum.bit
   %3 = quantum.insert %0[%c0_i64], %2 : !quantum.reg, !quantum.bit
-  %4 = quantum.adjoint(%3) : !quantum.reg -> !quantum.reg {
+  %4 = quantum.adjoint(%3) : !quantum.reg {
   // CHECK:        PauliZ
   // CHECK-SAME:          adj
   // CHECK:        PauliY
@@ -69,19 +69,19 @@ func.func private @workflow_nested() -> tensor<4xcomplex<f64>> attributes {} {
   %c0_i64 = arith.constant 0 : i64
   quantum.device ["rtd_lightning.so", "LightningQubit", "{shots: 0}"]
   %0 = quantum.alloc( 2) : !quantum.reg
-  %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
+  %1 = quantum.adjoint(%0) : !quantum.reg {
   ^bb0(%arg0: !quantum.reg):
     %6 = quantum.extract %arg0[%c1_i64] : !quantum.reg -> !quantum.bit
     %7 = quantum.custom "OpA"() %6 : !quantum.bit
     %8 = quantum.custom "OpB"() %7 : !quantum.bit
     %9 = quantum.insert %arg0[%c1_i64], %8 : !quantum.reg, !quantum.bit
-    %10 = quantum.adjoint(%9) : !quantum.reg -> !quantum.reg {
+    %10 = quantum.adjoint(%9) : !quantum.reg {
     ^bb0(%arg1: !quantum.reg):
       %11 = quantum.extract %arg1[%c1_i64] : !quantum.reg -> !quantum.bit
       %12 = quantum.custom "OpC"() %11 : !quantum.bit
       %13 = quantum.custom "OpD"() %12 : !quantum.bit
       %14 = quantum.insert %arg1[%c1_i64], %13 : !quantum.reg, !quantum.bit
-      %15 = quantum.adjoint(%14) : !quantum.reg -> !quantum.reg {
+      %15 = quantum.adjoint(%14) : !quantum.reg {
       ^bb0(%arg2: !quantum.reg):
         %16 = quantum.extract %arg2[%c1_i64] : !quantum.reg -> !quantum.bit
         %17 = quantum.custom "OpE"() %16 : !quantum.bit
@@ -116,7 +116,7 @@ func.func private @workflow_many_args() -> tensor<4xcomplex<f64>> attributes {} 
   %1 = quantum.extract %0[%c0_i64] : !quantum.reg -> !quantum.bit
   %2 = quantum.custom "RX"(%cst) %1 : !quantum.bit
   %3 = quantum.extract %0[%c1_i64] : !quantum.reg -> !quantum.bit
-  %4:2 = quantum.adjoint(%2, %3) : !quantum.bit, !quantum.bit -> !quantum.bit, !quantum.bit {
+  %4:2 = quantum.adjoint(%2, %3) : !quantum.bit, !quantum.bit {
   // CHECK: [[CNOT:%.+]]:2 = quantum.custom "CNOT"() [[RX]], [[q1]] adj : !quantum.bit, !quantum.bit
   // CHECK: [[PauliY:%.+]] = quantum.custom "PauliY"() [[CNOT]]#1 adj : !quantum.bit
   // CHECK: [[PauliX:%.+]] = quantum.custom "PauliX"() [[CNOT]]#0 adj : !quantum.bit
@@ -144,7 +144,7 @@ func.func private @workflow_many_args() -> tensor<4xcomplex<f64>> attributes {} 
 
 func.func @workflow_unhandled() {
   %0 = quantum.alloc(1) : !quantum.reg
-  %1 = quantum.adjoint (%0) : !quantum.reg -> !quantum.reg {
+  %1 = quantum.adjoint (%0) : !quantum.reg {
   ^bb0(%arg0: !quantum.reg):
     %qb = quantum.extract %arg0[0] : !quantum.reg -> !quantum.bit
     // expected-error@+1 {{Unhandled operation in adjoint region}}
@@ -161,7 +161,7 @@ func.func @workflow_unhandled() {
 func.func private @qubit_unitary_test(%arg0: tensor<4x4xcomplex<f64>>) -> tensor<4xcomplex<f64>> {
     quantum.device ["rtd_lightning.so", "LightningQubit", "{shots: 0}"]
     %0 = quantum.alloc( 2) : !quantum.reg
-    %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
+    %1 = quantum.adjoint(%0) : !quantum.reg {
     ^bb0(%arg1: !quantum.reg):
       %6 = quantum.extract %arg1[ 0] : !quantum.reg -> !quantum.bit
       %7 = quantum.extract %arg1[ 1] : !quantum.reg -> !quantum.bit
@@ -243,7 +243,7 @@ func.func private @workflow_adjoint(%arg0: f64) -> tensor<4xcomplex<f64>> attrib
   %1 = quantum.extract %0[%c0_i64] : !quantum.reg -> !quantum.bit
   %2 = quantum.custom "RX"(%cst) %1 : !quantum.bit
   %3 = quantum.insert %0[%c0_i64], %2 : !quantum.reg, !quantum.bit
-  %4 = quantum.adjoint(%3) : !quantum.reg -> !quantum.reg {
+  %4 = quantum.adjoint(%3) : !quantum.reg {
     ^bb0(%arg1: !quantum.reg):
       %5 = quantum.extract %arg1[%c0_i64] : !quantum.reg -> !quantum.bit
       %6 = quantum.custom "PauliX"() %5 : !quantum.bit
@@ -299,7 +299,7 @@ func.func private @workflow_adjoint(%arg0: f64) -> tensor<4xcomplex<f64>> attrib
   %0 = quantum.alloc( 2) : !quantum.reg
   %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
   %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
-  %3:2 = quantum.adjoint(%1, %2) : !quantum.bit, !quantum.bit -> !quantum.bit, !quantum.bit {
+  %3:2 = quantum.adjoint(%1, %2) : !quantum.bit, !quantum.bit {
     ^bb0(%arg1: !quantum.bit, %arg2: !quantum.bit):
       %4 = quantum.custom "PauliX"() %arg1 : !quantum.bit
       %5 = quantum.custom "RX"(%arg0) %4 : !quantum.bit
@@ -333,7 +333,7 @@ func.func private @param_ordering(%0: !quantum.reg) -> !quantum.reg {
   // CHECK:     catalyst.list_push [[C3]]
 
   // CHECK-NOT: quantum.adjoint
-  %1 = quantum.adjoint(%0) : !quantum.reg -> !quantum.reg {
+  %1 = quantum.adjoint(%0) : !quantum.reg {
   ^bb0(%r0: !quantum.reg):
     %q0 = quantum.extract %r0[ 0] : !quantum.reg -> !quantum.bit
 

--- a/mlir/test/Quantum/AdjointTest.mlir
+++ b/mlir/test/Quantum/AdjointTest.mlir
@@ -281,10 +281,11 @@ func.func private @circuit(%arg0: f64, %arg1: !quantum.bit, %arg2: !quantum.bit)
 // CHECK:   return [[X]], [[RX]] : !quantum.bit, !quantum.bit
 
 // CHECK:   func.func private @workflow_adjoint(%arg0: f64) -> tensor<4xcomplex<f64>> {
+// CHECK:   [[cst:%.+]] = arith.constant 4.000000e-01 : f64
 // CHECK:   [[q0:%.+]] = quantum.extract {{%.+}}[ 0] : !quantum.reg -> !quantum.bit
 // CHECK:   [[q1:%.+]] = quantum.extract {{%.+}}[ 1] : !quantum.reg -> !quantum.bit
 // CHECK:   [[RY:%.+]] = quantum.custom "RY"({{%.+}}) [[q1]] adj : !quantum.bit
-// CHECK:   [[call:%.+]]:2 = call @circuit.adjoint(%arg0, [[q0]], [[RY]]) : (f64, !quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+// CHECK:   [[call:%.+]]:2 = call @circuit.adjoint([[cst]], [[q0]], [[RY]]) : (f64, !quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
 // CHECK:   [[Z:%.+]] = quantum.custom "PauliZ"() [[call]]#1 adj : !quantum.bit
 // CHECK:   [[RX:%.+]] = quantum.custom "RX"({{%.+}}) [[call]]#0 adj : !quantum.bit
 // CHECK:   [[X:%.+]] = quantum.custom "PauliX"() [[RX]] adj : !quantum.bit
@@ -303,7 +304,8 @@ func.func private @workflow_adjoint(%arg0: f64) -> tensor<4xcomplex<f64>> attrib
       %4 = quantum.custom "PauliX"() %arg1 : !quantum.bit
       %5 = quantum.custom "RX"(%arg0) %4 : !quantum.bit
       %6 = quantum.custom "PauliZ"() %arg2 : !quantum.bit
-      %7:2 = func.call @circuit(%arg0, %5, %6): (f64, !quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+      %cst = arith.constant 4.000000e-01 : f64
+      %7:2 = func.call @circuit(%cst, %5, %6): (f64, !quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
       %8 = quantum.custom "RY"(%arg0) %7#1 : !quantum.bit
       quantum.yield %7#0, %8 : !quantum.bit, !quantum.bit
   }

--- a/mlir/test/Quantum/AdjointTest.mlir
+++ b/mlir/test/Quantum/AdjointTest.mlir
@@ -267,6 +267,56 @@ func.func private @workflow_adjoint(%arg0: f64) -> tensor<4xcomplex<f64>> attrib
 
 // -----
 
+func.func private @circuit(%arg0: f64, %arg1: !quantum.bit, %arg2: !quantum.bit) -> (!quantum.bit, !quantum.bit) {
+    %0 = quantum.custom "PauliX"() %arg1 : !quantum.bit
+    %1 = quantum.custom "RX"(%arg0) %arg2 : !quantum.bit
+    %2 = quantum.custom "PauliZ"() %1 : !quantum.bit
+    func.return %0, %2: !quantum.bit, !quantum.bit
+}
+
+// CHECK:   func.func private @circuit.adjoint(%arg0: f64, %arg1: !quantum.bit, %arg2: !quantum.bit) -> (!quantum.bit, !quantum.bit) {
+// CHECK:   [[Z:%.+]] = quantum.custom "PauliZ"() %arg2 adj : !quantum.bit
+// CHECK:   [[RX:%.+]] = quantum.custom "RX"({{%.+}}) [[Z]] adj : !quantum.bit
+// CHECK:   [[X:%.+]] = quantum.custom "PauliX"() %arg1 adj : !quantum.bit
+// CHECK:   return [[X]], [[RX]] : !quantum.bit, !quantum.bit
+
+// CHECK:   func.func private @workflow_adjoint(%arg0: f64) -> tensor<4xcomplex<f64>> {
+// CHECK:   [[q0:%.+]] = quantum.extract {{%.+}}[ 0] : !quantum.reg -> !quantum.bit
+// CHECK:   [[q1:%.+]] = quantum.extract {{%.+}}[ 1] : !quantum.reg -> !quantum.bit
+// CHECK:   [[RY:%.+]] = quantum.custom "RY"({{%.+}}) [[q1]] adj : !quantum.bit
+// CHECK:   [[call:%.+]]:2 = call @circuit.adjoint(%arg0, [[q0]], [[RY]]) : (f64, !quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+// CHECK:   [[Z:%.+]] = quantum.custom "PauliZ"() [[call]]#1 adj : !quantum.bit
+// CHECK:   [[RX:%.+]] = quantum.custom "RX"({{%.+}}) [[call]]#0 adj : !quantum.bit
+// CHECK:   [[X:%.+]] = quantum.custom "PauliX"() [[RX]] adj : !quantum.bit
+// CHECK:   [[obs:%.+]] = quantum.compbasis qubits [[X]], [[Z]] : !quantum.obs
+// CHECK:   quantum.state [[obs]] : tensor<4xcomplex<f64>>
+// CHECK:   [[insert0:%.+]] = quantum.insert {{%.+}}[ 0], [[X]] : !quantum.reg, !quantum.bit
+// CHECK:   [[insert1:%.+]] = quantum.insert [[insert0]][ 1], [[Z]] : !quantum.reg, !quantum.bit
+// CHECK:   quantum.dealloc [[insert1]] : !quantum.reg
+
+func.func private @workflow_adjoint(%arg0: f64) -> tensor<4xcomplex<f64>> attributes {} {
+  %0 = quantum.alloc( 2) : !quantum.reg
+  %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+  %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+  %3:2 = quantum.adjoint(%1, %2) : !quantum.bit, !quantum.bit -> !quantum.bit, !quantum.bit {
+    ^bb0(%arg1: !quantum.bit, %arg2: !quantum.bit):
+      %4 = quantum.custom "PauliX"() %arg1 : !quantum.bit
+      %5 = quantum.custom "RX"(%arg0) %4 : !quantum.bit
+      %6 = quantum.custom "PauliZ"() %arg2 : !quantum.bit
+      %7:2 = func.call @circuit(%arg0, %5, %6): (f64, !quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+      %8 = quantum.custom "RY"(%arg0) %7#1 : !quantum.bit
+      quantum.yield %7#0, %8 : !quantum.bit, !quantum.bit
+  }
+  %9 = quantum.compbasis qubits %3#0, %3#1 : !quantum.obs
+  %10 = quantum.state %9 : tensor<4xcomplex<f64>>
+  %11 = quantum.insert %0[ 0], %3#0 : !quantum.reg, !quantum.bit
+  %12 = quantum.insert %11[ 1], %3#1 : !quantum.reg, !quantum.bit
+  quantum.dealloc %12 : !quantum.reg
+  return %10 : tensor<4xcomplex<f64>>
+}
+
+// -----
+
 // CHECK-LABEL: @param_ordering
 func.func private @param_ordering(%0: !quantum.reg) -> !quantum.reg {
   // CHECK-DAG: [[C1:%.+]] = arith.constant 1.000000e-01

--- a/mlir/test/Quantum/AdjointTest.mlir
+++ b/mlir/test/Quantum/AdjointTest.mlir
@@ -101,6 +101,45 @@ func.func private @workflow_nested() -> tensor<4xcomplex<f64>> attributes {} {
   return %5 : tensor<4xcomplex<f64>>
 }
 
+
+// CHECK-LABEL:      @workflow_many_args
+func.func private @workflow_many_args() -> tensor<4xcomplex<f64>> attributes {} {
+  %cst = arith.constant 4.000000e-01 : f64
+  %c0_i64 = arith.constant 0 : i64
+  %c1_i64 = arith.constant 1 : i64
+  quantum.device ["rtd_lightning.so", "LightningQubit", "{shots: 0}"]
+  %0 = quantum.alloc( 2) : !quantum.reg
+
+  // CHECK: [[q0:%.+]] = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+  // CHECK: [[RX:%.+]] = quantum.custom "RX"({{%.+}}) [[q0]] : !quantum.bit
+  // CHECK: [[q1:%.+]] = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+  %1 = quantum.extract %0[%c0_i64] : !quantum.reg -> !quantum.bit
+  %2 = quantum.custom "RX"(%cst) %1 : !quantum.bit
+  %3 = quantum.extract %0[%c1_i64] : !quantum.reg -> !quantum.bit
+  %4:2 = quantum.adjoint(%2, %3) : !quantum.bit, !quantum.bit -> !quantum.bit, !quantum.bit {
+  // CHECK: [[CNOT:%.+]]:2 = quantum.custom "CNOT"() [[RX]], [[q1]] adj : !quantum.bit, !quantum.bit
+  // CHECK: [[PauliY:%.+]] = quantum.custom "PauliY"() [[CNOT]]#1 adj : !quantum.bit
+  // CHECK: [[PauliX:%.+]] = quantum.custom "PauliX"() [[CNOT]]#0 adj : !quantum.bit
+
+  ^bb0(%arg0: !quantum.bit, %arg1: !quantum.bit):
+    %5 = quantum.custom "PauliX"() %arg0 : !quantum.bit
+    %6 = quantum.custom "PauliY"() %arg1 : !quantum.bit
+    %7:2 = quantum.custom "CNOT"() %5, %6 : !quantum.bit, !quantum.bit
+    quantum.yield %7#0, %7#1 : !quantum.bit, !quantum.bit
+  }
+
+  // CHECK: [[RY:%.+]] = quantum.custom "RY"({{%.+}}) [[PauliX]] : !quantum.bit
+  // CHECK: [[insert0:%.+]] = quantum.insert {{%.+}}[ 0], [[RY]] : !quantum.reg, !quantum.bit
+  // CHECK: [[insert1:%.+]] = quantum.insert [[insert0]][ 1], [[PauliY]] : !quantum.reg, !quantum.bit
+  %8 = quantum.custom "RY"(%cst) %4#0 : !quantum.bit
+  %9 = quantum.insert %0[%c0_i64], %8 : !quantum.reg, !quantum.bit
+  %10 = quantum.insert %9[%c1_i64], %4#1 : !quantum.reg, !quantum.bit
+  %11 = quantum.compbasis qreg %10 : !quantum.obs
+  %12 = quantum.state %11 : tensor<4xcomplex<f64>>
+  quantum.dealloc %10 : !quantum.reg
+  return %12 : tensor<4xcomplex<f64>>
+}
+
 // -----
 
 func.func @workflow_unhandled() {


### PR DESCRIPTION
**Context:**
Currently, the `quantum.adjoint` operation can only take in a single register value.
We generalize it to take in an arbitrary list of register and qubit values. 

This is to prepare for the migration of the frontend to reference semantics, when we remove the constraint that scopes must take in the global qreg. 

**Description of the Change:**
`quantum.adjoint` operation can take in `Variadic<AnyTypeOf<[QubitType, QuregType]>>` instead of just a single `QuregType`.

`qref.adjoint` operation takes in no operands anymore, as it only needs to capture all references by clousure.

Some logic in adjoint lowering pass is updated correspondingly.

I also noticed a small bug in the adjoint lowering pass, where classical Values from within the adjoint region are not replaced by their clone outside the region when creating the new call to the adjointed func op. I fixed this too.

**Benefits:**
Prepare for future reference semantics work on them.

[sc-111989]