### PR TITLE
Allow identity named observable to take in multiple wires 

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -439,6 +439,7 @@
   when there are multiple named observables or Hermitian observables on that same wire index,
   when capture is not enabled.
   [(#2641)](https://github.com/PennyLaneAI/catalyst/pull/2641)
+  [(#2646)](https://github.com/PennyLaneAI/catalyst/pull/2646)
 
 * :func:`~pennylane.adjoint` can now be used on subroutines with classical arguments.
   [(#2590)](https://github.com/PennyLaneAI/catalyst/pull/2590)

--- a/frontend/catalyst/from_plxpr/qfunc_interpreter.py
+++ b/frontend/catalyst/from_plxpr/qfunc_interpreter.py
@@ -215,7 +215,7 @@ class PLxPRToQuantumJaxprInterpreter(PlxprInterpreter):
         wires = [self.init_qreg[w] for w in obs.wires]
         if obs.name == "Hermitian":
             return hermitian_p.bind(obs.data[0], *wires)
-        return namedobs_p.bind(*wires, *obs.data, kind=obs.name)
+        return namedobs_p.bind(wires[0], *obs.data, kind=obs.name)
 
     def _compbasis_obs(self, *wires):
         """Add a computational basis sampling observable."""

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -976,7 +976,6 @@ def trace_observables(
         # won't actually lead to wrong execution results, since the only exception is the identity
         # But of course we should fix this at some time.
         # TODO: make the NamedObs op take in multiple qubit values
-        # https://github.com/PennyLaneAI/catalyst/issues/2645
 
         qubits = qrp.extract([wires[0]], allow_reuse=True)
         obs_tracers = namedobs_p.bind(qubits[0], kind=type(obs).__name__)

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -974,8 +974,9 @@ def trace_observables(
         # When there are multiple named obs, they could be on the same wire
         # qrp.insert ensures the extracted wires are added to cache, however this call is only
         # allowed on wires that aren't already in the cache.
-        if wires[0] not in qrp.cache:
-            qrp.insert(wires, qubits)
+        for w, q in zip(wires, qubits):
+            if w not in qrp.cache:
+                qrp.insert([w], [q])
     elif isinstance(obs, qml.Hermitian):
         # TODO: remove once fixed upstream: https://github.com/PennyLaneAI/pennylane/issues/4263
         qubits = qrp.extract(wires, allow_reuse=True)

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -969,19 +969,27 @@ def trace_observables(
             qubits = qrp.extract(wires, allow_reuse=True)
             obs_tracers = compbasis_p.bind(*qubits)
     elif isinstance(obs, KNOWN_NAMED_OBS):
-        qubits = qrp.extract(wires, allow_reuse=True)
+        # The MLIR NamedObs operation only takes in a single qubit value, instead of a variadic
+        # range.
+        # This is fine for most named observables, but qml.Identity can take in multiple wires
+        # While the current logic here assumes there is only one wire on the observable, this
+        # won't actually lead to wrong execution results, since the only exception is the identity
+        # But of course we should fix this at some time.
+        # TODO: make the NamedObs op take in multiple qubit values
+        # https://github.com/PennyLaneAI/catalyst/issues/2645
+
+        qubits = qrp.extract([wires[0]], allow_reuse=True)
         obs_tracers = namedobs_p.bind(qubits[0], kind=type(obs).__name__)
         # When there are multiple named obs, they could be on the same wire
         # qrp.insert ensures the extracted wires are added to cache, however this call is only
         # allowed on wires that aren't already in the cache.
-        for w, q in zip(wires, qubits):
-            if w not in qrp.cache:
-                qrp.insert([w], [q])
+        if wires[0] not in qrp.cache:
+            qrp.insert([wires[0]], [qubits[0]])
     elif isinstance(obs, qml.Hermitian):
         # TODO: remove once fixed upstream: https://github.com/PennyLaneAI/pennylane/issues/4263
         qubits = qrp.extract(wires, allow_reuse=True)
         obs_tracers = hermitian_p.bind(jax.numpy.asarray(*obs.parameters), *qubits)
-        for w, q in zip(wires, qubits):
+        for w, q in zip(wires, qubits, strict=True):
             if w not in qrp.cache:
                 qrp.insert([w], [q])
     elif isinstance(obs, qml.ops.op_math.Prod):

--- a/frontend/test/pytest/test_measurements_results.py
+++ b/frontend/test/pytest/test_measurements_results.py
@@ -251,7 +251,8 @@ class TestExpval:
         observed = expval1(np.pi)
         assert np.isclose(observed, expected)
 
-    def test_named_identity(self, backend):
+    @pytest.mark.capture_todo
+    def test_named_identity(self, backend, capture_mode):
         """
         Test expval for identity named observable on multiple wires.
 
@@ -259,7 +260,7 @@ class TestExpval:
         https://github.com/PennyLaneAI/catalyst/issues/2645
         """
 
-        @qjit(capture=False)
+        @qjit(capture=capture_mode)
         @qml.qnode(qml.device(backend, wires=3))
         def expval():
             return qml.expval(qml.Identity(wires=[1, 2])), qml.expval(qml.Identity(wires=[0, 1, 2]))

--- a/frontend/test/pytest/test_measurements_results.py
+++ b/frontend/test/pytest/test_measurements_results.py
@@ -251,16 +251,12 @@ class TestExpval:
         observed = expval1(np.pi)
         assert np.isclose(observed, expected)
 
-    @pytest.mark.capture_todo
     def test_named_identity(self, backend, capture_mode):
         """
         Test expval for identity named observable on multiple wires.
-
-        Note that the identity observable on multiple wires doesn't yet work in capture:
-        https://github.com/PennyLaneAI/catalyst/issues/2645
         """
 
-        @qjit(capture=capture_mode)
+        @qjit
         @qml.qnode(qml.device(backend, wires=3))
         def expval():
             return qml.expval(qml.Identity(wires=[1, 2])), qml.expval(qml.Identity(wires=[0, 1, 2]))

--- a/frontend/test/pytest/test_measurements_results.py
+++ b/frontend/test/pytest/test_measurements_results.py
@@ -251,6 +251,23 @@ class TestExpval:
         observed = expval1(np.pi)
         assert np.isclose(observed, expected)
 
+    def test_named_identity(self, backend):
+        """
+        Test expval for identity named observable on multiple wires.
+
+        Note that the identity observable on multiple wires doesn't yet work in capture:
+        https://github.com/PennyLaneAI/catalyst/issues/2645
+        """
+
+        @qjit(capture=False)
+        @qml.qnode(qml.device(backend, wires=3))
+        def expval():
+            return qml.expval(qml.Identity(wires=[1, 2])), qml.expval(qml.Identity(wires=[0, 1, 2]))
+
+        expected = np.array([1.0, 1.0])
+        observed = expval()
+        assert np.allclose(observed, expected)
+
     def test_hermitian_1(self, backend):
         """Test expval for Hermitian observable."""
 

--- a/frontend/test/pytest/test_measurements_results.py
+++ b/frontend/test/pytest/test_measurements_results.py
@@ -251,7 +251,7 @@ class TestExpval:
         observed = expval1(np.pi)
         assert np.isclose(observed, expected)
 
-    def test_named_identity(self, backend, capture_mode):
+    def test_named_identity(self, backend):
         """
         Test expval for identity named observable on multiple wires.
         """


### PR DESCRIPTION
**Context:**
As a follow up to #2641, the logic is updated to only use the index-0 wire in named obs handling, since the MLIR named obs op cannot take in a variadic range of qubits.

**Benefits:**
Correctness when a named obs takes in multiple wires, e.g. `qml.Identity(wires=[0,1,2])`

**Related GitHub issues:**
closes #2645 
[sc-115409]
