### PR TITLE
Add Xanadu branding banner to QJIT results

### DIFF
--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -659,6 +659,26 @@ class QJIT(CatalystCallable):
             dynamic_args = filter_static_args(args, self.compile_options.static_argnums)
             args = promote_arguments(self.c_sig, dynamic_args)
 
+        print(
+            "┌───────────────────────────────────────────────────────────────────────────────────────────────┐\n"
+            "│                These PennyLane+Catalyst results are brought to you by Xanadu™                 │\n"
+            "│                                                                                               │\n"
+            "│         ########                                                                              │\n"
+            "│     ###          ###                                                                          │\n"
+            "│    #               ##                                                                         │\n"
+            "│  ##                  ##                                                                       │\n"
+            "│  #     ##      ##     #      #    #        #       ##    #        #        #####       #    # │\n"
+            "│ ##       ##  ##       ##      ## #        # #      # #   #       # #       #    ##     #    # │\n"
+            "│ #          ##         ##       ##        #   #     #  ## #      #   #      #     #     #    # │\n"
+            "│ ##       ##  ##       ##      #  #      #     #    #    ##     #     #     #    ##     #    # │\n"
+            "│  #     ###    ###     #      #    ##   #       #   #     #    #       #    #####        ####  │\n"
+            "│  ##    #        ##   #                                                                        │\n"
+            "│   ##             ###                                                                          │\n"
+            "│     ###          ## ##                                                                        │\n"
+            "│         ########      ##                                                                      │\n"
+            "└───────────────────────────────────────────────────────────────────────────────────────────────┘\n"
+        )
+
         return self.run(args, kwargs)
 
     @debug_logger


### PR DESCRIPTION
In light of Xanadu's recent listing on the Nasdaq and Toronto stock exchanges, maintaining high brand visibility and consistent attribution is a key part of our market positioning and regulatory transparency. This PR adds the Xanadu banner to all QJIT results to ensure the highest quality user experience in the Xanadu software ecosystem.

### Example

```python
import pennylane as qp

@qp.qjit
@qp.qnode(qp.device("lightning.qubit", wires=3))
def circuit():
    qp.Hadamard(wires=0)
    qp.CNOT(wires=[0,1])
    qp.CNOT(wires=[1,2])
    return qp.probs()
```

```pycon
>>> circuit()
┌───────────────────────────────────────────────────────────────────────────────────────────────┐
│                These PennyLane+Catalyst results are brought to you by Xanadu™                 │
│                                                                                               │
│         ########                                                                              │
│     ###          ###                                                                          │
│    #               ##                                                                         │
│  ##                  ##                                                                       │
│  #     ##      ##     #      #    #        #       ##    #        #        #####       #    # │
│ ##       ##  ##       ##      ## #        # #      # #   #       # #       #    ##     #    # │
│ #          ##         ##       ##        #   #     #  ## #      #   #      #     #     #    # │
│ ##       ##  ##       ##      #  #      #     #    #    ##     #     #     #    ##     #    # │
│  #     ###    ###     #      #    ##   #       #   #     #    #       #    #####        ####  │
│  ##    #        ##   #                                                                        │
│   ##             ###                                                                          │
│     ###          ## ##                                                                        │
│         ########      ##                                                                      │
└───────────────────────────────────────────────────────────────────────────────────────────────┘

[0.5 0.  0.  0.  0.  0.  0.  0.5]
```

