### PR TITLE
Docstring fixes to functions in `passes` module

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -852,7 +852,7 @@
   [(#2546)](https://github.com/PennyLaneAI/catalyst/pull/2546)
 
 * Typos and rendering issues in various docstrings in the :mod:`catalyst.passes` module were fixed.
-  [(#???)](https://github.com/PennyLaneAI/catalyst/pull/???)
+  [(#2649)](https://github.com/PennyLaneAI/catalyst/pull/2649)
 
 * Updated the Unified Compiler Cookbook to be compatible with the latest versions of PennyLane and Catalyst.
   [(#2406)](https://github.com/PennyLaneAI/catalyst/pull/2406)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -851,6 +851,9 @@
   by using updated features for inspection and by calling them from the PennyLane frontend.
   [(#2546)](https://github.com/PennyLaneAI/catalyst/pull/2546)
 
+* Typos and rendering issues in various docstrings in the :mod:`catalyst.passes` module were fixed.
+  [(#???)](https://github.com/PennyLaneAI/catalyst/pull/???)
+
 * Updated the Unified Compiler Cookbook to be compatible with the latest versions of PennyLane and Catalyst.
   [(#2406)](https://github.com/PennyLaneAI/catalyst/pull/2406)
 
@@ -879,6 +882,7 @@ This release contains contributions from (in alphabetical order):
 Ali Asadi,
 Joey Carter,
 Yushao Chen,
+Isaac De Vlugt,
 Marcus Edwards,
 Lillian Frederiksen,
 Sengthai Heng,

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -49,7 +49,7 @@ def cancel_inverses(qnode):
     :class:`qml.SWAP <pennylane.SWAP>`
 
     Three-bit Gates:
-    - :class:`qml.Toffoli <pennylane.Toffoli>`
+    :class:`qml.Toffoli <pennylane.Toffoli>`
 
     .. note::
 
@@ -260,11 +260,11 @@ def diagonalize_measurements(
 
 
 def disentangle_cnot(qnode):
-    """A peephole optimization for replacing ``CNOT`` gates with single-qubit gates.
+    r"""A peephole optimization for replacing ``CNOT`` gates with single-qubit gates.
 
     .. note::
 
-        This transform requires decorating the workflow with :func:`pennylane.qjit`.
+        This transform requires decorating the workflow with :func:`~.qjit`.
 
     Args:
         fn (QNode): the QNode to apply the pass to
@@ -319,10 +319,10 @@ def disentangle_swap(qnode):
 
     .. note::
 
-        This transform requires decorating the workflow with :func:`pennylane.qjit`.
+        This transform requires decorating the workflow with :func:`~.qjit`.
 
     Args:
-        fn (QNode): the QNode to apply the pass to.
+        fn (QNode): the QNode to apply the pass to
 
     Returns:
         :class:`QNode <pennylane.QNode>`
@@ -388,7 +388,6 @@ def merge_rotations(qnode):
     :class:`qml.CRot <pennylane.CRot>`,
     :class:`qml.MultiRZ <pennylane.MultiRZ>`.
 
-
     .. note::
 
         Unlike PennyLane :doc:`circuit transformations <introduction/compiling_circuits>`,
@@ -403,7 +402,7 @@ def merge_rotations(qnode):
         :func:`~.get_compilation_stage` function.
 
     Args:
-        fn (QNode): the QNode to apply the cancel inverses compiler pass to
+        fn (QNode): the QNode to apply the merge rotations compiler pass to
 
     Returns:
         :class:`QNode <pennylane.QNode>`
@@ -442,7 +441,7 @@ def decompose_lowering(qnode):
     recursively.
 
     Args:
-        fn (QNode): the QNode to apply the cancel inverses compiler pass to
+        fn (QNode): the QNode to apply the decompose-lowering compiler pass to
 
     Returns:
         :class:`QNode <pennylane.QNode>`
@@ -780,7 +779,7 @@ def commute_ppr(qnode=None, *, max_pauli_size=0):
     `Compilation Hub <https://pennylane.ai/compilation/pauli-product-rotations>`_.
 
     Args:
-        fn (QNode): QNode to apply the pass to.
+        fn (QNode): QNode to apply the pass to
         max_pauli_size (int):
             The maximum size of Pauli strings resulting from commutation. If a commutation results
             in a PPR that acts on more than ``max_pauli_size`` qubits, that commutation will not be
@@ -973,7 +972,7 @@ def ppr_to_ppm(qnode=None, *, decompose_method="pauli-corrected", avoid_y_measur
     the `Compilation Hub <https://pennylane.ai/compilation/pauli-based-computation>`_.
 
     Args:
-        qnode (QNode): QNode to apply the pass to.
+        qnode (QNode): QNode to apply the pass to
         decompose_method (str): The method to use for decomposing non-Clifford PPRs.
             Options are ``"pauli-corrected"``, ``"auto-corrected"``, and ``"clifford-corrected"``.
             Defaults to ``"pauli-corrected"``.
@@ -1310,7 +1309,7 @@ def reduce_t_depth(qnode):
         ``reduce_t_depth``.
 
     Args:
-        qnode (QNode): QNode to apply the pass to.
+        qnode (QNode): the QNode to apply the pass to
 
     Returns:
         :class:`QNode <pennylane.QNode>`
@@ -1413,7 +1412,7 @@ def ppr_to_mbqc(qnode):
         after :func:`~.passes.to_ppr`.
 
     Args:
-        fn (QNode): QNode to apply the pass to.
+        fn (QNode): the QNode to apply the pass to
 
     Returns:
         :class:`QNode <pennylane.QNode>`
@@ -1490,7 +1489,7 @@ def decompose_arbitrary_ppr(qnode):  # pragma: nocover
         ``decompose_arbitrary_ppr``.
 
     Args:
-        qnode (QNode): QNode to apply the pass to.
+        qnode (QNode): the QNode to apply the pass to
 
     Returns:
         :class:`QNode <pennylane.QNode>`

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -371,7 +371,7 @@ def disentangle_swap(qnode):
 
 
 def merge_rotations(qnode):
-    """Specify that the ``-merge-rotations`` MLIR compiler pass
+    r"""Specify that the ``-merge-rotations`` MLIR compiler pass
     for merging roations (peephole) will be applied.
 
     The full list of supported gates are as follows:


### PR DESCRIPTION
**Context:** Couple typos and rendering issues in docstrings in the passes module 

**Description of the Change:** docstring fixes

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
