### PR TITLE
Add --debug-pipeline option for run_filecheck tests

### DIFF
--- a/frontend/test/conftest.py
+++ b/frontend/test/conftest.py
@@ -77,7 +77,9 @@ def pytest_addoption(parser):
         action="store_true",
         help=(
             "For tests that use the run_filecheck fixture, display the full xDSL module IR before "
-            "and after applying a compilation pipeline",
+            "and after applying a compilation pipeline. This option should generally be used with "
+            "either the '--capture=no' or '-s' option (or similar) in order to display the output "
+            "to the terminal."
         ),
     )
 

--- a/frontend/test/conftest.py
+++ b/frontend/test/conftest.py
@@ -72,6 +72,15 @@ def pytest_addoption(parser):
         " runtime must be compiled with `ENABLE_OPENQASM=ON`",
     )
 
+    parser.addoption(
+        "--debug-pipeline",
+        action="store_true",
+        help=(
+            "For tests that use the run_filecheck fixture, display the full xDSL module IR before "
+            "and after applying a compilation pipeline",
+        ),
+    )
+
 
 def pytest_generate_tests(metafunc):
     """A pytest fixture to define custom parametrization"""

--- a/frontend/test/pytest/python_interface/conftest.py
+++ b/frontend/test/pytest/python_interface/conftest.py
@@ -39,19 +39,7 @@ except (ImportError, ModuleNotFoundError):
     deps_available = False
 
 
-def pytest_addoption(parser: pytest.Parser):
-    """Register custom command line options to pytest."""
-    parser.addoption(
-        "--debug-pipeline",
-        action="store_true",
-        help=(
-            "For tests that use the run_filecheck fixture, display the full xDSL module IR before "
-            "and after applying a compilation pipeline",
-        ),
-    )
-
-
-@pytest.fixture(name="debug_pipeline", scope="session")
+@pytest.fixture(scope="session", name="debug_pipeline")
 def debug_pipeline_fixture(request: pytest.FixtureRequest):
     """Returns whether the --debug-pipeline command line option has been given."""
     return request.config.getoption("--debug-pipeline")

--- a/frontend/test/pytest/python_interface/conftest.py
+++ b/frontend/test/pytest/python_interface/conftest.py
@@ -53,11 +53,16 @@ def pytest_addoption(parser: pytest.Parser):
 
 @pytest.fixture(scope="session")
 def debug_pipeline(request: pytest.FixtureRequest):
+    """Returns whether the --debug-pipeline command line option has been given."""
     return request.config.getoption("--debug-pipeline")
 
 
 @contextmanager
 def debug_step(message, enabled=True):
+    """A convenience context manager that prints a debug message before running a block of code.
+
+    If the block of code executes without error, "OK" is appended to the debug message.
+    """
     if enabled:
         print(f"[DEBUG] {message}... ", end="", flush=True)
 

