### PR TITLE
Update catch2 to v3.11.0

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -498,6 +498,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Updated Catalyst's Catch2 dependency to v3.11.0.
+  [(#2634)](https://github.com/PennyLaneAI/catalyst/pull/2634)
+
 * `rtio.rpc` operation is added to the RTIO dialect for OQD. It represents a host RPC call triggered by the kernel, optionally carrying runtime arguments and supporting both synchronous and async modes. The op is lowered to rpc_send / rpc_recv LLVM calls (the ARTIQ RPC wire protocol). It is required by both AWG control (program_awg, awg_close) and measurement result collection (set_dataset, transfer_data).
   [(#2577)](https://github.com/PennyLaneAI/catalyst/pull/2577)
 

--- a/frontend/catalyst/third_party/oqc/src/tests/CMakeLists.txt
+++ b/frontend/catalyst/third_party/oqc/src/tests/CMakeLists.txt
@@ -3,13 +3,13 @@ Include(FetchContent)
 FetchContent_Declare(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG        v2.13.9
+    GIT_TAG        v3.11.0
 )
 
 FetchContent_MakeAvailable(Catch2)
 
 # Required for catch_discover_tests().
-list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 
 # Modify `ctest` to only run the supported subset of tests.
 include(CTest)

--- a/frontend/catalyst/third_party/oqc/src/tests/Test_OQCDevice.cpp
+++ b/frontend/catalyst/third_party/oqc/src/tests/Test_OQCDevice.cpp
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 #include <pybind11/embed.h>
 
 #include "OQCDevice.cpp"
@@ -26,7 +27,8 @@ TEST_CASE("Test the OQCDevice constructor", "[openqasm]")
     auto device = OQCDevice("{shots : 100}");
     CHECK(device.GetNumQubits() == 0);
 
-    REQUIRE_THROWS_WITH(device.Measure(0), Catch::Contains("unsupported by device"));
+    REQUIRE_THROWS_WITH(device.Measure(0),
+                        Catch::Matchers::ContainsSubstring("unsupported by device"));
 }
 
 TEST_CASE("Test qubits allocation OpenQasmDevice", "[openqasm]")
@@ -89,6 +91,7 @@ TEST_CASE("Test counts", "[openqasm][counts]")
     DataView<double, 1> eigvals_view(eigvals);
     DataView<int64_t, 1> counts_view(counts);
 
-    REQUIRE_THROWS_WITH(device->PartialCounts(eigvals_view, counts_view, {wires[0], wires[1]}),
-                        Catch::Contains("OQC credentials not found in environment variables"));
+    REQUIRE_THROWS_WITH(
+        device->PartialCounts(eigvals_view, counts_view, {wires[0], wires[1]}),
+        Catch::Matchers::ContainsSubstring("OQC credentials not found in environment variables"));
 }

--- a/frontend/catalyst/third_party/oqc/src/tests/Test_OpenQASM2Builder.cpp
+++ b/frontend/catalyst/third_party/oqc/src/tests/Test_OpenQASM2Builder.cpp
@@ -18,7 +18,8 @@
 
 #include "OpenQASM2Builder.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
 
 #define TYPE_INFO(x) std::string(typeid(x).name())
 
@@ -34,9 +35,9 @@ TEST_CASE("Test lookup openqasm gate names from QIR -> OpenQasm map", "[openqasm
     CHECK(lookup_qasm_gate_name("Toffoli") == "ccx");
 
     // Check lookup an unsupported gate
-    REQUIRE_THROWS_WITH(
-        lookup_qasm_gate_name("ABC"),
-        Catch::Contains("The given QIR gate name is not supported by the OpenQASM builder"));
+    REQUIRE_THROWS_WITH(lookup_qasm_gate_name("ABC"),
+                        Catch::Matchers::ContainsSubstring(
+                            "The given QIR gate name is not supported by the OpenQASM builder"));
 }
 
 TEST_CASE("Test QasmRegister(type=Qubit) from OpenQasmBuilder", "[openqasm]")
@@ -59,9 +60,10 @@ TEST_CASE("Test QasmRegister(type=Qubit) from OpenQasmBuilder", "[openqasm]")
     std::string case2 = "reset qubits;\n";
     CHECK(reg.toOpenQASM2(RegisterMode::Reset) == case2);
 
-    REQUIRE_THROWS_WITH(reg.toOpenQASM2(static_cast<RegisterMode>(4)),
-                        Catch::Contains("[Function:toOpenQASM2] Error in Catalyst Runtime: "
-                                        "Unsupported OpenQasm register mode"));
+    REQUIRE_THROWS_WITH(
+        reg.toOpenQASM2(static_cast<RegisterMode>(4)),
+        Catch::Matchers::ContainsSubstring("[Function:toOpenQASM2] Error in Catalyst Runtime: "
+                                           "Unsupported OpenQasm register mode"));
 }
 
 TEST_CASE("Test QasmRegister(type=Bit) from OpenQasmBuilder", "[openqasm]")
@@ -86,13 +88,15 @@ TEST_CASE("Test QasmRegister(type=Bit) from OpenQasmBuilder", "[openqasm]")
 
     // Check edge cases
     auto reg_buggy = QASMRegister(static_cast<RegisterType>(3), "random", 5);
-    REQUIRE_THROWS_WITH(reg_buggy.toOpenQASM2(RegisterMode::Alloc),
-                        Catch::Contains("[Function:toOpenQASM2] Error in Catalyst Runtime: "
-                                        "Unsupported OpenQasm register type"));
+    REQUIRE_THROWS_WITH(
+        reg_buggy.toOpenQASM2(RegisterMode::Alloc),
+        Catch::Matchers::ContainsSubstring("[Function:toOpenQASM2] Error in Catalyst Runtime: "
+                                           "Unsupported OpenQasm register type"));
 
-    REQUIRE_THROWS_WITH(reg.toOpenQASM2(static_cast<RegisterMode>(4)),
-                        Catch::Contains("[Function:toOpenQASM2] Error in Catalyst Runtime: "
-                                        "Unsupported OpenQasm register mode"));
+    REQUIRE_THROWS_WITH(
+        reg.toOpenQASM2(static_cast<RegisterMode>(4)),
+        Catch::Matchers::ContainsSubstring("[Function:toOpenQASM2] Error in Catalyst Runtime: "
+                                           "Unsupported OpenQasm register mode"));
 }
 
 TEST_CASE("Test QasmGate from OpenQasmBuilder", "[openqasm]")
@@ -140,8 +144,9 @@ TEST_CASE("Test QasmGate from OpenQasmBuilder", "[openqasm]")
     // Check edge cases
     REQUIRE_THROWS_WITH(
         QASMGate("ABC", {}, {}),
-        Catch::Contains("[Function:lookup_qasm_gate_name] Error in Catalyst Runtime: The given QIR "
-                        "gate name is not supported by the OpenQASM builder"));
+        Catch::Matchers::ContainsSubstring(
+            "[Function:lookup_qasm_gate_name] Error in Catalyst Runtime: The given QIR "
+            "gate name is not supported by the OpenQASM builder"));
 }
 
 TEST_CASE("Test QasmMeasure from OpenQasmBuilder", "[openqasm]")

