### PR TITLE
Enable grouping MLIR passes to reduce the number of roundtrips with the xDSL pipeline

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -401,6 +401,11 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Added a optimized pathway to the xDSL `ApplyTransformSequencePass` so that it can schedule consecutive MLIR
+  passes together rather than individually. This minimizes the number of round-trips between xDSL and MLIR, improving
+  performance when several consecutive MLIR passes are used when there are also xDSL passes in the pipeline.
+  [(#2592)](https://github.com/PennyLaneAI/catalyst/pull/2592)
+
 * Catalyst internally uses the new unified transforms API rather than `PassPipelineWrapper`.
   [(#2525)](https://github.com/PennyLaneAI/catalyst/pull/2525)
 

--- a/frontend/catalyst/python_interface/pass_api/apply_transform_sequence.py
+++ b/frontend/catalyst/python_interface/pass_api/apply_transform_sequence.py
@@ -208,7 +208,6 @@ class ApplyTransformSequenceNoCallbackPattern(RewritePattern):
     ):
         self.ctx = ctx
         self.passes = passes
-        self.pass_level = 0
 
     @op_type_rewrite_pattern
     def match_and_rewrite(self, transformer: builtin.ModuleOp, rewriter: PatternRewriter):

--- a/frontend/catalyst/python_interface/pass_api/apply_transform_sequence.py
+++ b/frontend/catalyst/python_interface/pass_api/apply_transform_sequence.py
@@ -259,7 +259,7 @@ class ApplyTransformSequenceNoCallbackPattern(RewritePattern):
     def _apply_xdsl_pipeline(
         self, payload: builtin.ModuleOp, pass_ops: list[transform.ApplyRegisteredPassOp]
     ) -> None:
-        """Interpret a sequence of ``ApplyRegisteredPassOp``\ s corresponding to xDSL passes."""
+        r"""Interpret a sequence of ``ApplyRegisteredPassOp``\ s corresponding to xDSL passes."""
         pipeline = []
         for op in pass_ops:
             pass_class = self.passes[op.pass_name.data]()
@@ -277,7 +277,7 @@ class ApplyTransformSequenceNoCallbackPattern(RewritePattern):
         pass_ops: list[transform.ApplyRegisteredPassOp],
         rewriter: PatternRewriter,
     ) -> builtin.ModuleOp:
-        """Interpret a sequence of ``ApplyRegisteredPassOp``\ s corresponding to MLIR passes."""
+        r"""Interpret a sequence of ``ApplyRegisteredPassOp``\ s corresponding to MLIR passes."""
         buffer = StringIO()
         Printer(stream=buffer, print_generic_format=True).print_op(payload)
 

--- a/frontend/catalyst/python_interface/pass_api/apply_transform_sequence.py
+++ b/frontend/catalyst/python_interface/pass_api/apply_transform_sequence.py
@@ -17,6 +17,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from functools import partial
 from io import StringIO
+from itertools import groupby
 from typing import Any, Callable
 
 from xdsl.context import Context
@@ -213,7 +214,8 @@ class ApplyTransformSequenceNoCallbackPattern(RewritePattern):
     def match_and_rewrite(self, transformer: builtin.ModuleOp, rewriter: PatternRewriter):
         """Rewrite modules containing transform.named_sequences."""
         payload: builtin.ModuleOp = transformer.parent_op()
-        rewriter.erase_op(transformer)
+        # Detach the transformer from the payload module without destroying it
+        transformer.detach()
 
         pass_ops = []
         for ns in transformer.ops:
@@ -225,35 +227,16 @@ class ApplyTransformSequenceNoCallbackPattern(RewritePattern):
         if len(pass_ops) == 0:
             return
 
-        schedule = self._cluster_passes(pass_ops)
-        for subschedule in schedule:
-            if subschedule[0].pass_name.data in self.passes:
-                self._apply_xdsl_pipeline(payload, subschedule)
+        # self.passes maps pass names to xDSL passes. If the pass name is in self.passes, we know
+        # that it is an xDSL pass. Otherwise, we assume that the name corresponds to an MLIR pass.
+        pass_groups = groupby(pass_ops, key=lambda op: is_xdsl_pass(op.pass_name.data))
+
+        for is_xdsl_group, group in pass_groups:
+            group = tuple(group)
+            if is_xdsl_group:
+                self._apply_xdsl_pipeline(payload, group)
             else:
-                payload = self._apply_mlir_pipeline(payload, subschedule, rewriter)
-
-    def _cluster_passes(
-        self, pass_ops: list[transform.ApplyRegisteredPassOp]
-    ) -> list[list[transform.ApplyRegisteredPassOp]]:
-        """Create a schedule that clusters consecutive xDSL/MLIR passes together."""
-        if not pass_ops:  # pragma: no cover
-            return []
-
-        schedule = []
-        cur_schedule = [pass_ops[0]]
-        cur_state = pass_ops[0].pass_name.data in self.passes
-
-        for op in pass_ops[1:]:
-            new_state = op.pass_name.data in self.passes
-            if new_state == cur_state:
-                cur_schedule.append(op)
-            else:
-                schedule.append(cur_schedule)
-                cur_schedule = [op]
-                cur_state = new_state
-
-        schedule.append(cur_schedule)
-        return schedule
+                payload = self._apply_mlir_pipeline(payload, group, rewriter)
 
     def _apply_xdsl_pipeline(
         self, payload: builtin.ModuleOp, pass_ops: list[transform.ApplyRegisteredPassOp]

--- a/frontend/catalyst/python_interface/pass_api/apply_transform_sequence.py
+++ b/frontend/catalyst/python_interface/pass_api/apply_transform_sequence.py
@@ -237,7 +237,7 @@ class ApplyTransformSequenceNoCallbackPattern(RewritePattern):
         self, pass_ops: list[transform.ApplyRegisteredPassOp]
     ) -> list[list[transform.ApplyRegisteredPassOp]]:
         """Create a schedule that clusters consecutive xDSL/MLIR passes together."""
-        if not pass_ops:
+        if not pass_ops:  # pragma: no cover
             return []
 
         schedule = []

--- a/frontend/catalyst/python_interface/pass_api/apply_transform_sequence.py
+++ b/frontend/catalyst/python_interface/pass_api/apply_transform_sequence.py
@@ -227,9 +227,7 @@ class ApplyTransformSequenceNoCallbackPattern(RewritePattern):
         if len(pass_ops) == 0:
             return
 
-        # self.passes maps pass names to xDSL passes. If the pass name is in self.passes, we know
-        # that it is an xDSL pass. Otherwise, we assume that the name corresponds to an MLIR pass.
-        pass_groups = groupby(pass_ops, key=lambda op: is_xdsl_pass(op.pass_name.data))
+        pass_groups = groupby(pass_ops, key=self._is_xdsl_pass)
 
         for is_xdsl_group, group in pass_groups:
             group = tuple(group)
@@ -237,6 +235,12 @@ class ApplyTransformSequenceNoCallbackPattern(RewritePattern):
                 self._apply_xdsl_pipeline(payload, group)
             else:
                 payload = self._apply_mlir_pipeline(payload, group, rewriter)
+
+    def _is_xdsl_pass(self, op: transform.ApplyRegisteredPassOp) -> bool:
+        """Check whether a registered pass op corresponds to an xDSL or MLIR pass."""
+        # self.passes maps pass names to xDSL passes. If the pass name is in self.passes, we know
+        # that it is an xDSL pass. Otherwise, we assume that the name corresponds to an MLIR pass.
+        return op.pass_name.data in self.passes
 
     def _apply_xdsl_pipeline(
         self, payload: builtin.ModuleOp, pass_ops: list[transform.ApplyRegisteredPassOp]

--- a/frontend/catalyst/python_interface/pass_api/apply_transform_sequence.py
+++ b/frontend/catalyst/python_interface/pass_api/apply_transform_sequence.py
@@ -198,8 +198,8 @@ class ApplyTransformSequencePattern(RewritePattern):
 
 class ApplyTransformSequenceNoCallbackPattern(RewritePattern):
     """RewritePattern for applying transform sequences when no callback is provided.
-    This is functionally the same as the ``ApplyTransformSequenceWithCallbackPattern``,
-    but uses a more optimized pathway, which is enabled by the lack of a callback."""
+    This is functionally the same as the ``ApplyTransformSequencePattern``, but uses
+    a more optimized pathway, which is enabled by the lack of a callback."""
 
     def __init__(
         self,

--- a/frontend/catalyst/python_interface/pass_api/apply_transform_sequence.py
+++ b/frontend/catalyst/python_interface/pass_api/apply_transform_sequence.py
@@ -135,6 +135,9 @@ class ApplyTransformSequencePattern(RewritePattern):
     def match_and_rewrite(self, transformer: builtin.ModuleOp, rewriter: PatternRewriter):
         """Rewrite modules containing transform.named_sequences."""
         payload: builtin.ModuleOp = transformer.parent_op()
+        # Erase the transformer from the payload module. Note that PatternRewriter.erase_op
+        # erases the operation from its parent block without destroying the object. Hence,
+        # we can keep interacting with the transformer after the erasure.
         rewriter.erase_op(transformer)
 
         pass_ops = []
@@ -214,8 +217,10 @@ class ApplyTransformSequenceNoCallbackPattern(RewritePattern):
     def match_and_rewrite(self, transformer: builtin.ModuleOp, rewriter: PatternRewriter):
         """Rewrite modules containing transform.named_sequences."""
         payload: builtin.ModuleOp = transformer.parent_op()
-        # Detach the transformer from the payload module without destroying it
-        transformer.detach()
+        # Erase the transformer from the payload module. Note that PatternRewriter.erase_op
+        # erases the operation from its parent block without destroying the object. Hence,
+        # we can keep interacting with the transformer after the erasure.
+        rewriter.erase_op(transformer)
 
         pass_ops = []
         for ns in transformer.ops:

--- a/frontend/catalyst/python_interface/pass_api/apply_transform_sequence.py
+++ b/frontend/catalyst/python_interface/pass_api/apply_transform_sequence.py
@@ -13,16 +13,17 @@
 # limitations under the License.
 """This file contains the pass that applies all passes present in the program representation."""
 
-import io
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from functools import partial
+from io import StringIO
 from typing import Any, Callable
 
 from xdsl.context import Context
 from xdsl.dialects import builtin, transform
 from xdsl.ir import Attribute
 from xdsl.parser import Parser
-from xdsl.passes import ModulePass
+from xdsl.passes import ModulePass, PassPipeline
 from xdsl.pattern_rewriter import PatternRewriter, RewritePattern, op_type_rewrite_pattern
 from xdsl.printer import Printer
 
@@ -98,25 +99,31 @@ class ApplyTransformSequencePass(ModulePass):
             if isinstance(_op, builtin.ModuleOp):
                 nested_modules.append(_op)
 
+        pattern_cls = (
+            partial(ApplyTransformSequencePattern, callback=self.callback)
+            if self.callback
+            else ApplyTransformSequenceNoCallbackPattern
+        )
+
         for mod in nested_modules:
             transformer = self.find_transform_entry_point(mod)
             if transformer is None:
                 continue  # pragma: no cover
 
             # Need to create a new pattern for each nested module to properly handle callbacks
-            pattern = ApplyTransformSequencePattern(ctx, self.passes, self.callback)
+            pattern = pattern_cls(ctx=ctx, passes=self.passes)
             rewriter = PatternRewriter(transformer)
             pattern.match_and_rewrite(transformer, rewriter)
 
 
 class ApplyTransformSequencePattern(RewritePattern):
-    """RewritePattern for applying transform sequences."""
+    """RewritePattern for applying transform sequences when a callback is provided."""
 
     def __init__(
         self,
         ctx: Context,
         passes: dict[str, Callable[[], type[ModulePass]]],
-        callback: Callable | None = None,
+        callback: Callable,
     ):
         self.ctx = ctx
         self.passes = passes
@@ -145,16 +152,12 @@ class ApplyTransformSequencePattern(RewritePattern):
 
     def _pre_pass_callback(self, compilation_pass, module):
         """Callback wrapper to run the callback function before a pass."""
-        if not self.callback:
-            return
         if self.pass_level == 0:
             # Since this is the first pass, there is no previous pass
             self.callback(None, module, compilation_pass, pass_level=0)
 
     def _post_pass_callback(self, compilation_pass, module):
         """Increment level and run callback if defined."""
-        if not self.callback:
-            return
         self.pass_level += 1
         self.callback(compilation_pass, module, None, pass_level=self.pass_level)
 
@@ -181,9 +184,9 @@ class ApplyTransformSequencePattern(RewritePattern):
             return module
 
         # ---- Catalyst path ----
-        buffer = io.StringIO()
+        buffer = StringIO()
         Printer(stream=buffer, print_generic_format=True).print_op(module)
-        schedule = _create_mlir_schedule([op])
+        schedule = _create_mlir_cli_schedule([op])
         self._pre_pass_callback(pass_name, module)
         modified = _quantum_opt(*schedule, "-mlir-print-op-generic", stdin=buffer.getvalue())
 
@@ -193,7 +196,92 @@ class ApplyTransformSequencePattern(RewritePattern):
         return data
 
 
-def _create_mlir_schedule(pass_ops: Sequence[transform.ApplyRegisteredPassOp]) -> list[str]:
+class ApplyTransformSequenceNoCallbackPattern(RewritePattern):
+    """RewritePattern for applying transform sequences when no callback is provided.
+    This is functionally the same as the ``ApplyTransformSequenceWithCallbackPattern``,
+    but uses a more optimized pathway, which is enabled by the lack of a callback."""
+
+    def __init__(
+        self,
+        ctx: Context,
+        passes: dict[str, Callable[[], type[ModulePass]]],
+    ):
+        self.ctx = ctx
+        self.passes = passes
+        self.pass_level = 0
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, transformer: builtin.ModuleOp, rewriter: PatternRewriter):
+        """Rewrite modules containing transform.named_sequences."""
+        payload: builtin.ModuleOp = transformer.parent_op()
+        rewriter.erase_op(transformer)
+
+        pass_ops = []
+        for ns in transformer.ops:
+            assert isinstance(ns, transform.NamedSequenceOp)
+            pass_ops.extend(
+                op for op in ns.body.ops if isinstance(op, transform.ApplyRegisteredPassOp)
+            )
+
+        if len(pass_ops) == 0:
+            return
+
+        schedule = self._cluster_passes(pass_ops)
+        for subschedule in schedule:
+
+            # ---- xDSL path ----
+            if subschedule[0].pass_name.data in self.passes:
+                xdsl_pipeline = []
+                for op in subschedule:
+                    pass_class = self.passes[op.pass_name.data]()
+                    options = {
+                        k.replace("-", "_"): v
+                        for k, v in get_pyval_from_xdsl_attr(op.options).items()
+                    }
+                    xdsl_pipeline.append(pass_class(**options))
+
+                pipeline = PassPipeline(xdsl_pipeline)
+                pipeline.apply(self.ctx, payload)
+
+            # ---- MLIR path ----
+            else:
+                buffer = StringIO()
+                Printer(stream=buffer, print_generic_format=True).print_op(payload)
+
+                mlir_pipeline = _create_mlir_cli_schedule(subschedule)
+                modified = _quantum_opt(
+                    *mlir_pipeline, "-mlir-print-op-generic", stdin=buffer.getvalue()
+                )
+
+                data = Parser(self.ctx, modified).parse_module()
+                rewriter.replace_op(payload, data)
+                payload = data
+
+    def _cluster_passes(
+        self, pass_ops: list[transform.ApplyRegisteredPassOp]
+    ) -> list[list[transform.ApplyRegisteredPassOp]]:
+        """Create a schedule that clusters consecutive xDSL/MLIR passes together."""
+        if not pass_ops:
+            return []
+
+        schedule = []
+        cur_schedule = [pass_ops[0]]
+        cur_state = pass_ops[0].pass_name.data in self.passes
+
+        for op in pass_ops[1:]:
+            new_state = op.pass_name.data in self.passes
+            if new_state == cur_state:
+                cur_schedule.append(op)
+            else:
+                schedule.append(cur_schedule)
+                cur_schedule = [op]
+                cur_state = new_state
+
+        schedule.append(cur_schedule)
+        return schedule
+
+
+def _create_mlir_cli_schedule(pass_ops: Sequence[transform.ApplyRegisteredPassOp]) -> list[str]:
     """Create a pass schedule for applying MLIR pass via CLI flags.
 
     For a pass with options, the corresponding CLI flag will be the following:

--- a/frontend/catalyst/python_interface/pass_api/apply_transform_sequence.py
+++ b/frontend/catalyst/python_interface/pass_api/apply_transform_sequence.py
@@ -228,34 +228,10 @@ class ApplyTransformSequenceNoCallbackPattern(RewritePattern):
 
         schedule = self._cluster_passes(pass_ops)
         for subschedule in schedule:
-
-            # ---- xDSL path ----
             if subschedule[0].pass_name.data in self.passes:
-                xdsl_pipeline = []
-                for op in subschedule:
-                    pass_class = self.passes[op.pass_name.data]()
-                    options = {
-                        k.replace("-", "_"): v
-                        for k, v in get_pyval_from_xdsl_attr(op.options).items()
-                    }
-                    xdsl_pipeline.append(pass_class(**options))
-
-                pipeline = PassPipeline(xdsl_pipeline)
-                pipeline.apply(self.ctx, payload)
-
-            # ---- MLIR path ----
+                self._apply_xdsl_pipeline(payload, subschedule)
             else:
-                buffer = StringIO()
-                Printer(stream=buffer, print_generic_format=True).print_op(payload)
-
-                mlir_pipeline = _create_mlir_cli_schedule(subschedule)
-                modified = _quantum_opt(
-                    *mlir_pipeline, "-mlir-print-op-generic", stdin=buffer.getvalue()
-                )
-
-                data = Parser(self.ctx, modified).parse_module()
-                rewriter.replace_op(payload, data)
-                payload = data
+                payload = self._apply_mlir_pipeline(payload, subschedule, rewriter)
 
     def _cluster_passes(
         self, pass_ops: list[transform.ApplyRegisteredPassOp]
@@ -279,6 +255,38 @@ class ApplyTransformSequenceNoCallbackPattern(RewritePattern):
 
         schedule.append(cur_schedule)
         return schedule
+
+    def _apply_xdsl_pipeline(
+        self, payload: builtin.ModuleOp, pass_ops: list[transform.ApplyRegisteredPassOp]
+    ) -> None:
+        """Interpret a sequence of ``ApplyRegisteredPassOp``\ s corresponding to xDSL passes."""
+        pipeline = []
+        for op in pass_ops:
+            pass_class = self.passes[op.pass_name.data]()
+            options = {
+                k.replace("-", "_"): v for k, v in get_pyval_from_xdsl_attr(op.options).items()
+            }
+            pipeline.append(pass_class(**options))
+
+        pipeline = PassPipeline(pipeline)
+        pipeline.apply(self.ctx, payload)
+
+    def _apply_mlir_pipeline(
+        self,
+        payload: builtin.ModuleOp,
+        pass_ops: list[transform.ApplyRegisteredPassOp],
+        rewriter: PatternRewriter,
+    ) -> builtin.ModuleOp:
+        """Interpret a sequence of ``ApplyRegisteredPassOp``\ s corresponding to MLIR passes."""
+        buffer = StringIO()
+        Printer(stream=buffer, print_generic_format=True).print_op(payload)
+
+        pipeline = _create_mlir_cli_schedule(pass_ops)
+        modified = _quantum_opt(*pipeline, "-mlir-print-op-generic", stdin=buffer.getvalue())
+
+        data = Parser(self.ctx, modified).parse_module()
+        rewriter.replace_op(payload, data)
+        return data
 
 
 def _create_mlir_cli_schedule(pass_ops: Sequence[transform.ApplyRegisteredPassOp]) -> list[str]:

--- a/frontend/test/pytest/python_interface/pass_api/test_apply_transform_sequence_pass.py
+++ b/frontend/test/pytest/python_interface/pass_api/test_apply_transform_sequence_pass.py
@@ -15,7 +15,6 @@
 # pylint: disable=line-too-long
 
 import subprocess
-from io import StringIO
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -25,7 +24,6 @@ from xdsl.context import Context
 from xdsl.dialects import builtin, func, test, transform
 from xdsl.ir import Attribute, SSAValue
 from xdsl.passes import ModulePass
-from xdsl.printer import Printer
 
 from catalyst import qjit
 from catalyst.python_interface import QuantumParser

--- a/frontend/test/pytest/python_interface/pass_api/test_apply_transform_sequence_pass.py
+++ b/frontend/test/pytest/python_interface/pass_api/test_apply_transform_sequence_pass.py
@@ -15,6 +15,7 @@
 # pylint: disable=line-too-long
 
 import subprocess
+from io import StringIO
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -24,6 +25,7 @@ from xdsl.context import Context
 from xdsl.dialects import builtin, func, test, transform
 from xdsl.ir import Attribute, SSAValue
 from xdsl.passes import ModulePass
+from xdsl.printer import Printer
 
 from catalyst import qjit
 from catalyst.python_interface import QuantumParser
@@ -283,6 +285,93 @@ class TestApplyTransformSequencePass:
         assert "--mlir-pass1=a=1 b='foo'" in captured_cmds[0]
         # We check that there is a space after the pass name to check that no options were specified
         assert "--mlir-pass2 " in captured_cmds[1]
+
+    def test_interpret_named_sequence_consecutive_mlir_passes(self, mocker, capsys):
+        """Test that a NamedSequenceOp can be interpreted correctly when it contains
+        both xDSL and MLIR passes."""
+        program = """
+            builtin.module @workflow {
+                builtin.module {
+                    builtin.module attributes {transform.with_named_sequence} {
+                        transform.named_sequence @__transform_0(%t0_arg0 : !transform.op<"builtin.module">) {
+                            %t0_0 = transform.apply_registered_pass "options-pass" to %t0_arg0 : (!transform.op<"builtin.module">) -> !transform.op<"builtin.module">
+                            %t0_1 = transform.apply_registered_pass "mlir-pass1" with options = {a = 1 : i64, b = "foo"} to %t0_0 : (!transform.op<"builtin.module">) -> !transform.op<"builtin.module">
+                            %t0_2 = transform.apply_registered_pass "mlir-pass2" to %t0_1 : (!transform.op<"builtin.module">) -> !transform.op<"builtin.module">
+                            %t0_3 = transform.apply_registered_pass "mlir-pass2" with options = {c = [1 : i64, 2 : i64, 3 : i64], d = false} to %t0_2 : (!transform.op<"builtin.module">) -> !transform.op<"builtin.module">
+                            %t0_4 = transform.apply_registered_pass "mlir-pass1" to %t0_3 : (!transform.op<"builtin.module">) -> !transform.op<"builtin.module">
+                            transform.yield
+                        }
+                    }
+                }
+            }
+        """
+
+        pass_options = [{}, {"a": 1, "b": "foo"}, {}, {"c": (1, 2, 3), "d": False}, {}]
+        mod = parse_generic_to_xdsl_module(program)
+
+        captured_cmds = []
+        num_calls = 0
+
+        def mock_subprocess_run(cmd, **kwargs):
+            """Mock implementation of subprocess.run"""
+            nonlocal captured_cmds
+            nonlocal num_calls
+            captured_cmds.append(subprocess.list2cmdline(cmd))
+            num_calls += 1
+            return MagicMock(args=cmd, stdout=kwargs.get("input", ""), returncode=0)
+
+        mocker.patch("subprocess.run", side_effect=mock_subprocess_run)
+
+        _pass = ApplyTransformSequencePass(
+            passes={"options-pass": lambda: OptionsPass}, callback=None
+        )
+        ctx = Context()
+        ctx.load_dialect(builtin.Builtin)
+        ctx.load_dialect(transform.Transform)
+        _pass.apply(ctx, mod)
+
+        # Assert that xDSL passes were applied correctly
+        captured = capsys.readouterr()
+        assert captured.out.strip().split("\n") == [
+            f"Applying options-pass with options {pass_options[0]}"
+        ]
+
+        # Assert that MLIR passes were applied correctly
+        assert len(captured_cmds) == 1
+        assert (
+            '"--mlir-pass1=a=1 b=\'foo\'" --mlir-pass2 "--mlir-pass2=c=1,2,3 d=false" --mlir-pass1'
+            in captured_cmds[0]
+        )
+
+    def test_interpret_named_sequence_no_passes(self):
+        """Test that a NamedSequenceOp can be interpreted correctly when there are no passes."""
+        program = """
+            builtin.module @workflow {
+                builtin.module {
+                    builtin.module attributes {transform.with_named_sequence} {
+                        transform.named_sequence @__transform_0(%t0_arg0 : !transform.op<"builtin.module">) {
+                            transform.yield
+                        }
+                    }
+                }
+            }
+        """
+        mod = parse_generic_to_xdsl_module(program)
+        _pass = ApplyTransformSequencePass()
+
+        ctx = Context()
+        ctx.load_dialect(builtin.Builtin)
+        ctx.load_dialect(transform.Transform)
+        _pass.apply(ctx, mod)
+
+        expected_program = """
+            builtin.module @workflow {
+                builtin.module {
+                }
+            }
+        """
+        expected_mod = parse_generic_to_xdsl_module(expected_program)
+        assert mod.is_structurally_equivalent(expected_mod)
 
     def test_callback_count_with_passes(self):
         """Test that the apply function calls the callback the correct number of times."""

--- a/frontend/test/pytest/python_interface/pass_api/test_apply_transform_sequence_pass.py
+++ b/frontend/test/pytest/python_interface/pass_api/test_apply_transform_sequence_pass.py
@@ -31,7 +31,7 @@ from catalyst.python_interface.conversion import parse_generic_to_xdsl_module, x
 from catalyst.python_interface.dialects import quantum
 from catalyst.python_interface.pass_api.apply_transform_sequence import (
     ApplyTransformSequencePass,
-    _create_mlir_schedule,
+    _create_mlir_cli_schedule,
 )
 from catalyst.python_interface.transforms import merge_rotations_pass
 
@@ -95,7 +95,7 @@ class TestCreateMLIRSchedule:
     def test_pass_no_options(self):
         """Test that passes with no options are parsed correctly."""
         pass_op = create_apply_registered_pass_op("test-pass")
-        schedule = _create_mlir_schedule(pass_ops=[pass_op])
+        schedule = _create_mlir_cli_schedule(pass_ops=[pass_op])
         assert len(schedule) == 1
         assert schedule[0] == "--test-pass"
 
@@ -111,7 +111,7 @@ class TestCreateMLIRSchedule:
                 "str-opt-with-spaces": "foo bar",
             },
         )
-        schedule = _create_mlir_schedule(pass_ops=[pass_op])
+        schedule = _create_mlir_cli_schedule(pass_ops=[pass_op])
         assert len(schedule) == 1
         assert schedule[0] == (
             "--test-pass=int-opt=1 float-opt=1.5 bool-opt=false str-opt='test_string' "
@@ -121,7 +121,7 @@ class TestCreateMLIRSchedule:
     def test_pass_array_options(self):
         """Test that passes with array options are parsed correctly."""
         pass_op = create_apply_registered_pass_op("test-pass", options={"list-opt": (1, 2, 3, 4)})
-        schedule = _create_mlir_schedule(pass_ops=[pass_op])
+        schedule = _create_mlir_cli_schedule(pass_ops=[pass_op])
         assert len(schedule) == 1
         assert schedule[0] == "--test-pass=list-opt=1,2,3,4"
 
@@ -130,7 +130,7 @@ class TestCreateMLIRSchedule:
         pass_op = create_apply_registered_pass_op(
             "test-pass", options={"dict-opt": {"a": 1, "b": 2, "c": 3, "d": 4}}
         )
-        schedule = _create_mlir_schedule(pass_ops=[pass_op])
+        schedule = _create_mlir_cli_schedule(pass_ops=[pass_op])
         assert len(schedule) == 1
         assert schedule[0] == "--test-pass=dict-opt={a=1 b=2 c=3 d=4}"
 
@@ -143,7 +143,7 @@ class TestCreateMLIRSchedule:
                 "dict-opt": {"f": (1, 2), "g": 1},
             },
         )
-        schedule = _create_mlir_schedule(pass_ops=[pass_op])
+        schedule = _create_mlir_cli_schedule(pass_ops=[pass_op])
         assert len(schedule) == 1
         assert (
             schedule[0]
@@ -157,7 +157,7 @@ class TestCreateMLIRSchedule:
         pass_op3 = create_apply_registered_pass_op(
             "test-pass3", options={"list-opt": (False, True, False)}
         )
-        schedule = _create_mlir_schedule(pass_ops=[pass_op1, pass_op2, pass_op3])
+        schedule = _create_mlir_cli_schedule(pass_ops=[pass_op1, pass_op2, pass_op3])
         assert len(schedule) == 3
         assert schedule[0] == "--test-pass1"
         assert schedule[1] == "--test-pass2=int-opt=1"


### PR DESCRIPTION
**Context:**
Currently, when an MLIR transform is present in the pipeline with the unified compiler, we print the IR, invoke `quantum-opt` and parse the output back to xDSL. This happens for every single MLIR pass in the pipeline. This creates a lot of avoidable overhead if there are a lot of consecutive MLIR passes. We want to collect consecutive MLIR passes into a single pipeline that can be given to `quantum-opt`.

**Description of the Change:**
* Make `callback` argument of `ApplyTransformSequencePattern` required. This rewrite pattern should only be called when callbacks are being used.
* Add a `ApplyTransformSequenceNoCallbackPattern`, which creates sub-schedules containing consecutive xDSL/MLIR passes that are applied in one go.
  * This pattern is only used when there are no callbacks. We need to do this because callbacks **have** to be called after pass, so we can't schedule multiple passes together.

**Benefits:**
Much better performance when there are multiple consecutive MLIR passes

**Possible Drawbacks:**

**Related GitHub Issues:**


[sc-114436]