### PR TITLE
[qref 2.5.1] Skip transform sequences when looking for subroutine functions

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -601,6 +601,7 @@
   [(#2492)](https://github.com/PennyLaneAI/catalyst/pull/2492)
   [(#2674)](https://github.com/PennyLaneAI/catalyst/pull/2674)
   [(#2642)](https://github.com/PennyLaneAI/catalyst/pull/2642)
+  [(#2692)](https://github.com/PennyLaneAI/catalyst/pull/2692)
 
   Unlike qubit (or qreg) SSA values in the `Quantum` dialect, a qubit (or qreg) reference SSA value
   in the `QRef` dialect is allowed to be used multiple times. The operands of gates and observables

--- a/mlir/lib/QRef/Transforms/value_semantics_conversion.cpp
+++ b/mlir/lib/QRef/Transforms/value_semantics_conversion.cpp
@@ -1745,8 +1745,13 @@ struct ValueSemanticsConversionPass
         // iterator), so that a caller subroutine can correctly collect the qref operands on its
         // call op to a callee subroutine.
         const CallGraph callGraph(mod);
+
         for (auto scc = llvm::scc_begin(&callGraph); !scc.isAtEnd(); ++scc) {
             if ((*scc->begin())->isExternal()) {
+                continue;
+            }
+
+            if (!isa<func::FuncOp>((*scc->begin())->getCallableRegion()->getParentOp())) {
                 continue;
             }
 


### PR DESCRIPTION
**Context:**
When determining which functions are qref subroutines, there's a unconditional cast to `func::FuncOp` in the code. 

As it turns out, in a `mlir::CallGraph`, each node is not guaranteed to be a `func::FuncOp`. Things like `transform.named_sequence` are also considered call graph nodes. 

Which makes sense: each call graph node is only supposed to be a callable, which are all things `FunctionOpInterface`.


**Description of the Change:**
Early exit if the call graph node is not a `func::FuncOp`.


**Benefits:**
Correctness.

[sc-115119]
