### PR TITLE
Adjoint Callable with lazy=False is QJIT compatible

### DIFF
--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -391,23 +391,29 @@ class AdjointCallable:
         else:
             raise ValueError(f"Expected a callable or a qml.Operator, not {target}")
 
-        if not self.lazy and not self.single_op:
-            # Supporting this for a qfunc is technically possible by invoking the decomposition on
-            # HybridAdjoint with laza=False, however one would need to outline the classical jaxpr
-            # into the outer scope, and possibly re-mapping tracers in the quantum operators,
-            # in order to avoid escaped tracers which indicate an invalid program.
-            raise ValueError(
-                "Eagerly computing the adjoint (lazy=False) is only supported on single operators."
-            )
-
     def __call__(self, *args, **kwargs):
         if self.single_op:
             base_op = self.target if self.instantiated else self.target(*args, **kwargs)
             return create_adjoint_op(base_op, self.lazy)
 
+        if not self.lazy:
+            return self._expand_adjoint_callable(args, kwargs)
+
         tracing_artifacts = self.trace_body(args, kwargs)
         dbg = tracing_artifacts[3]
         return HybridAdjoint(*tracing_artifacts[0:3], debug_info=dbg)
+
+    def _expand_adjoint_callable(self, args, kwargs):
+        """Expand a callable into individual ops, then reverse and adjoint each one."""
+        with QueuingManager.stop_recording(), QuantumTape() as tape:
+            self.target(*args, **kwargs)
+
+        for op in reversed(tape.operations):
+            # HybridAdjoint and HybridCtrl can be handled by create_adjoint_op directly
+            if isinstance(op, HybridOp) and not isinstance(op, (HybridAdjoint, HybridCtrl)):
+                AdjointCallable(lambda bound_op=op: qml.apply(bound_op) and None, lazy=True)()
+            else:
+                create_adjoint_op(op, lazy=False)
 
     def trace_body(self, args, kwargs):
         """Generate a HybridOpRegion for use by Catalyst."""

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -409,8 +409,9 @@ class AdjointCallable:
             self.target(*args, **kwargs)
 
         for op in reversed(tape.operations):
-            # HybridAdjoint and HybridCtrl can be handled by create_adjoint_op directly
-            if isinstance(op, HybridOp) and not isinstance(op, (HybridAdjoint, HybridCtrl)):
+            # For Adjoint of HybridAdjoint, we still create the HybridAdjoint of HybridAdjoint, so
+            # that the MLIR adjoint-lowering pass can handle the reversal.
+            if isinstance(op, HybridOp):
                 AdjointCallable(lambda bound_op=op: qml.apply(bound_op) and None, lazy=True)()
             else:
                 create_adjoint_op(op, lazy=False)

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -639,16 +639,6 @@ class TestCatalyst:
         assert isinstance(decomp[1].base, qml.RY)
         assert decomp[1].base.data == (0.7,)
 
-    def test_qfunc_eager(self, backend):
-        """Test the error message raised for eager adjoint on qfuncs."""
-
-        def qfunc(x, w):
-            qml.RY(x, wires=w)
-            qml.CNOT(wires=[1, w])
-
-        with pytest.raises(ValueError, match="Eagerly computing the adjoint"):
-            catalyst.adjoint(qfunc, lazy=False)(0.1, 0)
-
 
 #####################################################################################
 #### ADJOINT TEST SUITE COPIED OVER FROM PENNYLANE FOR UNIFIED BEHAVIOUR TESTING ####

--- a/frontend/test/pytest/test_preprocess.py
+++ b/frontend/test/pytest/test_preprocess.py
@@ -680,7 +680,7 @@ class TestAdjointCallableLazyFalse:
     def test_adjoint_callable_lazy_false_with_nested_hybrid_adjoint(self):
         """Test adjoint(callable, lazy=False) when the callable contains a HybridAdjoint.
 
-        It's expected to produce a HybridAdjoint of HybridAdjoint(Z) so that the MLIR
+        It's expected to produce a HybridAdjoint of HybridAdjoint(RX) so that the MLIR
         adjoint-lowering pass can handle the reversal.
         """
 
@@ -688,7 +688,7 @@ class TestAdjointCallableLazyFalse:
 
         def g():
             qml.H(0)
-            qml.adjoint(lambda: qml.Z(0) and None)()
+            qml.adjoint(lambda: qml.RX(1.23, 0) and None)()
             qml.X(0)
 
         @qjit(capture=False)

