### PR TITLE
Fix catalyst `--emit-bytecode` flag

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -340,6 +340,9 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a bug where the `catalyst` CLI tool would emit text when called with `--emit-bytecode`.
+  [(#2596)](https://github.com/PennyLaneAI/catalyst/pull/2596)
+
 * Fixed a bug where input array arguments could be mutated during execution when copied inputs
   were updated in-place. Entry-point arguments are now treated as non-writable during bufferization,
   preserving the expected immutability of user inputs.

--- a/mlir/include/Driver/CompilerDriver.h
+++ b/mlir/include/Driver/CompilerDriver.h
@@ -79,6 +79,8 @@ struct CompilerOptions {
     Action loweringAction;
     /// If true, the compiler will dump the pass pipeline that will be run.
     bool dumpPassPipeline;
+    /// If true, the compiler will write bytecode rather than text.
+    bool shouldEmitBytecode;
 
     /// Get the destination of the object file at the end of compilation.
     std::string getObjectFile() const

--- a/mlir/lib/Driver/CompilerDriver.cpp
+++ b/mlir/lib/Driver/CompilerDriver.cpp
@@ -44,6 +44,7 @@
 #include "llvm/Transforms/Coroutines/CoroSplit.h"
 #include "llvm/Transforms/IPO/GlobalDCE.h"
 
+#include "mlir/Bytecode/BytecodeWriter.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/InitAllDialects.h"
@@ -905,8 +906,13 @@ LogicalResult QuantumDriverMain(const CompilerOptions &options, CompilerOutput &
         // already handled
     }
     else if (output.outputFilename == "-" && mlirModule) {
-        mlirModule->print(outfile->os(), opPrintingFlags);
-        outfile->keep();
+        if (options.shouldEmitBytecode) {
+            return mlir::writeBytecodeToFile(mlirModule.get(), outfile->os());
+        }
+        else {
+            mlirModule->print(outfile->os(), opPrintingFlags);
+            outfile->keep();
+        }
     }
 
     if (options.keepIntermediate and output.outputFilename != "-") {
@@ -1088,7 +1094,8 @@ int QuantumDriverMainFromCL(int argc, char **argv)
                             .pipelinesCfg = parsePipelines(CatalystPipeline),
                             .checkpointStage = CheckpointStage,
                             .loweringAction = LoweringAction,
-                            .dumpPassPipeline = DumpPassPipeline};
+                            .dumpPassPipeline = DumpPassPipeline,
+                            .shouldEmitBytecode = config.shouldEmitBytecode()};
 
     mlir::LogicalResult result = QuantumDriverMain(options, *output, registry);
 

--- a/mlir/test/cli/EmitBytecode.mlir
+++ b/mlir/test/cli/EmitBytecode.mlir
@@ -20,4 +20,4 @@ module {
 // COM: We can't test bytes against text with FileCheck, so we only verify the bytecode header.
 // COM: This header would not be present if bytecode had not been written by mlir-opt, so this 
 // COM: should be sufficient.
-// CHECK: MLIR22.0.0git
+// CHECK: MLIR{{.+}}git

--- a/mlir/test/cli/EmitBytecode.mlir
+++ b/mlir/test/cli/EmitBytecode.mlir
@@ -1,0 +1,23 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RUN: catalyst --tool=opt --emit-bytecode %s | FileCheck %s
+
+module {
+}
+
+// COM: We can't test bytes against text with FileCheck, so we only verify the bytecode header.
+// COM: This header would not be present if bytecode had not been written by mlir-opt, so this 
+// COM: should be sufficient.
+// CHECK: MLIR22.0.0git


### PR DESCRIPTION
**Context:**
The `catalyst` CLI tool has some dangling options (i.e. accepts the flag but does not change behaviour). One of these is the `--emit-bytecode` option.

**Description of the Change:**
Correctly registers and applied bytecode logic when the `--emit-bytecode` flag is present.

**Benefits:**
The `catalyst` CLI tool can emit bytecode, and responds correctly to the flag.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
closes #2594