### PR TITLE
Fix performance issue in xDSL transform `measurements_from_samples` for probs

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -309,6 +309,10 @@
 * Added support for `stopping_condition` in user-defined `qp.decompose` when capture is enabled with both graph enabled and disabled.
   [(#2486)](https://github.com/PennyLaneAI/catalyst/pull/2486)
 
+* A performance issue in the xDSL transform `measurements-from-samples` that was caused by the
+  unrolling of a `for` loop for QNodes returning `probs` has been fixed.
+  [(#2611)](https://github.com/PennyLaneAI/catalyst/pull/2611)
+
 <h3>Breaking changes 💔</h3>
 
 * The ``-disentangle-CNOT`` and ``-disentangle-SWAP`` Catalyst CLI commands have been renamed to

--- a/frontend/catalyst/python_interface/transforms/quantum/measurements_from_samples.py
+++ b/frontend/catalyst/python_interface/transforms/quantum/measurements_from_samples.py
@@ -656,8 +656,12 @@ def _postprocessing_probs(samples):
     # which we currently do not support.
     # If Catalyst PR https://github.com/PennyLaneAI/catalyst/pull/1849 is merged, then we should be
     # able to use bincount.
-    counts = jnp.zeros(dim, dtype=int)
-    for i in indices.astype(int):
-        counts = counts.at[i].add(1)
+    init_counts = jnp.zeros(dim, dtype=int)
+
+    def body_fun(i, counts):
+        idx = indices[i].astype(int)
+        return counts.at[idx].add(1)
+
+    counts = jax.lax.fori_loop(0, n_samples, body_fun, init_counts)
 
     return counts / n_samples


### PR DESCRIPTION
**Context:** We observed slow compile times for circuits returning `probs()` with the `measurements_from_samples` xDSL transform. The compile time scaled with the number of shots. This was due to a Python `for` loop that was being unrolled in a JAX JIT module that performs the post-processing to compute the probabilities from the input sample array.

**Description of the Change:** Replace the Python `for` loop with a `jax.lax.fori_loop`.

**Notes**

The operation in question effectively amounts to a [`jax.numpy.bincount`](https://docs.jax.dev/en/latest/_autosummary/jax.numpy.bincount.html) operation. However, we are blocked from using this function due to our restriction in the bufferization stage that `stablehlo.scatter` ops have parameters `indices_are_sorted=True` and `unique_indices=True`. See

https://github.com/PennyLaneAI/catalyst/blob/d27a690341fdf87a14d84004727aec590ad44834/mlir/lib/hlo-extensions/Transforms/ScatterPatterns.cpp#L172-L177

and

https://github.com/PennyLaneAI/catalyst/blob/d27a690341fdf87a14d84004727aec590ad44834/mlir/lib/hlo-extensions/Transforms/ScatterPatterns.cpp#L307-L312

We have a PR open to test if we can remove these restrictions: #1849. However, we don't have a timeline on when, or even if, we'll merge this.

[sc-114564]