### PR TITLE
Support adjoint of switch operator

### DIFF
--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -1664,6 +1664,13 @@ class Switch(HybridOp):
     """PennyLane's switch operation"""
 
     binder = switch_p.bind
+    has_adjoint = True
+
+    def adjoint(self):
+        """Produce an adjoint version of this operator. Here, we simply regenerate a HybridAdjoint
+        version of the operation, which is generally supported by Catalyst."""
+
+        return qml.adjoint(lambda: qml.apply(self) and None)()
 
     def trace_quantum(self, ctx, device, trace, qrp) -> QRegPromise:
         return trace_quantum_branches(self, ctx, device, trace, qrp)

--- a/frontend/catalyst/device/verification.py
+++ b/frontend/catalyst/device/verification.py
@@ -43,7 +43,7 @@ from pennylane.ops import (
 )
 from pennylane.tape import QuantumTape
 
-from catalyst.api_extensions import Cond, ForLoop, HybridAdjoint, HybridCtrl, WhileLoop
+from catalyst.api_extensions import Cond, ForLoop, HybridAdjoint, HybridCtrl, WhileLoop, Switch
 from catalyst.device.op_support import (
     EMPTY_PROPERTIES,
     is_active,
@@ -180,7 +180,7 @@ def verify_operations(tape: QuantumTape, grad_method, qjit_device):
             _inv_op_checker(op.base, in_inverse)
             return in_inverse
         # Exclude control flow ops we always know how to invert
-        if type(op) in (Cond, ForLoop, WhileLoop):
+        if type(op) in (Cond, ForLoop, WhileLoop, Switch):
             return in_inverse
         # Early exit when not in inverse, only determine the inverse status for recursing later.
         elif not in_inverse:

--- a/frontend/catalyst/device/verification.py
+++ b/frontend/catalyst/device/verification.py
@@ -43,7 +43,7 @@ from pennylane.ops import (
 )
 from pennylane.tape import QuantumTape
 
-from catalyst.api_extensions import Cond, ForLoop, HybridAdjoint, HybridCtrl, WhileLoop, Switch
+from catalyst.api_extensions import Cond, ForLoop, HybridAdjoint, HybridCtrl, Switch, WhileLoop
 from catalyst.device.op_support import (
     EMPTY_PROPERTIES,
     is_active,

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -1756,8 +1756,8 @@ class TestAdjointOfTemplates:
 
             return qml.expval(qml.Z(0))
 
-        with pytest.raises(cat.CompileError, match=r"Adjoint\(Switch.+\) not supported"):
-            qjit(circuit)
+        result = qjit(circuit)(0)
+        assert np.isclose(result, 1.0)
 
 
 if __name__ == "__main__":

--- a/mlir/include/Quantum/Utils/QuantumSplitting.h
+++ b/mlir/include/Quantum/Utils/QuantumSplitting.h
@@ -54,6 +54,7 @@ class AugmentedCircuitGenerator {
     void visitOperation(mlir::scf::ForOp forOp, mlir::OpBuilder &builder);
     void visitOperation(mlir::scf::WhileOp forOp, mlir::OpBuilder &builder);
     void visitOperation(mlir::scf::IfOp forOp, mlir::OpBuilder &builder);
+    void visitOperation(mlir::scf::IndexSwitchOp indexSwitchOp, mlir::OpBuilder &builder);
 
     void cloneTerminatorClassicalOperands(mlir::Operation *terminator, mlir::OpBuilder &builder);
 

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -101,6 +101,9 @@ class AdjointGenerator {
             else if (auto whileOp = dyn_cast<scf::WhileOp>(op)) {
                 visitOperation(whileOp, builder);
             }
+            else if (auto switchOp = dyn_cast<scf::IndexSwitchOp>(op)) {
+                visitOperation(switchOp, builder);
+            }
             else if (auto insertOp = dyn_cast<quantum::InsertOp>(op)) {
                 Value dynamicWire = getDynamicWire(insertOp, builder);
                 auto extractOp = quantum::ExtractOp::create(
@@ -545,6 +548,58 @@ class AdjointGenerator {
                         getQuantumReg(whileOp.getAfter().front().getArguments()).value()));
             });
         remappedValues.map(getQuantumReg(whileOp.getInits()).value(), replacedWhile.getResult(0));
+    }
+
+    void visitOperation(scf::IndexSwitchOp switchOp, OpBuilder &builder)
+    {
+        std::optional<Value> qureg = getQuantumReg(switchOp.getResults());
+        if (!qureg.has_value()) {
+            return;
+        }
+
+        Value tape = cache.controlFlowTapes.at(switchOp.getOperation());
+        Value index = ListPopOp::create(builder, switchOp.getLoc(), tape);
+        Value reversedResult = remappedValues.lookup(getQuantumReg(switchOp.getResults()).value());
+
+        auto findOldestQuregInRegion = [&](Region &region) {
+            for (Operation &innerOp : region.getOps()) {
+                for (Value operand : innerOp.getOperands()) {
+                    if (isa<quantum::QuregType>(operand.getType())) {
+                        return operand;
+                    }
+                }
+            }
+            llvm_unreachable("failed to find qureg in scf.index_switch region");
+        };
+
+        auto newSwitchOp = scf::IndexSwitchOp::create(builder, switchOp.getLoc(),
+                                                      TypeRange{reversedResult.getType()}, index,
+                                                      switchOp.getCases(), switchOp.getNumCases());
+
+        auto fillRegion = [&](Region &oldRegion, Region &newRegion) {
+            OpBuilder::InsertionGuard guard(builder);
+            newRegion.push_back(new Block());
+            builder.setInsertionPointToStart(&newRegion.front());
+
+            std::optional<Value> yieldedQureg =
+                getQuantumReg(oldRegion.front().getTerminator()->getOperands());
+            remappedValues.map(yieldedQureg.value(), reversedResult);
+            generateImpl(oldRegion, builder);
+            scf::YieldOp::create(builder, switchOp.getLoc(),
+                                 remappedValues.lookup(findOldestQuregInRegion(oldRegion)));
+        };
+
+        // Case regions:
+        for (auto [oldCaseRegion, newCaseRegion] :
+             llvm::zip_equal(switchOp.getCaseRegions(), newSwitchOp.getCaseRegions())) {
+            fillRegion(oldCaseRegion, newCaseRegion);
+        }
+
+        // Default region:
+        fillRegion(switchOp.getDefaultRegion(), newSwitchOp.getDefaultRegion());
+
+        Value startingQureg = findOldestQuregInRegion(switchOp.getDefaultRegion());
+        remappedValues.map(startingQureg, newSwitchOp.getResult(0));
     }
 
   private:

--- a/mlir/lib/Quantum/Utils/QuantumSplitting.cpp
+++ b/mlir/lib/Quantum/Utils/QuantumSplitting.cpp
@@ -94,7 +94,7 @@ QuantumCache QuantumCache::initialize(Region &region, OpBuilder &builder, Locati
     // Initialize the tapes that store the structure of control flow.
     DenseMap<Operation *, TypedValue<ArrayListType>> controlFlowTapes;
     region.walk([&](Operation *op) {
-        if (isa<scf::ForOp, scf::IfOp, scf::WhileOp>(op)) {
+        if (isa<scf::ForOp, scf::IfOp, scf::WhileOp, scf::IndexSwitchOp>(op)) {
             auto tape = catalyst::ListInitOp::create(builder, loc, controlFlowTapeType);
             controlFlowTapes.insert({op, tape});
         }
@@ -222,6 +222,9 @@ void AugmentedCircuitGenerator::generate(Region &region, OpBuilder &builder)
         else if (auto whileOp = dyn_cast<scf::WhileOp>(&op)) {
             visitOperation(whileOp, builder);
         }
+        else if (auto switchOp = dyn_cast<scf::IndexSwitchOp>(op)) {
+            visitOperation(switchOp, builder);
+        }
         else if (auto callOp = dyn_cast<func::CallOp>(op)) {
             auto results = callOp.getResultTypes();
             bool quantum = std::any_of(results.begin(), results.end(), [](const auto &value) {
@@ -330,6 +333,56 @@ void AugmentedCircuitGenerator::visitOperation(scf::WhileOp whileOp, OpBuilder &
     Value numIters = memref::LoadOp::create(builder, whileOp.getLoc(), counter);
     Value tape = cache.controlFlowTapes.at(whileOp);
     ListPushOp::create(builder, whileOp.getLoc(), numIters, tape);
+}
+
+void AugmentedCircuitGenerator::visitOperation(scf::IndexSwitchOp switchOp, OpBuilder &builder)
+{
+    auto getRegionBuilder = [&](Region &oldRegion) {
+        return [&](OpBuilder &builder, Location loc) {
+            generate(oldRegion, builder);
+            cloneTerminatorClassicalOperands(oldRegion.front().getTerminator(), builder);
+        };
+    };
+    DenseMap<unsigned, unsigned> argIdxMapping;
+    populateArgIdxMapping(switchOp.getResultTypes(), argIdxMapping);
+
+    // Cache the switch index to the current control flow tape
+    Value arg = oldToCloned.lookupOrDefault(switchOp.getArg());
+    Value tape = cache.controlFlowTapes.at(switchOp.getOperation());
+    ListPushOp::create(builder, switchOp.getLoc(), oldToCloned.lookupOrDefault(switchOp.getArg()),
+                       tape);
+
+    SmallVector<Type> classicalResultTypes;
+    for (Type ty : switchOp.getResultTypes()) {
+        if (!isQuantumType(ty)) {
+            classicalResultTypes.push_back(ty);
+        }
+    }
+
+    auto newSwitchOp = scf::IndexSwitchOp::create(builder, switchOp.getLoc(), classicalResultTypes,
+                                                  arg, switchOp.getCases(), switchOp.getNumCases());
+
+    // Case and default regions are gotten by different APIs
+    // Here we handle them separately.
+
+    // Case regions:
+    for (auto [oldCaseRegion, newCaseRegion] :
+         llvm::zip_equal(switchOp.getCaseRegions(), newSwitchOp.getCaseRegions())) {
+        OpBuilder::InsertionGuard guard(builder);
+        newCaseRegion.push_back(new Block());
+        builder.setInsertionPointToStart(&newCaseRegion.front());
+        getRegionBuilder(oldCaseRegion)(builder, switchOp.getLoc());
+    }
+
+    // Default region:
+    {
+        OpBuilder::InsertionGuard guard(builder);
+        newSwitchOp.getDefaultRegion().push_back(new Block());
+        builder.setInsertionPointToStart(&newSwitchOp.getDefaultRegion().front());
+        getRegionBuilder(switchOp.getDefaultRegion())(builder, switchOp.getLoc());
+    }
+
+    mapResults(switchOp, newSwitchOp, argIdxMapping);
 }
 
 void AugmentedCircuitGenerator::visitOperation(scf::IfOp ifOp, OpBuilder &builder)

--- a/mlir/test/Quantum/AdjointTest.mlir
+++ b/mlir/test/Quantum/AdjointTest.mlir
@@ -349,3 +349,48 @@ func.func private @param_ordering(%0: !quantum.reg) -> !quantum.reg {
 
   return %1 : !quantum.reg
 }
+
+// -----
+
+// Test adjoint of scf.index_switch
+
+// CHECK-LABEL: @adjoint_index_switch
+func.func private @adjoint_index_switch(%idx: index) -> !quantum.reg {
+  %0 = quantum.alloc( 1) : !quantum.reg
+
+  // CHECK:       catalyst.list_push
+  // CHECK:       [[popped:%.+]] = catalyst.list_pop
+  // CHECK:       scf.index_switch [[popped]]
+  // CHECK:       case 0 {
+  // CHECK:         "PauliX"() {{%.+}} adj
+  // CHECK:       case 1 {
+  // CHECK:         "PauliY"() {{%.+}} adj
+  // CHECK:       default {
+  // CHECK:         "PauliZ"() {{%.+}} adj
+
+  %1 = quantum.adjoint(%0) : !quantum.reg {
+  ^bb0(%arg0: !quantum.reg):
+    %sw = scf.index_switch %idx -> !quantum.reg
+    case 0 {
+      %q = quantum.extract %arg0[ 0] : !quantum.reg -> !quantum.bit
+      %r = quantum.custom "PauliX"() %q : !quantum.bit
+      %out = quantum.insert %arg0[ 0], %r : !quantum.reg, !quantum.bit
+      scf.yield %out : !quantum.reg
+    }
+    case 1 {
+      %q = quantum.extract %arg0[ 0] : !quantum.reg -> !quantum.bit
+      %r = quantum.custom "PauliY"() %q : !quantum.bit
+      %out = quantum.insert %arg0[ 0], %r : !quantum.reg, !quantum.bit
+      scf.yield %out : !quantum.reg
+    }
+    default {
+      %q = quantum.extract %arg0[ 0] : !quantum.reg -> !quantum.bit
+      %r = quantum.custom "PauliZ"() %q : !quantum.bit
+      %out = quantum.insert %arg0[ 0], %r : !quantum.reg, !quantum.bit
+      scf.yield %out : !quantum.reg
+    }
+    quantum.yield %sw : !quantum.reg
+  }
+
+  return %1 : !quantum.reg
+}


### PR DESCRIPTION
**Context:**

Adjoint of `switch` operation is not supported currently.

**Description of the Change:**

Handle the adjoint of switch in MLIR.
This PR is expected based on [the adjoint of control flow's PR](https://github.com/PennyLaneAI/catalyst/pull/2667).

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
https://github.com/PennyLaneAI/catalyst/issues/2670
