### PR TITLE
Add skeleton qecl-to-qecp dialect-conversion pass

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -888,6 +888,10 @@
   [(#2576)](https://github.com/PennyLaneAI/catalyst/pull/2576)
   [(#2673)](https://github.com/PennyLaneAI/catalyst/pull/2673)
 
+* A new, experimental compiler pass `convert-qecl-to-qecp` has been added to lower operations
+  from the QEC Logical (`qecl`) dialect into the QEC Physical (`qecp`) dialect.
+  [(#2697)](https://github.com/PennyLaneAI/catalyst/pull/2697)
+
 * A number of deprecation warnings have been fixed in the compiler python interface.
   [(#2621)](https://github.com/PennyLaneAI/catalyst/pull/2621)
 

--- a/frontend/catalyst/python_interface/transforms/qecp/__init__.py
+++ b/frontend/catalyst/python_interface/transforms/qecp/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""xDSL API for qecp transforms"""
+
+from .convert_qecl_to_qecp import ConvertQecLogicalToQecPhysicalPass, convert_qecl_to_qecp_pass
+
+__all__ = [
+    "ConvertQecLogicalToQecPhysicalPass",
+    "convert_qecl_to_qecp_pass",
+]

--- a/frontend/catalyst/python_interface/transforms/qecp/convert_qecl_to_qecp.py
+++ b/frontend/catalyst/python_interface/transforms/qecp/convert_qecl_to_qecp.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""QEC Logical to QEC Physical dialect conversion.
+
+This module contains the implementation of the xDSL convert-qecl-to-qecp dialect-conversion pass.
+To apply this pass, the QEC code must be know.
+"""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from xdsl.context import Context
+from xdsl.dialects import builtin
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriteWalker,
+)
+from xdsl.transforms.reconcile_unrealized_casts import ReconcileUnrealizedCastsPass
+
+from catalyst.python_interface.pass_api.compiler_transform import compiler_transform
+
+
+class QecCodeKey(StrEnum):
+    """The set of supported QEC codes."""
+
+    # List the supported QEC codes here, e.g.
+    # STEANE_7_1_3 = "steane[[7,1,3]]"
+
+
+# MARK: Conversion Pass
+
+
+@dataclass(frozen=True)
+class ConvertQecLogicalToQecPhysicalPass(ModulePass):
+    """
+    Convert QEC logical instructions to QEC physical instructions.
+    """
+
+    name = "convert-qecl-to-qecp"
+
+    qec_code: QecCodeKey
+
+    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        """Apply the convert-qecl-to-qecp pass."""
+
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier(
+                [
+                    # Insert conversion patterns here
+                ]
+            )
+        ).rewrite_module(op)
+
+        # Certain patterns leave behind `builtin.unrealized_conversion_cast` ops;
+        # this pass removes them
+        ReconcileUnrealizedCastsPass().apply(ctx, op)
+
+
+convert_qecl_to_qecp_pass = compiler_transform(ConvertQecLogicalToQecPhysicalPass)

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecl_to_qecp.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecl_to_qecp.py
@@ -1,0 +1,24 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test module for the convert-qecl-to-qecp dialect-conversion transform."""
+
+import pytest
+
+# from catalyst.python_interface.transforms.qecp import (
+#     ConvertQecLogicalToQecPhysicalPass,
+#     convert_qecl_to_qecp,
+# )
+
+pytestmark = pytest.mark.xdsl


### PR DESCRIPTION
**Context:** In preparation to build a prototype QEC compilation pipeline, this PR adds a skeleton pass to lower a program in a QEC logical representation to a QEC physical representation.

**Description of the Change:** This PR adds a skeleton `convert-qecl-to-qecp` dialect-conversion pass, implemented in xDSL. It contains no rewrite patterns at the moment; these will be added in subsequent PRs. It also adds an empty `QecCodeKey` string-enum class to list the set of QEC codes that this pass will support.

[sc-116637]