--- a/frontend/test/pytest/python_interface/conftest.py
+++ b/frontend/test/pytest/python_interface/conftest.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Pytest configuration for tests for the catalyst.python_interface submodule."""
 
+from contextlib import contextmanager
 from inspect import getsource
 from io import StringIO
 
@@ -38,10 +39,39 @@ except (ImportError, ModuleNotFoundError):
     deps_available = False
 
 
+def pytest_addoption(parser: pytest.Parser):
+    """Register custom command line options to pytest."""
+    parser.addoption(
+        "--debug-pipeline",
+        action="store_true",
+        help=(
+            "For tests that use the run_filecheck fixture, display the full xDSL module IR before "
+            "and after applying a compilation pipeline",
+        ),
+    )
+
+
+@pytest.fixture(scope="session")
+def debug_pipeline(request: pytest.FixtureRequest):
+    return request.config.getoption("--debug-pipeline")
+
+
+@contextmanager
+def debug_step(message, enabled=True):
+    if enabled:
+        print(f"[DEBUG] {message}... ", end="", flush=True)
+
+    yield  # The code inside the 'with' block runs here
+
+    if enabled:
+        print("OK")
+
+
 # pylint: disable=too-many-positional-arguments,too-many-arguments
 def _run_filecheck_impl(
+    debug_pipeline,
     program_str: str,
-    pipeline: tuple[ModulePass, ...] = (),
+    passes: tuple[ModulePass, ...] = (),
     verify: bool = False,
     roundtrip: bool = False,
     to_mlir: bool = True,
@@ -54,6 +84,11 @@ def _run_filecheck_impl(
 
     ctx = Context(allow_unregistered=False)
     xdsl_module = QuantumParser(ctx, program_str, extra_dialects=(test.Test,)).parse_module()
+
+    if debug_pipeline:
+        print("\n[DEBUG] ========== RUNNING FILECHECK ==========")
+        print("[DEBUG] Initial xDSL module:")
+        print(xdsl_module)
 
     if roundtrip:
         # Print -> parse to xDSL
@@ -77,8 +112,14 @@ def _run_filecheck_impl(
     if verify:
         xdsl_module.verify()
 
-    pipeline = PassPipeline(pipeline)
-    pipeline.apply(ctx, xdsl_module)
+    pipeline = PassPipeline(passes)
+
+    with debug_step(f"Applying pass pipeline '{pipeline}'", debug_pipeline):
+        pipeline.apply(ctx, xdsl_module)
+
+    if debug_pipeline:
+        print("[DEBUG] After:")
+        print(xdsl_module)
 
     if verify:
         xdsl_module.verify()
@@ -105,7 +146,7 @@ def _run_filecheck_impl(
 
 
 @pytest.fixture(scope="function")
-def run_filecheck():
+def run_filecheck(debug_pipeline):
     """Fixture to run filecheck on an xDSL module.
 
     This fixture uses FileCheck to verify the correctness of a parsed MLIR string. Testers
@@ -132,7 +173,10 @@ def run_filecheck():
     if not deps_available:
         pytest.skip("Cannot run xDSL lit tests without the Python 'filecheck' package.")
 
-    yield _run_filecheck_impl
+    def wrapper(*args, **kwargs):
+        return _run_filecheck_impl(debug_pipeline, *args, **kwargs)
+
+    yield wrapper
 
 
 def _get_filecheck_directives(qjit_fn):

--- a/frontend/test/pytest/python_interface/conftest.py
+++ b/frontend/test/pytest/python_interface/conftest.py
@@ -51,8 +51,8 @@ def pytest_addoption(parser: pytest.Parser):
     )
 
 
-@pytest.fixture(scope="session")
-def debug_pipeline(request: pytest.FixtureRequest):
+@pytest.fixture(name="debug_pipeline", scope="session")
+def debug_pipeline_fixture(request: pytest.FixtureRequest):
     """Returns whether the --debug-pipeline command line option has been given."""
     return request.config.getoption("--debug-pipeline")
 


### PR DESCRIPTION
**Context:** Often a compiler-pass developer wants to see the full IR before and after applying some pass or pipeline, but it is not currently convenient to do so for xDSL tests in the Catalyst Python interface that use the `run_filecheck` fixture.

**Description of the Change:** This PR adds a pytest command line option `--debug-pipeline` that prints out the full IR before and after the given pass pipeline is applied. For example:

```console
$ pytest frontend/test/pytest/python_interface/transforms/quantum/test_xdsl_cancel_inverses.py -k test_simple_self_inverses -s --debug-pipeline
=== test session starts ===
...

frontend/test/pytest/python_interface/transforms/quantum/test_xdsl_cancel_inverses.py 
[DEBUG] ========== RUNNING FILECHECK ==========
[DEBUG] Initial xDSL module:
builtin.module {
  func.func @test_func() {
    %0 = "test.op"() : () -> !quantum.bit
    %1 = quantum.custom "PauliX"() %0 : !quantum.bit
    %2 = quantum.custom "PauliX"() %1 : !quantum.bit
    quantum.dealloc_qb %2 : !quantum.bit
    func.return
  }
}
[DEBUG] Applying pass pipeline 'PassPipeline(passes=(IterativeCancelInversesPass(),), callback=None)'... OK
[DEBUG] After:
builtin.module {
  func.func @test_func() {
    %0 = "test.op"() : () -> !quantum.bit
    quantum.dealloc_qb %0 : !quantum.bit
    func.return
  }
}
.
```

Note that the pytest `--capture=no` or `-s` option (or similar) must also be supplied in order to view the output in the terminal.

[sc-116855]