### PR TITLE
Support adjoint of operators who decompose with control flow

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -474,6 +474,11 @@
   tools like `xdsl-opt` to work with Catalyst's custom Python dialects.
   [(#2471)](https://github.com/PennyLaneAI/catalyst/pull/2471)
 
+* Fix symbolic adjoint support for control flow operation. This means operators who are the target
+  of `qp.adjoint` but require decomposition can have decompositions with control flow in them,
+  which would previously raise an error. Adjoint on functions is unaffected.
+  [(#2667)](https://github.com/PennyLaneAI/catalyst/pull/2667)
+
 * Fix a bug with the xDSL `ParitySynth` pass that caused failure when the QNode being transformed
   contained operations with regions.
   [(#2408)](https://github.com/PennyLaneAI/catalyst/pull/2408)

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -1572,6 +1572,9 @@ class Cond(HybridOp):
     has_adjoint = True
 
     def adjoint(self):
+        """Produce an adjoint version of this operator. Here, we simply regenerate a HybridAdjoint
+        version of the operation, which is generally supported by Catalyst."""
+
         return qml.adjoint(lambda: qml.apply(self) and None)()
 
     def trace_quantum(self, ctx, device, trace, qrp) -> QRegPromise:
@@ -1585,6 +1588,9 @@ class ForLoop(HybridOp):
     has_adjoint = True
 
     def adjoint(self):
+        """Produce an adjoint version of this operator. Here, we simply regenerate a HybridAdjoint
+        version of the operation, which is generally supported by Catalyst."""
+
         return qml.adjoint(lambda: qml.apply(self) and None)()
 
     def trace_quantum(self, ctx, device, trace, qrp) -> QRegPromise:
@@ -1670,6 +1676,9 @@ class WhileLoop(HybridOp):
     has_adjoint = True
 
     def adjoint(self):
+        """Produce an adjoint version of this operator. Here, we simply regenerate a HybridAdjoint
+        version of the operation, which is generally supported by Catalyst."""
+
         return qml.adjoint(lambda: qml.apply(self) and None)()
 
     def trace_quantum(self, ctx, device, trace, qrp) -> QRegPromise:

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -1569,6 +1569,10 @@ class Cond(HybridOp):
     """PennyLane's conditional operation."""
 
     binder = cond_p.bind
+    has_adjoint = True
+
+    def adjoint(self):
+        return qml.adjoint(lambda: qml.apply(self) and None)()
 
     def trace_quantum(self, ctx, device, trace, qrp) -> QRegPromise:
         return trace_quantum_branches(self, ctx, device, trace, qrp)
@@ -1578,6 +1582,10 @@ class ForLoop(HybridOp):
     """PennyLane ForLoop Operation."""
 
     binder = for_p.bind
+    has_adjoint = True
+
+    def adjoint(self):
+        return qml.adjoint(lambda: qml.apply(self) and None)()
 
     def trace_quantum(self, ctx, device, trace, qrp) -> QRegPromise:
         op = self
@@ -1659,6 +1667,10 @@ class WhileLoop(HybridOp):
     """PennyLane's while loop operation."""
 
     binder = while_p.bind
+    has_adjoint = True
+
+    def adjoint(self):
+        return qml.adjoint(lambda: qml.apply(self) and None)()
 
     def trace_quantum(self, ctx, device, trace, qrp) -> QRegPromise:
         cond_trace = self.regions[0].trace

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -502,6 +502,10 @@ class HybridAdjoint(HybridOp):
         in reverse. Note that decomposition of control flow ops like for loops are only supported
         in the compiler."""
         assert len(self.regions) == 1, "Expected a single nested region for HybridAdjoint"
+        assert not any(
+            isinstance(op, HybridOp) and not isinstance(op, (HybridAdjoint, HybridCtrl))
+            for op in self.regions[0].quantum_tape.operations
+        ), "Cannot decompose Adjoint(HybridOp) in PennyLane"
 
         return [
             create_adjoint_op(op, lazy=True)
@@ -596,7 +600,7 @@ class HybridCtrl(HybridOp):
 
     def decomposition(self):
         """Compute quantum decomposition of the gate by recursively scanning the nested tape and
-        distributing the quantum control operaiton over the tape operations."""
+        distributing the quantum control operation over the tape operations."""
         assert len(self.regions) == 1, "HybridCtrl is expected to have one region"
 
         _check_no_measurements(self.regions[0].quantum_tape)

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -253,12 +253,15 @@ def get_qjit_device_capabilities(target_capabilities: DeviceCapabilities) -> Dev
     # Control-flow gates to be lowered down to the LLVM control-flow instructions
     qjit_capabilities.operations.update(
         {
-            "Cond": OperatorProperties(invertible=True, controllable=True, differentiable=True),
+            # CF inversion is only support via hybrid adjoint in the compiler, never via PL Operator
+            # adjoint, so we have to set this flag to False. Supported ops will be "decomposed" to
+            # hybrid adjoints automatically.
+            "Cond": OperatorProperties(invertible=False, controllable=True, differentiable=True),
             "WhileLoop": OperatorProperties(
-                invertible=True, controllable=True, differentiable=True
+                invertible=False, controllable=True, differentiable=True
             ),
-            "ForLoop": OperatorProperties(invertible=True, controllable=True, differentiable=True),
-            "Switch": OperatorProperties(invertible=True, controllable=True, differentiable=True),
+            "ForLoop": OperatorProperties(invertible=False, controllable=True, differentiable=True),
+            "Switch": OperatorProperties(invertible=False, controllable=True, differentiable=True),
         }
     )
 

--- a/frontend/catalyst/device/verification.py
+++ b/frontend/catalyst/device/verification.py
@@ -43,7 +43,7 @@ from pennylane.ops import (
 )
 from pennylane.tape import QuantumTape
 
-from catalyst.api_extensions import HybridAdjoint, HybridCtrl
+from catalyst.api_extensions import Cond, ForLoop, HybridAdjoint, HybridCtrl, WhileLoop
 from catalyst.device.op_support import (
     EMPTY_PROPERTIES,
     is_active,
@@ -178,6 +178,9 @@ def verify_operations(tape: QuantumTape, grad_method, qjit_device):
         # PL simplification should mean pure PL operators will not be more nested than this.
         if type(op) in (Controlled, ControlledOp):
             _inv_op_checker(op.base, in_inverse)
+            return in_inverse
+        # Exclude control flow ops we always know how to invert
+        if type(op) in (Cond, ForLoop, WhileLoop):
             return in_inverse
         # Early exit when not in inverse, only determine the inverse status for recursing later.
         elif not in_inverse:

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -26,6 +26,7 @@ from pennylane import adjoint, cond, for_loop, qjit, while_loop
 from pennylane.ops.op_math.adjoint import Adjoint, AdjointOperation
 
 import catalyst
+import catalyst as cat
 from catalyst import debug, measure, qjit
 
 # pylint: disable=too-many-lines,missing-class-docstring,missing-function-docstring,too-many-public-methods
@@ -1669,6 +1670,94 @@ class TestMidCircuitMeasurementAfterAdjoint:
             return res
 
         assert not circuit()
+
+
+class TestAdjointOfTemplates:
+    """Test behaviour of adjoint around complex templates."""
+
+    def test_adjoint_for_loop(self, backend):
+        """Test operator adjoint works around templates that decompose into for loops."""
+
+        @qml.qjit
+        @qml.qnode(qml.device(backend, wires=1))
+        def circuit(n: int):
+            qml.H(0)
+
+            @cat.for_loop(0, n, 1)
+            def f(_):
+                qml.T(0)
+
+            f()
+            qml.adjoint(f.operation)  # orig f is dequeued
+
+            qml.H(0)
+            return qml.expval(qml.Z(0))
+
+        assert np.allclose(circuit(0), 1.0)
+        assert np.allclose(circuit(1), 1.0 / np.sqrt(2))
+        assert np.allclose(circuit(2), 0.0)
+
+    def test_adjoint_while_loop(self, backend):
+        """Test operator adjoint works around templates that decompose into for loops."""
+
+        @qml.qjit
+        @qml.qnode(qml.device(backend, wires=1))
+        def circuit(n: int):
+            qml.H(0)
+
+            @cat.while_loop(lambda i: i < n)
+            def f(i):
+                qml.T(0)
+                return i + 1
+
+            f(0)
+            qml.adjoint(f.operation)  # orig f is dequeued
+
+            qml.H(0)
+            return qml.expval(qml.Z(0))
+
+        assert np.allclose(circuit(0), 1.0)
+        assert np.allclose(circuit(1), 1.0 / np.sqrt(2))
+        assert np.allclose(circuit(2), 0.0)
+
+    def test_adjoint_cond(self, backend):
+        """Test operator adjoint works around templates that decompose into if conditionals."""
+
+        @qml.qjit
+        @qml.qnode(qml.device(backend, wires=1))
+        def circuit(b: bool):
+            qml.H(0)
+
+            @cat.cond(b)
+            def f():
+                qml.T(0)
+
+            f()
+            qml.adjoint(f.operation)  # orig f is dequeued
+
+            qml.H(0)
+            return qml.expval(qml.Z(0))
+
+        assert np.allclose(circuit(0), 1.0)
+        assert np.allclose(circuit(1), 1.0 / np.sqrt(2))
+
+    def test_adjoint_switch(self, backend):
+        """Catalyst's adjoint algorithm doesn't work on switch yet."""
+
+        @qml.qnode(qml.device(backend, wires=1))
+        def circuit(s: int):
+
+            @cat.switch(s)
+            def f():
+                qml.T(0)
+
+            f()
+            qml.adjoint(f.operation)  # orig f is dequeued
+
+            return qml.expval(qml.Z(0))
+
+        with pytest.raises(cat.CompileError, match="Adjoint\(Switch.+\) not supported"):
+            qjit(circuit)
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -1738,8 +1738,8 @@ class TestAdjointOfTemplates:
             qml.H(0)
             return qml.expval(qml.Z(0))
 
-        assert np.allclose(circuit(0), 1.0)
-        assert np.allclose(circuit(1), 1.0 / np.sqrt(2))
+        assert np.allclose(circuit(False), 1.0)
+        assert np.allclose(circuit(True), 1.0 / np.sqrt(2))
 
     def test_adjoint_switch(self, backend):
         """Catalyst's adjoint algorithm doesn't work on switch yet."""
@@ -1756,7 +1756,7 @@ class TestAdjointOfTemplates:
 
             return qml.expval(qml.Z(0))
 
-        with pytest.raises(cat.CompileError, match="Adjoint\(Switch.+\) not supported"):
+        with pytest.raises(cat.CompileError, match=r"Adjoint\(Switch.+\) not supported"):
             qjit(circuit)
 
 


### PR DESCRIPTION
Currently, something like the following fails with an error:

```py
import pennylane as qp

class MyOperator(qp.operation.Operation):

    def decomposition(self):
        with qp.queuing.AnnotatedQueue() as q:
            _my_decomposition(self.wires)

        if qp.QueuingManager.recording():
            for op in q.queue:
                qp.apply(op)

        return q.queue

def _my_decomposition(wires, **_):

    qp.H(wires[0])

    @qp.for_loop(1, len(wires))
    def _loop(i):
        array_wires = qp.math.array(wires, like=i)
        qp.CNOT(wires=[array_wires[i - 1], array_wires[i]])

    _loop()

@qp.qjit
@qp.qnode(qp.device("lightning.qubit", wires=4))
def circuit():
    MyOperator([0, 1, 2, 3])
    qp.adjoint(MyOperator)([0, 1, 2, 3])

    return qp.state()
```

```
catalyst.utils.exceptions.CompileError: Cannot compile PennyLane inverse of the hybrid op <class 'catalyst.api_extensions.control_flow.ForLoop'>.
```

The reason is that the adjoint is applied directly to an operator, generating a symbolic `Adjoint()` op instance, whereas applying adjoint to functions generates `HybridAdjoint()` instances with a separate body region. While the latter has support for computing the adjoint of control flow operations in the compiler, the former (in Python PennyLane) does not.
This hasn't been a problem so far because `ForLoop` instances are not manipulated directly in user workflows, and so adjoint with control flow would have always generated the function version. With control flow appearing as part of decompositions however it's possible for `Adjoint(ForLoop)` instances to be generated now, for example when an adjointed operator like a template needs to be decomposed.

The fix consists of automatically "decomposing" `Adjoint(ForLoop)` into `HybridAdjoint([ForLoop])`. The same is done for while loops and conditionals. However, switch statements are not yet included because the adjoint algorithm in catalyst does not have support for it (since it was added later).

closes #2669 
[sc-116053]
[sc-116179]