--- a/frontend/catalyst/third_party/oqc/src/tests/runner_main.cpp
+++ b/frontend/catalyst/third_party/oqc/src/tests/runner_main.cpp
@@ -12,5 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <catch2/catch_session.hpp>
+
+int main(int argc, char *argv[]) { return Catch::Session().run(argc, argv); }

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ Include(FetchContent)
 FetchContent_Declare(
     Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG        v3.8.0
+    GIT_TAG        v3.11.0
 )
 
 # Raised by Catch2 with GCC-13, so we disable it here before including their project.
@@ -21,7 +21,7 @@ execute_process(
 find_package(pybind11 CONFIG REQUIRED)
 
 # Required for catch_discover_tests().
-list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/contrib)
+list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)
 
 # Modify `ctest` to only run the supported subset of tests.
 include(CTest)

--- a/runtime/tests/Test_DataView.cpp
+++ b/runtime/tests/Test_DataView.cpp
@@ -14,8 +14,8 @@
 
 #include <cstdio>
 
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 
 #include "DataView.hpp"
@@ -35,9 +35,9 @@ TEST_CASE("Test DataView Pre-Increment Iterator - double, 1", "[DataView]")
 
     auto view_iter = view.begin();
 
-    CHECK(*view_iter == Catch::Approx(1.0).epsilon(1e-5));
-    CHECK(*++view_iter == Catch::Approx(1.1).epsilon(1e-5));
-    CHECK(*++view_iter == Catch::Approx(1.2).epsilon(1e-5));
+    CHECK_THAT(*view_iter, WithinRel(1.0, 1e-5));
+    CHECK_THAT(*++view_iter, WithinRel(1.1, 1e-5));
+    CHECK_THAT(*++view_iter, WithinRel(1.2, 1e-5));
 }
 
 TEST_CASE("Test DataView Pre-Increment Iterator - int, 2", "[DataView]")
@@ -89,9 +89,9 @@ TEST_CASE("Test DataView Post-Increment Iterator - double, 1", "[DataView]")
 
     auto view_iter = view.begin();
 
-    CHECK(*view_iter++ == Catch::Approx(3.2).epsilon(1e-5));
-    CHECK(*view_iter++ == Catch::Approx(4.1).epsilon(1e-5));
-    CHECK(*view_iter == Catch::Approx(1.6).epsilon(1e-5));
+    CHECK_THAT(*view_iter++, WithinRel(3.2, 1e-5));
+    CHECK_THAT(*view_iter++, WithinRel(4.1, 1e-5));
+    CHECK_THAT(*view_iter, WithinRel(1.6, 1e-5));
 }
 
 TEST_CASE("Test DataView Post-Increment Iterator - int, 2", "[DataView]")

--- a/runtime/tests/Test_NullQubit.cpp
+++ b/runtime/tests/Test_NullQubit.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <cstdint>
 #include <cstdio>
@@ -323,7 +323,7 @@ TEST_CASE("Test __catalyst__qis__Sample with num_qubits=2 and PartialSample call
 
     auto obs = __catalyst__qis__NamedObs(ObsId::PauliZ, *ctrls);
 
-    CHECK(__catalyst__qis__Variance(obs) == Catch::Approx(0.0).margin(1e-5));
+    CHECK_THAT(__catalyst__qis__Variance(obs), WithinAbs(0.0, 1e-5));
 
     __catalyst__rt__qubit_release_array(qs);
     __catalyst__rt__device_release();
@@ -341,8 +341,8 @@ TEST_CASE("Test NullQubit state vector - 0 qubits", "[NullQubit]")
     sim->State(view);
 
     CHECK(view.size() == 1);
-    CHECK(view(0).real() == Catch::Approx(1.0).epsilon(1e-5));
-    CHECK(view(0).imag() == Catch::Approx(0.0).epsilon(1e-5));
+    CHECK_THAT(view(0).real(), WithinRel(1.0, 1e-5));
+    CHECK_THAT(view(0).imag(), WithinRel(0.0, 1e-5));
 }
 
 TEST_CASE("Test NullQubit state vector - 1 qubit", "[NullQubit]")
@@ -358,10 +358,10 @@ TEST_CASE("Test NullQubit state vector - 1 qubit", "[NullQubit]")
     sim->State(view);
 
     CHECK(view.size() == 2);
-    CHECK(view(0).real() == Catch::Approx(1.0).epsilon(1e-5));
-    CHECK(view(0).imag() == Catch::Approx(0.0).epsilon(1e-5));
-    CHECK(view(1).real() == Catch::Approx(0.0).epsilon(1e-5));
-    CHECK(view(1).imag() == Catch::Approx(0.0).epsilon(1e-5));
+    CHECK_THAT(view(0).real(), WithinRel(1.0, 1e-5));
+    CHECK_THAT(view(0).imag(), WithinRel(0.0, 1e-5));
+    CHECK_THAT(view(1).real(), WithinRel(0.0, 1e-5));
+    CHECK_THAT(view(1).imag(), WithinRel(0.0, 1e-5));
 }
 
 TEST_CASE("Test NullQubit state vector - 2 qubits", "[NullQubit]")
@@ -378,14 +378,14 @@ TEST_CASE("Test NullQubit state vector - 2 qubits", "[NullQubit]")
     sim->State(view);
 
     CHECK(view.size() == 4);
-    CHECK(view(0).real() == Catch::Approx(1.0).epsilon(1e-5));
-    CHECK(view(0).imag() == Catch::Approx(0.0).epsilon(1e-5));
-    CHECK(view(1).real() == Catch::Approx(0.0).epsilon(1e-5));
-    CHECK(view(1).imag() == Catch::Approx(0.0).epsilon(1e-5));
-    CHECK(view(2).real() == Catch::Approx(0.0).epsilon(1e-5));
-    CHECK(view(2).imag() == Catch::Approx(0.0).epsilon(1e-5));
-    CHECK(view(3).real() == Catch::Approx(0.0).epsilon(1e-5));
-    CHECK(view(3).imag() == Catch::Approx(0.0).epsilon(1e-5));
+    CHECK_THAT(view(0).real(), WithinRel(1.0, 1e-5));
+    CHECK_THAT(view(0).imag(), WithinRel(0.0, 1e-5));
+    CHECK_THAT(view(1).real(), WithinRel(0.0, 1e-5));
+    CHECK_THAT(view(1).imag(), WithinRel(0.0, 1e-5));
+    CHECK_THAT(view(2).real(), WithinRel(0.0, 1e-5));
+    CHECK_THAT(view(2).imag(), WithinRel(0.0, 1e-5));
+    CHECK_THAT(view(3).real(), WithinRel(0.0, 1e-5));
+    CHECK_THAT(view(3).imag(), WithinRel(0.0, 1e-5));
 }
 
 TEST_CASE("Test NullQubit state vector after ReleaseQubit", "[NullQubit]")
@@ -406,10 +406,10 @@ TEST_CASE("Test NullQubit state vector after ReleaseQubit", "[NullQubit]")
     sim->State(view);
 
     CHECK(view.size() == 2);
-    CHECK(view(0).real() == Catch::Approx(1.0).epsilon(1e-5));
-    CHECK(view(0).imag() == Catch::Approx(0.0).epsilon(1e-5));
-    CHECK(view(1).real() == Catch::Approx(0.0).epsilon(1e-5));
-    CHECK(view(1).imag() == Catch::Approx(0.0).epsilon(1e-5));
+    CHECK_THAT(view(0).real(), WithinRel(1.0, 1e-5));
+    CHECK_THAT(view(0).imag(), WithinRel(0.0, 1e-5));
+    CHECK_THAT(view(1).real(), WithinRel(0.0, 1e-5));
+    CHECK_THAT(view(1).imag(), WithinRel(0.0, 1e-5));
 }
 
 TEST_CASE("Test NullQubit state vector after AllocateQubits", "[NullQubit]")
