### PR TITLE
Ignore deprecation warning in upstream

### DIFF
--- a/mlir/lib/Ion/Transforms/CMakeLists.txt
+++ b/mlir/lib/Ion/Transforms/CMakeLists.txt
@@ -45,6 +45,6 @@ set_source_files_properties(
     gates_to_pulses.cpp
     GatesToPulsesPatterns.cpp
     PROPERTIES
-    COMPILE_FLAGS "-Wno-covered-switch-default"
+    COMPILE_FLAGS "-Wno-covered-switch-default -Wno-deprecated-literal-operator"
 )
 endif()


### PR DESCRIPTION
Most recent version of clang warns about deprecated code in the toml dependency, which breaks our build (warnings as errors). Since we have no control over upstream, we silence it for affected modules only.