### PR TITLE
Fix miscellaneous issues in compiler python interface

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -746,6 +746,9 @@
   been added for compatibility with the Python interface to Catalyst.
   [(#2519)](https://github.com/PennyLaneAI/catalyst/pull/2519)
 
+* A number of deprecation warnings have been fixed in the compiler python interface.
+  [(#2621)](https://github.com/PennyLaneAI/catalyst/pull/2621)
+
 <h3>Documentation 📝</h3>
 
 * Docstrings for :func:`~.passes.disentangle_cnot` and :func:`~.passes.disentangle_swap` have been improved

--- a/frontend/catalyst/python_interface/dialects/mbqc.py
+++ b/frontend/catalyst/python_interface/dialects/mbqc.py
@@ -28,14 +28,20 @@ from typing import TypeAlias
 
 from xdsl.dialects.builtin import (
     I32,
-    AnyAttr,
     Float64Type,
     IntegerAttr,
     IntegerType,
     StringAttr,
     i1,
 )
-from xdsl.ir import Dialect, EnumAttribute, Operation, SpacedOpaqueSyntaxAttribute, SSAValue
+from xdsl.ir import (
+    Attribute,
+    Dialect,
+    EnumAttribute,
+    Operation,
+    SpacedOpaqueSyntaxAttribute,
+    SSAValue,
+)
 from xdsl.irdl import (
     IntSetConstraint,
     IRDLOperation,
@@ -98,13 +104,13 @@ class MeasureInBasisOp(IRDLOperation):
         self,
         in_qubit: QubitSSAValue | Operation,
         plane: MeasurementPlaneAttr,
-        angle: SSAValue[Float64Type],
+        angle: SSAValue[Float64Type] | Operation,
         postselect: int | IntegerAttr | None = None,
     ):
-        properties = {"plane": plane}
+        properties: dict[str, Attribute] = {"plane": plane}
 
         if isinstance(postselect, int):
-            postselect = IntegerAttr.from_int_and_width(postselect, 32)
+            postselect = IntegerAttr(postselect, 32)
 
         if postselect is not None:
             properties["postselect"] = postselect
@@ -137,7 +143,10 @@ class GraphStatePrepOp(IRDLOperation):
     qreg = result_def(QuregType)
 
     def __init__(
-        self, adj_matrix: AnyAttr, init_op: str | StringAttr, entangle_op: str | StringAttr
+        self,
+        adj_matrix: SSAValue[Attribute] | Operation,
+        init_op: str | StringAttr,
+        entangle_op: str | StringAttr,
     ):
         if isinstance(init_op, str):
             init_op = StringAttr(data=init_op)
@@ -145,7 +154,7 @@ class GraphStatePrepOp(IRDLOperation):
         if isinstance(entangle_op, str):
             entangle_op = StringAttr(data=entangle_op)
 
-        properties = {"init_op": init_op, "entangle_op": entangle_op}
+        properties: dict[str, Attribute] = {"init_op": init_op, "entangle_op": entangle_op}
 
         qreg = QuregType()
 

--- a/frontend/catalyst/python_interface/dialects/quantum/operations/measurement_ops.py
+++ b/frontend/catalyst/python_interface/dialects/quantum/operations/measurement_ops.py
@@ -73,7 +73,7 @@ class MeasureOp(IRDLOperation):
         self, in_qubit: QubitSSAValue | Operation, postselect: int | IntegerAttr | None = None
     ):
         if isinstance(postselect, int):
-            postselect = IntegerAttr.from_int_and_width(postselect, 32)
+            postselect = IntegerAttr(postselect, 32)
 
         if postselect is None:
             properties = {}

--- a/frontend/catalyst/python_interface/dialects/quantum/operations/qubit_ops.py
+++ b/frontend/catalyst/python_interface/dialects/quantum/operations/qubit_ops.py
@@ -60,7 +60,7 @@ class AllocOp(IRDLOperation):
 
     def __init__(self, nqubits):
         if isinstance(nqubits, int):
-            nqubits = IntegerAttr.from_int_and_width(nqubits, 64)
+            nqubits = IntegerAttr(nqubits, 64)
 
         if isinstance(nqubits, IntegerAttr):
             operands = (None,)
@@ -144,7 +144,7 @@ class ExtractOp(IRDLOperation):
         idx: int | SSAValue[IntegerType] | Operation | IntegerAttr,
     ):
         if isinstance(idx, int):
-            idx = IntegerAttr.from_int_and_width(idx, 64)
+            idx = IntegerAttr(idx, 64)
 
         if isinstance(idx, IntegerAttr):
             operands = (qreg, None)
@@ -189,7 +189,7 @@ class InsertOp(IRDLOperation):
         qubit: QubitSSAValue | Operation,
     ):
         if isinstance(idx, int):
-            idx = IntegerAttr.from_int_and_width(idx, 64)
+            idx = IntegerAttr(idx, 64)
 
         if isinstance(idx, IntegerAttr):
             operands = (in_qreg, None, qubit)

--- a/frontend/catalyst/python_interface/pass_api/compiler_transform.py
+++ b/frontend/catalyst/python_interface/pass_api/compiler_transform.py
@@ -45,7 +45,7 @@ class CompilerTransform(Transform):
         super().__init__(pass_name=module_pass.name)
 
 
-def compiler_transform(module_pass: ModulePass) -> CompilerTransform:
+def compiler_transform(module_pass: type[ModulePass]) -> CompilerTransform:
     """Function to register compilation passes to use within :func:`~.qjit`'d workflows as
     decorators on top of QNodes.
 
@@ -273,7 +273,7 @@ def _update_op_type_hint(hint: type[Operation]) -> Callable:
     return _update_match_and_rewrite
 
 
-def _create_rewrite_pattern(hint: type[Operation], action: Callable) -> RewritePattern:
+def _create_rewrite_pattern(hint: type[Operation], action: Callable) -> type[RewritePattern]:
     """Given an action defined as a function, create a ``RewritePattern`` which
     can be used with xDSL's pass API."""
 

--- a/frontend/catalyst/python_interface/transforms/mbqc/decompose_graph_state.py
+++ b/frontend/catalyst/python_interface/transforms/mbqc/decompose_graph_state.py
@@ -28,6 +28,7 @@ from typing import TypeAlias
 
 from xdsl import context, passes, pattern_rewriter
 from xdsl.dialects import builtin
+from xdsl.ir import Operation
 from xdsl.pattern_rewriter import PatternRewriter, RewritePattern
 
 from catalyst.python_interface.dialects import mbqc, quantum
@@ -131,9 +132,13 @@ class DecomposeGraphStatePattern(RewritePattern):
         # Finally, erase the ops that have now been replaced with quantum ops
         rewriter.erase_op(graph_prep_op)
 
-        # Erase the constant op that returned the adjacency matrix only if it has no other uses
-        if graph_prep_op.adj_matrix.uses.get_length() == 0:
-            rewriter.erase_op(graph_prep_op.adj_matrix.owner)
+        # Erase the constant op that returned the adjacency matrix only if it has no other uses and
+        # it is an operation (and not e.g. a block argument)
+        adj_matrix_owner = graph_prep_op.adj_matrix.owner
+        if graph_prep_op.adj_matrix.uses.get_length() == 0 and isinstance(
+            adj_matrix_owner, Operation
+        ):
+            rewriter.erase_op(adj_matrix_owner)
 
 
 @dataclass(frozen=True)
@@ -175,9 +180,13 @@ class NullDecomposeGraphStatePattern(RewritePattern):
         # Finally, erase the ops that have now been replaced with quantum ops
         rewriter.erase_op(graph_prep_op)
 
-        # Erase the constant op that returned the adjacency matrix only if it has no other uses
-        if graph_prep_op.adj_matrix.uses.get_length() == 0:
-            rewriter.erase_op(graph_prep_op.adj_matrix.owner)
+        # Erase the constant op that returned the adjacency matrix only if it has no other uses and
+        # it is an operation (and not e.g. a block argument)
+        adj_matrix_owner = graph_prep_op.adj_matrix.owner
+        if graph_prep_op.adj_matrix.uses.get_length() == 0 and isinstance(
+            adj_matrix_owner, Operation
+        ):
+            rewriter.erase_op(adj_matrix_owner)
 
 
 def _parse_adj_matrix(graph_prep_op: mbqc.GraphStatePrepOp) -> list[int]:
@@ -193,6 +202,11 @@ def _parse_adj_matrix(graph_prep_op: mbqc.GraphStatePrepOp) -> list[int]:
         documentation for a description of this format.
     """
     adj_matrix_const_op = graph_prep_op.adj_matrix.owner
+    assert isinstance(adj_matrix_const_op, Operation), (
+        f"Expected graph adjacency matrix to be defined as the result of an operation, but got "
+        f"'{type(adj_matrix_const_op).__name__}'"
+    )
+
     adj_matrix_value = adj_matrix_const_op.properties.get("value")
     assert adj_matrix_value is not None and hasattr(
         adj_matrix_value, "data"

--- a/frontend/catalyst/python_interface/transforms/mbqc/outline_state_evolution.py
+++ b/frontend/catalyst/python_interface/transforms/mbqc/outline_state_evolution.py
@@ -154,7 +154,7 @@ class OutlineStateEvolutionPattern(pattern_rewriter.RewritePattern):
         for qb, idx in list(qubit_to_reg_idx.items()):
             extract_op = quantum.ExtractOp(current_reg, idx)
             rewriter.insert_op(extract_op, insertion_point=insertion_point)
-            qb.replace_by_if(extract_op.qubit, lambda use: use.operation not in insert_ops)
+            qb.replace_uses_with_if(extract_op.qubit, lambda use: use.operation not in insert_ops)
             for use in qb.uses:
                 rewriter.notify_op_modified(use.operation)
             # update the qubit_to_reg_idx dict

--- a/frontend/catalyst/python_interface/transforms/quantum/combine_global_phases.py
+++ b/frontend/catalyst/python_interface/transforms/quantum/combine_global_phases.py
@@ -64,7 +64,7 @@ class CombineGlobalPhasesPattern(
                 rewriter.erase_op(prev)
                 prev = current
 
-            prev.operands[0].replace_by_if(phi_sum, lambda use: use.operation == prev)
+            prev.operands[0].replace_uses_with_if(phi_sum, lambda use: use.operation == prev)
             rewriter.notify_op_modified(prev)
 
 

--- a/frontend/catalyst/python_interface/transforms/quantum/diagonalize_measurements.py
+++ b/frontend/catalyst/python_interface/transforms/quantum/diagonalize_measurements.py
@@ -223,7 +223,7 @@ class DiagonalizeFinalMeasurementsPattern(
                 ]
 
                 # pylint: disable = cell-var-from-loop
-                op.qubit.replace_by_if(qubit, lambda use: use in uses_to_change)
+                op.qubit.replace_uses_with_if(qubit, lambda use: use in uses_to_change)
                 for use in uses_to_change:
                     rewriter.notify_op_modified(use.operation)
 


### PR DESCRIPTION
Fixes and improvements include:

  - Fixed a number of deprecation warnings (e.g. from `IntegerAttr.from_int_and_width()`, `SSAValue.replace_by_if()`)
  - Better type hints, where applicable
  - Improved logic in the decompose-graph-state rewrite patterns
