### PR TITLE
Remove dynamic qubit allocation from device capabilities in legacy frontend

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -293,10 +293,6 @@
 
 <h3>Improvements 🛠</h3>
 
-* The legacy frontend no longer registers `qml.allocate()` and `qml.deallocate()` onto the qjit device
-  capabilities, since dynamic qubit allocation is only implemented for the capture frontend.
-  [(#2696)](https://github.com/PennyLaneAI/catalyst/pull/2696)
-
 * Added support for ``StatePrep`` kwargs ``pad_with`` and ``normalize`` with program capture enabled.
   [(#2620)](https://github.com/PennyLaneAI/catalyst/pull/2620)
 
@@ -539,6 +535,10 @@
   [(#2582)](https://github.com/PennyLaneAI/catalyst/pull/2582)
 
 <h3>Internal changes ⚙️</h3>
+
+* The legacy frontend no longer registers `qml.allocate()` and `qml.deallocate()` onto the qjit device
+  capabilities, since dynamic qubit allocation is only implemented for the capture frontend.
+  [(#2696)](https://github.com/PennyLaneAI/catalyst/pull/2696)
 
 * Refactors `draw_graph` implementation to improve maintainability.
   [(#2659)](https://github.com/PennyLaneAI/catalyst/pull/2659)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -293,6 +293,10 @@
 
 <h3>Improvements 🛠</h3>
 
+* The legacy frontend no longer registers `qml.allocate()` and `qml.deallocate()` onto the qjit device
+  capabilities, since dynamic qubit allocation is only implemented for the capture frontend.
+  [(#2696)](https://github.com/PennyLaneAI/catalyst/pull/2696)
+
 * Added support for ``StatePrep`` kwargs ``pad_with`` and ``normalize`` with program capture enabled.
   [(#2620)](https://github.com/PennyLaneAI/catalyst/pull/2620)
 

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -238,19 +238,6 @@ def get_qjit_device_capabilities(target_capabilities: DeviceCapabilities) -> Dev
         target_capabilities.measurement_processes, RUNTIME_MPS
     )
 
-    # Enable dynamic qubit allocation with qml.allocate and qml.deallocate
-    # if target_capabilities.dynamic_qubit_management:
-    # qjit_capabilities.operations.update(
-    #     {
-    #         "allocate": OperatorProperties(
-    #             invertible=False, controllable=False, differentiable=False
-    #         ),
-    #         "deallocate": OperatorProperties(
-    #             invertible=False, controllable=False, differentiable=False
-    #         ),
-    #     }
-    # )
-
     # Control-flow gates to be lowered down to the LLVM control-flow instructions
     qjit_capabilities.operations.update(
         {

--- a/frontend/catalyst/device/qjit_device.py
+++ b/frontend/catalyst/device/qjit_device.py
@@ -239,16 +239,17 @@ def get_qjit_device_capabilities(target_capabilities: DeviceCapabilities) -> Dev
     )
 
     # Enable dynamic qubit allocation with qml.allocate and qml.deallocate
-    qjit_capabilities.operations.update(
-        {
-            "allocate": OperatorProperties(
-                invertible=False, controllable=False, differentiable=False
-            ),
-            "deallocate": OperatorProperties(
-                invertible=False, controllable=False, differentiable=False
-            ),
-        }
-    )
+    # if target_capabilities.dynamic_qubit_management:
+    # qjit_capabilities.operations.update(
+    #     {
+    #         "allocate": OperatorProperties(
+    #             invertible=False, controllable=False, differentiable=False
+    #         ),
+    #         "deallocate": OperatorProperties(
+    #             invertible=False, controllable=False, differentiable=False
+    #         ),
+    #     }
+    # )
 
     # Control-flow gates to be lowered down to the LLVM control-flow instructions
     qjit_capabilities.operations.update(


### PR DESCRIPTION
**Context:**
We unconditionally add `qml.allocate()` and `qml.deallocate()` to the device's capability set, regardless of what the device toml says.

This is obviously wrong. In fact, we don't actually need to register these capabilities, because dynamic qubit allocation is only implemented for the plxpr frontend. Catalyst sees the primitives, not the operators.

**Description of the Change:**
Remove the registry of `qml.allocate()` and `qml.deallocate()` from the `qjit_device`'s capabilities.
