### PR TITLE
update plugin lowering

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -530,6 +530,7 @@
 * Catalyst internally uses the new unified transforms API rather than `PassPipelineWrapper`.
   [(#2525)](https://github.com/PennyLaneAI/catalyst/pull/2525)
   [(#2614)](https://github.com/PennyLaneAI/catalyst/pull/2614)
+  [(#2647)](https://github.com/PennyLaneAI/catalyst/pull/2647)
 
 * Added an `EmptyPass` MLIR pass that does not transform the program for debugging and standing in for
   unimplemented transforms.

--- a/frontend/catalyst/jax_primitives_utils.py
+++ b/frontend/catalyst/jax_primitives_utils.py
@@ -399,10 +399,7 @@ def transform_named_sequence_lowering(pipeline, sym_name):
         target = bb_named_sequence.arguments[0]
         for _pass in pipeline:
             assert isinstance(_pass, BoundTransform) or isinstance(_pass, PassPlugin)
-            if isinstance(_pass, BoundTransform):
-                name = _pass.pass_name
-            else:
-                name = _pass.name
+            name = _pass.pass_name if isinstance(_pass, BoundTransform) else _pass.name
             options = _lowered_options(_pass)
             apply_registered_pass_op = ApplyRegisteredPassOp(
                 result=transform_mod_type,

--- a/frontend/catalyst/jax_primitives_utils.py
+++ b/frontend/catalyst/jax_primitives_utils.py
@@ -398,7 +398,7 @@ def transform_named_sequence_lowering(pipeline, sym_name):
     with ir.InsertionPoint(bb_named_sequence):
         target = bb_named_sequence.arguments[0]
         for _pass in pipeline:
-            assert isinstance(_pass, BoundTransform) or isinstance(_pass, PassPlugin)
+            assert isinstance(_pass, (BoundTransform, PassPlugin))
             name = _pass.pass_name if isinstance(_pass, BoundTransform) else _pass.name
             options = _lowered_options(_pass)
             apply_registered_pass_op = ApplyRegisteredPassOp(

--- a/frontend/catalyst/jax_primitives_utils.py
+++ b/frontend/catalyst/jax_primitives_utils.py
@@ -27,6 +27,7 @@ from mlir_quantum.dialects.catalyst import LaunchKernelOp
 from pennylane.transforms.core import BoundTransform
 
 from catalyst.jax_extras.lowering import get_mlir_attribute_from_pyval
+from catalyst.passes import PassPlugin
 
 
 def _all_expval(call_jaxpr: core.ClosedJaxpr) -> bool:
@@ -325,10 +326,12 @@ class NestedModule:
         self.ctx.module_context = self.old_module_context
 
 
-def _lowered_options(_pass: BoundTransform):
+def _lowered_options(_pass: BoundTransform | PassPlugin):
+    args = _pass.args if isinstance(_pass, BoundTransform) else _pass.options
+    kwargs = _pass.kwargs if isinstance(_pass, BoundTransform) else _pass.valued_options
     return get_mlir_attribute_from_pyval(
-        {str(arg).replace("_", "-"): True for arg in _pass.args}
-        | {k.replace("_", "-"): v for k, v in _pass.kwargs.items()}
+        {str(arg).replace("_", "-"): True for arg in args}
+        | {k.replace("_", "-"): v for k, v in kwargs.items()}
     )
 
 
@@ -395,9 +398,12 @@ def transform_named_sequence_lowering(pipeline, sym_name):
     with ir.InsertionPoint(bb_named_sequence):
         target = bb_named_sequence.arguments[0]
         for _pass in pipeline:
-            assert isinstance(_pass, BoundTransform)
+            assert isinstance(_pass, BoundTransform) or isinstance(_pass, PassPlugin)
+            if isinstance(_pass, BoundTransform):
+                name = _pass.pass_name
+            else:
+                name = _pass.name
             options = _lowered_options(_pass)
-            name = _pass.pass_name
             apply_registered_pass_op = ApplyRegisteredPassOp(
                 result=transform_mod_type,
                 target=target,


### PR DESCRIPTION
**Context:**
Recent changes to callable lowering did not consider plugin lowering, which now fails due to an interface mismatch with `BoundTransform`s.

**Description of the Change:**
Adds small detours from the `BoundTransform` pathway to accommodate the interface differences with `PassPlugin`.

**Benefits:**
Plugins are successfully lowered. Tests had to be run manually with actions, available here: [macOS](https://github.com/PennyLaneAI/catalyst/actions/runs/23912439486/job/69740203833), [linux (arm)](https://github.com/PennyLaneAI/catalyst/actions/runs/23912510353/job/69741387699), [linux (x86)](https://github.com/PennyLaneAI/catalyst/actions/runs/23912497721/job/69740349214).

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
closes #2635 