### PR TITLE
Fix quantum kernel detection

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -289,6 +289,16 @@
   `shots` aren't set. Instead, an informative error message is raised.
   [(#2456)](https://github.com/PennyLaneAI/catalyst/pull/2456)
 
+* The quantum kernel abstraction in Catalyst's IR (a nested module operation with its own transform
+  schedule and entry point and subroutine functions representing a PennyLane QNode) has been
+  documented and equipped with additional verification. Transformation passes scheduled from the
+  frontend must ensure, and can rely on, the presence of the `quantum.node` attribute to indicate
+  which functions in the module represent a separate quantum execution (with device initialization,
+  shots configuration, and set of measurement processes).
+  [(#2483)](https://github.com/PennyLaneAI/catalyst/pull/2483)
+  [(#2497)](https://github.com/PennyLaneAI/catalyst/pull/2497)
+  [(#2597)](https://github.com/PennyLaneAI/catalyst/pull/2597)
+
 * Graph decomposition with qjit now accepts `num_work_wires`, and lowers and decomposes correctly
   with the `decompose-lowering` pass and with `qp.transforms.decompose`.
   [(#2470)](https://github.com/PennyLaneAI/catalyst/pull/2470)

--- a/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
@@ -666,111 +666,107 @@ class TestAssemblyFormat:
         # Tests for measurements: CountsOp, ExpvalOp, MeasureOp, ProbsOp, SampleOp,
         #                         StateOp, VarianceOp
         program = """
-        func.func private @test_measurements() attributes {quantum.node} {
-            ///////////////////////////////////////////////////
-            //////////// Observables and constants ////////////
-            ///////////////////////////////////////////////////
-            // CHECK: [[Q0:%.+]], [[Q1:%.+]], [[Q2:%.+]] = "test.op"() : () -> (!quantum.bit
-            %q0, %q1, %q2 = "test.op"() : () -> (!quantum.bit, !quantum.bit, !quantum.bit)
-            // CHECK: [[QREG:%.+]] = "test.op"() : () -> !quantum.reg
-            %qreg = "test.op"() : () -> !quantum.reg
+        ///////////////////////////////////////////////////
+        //////////// Observables and constants ////////////
+        ///////////////////////////////////////////////////
+        // CHECK: [[Q0:%.+]], [[Q1:%.+]], [[Q2:%.+]] = "test.op"() : () -> (!quantum.bit
+        %q0, %q1, %q2 = "test.op"() : () -> (!quantum.bit, !quantum.bit, !quantum.bit)
+        // CHECK: [[QREG:%.+]] = "test.op"() : () -> !quantum.reg
+        %qreg = "test.op"() : () -> !quantum.reg
 
-            // CHECK: [[X_OBS:%.+]] = quantum.namedobs [[Q0]][PauliX] : !quantum.obs
-            %x_obs = quantum.namedobs %q0[PauliX] : !quantum.obs
-            // CHECK: [[C_OBS:%.+]] = quantum.compbasis qubits [[Q0]], [[Q1]], [[Q2]] : !quantum.obs
-            %c_obs = quantum.compbasis qubits %q0, %q1, %q2 : !quantum.obs
-            // CHECK: [[C_OBS_ALL:%.+]] = quantum.compbasis qreg [[QREG]] : !quantum.obs
-            %c_obs_all = quantum.compbasis qreg %qreg : !quantum.obs
+        // CHECK: [[X_OBS:%.+]] = quantum.namedobs [[Q0]][PauliX] : !quantum.obs
+        %x_obs = quantum.namedobs %q0[PauliX] : !quantum.obs
+        // CHECK: [[C_OBS:%.+]] = quantum.compbasis qubits [[Q0]], [[Q1]], [[Q2]] : !quantum.obs
+        %c_obs = quantum.compbasis qubits %q0, %q1, %q2 : !quantum.obs
+        // CHECK: [[C_OBS_ALL:%.+]] = quantum.compbasis qreg [[QREG]] : !quantum.obs
+        %c_obs_all = quantum.compbasis qreg %qreg : !quantum.obs
 
-            // CHECK: [[DYN_WIRES:%.+]] = "test.op"() : () -> i64
-            %dyn_wires = "test.op"() : () -> i64
-            // CHECK: [[DYN_SHOTS:%.+]] = "test.op"() : () -> i64
-            %dyn_shots = "test.op"() : () -> i64
+        // CHECK: [[DYN_WIRES:%.+]] = "test.op"() : () -> i64
+        %dyn_wires = "test.op"() : () -> i64
+        // CHECK: [[DYN_SHOTS:%.+]] = "test.op"() : () -> i64
+        %dyn_shots = "test.op"() : () -> i64
 
-            ///////////////////////////////////////////////
-            //////////// **Measurement tests** ////////////
-            ///////////////////////////////////////////////
+        ///////////////////////////////////////////////
+        //////////// **Measurement tests** ////////////
+        ///////////////////////////////////////////////
 
-            ///////////////////// **ExpvalOp** /////////////////////
-            // CHECK: {{%.+}} = quantum.expval [[X_OBS]] : f64
-            %expval = quantum.expval %x_obs : f64
+        ///////////////////// **ExpvalOp** /////////////////////
+        // CHECK: {{%.+}} = quantum.expval [[X_OBS]] : f64
+        %expval = quantum.expval %x_obs : f64
 
-            ///////////////////// **VarianceOp** /////////////////////
-            // CHECK: {{%.+}} = quantum.var [[X_OBS]] : f64
-            %var = quantum.var %x_obs : f64
+        ///////////////////// **VarianceOp** /////////////////////
+        // CHECK: {{%.+}} = quantum.var [[X_OBS]] : f64
+        %var = quantum.var %x_obs : f64
 
-            ///////////////////// **CountsOp** /////////////////////
-            // Counts with static shape
-            // CHECK: {{%.+}}, {{%.+}} = quantum.counts [[X_OBS]] : tensor<2xf64>, tensor<2xi64>
-            %eigvals1, %counts1 = quantum.counts %x_obs : tensor<2xf64>, tensor<2xi64>
+        ///////////////////// **CountsOp** /////////////////////
+        // Counts with static shape
+        // CHECK: {{%.+}}, {{%.+}} = quantum.counts [[X_OBS]] : tensor<2xf64>, tensor<2xi64>
+        %eigvals1, %counts1 = quantum.counts %x_obs : tensor<2xf64>, tensor<2xi64>
 
-            // Counts with dynamic shape
-            // CHECK: {{%.+}}, {{%.+}} = quantum.counts [[C_OBS_ALL]] shape [[DYN_WIRES]] : tensor<?xf64>, tensor<?xi64>
-            %eigvals2, %counts2 = quantum.counts %c_obs_all shape %dyn_wires : tensor<?xf64>, tensor<?xi64>
+        // Counts with dynamic shape
+        // CHECK: {{%.+}}, {{%.+}} = quantum.counts [[C_OBS_ALL]] shape [[DYN_WIRES]] : tensor<?xf64>, tensor<?xi64>
+        %eigvals2, %counts2 = quantum.counts %c_obs_all shape %dyn_wires : tensor<?xf64>, tensor<?xi64>
 
-            // Counts with no results (mutate memref in-place)
-            // CHECK: [[EIGVALS_IN:%.+]] = "test.op"() : () -> memref<8xf64>
-            // CHECK: [[COUNTS_IN:%.+]] = "test.op"() : () -> memref<8xi64>
-            // CHECK: quantum.counts [[C_OBS]] in([[EIGVALS_IN]] : memref<8xf64>, [[COUNTS_IN]] : memref<8xi64>)
-            %eigvals_in = "test.op"() : () -> memref<8xf64>
-            %counts_in = "test.op"() : () -> memref<8xi64>
-            quantum.counts %c_obs in(%eigvals_in : memref<8xf64>, %counts_in : memref<8xi64>)
+        // Counts with no results (mutate memref in-place)
+        // CHECK: [[EIGVALS_IN:%.+]] = "test.op"() : () -> memref<8xf64>
+        // CHECK: [[COUNTS_IN:%.+]] = "test.op"() : () -> memref<8xi64>
+        // CHECK: quantum.counts [[C_OBS]] in([[EIGVALS_IN]] : memref<8xf64>, [[COUNTS_IN]] : memref<8xi64>)
+        %eigvals_in = "test.op"() : () -> memref<8xf64>
+        %counts_in = "test.op"() : () -> memref<8xi64>
+        quantum.counts %c_obs in(%eigvals_in : memref<8xf64>, %counts_in : memref<8xi64>)
 
-            ///////////////////// **ProbsOp** /////////////////////
-            // Probs with static shape
-            // CHECK: {{%.+}} = quantum.probs [[C_OBS]] : tensor<8xf64>
-            %probs1 = quantum.probs %c_obs : tensor<8xf64>
+        ///////////////////// **ProbsOp** /////////////////////
+        // Probs with static shape
+        // CHECK: {{%.+}} = quantum.probs [[C_OBS]] : tensor<8xf64>
+        %probs1 = quantum.probs %c_obs : tensor<8xf64>
 
-            // Probs with dynamic shape
-            // CHECK: {{%.+}} = quantum.probs [[C_OBS_ALL]] shape [[DYN_WIRES]] : tensor<?xf64>
-            %probs2 = quantum.probs %c_obs_all shape %dyn_wires : tensor<?xf64>
+        // Probs with dynamic shape
+        // CHECK: {{%.+}} = quantum.probs [[C_OBS_ALL]] shape [[DYN_WIRES]] : tensor<?xf64>
+        %probs2 = quantum.probs %c_obs_all shape %dyn_wires : tensor<?xf64>
 
-            // Probs with no results (mutate memref in-place)
-            // CHECK: [[PROBS_IN:%.+]] = "test.op"() : () -> memref<8xf64>
-            // CHECK: quantum.probs [[C_OBS]] in([[PROBS_IN]] : memref<8xf64>)
-            %probs_in = "test.op"() : () -> memref<8xf64>
-            quantum.probs %c_obs in(%probs_in : memref<8xf64>)
+        // Probs with no results (mutate memref in-place)
+        // CHECK: [[PROBS_IN:%.+]] = "test.op"() : () -> memref<8xf64>
+        // CHECK: quantum.probs [[C_OBS]] in([[PROBS_IN]] : memref<8xf64>)
+        %probs_in = "test.op"() : () -> memref<8xf64>
+        quantum.probs %c_obs in(%probs_in : memref<8xf64>)
 
-            ///////////////////// **StateOp** /////////////////////
-            // State with static shape
-            // CHECK: {{%.+}} = quantum.state [[C_OBS_ALL]] : tensor<8xcomplex<f64>>
-            %state1 = quantum.state %c_obs_all : tensor<8xcomplex<f64>>
+        ///////////////////// **StateOp** /////////////////////
+        // State with static shape
+        // CHECK: {{%.+}} = quantum.state [[C_OBS_ALL]] : tensor<8xcomplex<f64>>
+        %state1 = quantum.state %c_obs_all : tensor<8xcomplex<f64>>
 
-            // State with dynamic shape
-            // CHECK: {{%.+}} = quantum.state [[C_OBS_ALL]] shape [[DYN_WIRES]] : tensor<?xcomplex<f64>>
-            %state2 = quantum.state %c_obs_all shape %dyn_wires : tensor<?xcomplex<f64>>
+        // State with dynamic shape
+        // CHECK: {{%.+}} = quantum.state [[C_OBS_ALL]] shape [[DYN_WIRES]] : tensor<?xcomplex<f64>>
+        %state2 = quantum.state %c_obs_all shape %dyn_wires : tensor<?xcomplex<f64>>
 
-            // State with no results (mutate memref in-place)
-            // CHECK: [[STATE_IN:%.+]] = "test.op"() : () -> memref<8xcomplex<f64>>
-            // CHECK: quantum.state [[C_OBS_ALL]] in([[STATE_IN]] : memref<8xcomplex<f64>>)
-            %state_in = "test.op"() : () -> memref<8xcomplex<f64>>
-            quantum.state %c_obs_all in(%state_in : memref<8xcomplex<f64>>)
+        // State with no results (mutate memref in-place)
+        // CHECK: [[STATE_IN:%.+]] = "test.op"() : () -> memref<8xcomplex<f64>>
+        // CHECK: quantum.state [[C_OBS_ALL]] in([[STATE_IN]] : memref<8xcomplex<f64>>)
+        %state_in = "test.op"() : () -> memref<8xcomplex<f64>>
+        quantum.state %c_obs_all in(%state_in : memref<8xcomplex<f64>>)
 
-            ///////////////////// **SampleOp** /////////////////////
-            // Samples with static shape
-            // CHECK: {{%.+}} = quantum.sample [[C_OBS]] : tensor<10x3xf64>
-            %samples1 = quantum.sample %c_obs : tensor<10x3xf64>
+        ///////////////////// **SampleOp** /////////////////////
+        // Samples with static shape
+        // CHECK: {{%.+}} = quantum.sample [[C_OBS]] : tensor<10x3xf64>
+        %samples1 = quantum.sample %c_obs : tensor<10x3xf64>
 
-            // Samples with dynamic wires
-            // CHECK: {{%.+}} = quantum.sample [[C_OBS_ALL]] shape [[DYN_WIRES]] : tensor<10x?xf64>
-            %samples2 = quantum.sample %c_obs_all shape %dyn_wires : tensor<10x?xf64>
+        // Samples with dynamic wires
+        // CHECK: {{%.+}} = quantum.sample [[C_OBS_ALL]] shape [[DYN_WIRES]] : tensor<10x?xf64>
+        %samples2 = quantum.sample %c_obs_all shape %dyn_wires : tensor<10x?xf64>
 
-            // Samples with dynamic shots
-            // CHECK: {{%.+}} = quantum.sample [[C_OBS]] shape [[DYN_SHOTS]] : tensor<?x3xf64>
-            %samples3 = quantum.sample %c_obs shape %dyn_shots : tensor<?x3xf64>
+        // Samples with dynamic shots
+        // CHECK: {{%.+}} = quantum.sample [[C_OBS]] shape [[DYN_SHOTS]] : tensor<?x3xf64>
+        %samples3 = quantum.sample %c_obs shape %dyn_shots : tensor<?x3xf64>
 
-            // Samples with dynamic wires and shots
-            // CHECK: {{%.+}} = quantum.sample [[C_OBS_ALL]] shape [[DYN_SHOTS]], [[DYN_WIRES]] : tensor<?x?xf64>
-            %samples4 = quantum.sample %c_obs_all shape %dyn_shots, %dyn_wires : tensor<?x?xf64>
+        // Samples with dynamic wires and shots
+        // CHECK: {{%.+}} = quantum.sample [[C_OBS_ALL]] shape [[DYN_SHOTS]], [[DYN_WIRES]] : tensor<?x?xf64>
+        %samples4 = quantum.sample %c_obs_all shape %dyn_shots, %dyn_wires : tensor<?x?xf64>
 
-            // Samples with no results (mutate memref in-place)
-            // CHECK: [[SAMPLES_IN:%.+]] = "test.op"() : () -> memref<7x3xf64>
-            // CHECK: quantum.sample [[C_OBS]] in([[SAMPLES_IN]] : memref<7x3xf64>)
-            %samples_in = "test.op"() : () -> memref<7x3xf64>
-            quantum.sample %c_obs in(%samples_in : memref<7x3xf64>)
-
-            return
-        }
+        // Samples with no results (mutate memref in-place)
+        // CHECK: [[SAMPLES_IN:%.+]] = "test.op"() : () -> memref<7x3xf64>
+        // CHECK: quantum.sample [[C_OBS]] in([[SAMPLES_IN]] : memref<7x3xf64>)
+        %samples_in = "test.op"() : () -> memref<7x3xf64>
+        quantum.sample %c_obs in(%samples_in : memref<7x3xf64>)
         """
 
         run_filecheck(program, roundtrip=True, verify=True, pretty_print=pretty_print)

--- a/mlir/lib/Quantum/IR/QuantumOps.cpp
+++ b/mlir/lib/Quantum/IR/QuantumOps.cpp
@@ -310,11 +310,16 @@ LogicalResult QubitUnitaryOp::verify()
 
 static LogicalResult verifyInQNodeFunction(Operation *op)
 {
-    auto parentModule = op->getParentOfType<ModuleOp>();
-    auto rootModule = parentModule->getParentOfType<ModuleOp>();
-    bool inQuantumKernel = parentModule && rootModule;
-    if (!inQuantumKernel) {
-        return success(); // strict verification only for quantum kernels
+    // strict verification only for quantum kernels
+    // detection is a bit tricky until we have a dedicated operation, use heuristics for now
+    auto kernelModule = op->getParentOfType<ModuleOp>();
+    if (!kernelModule) {
+        return success();
+    }
+
+    auto modIt = kernelModule.getOps<ModuleOp>();
+    if (modIt.empty() || !(*modIt.begin())->hasAttr("transform.with_named_sequence")) {
+        return success();
     }
 
     auto parentFunc = op->getParentOfType<func::FuncOp>();

--- a/mlir/test/Catalyst/Async.mlir
+++ b/mlir/test/Catalyst/Async.mlir
@@ -146,34 +146,36 @@ module @workflow {
 
 // Test to make sure that async is placed before uses even in the presence of control flow.
 
-func.func public @jit_bar(%arg0: tensor<i1>) -> tensor<2xcomplex<f64>> attributes {llvm.emit_c_interface} {
-  %0 = stablehlo.constant dense<(1.000000e+00,0.000000e+00)> : tensor<complex<f64>>
-  %1 = call @foo() : () -> tensor<2xcomplex<f64>>
-  %extracted = tensor.extract %arg0[] : tensor<i1>
-  %2 = scf.if %extracted -> (tensor<2xcomplex<f64>>) {
-    // CHECK: scf.if
-    // CHECK: async.await
-    // CHECK: scf.yield
-    %3 = stablehlo.broadcast_in_dim %0, dims = [] : (tensor<complex<f64>>) -> tensor<2xcomplex<f64>>
-    %4 = stablehlo.add %1, %3 : tensor<2xcomplex<f64>>
-    scf.yield %4 : tensor<2xcomplex<f64>>
-  } else {
-    // CHECK: else
-    // CHECK: async.await
-    // CHECK: scf.yield
-    %3 = stablehlo.broadcast_in_dim %0, dims = [] : (tensor<complex<f64>>) -> tensor<2xcomplex<f64>>
-    %4 = stablehlo.subtract %1, %3 : tensor<2xcomplex<f64>>
-    scf.yield %4 : tensor<2xcomplex<f64>>
+module @bar {
+  func.func public @jit_bar(%arg0: tensor<i1>) -> tensor<2xcomplex<f64>> attributes {llvm.emit_c_interface} {
+    %0 = stablehlo.constant dense<(1.000000e+00,0.000000e+00)> : tensor<complex<f64>>
+    %1 = call @foo() : () -> tensor<2xcomplex<f64>>
+    %extracted = tensor.extract %arg0[] : tensor<i1>
+    %2 = scf.if %extracted -> (tensor<2xcomplex<f64>>) {
+      // CHECK: scf.if
+      // CHECK: async.await
+      // CHECK: scf.yield
+      %3 = stablehlo.broadcast_in_dim %0, dims = [] : (tensor<complex<f64>>) -> tensor<2xcomplex<f64>>
+      %4 = stablehlo.add %1, %3 : tensor<2xcomplex<f64>>
+      scf.yield %4 : tensor<2xcomplex<f64>>
+    } else {
+      // CHECK: else
+      // CHECK: async.await
+      // CHECK: scf.yield
+      %3 = stablehlo.broadcast_in_dim %0, dims = [] : (tensor<complex<f64>>) -> tensor<2xcomplex<f64>>
+      %4 = stablehlo.subtract %1, %3 : tensor<2xcomplex<f64>>
+      scf.yield %4 : tensor<2xcomplex<f64>>
+    }
+    return %2 : tensor<2xcomplex<f64>>
   }
-  return %2 : tensor<2xcomplex<f64>>
-}
-func.func private @foo() -> tensor<2xcomplex<f64>> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
-  quantum.device["/home/ubuntu/code/catalyst/frontend/catalyst/utils/../../../runtime/build/lib/librtd_lightning.so", "LightningSimulator", "{'shots': 0, 'mcmc': False}"]
-  %0 = quantum.alloc( 1) : !quantum.reg
-  %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
-  %2 = quantum.compbasis qubits %1 : !quantum.obs
-  %3 = quantum.state %2 : tensor<2xcomplex<f64>>
-  quantum.dealloc %0 : !quantum.reg
-  quantum.device_release
-  return %3 : tensor<2xcomplex<f64>>
+  func.func private @foo() -> tensor<2xcomplex<f64>> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
+    quantum.device["/home/ubuntu/code/catalyst/frontend/catalyst/utils/../../../runtime/build/lib/librtd_lightning.so", "LightningSimulator", "{'shots': 0, 'mcmc': False}"]
+    %0 = quantum.alloc( 1) : !quantum.reg
+    %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+    %2 = quantum.compbasis qubits %1 : !quantum.obs
+    %3 = quantum.state %2 : tensor<2xcomplex<f64>>
+    quantum.dealloc %0 : !quantum.reg
+    quantum.device_release
+    return %3 : tensor<2xcomplex<f64>>
+  }
 }

--- a/mlir/test/Gradient/StaticAllocaTest.mlir
+++ b/mlir/test/Gradient/StaticAllocaTest.mlir
@@ -14,49 +14,55 @@
 
 // RUN: quantum-opt --lower-gradients --split-input-file %s | FileCheck %s
 
-// CHECK-LABEL: @structured_circuit.qgrad
-// CHECK-NOT: scf
-// CHECK: memref.alloca
-// CHECK-NOT: scf
-// CHECK: memref.alloca
+// CHECK-LABEL: @static_alloca_qubit_grad
+module @static_alloca_qubit_grad {
 
-// CHECK-LABEL: @structured_circuit.pcount
-// CHECK-NOT: scf
-// CHECK: memref.alloca
+   // CHECK-LABEL: @structured_circuit.qgrad
+   // CHECK-NOT: scf
+   // CHECK: memref.alloca
+   // CHECK-NOT: scf
+   // CHECK: memref.alloca
 
-// CHECK-LABEL: @structured_circuit.quantum
-// CHECK-NOT: scf
-// CHECK: memref.alloca
+   // CHECK-LABEL: @structured_circuit.pcount
+   // CHECK-NOT: scf
+   // CHECK: memref.alloca
 
-func.func @structured_circuit(%arg0: f64, %arg1: i1, %arg2: i1) -> f64 attributes {qnode, diff_method = "parameter-shift"} {
-  %idx = arith.constant 0 : i64
-  %r = quantum.alloc(1) : !quantum.reg
-  %q_0 = quantum.extract %r[%idx] : !quantum.reg -> !quantum.bit
-  %q_1 = quantum.custom "rx"(%arg0) %q_0 : !quantum.bit
-  %q_2 = scf.if %arg1 -> !quantum.bit {
-      %q_1_0 = quantum.custom "ry"(%arg0) %q_1 : !quantum.bit
-      %q_1_1 = scf.if %arg2 -> !quantum.bit {
-          %q_1_0_0 = quantum.custom "rz"(%arg0) %q_1_0 : !quantum.bit
-          scf.yield %q_1_0_0 : !quantum.bit
-      } else {
-          %q_1_0_1 = quantum.custom "rz"(%arg0) %q_1_0 : !quantum.bit
-          %q_1_0_2 = quantum.custom "rz"(%arg0) %q_1_0_1 : !quantum.bit
-          scf.yield %q_1_0_2 : !quantum.bit
-      }
-      scf.yield %q_1_1 : !quantum.bit
-  } else {
-      scf.yield %q_1 : !quantum.bit
+   // CHECK-LABEL: @structured_circuit.quantum
+   // CHECK-NOT: scf
+   // CHECK: memref.alloca
+
+   func.func @structured_circuit(%arg0: f64, %arg1: i1, %arg2: i1) -> f64 attributes {qnode, diff_method = "parameter-shift"} {
+    %idx = arith.constant 0 : i64
+    %r = quantum.alloc(1) : !quantum.reg
+    %q_0 = quantum.extract %r[%idx] : !quantum.reg -> !quantum.bit
+    %q_1 = quantum.custom "rx"(%arg0) %q_0 : !quantum.bit
+    %q_2 = scf.if %arg1 -> !quantum.bit {
+        %q_1_0 = quantum.custom "ry"(%arg0) %q_1 : !quantum.bit
+        %q_1_1 = scf.if %arg2 -> !quantum.bit {
+            %q_1_0_0 = quantum.custom "rz"(%arg0) %q_1_0 : !quantum.bit
+            scf.yield %q_1_0_0 : !quantum.bit
+        } else {
+            %q_1_0_1 = quantum.custom "rz"(%arg0) %q_1_0 : !quantum.bit
+            %q_1_0_2 = quantum.custom "rz"(%arg0) %q_1_0_1 : !quantum.bit
+            scf.yield %q_1_0_2 : !quantum.bit
+        }
+        scf.yield %q_1_1 : !quantum.bit
+    } else {
+        scf.yield %q_1 : !quantum.bit
+    }
+    cf.br ^exit
+  ^exit:
+    %q_3 = quantum.custom "rx"(%arg0) %q_2 : !quantum.bit
+    %obs = quantum.namedobs %q_3[PauliX] : !quantum.obs
+    %expval = quantum.expval %obs : f64
+    func.return %expval : f64
   }
-  cf.br ^exit
-^exit:
-  %q_3 = quantum.custom "rx"(%arg0) %q_2 : !quantum.bit
-  %obs = quantum.namedobs %q_3[PauliX] : !quantum.obs
-  %expval = quantum.expval %obs : f64
-  func.return %expval : f64
+
+  func.func @gradCall1(%arg0: f64, %b0: i1, %b1: i1) -> f64 {
+    
+    %0 = gradient.grad "auto" @structured_circuit(%arg0, %b0, %b1) : (f64, i1, i1) -> f64
+    func.return %0 : f64
+  }
 }
 
-func.func @gradCall1(%arg0: f64, %b0: i1, %b1: i1) -> f64 {
-
-  %0 = gradient.grad "auto" @structured_circuit(%arg0, %b0, %b1) : (f64, i1, i1) -> f64
-  func.return %0 : f64
-}
+// -----

--- a/mlir/test/Ion/IonToRTIO.mlir
+++ b/mlir/test/Ion/IonToRTIO.mlir
@@ -19,57 +19,67 @@
 // CHECK: memref.global "private" constant @__qubit_map_0 : memref<2xindex> = dense<[0, 1]>
 // CHECK-LABEL: func.func @__kernel__()
 // CHECK-SAME: attributes {diff_method = "parameter-shift", qnode}
-func.func public @rx_circuit() -> (memref<4xi64>, memref<4xi64>) attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
-  %0 = ion.ion {charge = -1.000000e+00 : f64, levels = [#ion.level<label = "downstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 0.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 0.000000e+00 : f64>, #ion.level<label = "upstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 79438311838.671509 : f64>, #ion.level<label = "estate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = -1.000000e+00 : f64, energy = 0x43321C22CEFBBBDF : f64>, #ion.level<label = "estate2", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 1.000000e+00 : f64, energy = 0x433456BB2DC221F8 : f64>], mass = 1.710000e+02 : f64, name = "Yb171", position = array<f64: 0.000000e+00, 0.000000e+00, 0.000000e+00>, transitions = [#ion.transition<level_0 = "downstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "downstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">]} : !ion.ion
-  ion.mode {modes = [#ion.phonon<energy = 6283185.307179586 : f64, eigenvector = [7.071068e-01, 0.000000e+00, 0.000000e+00, 7.071068e-01, 0.000000e+00, 0.000000e+00]>]}
-  %c1_i64 = arith.constant 1 : i64
-  %cst = arith.constant 1.5707963267948966 : f64
-  quantum.device shots(%c1_i64) ["/path/to/device.dylib", "oqd", "{}"]
-  %1 = quantum.alloc( 2) : !quantum.reg
-  %2 = quantum.extract %1[ 1] : !quantum.reg -> !quantum.bit
-  %cst_0 = arith.constant 12.566370614359172 : f64
-  %3 = arith.remf %cst, %cst_0 : f64
-  %cst_1 = arith.constant 0.000000e+00 : f64
-  %4 = arith.cmpf olt, %3, %cst_1 : f64
-  %5 = scf.if %4 -> (f64) {
-    %16 = arith.addf %3, %cst_0 : f64
-    scf.yield %16 : f64
-  } else {
-    scf.yield %3 : f64
+module @circuit {
+  func.func public @circuit_0() -> (memref<4xi64>, memref<4xi64>) attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
+    %0 = ion.ion {charge = -1.000000e+00 : f64, levels = [#ion.level<label = "downstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 0.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 0.000000e+00 : f64>, #ion.level<label = "upstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 79438311838.671509 : f64>, #ion.level<label = "estate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = -1.000000e+00 : f64, energy = 0x43321C22CEFBBBDF : f64>, #ion.level<label = "estate2", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 1.000000e+00 : f64, energy = 0x433456BB2DC221F8 : f64>], mass = 1.710000e+02 : f64, name = "Yb171", position = array<f64: 0.000000e+00, 0.000000e+00, 0.000000e+00>, transitions = [#ion.transition<level_0 = "downstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "downstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">]} : !ion.ion
+    ion.mode {modes = [#ion.phonon<energy = 6283185.307179586 : f64, eigenvector = [7.071068e-01, 0.000000e+00, 0.000000e+00, 7.071068e-01, 0.000000e+00, 0.000000e+00]>]}
+    %c1_i64 = arith.constant 1 : i64
+    %cst = arith.constant 1.5707963267948966 : f64
+    quantum.device shots(%c1_i64) ["/path/to/device.dylib", "oqd", "{}"]
+    %1 = quantum.alloc( 2) : !quantum.reg
+    %2 = quantum.extract %1[ 1] : !quantum.reg -> !quantum.bit
+    %cst_0 = arith.constant 12.566370614359172 : f64
+    %3 = arith.remf %cst, %cst_0 : f64
+    %cst_1 = arith.constant 0.000000e+00 : f64
+    %4 = arith.cmpf olt, %3, %cst_1 : f64
+    %5 = scf.if %4 -> (f64) {
+      %16 = arith.addf %3, %cst_0 : f64
+      scf.yield %16 : f64
+    } else {
+      scf.yield %3 : f64
+    }
+    %cst_2 = arith.constant 62831853071.79586 : f64
+    %cst_3 = arith.constant 417140672543652.75 : f64
+    %6 = arith.mulf %5, %cst_3 : f64
+    %7 = arith.mulf %cst_2, %cst_2 : f64
+    %8 = arith.divf %6, %7 : f64
+    %9 = builtin.unrealized_conversion_cast %2 : !quantum.bit to !ion.qubit
+    // CHECK: %[[EMPTY:.*]] = rtio.empty : !rtio.event
+    // CHECK: %[[CH:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 2>
+    // CHECK: %[[PULSE:.*]] = rtio.pulse %[[CH]] duration(%{{.*}}) frequency(%{{.*}}) phase(%{{.*}}) wait(%[[EMPTY]])
+    // CHECK: return
+    %10 = ion.parallelprotocol(%9) : !ion.qubit {
+    ^bb0(%arg0: !ion.qubit):
+      %16 = ion.pulse(%8 : f64) %arg0 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+      %17 = ion.pulse(%8 : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+      ion.yield %arg0 : !ion.qubit
+    }
+    %11 = builtin.unrealized_conversion_cast %10 : !ion.qubit to !quantum.bit
+    %12 = quantum.extract %1[ 0] : !quantum.reg -> !quantum.bit
+    %13 = quantum.compbasis qubits %12, %11 : !quantum.obs
+    %alloca = memref.alloca() : memref<4xf64>
+    %alloc = memref.alloc() : memref<4xi64>
+    quantum.counts %13 in(%alloca : memref<4xf64>, %alloc : memref<4xi64>)
+    %alloc_4 = memref.alloc() {alignment = 64 : i64} : memref<4xi64>
+    linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%alloca : memref<4xf64>) outs(%alloc_4 : memref<4xi64>) {
+    ^bb0(%in: f64, %out: i64):
+      %16 = arith.fptosi %in : f64 to i64
+      linalg.yield %16 : i64
+    }
+    %14 = quantum.insert %1[ 1], %11 : !quantum.reg, !quantum.bit
+    %15 = quantum.insert %14[ 0], %12 : !quantum.reg, !quantum.bit
+    quantum.dealloc %15 : !quantum.reg
+    quantum.device_release
+    return %alloc_4, %alloc : memref<4xi64>, memref<4xi64>
   }
-  %cst_2 = arith.constant 62831853071.79586 : f64
-  %cst_3 = arith.constant 417140672543652.75 : f64
-  %6 = arith.mulf %5, %cst_3 : f64
-  %7 = arith.mulf %cst_2, %cst_2 : f64
-  %8 = arith.divf %6, %7 : f64
-  %9 = builtin.unrealized_conversion_cast %2 : !quantum.bit to !ion.qubit
-  // CHECK: %[[EMPTY:.*]] = rtio.empty : !rtio.event
-  // CHECK: %[[CH:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 2>
-  // CHECK: %[[PULSE:.*]] = rtio.pulse %[[CH]] duration(%{{.*}}) frequency(%{{.*}}) phase(%{{.*}}) wait(%[[EMPTY]])
-  // CHECK: return
-  %10 = ion.parallelprotocol(%9) : !ion.qubit {
-  ^bb0(%arg0: !ion.qubit):
-    %16 = ion.pulse(%8 : f64) %arg0 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-    %17 = ion.pulse(%8 : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-    ion.yield %arg0 : !ion.qubit
+  func.func @setup() {
+    quantum.init
+    return
   }
-  %11 = builtin.unrealized_conversion_cast %10 : !ion.qubit to !quantum.bit
-  %12 = quantum.extract %1[ 0] : !quantum.reg -> !quantum.bit
-  %13 = quantum.compbasis qubits %12, %11 : !quantum.obs
-  %alloca = memref.alloca() : memref<4xf64>
-  %alloc = memref.alloc() : memref<4xi64>
-  quantum.counts %13 in(%alloca : memref<4xf64>, %alloc : memref<4xi64>)
-  %alloc_4 = memref.alloc() {alignment = 64 : i64} : memref<4xi64>
-  linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%alloca : memref<4xf64>) outs(%alloc_4 : memref<4xi64>) {
-  ^bb0(%in: f64, %out: i64):
-    %16 = arith.fptosi %in : f64 to i64
-    linalg.yield %16 : i64
+  func.func @teardown() {
+    quantum.finalize
+    return
   }
-  %14 = quantum.insert %1[ 1], %11 : !quantum.reg, !quantum.bit
-  %15 = quantum.insert %14[ 0], %12 : !quantum.reg, !quantum.bit
-  quantum.dealloc %15 : !quantum.reg
-  quantum.device_release
-  return %alloc_4, %alloc : memref<4xi64>, memref<4xi64>
 }
 
 // -----
@@ -78,179 +88,189 @@ func.func public @rx_circuit() -> (memref<4xi64>, memref<4xi64>) attributes {dif
 
 // CHECK: memref.global "private" constant @__qubit_map_0 : memref<2xindex> = dense<[0, 1]>
 // CHECK-LABEL: func.func @__kernel__()
-func.func public @cnot_circuit() -> (memref<4xi64>, memref<4xi64>) attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
-  %0 = ion.ion {charge = -1.000000e+00 : f64, levels = [#ion.level<label = "downstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 0.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 0.000000e+00 : f64>, #ion.level<label = "upstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 79438311838.671509 : f64>, #ion.level<label = "estate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = -1.000000e+00 : f64, energy = 0x43321C22CEFBBBDF : f64>, #ion.level<label = "estate2", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 1.000000e+00 : f64, energy = 0x433456BB2DC221F8 : f64>], mass = 1.710000e+02 : f64, name = "Yb171", position = array<f64: 0.000000e+00, 0.000000e+00, 0.000000e+00>, transitions = [#ion.transition<level_0 = "downstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "downstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">]} : !ion.ion
-  ion.mode {modes = [#ion.phonon<energy = 6283185.307179586 : f64, eigenvector = [7.071068e-01, 0.000000e+00, 0.000000e+00, 7.071068e-01, 0.000000e+00, 0.000000e+00]>]}
-  %cst = arith.constant -1.5707963267948966 : f64
-  %cst_0 = arith.constant 1.5707963267948966 : f64
-  %c1_i64 = arith.constant 1 : i64
-  quantum.device shots(%c1_i64) ["/path/to/device.dylib", "oqd", "{}"]
-  %1 = quantum.alloc( 2) : !quantum.reg
-  %2 = quantum.extract %1[ 0] : !quantum.reg -> !quantum.bit
-  %3 = quantum.extract %1[ 1] : !quantum.reg -> !quantum.bit
+module @cnot_circuit {
+  func.func public @circuit_0() -> (memref<4xi64>, memref<4xi64>) attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
+    %0 = ion.ion {charge = -1.000000e+00 : f64, levels = [#ion.level<label = "downstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 0.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 0.000000e+00 : f64>, #ion.level<label = "upstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 79438311838.671509 : f64>, #ion.level<label = "estate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = -1.000000e+00 : f64, energy = 0x43321C22CEFBBBDF : f64>, #ion.level<label = "estate2", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 1.000000e+00 : f64, energy = 0x433456BB2DC221F8 : f64>], mass = 1.710000e+02 : f64, name = "Yb171", position = array<f64: 0.000000e+00, 0.000000e+00, 0.000000e+00>, transitions = [#ion.transition<level_0 = "downstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "downstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">]} : !ion.ion
+    ion.mode {modes = [#ion.phonon<energy = 6283185.307179586 : f64, eigenvector = [7.071068e-01, 0.000000e+00, 0.000000e+00, 7.071068e-01, 0.000000e+00, 0.000000e+00]>]}
+    %cst = arith.constant -1.5707963267948966 : f64
+    %cst_0 = arith.constant 1.5707963267948966 : f64
+    %c1_i64 = arith.constant 1 : i64
+    quantum.device shots(%c1_i64) ["/path/to/device.dylib", "oqd", "{}"]
+    %1 = quantum.alloc( 2) : !quantum.reg
+    %2 = quantum.extract %1[ 0] : !quantum.reg -> !quantum.bit
+    %3 = quantum.extract %1[ 1] : !quantum.reg -> !quantum.bit
 
-  %cst_1 = arith.constant 12.566370614359172 : f64
-  %4 = arith.remf %cst_0, %cst_1 : f64
-  %cst_2 = arith.constant 0.000000e+00 : f64
-  %5 = arith.cmpf olt, %4, %cst_2 : f64
-  %6 = scf.if %5 -> (f64) {
-    %54 = arith.addf %4, %cst_1 : f64
-    scf.yield %54 : f64
-  } else {
-    scf.yield %4 : f64
-  }
-  %cst_3 = arith.constant 62831853071.79586 : f64
-  %cst_4 = arith.constant 417140672543652.75 : f64
-  %7 = arith.mulf %6, %cst_4 : f64
-  %8 = arith.mulf %cst_3, %cst_3 : f64
-  %9 = arith.divf %7, %8 : f64
-  %10 = builtin.unrealized_conversion_cast %2 : !quantum.bit to !ion.qubit
+    %cst_1 = arith.constant 12.566370614359172 : f64
+    %4 = arith.remf %cst_0, %cst_1 : f64
+    %cst_2 = arith.constant 0.000000e+00 : f64
+    %5 = arith.cmpf olt, %4, %cst_2 : f64
+    %6 = scf.if %5 -> (f64) {
+      %54 = arith.addf %4, %cst_1 : f64
+      scf.yield %54 : f64
+    } else {
+      scf.yield %4 : f64
+    }
+    %cst_3 = arith.constant 62831853071.79586 : f64
+    %cst_4 = arith.constant 417140672543652.75 : f64
+    %7 = arith.mulf %6, %cst_4 : f64
+    %8 = arith.mulf %cst_3, %cst_3 : f64
+    %9 = arith.divf %7, %8 : f64
+    %10 = builtin.unrealized_conversion_cast %2 : !quantum.bit to !ion.qubit
 
-  // CHECK: %[[EMPTY:.*]] = rtio.empty : !rtio.event
-  // CHECK: %[[CH0:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 0>
-  // CHECK: %[[P1:.*]] = rtio.pulse %[[CH0]] {{.*}} wait(%[[EMPTY]])
-  %11 = ion.parallelprotocol(%10) : !ion.qubit {
-  ^bb0(%arg0: !ion.qubit):
-    %54 = ion.pulse(%9 : f64) %arg0 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 1.5707963267948966 : f64} : !ion.pulse
-    %55 = ion.pulse(%9 : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-    ion.yield %arg0 : !ion.qubit
-  }
-  %12 = builtin.unrealized_conversion_cast %11 : !ion.qubit to !quantum.bit
+    // CHECK: %[[EMPTY:.*]] = rtio.empty : !rtio.event
+    // CHECK: %[[CH0:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 0>
+    // CHECK: %[[P1:.*]] = rtio.pulse %[[CH0]] {{.*}} wait(%[[EMPTY]])
+    %11 = ion.parallelprotocol(%10) : !ion.qubit {
+    ^bb0(%arg0: !ion.qubit):
+      %54 = ion.pulse(%9 : f64) %arg0 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 1.5707963267948966 : f64} : !ion.pulse
+      %55 = ion.pulse(%9 : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+      ion.yield %arg0 : !ion.qubit
+    }
+    %12 = builtin.unrealized_conversion_cast %11 : !ion.qubit to !quantum.bit
 
-  %cst_5 = arith.constant 12.566370614359172 : f64
-  %13 = arith.remf %cst_0, %cst_5 : f64
-  %cst_6 = arith.constant 0.000000e+00 : f64
-  %14 = arith.cmpf olt, %13, %cst_6 : f64
-  %15 = scf.if %14 -> (f64) {
-    %54 = arith.addf %13, %cst_5 : f64
-    scf.yield %54 : f64
-  } else {
-    scf.yield %13 : f64
-  }
-  %cst_7 = arith.constant 8885765876.3167324 : f64
-  %cst_8 = arith.constant 417140672543652.75 : f64
-  %16 = arith.mulf %15, %cst_8 : f64
-  %17 = arith.mulf %cst_7, %cst_7 : f64
-  %18 = arith.divf %16, %17 : f64
-  %19 = builtin.unrealized_conversion_cast %12 : !quantum.bit to !ion.qubit
-  %20 = builtin.unrealized_conversion_cast %3 : !quantum.bit to !ion.qubit
+    %cst_5 = arith.constant 12.566370614359172 : f64
+    %13 = arith.remf %cst_0, %cst_5 : f64
+    %cst_6 = arith.constant 0.000000e+00 : f64
+    %14 = arith.cmpf olt, %13, %cst_6 : f64
+    %15 = scf.if %14 -> (f64) {
+      %54 = arith.addf %13, %cst_5 : f64
+      scf.yield %54 : f64
+    } else {
+      scf.yield %13 : f64
+    }
+    %cst_7 = arith.constant 8885765876.3167324 : f64
+    %cst_8 = arith.constant 417140672543652.75 : f64
+    %16 = arith.mulf %15, %cst_8 : f64
+    %17 = arith.mulf %cst_7, %cst_7 : f64
+    %18 = arith.divf %16, %17 : f64
+    %19 = builtin.unrealized_conversion_cast %12 : !quantum.bit to !ion.qubit
+    %20 = builtin.unrealized_conversion_cast %3 : !quantum.bit to !ion.qubit
 
-  // CHECK: %[[SYNC1:.*]] = rtio.sync %[[P1]], %[[EMPTY]] : !rtio.event
-  // CHECK: %[[P2:.*]] = rtio.pulse %[[CH0]] {{.*}} wait(%[[SYNC1]])
-  // CHECK: %[[CH1:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 1>
-  // CHECK: %[[P3:.*]] = rtio.pulse %[[CH1]] {{.*}} wait(%[[SYNC1]])
-  // CHECK: %[[CH2:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 2>
-  // CHECK: %[[P4:.*]] = rtio.pulse %[[CH2]] {{.*}} wait(%[[SYNC1]])
-  // CHECK: %[[CH3:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 3>
-  // CHECK: %[[P5:.*]] = rtio.pulse %[[CH3]] {{.*}} wait(%[[SYNC1]])
-  // CHECK: %[[SYNC2:.*]] = rtio.sync %[[P2]], %[[P3]], %[[P4]], %[[P5]] : !rtio.event
-  %21:2 = ion.parallelprotocol(%19, %20) : !ion.qubit, !ion.qubit {
-  ^bb0(%arg0: !ion.qubit, %arg1: !ion.qubit):
-    %54 = ion.pulse(%18 : f64) %arg0 {beam = #ion.beam<transition_index = 0 : i64, rabi = 8885765876.3167324 : f64, detuning = 208570336271826.38 : f64, polarization = [0, 1, 0], wavevector = [-1, 0, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-    %55 = ion.pulse(%18 : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 8885765876.3167324 : f64, detuning = 208570342555011.69 : f64, polarization = [0, 1, 0], wavevector = [1, 0, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-    %56 = ion.pulse(%18 : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 8885765876.3167324 : f64, detuning = 208570329988641.06 : f64, polarization = [0, 1, 0], wavevector = [1, 0, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-    %57 = ion.pulse(%18 : f64) %arg1 {beam = #ion.beam<transition_index = 0 : i64, rabi = 8885765876.3167324 : f64, detuning = 208570336271826.38 : f64, polarization = [0, 1, 0], wavevector = [-1, 0, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-    %58 = ion.pulse(%18 : f64) %arg1 {beam = #ion.beam<transition_index = 2 : i64, rabi = 8885765876.3167324 : f64, detuning = 208570341926693.16 : f64, polarization = [0, 1, 0], wavevector = [1, 0, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-    %59 = ion.pulse(%18 : f64) %arg1 {beam = #ion.beam<transition_index = 2 : i64, rabi = 8885765876.3167324 : f64, detuning = 208570330616959.59 : f64, polarization = [0, 1, 0], wavevector = [1, 0, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-    ion.yield %arg0, %arg1 : !ion.qubit, !ion.qubit
-  }
-  %22 = builtin.unrealized_conversion_cast %21#0 : !ion.qubit to !quantum.bit
-  %23 = builtin.unrealized_conversion_cast %21#1 : !ion.qubit to !quantum.bit
+    // CHECK: %[[SYNC1:.*]] = rtio.sync %[[P1]], %[[EMPTY]] : !rtio.event
+    // CHECK: %[[P2:.*]] = rtio.pulse %[[CH0]] {{.*}} wait(%[[SYNC1]])
+    // CHECK: %[[CH1:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 1>
+    // CHECK: %[[P3:.*]] = rtio.pulse %[[CH1]] {{.*}} wait(%[[SYNC1]])
+    // CHECK: %[[CH2:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 2>
+    // CHECK: %[[P4:.*]] = rtio.pulse %[[CH2]] {{.*}} wait(%[[SYNC1]])
+    // CHECK: %[[CH3:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 3>
+    // CHECK: %[[P5:.*]] = rtio.pulse %[[CH3]] {{.*}} wait(%[[SYNC1]])
+    // CHECK: %[[SYNC2:.*]] = rtio.sync %[[P2]], %[[P3]], %[[P4]], %[[P5]] : !rtio.event
+    %21:2 = ion.parallelprotocol(%19, %20) : !ion.qubit, !ion.qubit {
+    ^bb0(%arg0: !ion.qubit, %arg1: !ion.qubit):
+      %54 = ion.pulse(%18 : f64) %arg0 {beam = #ion.beam<transition_index = 0 : i64, rabi = 8885765876.3167324 : f64, detuning = 208570336271826.38 : f64, polarization = [0, 1, 0], wavevector = [-1, 0, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+      %55 = ion.pulse(%18 : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 8885765876.3167324 : f64, detuning = 208570342555011.69 : f64, polarization = [0, 1, 0], wavevector = [1, 0, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+      %56 = ion.pulse(%18 : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 8885765876.3167324 : f64, detuning = 208570329988641.06 : f64, polarization = [0, 1, 0], wavevector = [1, 0, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+      %57 = ion.pulse(%18 : f64) %arg1 {beam = #ion.beam<transition_index = 0 : i64, rabi = 8885765876.3167324 : f64, detuning = 208570336271826.38 : f64, polarization = [0, 1, 0], wavevector = [-1, 0, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+      %58 = ion.pulse(%18 : f64) %arg1 {beam = #ion.beam<transition_index = 2 : i64, rabi = 8885765876.3167324 : f64, detuning = 208570341926693.16 : f64, polarization = [0, 1, 0], wavevector = [1, 0, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+      %59 = ion.pulse(%18 : f64) %arg1 {beam = #ion.beam<transition_index = 2 : i64, rabi = 8885765876.3167324 : f64, detuning = 208570330616959.59 : f64, polarization = [0, 1, 0], wavevector = [1, 0, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+      ion.yield %arg0, %arg1 : !ion.qubit, !ion.qubit
+    }
+    %22 = builtin.unrealized_conversion_cast %21#0 : !ion.qubit to !quantum.bit
+    %23 = builtin.unrealized_conversion_cast %21#1 : !ion.qubit to !quantum.bit
 
-  %cst_9 = arith.constant 12.566370614359172 : f64
-  %24 = arith.remf %cst, %cst_9 : f64
-  %cst_10 = arith.constant 0.000000e+00 : f64
-  %25 = arith.cmpf olt, %24, %cst_10 : f64
-  %26 = scf.if %25 -> (f64) {
-    %54 = arith.addf %24, %cst_9 : f64
-    scf.yield %54 : f64
-  } else {
-    scf.yield %24 : f64
-  }
-  %cst_11 = arith.constant 62831853071.79586 : f64
-  %cst_12 = arith.constant 417140672543652.75 : f64
-  %27 = arith.mulf %26, %cst_12 : f64
-  %28 = arith.mulf %cst_11, %cst_11 : f64
-  %29 = arith.divf %27, %28 : f64
-  %30 = builtin.unrealized_conversion_cast %22 : !quantum.bit to !ion.qubit
+    %cst_9 = arith.constant 12.566370614359172 : f64
+    %24 = arith.remf %cst, %cst_9 : f64
+    %cst_10 = arith.constant 0.000000e+00 : f64
+    %25 = arith.cmpf olt, %24, %cst_10 : f64
+    %26 = scf.if %25 -> (f64) {
+      %54 = arith.addf %24, %cst_9 : f64
+      scf.yield %54 : f64
+    } else {
+      scf.yield %24 : f64
+    }
+    %cst_11 = arith.constant 62831853071.79586 : f64
+    %cst_12 = arith.constant 417140672543652.75 : f64
+    %27 = arith.mulf %26, %cst_12 : f64
+    %28 = arith.mulf %cst_11, %cst_11 : f64
+    %29 = arith.divf %27, %28 : f64
+    %30 = builtin.unrealized_conversion_cast %22 : !quantum.bit to !ion.qubit
 
-  // CHECK: %[[P6:.*]] = rtio.pulse %[[CH0]] {{.*}} wait(%[[SYNC2]])
-  %31 = ion.parallelprotocol(%30) : !ion.qubit {
-  ^bb0(%arg0: !ion.qubit):
-    %54 = ion.pulse(%29 : f64) %arg0 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-    %55 = ion.pulse(%29 : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-    ion.yield %arg0 : !ion.qubit
-  }
-  %32 = builtin.unrealized_conversion_cast %31 : !ion.qubit to !quantum.bit
+    // CHECK: %[[P6:.*]] = rtio.pulse %[[CH0]] {{.*}} wait(%[[SYNC2]])
+    %31 = ion.parallelprotocol(%30) : !ion.qubit {
+    ^bb0(%arg0: !ion.qubit):
+      %54 = ion.pulse(%29 : f64) %arg0 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+      %55 = ion.pulse(%29 : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+      ion.yield %arg0 : !ion.qubit
+    }
+    %32 = builtin.unrealized_conversion_cast %31 : !ion.qubit to !quantum.bit
 
-  %cst_13 = arith.constant 12.566370614359172 : f64
-  %33 = arith.remf %cst, %cst_13 : f64
-  %cst_14 = arith.constant 0.000000e+00 : f64
-  %34 = arith.cmpf olt, %33, %cst_14 : f64
-  %35 = scf.if %34 -> (f64) {
-    %54 = arith.addf %33, %cst_13 : f64
-    scf.yield %54 : f64
-  } else {
-    scf.yield %33 : f64
-  }
-  %cst_15 = arith.constant 62831853071.79586 : f64
-  %cst_16 = arith.constant 417140672543652.75 : f64
-  %36 = arith.mulf %35, %cst_16 : f64
-  %37 = arith.mulf %cst_15, %cst_15 : f64
-  %38 = arith.divf %36, %37 : f64
-  %39 = builtin.unrealized_conversion_cast %23 : !quantum.bit to !ion.qubit
+    %cst_13 = arith.constant 12.566370614359172 : f64
+    %33 = arith.remf %cst, %cst_13 : f64
+    %cst_14 = arith.constant 0.000000e+00 : f64
+    %34 = arith.cmpf olt, %33, %cst_14 : f64
+    %35 = scf.if %34 -> (f64) {
+      %54 = arith.addf %33, %cst_13 : f64
+      scf.yield %54 : f64
+    } else {
+      scf.yield %33 : f64
+    }
+    %cst_15 = arith.constant 62831853071.79586 : f64
+    %cst_16 = arith.constant 417140672543652.75 : f64
+    %36 = arith.mulf %35, %cst_16 : f64
+    %37 = arith.mulf %cst_15, %cst_15 : f64
+    %38 = arith.divf %36, %37 : f64
+    %39 = builtin.unrealized_conversion_cast %23 : !quantum.bit to !ion.qubit
 
-  // CHECK: %[[P7:.*]] = rtio.pulse %[[CH2]] {{.*}} wait(%[[SYNC2]])
-  %40 = ion.parallelprotocol(%39) : !ion.qubit {
-  ^bb0(%arg0: !ion.qubit):
-    %54 = ion.pulse(%38 : f64) %arg0 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 1.5707963267948966 : f64} : !ion.pulse
-    %55 = ion.pulse(%38 : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-    ion.yield %arg0 : !ion.qubit
-  }
-  %41 = builtin.unrealized_conversion_cast %40 : !ion.qubit to !quantum.bit
+    // CHECK: %[[P7:.*]] = rtio.pulse %[[CH2]] {{.*}} wait(%[[SYNC2]])
+    %40 = ion.parallelprotocol(%39) : !ion.qubit {
+    ^bb0(%arg0: !ion.qubit):
+      %54 = ion.pulse(%38 : f64) %arg0 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 1.5707963267948966 : f64} : !ion.pulse
+      %55 = ion.pulse(%38 : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+      ion.yield %arg0 : !ion.qubit
+    }
+    %41 = builtin.unrealized_conversion_cast %40 : !ion.qubit to !quantum.bit
 
-  %cst_17 = arith.constant 12.566370614359172 : f64
-  %42 = arith.remf %cst, %cst_17 : f64
-  %cst_18 = arith.constant 0.000000e+00 : f64
-  %43 = arith.cmpf olt, %42, %cst_18 : f64
-  %44 = scf.if %43 -> (f64) {
-    %54 = arith.addf %42, %cst_17 : f64
-    scf.yield %54 : f64
-  } else {
-    scf.yield %42 : f64
-  }
-  %cst_19 = arith.constant 62831853071.79586 : f64
-  %cst_20 = arith.constant 417140672543652.75 : f64
-  %45 = arith.mulf %44, %cst_20 : f64
-  %46 = arith.mulf %cst_19, %cst_19 : f64
-  %47 = arith.divf %45, %46 : f64
-  %48 = builtin.unrealized_conversion_cast %32 : !quantum.bit to !ion.qubit
+    %cst_17 = arith.constant 12.566370614359172 : f64
+    %42 = arith.remf %cst, %cst_17 : f64
+    %cst_18 = arith.constant 0.000000e+00 : f64
+    %43 = arith.cmpf olt, %42, %cst_18 : f64
+    %44 = scf.if %43 -> (f64) {
+      %54 = arith.addf %42, %cst_17 : f64
+      scf.yield %54 : f64
+    } else {
+      scf.yield %42 : f64
+    }
+    %cst_19 = arith.constant 62831853071.79586 : f64
+    %cst_20 = arith.constant 417140672543652.75 : f64
+    %45 = arith.mulf %44, %cst_20 : f64
+    %46 = arith.mulf %cst_19, %cst_19 : f64
+    %47 = arith.divf %45, %46 : f64
+    %48 = builtin.unrealized_conversion_cast %32 : !quantum.bit to !ion.qubit
 
-  // CHECK: %[[P8:.*]] = rtio.pulse %[[CH0]] {{.*}} wait(%[[P6]])
-  %49 = ion.parallelprotocol(%48) : !ion.qubit {
-  ^bb0(%arg0: !ion.qubit):
-    %54 = ion.pulse(%47 : f64) %arg0 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 1.5707963267948966 : f64} : !ion.pulse
-    %55 = ion.pulse(%47 : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-    ion.yield %arg0 : !ion.qubit
-  }
-  %50 = builtin.unrealized_conversion_cast %49 : !ion.qubit to !quantum.bit
+    // CHECK: %[[P8:.*]] = rtio.pulse %[[CH0]] {{.*}} wait(%[[P6]])
+    %49 = ion.parallelprotocol(%48) : !ion.qubit {
+    ^bb0(%arg0: !ion.qubit):
+      %54 = ion.pulse(%47 : f64) %arg0 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 1.5707963267948966 : f64} : !ion.pulse
+      %55 = ion.pulse(%47 : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+      ion.yield %arg0 : !ion.qubit
+    }
+    %50 = builtin.unrealized_conversion_cast %49 : !ion.qubit to !quantum.bit
 
-  // CHECK: return
-  %51 = quantum.compbasis qubits %41, %50 : !quantum.obs
-  %alloca = memref.alloca() : memref<4xf64>
-  %alloc = memref.alloc() : memref<4xi64>
-  quantum.counts %51 in(%alloca : memref<4xf64>, %alloc : memref<4xi64>)
-  %alloc_21 = memref.alloc() {alignment = 64 : i64} : memref<4xi64>
-  linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%alloca : memref<4xf64>) outs(%alloc_21 : memref<4xi64>) {
-  ^bb0(%in: f64, %out: i64):
-    %54 = arith.fptosi %in : f64 to i64
-    linalg.yield %54 : i64
+    // CHECK: return
+    %51 = quantum.compbasis qubits %41, %50 : !quantum.obs
+    %alloca = memref.alloca() : memref<4xf64>
+    %alloc = memref.alloc() : memref<4xi64>
+    quantum.counts %51 in(%alloca : memref<4xf64>, %alloc : memref<4xi64>)
+    %alloc_21 = memref.alloc() {alignment = 64 : i64} : memref<4xi64>
+    linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%alloca : memref<4xf64>) outs(%alloc_21 : memref<4xi64>) {
+    ^bb0(%in: f64, %out: i64):
+      %54 = arith.fptosi %in : f64 to i64
+      linalg.yield %54 : i64
+    }
+    %52 = quantum.insert %1[ 0], %41 : !quantum.reg, !quantum.bit
+    %53 = quantum.insert %52[ 1], %50 : !quantum.reg, !quantum.bit
+    quantum.dealloc %53 : !quantum.reg
+    quantum.device_release
+    return %alloc_21, %alloc : memref<4xi64>, memref<4xi64>
   }
-  %52 = quantum.insert %1[ 0], %41 : !quantum.reg, !quantum.bit
-  %53 = quantum.insert %52[ 1], %50 : !quantum.reg, !quantum.bit
-  quantum.dealloc %53 : !quantum.reg
-  quantum.device_release
-  return %alloc_21, %alloc : memref<4xi64>, memref<4xi64>
+  func.func @setup() {
+    quantum.init
+    return
+  }
+  func.func @teardown() {
+    quantum.finalize
+    return
+  }
 }
 
 // -----
@@ -259,40 +279,42 @@ func.func public @cnot_circuit() -> (memref<4xi64>, memref<4xi64>) attributes {d
 
 // CHECK: memref.global "private" constant @__qubit_map_0 : memref<1xindex> = dense<0>
 // CHECK-LABEL: func.func @__kernel__()
-func.func public @sequential_circuit() attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
-  %0 = ion.ion {charge = -1.000000e+00 : f64, levels = [#ion.level<label = "downstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 0.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 0.000000e+00 : f64>, #ion.level<label = "upstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 79438311838.671509 : f64>, #ion.level<label = "estate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = -1.000000e+00 : f64, energy = 0x43321C22CEFBBBDF : f64>, #ion.level<label = "estate2", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 1.000000e+00 : f64, energy = 0x433456BB2DC221F8 : f64>], mass = 1.710000e+02 : f64, name = "Yb171", position = array<f64: 0.000000e+00, 0.000000e+00, 0.000000e+00>, transitions = [#ion.transition<level_0 = "downstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "downstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">]} : !ion.ion
-  ion.mode {modes = [#ion.phonon<energy = 6283185.307179586 : f64, eigenvector = [7.071068e-01, 0.000000e+00, 0.000000e+00]>]}
-  %c1_i64 = arith.constant 1 : i64
-  quantum.device shots(%c1_i64) ["/path/to/device.dylib", "oqd", "{}"]
-  %reg = quantum.alloc( 1) : !quantum.reg
-  %q0 = quantum.extract %reg[ 0] : !quantum.reg -> !quantum.bit
+module @sequential_circuit {
+  func.func public @circuit_0() attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
+    %0 = ion.ion {charge = -1.000000e+00 : f64, levels = [#ion.level<label = "downstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 0.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 0.000000e+00 : f64>, #ion.level<label = "upstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 79438311838.671509 : f64>, #ion.level<label = "estate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = -1.000000e+00 : f64, energy = 0x43321C22CEFBBBDF : f64>, #ion.level<label = "estate2", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 1.000000e+00 : f64, energy = 0x433456BB2DC221F8 : f64>], mass = 1.710000e+02 : f64, name = "Yb171", position = array<f64: 0.000000e+00, 0.000000e+00, 0.000000e+00>, transitions = [#ion.transition<level_0 = "downstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "downstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">]} : !ion.ion
+    ion.mode {modes = [#ion.phonon<energy = 6283185.307179586 : f64, eigenvector = [7.071068e-01, 0.000000e+00, 0.000000e+00]>]}
+    %c1_i64 = arith.constant 1 : i64
+    quantum.device shots(%c1_i64) ["/path/to/device.dylib", "oqd", "{}"]
+    %reg = quantum.alloc( 1) : !quantum.reg
+    %q0 = quantum.extract %reg[ 0] : !quantum.reg -> !quantum.bit
 
-  %cst_duration = arith.constant 1.0e-7 : f64
+    %cst_duration = arith.constant 1.0e-7 : f64
 
-  %ion_q0 = builtin.unrealized_conversion_cast %q0 : !quantum.bit to !ion.qubit
+    %ion_q0 = builtin.unrealized_conversion_cast %q0 : !quantum.bit to !ion.qubit
 
-  // CHECK: %[[EMPTY:.*]] = rtio.empty : !rtio.event
-  // CHECK: %[[CH:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 0>
-  // CHECK: %[[PULSE1:.*]] = rtio.pulse %[[CH]] {{.*}} wait(%[[EMPTY]])
-  %out1 = ion.parallelprotocol(%ion_q0) : !ion.qubit {
-  ^bb0(%arg0: !ion.qubit):
-    %p0 = ion.pulse(%cst_duration : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-    ion.yield %arg0 : !ion.qubit
+    // CHECK: %[[EMPTY:.*]] = rtio.empty : !rtio.event
+    // CHECK: %[[CH:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 0>
+    // CHECK: %[[PULSE1:.*]] = rtio.pulse %[[CH]] {{.*}} wait(%[[EMPTY]])
+    %out1 = ion.parallelprotocol(%ion_q0) : !ion.qubit {
+    ^bb0(%arg0: !ion.qubit):
+      %p0 = ion.pulse(%cst_duration : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+      ion.yield %arg0 : !ion.qubit
+    }
+
+    // CHECK: %[[PULSE2:.*]] = rtio.pulse %[[CH]] {{.*}} wait(%[[PULSE1]])
+    %out2 = ion.parallelprotocol(%out1) : !ion.qubit {
+    ^bb0(%arg0: !ion.qubit):
+      %p0 = ion.pulse(%cst_duration : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 1.5707963267948966 : f64} : !ion.pulse
+      ion.yield %arg0 : !ion.qubit
+    }
+
+    // CHECK: return
+    %bit_q0 = builtin.unrealized_conversion_cast %out2 : !ion.qubit to !quantum.bit
+    %reg2 = quantum.insert %reg[ 0], %bit_q0 : !quantum.reg, !quantum.bit
+    quantum.dealloc %reg2 : !quantum.reg
+    quantum.device_release
+    return
   }
-
-  // CHECK: %[[PULSE2:.*]] = rtio.pulse %[[CH]] {{.*}} wait(%[[PULSE1]])
-  %out2 = ion.parallelprotocol(%out1) : !ion.qubit {
-  ^bb0(%arg0: !ion.qubit):
-    %p0 = ion.pulse(%cst_duration : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 1.5707963267948966 : f64} : !ion.pulse
-    ion.yield %arg0 : !ion.qubit
-  }
-
-  // CHECK: return
-  %bit_q0 = builtin.unrealized_conversion_cast %out2 : !ion.qubit to !quantum.bit
-  %reg2 = quantum.insert %reg[ 0], %bit_q0 : !quantum.reg, !quantum.bit
-  quantum.dealloc %reg2 : !quantum.reg
-  quantum.device_release
-  return
 }
 
 // -----
@@ -301,155 +323,165 @@ func.func public @sequential_circuit() attributes {diff_method = "parameter-shif
 
 // CHECK: memref.global "private" constant @__qubit_map_0 : memref<2xindex> = dense<[0, 1]>
 // CHECK-LABEL: func.func @__kernel__()
-func.func public @loop_circuit() -> (memref<4xi64>, memref<4xi64>) attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
-  %0 = ion.ion {charge = -1.000000e+00 : f64, levels = [#ion.level<label = "downstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 0.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 0.000000e+00 : f64>, #ion.level<label = "upstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 79438311838.671509 : f64>, #ion.level<label = "estate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = -1.000000e+00 : f64, energy = 0x43321C22CEFBBBDF : f64>, #ion.level<label = "estate2", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 1.000000e+00 : f64, energy = 0x433456BB2DC221F8 : f64>], mass = 1.710000e+02 : f64, name = "Yb171", position = array<f64: 0.000000e+00, 0.000000e+00, 0.000000e+00>, transitions = [#ion.transition<level_0 = "downstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "downstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">]} : !ion.ion
-  ion.mode {modes = [#ion.phonon<energy = 6283185.307179586 : f64, eigenvector = [7.071068e-01, 0.000000e+00, 0.000000e+00, 7.071068e-01, 0.000000e+00, 0.000000e+00]>]}
-  %cst = arith.constant -1.5707963267948966 : f64
-  %c1_i64 = arith.constant 1 : i64
-  %cst_0 = arith.constant 0.78539816339744828 : f64
-  %c0 = arith.constant 0 : index
-  %c10 = arith.constant 10 : index
-  %c1 = arith.constant 1 : index
-  %cst_1 = arith.constant 1.5707963267948966 : f64
-  quantum.device shots(%c1_i64) ["/path/to/device.dylib", "oqd", "{}"]
-  %1 = quantum.alloc( 2) : !quantum.reg
-  %2 = quantum.extract %1[ 0] : !quantum.reg -> !quantum.bit
-  %cst_2 = arith.constant 12.566370614359172 : f64
-  %3 = arith.remf %cst_0, %cst_2 : f64
-  %cst_3 = arith.constant 0.000000e+00 : f64
-  %4 = arith.cmpf olt, %3, %cst_3 : f64
-  %5 = scf.if %4 -> (f64) {
-    %66 = arith.addf %3, %cst_2 : f64
-    scf.yield %66 : f64
-  } else {
-    scf.yield %3 : f64
-  }
-  %cst_4 = arith.constant 62831853071.79586 : f64
-  %cst_5 = arith.constant 417140672543652.75 : f64
-  %6 = arith.mulf %5, %cst_5 : f64
-  %7 = arith.mulf %cst_4, %cst_4 : f64
-  %8 = arith.divf %6, %7 : f64
-  %9 = builtin.unrealized_conversion_cast %2 : !quantum.bit to !ion.qubit
-
-  // Gate before the loop
-  // CHECK: %[[EMPTY:.*]] = rtio.empty : !rtio.event
-  // CHECK: %[[CH0:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 0>
-  // CHECK: %[[P0:.*]] = rtio.pulse %[[CH0]] {{.*}} wait(%[[EMPTY]])
-  %10 = ion.parallelprotocol(%9) : !ion.qubit {
-  ^bb0(%arg0: !ion.qubit):
-    %66 = ion.pulse(%8 : f64) %arg0 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 1.5707963267948966 : f64} : !ion.pulse
-    %67 = ion.pulse(%8 : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-    ion.yield %arg0 : !ion.qubit
-  }
-  %11 = builtin.unrealized_conversion_cast %10 : !ion.qubit to !quantum.bit
-  %12 = quantum.insert %1[ 0], %11 : !quantum.reg, !quantum.bit
-
-  // Loop
-  // CHECK: %[[LOOP:.*]] = scf.for {{.*}} iter_args(%[[ARG:.*]] = %[[P0]]) -> (!rtio.event) {
-  // CHECK:   %[[CH2_LOOP:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 2>
-  // CHECK:   %[[P_Q1:.*]] = rtio.pulse %[[CH2_LOOP]] {{.*}} wait(%[[ARG]])
-  // CHECK:   %[[P_Q0:.*]] = rtio.pulse %[[CH0]] {{.*}} wait(%[[ARG]])
-  // CHECK:   %[[SYNC_LOOP:.*]] = rtio.sync %[[P_Q0]], %[[P_Q1]] : !rtio.event
-  // CHECK:   scf.yield %[[SYNC_LOOP]] : !rtio.event
-  // CHECK: }
-  %13 = scf.for %arg0 = %c0 to %c10 step %c1 iter_args(%arg1 = %12) -> (!quantum.reg) {
-    %66 = quantum.extract %arg1[ 1] : !quantum.reg -> !quantum.bit
-    %cst_27 = arith.constant 12.566370614359172 : f64
-    %67 = arith.remf %cst_1, %cst_27 : f64
-    %cst_28 = arith.constant 0.000000e+00 : f64
-    %68 = arith.cmpf olt, %67, %cst_28 : f64
-    %69 = scf.if %68 -> (f64) {
-      %88 = arith.addf %67, %cst_27 : f64
-      scf.yield %88 : f64
+module @loop_circuit {
+  func.func public @circuit_0() -> (memref<4xi64>, memref<4xi64>) attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
+    %0 = ion.ion {charge = -1.000000e+00 : f64, levels = [#ion.level<label = "downstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 0.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 0.000000e+00 : f64>, #ion.level<label = "upstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 79438311838.671509 : f64>, #ion.level<label = "estate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = -1.000000e+00 : f64, energy = 0x43321C22CEFBBBDF : f64>, #ion.level<label = "estate2", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 1.000000e+00 : f64, energy = 0x433456BB2DC221F8 : f64>], mass = 1.710000e+02 : f64, name = "Yb171", position = array<f64: 0.000000e+00, 0.000000e+00, 0.000000e+00>, transitions = [#ion.transition<level_0 = "downstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "downstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">]} : !ion.ion
+    ion.mode {modes = [#ion.phonon<energy = 6283185.307179586 : f64, eigenvector = [7.071068e-01, 0.000000e+00, 0.000000e+00, 7.071068e-01, 0.000000e+00, 0.000000e+00]>]}
+    %cst = arith.constant -1.5707963267948966 : f64
+    %c1_i64 = arith.constant 1 : i64
+    %cst_0 = arith.constant 0.78539816339744828 : f64
+    %c0 = arith.constant 0 : index
+    %c10 = arith.constant 10 : index
+    %c1 = arith.constant 1 : index
+    %cst_1 = arith.constant 1.5707963267948966 : f64
+    quantum.device shots(%c1_i64) ["/path/to/device.dylib", "oqd", "{}"]
+    %1 = quantum.alloc( 2) : !quantum.reg
+    %2 = quantum.extract %1[ 0] : !quantum.reg -> !quantum.bit
+    %cst_2 = arith.constant 12.566370614359172 : f64
+    %3 = arith.remf %cst_0, %cst_2 : f64
+    %cst_3 = arith.constant 0.000000e+00 : f64
+    %4 = arith.cmpf olt, %3, %cst_3 : f64
+    %5 = scf.if %4 -> (f64) {
+      %66 = arith.addf %3, %cst_2 : f64
+      scf.yield %66 : f64
     } else {
-      scf.yield %67 : f64
+      scf.yield %3 : f64
     }
-    %cst_29 = arith.constant 62831853071.79586 : f64
-    %cst_30 = arith.constant 417140672543652.75 : f64
-    %70 = arith.mulf %69, %cst_30 : f64
-    %71 = arith.mulf %cst_29, %cst_29 : f64
-    %72 = arith.divf %70, %71 : f64
-    %73 = builtin.unrealized_conversion_cast %66 : !quantum.bit to !ion.qubit
-    %74 = ion.parallelprotocol(%73) : !ion.qubit {
-    ^bb0(%arg2: !ion.qubit):
-      %88 = ion.pulse(%72 : f64) %arg2 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-      %89 = ion.pulse(%72 : f64) %arg2 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-      ion.yield %arg2 : !ion.qubit
+    %cst_4 = arith.constant 62831853071.79586 : f64
+    %cst_5 = arith.constant 417140672543652.75 : f64
+    %6 = arith.mulf %5, %cst_5 : f64
+    %7 = arith.mulf %cst_4, %cst_4 : f64
+    %8 = arith.divf %6, %7 : f64
+    %9 = builtin.unrealized_conversion_cast %2 : !quantum.bit to !ion.qubit
+
+    // Gate before the loop
+    // CHECK: %[[EMPTY:.*]] = rtio.empty : !rtio.event
+    // CHECK: %[[CH0:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 0>
+    // CHECK: %[[P0:.*]] = rtio.pulse %[[CH0]] {{.*}} wait(%[[EMPTY]])
+    %10 = ion.parallelprotocol(%9) : !ion.qubit {
+    ^bb0(%arg0: !ion.qubit):
+      %66 = ion.pulse(%8 : f64) %arg0 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 1.5707963267948966 : f64} : !ion.pulse
+      %67 = ion.pulse(%8 : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+      ion.yield %arg0 : !ion.qubit
     }
-    %75 = builtin.unrealized_conversion_cast %74 : !ion.qubit to !quantum.bit
-    %76 = quantum.extract %arg1[ 0] : !quantum.reg -> !quantum.bit
-    %cst_31 = arith.constant 12.566370614359172 : f64
-    %77 = arith.remf %cst_0, %cst_31 : f64
-    %cst_32 = arith.constant 0.000000e+00 : f64
-    %78 = arith.cmpf olt, %77, %cst_32 : f64
-    %79 = scf.if %78 -> (f64) {
-      %88 = arith.addf %77, %cst_31 : f64
-      scf.yield %88 : f64
+    %11 = builtin.unrealized_conversion_cast %10 : !ion.qubit to !quantum.bit
+    %12 = quantum.insert %1[ 0], %11 : !quantum.reg, !quantum.bit
+
+    // Loop
+    // CHECK: %[[LOOP:.*]] = scf.for {{.*}} iter_args(%[[ARG:.*]] = %[[P0]]) -> (!rtio.event) {
+    // CHECK:   %[[CH2_LOOP:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 2>
+    // CHECK:   %[[P_Q1:.*]] = rtio.pulse %[[CH2_LOOP]] {{.*}} wait(%[[ARG]])
+    // CHECK:   %[[P_Q0:.*]] = rtio.pulse %[[CH0]] {{.*}} wait(%[[ARG]])
+    // CHECK:   %[[SYNC_LOOP:.*]] = rtio.sync %[[P_Q0]], %[[P_Q1]] : !rtio.event
+    // CHECK:   scf.yield %[[SYNC_LOOP]] : !rtio.event
+    // CHECK: }
+    %13 = scf.for %arg0 = %c0 to %c10 step %c1 iter_args(%arg1 = %12) -> (!quantum.reg) {
+      %66 = quantum.extract %arg1[ 1] : !quantum.reg -> !quantum.bit
+      %cst_27 = arith.constant 12.566370614359172 : f64
+      %67 = arith.remf %cst_1, %cst_27 : f64
+      %cst_28 = arith.constant 0.000000e+00 : f64
+      %68 = arith.cmpf olt, %67, %cst_28 : f64
+      %69 = scf.if %68 -> (f64) {
+        %88 = arith.addf %67, %cst_27 : f64
+        scf.yield %88 : f64
+      } else {
+        scf.yield %67 : f64
+      }
+      %cst_29 = arith.constant 62831853071.79586 : f64
+      %cst_30 = arith.constant 417140672543652.75 : f64
+      %70 = arith.mulf %69, %cst_30 : f64
+      %71 = arith.mulf %cst_29, %cst_29 : f64
+      %72 = arith.divf %70, %71 : f64
+      %73 = builtin.unrealized_conversion_cast %66 : !quantum.bit to !ion.qubit
+      %74 = ion.parallelprotocol(%73) : !ion.qubit {
+      ^bb0(%arg2: !ion.qubit):
+        %88 = ion.pulse(%72 : f64) %arg2 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+        %89 = ion.pulse(%72 : f64) %arg2 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+        ion.yield %arg2 : !ion.qubit
+      }
+      %75 = builtin.unrealized_conversion_cast %74 : !ion.qubit to !quantum.bit
+      %76 = quantum.extract %arg1[ 0] : !quantum.reg -> !quantum.bit
+      %cst_31 = arith.constant 12.566370614359172 : f64
+      %77 = arith.remf %cst_0, %cst_31 : f64
+      %cst_32 = arith.constant 0.000000e+00 : f64
+      %78 = arith.cmpf olt, %77, %cst_32 : f64
+      %79 = scf.if %78 -> (f64) {
+        %88 = arith.addf %77, %cst_31 : f64
+        scf.yield %88 : f64
+      } else {
+        scf.yield %77 : f64
+      }
+      %cst_33 = arith.constant 62831853071.79586 : f64
+      %cst_34 = arith.constant 417140672543652.75 : f64
+      %80 = arith.mulf %79, %cst_34 : f64
+      %81 = arith.mulf %cst_33, %cst_33 : f64
+      %82 = arith.divf %80, %81 : f64
+      %83 = builtin.unrealized_conversion_cast %76 : !quantum.bit to !ion.qubit
+      %84 = ion.parallelprotocol(%83) : !ion.qubit {
+      ^bb0(%arg2: !ion.qubit):
+        %88 = ion.pulse(%82 : f64) %arg2 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 1.5707963267948966 : f64} : !ion.pulse
+        %89 = ion.pulse(%82 : f64) %arg2 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+        ion.yield %arg2 : !ion.qubit
+      }
+      %85 = builtin.unrealized_conversion_cast %84 : !ion.qubit to !quantum.bit
+      %86 = quantum.insert %arg1[ 1], %75 : !quantum.reg, !quantum.bit
+      %87 = quantum.insert %86[ 0], %85 : !quantum.reg, !quantum.bit
+      scf.yield %87 : !quantum.reg
+    }
+    %14 = quantum.extract %13[ 0] : !quantum.reg -> !quantum.bit
+    %15 = quantum.extract %13[ 1] : !quantum.reg -> !quantum.bit
+
+    // Gate after the loop
+    // CHECK: %[[P_AFTER:.*]] = rtio.pulse %[[CH0]] {{.*}} wait(%[[LOOP]])
+    %cst_6 = arith.constant 12.566370614359172 : f64
+    %16 = arith.remf %cst_1, %cst_6 : f64
+    %cst_7 = arith.constant 0.000000e+00 : f64
+    %17 = arith.cmpf olt, %16, %cst_7 : f64
+    %18 = scf.if %17 -> (f64) {
+      %66 = arith.addf %16, %cst_6 : f64
+      scf.yield %66 : f64
     } else {
-      scf.yield %77 : f64
+      scf.yield %16 : f64
     }
-    %cst_33 = arith.constant 62831853071.79586 : f64
-    %cst_34 = arith.constant 417140672543652.75 : f64
-    %80 = arith.mulf %79, %cst_34 : f64
-    %81 = arith.mulf %cst_33, %cst_33 : f64
-    %82 = arith.divf %80, %81 : f64
-    %83 = builtin.unrealized_conversion_cast %76 : !quantum.bit to !ion.qubit
-    %84 = ion.parallelprotocol(%83) : !ion.qubit {
-    ^bb0(%arg2: !ion.qubit):
-      %88 = ion.pulse(%82 : f64) %arg2 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 1.5707963267948966 : f64} : !ion.pulse
-      %89 = ion.pulse(%82 : f64) %arg2 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-      ion.yield %arg2 : !ion.qubit
+    %cst_8 = arith.constant 62831853071.79586 : f64
+    %cst_9 = arith.constant 417140672543652.75 : f64
+    %19 = arith.mulf %18, %cst_9 : f64
+    %20 = arith.mulf %cst_8, %cst_8 : f64
+    %21 = arith.divf %19, %20 : f64
+    %22 = builtin.unrealized_conversion_cast %14 : !quantum.bit to !ion.qubit
+    %23 = ion.parallelprotocol(%22) : !ion.qubit {
+    ^bb0(%arg0: !ion.qubit):
+      %66 = ion.pulse(%21 : f64) %arg0 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 1.5707963267948966 : f64} : !ion.pulse
+      %67 = ion.pulse(%21 : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+      ion.yield %arg0 : !ion.qubit
     }
-    %85 = builtin.unrealized_conversion_cast %84 : !ion.qubit to !quantum.bit
-    %86 = quantum.insert %arg1[ 1], %75 : !quantum.reg, !quantum.bit
-    %87 = quantum.insert %86[ 0], %85 : !quantum.reg, !quantum.bit
-    scf.yield %87 : !quantum.reg
-  }
-  %14 = quantum.extract %13[ 0] : !quantum.reg -> !quantum.bit
-  %15 = quantum.extract %13[ 1] : !quantum.reg -> !quantum.bit
+    %24 = builtin.unrealized_conversion_cast %23 : !ion.qubit to !quantum.bit
 
-  // Gate after the loop
-  // CHECK: %[[P_AFTER:.*]] = rtio.pulse %[[CH0]] {{.*}} wait(%[[LOOP]])
-  %cst_6 = arith.constant 12.566370614359172 : f64
-  %16 = arith.remf %cst_1, %cst_6 : f64
-  %cst_7 = arith.constant 0.000000e+00 : f64
-  %17 = arith.cmpf olt, %16, %cst_7 : f64
-  %18 = scf.if %17 -> (f64) {
-    %66 = arith.addf %16, %cst_6 : f64
-    scf.yield %66 : f64
-  } else {
-    scf.yield %16 : f64
+    // CHECK: return
+    %51 = quantum.compbasis qubits %15, %24 : !quantum.obs
+    %alloca = memref.alloca() : memref<4xf64>
+    %alloc = memref.alloc() : memref<4xi64>
+    quantum.counts %51 in(%alloca : memref<4xf64>, %alloc : memref<4xi64>)
+    %alloc_21 = memref.alloc() {alignment = 64 : i64} : memref<4xi64>
+    linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%alloca : memref<4xf64>) outs(%alloc_21 : memref<4xi64>) {
+    ^bb0(%in: f64, %out: i64):
+      %66 = arith.fptosi %in : f64 to i64
+      linalg.yield %66 : i64
+    }
+    %52 = quantum.insert %13[ 0], %15 : !quantum.reg, !quantum.bit
+    %53 = quantum.insert %52[ 1], %24 : !quantum.reg, !quantum.bit
+    quantum.dealloc %53 : !quantum.reg
+    quantum.device_release
+    return %alloc_21, %alloc : memref<4xi64>, memref<4xi64>
   }
-  %cst_8 = arith.constant 62831853071.79586 : f64
-  %cst_9 = arith.constant 417140672543652.75 : f64
-  %19 = arith.mulf %18, %cst_9 : f64
-  %20 = arith.mulf %cst_8, %cst_8 : f64
-  %21 = arith.divf %19, %20 : f64
-  %22 = builtin.unrealized_conversion_cast %14 : !quantum.bit to !ion.qubit
-  %23 = ion.parallelprotocol(%22) : !ion.qubit {
-  ^bb0(%arg0: !ion.qubit):
-    %66 = ion.pulse(%21 : f64) %arg0 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 1.5707963267948966 : f64} : !ion.pulse
-    %67 = ion.pulse(%21 : f64) %arg0 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-    ion.yield %arg0 : !ion.qubit
+  func.func @setup() {
+    quantum.init
+    return
   }
-  %24 = builtin.unrealized_conversion_cast %23 : !ion.qubit to !quantum.bit
-
-  // CHECK: return
-  %51 = quantum.compbasis qubits %15, %24 : !quantum.obs
-  %alloca = memref.alloca() : memref<4xf64>
-  %alloc = memref.alloc() : memref<4xi64>
-  quantum.counts %51 in(%alloca : memref<4xf64>, %alloc : memref<4xi64>)
-  %alloc_21 = memref.alloc() {alignment = 64 : i64} : memref<4xi64>
-  linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%alloca : memref<4xf64>) outs(%alloc_21 : memref<4xi64>) {
-  ^bb0(%in: f64, %out: i64):
-    %66 = arith.fptosi %in : f64 to i64
-    linalg.yield %66 : i64
+  func.func @teardown() {
+    quantum.finalize
+    return
   }
-  %52 = quantum.insert %13[ 0], %15 : !quantum.reg, !quantum.bit
-  %53 = quantum.insert %52[ 1], %24 : !quantum.reg, !quantum.bit
-  quantum.dealloc %53 : !quantum.reg
-  quantum.device_release
-  return %alloc_21, %alloc : memref<4xi64>, memref<4xi64>
 }
 
 // -----
@@ -458,161 +490,163 @@ func.func public @loop_circuit() -> (memref<4xi64>, memref<4xi64>) attributes {d
 
 // CHECK: memref.global "private" constant @__qubit_map_0 : memref<2xindex> = dense<[0, 1]>
 // CHECK-LABEL: func.func @__kernel__(%arg0: memref<i64>)
-func.func public @if_circuit(%arg0: memref<i64>) -> (memref<4xi64>, memref<4xi64>) attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
-  %0 = ion.ion {charge = -1.000000e+00 : f64, levels = [#ion.level<label = "downstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 0.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 0.000000e+00 : f64>, #ion.level<label = "upstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 79438311838.671509 : f64>, #ion.level<label = "estate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = -1.000000e+00 : f64, energy = 0x43321C22CEFBBBDF : f64>, #ion.level<label = "estate2", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 1.000000e+00 : f64, energy = 0x433456BB2DC221F8 : f64>], mass = 1.710000e+02 : f64, name = "Yb171", position = array<f64: 0.000000e+00, 0.000000e+00, 0.000000e+00>, transitions = [#ion.transition<level_0 = "downstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "downstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">]} : !ion.ion
-  ion.mode {modes = [#ion.phonon<energy = 6283185.307179586 : f64, eigenvector = [7.071068e-01, 0.000000e+00, 0.000000e+00, 7.071068e-01, 0.000000e+00, 0.000000e+00]>]}
-  %c1_i64 = arith.constant 1 : i64
-  %cst = arith.constant 0.78539816339744828 : f64
-  %cst_0 = arith.constant 1.5707963267948966 : f64
-  %c0_i64 = arith.constant 0 : i64
-  %1 = memref.load %arg0[] : memref<i64>
-  quantum.device shots(%c1_i64) ["/path/to/device.dylib", "oqd", "{}"]
-  %2 = quantum.alloc( 2) : !quantum.reg
-  %3 = quantum.extract %2[ 0] : !quantum.reg -> !quantum.bit
+module @if_circuit {
+  func.func public @circuit_0(%arg0: memref<i64>) -> (memref<4xi64>, memref<4xi64>) attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, qnode} {
+    %0 = ion.ion {charge = -1.000000e+00 : f64, levels = [#ion.level<label = "downstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 0.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 0.000000e+00 : f64>, #ion.level<label = "upstate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 0.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 0.000000e+00 : f64, energy = 79438311838.671509 : f64>, #ion.level<label = "estate", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = -1.000000e+00 : f64, energy = 0x43321C22CEFBBBDF : f64>, #ion.level<label = "estate2", principal = 6 : i64, spin = 5.000000e-01 : f64, orbital = 1.000000e+00 : f64, nuclear = 5.000000e-01 : f64, spin_orbital = 5.000000e-01 : f64, spin_orbital_nuclear = 1.000000e+00 : f64, spin_orbital_nuclear_magnetization = 1.000000e+00 : f64, energy = 0x433456BB2DC221F8 : f64>], mass = 1.710000e+02 : f64, name = "Yb171", position = array<f64: 0.000000e+00, 0.000000e+00, 0.000000e+00>, transitions = [#ion.transition<level_0 = "downstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "downstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate", einstein_a = 1.000000e+00 : f64, multipole = "E1">, #ion.transition<level_0 = "upstate", level_1 = "estate2", einstein_a = 1.000000e+00 : f64, multipole = "E1">]} : !ion.ion
+    ion.mode {modes = [#ion.phonon<energy = 6283185.307179586 : f64, eigenvector = [7.071068e-01, 0.000000e+00, 0.000000e+00, 7.071068e-01, 0.000000e+00, 0.000000e+00]>]}
+    %c1_i64 = arith.constant 1 : i64
+    %cst = arith.constant 0.78539816339744828 : f64
+    %cst_0 = arith.constant 1.5707963267948966 : f64
+    %c0_i64 = arith.constant 0 : i64
+    %1 = memref.load %arg0[] : memref<i64>
+    quantum.device shots(%c1_i64) ["/path/to/device.dylib", "oqd", "{}"]
+    %2 = quantum.alloc( 2) : !quantum.reg
+    %3 = quantum.extract %2[ 0] : !quantum.reg -> !quantum.bit
 
-  %cst_1 = arith.constant 12.566370614359172 : f64
-  %4 = arith.remf %cst, %cst_1 : f64
-  %cst_2 = arith.constant 0.000000e+00 : f64
-  %5 = arith.cmpf olt, %4, %cst_2 : f64
-  %6 = scf.if %5 -> (f64) {
-    %30 = arith.addf %4, %cst_1 : f64
-    scf.yield %30 : f64
-  } else {
-    scf.yield %4 : f64
-  }
-  %cst_3 = arith.constant 62831853071.79586 : f64
-  %cst_4 = arith.constant 417140672543652.75 : f64
-  %7 = arith.mulf %6, %cst_4 : f64
-  %8 = arith.mulf %cst_3, %cst_3 : f64
-  %9 = arith.divf %7, %8 : f64
-  %10 = builtin.unrealized_conversion_cast %3 : !quantum.bit to !ion.qubit
-
-  // Gate before the if
-  // CHECK: %[[EMPTY:.*]] = rtio.empty : !rtio.event
-  // CHECK: %[[CH0:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 0>
-  // CHECK: %[[P0:.*]] = rtio.pulse %[[CH0]] {{.*}} wait(%[[EMPTY]])
-  %11 = ion.parallelprotocol(%10) : !ion.qubit {
-  ^bb0(%arg1: !ion.qubit):
-    %30 = ion.pulse(%9 : f64) %arg1 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 1.5707963267948966 : f64} : !ion.pulse
-    %31 = ion.pulse(%9 : f64) %arg1 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-    ion.yield %arg1 : !ion.qubit
-  }
-  %12 = builtin.unrealized_conversion_cast %11 : !ion.qubit to !quantum.bit
-  %13 = arith.cmpi slt, %1, %c0_i64 : i64
-  %14 = quantum.insert %2[ 0], %12 : !quantum.reg, !quantum.bit
-
-  // If branches
-  // TODO: it's not fully optimized yet, the P0 event is already dominated by the P_THEN event,
-  //       so it's no need to sync P0 and P_THEN.
-  // CHECK: %[[IF_RESULT:.*]] = scf.if {{.*}} -> (!rtio.event) {
-  // CHECK:   %[[CH2_THEN:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 2>
-  // CHECK:   %[[P_THEN:.*]] = rtio.pulse %[[CH2_THEN]] {{.*}} wait(%[[P0]])
-  // CHECK:   %[[SYNC_THEN:.*]] = rtio.sync %[[P_THEN]], %[[P0]] : !rtio.event
-  // CHECK:   scf.yield %[[SYNC_THEN]] : !rtio.event
-  // CHECK: } else {
-  // CHECK:   %[[P_ELSE:.*]] = rtio.pulse %[[CH0]] {{.*}} wait(%[[P0]])
-  // CHECK:   %[[SYNC_ELSE:.*]] = rtio.sync %[[P_ELSE]], %[[P0]] : !rtio.event
-  // CHECK:   scf.yield %[[SYNC_ELSE]] : !rtio.event
-  // CHECK: }
-  %15 = scf.if %13 -> (!quantum.reg) {
-    %30 = quantum.extract %14[ 1] : !quantum.reg -> !quantum.bit
-    %cst_10 = arith.constant 12.566370614359172 : f64
-    %31 = arith.remf %cst_0, %cst_10 : f64
-    %cst_11 = arith.constant 0.000000e+00 : f64
-    %32 = arith.cmpf olt, %31, %cst_11 : f64
-    %33 = scf.if %32 -> (f64) {
-      %41 = arith.addf %31, %cst_10 : f64
-      scf.yield %41 : f64
+    %cst_1 = arith.constant 12.566370614359172 : f64
+    %4 = arith.remf %cst, %cst_1 : f64
+    %cst_2 = arith.constant 0.000000e+00 : f64
+    %5 = arith.cmpf olt, %4, %cst_2 : f64
+    %6 = scf.if %5 -> (f64) {
+      %30 = arith.addf %4, %cst_1 : f64
+      scf.yield %30 : f64
     } else {
-      scf.yield %31 : f64
+      scf.yield %4 : f64
     }
-    %cst_12 = arith.constant 62831853071.79586 : f64
-    %cst_13 = arith.constant 417140672543652.75 : f64
-    %34 = arith.mulf %33, %cst_13 : f64
-    %35 = arith.mulf %cst_12, %cst_12 : f64
-    %36 = arith.divf %34, %35 : f64
-    %37 = builtin.unrealized_conversion_cast %30 : !quantum.bit to !ion.qubit
-    %38 = ion.parallelprotocol(%37) : !ion.qubit {
+    %cst_3 = arith.constant 62831853071.79586 : f64
+    %cst_4 = arith.constant 417140672543652.75 : f64
+    %7 = arith.mulf %6, %cst_4 : f64
+    %8 = arith.mulf %cst_3, %cst_3 : f64
+    %9 = arith.divf %7, %8 : f64
+    %10 = builtin.unrealized_conversion_cast %3 : !quantum.bit to !ion.qubit
+
+    // Gate before the if
+    // CHECK: %[[EMPTY:.*]] = rtio.empty : !rtio.event
+    // CHECK: %[[CH0:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 0>
+    // CHECK: %[[P0:.*]] = rtio.pulse %[[CH0]] {{.*}} wait(%[[EMPTY]])
+    %11 = ion.parallelprotocol(%10) : !ion.qubit {
     ^bb0(%arg1: !ion.qubit):
-      %41 = ion.pulse(%36 : f64) %arg1 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-      %42 = ion.pulse(%36 : f64) %arg1 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+      %30 = ion.pulse(%9 : f64) %arg1 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 1.5707963267948966 : f64} : !ion.pulse
+      %31 = ion.pulse(%9 : f64) %arg1 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
       ion.yield %arg1 : !ion.qubit
     }
-    %39 = builtin.unrealized_conversion_cast %38 : !ion.qubit to !quantum.bit
-    %40 = quantum.insert %14[ 1], %39 : !quantum.reg, !quantum.bit
-    scf.yield %40 : !quantum.reg
-  } else {
-    %30 = quantum.extract %14[ 0] : !quantum.reg -> !quantum.bit
-    %cst_10 = arith.constant 12.566370614359172 : f64
-    %31 = arith.remf %cst, %cst_10 : f64
-    %cst_11 = arith.constant 0.000000e+00 : f64
-    %32 = arith.cmpf olt, %31, %cst_11 : f64
-    %33 = scf.if %32 -> (f64) {
-      %41 = arith.addf %31, %cst_10 : f64
-      scf.yield %41 : f64
+    %12 = builtin.unrealized_conversion_cast %11 : !ion.qubit to !quantum.bit
+    %13 = arith.cmpi slt, %1, %c0_i64 : i64
+    %14 = quantum.insert %2[ 0], %12 : !quantum.reg, !quantum.bit
+
+    // If branches
+    // TODO: it's not fully optimized yet, the P0 event is already dominated by the P_THEN event,
+    //       so it's no need to sync P0 and P_THEN.
+    // CHECK: %[[IF_RESULT:.*]] = scf.if {{.*}} -> (!rtio.event) {
+    // CHECK:   %[[CH2_THEN:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 2>
+    // CHECK:   %[[P_THEN:.*]] = rtio.pulse %[[CH2_THEN]] {{.*}} wait(%[[P0]])
+    // CHECK:   %[[SYNC_THEN:.*]] = rtio.sync %[[P_THEN]], %[[P0]] : !rtio.event
+    // CHECK:   scf.yield %[[SYNC_THEN]] : !rtio.event
+    // CHECK: } else {
+    // CHECK:   %[[P_ELSE:.*]] = rtio.pulse %[[CH0]] {{.*}} wait(%[[P0]])
+    // CHECK:   %[[SYNC_ELSE:.*]] = rtio.sync %[[P_ELSE]], %[[P0]] : !rtio.event
+    // CHECK:   scf.yield %[[SYNC_ELSE]] : !rtio.event
+    // CHECK: }
+    %15 = scf.if %13 -> (!quantum.reg) {
+      %30 = quantum.extract %14[ 1] : !quantum.reg -> !quantum.bit
+      %cst_10 = arith.constant 12.566370614359172 : f64
+      %31 = arith.remf %cst_0, %cst_10 : f64
+      %cst_11 = arith.constant 0.000000e+00 : f64
+      %32 = arith.cmpf olt, %31, %cst_11 : f64
+      %33 = scf.if %32 -> (f64) {
+        %41 = arith.addf %31, %cst_10 : f64
+        scf.yield %41 : f64
+      } else {
+        scf.yield %31 : f64
+      }
+      %cst_12 = arith.constant 62831853071.79586 : f64
+      %cst_13 = arith.constant 417140672543652.75 : f64
+      %34 = arith.mulf %33, %cst_13 : f64
+      %35 = arith.mulf %cst_12, %cst_12 : f64
+      %36 = arith.divf %34, %35 : f64
+      %37 = builtin.unrealized_conversion_cast %30 : !quantum.bit to !ion.qubit
+      %38 = ion.parallelprotocol(%37) : !ion.qubit {
+      ^bb0(%arg1: !ion.qubit):
+        %41 = ion.pulse(%36 : f64) %arg1 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+        %42 = ion.pulse(%36 : f64) %arg1 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+        ion.yield %arg1 : !ion.qubit
+      }
+      %39 = builtin.unrealized_conversion_cast %38 : !ion.qubit to !quantum.bit
+      %40 = quantum.insert %14[ 1], %39 : !quantum.reg, !quantum.bit
+      scf.yield %40 : !quantum.reg
     } else {
-      scf.yield %31 : f64
+      %30 = quantum.extract %14[ 0] : !quantum.reg -> !quantum.bit
+      %cst_10 = arith.constant 12.566370614359172 : f64
+      %31 = arith.remf %cst, %cst_10 : f64
+      %cst_11 = arith.constant 0.000000e+00 : f64
+      %32 = arith.cmpf olt, %31, %cst_11 : f64
+      %33 = scf.if %32 -> (f64) {
+        %41 = arith.addf %31, %cst_10 : f64
+        scf.yield %41 : f64
+      } else {
+        scf.yield %31 : f64
+      }
+      %cst_12 = arith.constant 62831853071.79586 : f64
+      %cst_13 = arith.constant 417140672543652.75 : f64
+      %34 = arith.mulf %33, %cst_13 : f64
+      %35 = arith.mulf %cst_12, %cst_12 : f64
+      %36 = arith.divf %34, %35 : f64
+      %37 = builtin.unrealized_conversion_cast %30 : !quantum.bit to !ion.qubit
+      %38 = ion.parallelprotocol(%37) : !ion.qubit {
+      ^bb0(%arg1: !ion.qubit):
+        %41 = ion.pulse(%36 : f64) %arg1 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 1.5707963267948966 : f64} : !ion.pulse
+        %42 = ion.pulse(%36 : f64) %arg1 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+        ion.yield %arg1 : !ion.qubit
+      }
+      %39 = builtin.unrealized_conversion_cast %38 : !ion.qubit to !quantum.bit
+      %40 = quantum.insert %14[ 0], %39 : !quantum.reg, !quantum.bit
+      scf.yield %40 : !quantum.reg
     }
-    %cst_12 = arith.constant 62831853071.79586 : f64
-    %cst_13 = arith.constant 417140672543652.75 : f64
-    %34 = arith.mulf %33, %cst_13 : f64
-    %35 = arith.mulf %cst_12, %cst_12 : f64
-    %36 = arith.divf %34, %35 : f64
-    %37 = builtin.unrealized_conversion_cast %30 : !quantum.bit to !ion.qubit
-    %38 = ion.parallelprotocol(%37) : !ion.qubit {
+
+    // Gate after the if
+    // CHECK: %[[CH2_AFTER:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 2>
+    // CHECK: %[[P_AFTER:.*]] = rtio.pulse %[[CH2_AFTER]] {{.*}} wait(%[[IF_RESULT]])
+    %16 = quantum.extract %15[ 1] : !quantum.reg -> !quantum.bit
+    %cst_5 = arith.constant 12.566370614359172 : f64
+    %17 = arith.remf %cst_0, %cst_5 : f64
+    %cst_6 = arith.constant 0.000000e+00 : f64
+    %18 = arith.cmpf olt, %17, %cst_6 : f64
+    %19 = scf.if %18 -> (f64) {
+      %30 = arith.addf %17, %cst_5 : f64
+      scf.yield %30 : f64
+    } else {
+      scf.yield %17 : f64
+    }
+    %cst_7 = arith.constant 62831853071.79586 : f64
+    %cst_8 = arith.constant 417140672543652.75 : f64
+    %20 = arith.mulf %19, %cst_8 : f64
+    %21 = arith.mulf %cst_7, %cst_7 : f64
+    %22 = arith.divf %20, %21 : f64
+    %23 = builtin.unrealized_conversion_cast %16 : !quantum.bit to !ion.qubit
+    %24 = ion.parallelprotocol(%23) : !ion.qubit {
     ^bb0(%arg1: !ion.qubit):
-      %41 = ion.pulse(%36 : f64) %arg1 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 1.5707963267948966 : f64} : !ion.pulse
-      %42 = ion.pulse(%36 : f64) %arg1 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+      %30 = ion.pulse(%22 : f64) %arg1 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
+      %31 = ion.pulse(%22 : f64) %arg1 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
       ion.yield %arg1 : !ion.qubit
     }
-    %39 = builtin.unrealized_conversion_cast %38 : !ion.qubit to !quantum.bit
-    %40 = quantum.insert %14[ 0], %39 : !quantum.reg, !quantum.bit
-    scf.yield %40 : !quantum.reg
-  }
+    %25 = builtin.unrealized_conversion_cast %24 : !ion.qubit to !quantum.bit
 
-  // Gate after the if
-  // CHECK: %[[CH2_AFTER:.*]] = rtio.channel : !rtio.channel<"dds", [2 : i64], 2>
-  // CHECK: %[[P_AFTER:.*]] = rtio.pulse %[[CH2_AFTER]] {{.*}} wait(%[[IF_RESULT]])
-  %16 = quantum.extract %15[ 1] : !quantum.reg -> !quantum.bit
-  %cst_5 = arith.constant 12.566370614359172 : f64
-  %17 = arith.remf %cst_0, %cst_5 : f64
-  %cst_6 = arith.constant 0.000000e+00 : f64
-  %18 = arith.cmpf olt, %17, %cst_6 : f64
-  %19 = scf.if %18 -> (f64) {
-    %30 = arith.addf %17, %cst_5 : f64
-    scf.yield %30 : f64
-  } else {
-    scf.yield %17 : f64
+    // CHECK: return
+    %26 = quantum.extract %15[ 0] : !quantum.reg -> !quantum.bit
+    %27 = quantum.compbasis qubits %26, %25 : !quantum.obs
+    %alloca = memref.alloca() : memref<4xf64>
+    %alloc = memref.alloc() : memref<4xi64>
+    quantum.counts %27 in(%alloca : memref<4xf64>, %alloc : memref<4xi64>)
+    %alloc_9 = memref.alloc() {alignment = 64 : i64} : memref<4xi64>
+    linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%alloca : memref<4xf64>) outs(%alloc_9 : memref<4xi64>) {
+    ^bb0(%in: f64, %out: i64):
+      %30 = arith.fptosi %in : f64 to i64
+      linalg.yield %30 : i64
+    }
+    %28 = quantum.insert %15[ 1], %25 : !quantum.reg, !quantum.bit
+    %29 = quantum.insert %28[ 0], %26 : !quantum.reg, !quantum.bit
+    quantum.dealloc %29 : !quantum.reg
+    quantum.device_release
+    return %alloc_9, %alloc : memref<4xi64>, memref<4xi64>
   }
-  %cst_7 = arith.constant 62831853071.79586 : f64
-  %cst_8 = arith.constant 417140672543652.75 : f64
-  %20 = arith.mulf %19, %cst_8 : f64
-  %21 = arith.mulf %cst_7, %cst_7 : f64
-  %22 = arith.divf %20, %21 : f64
-  %23 = builtin.unrealized_conversion_cast %16 : !quantum.bit to !ion.qubit
-  %24 = ion.parallelprotocol(%23) : !ion.qubit {
-  ^bb0(%arg1: !ion.qubit):
-    %30 = ion.pulse(%22 : f64) %arg1 {beam = #ion.beam<transition_index = 0 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-    %31 = ion.pulse(%22 : f64) %arg1 {beam = #ion.beam<transition_index = 2 : i64, rabi = 62831853071.79586 : f64, detuning = 208570336271826.38 : f64, polarization = [1, 0, 0], wavevector = [0, 1, 0]>, phase = 0.000000e+00 : f64} : !ion.pulse
-    ion.yield %arg1 : !ion.qubit
-  }
-  %25 = builtin.unrealized_conversion_cast %24 : !ion.qubit to !quantum.bit
-
-  // CHECK: return
-  %26 = quantum.extract %15[ 0] : !quantum.reg -> !quantum.bit
-  %27 = quantum.compbasis qubits %26, %25 : !quantum.obs
-  %alloca = memref.alloca() : memref<4xf64>
-  %alloc = memref.alloc() : memref<4xi64>
-  quantum.counts %27 in(%alloca : memref<4xf64>, %alloc : memref<4xi64>)
-  %alloc_9 = memref.alloc() {alignment = 64 : i64} : memref<4xi64>
-  linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%alloca : memref<4xf64>) outs(%alloc_9 : memref<4xi64>) {
-  ^bb0(%in: f64, %out: i64):
-    %30 = arith.fptosi %in : f64 to i64
-    linalg.yield %30 : i64
-  }
-  %28 = quantum.insert %15[ 1], %25 : !quantum.reg, !quantum.bit
-  %29 = quantum.insert %28[ 0], %26 : !quantum.reg, !quantum.bit
-  quantum.dealloc %29 : !quantum.reg
-  quantum.device_release
-  return %alloc_9, %alloc : memref<4xi64>, memref<4xi64>
 }

--- a/mlir/test/Quantum/StaticAllocaTest.mlir
+++ b/mlir/test/Quantum/StaticAllocaTest.mlir
@@ -15,119 +15,143 @@
 // RUN: quantum-opt --convert-quantum-to-llvm --split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: @static_alloca_qubit_unitary
-func.func @static_alloca_qubit_unitary(%arg0: memref<2x2xcomplex<f64>>, %arg1 : !quantum.bit) -> () {
-  // CHECK-NOT: ^bb1:
-  // CHECK: [[val:%.+]] = llvm.mlir.constant(1 : i64)
-  // CHECK-NEXT: llvm.alloca [[val]] x !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
-  // CHECK: ^bb1:
-  cf.br ^bb1
-^bb1:
-  %q1 = quantum.unitary(%arg0 : memref<2x2xcomplex<f64>>) %arg1 : !quantum.bit
-  return
+module @static_alloca_qubit_unitary {
+  // CHECK-LABEL: @test
+  func.func @test(%arg0: memref<2x2xcomplex<f64>>, %arg1 : !quantum.bit) -> () {
+    // CHECK-NOT: ^bb1:
+    // CHECK: [[val:%.+]] = llvm.mlir.constant(1 : i64)
+    // CHECK-NEXT: llvm.alloca [[val]] x !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
+    // CHECK: ^bb1:
+    cf.br ^bb1
+  ^bb1:
+    %q1 = quantum.unitary(%arg0 : memref<2x2xcomplex<f64>>) %arg1 : !quantum.bit
+    return
+  }
 }
 
 // -----
 
 // CHECK-LABEL: @static_alloca_qubit_unitary_ctrl
-func.func @static_alloca_qubit_unitary_ctrl(%arg0: memref<2x2xcomplex<f64>>, %arg1 : !quantum.bit, %arg2 : !quantum.bit, %arg3 : i1) -> () {
-  // CHECK-NOT: ^bb1:
-  // CHECK:      [[c1:%.+]] = llvm.mlir.constant(1 : i64)
-  // CHECK-NEXT: llvm.alloca [[c1]] x !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
-  // CHECK-NEXT: [[c1:%.+]] = llvm.mlir.constant(1 : i64)
-  // CHECK-NEXT: llvm.alloca [[c1]] x i1
-  // CHECK-NEXT: [[c1:%.+]] = llvm.mlir.constant(1 : i64)
-  // CHECK-NEXT: llvm.alloca [[c1]] x !llvm.ptr
-  // CHECK-NEXT: [[c1:%.+]] = llvm.mlir.constant(1 : i64)
-  // CHECK-NEXT: llvm.alloca [[c1]] x !llvm.struct<(i1, i64, ptr, ptr)>
-  // CHECK: ^bb1:
-  cf.br ^bb1
-^bb1:
-  %q1, %q2 = quantum.unitary(%arg0 : memref<2x2xcomplex<f64>>) %arg1 ctrls(%arg2) ctrlvals(%arg3) : !quantum.bit ctrls !quantum.bit
-  return
+module @static_alloca_qubit_unitary_ctrl {
+  // CHECK-LABEL: @test
+  func.func @test(%arg0: memref<2x2xcomplex<f64>>, %arg1 : !quantum.bit, %arg2 : !quantum.bit, %arg3 : i1) -> () {
+    // CHECK-NOT: ^bb1:
+    // CHECK:      [[c1:%.+]] = llvm.mlir.constant(1 : i64)
+    // CHECK-NEXT: llvm.alloca [[c1]] x !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
+    // CHECK-NEXT: [[c1:%.+]] = llvm.mlir.constant(1 : i64)
+    // CHECK-NEXT: llvm.alloca [[c1]] x i1
+    // CHECK-NEXT: [[c1:%.+]] = llvm.mlir.constant(1 : i64)
+    // CHECK-NEXT: llvm.alloca [[c1]] x !llvm.ptr
+    // CHECK-NEXT: [[c1:%.+]] = llvm.mlir.constant(1 : i64)
+    // CHECK-NEXT: llvm.alloca [[c1]] x !llvm.struct<(i1, i64, ptr, ptr)>
+    // CHECK: ^bb1:
+    cf.br ^bb1
+  ^bb1:
+    %q1, %q2 = quantum.unitary(%arg0 : memref<2x2xcomplex<f64>>) %arg1 ctrls(%arg2) ctrlvals(%arg3) : !quantum.bit ctrls !quantum.bit
+    return
+  }
 }
 
 // -----
 
 // CHECK-LABEL: @static_alloca_hermitian
-func.func @static_alloca_hermitian(%arg0: memref<2x2xcomplex<f64>>, %arg1: !quantum.bit) -> () {
-  // CHECK-NOT: ^bb1:
-  // CHECK:      [[one:%.+]] = llvm.mlir.constant(1 : i64)
-  // CHECK-NEXT: llvm.alloca [[one]] x !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
-  // CHECK: ^bb1:
-  cf.br ^bb1
-^bb1:
-  %0 = quantum.hermitian(%arg0: memref<2x2xcomplex<f64>>) %arg1: !quantum.obs
-  return
+module @static_alloca_hermitian {
+  // CHECK-LABEL: @test
+  func.func @test(%arg0: memref<2x2xcomplex<f64>>, %arg1: !quantum.bit) -> () {
+    // CHECK-NOT: ^bb1:
+    // CHECK:      [[one:%.+]] = llvm.mlir.constant(1 : i64)
+    // CHECK-NEXT: llvm.alloca [[one]] x !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
+    // CHECK: ^bb1:
+    cf.br ^bb1
+  ^bb1:
+    %0 = quantum.hermitian(%arg0: memref<2x2xcomplex<f64>>) %arg1: !quantum.obs
+    return
+  }
 }
 
 // -----
 
 // CHECK-LABEL: @static_alloca_hamiltonian
-func.func @static_alloca_hamiltonian(%arg0: memref<1xf64>, %arg1 : !quantum.obs) -> () {
-  // CHECK-NOT: ^bb1:
-  // CHECK:     [[one:%.+]] = llvm.mlir.constant(1 : i64)
-  // CHECK-NEXT:     llvm.alloca [[one]] x !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
-  // CHECK: ^bb1:
-  cf.br ^bb1
-^bb1:
-  %0 = quantum.hamiltonian(%arg0: memref<1xf64>) %arg1 : !quantum.obs
-  return
+module @static_alloca_hamiltonian {
+  // CHECK-LABEL: @test
+  func.func @test(%arg0: memref<1xf64>, %arg1 : !quantum.obs) -> () {
+    // CHECK-NOT: ^bb1:
+    // CHECK:     [[one:%.+]] = llvm.mlir.constant(1 : i64)
+    // CHECK-NEXT:     llvm.alloca [[one]] x !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+    // CHECK: ^bb1:
+    cf.br ^bb1
+  ^bb1:
+    %0 = quantum.hamiltonian(%arg0: memref<1xf64>) %arg1 : !quantum.obs
+    return
+  }
 }
 
 // -----
 
 // CHECK-LABEL: @static_alloca_sample
-func.func @static_alloca_sample(%arg0 : !quantum.bit, %alloc : memref<1x1xf64>) -> () {
-  // CHECK-NOT: ^bb1:
-  // CHECK:      [[one:%.+]] = llvm.mlir.constant(1 : i64)
-  // CHECK-NEXT: llvm.alloca [[one]] x !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
-  // CHECK: ^bb1:
-  cf.br ^bb1
-^bb1:
-  %obs = quantum.compbasis qubits %arg0 : !quantum.obs
-  quantum.sample %obs in(%alloc : memref<1x1xf64>)
-  return
+module @static_alloca_sample {
+  // CHECK-LABEL: @test
+  func.func @test(%arg0 : !quantum.bit, %alloc : memref<1x1xf64>) -> () {
+    // CHECK-NOT: ^bb1:
+    // CHECK:      [[one:%.+]] = llvm.mlir.constant(1 : i64)
+    // CHECK-NEXT: llvm.alloca [[one]] x !llvm.struct<(ptr, ptr, i64, array<2 x i64>, array<2 x i64>)>
+    // CHECK: ^bb1:
+    cf.br ^bb1
+  ^bb1:
+    %obs = quantum.compbasis qubits %arg0 : !quantum.obs
+    quantum.sample %obs in(%alloc : memref<1x1xf64>)
+    return
+  }
 }
 
 // -----
 
 // CHECK-LABEL: @static_alloca_state
-func.func @static_alloca_state(%arg0 : !quantum.bit, %alloc : memref<2xcomplex<f64>>) -> () {
-  cf.br ^bb1
-  // CHECK-NOT: ^bb1:
-  // CHECK:      [[one:%.+]] = llvm.mlir.constant(1 : i64)
-  // CHECK-NEXT: llvm.alloca [[one]] x !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
-  // CHECK: ^bb1:
-^bb1:
-  %obs = quantum.compbasis qubits %arg0 : !quantum.obs
-  quantum.state %obs in(%alloc : memref<2xcomplex<f64>>)
-  return
+module @static_alloca_state {
+  // CHECK-LABEL: @test
+  func.func @test(%arg0 : !quantum.bit, %alloc : memref<2xcomplex<f64>>) -> () {
+    cf.br ^bb1
+    // CHECK-NOT: ^bb1:
+    // CHECK:      [[one:%.+]] = llvm.mlir.constant(1 : i64)
+    // CHECK-NEXT: llvm.alloca [[one]] x !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+    // CHECK: ^bb1:
+  ^bb1:
+    %obs = quantum.compbasis qubits %arg0 : !quantum.obs
+    quantum.state %obs in(%alloc : memref<2xcomplex<f64>>)
+    return
+  }
 }
 
 // -----
 
 // CHECK-LABEL: @static_alloca_set_state
-func.func @static_alloca_set_state(%arg0 : memref<2xcomplex<f64>>, %arg1 : !quantum.bit) -> () {
-  // CHECK-NOT: ^bb1:
-  // CHECK:      [[one:%.+]] = llvm.mlir.constant(1 : i64)
-  // CHECK-NEXT: llvm.alloca [[one]] x !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
-  // CHECK: ^bb1:
-  cf.br ^bb1
-^bb1:
-  %0 = quantum.set_state(%arg0) %arg1 : (memref<2xcomplex<f64>>, !quantum.bit) -> !quantum.bit
-  return
+module @static_alloca_set_state {
+  // CHECK-LABEL: @test
+  func.func @test(%arg0 : memref<2xcomplex<f64>>, %arg1 : !quantum.bit) -> () {
+    // CHECK-NOT: ^bb1:
+    // CHECK:      [[one:%.+]] = llvm.mlir.constant(1 : i64)
+    // CHECK-NEXT: llvm.alloca [[one]] x !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+    // CHECK: ^bb1:
+    cf.br ^bb1
+  ^bb1:
+    %0 = quantum.set_state(%arg0) %arg1 : (memref<2xcomplex<f64>>, !quantum.bit) -> !quantum.bit
+    return
+  }
 }
 
 // -----
 
 // CHECK-LABEL: @static_alloca_basis_state
-func.func @static_alloca_basis_state(%arg0 : memref<1xi1>, %arg1 : !quantum.bit) -> () {
-  // CHECK-NOT: ^bb1:
-  // CHECK:      [[one:%.+]] = llvm.mlir.constant(1 : i64)
-  // CHECK-NEXT: llvm.alloca [[one]] x !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
-  // CHECK: ^bb1:
-  cf.br ^bb1
-^bb1:
-  %0 = quantum.set_basis_state(%arg0) %arg1 : (memref<1xi1>, !quantum.bit) -> !quantum.bit
-  return
+module @static_alloca_basis_state {
+  // CHECK-LABEL: @test
+  func.func @test(%arg0 : memref<1xi1>, %arg1 : !quantum.bit) -> () {
+    // CHECK-NOT: ^bb1:
+    // CHECK:      [[one:%.+]] = llvm.mlir.constant(1 : i64)
+    // CHECK-NEXT: llvm.alloca [[one]] x !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>
+    // CHECK: ^bb1:
+    cf.br ^bb1
+  ^bb1:
+    %0 = quantum.set_basis_state(%arg0) %arg1 : (memref<1xi1>, !quantum.bit) -> !quantum.bit
+    return
+  }
 }

--- a/mlir/test/Quantum/VerifierTest.mlir
+++ b/mlir/test/Quantum/VerifierTest.mlir
@@ -486,6 +486,7 @@ func.func @expval_and_var_good(%q : !quantum.bit) attributes {quantum.node} {
 // -----
 
 module {
+module attributes {transform.with_named_sequence} {}
 func.func @measurement_without_qnode(%q : !quantum.bit) {
     %obs = quantum.namedobs %q[PauliZ] : !quantum.obs
     // expected-error@+1 {{requires parent function to carry 'quantum.node' attribute}}
@@ -497,6 +498,7 @@ func.func @measurement_without_qnode(%q : !quantum.bit) {
 // -----
 
 module {
+    module attributes {transform.with_named_sequence} {}
     %q = quantum.alloc_qb : !quantum.bit
     %obs = quantum.namedobs %q[PauliZ] : !quantum.obs
     // expected-error@+1 {{'quantum.expval' op must be nested inside a 'func.func' operation}}


### PR DESCRIPTION
PR #2497 Introduced a verifier for the `quantum.node` attribute, and also expanded verification for measurement processes. The issue is that detection logic is not very robust because we don't have a dedicated quantum kernel operation. The verification is intended to only run on operations within a quantum kernel.

The detection logic is updated to detect the presence of the transform program in the quantum kernel, making it more robust / narrow. This also allows us to revert the test changes from the previous PR (actual changes in this PR are very small, see commits).

#### Details

The verifier is intended to catch missing quantum.node attributes within quantum kernels (the abstraction frontend-scheduled passes run on), as per [the guide](https://github.com/PennyLaneAI/catalyst/blob/main/frontend/catalyst/python_interface/transforms/qnode-transform-guide.md). For instance, the following should raise an error:
```mlir
module @root {
  func.func public @jit_main_function() { ... }
  module @kernel_module {
    module attributes {transform.with_name_sequence} { ... }
    func.func @circuit() {  // missing quantum.node attribute
      ...
      quantum.expval %obs : f64
    }
  }
}
```

The issue prompting this fix is that the verifier was erroneously triggering when sending and intermediate output from the compiler back into the opt tool. For instance, while the following IR would not trigger a verification error while already loaded in memory (only one module):
```mlir
module {
  func.func @circuit() {
    ...
    quantum.expval %obs : f64
  }
}
```
it will trigger when parsing it back with our command line tools.

From testing I discovered that round-tripping a piece of IR with opt will run the verifier twice, and one of those times an additional module is wrapped around the program (for what reason I don't know yet). So the above program will be verified twice with:
1) `quantum.expval` having two parent modules
2) --------"-------- having one parent module

Note that this phenomenon is not the same as opt inserting a module into the IR when none is present in the input, e.g.
```mlir
quantum.expval %obs : f64
```
turning into
```
module {
  quantum.expval %obs : f64
}
```
This behaviour can be turned off with `--no-implicit-module` and is orthogonal to behaviour described above.

[sc-107492]