### PR TITLE
hard-code decomp ops

### DIFF
--- a/frontend/catalyst/utils/precompile_decomposition_rules.py
+++ b/frontend/catalyst/utils/precompile_decomposition_rules.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 
 """Utilities for AOT compiling PennyLane's decomposition rules to MLIR Bytecode."""
-import inspect
 import warnings
-from functools import lru_cache
 from pathlib import Path
 
 import jax
@@ -32,82 +30,46 @@ BYTECODE_FILE_PATH = Path(__file__).parent.parent / Path("resources/decompositio
 # TODO: Uncomment dynamic size wires ops once they are supported
 # FIXME: Use the Gate class instead of this list of compiler ops
 #              https://github.com/PennyLaneAI/pennylane/pull/8767
-COMPILER_OPS_FOR_DECOMPOSITION = frozenset(
-    {
-        "CNOT",
-        "ControlledPhaseShift",
-        "CRot",
-        "CRX",
-        "CRY",
-        "CRZ",
-        "CSWAP",
-        "CY",
-        "CZ",
-        "Hadamard",
-        # "Identity",
-        "IsingXX",
-        "IsingXY",
-        "IsingYY",
-        "IsingZZ",
-        "SingleExcitation",
-        "DoubleExcitation",
-        "ISWAP",
-        "PauliX",
-        "PauliY",
-        "PauliZ",
-        # "PauliRot",
-        # "PauliMeasure",
-        "PhaseShift",
-        "PSWAP",
-        "Rot",
-        "RX",
-        "RY",
-        "RZ",
-        "S",
-        "SWAP",
-        "T",
-        "Toffoli",
-        "U1",
-        "U2",
-        "U3",
-        # "MultiRZ",
-        # "GlobalPhase",
-    }
-)
-
-
-@lru_cache
-def get_compiler_ops(
-    _supported_compiler_op_names: frozenset[str] = COMPILER_OPS_FOR_DECOMPOSITION,
-) -> set[type[Operator]]:
-    """
-    Extracts all ops from pennylane that have decompositions in catalyst.
-
-    Returns:
-        set[Operation]: the set of PennyLane ops that are compiler-compatible
-                        (as defined by COMPILER_OPS_FOR_DECOMPOSITION)
-        int: the number of compiler-compatible ops that could not be found in PennyLane
-    """
-    pl_op_classes = set(
-        value
-        for _, value in inspect.getmembers(
-            qp, lambda obj: inspect.isclass(obj) and issubclass(obj, Operator)
-        )
-    )
-
-    # FIXME: manual override for PauliMeasure
-    pl_op_classes.add(qp.ops.PauliMeasure)
-
-    compiler_op_classes = set(
-        op_class for op_class in pl_op_classes if op_class.__name__ in _supported_compiler_op_names
-    )
-
-    compiler_op_class_names = set(op_class.__name__ for op_class in compiler_op_classes)
-
-    for class_name in _supported_compiler_op_names.difference(compiler_op_class_names):
-        warnings.warn(f"failed to collect pennylane op with name {class_name}")
-
-    return compiler_op_classes
+COMPILER_OPS_FOR_DECOMPOSITION = {
+    qp.CNOT,
+    qp.ControlledPhaseShift,
+    qp.CRot,
+    qp.CRX,
+    qp.CRY,
+    qp.CRZ,
+    qp.CSWAP,
+    qp.CY,
+    qp.CZ,
+    qp.H,
+    # qp.I,
+    qp.IsingXX,
+    qp.IsingXY,
+    qp.IsingYY,
+    qp.IsingZZ,
+    qp.SingleExcitation,
+    qp.DoubleExcitation,
+    qp.ISWAP,
+    qp.PauliX,
+    qp.PauliY,
+    qp.PauliZ,
+    # qp.PauliRot,
+    # qp.PauliMeasure,
+    qp.PhaseShift,
+    qp.PSWAP,
+    qp.Rot,
+    qp.RX,
+    qp.RY,
+    qp.RZ,
+    qp.S,
+    qp.SWAP,
+    qp.T,
+    qp.Toffoli,
+    qp.U1,
+    qp.U2,
+    qp.U3,
+    # qp.MultiRZ,
+    # qp.GlobalPhase,
+}
 
 
 def get_abstract_args(op_class: type[Operator]) -> list[type]:
@@ -250,11 +212,9 @@ def precompile_decomp_rules(decomp_file_path: Path = BYTECODE_FILE_PATH):
     """
     decomp_file_path.parent.mkdir(parents=True, exist_ok=True)
 
-    target_ops = get_compiler_ops()
-
     mlir_rules = "".join(
         str(mlir).replace("@rule_wrapper", f"@__builtin_{name}")
-        for func in target_ops
+        for func in COMPILER_OPS_FOR_DECOMPOSITION
         for name, mlir in compile_op_decomp_rules(func).items()
     )
 

--- a/frontend/test/pytest/test_precompile_decomp_rules.py
+++ b/frontend/test/pytest/test_precompile_decomp_rules.py
@@ -23,24 +23,8 @@ from catalyst.utils.precompile_decomposition_rules import (
     COMPILER_OPS_FOR_DECOMPOSITION,
     compile_op_decomp_rules,
     get_abstract_args,
-    get_compiler_ops,
     precompile_decomp_rules,
 )
-
-
-class TestGetCompilerOps:
-    """Tests for get_compiler_ops."""
-
-    def test_get_compiler_ops(self):
-        """Test that get_compiler_ops succeeds in finding all compiler ops."""
-        ops = get_compiler_ops()
-
-        assert len(ops) == len(COMPILER_OPS_FOR_DECOMPOSITION)
-
-    def test_warning(self):
-        """Test that get_compiler_ops warns when an op is not found."""
-        with pytest.warns():
-            get_compiler_ops(frozenset(["fake_op"]))
 
 
 class TestGetAbstractArgs:


### PR DESCRIPTION
**Context:**
Ops that have precompiled decomposition rules are currently listed by name and captured from PennyLane. This can be simplified and made less error-prone by using a set of PennyLane ops.

**Description of the Change:**
Changes the set of op names to a set of ops, and removes the logic for gathering the ops from PennyLane.

**Benefits:**
Reduced complexity of precompilation. As a side-effect, this should avoid this [flaky test failure](https://github.com/PennyLaneAI/catalyst/actions/runs/23391445367/job/68046660192).

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A