--- a/frontend/test/pytest/test_preprocess.py
+++ b/frontend/test/pytest/test_preprocess.py
@@ -632,5 +632,51 @@ class TestPreprocessHybridOp:
             _ = catalyst_decompose(tape, None, grad_method="fd", target_gates={"X"})
 
 
+class TestAdjointCallableLazyFalse:
+    """Test adjoint(callable, lazy=False) in @qjit."""
+
+    def test_qml_adjoint_callable_lazy_false_with_for_loop(self):
+        """Test that qml.adjoint(callable, lazy=False) works."""
+        dev = qml.device("lightning.qubit", wires=6)
+
+        @qjit(capture=False)
+        @qml.qnode(dev)
+        def circuit():
+            @for_loop(0, 3, 1)
+            def loop(i):
+                qml.Toffoli(wires=[i, i + 1, i + 2])
+
+            qml.adjoint(lambda: loop(), lazy=False)()
+            return qml.state()
+
+        result = circuit()
+        assert np.isclose(result[0], 1.0)
+
+    def test_adjoint_callable_lazy_false_mixed_ops_identity(self):
+        """Test adjoint(sub) == Identity for a callable with mixed gates and for_loop."""
+        dev = qml.device("lightning.qubit", wires=6)
+
+        @qjit(capture=False)
+        @qml.qnode(dev)
+        def circuit():
+            def sub():
+                qml.Hadamard(0)
+
+                @for_loop(0, 3, 1)
+                def loop(i):
+                    qml.RX(0.5, wires=i)
+                    qml.CNOT(wires=[i, i + 1])
+
+                loop()
+                qml.T(wires=2)
+
+            qml.adjoint(sub, lazy=False)()
+            sub()
+            return qml.state()
+
+        result = circuit()
+        assert np.isclose(result[0], 1.0)
+
+
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_preprocess.py
+++ b/frontend/test/pytest/test_preprocess.py
@@ -664,7 +664,7 @@ class TestAdjointCallableLazyFalse:
 
                 @for_loop(0, 3, 1)
                 def loop(i):
-                    qml.RX(0.5, wires=i)
+                    qml.RY(0.5, wires=i)
                     qml.CNOT(wires=[i, i + 1])
 
                 loop()

--- a/frontend/test/pytest/test_preprocess.py
+++ b/frontend/test/pytest/test_preprocess.py
@@ -677,6 +677,30 @@ class TestAdjointCallableLazyFalse:
         result = circuit()
         assert np.isclose(result[0], 1.0)
 
+    def test_adjoint_callable_lazy_false_with_nested_hybrid_adjoint(self):
+        """Test adjoint(callable, lazy=False) when the callable contains a HybridAdjoint.
+
+        It's expected to produce a HybridAdjoint of HybridAdjoint(Z) so that the MLIR
+        adjoint-lowering pass can handle the reversal.
+        """
+
+        dev = qml.device("lightning.qubit", wires=1)
+
+        def g():
+            qml.H(0)
+            qml.adjoint(lambda: qml.Z(0) and None)()
+            qml.X(0)
+
+        @qjit(capture=False)
+        @qml.qnode(dev)
+        def circuit():
+            g()
+            qml.adjoint(g, lazy=False)()
+            return qml.state()
+
+        result = circuit()
+        assert np.isclose(result[0], 1.0)
+
 
 if __name__ == "__main__":
     pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_transform.py
+++ b/frontend/test/pytest/test_transform.py
@@ -1399,9 +1399,6 @@ def test_dynamic_one_shot(backend):
     assert expected_shape == observed_shape
 
 
-@pytest.mark.xfail(
-    reason="QJIT fails with ValueError: Eagerly computing the adjoint (lazy=False) is only supported on single operators."
-)
 def test_pattern_matching_optimization(backend):
     """Test pattern_matching_optimization"""
 


### PR DESCRIPTION
**Context:**

Previously, the eager adjoint of a callable will raise a `ValueError` inside `@qjit` because eagerly computing the adjoint of a callable was not supported. This is needed for QJIT compatibility of MultiControlledX (used in `_mcx_one_worker` and `_mcx_two_workers`), whose decomposition rules use `adjoint(fn, lazy=False)`.

**Description of the Change:**

The new `_expand_adjoint_callable` method handles this by executing the callable, collecting the resulting ops, then processing each one in reverse order:

1. Simple gates (RX, Toffoli, etc.) are eagerly adjointed via `create_adjoint_op(op, lazy=False)`, so the tape contains concrete adjoint gates
2. For HybridOps (ForLoop, Cond, WhileLoop) are individually wrapped in HybridAdjoint, delegating their reversal to the MLIR adjoint-lowering pass.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-116178]