### PR TITLE
Add phase2 of RY gate for AWG

### DIFF
--- a/frontend/test/test_oqd/oqd/test_single_CNOT.json
+++ b/frontend/test/test_oqd/oqd/test_single_CNOT.json
@@ -75,7 +75,7 @@
               },
               "phase": {
                 "class_": "MathNum",
-                "value": 0.0
+                "value": 1.5707963267948966
               },
               "polarization": [
                 1,
@@ -690,7 +690,7 @@
               },
               "phase": {
                 "class_": "MathNum",
-                "value": 0.0
+                "value": 1.5707963267948966
               },
               "polarization": [
                 1,
@@ -815,7 +815,7 @@
               },
               "phase": {
                 "class_": "MathNum",
-                "value": 0.0
+                "value": 1.5707963267948966
               },
               "polarization": [
                 1,

--- a/mlir/lib/Ion/Transforms/GatesToPulsesPatterns.cpp
+++ b/mlir/lib/Ion/Transforms/GatesToPulsesPatterns.cpp
@@ -598,7 +598,8 @@ struct GatesToPulsesRewritePattern : public mlir::OpConversionPattern<CustomOp> 
         }
         // RY case -> PP(P1, P2)
         else if (op.getGateName() == "RY") {
-            auto result = oneQubitGateToPulse(op, rewriter, llvm::numbers::pi / 2, 0, beams1);
+            auto result = oneQubitGateToPulse(op, rewriter, llvm::numbers::pi / 2,
+                                              llvm::numbers::pi / 2, beams1);
             return result;
         }
         // MS case -> PP(P1, P2, P3, P4, P5, P6)

--- a/mlir/test/Ion/QuantumToIon.mlir
+++ b/mlir/test/Ion/QuantumToIon.mlir
@@ -187,7 +187,7 @@ func.func @example_ion_two_qubit(%arg0: f64) -> !quantum.bit  attributes {qnode}
     // CHECK-SAME:         detuning = 2.200000e+00 : f64,
     // CHECK-SAME:         polarization = [0, 1, 2],
     // CHECK-SAME:         wavevector = [-2, 3, 4]>,
-    // CHECK-SAME:     phase = 0.000000e+00 : f64}
+    // CHECK-SAME:     phase = 1.5707963267{{[0-9]*}} : f64}
     // CHECK-NEXT:   ion.yield %arg1 : !ion.qubit
     // CHECK-NEXT: }
     // CHECK-NEXT: [[ry1out:%.+]] = builtin.unrealized_conversion_cast [[ry1out_ion]] : !ion.qubit to !quantum.bit


### PR DESCRIPTION
**Context:**

Spectrum AWG exposes carrier phase via `dds_channel_phase(..., phase_deg=90.0)`. Now RY pulse's phase2 is updated to pi/2.

**Description of the Change:**

RY uses `oneQubitGateToPulse(..., pi/2, pi/2, ...)` for converting to gate pulse
 
**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
