### PR TITLE
Faster and more robust MLIR generation for inspection functionality

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -512,6 +512,10 @@
   definitions in separate file scopes.
   [(#2329)](https://github.com/PennyLaneAI/catalyst/pull/2329)
 
+* Improve speed and reliability of xDSL inspection functionality by only running the necessary
+  compilation steps if the QJIT object does not already have an MLIR representation.
+  [(#2598)](https://github.com/PennyLaneAI/catalyst/pull/2598)
+
 * Added lowering of `pbc.ppm`, `pbc.ppr`, and `quantum.paulirot` to the runtime CAPI and QuantumDevice C++ API.
   [(#2348)](https://github.com/PennyLaneAI/catalyst/pull/2348)
   [(#2413)](https://github.com/PennyLaneAI/catalyst/pull/2413)

--- a/frontend/catalyst/python_interface/inspection/xdsl_conversion.py
+++ b/frontend/catalyst/python_interface/inspection/xdsl_conversion.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 import contextlib
 import inspect
 from collections.abc import Callable
-from copy import deepcopy
 from itertools import compress
 from typing import TYPE_CHECKING
 

--- a/frontend/catalyst/python_interface/inspection/xdsl_conversion.py
+++ b/frontend/catalyst/python_interface/inspection/xdsl_conversion.py
@@ -52,6 +52,7 @@ from catalyst.python_interface.dialects.quantum import (
     SetBasisStateOp,
     SetStateOp,
 )
+from catalyst.utils.patching import Patcher
 
 if TYPE_CHECKING:
     from jaxlib.mlir._mlir_libs._mlir.ir import Module
@@ -85,14 +86,13 @@ def get_mlir_module(workflow: QJIT, args, kwargs) -> Module:
     if (mlir_module := getattr(workflow, "mlir_module", None)) is not None:
         return mlir_module
 
-    # Deep copy as to not mutate compile_options
-    compile_options = deepcopy(workflow.compile_options)
-    compile_options.autograph = False  # Autograph has already been applied for `user_function`
+    if (jaxpr := getattr(workflow, "jaxpr", None)) is None:
+        jaxpr, *_ = workflow.capture(args, **kwargs)
 
-    jitted_qnode = QJIT(workflow.user_function, compile_options)
+    with Patcher((workflow, "jaxpr", jaxpr)):
+        mlir_module = workflow.generate_ir()
 
-    jitted_qnode.jit_compile(args, **kwargs)
-    return jitted_qnode.mlir_module
+    return mlir_module
 
 
 from_str_to_PL_gate = {


### PR DESCRIPTION
The `get_mlir_module` function is used by a few Python interface functions (e.g. drawing, specs) to fetch the starting IR for their process. In particular, when the program doesn't already have an MLIR representation (e.g. from AOT compilation or a previous execution), the code will run full jit compilation on the QJIT object.

This is unnecessary, because we are only interested in the starting module. We can save a good amount of time by not compiling down all the way to LLVM and binary (which can be costly for large programs). Additionally, if we wish to inspect programs that cannot be compiled to that level, this would also fail.

[sc-114933]