@@ -427,14 +427,14 @@ TEST_CASE("Test NullQubit state vector after AllocateQubits", "[NullQubit]")
     sim->State(view);
 
     CHECK(view.size() == 4);
-    CHECK(view(0).real() == Catch::Approx(1.0).epsilon(1e-5));
-    CHECK(view(0).imag() == Catch::Approx(0.0).epsilon(1e-5));
-    CHECK(view(1).real() == Catch::Approx(0.0).epsilon(1e-5));
-    CHECK(view(1).imag() == Catch::Approx(0.0).epsilon(1e-5));
-    CHECK(view(2).real() == Catch::Approx(0.0).epsilon(1e-5));
-    CHECK(view(2).imag() == Catch::Approx(0.0).epsilon(1e-5));
-    CHECK(view(3).real() == Catch::Approx(0.0).epsilon(1e-5));
-    CHECK(view(3).imag() == Catch::Approx(0.0).epsilon(1e-5));
+    CHECK_THAT(view(0).real(), WithinRel(1.0, 1e-5));
+    CHECK_THAT(view(0).imag(), WithinRel(0.0, 1e-5));
+    CHECK_THAT(view(1).real(), WithinRel(0.0, 1e-5));
+    CHECK_THAT(view(1).imag(), WithinRel(0.0, 1e-5));
+    CHECK_THAT(view(2).real(), WithinRel(0.0, 1e-5));
+    CHECK_THAT(view(2).imag(), WithinRel(0.0, 1e-5));
+    CHECK_THAT(view(3).real(), WithinRel(0.0, 1e-5));
+    CHECK_THAT(view(3).imag(), WithinRel(0.0, 1e-5));
 }
 
 TEST_CASE("Test NullQubit state vector after AllocateQubits and ReleaseQubit", "[NullQubit]")
@@ -456,10 +456,10 @@ TEST_CASE("Test NullQubit state vector after AllocateQubits and ReleaseQubit", "
     sim->State(view);
 
     CHECK(view.size() == 2);
-    CHECK(view(0).real() == Catch::Approx(1.0).epsilon(1e-5));
-    CHECK(view(0).imag() == Catch::Approx(0.0).epsilon(1e-5));
-    CHECK(view(1).real() == Catch::Approx(0.0).epsilon(1e-5));
-    CHECK(view(1).imag() == Catch::Approx(0.0).epsilon(1e-5));
+    CHECK_THAT(view(0).real(), WithinRel(1.0, 1e-5));
+    CHECK_THAT(view(0).imag(), WithinRel(0.0, 1e-5));
+    CHECK_THAT(view(1).real(), WithinRel(0.0, 1e-5));
+    CHECK_THAT(view(1).imag(), WithinRel(0.0, 1e-5));
 }
 
 TEST_CASE("test AllocateQubits generates a proper std::vector<QubitIdType>", "[NullQubit]")
@@ -591,8 +591,8 @@ TEST_CASE("Mix Gate test R(X,Y,Z) num_qubits=4", "[NullQubit]")
     sim->State(view);
 
     CHECK(view.size() == 16);
-    CHECK(view(0).real() == Catch::Approx(1.0).epsilon(1e-5));
-    CHECK(view(0).imag() == Catch::Approx(0.0).epsilon(1e-5));
+    CHECK_THAT(view(0).real(), WithinRel(1.0, 1e-5));
+    CHECK_THAT(view(0).imag(), WithinRel(0.0, 1e-5));
 }
 
 TEST_CASE("Gate PCPhase num_qubits=3", "[NullQubit]")
@@ -609,8 +609,8 @@ TEST_CASE("Gate PCPhase num_qubits=3", "[NullQubit]")
     sim->State(view);
 
     CHECK(view.size() == 8);
