### PR TITLE
xdsl adjoint op can take in qreg and qubit

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -244,6 +244,7 @@
 * The `quantum.adjoint` operation can now take in multiple quantum values, allowing
   both qubits and registers, as opposed to constraining the operand to be a single quantum register.
   [(#2590)](https://github.com/PennyLaneAI/catalyst/pull/2590)
+  [(#????)](https://github.com/PennyLaneAI/catalyst/pull/????)
 
 * `qml.value_and_grad` can now be used with program capture `qml.qjit(capture=True)`.
   [(#2587)](https://github.com/PennyLaneAI/catalyst/pull/2587)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -244,7 +244,7 @@
 * The `quantum.adjoint` operation can now take in multiple quantum values, allowing
   both qubits and registers, as opposed to constraining the operand to be a single quantum register.
   [(#2590)](https://github.com/PennyLaneAI/catalyst/pull/2590)
-  [(#????)](https://github.com/PennyLaneAI/catalyst/pull/????)
+  [(#2610)](https://github.com/PennyLaneAI/catalyst/pull/2610)
 
 * `qml.value_and_grad` can now be used with program capture `qml.qjit(capture=True)`.
   [(#2587)](https://github.com/PennyLaneAI/catalyst/pull/2587)

--- a/frontend/catalyst/python_interface/dialects/quantum/operations/miscellaneous_ops.py
+++ b/frontend/catalyst/python_interface/dialects/quantum/operations/miscellaneous_ops.py
@@ -28,7 +28,8 @@ from xdsl.irdl import (
     AnyOf,
     IRDLOperation,
     ParsePropInAttrDict,
-    VarConstraint,
+    RangeOf,
+    RangeVarConstraint,
     irdl_op_definition,
     lazy_traits_def,
     opt_operand_def,
@@ -56,7 +57,7 @@ from ..attributes import QubitSSAValue, QubitType, QuregSSAValue, QuregType
 class AdjointOp(IRDLOperation):
     """Calculate the adjoint of the enclosed operations"""
 
-    T: ClassVar = VarConstraint("T", AnyOf([QubitType, QuregType]))
+    T: ClassVar = RangeVarConstraint("T", RangeOf(AnyOf([QubitType, QuregType])))
 
     name = "quantum.adjoint"
 

--- a/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
@@ -786,16 +786,18 @@ class TestAssemblyFormat:
         //////////// Quantum register ////////////
         //////////////////////////////////////////
         // CHECK: [[QREG:%.+]] = "test.op"() : () -> !quantum.reg
+        // CHECK: [[QUBIT:%.+]] = "test.op"() : () -> !quantum.bit
         %qreg = "test.op"() : () -> !quantum.reg
+        %qubit = "test.op"() : () -> !quantum.bit
 
         //////////// **AdjointOp and YieldOp tests** ////////////
-        // CHECK:      quantum.adjoint([[QREG]]) : !quantum.reg {
-        // CHECK-NEXT: ^bb0([[ARG_QREG:%.+]] : !quantum.reg):
-        // CHECK-NEXT:   quantum.yield [[ARG_QREG]] : !quantum.reg
+        // CHECK:      quantum.adjoint([[QREG]], [[QUBIT]]) : !quantum.reg, !quantum.bit {
+        // CHECK-NEXT: ^bb0([[ARG_QREG:%.+]] : !quantum.reg, [[ARG_QUBIT:%.+]] : !quantum.bit):
+        // CHECK-NEXT:   quantum.yield [[ARG_QREG]], [[ARG_QUBIT]] : !quantum.reg, !quantum.bit
         // CHECK-NEXT: }
-        %qreg1 = quantum.adjoint(%qreg) : !quantum.reg {
-        ^bb0(%arg_qreg: !quantum.reg):
-          quantum.yield %arg_qreg : !quantum.reg
+        %qreg1, %qubit1 = quantum.adjoint(%qreg, %qubit) : !quantum.reg, !quantum.bit {
+        ^bb0(%arg_qreg: !quantum.reg, %arg_qubit: !quantum.bit):
+          quantum.yield %arg_qreg, %arg_qubit : !quantum.reg, !quantum.bit
         }
 
         //////////// **DeviceInitOp tests** ////////////


### PR DESCRIPTION
**Context:**
Update xdsl `quantum.adjoint` operation's type constraints, so it can accept `Variadic<AnyTypeOf<Qubit, Qureg>>`, and understand that the operands and results have the exact same type.

**Benefits:**
Agreement with mlir `quantum.adjoint1 op.

This is a follow-up to #2590 
