### PR TITLE
Add NoiseOp to the qecl layer

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -842,6 +842,7 @@
   [(#2544)](https://github.com/PennyLaneAI/catalyst/pull/2544)
   [(#2547)](https://github.com/PennyLaneAI/catalyst/pull/2547)
   [(#2549)](https://github.com/PennyLaneAI/catalyst/pull/2549)
+  [(#2665)](https://github.com/PennyLaneAI/catalyst/pull/2665)
 
 * An experimental *QEC Physical* MLIR dialect has been added. An equivalent xDSL dialect has also
   been added for compatibility with the Python interface to Catalyst.

--- a/frontend/catalyst/python_interface/dialects/qecl.py
+++ b/frontend/catalyst/python_interface/dialects/qecl.py
@@ -354,6 +354,33 @@ class EncodeOp(IRDLOperation):
 
 
 @irdl_op_definition
+class NoiseOp(IRDLOperation):
+    """An operation indicates where to inject noise."""
+
+    T: ClassVar = VarConstraint("T", anyLogicalCodeblock)
+
+    name = "qecl.noise"
+
+    in_codeblock = operand_def(T)
+
+    out_codeblock = result_def(T)
+
+    assembly_format = """
+            $in_codeblock attr-dict `:` type($in_codeblock)
+        """
+
+    def __init__(
+        self,
+        in_codeblock: LogicalCodeBlockSSAValue | Operation,
+    ):
+        operands = (in_codeblock,)
+
+        in_codeblock_type = get_logical_codeblock_type(in_codeblock)
+
+        super().__init__(operands=operands, result_types=(in_codeblock_type,))
+
+
+@irdl_op_definition
 class QecCycleOp(IRDLOperation):
     """Perform a single cycle of a quantum error-correction protocol."""
 

--- a/frontend/catalyst/python_interface/dialects/qecl.py
+++ b/frontend/catalyst/python_interface/dialects/qecl.py
@@ -355,7 +355,7 @@ class EncodeOp(IRDLOperation):
 
 @irdl_op_definition
 class NoiseOp(IRDLOperation):
-    """An operation indicates where to inject noise."""
+    """Inject physical noise on elements of a logical codeblock."""
 
     T: ClassVar = VarConstraint("T", anyLogicalCodeblock)
 

--- a/frontend/catalyst/python_interface/dialects/qecl.py
+++ b/frontend/catalyst/python_interface/dialects/qecl.py
@@ -749,6 +749,7 @@ QecLogical = Dialect(
         ExtractCodeblockOp,
         InsertCodeblockOp,
         EncodeOp,
+        NoiseOp,
         QecCycleOp,
         IdentityOp,
         PauliXOp,

--- a/frontend/test/pytest/python_interface/dialects/test_qecl_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_qecl_dialect.py
@@ -42,6 +42,7 @@ expected_ops_names = {
     "ExtractCodeblockOp": "qecl.extract_block",
     "InsertCodeblockOp": "qecl.insert_block",
     "EncodeOp": "qecl.encode",
+    "NoiseOp": "qecl.noise",
     "QecCycleOp": "qecl.qec",
     "IdentityOp": "qecl.identity",
     "PauliXOp": "qecl.x",
@@ -165,6 +166,13 @@ class TestQecLogicalOps:
         assert isinstance(encode_op.result_types[0], qecl.LogicalCodeblockType)
         assert encode_op.result_types[0].k == self.k
 
+    def test_qecl_op_constructor_noise(self):
+        """Test the constructor of the qecl.noise op."""
+        noise_op = qecl.NoiseOp(in_codeblock=self._get_codeblock_value())
+        assert len(noise_op.result_types) == 1
+        assert isinstance(noise_op.result_types[0], qecl.LogicalCodeblockType)
+        assert noise_op.result_types[0].k == self.k
+
     def test_qecl_op_constructor_qec(self):
         """Test the constructor of the qecl.qec op."""
         qec_op = qecl.QecCycleOp(in_codeblock=self._get_codeblock_value())
@@ -260,8 +268,11 @@ def test_assembly_format(run_filecheck, pretty_print):
     // CHECK: [[block1:%.+]] = qecl.encode{{\s*}}[zero] [[block0]] : !qecl.codeblock<1>
     %block1 = qecl.encode [zero] %block0 : !qecl.codeblock<1>
 
-    // CHECK: [[block2:%.+]] = qecl.qec [[block1]] : !qecl.codeblock<1>
-    %block2 = qecl.qec %block1 : !qecl.codeblock<1>
+    // CHECK: [[block1_1:%.+]] = qecl.noise [[block1]] : !qecl.codeblock<1>
+    %block1_1 = qecl.noise %block1 : !qecl.codeblock<1>
+
+    // CHECK: [[block2:%.+]] = qecl.qec [[block1_1]] : !qecl.codeblock<1>
+    %block2 = qecl.qec %block1_1 : !qecl.codeblock<1>
 
     // CHECK: [[block3:%.+]] = qecl.identity [[block2]][{{\s*}}0] : !qecl.codeblock<1>
     %block3 = qecl.identity %block2[0] : !qecl.codeblock<1>

--- a/mlir/include/QecLogical/IR/QecLogicalOps.td
+++ b/mlir/include/QecLogical/IR/QecLogicalOps.td
@@ -124,6 +124,22 @@ def EncodeOp : QecLogical_Op<"encode", [AllTypesMatch<["in_codeblock", "out_code
     }];
 }
 
+def NoiseOp : QecLogical_Op<"noise", [AllTypesMatch<["in_codeblock", "out_codeblock"]>]> {
+    let summary = "Perform a single cycle of a quantum error-correction protocol.";
+
+    let arguments = (ins
+        LogicalCodeblockType:$in_codeblock
+    );
+
+    let results = (outs
+        LogicalCodeblockType:$out_codeblock
+    );
+
+    let assemblyFormat = [{
+        $in_codeblock attr-dict `:` qualified(type($in_codeblock))
+    }];
+}
+
 def QecCycleOp : QecLogical_Op<"qec", [AllTypesMatch<["in_codeblock", "out_codeblock"]>]> {
     let summary = "Perform a single cycle of a quantum error-correction protocol.";
 

--- a/mlir/include/QecLogical/IR/QecLogicalOps.td
+++ b/mlir/include/QecLogical/IR/QecLogicalOps.td
@@ -125,7 +125,7 @@ def EncodeOp : QecLogical_Op<"encode", [AllTypesMatch<["in_codeblock", "out_code
 }
 
 def NoiseOp : QecLogical_Op<"noise", [AllTypesMatch<["in_codeblock", "out_codeblock"]>]> {
-    let summary = "An operation indicates where to inject noise.";
+    let summary = "Inject physical noise on elements of a logical codeblock.";
 
     let arguments = (ins
         LogicalCodeblockType:$in_codeblock

--- a/mlir/include/QecLogical/IR/QecLogicalOps.td
+++ b/mlir/include/QecLogical/IR/QecLogicalOps.td
@@ -125,7 +125,7 @@ def EncodeOp : QecLogical_Op<"encode", [AllTypesMatch<["in_codeblock", "out_code
 }
 
 def NoiseOp : QecLogical_Op<"noise", [AllTypesMatch<["in_codeblock", "out_codeblock"]>]> {
-    let summary = "Perform a single cycle of a quantum error-correction protocol.";
+    let summary = "An operation indicates where to inject noise.";
 
     let arguments = (ins
         LogicalCodeblockType:$in_codeblock

--- a/mlir/test/QecLogical/DialectTest.mlir
+++ b/mlir/test/QecLogical/DialectTest.mlir
@@ -76,6 +76,13 @@ func.func @test_encode_block(%arg0 : !qecl.codeblock<1>) {
 
 // -----
 
+func.func @test_noise(%arg0 : !qecl.codeblock<1>) {
+    %0 = qecl.noise %arg0 : !qecl.codeblock<1>
+    func.return
+}
+
+// -----
+
 func.func @test_qec_cycle(%arg0 : !qecl.codeblock<1>) {
     %0 = qecl.qec %arg0 : !qecl.codeblock<1>
     func.return


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new functions and code must be clearly commented and documented.

- [x] Ensure that code is properly formatted by running `make format`.
      The latest version of black and `clang-format-20` are used in CI/CD to check formatting.

- [x] All new features must include a unit test.
      Integration and frontend tests should be added to [`frontend/test`](../frontend/test/),
      Quantum dialect and MLIR tests should be added to [`mlir/test`](../mlir/test/), and
      Runtime tests should be added to [`runtime/tests`](../runtime/tests/).

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

[sc-116013]

This PR introduces the `qecl.noise` operation to the QEC logical layer. This operation accepts a logical codeblock as input and returns a corresponding logical-layer codeblock.

Note that: this op is not intended to inject logical noise or errors but functions as a placeholder, enabling a simpler injection of noises into the QEC physical layer.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