-    CHECK(view(0).real() == Catch::Approx(1.0).epsilon(1e-5));
-    CHECK(view(0).imag() == Catch::Approx(0.0).epsilon(1e-5));
+    CHECK_THAT(view(0).real(), WithinRel(1.0, 1e-5));
+    CHECK_THAT(view(0).imag(), WithinRel(0.0, 1e-5));
 }
 
 TEST_CASE("Test __catalyst__qis__Gradient_params Op=[Hadamard,RZ,RY,RZ,S,T,ParamShift], "
@@ -658,9 +658,9 @@ TEST_CASE("Test __catalyst__qis__Gradient_params Op=[Hadamard,RZ,RY,RZ,S,T,Param
 
     __catalyst__rt__toggle_recorder(/* activate_cm */ false);
 
-    CHECK(result_tp.data_aligned[0] == Catch::Approx(0.0).margin(1e-5));
-    CHECK(result_tp.data_aligned[1] == Catch::Approx(0.0).margin(1e-5));
-    CHECK(result_tp.data_aligned[2] == Catch::Approx(0.0).margin(1e-5));
+    CHECK_THAT(result_tp.data_aligned[0], WithinAbs(0.0, 1e-5));
+    CHECK_THAT(result_tp.data_aligned[1], WithinAbs(0.0, 1e-5));
+    CHECK_THAT(result_tp.data_aligned[2], WithinAbs(0.0, 1e-5));
 
     __catalyst__rt__qubit_release(q1);
     __catalyst__rt__qubit_release(q0);
@@ -734,8 +734,8 @@ TEST_CASE("Test NullQubit measurement processes with num_qubits=0", "[NullQubit]
         DataView<std::complex<double>, 1> state_view(state);
         sim->State(state_view);
 
-        CHECK(state_view(0).real() == Catch::Approx(1.0).margin(1e-5));
-        CHECK(state_view(0).imag() == Catch::Approx(0.0).margin(1e-5));
+        CHECK_THAT(state_view(0).real(), WithinAbs(1.0, 1e-5));
+        CHECK_THAT(state_view(0).imag(), WithinAbs(0.0, 1e-5));
     }
 
     SECTION("Probs")
@@ -744,7 +744,7 @@ TEST_CASE("Test NullQubit measurement processes with num_qubits=0", "[NullQubit]
         DataView<double, 1> probs_view(probs);
         sim->Probs(probs_view);
 
-        CHECK(probs_view(0) == Catch::Approx(1.0).margin(1e-5));
+        CHECK_THAT(probs_view(0), WithinAbs(1.0, 1e-5));
     }
 
     SECTION("PartialProbs")
@@ -754,7 +754,7 @@ TEST_CASE("Test NullQubit measurement processes with num_qubits=0", "[NullQubit]
         std::vector<QubitIdType> wires;
         sim->PartialProbs(probs_view, wires);
 
-        CHECK(probs_view(0) == Catch::Approx(1.0).margin(1e-5));
+        CHECK_THAT(probs_view(0), WithinAbs(1.0, 1e-5));
     }
 
     SECTION("Sample")
@@ -792,7 +792,7 @@ TEST_CASE("Test NullQubit measurement processes with num_qubits=0", "[NullQubit]
         DataView<double, 1> eigvals_view(eigvals);
         sim->Counts(eigvals_view, counts_view);
 
-        CHECK(eigvals_view(0) == Catch::Approx(0.0).margin(1e-5));
+        CHECK_THAT(eigvals_view(0), WithinAbs(0.0, 1e-5));
         CHECK(counts_view(0) == shots);
     }
 
@@ -805,7 +805,7 @@ TEST_CASE("Test NullQubit measurement processes with num_qubits=0", "[NullQubit]
         std::vector<QubitIdType> wires;
         sim->PartialCounts(eigvals_view, counts_view, wires);
 
-        CHECK(eigvals_view(0) == Catch::Approx(0.0).margin(1e-5));
+        CHECK_THAT(eigvals_view(0), WithinAbs(0.0, 1e-5));
         CHECK(counts_view(0) == shots);
     }
 }
@@ -829,10 +829,10 @@ TEST_CASE("Test NullQubit measurement processes with num_qubits=1", "[NullQubit]
         DataView<std::complex<double>, 1> state_view(state);
         sim->State(state_view);
 
-        CHECK(state_view(0).real() == Catch::Approx(1.0).margin(1e-5));
-        CHECK(state_view(0).imag() == Catch::Approx(0.0).margin(1e-5));
-        CHECK(state_view(1).real() == Catch::Approx(0.0).margin(1e-5));
-        CHECK(state_view(1).imag() == Catch::Approx(0.0).margin(1e-5));
+        CHECK_THAT(state_view(0).real(), WithinAbs(1.0, 1e-5));
+        CHECK_THAT(state_view(0).imag(), WithinAbs(0.0, 1e-5));
+        CHECK_THAT(state_view(1).real(), WithinAbs(0.0, 1e-5));
+        CHECK_THAT(state_view(1).imag(), WithinAbs(0.0, 1e-5));
     }
 
     SECTION("Probs")
@@ -841,8 +841,8 @@ TEST_CASE("Test NullQubit measurement processes with num_qubits=1", "[NullQubit]
         DataView<double, 1> probs_view(probs);
         sim->Probs(probs_view);
 
-        CHECK(probs_view(0) == Catch::Approx(1.0).margin(1e-5));
-        CHECK(probs_view(1) == Catch::Approx(0.0).margin(1e-5));
+        CHECK_THAT(probs_view(0), WithinAbs(1.0, 1e-5));
+        CHECK_THAT(probs_view(1), WithinAbs(0.0, 1e-5));
     }
 
     SECTION("PartialProbs")
@@ -852,8 +852,8 @@ TEST_CASE("Test NullQubit measurement processes with num_qubits=1", "[NullQubit]
         std::vector<QubitIdType> wires;
         sim->PartialProbs(probs_view, wires);
 
-        CHECK(probs_view(0) == Catch::Approx(1.0).margin(1e-5));
-        CHECK(probs_view(1) == Catch::Approx(0.0).margin(1e-5));
+        CHECK_THAT(probs_view(0), WithinAbs(1.0, 1e-5));
+        CHECK_THAT(probs_view(1), WithinAbs(0.0, 1e-5));
     }
 
     SECTION("Sample")
@@ -893,8 +893,8 @@ TEST_CASE("Test NullQubit measurement processes with num_qubits=1", "[NullQubit]
         DataView<double, 1> eigvals_view(eigvals);
         sim->Counts(eigvals_view, counts_view);
 
-        CHECK(eigvals_view(0) == Catch::Approx(0.0).margin(1e-5));
-        CHECK(eigvals_view(1) == Catch::Approx(1.0).margin(1e-5));
+        CHECK_THAT(eigvals_view(0), WithinAbs(0.0, 1e-5));
+        CHECK_THAT(eigvals_view(1), WithinAbs(1.0, 1e-5));
         CHECK(counts_view(0) == shots);
         CHECK(counts_view(1) == 0);
     }
@@ -908,8 +908,8 @@ TEST_CASE("Test NullQubit measurement processes with num_qubits=1", "[NullQubit]
         std::vector<QubitIdType> wires;
         sim->PartialCounts(eigvals_view, counts_view, wires);
 
-        CHECK(eigvals_view(0) == Catch::Approx(0.0).margin(1e-5));
-        CHECK(eigvals_view(1) == Catch::Approx(1.0).margin(1e-5));
+        CHECK_THAT(eigvals_view(0), WithinAbs(0.0, 1e-5));
+        CHECK_THAT(eigvals_view(1), WithinAbs(1.0, 1e-5));
         CHECK(counts_view(0) == shots);
         CHECK(counts_view(1) == 0);
     }

--- a/runtime/tests/Test_OpenQasmDevice.cpp
+++ b/runtime/tests/Test_OpenQasmDevice.cpp
@@ -30,6 +30,16 @@ using namespace Catalyst::Runtime::Device;
 
 using BType = OpenQasm::BuilderType;
 
+static void ensurePythonInterpreter()
+{
+    // Initializing the Python interpreter is required to run Braket-backed tests.
+    // We use pybind11 for this since nanobind has no intention to support embedding a Python
+    // interpreter in C++.
+    if (!Py_IsInitialized()) {
+        pybind11::initialize_interpreter();
+    }
+}
+
 TEST_CASE("Test OpenQasmRunner base class", "[openqasm]")
 {
     // check the coverage support
@@ -65,6 +75,8 @@ TEST_CASE("Test OpenQasmRunner base class", "[openqasm]")
 
 TEST_CASE("Test BraketRunner", "[openqasm]")
 {
+    ensurePythonInterpreter();
+
     OpenQasm::BraketBuilder builder{};
 
     builder.Register(OpenQasm::RegisterType::Qubit, "q", 2);
@@ -75,13 +87,6 @@ TEST_CASE("Test BraketRunner", "[openqasm]")
     builder.Gate("PauliY", {}, {}, {0}, false);
 
     auto &&circuit = builder.toOpenQasm();
-
-    // Initializing the Python interpreter is required to run the circuit.
-    // We use pybind11 for this since nanobind has no intention to support embedding a Python
-    // interpreter in C++.
-    if (!Py_IsInitialized()) {
-        pybind11::initialize_interpreter();
-    }
 
     OpenQasm::BraketRunner runner{};
 
@@ -114,12 +119,7 @@ TEST_CASE("Test BraketRunner", "[openqasm]")
 
 TEST_CASE("Test BraketRunner Expval and Var", "[openqasm]")
 {
-    // Initializing the Python interpreter is required to run the circuit.
-    // We use pybind11 for this since nanobind has no intention to support embedding a Python
-    // interpreter in C++.
-    if (!Py_IsInitialized()) {
-        pybind11::initialize_interpreter();
-    }
+    ensurePythonInterpreter();
 
     OpenQasm::BraketBuilder builder{};
 
@@ -128,13 +128,6 @@ TEST_CASE("Test BraketRunner Expval and Var", "[openqasm]")
     builder.Gate("RX", {0.5}, {}, {0}, false);
     builder.Gate("Hadamard", {}, {}, {1}, false);
     builder.Gate("CNOT", {}, {}, {0, 1}, false);
-
-    // Initializing the Python interpreter is required to run the circuit.
-    // We use pybind11 for this since nanobind has no intention to support embedding a Python
-    // interpreter in C++.
-    if (!Py_IsInitialized()) {
-        pybind11::initialize_interpreter();
-    }
 
     OpenQasm::BraketRunner runner{};
 
@@ -179,12 +172,6 @@ TEST_CASE("Test BraketRunner Expval and Var", "[openqasm]")
 
 TEST_CASE("Test the OpenQasmDevice constructor", "[openqasm]")
 {
-    // Initializing the Python interpreter is required to run the circuit.
-    // We use pybind11 for this since nanobind has no intention to support embedding a Python
-    // interpreter in C++.
-    if (!Py_IsInitialized()) {
-        pybind11::initialize_interpreter();
-    }
 
     SECTION("Common")
     {
@@ -209,13 +196,6 @@ TEST_CASE("Test the OpenQasmDevice constructor", "[openqasm]")
 
 TEST_CASE("Test qubits allocation OpenQasmDevice", "[openqasm]")
 {
-    // Initializing the Python interpreter is required to run the circuit.
-    // We use pybind11 for this since nanobind has no intention to support embedding a Python
-    // interpreter in C++.
-    if (!Py_IsInitialized()) {
-        pybind11::initialize_interpreter();
-    }
-
     std::unique_ptr<OpenQasmDevice> device = std::make_unique<OpenQasmDevice>("{}");
 
     constexpr size_t n = 3;
@@ -230,13 +210,6 @@ TEST_CASE("Test qubits allocation OpenQasmDevice", "[openqasm]")
 
 TEST_CASE("Test the OpenQasmDevice setBasisState", "[openqasm]")
 {
-    // Initializing the Python interpreter is required to run the circuit.
-    // We use pybind11 for this since nanobind has no intention to support embedding a Python
-    // interpreter in C++.
-    if (!Py_IsInitialized()) {
-        pybind11::initialize_interpreter();
-    }
-
     std::unique_ptr<OpenQasmDevice> device = std::make_unique<OpenQasmDevice>("{}");
 
     constexpr size_t n = 2;
@@ -251,13 +224,6 @@ TEST_CASE("Test the OpenQasmDevice setBasisState", "[openqasm]")
 
 TEST_CASE("Test the OpenQasmDevice setState", "[openqasm]")
 {
-    // Initializing the Python interpreter is required to run the circuit.
-    // We use pybind11 for this since nanobind has no intention to support embedding a Python
-    // interpreter in C++.
-    if (!Py_IsInitialized()) {
-        pybind11::initialize_interpreter();
-    }
-
     std::unique_ptr<OpenQasmDevice> device = std::make_unique<OpenQasmDevice>("{}");
 
     constexpr size_t n = 2;
@@ -271,13 +237,6 @@ TEST_CASE("Test the OpenQasmDevice setState", "[openqasm]")
 
 TEST_CASE("Test the bell pair circuit with BuilderType::Common", "[openqasm]")
 {
-    // Initializing the Python interpreter is required to run the circuit.
-    // We use pybind11 for this since nanobind has no intention to support embedding a Python
-    // interpreter in C++.
-    if (!Py_IsInitialized()) {
-        pybind11::initialize_interpreter();
-    }
-
     std::unique_ptr<OpenQasmDevice> device = std::make_unique<OpenQasmDevice>("{}");
 
     constexpr size_t n = 2;
@@ -302,12 +261,7 @@ TEST_CASE("Test the bell pair circuit with BuilderType::Common", "[openqasm]")
 TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::Braket",
           "[openqasm]")
 {
-    // Initializing the Python interpreter is required to run the circuit.
-    // We use pybind11 for this since nanobind has no intention to support embedding a Python
-    // interpreter in C++.
-    if (!Py_IsInitialized()) {
-        pybind11::initialize_interpreter();
-    }
+    ensurePythonInterpreter();
 
     constexpr size_t shots{1000};
     std::unique_ptr<OpenQasmDevice> device =
@@ -445,12 +399,7 @@ TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::B
 
 TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket", "[openqasm]")
 {
-    // Initializing the Python interpreter is required to run the circuit.
-    // We use pybind11 for this since nanobind has no intention to support embedding a Python
-    // interpreter in C++.
-    if (!Py_IsInitialized()) {
-        pybind11::initialize_interpreter();
-    }
+    ensurePythonInterpreter();
 
     constexpr size_t shots{1000};
     std::unique_ptr<OpenQasmDevice> device =
@@ -631,12 +580,7 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
 
 TEST_CASE("Test MatrixOperation with BuilderType::Braket", "[openqasm]")
 {
-    // Initializing the Python interpreter is required to run the circuit.
-    // We use pybind11 for this since nanobind has no intention to support embedding a Python
-    // interpreter in C++.
-    if (!Py_IsInitialized()) {
-        pybind11::initialize_interpreter();
-    }
+    ensurePythonInterpreter();
 
     std::unique_ptr<OpenQasmDevice> device =
         std::make_unique<OpenQasmDevice>("{device_type : braket.local.qubit, backend : default}");
@@ -685,12 +629,7 @@ TEST_CASE("Test MatrixOperation with BuilderType::Braket", "[openqasm]")
 
 TEST_CASE("Test PSWAP and ISWAP with BuilderType::Braket", "[openqasm]")
 {
-    // Initializing the Python interpreter is required to run the circuit.
-    // We use pybind11 for this since nanobind has no intention to support embedding a Python
-    // interpreter in C++.
-    if (!Py_IsInitialized()) {
-        pybind11::initialize_interpreter();
-    }
+    ensurePythonInterpreter();
 
     std::unique_ptr<OpenQasmDevice> device =
         std::make_unique<OpenQasmDevice>("{device_type : braket.local.qubit, backend : default}");
@@ -710,13 +649,6 @@ TEST_CASE("Test PSWAP and ISWAP with BuilderType::Braket", "[openqasm]")
 
 TEST_CASE("Test MatrixOperation with OpenQasmDevice and BuilderType::Common", "[openqasm]")
 {
-    // Initializing the Python interpreter is required to run the circuit.
-    // We use pybind11 for this since nanobind has no intention to support embedding a Python
-    // interpreter in C++.
-    if (!Py_IsInitialized()) {
-        pybind11::initialize_interpreter();
-    }
-
     auto device = OpenQasmDevice("{}");
     auto wires = device.AllocateQubits(2);
     std::vector<std::complex<double>> matrix{
@@ -732,13 +664,6 @@ TEST_CASE("Test MatrixOperation with OpenQasmDevice and BuilderType::Common", "[
 
 TEST_CASE("Test __catalyst__rt__device_init registering the OpenQasm device", "[CoreQIS]")
 {
-    // Initializing the Python interpreter is required to run the circuit.
-    // We use pybind11 for this since nanobind has no intention to support embedding a Python
-    // interpreter in C++.
-    if (!Py_IsInitialized()) {
-        pybind11::initialize_interpreter();
-    }
-
     __catalyst__rt__initialize(nullptr);
 
     char device_aws[30] = "braket.aws.qubit";

--- a/runtime/tests/Test_OpenQasmDevice.cpp
+++ b/runtime/tests/Test_OpenQasmDevice.cpp
@@ -114,6 +114,13 @@ TEST_CASE("Test BraketRunner", "[openqasm]")
 
 TEST_CASE("Test BraketRunner Expval and Var", "[openqasm]")
 {
+    // Initializing the Python interpreter is required to run the circuit.
+    // We use pybind11 for this since nanobind has no intention to support embedding a Python
+    // interpreter in C++.
+    if (!Py_IsInitialized()) {
+        pybind11::initialize_interpreter();
+    }
+
     OpenQasm::BraketBuilder builder{};
 
     builder.Register(OpenQasm::RegisterType::Qubit, "q", 2);
@@ -172,6 +179,13 @@ TEST_CASE("Test BraketRunner Expval and Var", "[openqasm]")
 
 TEST_CASE("Test the OpenQasmDevice constructor", "[openqasm]")
 {
+    // Initializing the Python interpreter is required to run the circuit.
+    // We use pybind11 for this since nanobind has no intention to support embedding a Python
+    // interpreter in C++.
+    if (!Py_IsInitialized()) {
+        pybind11::initialize_interpreter();
+    }
+
     SECTION("Common")
     {
         auto device = OpenQasmDevice("{}");
@@ -195,6 +209,13 @@ TEST_CASE("Test the OpenQasmDevice constructor", "[openqasm]")
 
 TEST_CASE("Test qubits allocation OpenQasmDevice", "[openqasm]")
 {
+    // Initializing the Python interpreter is required to run the circuit.
+    // We use pybind11 for this since nanobind has no intention to support embedding a Python
+    // interpreter in C++.
+    if (!Py_IsInitialized()) {
+        pybind11::initialize_interpreter();
+    }
+
     std::unique_ptr<OpenQasmDevice> device = std::make_unique<OpenQasmDevice>("{}");
 
     constexpr size_t n = 3;
@@ -209,6 +230,13 @@ TEST_CASE("Test qubits allocation OpenQasmDevice", "[openqasm]")
 
 TEST_CASE("Test the OpenQasmDevice setBasisState", "[openqasm]")
 {
+    // Initializing the Python interpreter is required to run the circuit.
+    // We use pybind11 for this since nanobind has no intention to support embedding a Python
+    // interpreter in C++.
+    if (!Py_IsInitialized()) {
+        pybind11::initialize_interpreter();
+    }
+
     std::unique_ptr<OpenQasmDevice> device = std::make_unique<OpenQasmDevice>("{}");
 
     constexpr size_t n = 2;
@@ -223,6 +251,13 @@ TEST_CASE("Test the OpenQasmDevice setBasisState", "[openqasm]")
 
 TEST_CASE("Test the OpenQasmDevice setState", "[openqasm]")
 {
+    // Initializing the Python interpreter is required to run the circuit.
+    // We use pybind11 for this since nanobind has no intention to support embedding a Python
+    // interpreter in C++.
+    if (!Py_IsInitialized()) {
+        pybind11::initialize_interpreter();
+    }
+
     std::unique_ptr<OpenQasmDevice> device = std::make_unique<OpenQasmDevice>("{}");
 
     constexpr size_t n = 2;
@@ -236,6 +271,13 @@ TEST_CASE("Test the OpenQasmDevice setState", "[openqasm]")
 
 TEST_CASE("Test the bell pair circuit with BuilderType::Common", "[openqasm]")
 {
+    // Initializing the Python interpreter is required to run the circuit.
+    // We use pybind11 for this since nanobind has no intention to support embedding a Python
+    // interpreter in C++.
+    if (!Py_IsInitialized()) {
+        pybind11::initialize_interpreter();
+    }
+
     std::unique_ptr<OpenQasmDevice> device = std::make_unique<OpenQasmDevice>("{}");
 
     constexpr size_t n = 2;
@@ -260,6 +302,13 @@ TEST_CASE("Test the bell pair circuit with BuilderType::Common", "[openqasm]")
 TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::Braket",
           "[openqasm]")
 {
+    // Initializing the Python interpreter is required to run the circuit.
+    // We use pybind11 for this since nanobind has no intention to support embedding a Python
+    // interpreter in C++.
+    if (!Py_IsInitialized()) {
+        pybind11::initialize_interpreter();
+    }
+
     constexpr size_t shots{1000};
     std::unique_ptr<OpenQasmDevice> device =
         std::make_unique<OpenQasmDevice>("{device_type : braket.local.qubit, backend : default}");
@@ -396,6 +445,13 @@ TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::B
 
 TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket", "[openqasm]")
 {
+    // Initializing the Python interpreter is required to run the circuit.
+    // We use pybind11 for this since nanobind has no intention to support embedding a Python
+    // interpreter in C++.
+    if (!Py_IsInitialized()) {
+        pybind11::initialize_interpreter();
+    }
+
     constexpr size_t shots{1000};
     std::unique_ptr<OpenQasmDevice> device =
         std::make_unique<OpenQasmDevice>("{device_type : braket.local.qubit, backend : default}");
@@ -575,6 +631,13 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
 
 TEST_CASE("Test MatrixOperation with BuilderType::Braket", "[openqasm]")
 {
+    // Initializing the Python interpreter is required to run the circuit.
+    // We use pybind11 for this since nanobind has no intention to support embedding a Python
+    // interpreter in C++.
+    if (!Py_IsInitialized()) {
+        pybind11::initialize_interpreter();
+    }
+
     std::unique_ptr<OpenQasmDevice> device =
         std::make_unique<OpenQasmDevice>("{device_type : braket.local.qubit, backend : default}");
     device->SetDeviceShots(1000);
@@ -622,6 +685,13 @@ TEST_CASE("Test MatrixOperation with BuilderType::Braket", "[openqasm]")
 
 TEST_CASE("Test PSWAP and ISWAP with BuilderType::Braket", "[openqasm]")
 {
+    // Initializing the Python interpreter is required to run the circuit.
+    // We use pybind11 for this since nanobind has no intention to support embedding a Python
+    // interpreter in C++.
+    if (!Py_IsInitialized()) {
+        pybind11::initialize_interpreter();
+    }
+
     std::unique_ptr<OpenQasmDevice> device =
         std::make_unique<OpenQasmDevice>("{device_type : braket.local.qubit, backend : default}");
     device->SetDeviceShots(1000);
@@ -640,6 +710,13 @@ TEST_CASE("Test PSWAP and ISWAP with BuilderType::Braket", "[openqasm]")
 
 TEST_CASE("Test MatrixOperation with OpenQasmDevice and BuilderType::Common", "[openqasm]")
 {
+    // Initializing the Python interpreter is required to run the circuit.
+    // We use pybind11 for this since nanobind has no intention to support embedding a Python
+    // interpreter in C++.
+    if (!Py_IsInitialized()) {
+        pybind11::initialize_interpreter();
+    }
+
     auto device = OpenQasmDevice("{}");
     auto wires = device.AllocateQubits(2);
     std::vector<std::complex<double>> matrix{
@@ -655,6 +732,13 @@ TEST_CASE("Test MatrixOperation with OpenQasmDevice and BuilderType::Common", "[
 
 TEST_CASE("Test __catalyst__rt__device_init registering the OpenQasm device", "[CoreQIS]")
 {
+    // Initializing the Python interpreter is required to run the circuit.
+    // We use pybind11 for this since nanobind has no intention to support embedding a Python
+    // interpreter in C++.
+    if (!Py_IsInitialized()) {
+        pybind11::initialize_interpreter();
+    }
+
     __catalyst__rt__initialize(nullptr);
 
     char device_aws[30] = "braket.aws.qubit";

--- a/runtime/tests/Test_OpenQasmDevice.cpp
+++ b/runtime/tests/Test_OpenQasmDevice.cpp
@@ -172,7 +172,6 @@ TEST_CASE("Test BraketRunner Expval and Var", "[openqasm]")
 
 TEST_CASE("Test the OpenQasmDevice constructor", "[openqasm]")
 {
-
     SECTION("Common")
     {
         auto device = OpenQasmDevice("{}");

--- a/runtime/tests/Test_OpenQasmDevice.cpp
+++ b/runtime/tests/Test_OpenQasmDevice.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <pybind11/embed.h>
 
@@ -288,7 +288,7 @@ TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::B
         device->Probs(view);
 
         CHECK(probs[1] == probs[2]);
-        CHECK(probs[0] + probs[3] == Catch::Approx(1.f).margin(1e-5));
+        CHECK_THAT(probs[0] + probs[3], WithinAbs(1.0, 1e-5));
     }
 
     SECTION("PartialProbs")
@@ -297,7 +297,7 @@ TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::B
         DataView<double, 1> view(probs);
         device->PartialProbs(view, std::vector<QubitIdType>{0, 1});
 
-        CHECK(probs[0] + probs[3] == Catch::Approx(1.f).margin(1e-5));
+        CHECK_THAT(probs[0] + probs[3], WithinAbs(1.0, 1e-5));
     }
 
     SECTION("Samples")
@@ -362,7 +362,7 @@ TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::B
         device->SetDeviceShots(0); // to get deterministic results
         auto obs = device->Observable(ObsId::Hadamard, {}, std::vector<QubitIdType>{1});
         auto expval = device->Expval(obs);
-        CHECK(expval == Catch::Approx(0.0).margin(1e-5));
+        CHECK_THAT(expval, WithinAbs(0.0, 1e-5));
     }
 
     SECTION("Expval(x(0) @ h(1))")
@@ -372,7 +372,7 @@ TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::B
         auto obs_h = device->Observable(ObsId::Hadamard, {}, std::vector<QubitIdType>{1});
         auto obs = device->TensorObservable({obs_x, obs_h});
         auto expval = device->Expval(obs);
-        CHECK(expval == Catch::Approx(0.7071067812).margin(1e-5));
+        CHECK_THAT(expval, WithinAbs(0.7071067812, 1e-5));
     }
 
     SECTION("Var(h(1))")
@@ -380,7 +380,7 @@ TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::B
         device->SetDeviceShots(0); // to get deterministic results
         auto obs = device->Observable(ObsId::Hadamard, {}, std::vector<QubitIdType>{1});
         auto expval = device->Var(obs);
-        CHECK(expval == Catch::Approx(1.0).margin(1e-5));
+        CHECK_THAT(expval, WithinAbs(1.0, 1e-5));
     }
 
     SECTION("Var(x(0) @ h(1))")
@@ -390,7 +390,7 @@ TEST_CASE("Test measurement processes, the bell pair circuit with BuilderType::B
         auto obs_h = device->Observable(ObsId::Hadamard, {}, std::vector<QubitIdType>{1});
         auto obs = device->TensorObservable({obs_x, obs_h});
         auto expval = device->Var(obs);
-        CHECK(expval == Catch::Approx(0.5).margin(1e-5));
+        CHECK_THAT(expval, WithinAbs(0.5, 1e-5));
     }
 }
 
@@ -431,7 +431,7 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
         DataView<double, 1> view(probs);
         device->Probs(view);
 
-        CHECK(probs[27] + probs[26] == Catch::Approx(1.f).margin(1e-5));
+        CHECK_THAT(probs[27] + probs[26], WithinAbs(1.0, 1e-5));
     }
 
     SECTION("PartialProbs")
@@ -440,7 +440,7 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
         DataView<double, 1> view(probs);
         device->PartialProbs(view, std::vector<QubitIdType>{0, 1, 2, 3, 4});
 
-        CHECK(probs[27] + probs[26] == Catch::Approx(1.f).margin(1e-5));
+        CHECK_THAT(probs[27] + probs[26], WithinAbs(1.0, 1e-5));
     }
 
     SECTION("Samples")
@@ -505,7 +505,7 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
         device->SetDeviceShots(0); // to get deterministic results
         auto obs = device->Observable(ObsId::Hadamard, {}, std::vector<QubitIdType>{1});
         auto expval = device->Expval(obs);
-        CHECK(expval == Catch::Approx(-0.7071067812).margin(1e-5));
+        CHECK_THAT(expval, WithinAbs(-0.7071067812, 1e-5));
     }
 
     SECTION("Expval(hermitian(1))")
@@ -519,7 +519,7 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
         };
         auto obs = device->Observable(ObsId::Hermitian, matrix, std::vector<QubitIdType>{1});
         auto expval = device->Expval(obs);
-        CHECK(expval == Catch::Approx(0).margin(1e-5));
+        CHECK_THAT(expval, WithinAbs(0.0, 1e-5));
     }
 
     SECTION("Expval(x(0) @ h(1))")
@@ -529,7 +529,7 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
         auto obs_h = device->Observable(ObsId::Hadamard, {}, std::vector<QubitIdType>{1});
         auto tp = device->TensorObservable({obs_z, obs_h});
         auto expval = device->Expval(tp);
-        CHECK(expval == Catch::Approx(0.7071067812).margin(1e-5));
+        CHECK_THAT(expval, WithinAbs(0.7071067812, 1e-5));
 
         auto obs = device->HamiltonianObservable({0.2}, {tp});
         REQUIRE_THROWS_WITH(device->Expval(obs),
@@ -541,7 +541,7 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
         device->SetDeviceShots(0); // to get deterministic results
         auto obs = device->Observable(ObsId::Hadamard, {}, std::vector<QubitIdType>{1});
         auto var = device->Var(obs);
-        CHECK(var == Catch::Approx(0.5).margin(1e-5));
+        CHECK_THAT(var, WithinAbs(0.5, 1e-5));
     }
 
     SECTION("Var(hermitian(1))")
@@ -555,7 +555,7 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
         };
         auto obs = device->Observable(ObsId::Hermitian, matrix, std::vector<QubitIdType>{1});
         auto var = device->Var(obs);
-        CHECK(var == Catch::Approx(1).margin(1e-5));
+        CHECK_THAT(var, WithinAbs(1.0, 1e-5));
     }
 
     SECTION("Var(x(0) @ h(1))")
@@ -565,7 +565,7 @@ TEST_CASE("Test measurement processes, a simple circuit with BuilderType::Braket
         auto obs_h = device->Observable(ObsId::Hadamard, {}, std::vector<QubitIdType>{1});
         auto tp = device->TensorObservable({obs_z, obs_h});
         auto var = device->Var(tp);
-        CHECK(var == Catch::Approx(0.5).margin(1e-5));
+        CHECK_THAT(var, WithinAbs(0.5, 1e-5));
 
         auto obs = device->HamiltonianObservable({0.2}, {tp});
         REQUIRE_THROWS_WITH(device->Var(obs),
@@ -608,7 +608,7 @@ TEST_CASE("Test MatrixOperation with BuilderType::Braket", "[openqasm]")
         std::vector<double> probs(size);
         DataView<double, 1> view(probs);
         device->Probs(view);
-        CHECK(probs[1] == Catch::Approx(1.f).margin(1e-5));
+        CHECK_THAT(probs[1], WithinAbs(1.0, 1e-5));
     }
 
     SECTION("Expval(h(1))")
@@ -616,7 +616,7 @@ TEST_CASE("Test MatrixOperation with BuilderType::Braket", "[openqasm]")
         device->SetDeviceShots(0); // to get deterministic results
         auto obs = device->Observable(ObsId::Hadamard, {}, std::vector<QubitIdType>{1});
         auto expval = device->Expval(obs);
-        CHECK(expval == Catch::Approx(-0.7071067812).margin(1e-5));
+        CHECK_THAT(expval, WithinAbs(-0.7071067812, 1e-5));
     }
 }
 
@@ -635,7 +635,7 @@ TEST_CASE("Test PSWAP and ISWAP with BuilderType::Braket", "[openqasm]")
 
     auto obs = device->Observable(ObsId::PauliZ, {}, std::vector<QubitIdType>{1});
     auto expval = device->Expval(obs);
-    CHECK(expval == Catch::Approx(1).margin(1e-5));
+    CHECK_THAT(expval, WithinAbs(1.0, 1e-5));
 }
 
 TEST_CASE("Test MatrixOperation with OpenQasmDevice and BuilderType::Common", "[openqasm]")

--- a/runtime/tests/Test_RSDecomp.cpp
+++ b/runtime/tests/Test_RSDecomp.cpp
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include <catch2/catch_test_macros.hpp>
-#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/generators/catch_generators_all.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_range_equals.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <catch2/matchers/catch_matchers_vector.hpp>

--- a/runtime/tests/Test_RSDecomp.cpp
+++ b/runtime/tests/Test_RSDecomp.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/generators/catch_generators_all.hpp>
 #include <catch2/matchers/catch_matchers_range_equals.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
@@ -71,15 +71,15 @@ TEST_CASE("Test Matrix Multiplication", "[RSDecomp][Ross Selinger]")
     auto expected_HT = gate_type_to_matrix[GateType::HT];
 
     for (size_t i = 0; i < res_HT.size(); i++) {
-        CHECK(res_HT[i].real() == Catch::Approx(expected_HT[i].real()));
-        CHECK(res_HT[i].imag() == Catch::Approx(expected_HT[i].imag()));
+        CHECK_THAT(res_HT[i].real(), WithinRel(expected_HT[i].real()));
+        CHECK_THAT(res_HT[i].imag(), WithinRel(expected_HT[i].imag()));
     }
 
     auto res_SHT = multiply_matrices(res_HT, gate_type_to_matrix[GateType::S]);
     auto expected_SHT = gate_type_to_matrix[GateType::SHT];
     for (size_t i = 0; i < res_SHT.size(); i++) {
-        CHECK(res_SHT[i].real() == Catch::Approx(expected_SHT[i].real()));
-        CHECK(res_SHT[i].imag() == Catch::Approx(expected_SHT[i].imag()));
+        CHECK_THAT(res_SHT[i].real(), WithinRel(expected_SHT[i].real()));
+        CHECK_THAT(res_SHT[i].imag(), WithinRel(expected_SHT[i].imag()));
     }
 }
 
@@ -91,8 +91,8 @@ TEST_CASE("Test matrix_from_decomp_result", "[RSDecomp][Ross Selinger]")
     auto expected_matrix = gate_type_to_matrix[GateType::HT];
 
     for (size_t i = 0; i < result_matrix.size(); i++) {
-        CHECK(result_matrix[i].real() == Catch::Approx(expected_matrix[i].real()));
-        CHECK(result_matrix[i].imag() == Catch::Approx(expected_matrix[i].imag()));
+        CHECK_THAT(result_matrix[i].real(), WithinRel(expected_matrix[i].real()));
+        CHECK_THAT(result_matrix[i].imag(), WithinRel(expected_matrix[i].imag()));
     }
 
     decomp = {GateType::S, GateType::H, GateType::T};
@@ -101,8 +101,8 @@ TEST_CASE("Test matrix_from_decomp_result", "[RSDecomp][Ross Selinger]")
     expected_matrix = gate_type_to_matrix[GateType::SHT];
 
     for (size_t i = 0; i < result_matrix.size(); i++) {
-        CHECK(result_matrix[i].real() == Catch::Approx(expected_matrix[i].real()));
-        CHECK(result_matrix[i].imag() == Catch::Approx(expected_matrix[i].imag()));
+        CHECK_THAT(result_matrix[i].real(), WithinRel(expected_matrix[i].real()));
+        CHECK_THAT(result_matrix[i].imag(), WithinRel(expected_matrix[i].imag()));
     }
 }
 

--- a/runtime/tests/Test_RSDecompGridProblems.cpp
+++ b/runtime/tests/Test_RSDecompGridProblems.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <cstdint>
 #include <cstdio>
@@ -199,9 +199,9 @@ TEST_CASE("Test GridIterator", "[RSDecomp][GridProblems]")
             std::complex<double> final_complex = u_sol_complex / denominator;
 
             double expected_real = std::cos(theta);
-            REQUIRE(final_complex.real() == Catch::Approx(expected_real).margin(epsilon));
+            REQUIRE_THAT(final_complex.real(), WithinAbs(expected_real, epsilon));
             double expected_imag = std::sin(theta);
-            REQUIRE(final_complex.imag() == Catch::Approx(expected_imag).margin(epsilon));
+            REQUIRE_THAT(final_complex.imag(), WithinAbs(expected_imag, epsilon));
         }
     }
 }

--- a/runtime/tests/Test_RSDecompRings.cpp
+++ b/runtime/tests/Test_RSDecompRings.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <cstdio>
 
@@ -96,8 +96,8 @@ TEST_CASE("Test ZOmega class", "[RSDecomp][Rings]")
     CHECK(z2.norm4() == 14788);
 
     auto z1_complex = z1.to_complex();
-    CHECK(z1_complex.real() == Catch::Approx(5.41421356237309).margin(tol));
-    CHECK(z1_complex.imag() == Catch::Approx(4.82842712474619).margin(tol));
+    CHECK_THAT(z1_complex.real(), WithinAbs(5.41421356237309, tol));
+    CHECK_THAT(z1_complex.imag(), WithinAbs(4.82842712474619, tol));
     CHECK(z1.parity() == 0);
     CHECK(z2.parity() == 0);
     CHECK(ZOmega(0, 0, 1, 1).parity() == 1);
@@ -107,12 +107,11 @@ TEST_CASE("Test ZOmega class", "[RSDecomp][Rings]")
 
     ZOmega z1_conj = z1.conj();
     CHECK(z1_conj == ZOmega(-3, -2, -1, 4));
-    CHECK(z1_conj.to_complex().real() == Catch::Approx(std::conj(z1_complex).real()).margin(tol));
-    CHECK(z1_conj.to_complex().imag() == Catch::Approx(std::conj(z1_complex).imag()).margin(tol));
+    CHECK_THAT(z1_conj.to_complex().real(), WithinAbs(std::conj(z1_complex).real(), tol));
+    CHECK_THAT(z1_conj.to_complex().imag(), WithinAbs(std::conj(z1_complex).imag(), tol));
 
-    CHECK(
-        z2.norm2().to_complex().real() ==
-        Catch::Approx((std::abs(z2.to_complex()) * std::abs(z2.conj().to_complex()))).margin(tol));
+    CHECK_THAT(z2.norm2().to_complex().real(),
+               WithinAbs((std::abs(z2.to_complex()) * std::abs(z2.conj().to_complex())), tol));
 
     CHECK((z1 - ZOmega(2, 2, 2, 0)).to_sqrt_two() == ZSqrtTwo(4, 1));
 }


### PR DESCRIPTION
**Context:**
To keep consistent with the latest update on the Lightning repo, we update Catch2 from v2.8 to v3.11.0.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
