### PR TITLE
Fix double extracts when multiple compbasis obs are present

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -455,10 +455,11 @@
 <h3>Bug fixes 🐛</h3>
 
 * Fixed a bug where multiple `quantum.extract` operations from the same index were being created
-  when there are multiple named observables or Hermitian observables on that same wire index,
-  when capture is not enabled.
+  when there are multiple computational basis observables, named observables or Hermitian
+  observables on that same wire index, when capture is not enabled.
   [(#2641)](https://github.com/PennyLaneAI/catalyst/pull/2641)
   [(#2646)](https://github.com/PennyLaneAI/catalyst/pull/2646)
+  [(#????)](https://github.com/PennyLaneAI/catalyst/pull/????)
 
 * :func:`~pennylane.adjoint` can now be used on subroutines with classical arguments.
   [(#2590)](https://github.com/PennyLaneAI/catalyst/pull/2590)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -459,7 +459,7 @@
   observables on that same wire index, when capture is not enabled.
   [(#2641)](https://github.com/PennyLaneAI/catalyst/pull/2641)
   [(#2646)](https://github.com/PennyLaneAI/catalyst/pull/2646)
-  [(#????)](https://github.com/PennyLaneAI/catalyst/pull/????)
+  [(#2693)](https://github.com/PennyLaneAI/catalyst/pull/2693)
 
 * :func:`~pennylane.adjoint` can now be used on subroutines with classical arguments.
   [(#2590)](https://github.com/PennyLaneAI/catalyst/pull/2590)

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -938,7 +938,7 @@ def trace_quantum_operations(
     return qrp
 
 
-# pylint: disable=too-many-branches
+# pylint: disable=too-many-branches,complex-method
 @debug_logger
 def trace_observables(
     obs: Optional[Operator],

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -968,6 +968,9 @@ def trace_observables(
         else:
             qubits = qrp.extract(wires, allow_reuse=True)
             obs_tracers = compbasis_p.bind(*qubits)
+            for w, q in zip(wires, qubits, strict=True):
+                if w not in qrp.cache:
+                    qrp.insert([w], [q])
     elif isinstance(obs, KNOWN_NAMED_OBS):
         # The MLIR NamedObs operation only takes in a single qubit value, instead of a variadic
         # range.

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -938,7 +938,7 @@ def trace_quantum_operations(
     return qrp
 
 
-# pylint: disable=too-many-branches,complex-method
+# pylint: disable=too-many-branches
 @debug_logger
 def trace_observables(
     obs: Optional[Operator],

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -938,6 +938,18 @@ def trace_quantum_operations(
     return qrp
 
 
+def insert_observable_wires_into_cache(qrp, wires, qubits):
+    """
+    When there are multiple observables (compbasis, named or Hermitian), they could be on the same
+    wire.
+    qrp.insert ensures the extracted wires are added to cache, however this call is only
+    allowed on wires that aren't already in the cache.
+    """
+    for w, q in zip(wires, qubits, strict=True):
+        if w not in qrp.cache:
+            qrp.insert([w], [q])
+
+
 # pylint: disable=too-many-branches
 @debug_logger
 def trace_observables(
@@ -968,9 +980,7 @@ def trace_observables(
         else:
             qubits = qrp.extract(wires, allow_reuse=True)
             obs_tracers = compbasis_p.bind(*qubits)
-            for w, q in zip(wires, qubits, strict=True):
-                if w not in qrp.cache:
-                    qrp.insert([w], [q])
+            insert_observable_wires_into_cache(qrp, wires, qubits)
     elif isinstance(obs, KNOWN_NAMED_OBS):
         # The MLIR NamedObs operation only takes in a single qubit value, instead of a variadic
         # range.
@@ -979,21 +989,14 @@ def trace_observables(
         # won't actually lead to wrong execution results, since the only exception is the identity
         # But of course we should fix this at some time.
         # TODO: make the NamedObs op take in multiple qubit values
-
         qubits = qrp.extract([wires[0]], allow_reuse=True)
         obs_tracers = namedobs_p.bind(qubits[0], kind=type(obs).__name__)
-        # When there are multiple named obs, they could be on the same wire
-        # qrp.insert ensures the extracted wires are added to cache, however this call is only
-        # allowed on wires that aren't already in the cache.
-        if wires[0] not in qrp.cache:
-            qrp.insert([wires[0]], [qubits[0]])
+        insert_observable_wires_into_cache(qrp, [wires[0]], [qubits[0]])
     elif isinstance(obs, qml.Hermitian):
         # TODO: remove once fixed upstream: https://github.com/PennyLaneAI/pennylane/issues/4263
         qubits = qrp.extract(wires, allow_reuse=True)
         obs_tracers = hermitian_p.bind(jax.numpy.asarray(*obs.parameters), *qubits)
-        for w, q in zip(wires, qubits, strict=True):
-            if w not in qrp.cache:
-                qrp.insert([w], [q])
+        insert_observable_wires_into_cache(qrp, wires, qubits)
     elif isinstance(obs, qml.ops.op_math.Prod):
         nested_obs = [trace_observables(o, qrp, m_wires)[0] for o in obs]
         obs_tracers = tensorobs_p.bind(*nested_obs)

--- a/frontend/test/lit/test_measurements.py
+++ b/frontend/test/lit/test_measurements.py
@@ -759,3 +759,20 @@ def automatic_qubit_management():
 
 
 print(automatic_qubit_management.mlir)
+
+
+# CHECK-LABEL: @test_multiple_terminal_measurements
+@qjit(target="mlir")
+@qml.qnode(qml.device("null.qubit", wires=2), shots=1000)
+def test_multiple_terminal_measurements():
+    # CHECK: [[q0:%.+]] = quantum.extract {{%.+}}[ 0] : !quantum.reg -> !quantum.bit
+    # CHECK: [[compbasis:%.+]] = quantum.compbasis qubits [[q0]] : !quantum.obs
+    # CHECK: {{%.+}} = quantum.probs [[compbasis]] : tensor<2xf64>
+    # CHECK: [[compbasis:%.+]] = quantum.compbasis qubits [[q0]] : !quantum.obs
+    # CHECK: {{%.+}} = quantum.sample [[compbasis]] : tensor<1000x1xf64>
+    # CHECK: [[namedobs:%.+]] = quantum.namedobs [[q0]][ PauliX] : !quantum.obs
+    # CHECK: {{%.+}} = quantum.expval [[namedobs]] : f64
+    return qml.probs(wires=[0]), qml.sample(wires=[0]), qml.expval(qml.X(0))
+
+
+print(test_multiple_terminal_measurements.mlir)


### PR DESCRIPTION
**Context:**
In #2641, we fixed double extracts when multiple named observables or Hermitian observables are present. 

We should do the same for compbasis observable.

**Description of the Change:**
Insert qubits extracted for compbasis observables back into the cache.

**Benefits:**
No double extracts when multiple compbasis observables are present (in legacy frontend).

[sc-115297]
