### PR TITLE
Add a `NoiseOp` to the QEC physical layer

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -874,6 +874,7 @@
   [(#2574)](https://github.com/PennyLaneAI/catalyst/pull/2574)
   [(#2576)](https://github.com/PennyLaneAI/catalyst/pull/2576)
   [(#2673)](https://github.com/PennyLaneAI/catalyst/pull/2673)
+  [(#2686)](https://github.com/PennyLaneAI/catalyst/pull/2686)
 
 * A number of deprecation warnings have been fixed in the compiler python interface.
   [(#2621)](https://github.com/PennyLaneAI/catalyst/pull/2621)

--- a/frontend/catalyst/python_interface/dialects/qecp.py
+++ b/frontend/catalyst/python_interface/dialects/qecp.py
@@ -740,7 +740,7 @@ class RotOp(IRDLOperation):
 class NoiseOp(IRDLOperation):
     """Inject physical noise on elements of a physical codeblock."""
 
-    T: ClassVar = VarConstraint("T", PhysicalCodeblockType)
+    T: ClassVar = VarConstraint("T", anyPhysicalCodeblock)
 
     name = "qecp.noise"
 

--- a/frontend/catalyst/python_interface/dialects/qecp.py
+++ b/frontend/catalyst/python_interface/dialects/qecp.py
@@ -737,6 +737,33 @@ class RotOp(IRDLOperation):
 
 
 @irdl_op_definition
+class NoiseOp(IRDLOperation):
+    """Inject physical noise on elements of a physical codeblock."""
+
+    T: ClassVar = VarConstraint("T", PhysicalCodeblockType)
+
+    name = "qecp.noise"
+
+    in_codeblock = operand_def(T)
+
+    out_codeblock = result_def(T)
+
+    assembly_format = """
+            $in_codeblock attr-dict `:` type($in_codeblock)
+        """
+
+    def __init__(
+        self,
+        in_codeblock: PhysicalCodeBlockSSAValue | Operation,
+    ):
+        operands = (in_codeblock,)
+
+        in_codeblock_type = get_physical_codeblock_type(in_codeblock)
+
+        super().__init__(operands=operands, result_types=(in_codeblock_type,))
+
+
+@irdl_op_definition
 class MeasureOp(IRDLOperation):
     """A physical single-qubit projective measurement in the computational basis."""
 
@@ -878,6 +905,7 @@ QecPhysical = Dialect(
         SOp,
         CnotOp,
         MeasureOp,
+        NoiseOp,
         AssembleTannerGraphOp,
         DecodeEsmCssOp,
         DecodePhysicalMeasurementOp,

--- a/frontend/test/pytest/python_interface/dialects/test_qecl_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_qecl_dialect.py
@@ -302,6 +302,12 @@ def test_assembly_format(run_filecheck, pretty_print):
     // CHECK: [[block11:%.+]], [[block12:%.+]] = qecl.cnot [[block_ctrl]][{{\s*}}0], [[block10]][{{\s*}}0]
     %block_ctrl = "test.op"() : () -> !qecl.codeblock<1>
     %block11, %block12 = qecl.cnot %block_ctrl[0], %block10[0] : !qecl.codeblock<1>, !qecl.codeblock<1>
+    
+    // CHECK: [[block13:%.+]] = "test.op"() : () -> !qecl.codeblock<1>
+    // CHECK: [[block14:%.+]] = qecl.noise [[block13:%.+]] : !qecl.codeblock<1>
+    %block13 = "test.op"() : () -> !qecl.codeblock<1>
+    %block14 = qecl.noise %block13 : !qecl.codeblock<1>
+    
     """
 
     run_filecheck(program, roundtrip=True, verify=True, pretty_print=pretty_print)

--- a/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
@@ -62,6 +62,7 @@ expected_ops_names = {
     "SOp": "qecp.s",
     "RotOp": "qecp.rot",
     "CnotOp": "qecp.cnot",
+    "NoiseOp": "qecp.noise",
     "MeasureOp": "qecp.measure",
     "AssembleTannerGraphOp": "qecp.assemble_tanner",
     "DecodeEsmCssOp": "qecp.decode_esm_css",
@@ -400,6 +401,14 @@ class TestQecPhysicalOps:
         assert len(decode_physical_meas_op.result_types) == 1
         assert decode_physical_meas_op.result_types[0] == result_type
 
+    def test_qecp_op_constructor_noise(self):
+        """Test the constructor of the qecp.noise op."""
+        noise_op = qecp.NoiseOp(in_codeblock=self._get_codeblock_value())
+        assert len(noise_op.result_types) == 1
+        assert isinstance(noise_op.result_types[0], qecp.PhysicalCodeblockType)
+        assert noise_op.result_types[0].k == self.k
+        assert noise_op.result_types[0].n == self.n
+
 
 @pytest.mark.parametrize(
     "pretty_print", [pytest.param(True, id="pretty_print"), pytest.param(False, id="generic_print")]
@@ -523,6 +532,9 @@ def test_assembly_format(run_filecheck, pretty_print):
     // CHECK: [[mres1:%.+]], [[qa9:%.+]] = qecp.measure [[qa8]] : i1, !qecp.qubit<aux>
     %mres0, %qd9 = qecp.measure %qd8 : i1, !qecp.qubit<data>
     %mres1, %qa9 = qecp.measure %qa8 : i1, !qecp.qubit<aux>
+
+    // CHECK: [[block2:%.+]] = qecp.noise [[block1]] : !qecp.codeblock<1 x 7>
+    %block2 = qecp.noise %block1 : !qecp.codeblock<1 x 7>
 
     // CHECK: [[tgraph:%.+]] = qecp.assemble_tanner [[row_idx]], [[col_ptr]] : tensor<8xi32>, tensor<6xi32> -> !qecp.tanner_graph<8, 6, i32>
     %tgraph = qecp.assemble_tanner %row_idx, %col_ptr : tensor<8xi32>, tensor<6xi32> -> !qecp.tanner_graph<8, 6, i32>

--- a/mlir/include/QecPhysical/IR/QecPhysicalOps.td
+++ b/mlir/include/QecPhysical/IR/QecPhysicalOps.td
@@ -305,6 +305,22 @@ def RotOp: QecPhysical_Op<"rot", [AllTypesMatch<["in_qubit", "out_qubit"]>]> {
     }];
 }
 
+def NoiseOp : QecPhysical_Op<"noise", [AllTypesMatch<["in_codeblock", "out_codeblock"]>]> {
+    let summary = "Inject physical noise on elements of a physical codeblock.";
+
+    let arguments = (ins
+        PhysicalCodeblockType:$in_codeblock
+    );
+
+    let results = (outs
+        PhysicalCodeblockType:$out_codeblock
+    );
+
+    let assemblyFormat = [{
+        $in_codeblock attr-dict `:` qualified(type($in_codeblock))
+    }];
+}
+
 def MeasureOp : QecPhysical_Op<"measure", [AllTypesMatch<["in_qubit", "out_qubit"]>]> {
     let summary = "A physical single-qubit projective measurement in the computational basis.";
 

--- a/mlir/test/QecPhysical/DialectTest.mlir
+++ b/mlir/test/QecPhysical/DialectTest.mlir
@@ -196,6 +196,13 @@ func.func @test_gate_op_cnot(
 
 // -----
 
+func.func @test_noise(%arg0 : !qecp.codeblock<1>) {
+    %0 = qecp.noise %arg0 : !qecp.codeblock<1>
+    func.return
+}
+
+// -----
+
 func.func @test_tanner_graph_type(%arg0 : !qecp.tanner_graph<8, 6, i32>) {
     func.return
 }

--- a/mlir/test/QecPhysical/DialectTest.mlir
+++ b/mlir/test/QecPhysical/DialectTest.mlir
@@ -196,8 +196,8 @@ func.func @test_gate_op_cnot(
 
 // -----
 
-func.func @test_noise(%arg0 : !qecp.codeblock<1>) {
-    %0 = qecp.noise %arg0 : !qecp.codeblock<1>
+func.func @test_noise(%arg0 : !qecp.codeblock<1 x 7>) {
+    %0 = qecp.noise %arg0 : !qecp.codeblock<1 x 7>
     func.return
 }
 


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new functions and code must be clearly commented and documented.

- [x] Ensure that code is properly formatted by running `make format`.
      The latest version of black and `clang-format-20` are used in CI/CD to check formatting.

- [x] All new features must include a unit test.
      Integration and frontend tests should be added to [`frontend/test`](../frontend/test/),
      Quantum dialect and MLIR tests should be added to [`mlir/test`](../mlir/test/), and
      Runtime tests should be added to [`runtime/tests`](../runtime/tests/).

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

[sc-116499]

This PR add a `qecp.noise` operation to the `qecp` dialect. `qecp.noise` operations would be the rewriting targets for the `noise` operation to `noise subroutine` lowering instead of lowering the `qecl.noise` directly. With the QEC code information added to the `qecp.codeblock`, the `noise` operation to `subroutine` lowering would be more straight forward and safer.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
