### PR TITLE
update cmakelists

### DIFF
--- a/mlir/lib/Ion/Transforms/CMakeLists.txt
+++ b/mlir/lib/Ion/Transforms/CMakeLists.txt
@@ -9,6 +9,26 @@ file(GLOB SRC
     GatesToPulsesPatterns.cpp
 )
 
+include(CheckCXXCompilerFlag)
+
+set(ION_WARNING_FLAGS "")
+
+check_cxx_compiler_flag("-Wcovered-switch-default" HAS_COVERED_SWITCH)
+if(HAS_COVERED_SWITCH)
+    list(APPEND ION_WARNING_FLAGS "-Wno-covered-switch-default")
+endif()
+
+check_cxx_compiler_flag("-Wdeprecated-literal-operator" HAS_DEPRECATED_LITERAL)
+if(HAS_DEPRECATED_LITERAL)
+    list(APPEND ION_WARNING_FLAGS "-Wno-deprecated-literal-operator")
+endif()
+
+if(ION_WARNING_FLAGS)
+    set_source_files_properties(${SRC} PROPERTIES 
+        COMPILE_OPTIONS "${ION_WARNING_FLAGS}"
+    )
+endif()
+
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
 set(LIBS
@@ -22,14 +42,7 @@ set(DEPENDS
     MLIRIonPassIncGen
 )
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set_source_files_properties(${SRC} PROPERTIES 
-        COMPILE_OPTIONS "-Wno-deprecated-literal-operator;-Wno-covered-switch-default"
-    )
-endif()
-
 add_mlir_library(${LIBRARY_NAME} STATIC ${SRC} LINK_LIBS PRIVATE ${LIBS} DEPENDS ${DEPENDS})
-
 target_compile_features(${LIBRARY_NAME} PUBLIC cxx_std_20)
 target_include_directories(${LIBRARY_NAME} PUBLIC
                            .

--- a/mlir/lib/Ion/Transforms/CMakeLists.txt
+++ b/mlir/lib/Ion/Transforms/CMakeLists.txt
@@ -22,7 +22,14 @@ set(DEPENDS
     MLIRIonPassIncGen
 )
 
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    set_source_files_properties(${SRC} PROPERTIES 
+        COMPILE_OPTIONS "-Wno-deprecated-literal-operator;-Wno-covered-switch-default"
+    )
+endif()
+
 add_mlir_library(${LIBRARY_NAME} STATIC ${SRC} LINK_LIBS PRIVATE ${LIBS} DEPENDS ${DEPENDS})
+
 target_compile_features(${LIBRARY_NAME} PUBLIC cxx_std_20)
 target_include_directories(${LIBRARY_NAME} PUBLIC
                            .
@@ -33,18 +40,3 @@ target_link_libraries(${LIBRARY_NAME} PRIVATE
     tomlplusplus::tomlplusplus
     nlohmann_json::nlohmann_json
 )
-
-# toml++ source has a warning which we want to ignore. Surprisingly, the SYSTEM keyword does not
-# seem to affect the headers, at least with this specific warning (only present on clang, not gcc).
-if(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
-set_source_files_properties(
-    ion-to-llvm.cpp
-    ion-to-rtio.cpp
-    IonToRTIOPatterns.cpp
-    ConversionPatterns.cpp
-    gates_to_pulses.cpp
-    GatesToPulsesPatterns.cpp
-    PROPERTIES
-    COMPILE_FLAGS "-Wno-covered-switch-default -Wno-deprecated-literal-operator"
-)
-endif()


### PR DESCRIPTION
**Context:**
The prior fix for silencing deprecation warnings from toml++ worked for clang, but was applied in such a way that the wheels build using gcc raised an error for the unknown flag.

**Description of the Change:**
Update the cmake logic to use `COMPILE_OPTIONS` rather than `COMPILE_FLAGS`, apply before adding the library.

**Benefits:**
Wheels build.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A
