### PR TITLE
Add RotOp to the QEC Physical layer (for NoiseOp lowering)

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -853,6 +853,7 @@
   [(#2572)](https://github.com/PennyLaneAI/catalyst/pull/2572)
   [(#2574)](https://github.com/PennyLaneAI/catalyst/pull/2574)
   [(#2576)](https://github.com/PennyLaneAI/catalyst/pull/2576)
+  [(#2673)](https://github.com/PennyLaneAI/catalyst/pull/2673)
 
 * A number of deprecation warnings have been fixed in the compiler python interface.
   [(#2621)](https://github.com/PennyLaneAI/catalyst/pull/2621)

--- a/frontend/catalyst/python_interface/dialects/qecp.py
+++ b/frontend/catalyst/python_interface/dialects/qecp.py
@@ -703,7 +703,7 @@ class RotOp(IRDLOperation):
     name = "qecp.rot"
 
     assembly_format = """
-           `(` $phi `,` $theta `,` $omega `)` $in_qubit attr-dict `:` type($out_qubit)
+           `(` $phi `,` $theta `,` $omega `)` $in_qubit attr-dict `:` type($in_qubit)
         """
 
     phi = operand_def(Float64Type())

--- a/frontend/catalyst/python_interface/dialects/qecp.py
+++ b/frontend/catalyst/python_interface/dialects/qecp.py
@@ -26,10 +26,10 @@ from collections.abc import Sequence
 from typing import ClassVar, TypeAlias
 
 from xdsl.dialects.builtin import (
-    Float64Type,
     I64,
     ContainerOf,
     ContainerType,
+    Float64Type,
     IndexType,
     IntegerAttr,
     IntegerType,

--- a/frontend/catalyst/python_interface/dialects/qecp.py
+++ b/frontend/catalyst/python_interface/dialects/qecp.py
@@ -695,7 +695,7 @@ class RotOp(IRDLOperation):
     ```mlir
     %1 = qecp.rot (%phi, %theta, %omega) %0 : !qecp.qubit<data>
     ```
-
+    NOTE: This operation is for physical noise injection only.
     """
 
     T: ClassVar = VarConstraint("T", anyPhysicalQubit)

--- a/frontend/catalyst/python_interface/dialects/qecp.py
+++ b/frontend/catalyst/python_interface/dialects/qecp.py
@@ -687,6 +687,7 @@ class CnotOp(IRDLOperation):
             result_types=(in_ctrl_qubit_type, in_trgt_qubit_type),
         )
 
+
 @irdl_op_definition
 class RotOp(IRDLOperation):
     """A physical Rot gate operation.

--- a/frontend/catalyst/python_interface/dialects/qecp.py
+++ b/frontend/catalyst/python_interface/dialects/qecp.py
@@ -26,6 +26,7 @@ from collections.abc import Sequence
 from typing import ClassVar, TypeAlias
 
 from xdsl.dialects.builtin import (
+    Float64Type,
     I64,
     ContainerOf,
     ContainerType,
@@ -687,6 +688,51 @@ class CnotOp(IRDLOperation):
         )
 
 
+class RotOp(IRDLOperation):
+    """A physical Rot gate operation.
+
+    ```mlir
+    %1 = qecp.rot (%phi, %theta, %omega) %0 : !qecp.qubit<data>
+    ```
+
+    """
+
+    T: ClassVar = VarConstraint("T", anyPhysicalQubit)
+
+    assembly_format = """
+           `(` $phi `,` $theta `,` $omega `)` $in_qubit attr-dict `:` type($out_qubit)
+        """
+
+    phi = operand_def(Float64Type())
+
+    theta = operand_def(Float64Type())
+
+    omega = operand_def(Float64Type())
+
+    in_qubit = operand_def(T)
+
+    out_qubit = result_def(T)
+
+    def __init__(
+        self,
+        phi: SSAValue[Float64Type],
+        theta: SSAValue[Float64Type],
+        omega: SSAValue[Float64Type],
+        in_qubit: QecPhysicalQubitSSAValue | Operation,
+    ):
+        in_qubit_type = get_physical_qubit_type(in_qubit)
+
+        super().__init__(
+            operands=(
+                phi,
+                theta,
+                omega,
+                in_qubit,
+            ),
+            result_types=(in_qubit_type,),
+        )
+
+
 @irdl_op_definition
 class MeasureOp(IRDLOperation):
     """A physical single-qubit projective measurement in the computational basis."""
@@ -825,6 +871,7 @@ QecPhysical = Dialect(
         PauliYOp,
         PauliZOp,
         HadamardOp,
+        RotOp,
         SOp,
         CnotOp,
         MeasureOp,

--- a/frontend/catalyst/python_interface/dialects/qecp.py
+++ b/frontend/catalyst/python_interface/dialects/qecp.py
@@ -687,7 +687,7 @@ class CnotOp(IRDLOperation):
             result_types=(in_ctrl_qubit_type, in_trgt_qubit_type),
         )
 
-
+@irdl_op_definition
 class RotOp(IRDLOperation):
     """A physical Rot gate operation.
 
@@ -698,6 +698,8 @@ class RotOp(IRDLOperation):
     """
 
     T: ClassVar = VarConstraint("T", anyPhysicalQubit)
+
+    name = "qecp.rot"
 
     assembly_format = """
            `(` $phi `,` $theta `,` $omega `)` $in_qubit attr-dict `:` type($out_qubit)

--- a/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
@@ -292,7 +292,7 @@ class TestQecPhysicalOps:
             ),
         ],
     )
-    def test_qecp_op_constructor_hadamard(self, phi, theta, omega, qubit):
+    def test_qecp_op_constructor_rot(self, phi, theta, omega, qubit):
         """Test the constructor of the qecp.rot op."""
         rot_op = qecp.RotOp(phi, theta, omega, qubit)
         assert len(rot_op.operands) == 4

--- a/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
@@ -482,6 +482,17 @@ def test_assembly_format(run_filecheck, pretty_print):
     %qd7 = qecp.s %qd6 adj : !qecp.qubit<data>
     %qa7 = qecp.s %qa6 adj : !qecp.qubit<aux>
 
+    // CHECK: [[phi:%.+]] = "test.op"() : () -> f64
+    // CHECK: [[theta:%.+]] = "test.op"() : () -> f64
+    // CHECK: [[omega:%.+]] = "test.op"() : () -> f64
+    // CHECK: [[qd8:%.+]] = qecp.rot([[phi:%.+]], [[theta:%.+]], [[omega:%.+]]) [[qd7]] : !qecp.qubit<data>
+    // CHECK: [[qa8:%.+]] = qecp.rot([[phi:%.+]], [[theta:%.+]], [[omega:%.+]]) [[qa7]] : !qecp.qubit<aux>
+    %phi = "test.op"() : () -> f64
+    %theta = "test.op"() : () -> f64
+    %omega = "test.op"() : () -> f64
+    %qd8 = qecp.rot(%phi, %theta, %omega) %qd7 : !qecp.qubit<data>
+    %qa8 = qecp.rot(%phi, %theta, %omega) %qa7 : !qecp.qubit<aux>
+
     // CHECK: [[qd10:%.+]] = "test.op"() : () -> !qecp.qubit<data>
     // CHECK: [[qd20:%.+]] = "test.op"() : () -> !qecp.qubit<data>
     // CHECK: [[qa10:%.+]] = "test.op"() : () -> !qecp.qubit<aux>
@@ -508,10 +519,10 @@ def test_assembly_format(run_filecheck, pretty_print):
     %row_idx = "test.op"() : () -> tensor<8xi32>
     %col_ptr = "test.op"() : () -> tensor<6xi32>
 
-    // CHECK: [[mres0:%.+]], [[qd8:%.+]] = qecp.measure [[qd7]] : i1, !qecp.qubit<data>
-    // CHECK: [[mres1:%.+]], [[qa8:%.+]] = qecp.measure [[qa7]] : i1, !qecp.qubit<aux>
-    %mres0, %qd8 = qecp.measure %qd7 : i1, !qecp.qubit<data>
-    %mres1, %qa8 = qecp.measure %qa7 : i1, !qecp.qubit<aux>
+    // CHECK: [[mres0:%.+]], [[qd9:%.+]] = qecp.measure [[qd8]] : i1, !qecp.qubit<data>
+    // CHECK: [[mres1:%.+]], [[qa9:%.+]] = qecp.measure [[qa8]] : i1, !qecp.qubit<aux>
+    %mres0, %qd9 = qecp.measure %qd8 : i1, !qecp.qubit<data>
+    %mres1, %qa9 = qecp.measure %qa8 : i1, !qecp.qubit<aux>
 
     // CHECK: [[tgraph:%.+]] = qecp.assemble_tanner [[row_idx]], [[col_ptr]] : tensor<8xi32>, tensor<6xi32> -> !qecp.tanner_graph<8, 6, i32>
     %tgraph = qecp.assemble_tanner %row_idx, %col_ptr : tensor<8xi32>, tensor<6xi32> -> !qecp.tanner_graph<8, 6, i32>

--- a/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
@@ -19,6 +19,7 @@ from typing import cast
 import pytest
 from xdsl.dialects import test
 from xdsl.dialects.builtin import (
+    Float64Type,
     IndexType,
     IntegerAttr,
     IntegerType,
@@ -59,6 +60,7 @@ expected_ops_names = {
     "PauliZOp": "qecp.z",
     "HadamardOp": "qecp.hadamard",
     "SOp": "qecp.s",
+    "RotOp": "qecp.rot",
     "CnotOp": "qecp.cnot",
     "MeasureOp": "qecp.measure",
     "AssembleTannerGraphOp": "qecp.assemble_tanner",
@@ -272,6 +274,34 @@ class TestQecPhysicalOps:
         assert hadamard_op.operand_types[0] == qubit.type
         assert len(hadamard_op.result_types) == 1
         assert hadamard_op.result_types[0] == qubit.type
+
+    @pytest.mark.parametrize(
+        "qubit",
+        [
+            create_ssa_value(qecp.QecPhysicalQubitType("data")),
+            create_ssa_value(qecp.QecPhysicalQubitType("aux")),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "phi, theta, omega",
+        [
+            (
+                create_ssa_value(Float64Type()),
+                create_ssa_value(Float64Type()),
+                create_ssa_value(Float64Type()),
+            ),
+        ],
+    )
+    def test_qecp_op_constructor_hadamard(self, phi, theta, omega, qubit):
+        """Test the constructor of the qecp.rot op."""
+        rot_op = qecp.RotOp(phi, theta, omega, qubit)
+        assert len(rot_op.operands) == 4
+        assert rot_op.operand_types[0] == phi.type
+        assert rot_op.operand_types[1] == theta.type
+        assert rot_op.operand_types[2] == omega.type
+        assert rot_op.operand_types[3] == qubit.type
+        assert len(rot_op.result_types) == 1
+        assert rot_op.result_types[0] == qubit.type
 
     @pytest.mark.parametrize(
         "qubit",

--- a/mlir/include/QecPhysical/IR/QecPhysicalOps.td
+++ b/mlir/include/QecPhysical/IR/QecPhysicalOps.td
@@ -275,6 +275,32 @@ def CnotOp : QecPhysical_Op<"cnot", [
     }];
 }
 
+/**
+ * A physical Rot gate operation.
+ *
+ * ```mlir
+ * %1 = qecp.rot (%phi, %theta, %omega) %0 : !qecp.qubit<data>
+ * ```
+ *
+ */
+class Rot_Op<string mnemonic, list<Trait> traits = []> :
+        QecPhysical_Op<mnemonic, traits> {
+    let arguments = (ins
+        F64:$phi,
+        F64:$theta,
+        F64:$omega,
+        QecPhysicalQubitType:$in_qubit,
+    );
+
+    let results = (outs
+        QecPhysicalQubitType:$out_qubit
+    );
+
+    let assemblyFormat = [{
+        `(` $phi `,` $theta `,` $omega `)` $in_qubit attr-dict `:` qualified(type($in_qubit))
+    }];
+}
+
 def MeasureOp : QecPhysical_Op<"measure", [AllTypesMatch<["in_qubit", "out_qubit"]>]> {
     let summary = "A physical single-qubit projective measurement in the computational basis.";
 

--- a/mlir/include/QecPhysical/IR/QecPhysicalOps.td
+++ b/mlir/include/QecPhysical/IR/QecPhysicalOps.td
@@ -289,7 +289,7 @@ class Rot_Op<string mnemonic, list<Trait> traits = []> :
         F64:$phi,
         F64:$theta,
         F64:$omega,
-        QecPhysicalQubitType:$in_qubit,
+        QecPhysicalQubitType:$in_qubit
     );
 
     let results = (outs

--- a/mlir/include/QecPhysical/IR/QecPhysicalOps.td
+++ b/mlir/include/QecPhysical/IR/QecPhysicalOps.td
@@ -285,6 +285,10 @@ def CnotOp : QecPhysical_Op<"cnot", [
 def RotOp: QecPhysical_Op<"rot", [AllTypesMatch<["in_qubit", "out_qubit"]>]> {
     let summary = "A physical Rot gate operation.";
 
+    let description = [{
+        This operation is for physical noise injection only.
+    }];
+
     let arguments = (ins
         F64:$phi,
         F64:$theta,

--- a/mlir/include/QecPhysical/IR/QecPhysicalOps.td
+++ b/mlir/include/QecPhysical/IR/QecPhysicalOps.td
@@ -282,7 +282,7 @@ def CnotOp : QecPhysical_Op<"cnot", [
  * %1 = qecp.rot (%phi, %theta, %omega) %0 : !qecp.qubit<data>
  * ```
  */
-class RotOp: QecPhysical_Op<"rot", [AllTypesMatch<["in_qubit", "out_qubit"]>]> {
+def RotOp: QecPhysical_Op<"rot", [AllTypesMatch<["in_qubit", "out_qubit"]>]> {
     let summary = "A physical Rot gate operation.";
 
     let arguments = (ins

--- a/mlir/include/QecPhysical/IR/QecPhysicalOps.td
+++ b/mlir/include/QecPhysical/IR/QecPhysicalOps.td
@@ -281,10 +281,10 @@ def CnotOp : QecPhysical_Op<"cnot", [
  * ```mlir
  * %1 = qecp.rot (%phi, %theta, %omega) %0 : !qecp.qubit<data>
  * ```
- *
  */
-class Rot_Op<string mnemonic, list<Trait> traits = []> :
-        QecPhysical_Op<mnemonic, traits> {
+class RotOp: QecPhysical_Op<"rot", [AllTypesMatch<["in_qubit", "out_qubit"]>]> {
+    let summary = "A physical Rot gate operation.";
+
     let arguments = (ins
         F64:$phi,
         F64:$theta,

--- a/mlir/test/QecPhysical/DialectTest.mlir
+++ b/mlir/test/QecPhysical/DialectTest.mlir
@@ -173,6 +173,16 @@ func.func @test_gate_op_s(%arg0 : !qecp.qubit<data>, %arg1 : !qecp.qubit<aux>) {
 
 // -----
 
+func.func @test_gate_op_rot(%phi: f64, %theta: f64,  %omega: f64, %arg0 : !qecp.qubit<data>, %arg1 : !qecp.qubit<aux>) {
+    %0 = qecp.rot (%phi, %theta, %omega) %arg0 : !qecp.qubit<data>
+    %1 = qecp.rot (%phi, %theta, %omega) %0 : !qecp.qubit<data>
+    %2 = qecp.rot (%phi, %theta, %omega) %arg1 : !qecp.qubit<aux>
+    %3 = qecp.rot (%phi, %theta, %omega) %2 : !qecp.qubit<aux>
+    func.return
+}
+
+// -----
+
 func.func @test_gate_op_cnot(
     %arg0 : !qecp.qubit<data>, %arg1 : !qecp.qubit<data>,
     %arg2 : !qecp.qubit<aux>, %arg3 : !qecp.qubit<aux>

--- a/mlir/test/QecPhysical/DialectTest.mlir
+++ b/mlir/test/QecPhysical/DialectTest.mlir
@@ -174,10 +174,10 @@ func.func @test_gate_op_s(%arg0 : !qecp.qubit<data>, %arg1 : !qecp.qubit<aux>) {
 // -----
 
 func.func @test_gate_op_rot(%phi : f64, %theta : f64,  %omega : f64, %arg0 : !qecp.qubit<data>, %arg1 : !qecp.qubit<aux>) {
-    %0 = qecp.rot (%phi, %theta, %omega) %arg0 : !qecp.qubit<data>
-    %1 = qecp.rot (%phi, %theta, %omega) %0 : !qecp.qubit<data>
-    %2 = qecp.rot (%phi, %theta, %omega) %arg1 : !qecp.qubit<aux>
-    %3 = qecp.rot (%phi, %theta, %omega) %2 : !qecp.qubit<aux>
+    %0 = qecp.rot(%phi, %theta, %omega) %arg0 : !qecp.qubit<data>
+    %1 = qecp.rot(%phi, %theta, %omega) %0 : !qecp.qubit<data>
+    %2 = qecp.rot(%phi, %theta, %omega) %arg1 : !qecp.qubit<aux>
+    %3 = qecp.rot(%phi, %theta, %omega) %2 : !qecp.qubit<aux>
     func.return
 }
 

--- a/mlir/test/QecPhysical/DialectTest.mlir
+++ b/mlir/test/QecPhysical/DialectTest.mlir
@@ -173,7 +173,7 @@ func.func @test_gate_op_s(%arg0 : !qecp.qubit<data>, %arg1 : !qecp.qubit<aux>) {
 
 // -----
 
-func.func @test_gate_op_rot(%phi: f64, %theta: f64,  %omega: f64, %arg0 : !qecp.qubit<data>, %arg1 : !qecp.qubit<aux>) {
+func.func @test_gate_op_rot(%phi : f64, %theta : f64,  %omega : f64, %arg0 : !qecp.qubit<data>, %arg1 : !qecp.qubit<aux>) {
     %0 = qecp.rot (%phi, %theta, %omega) %arg0 : !qecp.qubit<data>
     %1 = qecp.rot (%phi, %theta, %omega) %0 : !qecp.qubit<data>
     %2 = qecp.rot (%phi, %theta, %omega) %arg1 : !qecp.qubit<aux>


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new functions and code must be clearly commented and documented.

- [x] Ensure that code is properly formatted by running `make format`.
      The latest version of black and `clang-format-20` are used in CI/CD to check formatting.

- [x] All new features must include a unit test.
      Integration and frontend tests should be added to [`frontend/test`](../frontend/test/),
      Quantum dialect and MLIR tests should be added to [`mlir/test`](../mlir/test/), and
      Runtime tests should be added to [`runtime/tests`](../runtime/tests/).

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

[sc-116176]

This PR adds a new `RotOp` to the QEC physical dialect to support the compile time noise injection. 

NOTE: This operation would be dropped later once we rely on the backend to inject noise. 

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
