### PR TITLE
Fix type hints in xDSL compiler_transform

### DIFF
--- a/frontend/catalyst/python_interface/pass_api/compiler_transform.py
+++ b/frontend/catalyst/python_interface/pass_api/compiler_transform.py
@@ -22,14 +22,14 @@ from .apply_transform_sequence import register_pass
 class PassDispatcher(Transform):
     """Wrapper class for applying passes to QJIT-ed workflows."""
 
-    module_pass: ModulePass
+    module_pass: type[ModulePass]
 
-    def __init__(self, module_pass: ModulePass):
+    def __init__(self, module_pass: type[ModulePass]):
         self.module_pass = module_pass
         super().__init__(pass_name=module_pass.name)
 
 
-def compiler_transform(module_pass: ModulePass) -> PassDispatcher:
+def compiler_transform(module_pass: type[ModulePass]) -> PassDispatcher:
     """Wrapper function to register xDSL passes to use with QJIT-ed workflows."""
     dispatcher = PassDispatcher(module_pass)
 


### PR DESCRIPTION
**Context:** The `module_pass` variable in the `compiler_transform` module had the type hint `ModulePass`, suggesting it should be an instance of this class, but really it should be `type[ModulePass]` to indicate that it should be a *type* that inherits from `ModulePass`.

**Description of the Change:** Change type hint `ModulePass` -> `type[ModulePass]`, where appropriate.

**Benefits:** Better type hints, fewer Python type-checker warnings in developers' IDEs.

**Possible Drawbacks:** None, type hints have no effect at runtime for most practical purposes.

