### PR TITLE
Decomposition of HybridAdjoint is handled by MLIR

### DIFF
--- a/frontend/catalyst/device/decomposition.py
+++ b/frontend/catalyst/device/decomposition.py
@@ -38,6 +38,7 @@ from pennylane.measurements import (
 from pennylane.transforms.decompose import _resolve_gate_set
 
 from catalyst.api_extensions import HybridCtrl
+from catalyst.api_extensions.quantum_operators import HybridAdjoint
 from catalyst.device.op_support import (
     is_active,
     is_controllable,
@@ -128,7 +129,10 @@ def catalyst_decompose(
                 "grad_method is not taken into account in catalyst_decompose if target_gates are "
                 "provided instead of device capabilities."
             )
-        target_gates, stopping_condition = _resolve_gate_set(target_gates, None)
+        target_gates, gate_set_stopping_condition = _resolve_gate_set(target_gates, None)
+        stopping_condition = lambda op: (
+            isinstance(op, HybridAdjoint) or gate_set_stopping_condition(op)
+        )
         decomposer = None
     else:
         if target_gates is not None:
@@ -252,6 +256,8 @@ def catalyst_acceptance(
         return None
 
     if isinstance(op, qml.ops.Adjoint):
+        if has_nested_tapes(op.base):
+            return None
         match = catalyst_acceptance(op.base, capabilities, grad_method)
         if match and is_invertible(op.base, capabilities):
             return match

--- a/frontend/test/pytest/test_preprocess.py
+++ b/frontend/test/pytest/test_preprocess.py
@@ -263,6 +263,28 @@ class TestPreprocessHybridOp:
                     [op.name in expected_ops for op in new_region.quantum_tape.operations]
                 )
 
+    def test_adjoint_of_loop_in_mlir(self):
+        """Test that adjoint of a ForLoop can be compiled to MLIR."""
+        from catalyst.debug import get_compilation_stage
+
+        dev = qml.device("lightning.qubit", wires=3)
+
+        @qjit(keep_intermediate=True)
+        @qml.qnode(dev)
+        def circuit():
+            @for_loop(0, 3, 1)
+            def loop(i):
+                qml.RX(0.5, wires=i)
+                qml.RY(0.5, wires=i)
+
+            adjoint(loop)()
+            return qml.state()
+
+        mlir_after = get_compilation_stage(circuit, "QuantumCompilationStage")
+
+        assert "quantum.adjoint" not in mlir_after
+        assert mlir_after.count("scf.for") > 0
+
     @pytest.mark.parametrize("x, y", [(1.23, -0.4), (0.7, 0.25), (-1.51, 0.6)])
     def test_decomposition_of_adjoint_circuit(self, x, y):
         """Test that unsupported operators nested in Adjoint are decompsed


### PR DESCRIPTION
**Context:**

Currently, the following code will run into failure during the decomposition. 
```python
import pennylane as qp
from catalyst.device.decomposition import catalyst_decompose

qp.decomposition.enable_graph()

gate_set = {"X", "ForLoop"}

@qp.qjit(capture=False)
@catalyst_decompose(capabilities=None, target_gates=gate_set)
@qp.qnode(qp.device("null.qubit"))
def node():
    @qp.for_loop(0, 5, 1)
    def loop(i):
        qp.X(i)

    qp.adjoint(loop)()
    return qp.probs()

print(node())
```

Failure:
```
catalyst.utils.exceptions.CompileError: Operator Adjoint(ForLoop(tapes=[[X(JitTracer<~int64[]>)]])) not supported with catalyst on this device and does not provide a decomposition.
```

**Description of the Change:**

There is a scenario where, if the transformation is done the way shown here:
```python
loop_region = HybridOpRegion(
    [], QuantumScript([qml.RX(0.123, 0), qml.RY(0.456, 1)]), [], []
)
loop_region.trace = None
forloop_op = ForLoop([0, 3, 1], [], [loop_region])
tape = QuantumScript([qml.adjoint(forloop_op)])

(new_tape,), _ = catalyst_decompose(
    tape, capabilities=None, target_gates={"RX", "RY", "ForLoop"}
)
```
then we need to support `ForLoop` in catalyst's `control_flow.py` with a matching adjoint implementation. And in catalyst's `jax_primitives.py` invert the loop index. But that approach only works for the code path above. If we go through `qjit`, we will run into JAX tracer limitations, so it cannot be resolved during tracing.

And because catalyst already supports adjoint lowering, a more practical approach could just put `HybridAdjoint` in the decomposition `stopping_condition`, so that this op is lowered and transformed on the MLIR side instead.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-116161]