### PR TITLE
Remove unnecessary registrations for graident primitives

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -538,6 +538,7 @@
 
 * Removes unnessary registrations for the various gradient primitives in `from_plxpr` when we
   are able to just inherit the base behaviour from `PlxprInterpreter`.
+  [(#2706)](https://github.com/PennyLaneAI/catalyst/pull/2706/)
 
 * The legacy frontend no longer registers `qml.allocate()` and `qml.deallocate()` onto the qjit device
   capabilities, since dynamic qubit allocation is only implemented for the capture frontend.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -536,6 +536,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Removes unnessary registrations for the various gradient primitives in `from_plxpr` when we
+  are able to just inherit the base behaviour from `PlxprInterpreter`.
+
 * The legacy frontend no longer registers `qml.allocate()` and `qml.deallocate()` onto the qjit device
   capabilities, since dynamic qubit allocation is only implemented for the capture frontend.
   [(#2696)](https://github.com/PennyLaneAI/catalyst/pull/2696)

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -27,11 +27,7 @@ import pennylane as qml
 from jax.extend.core import ClosedJaxpr, Jaxpr
 from pennylane.capture import PlxprInterpreter, qnode_prim
 from pennylane.capture.expand_transforms import ExpandTransformsInterpreter
-from pennylane.capture.primitives import jacobian_prim as pl_jac_prim
-from pennylane.capture.primitives import jvp_prim as pl_jvp_prim
 from pennylane.capture.primitives import transform_prim
-from pennylane.capture.primitives import value_and_grad_prim as pl_value_and_grad_prim
-from pennylane.capture.primitives import vjp_prim as pl_vjp_prim
 from pennylane.transforms import commute_controlled as pl_commute_controlled
 from pennylane.transforms import decompose as pl_decompose
 from pennylane.transforms import gridsynth as pl_gridsynth

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -258,54 +258,6 @@ class WorkflowInterpreter(PlxprInterpreter):
         super().__init__()
 
 
-@WorkflowInterpreter.register_primitive(pl_jac_prim)
-def handle_grad(self, *args, jaxpr, n_consts, **kwargs):
-    """Translate a grad equation."""
-    f = partial(copy(self).eval, jaxpr, args[:n_consts])
-    new_jaxpr = jax.make_jaxpr(f)(*args[n_consts:])
-
-    new_args = (*new_jaxpr.consts, *args[n_consts:])
-    return pl_jac_prim.bind(
-        *new_args, jaxpr=new_jaxpr.jaxpr, n_consts=len(new_jaxpr.consts), **kwargs
-    )
-
-
-@WorkflowInterpreter.register_primitive(pl_vjp_prim)
-def handle_vjp(self, *args, jaxpr, **kwargs):
-    """Translate a vjp equation."""
-    f = partial(copy(self).eval, jaxpr, [])
-    new_jaxpr = jax.make_jaxpr(f)(*args[: -len(jaxpr.outvars)])
-
-    new_args = (*new_jaxpr.consts, *args)
-    j = new_jaxpr.jaxpr
-    new_j = j.replace(constvars=(), invars=j.constvars + j.invars)
-    return pl_vjp_prim.bind(*new_args, jaxpr=new_j, **kwargs)
-
-
-@WorkflowInterpreter.register_primitive(pl_value_and_grad_prim)
-def handle_value_and_grad(self, *args, jaxpr, **kwargs):
-    """Translate a value_and_grad equation."""
-    f = partial(copy(self).eval, jaxpr, [])
-    new_jaxpr = jax.make_jaxpr(f)(*args)
-
-    new_args = (*new_jaxpr.consts, *args)
-    j = new_jaxpr.jaxpr
-    new_j = j.replace(constvars=(), invars=j.constvars + j.invars)
-    return pl_value_and_grad_prim.bind(*new_args, jaxpr=new_j, **kwargs)
-
-
-@WorkflowInterpreter.register_primitive(pl_jvp_prim)
-def handle_jvp(self, *args, jaxpr, **kwargs):
-    """Translate a vjp equation."""
-    f = partial(copy(self).eval, jaxpr, [])
-    new_jaxpr = jax.make_jaxpr(f)(*args[: len(jaxpr.invars)])
-
-    new_args = (*new_jaxpr.consts, *args)
-    j = new_jaxpr.jaxpr
-    new_j = j.replace(constvars=(), invars=j.constvars + j.invars)
-    return pl_jvp_prim.bind(*new_args, jaxpr=new_j, **kwargs)
-
-
 # pylint: disable=unused-argument, too-many-arguments
 @WorkflowInterpreter.register_primitive(qnode_prim)
 def handle_qnode(


### PR DESCRIPTION
**Context:**

Turns out we didn't actually need any of the registrations for gradients in `WorkflowInterpreter`, since we had the exact same implementation as that defined in the base `PlxprInterpreter`.

**Description of the Change:**

Deletes those unnecessary lines.

**Benefits:**

Less code!

**Possible Drawbacks:**

**Related GitHub Issues:**
