### PR TITLE
fix: update import path of `to_ppr` to fix LLL

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -406,6 +406,7 @@
 
 * `catalyst.from_plxpr.register_transforms` as a way to access MLIR passes from Python has been removed in favour of the new unified transforms API. MLIR passes can be accessed from Python using `qml.transform(pass_name="some-pass-name")`.
   [(#2509)](https://github.com/PennyLaneAI/catalyst/pull/2509)
+  [(#2680)](https://github.com/PennyLaneAI/catalyst/pull/2680)
 
 * `catalyst.jax_primitives.subroutine` has been moved to `qml.capture.subroutine`.
   [(#2396)](https://github.com/PennyLaneAI/catalyst/pull/2396)

--- a/frontend/test/pytest/test_pauli_rot_and_measure.py
+++ b/frontend/test/pytest/test_pauli_rot_and_measure.py
@@ -17,7 +17,7 @@
 import numpy as np
 import pennylane as qml
 import pytest
-from pennylane.transforms.decompositions import to_ppr
+from pennylane.transforms import to_ppr
 
 from catalyst import qjit
 

--- a/frontend/test/pytest/test_peephole_optimizations.py
+++ b/frontend/test/pytest/test_peephole_optimizations.py
@@ -17,7 +17,7 @@
 import numpy as np
 import pennylane as qml
 import pytest
-from pennylane.transforms.decompositions import to_ppr as qml_to_ppr
+from pennylane.transforms import to_ppr as qml_to_ppr
 
 from catalyst import measure, pipeline, qjit
 from catalyst.passes import (


### PR DESCRIPTION
**Context:**

https://github.com/PennyLaneAI/pennylane/pull/9020/changes updated the import of these Catalyst based transforms.

**Description of the Change:**

Updates the import path. Tested [here](https://github.com/PennyLaneAI/catalyst/actions/runs/24348647038).