### PR TITLE
Fixed propagation of work wire(s) type

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -532,7 +532,7 @@
 
 * Fixed a bug where the `work_wire_type` argument of `qml.ctrl` was silently dropped inside `@qjit` functions. 
   The parameter is now threaded through `catalyst.ctrl`, `CtrlCallable`, `HybridCtrl`, and
-  `ctrl_distribute`.
+  `ctrl_distribute`, with the default value being `"borrowed"`.
   [(#2710)](https://github.com/PennyLaneAI/catalyst/pull/2710)
 
 * Fixed a bug where multiple `quantum.extract` operations from the same index were being created

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -530,6 +530,11 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed the `work_wire_type` argument of `qml.ctrl` was silently dropped inside `@qjit` function. 
+  The parameter is now threaded through `catalyst.ctrl`, `CtrlCallable`, `HybridCtrl`, and
+  `ctrl_distribute`.
+  [(#2710)](https://github.com/PennyLaneAI/catalyst/pull/2710)
+
 * Fixed a bug where multiple `quantum.extract` operations from the same index were being created
   when there are multiple computational basis observables, named observables or Hermitian
   observables on that same wire index, when capture is not enabled.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -530,7 +530,7 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* Fixed the `work_wire_type` argument of `qml.ctrl` was silently dropped inside `@qjit` function. 
+* Fixed a bug where the `work_wire_type` argument of `qml.ctrl` was silently dropped inside `@qjit` functions. 
   The parameter is now threaded through `catalyst.ctrl`, `CtrlCallable`, `HybridCtrl`, and
   `ctrl_distribute`.
   [(#2710)](https://github.com/PennyLaneAI/catalyst/pull/2710)

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -532,6 +532,7 @@ class HybridAdjoint(HybridOp):
 class CtrlCallable:
     """Callable wrapper to produce a ctrl instance."""
 
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
     def __init__(self, target, control, control_values, work_wires, work_wire_type="borrowed"):
         self.target = target
         self.control_wires = control

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -733,7 +733,7 @@ def ctrl_distribute(
                 new_ops.extend(nested_ops)
             else:
                 for region in [region for region in op.regions if region.quantum_tape is not None]:
-                    # Re-enter a JAXPR frame but do not create a new one is none exists.
+                    # Re-enter a JAXPR frame but do not create a new one if none exists.
                     if cur_trace and region.trace:
                         trace_manager = EvaluationContext.frame_tracing_context(region.trace)
                     else:

--- a/frontend/catalyst/api_extensions/quantum_operators.py
+++ b/frontend/catalyst/api_extensions/quantum_operators.py
@@ -31,6 +31,7 @@ from jax._src.tree_util import tree_flatten
 from jax.api_util import debug_info
 from jax.core import get_aval
 from pennylane import QueuingManager
+from pennylane.decomposition.resources import resolve_work_wire_type
 from pennylane.operation import Operator
 from pennylane.ops.op_math.adjoint import create_adjoint_op
 from pennylane.ops.op_math.controlled import create_controlled_op
@@ -262,6 +263,7 @@ def ctrl(
     control: List[Any],
     control_values: Optional[List[Any]] = None,
     work_wires: Optional[List[Any]] = None,
+    work_wire_type: str = "borrowed",
 ) -> Callable:
     """Create a method that applies a controlled version of the provided op. This function is the
     Catalyst version of the ``qml.ctrl`` that supports Catalyst hybrid operations such as loops and
@@ -274,6 +276,7 @@ def ctrl(
         control_values (List[bool], optional): The value(s) the control wire(s) should take.
             Integers other than 0 or 1 will be treated as ``int(bool(x))``.
         work_wires (Any): Any auxiliary wires that can be used in the decomposition
+        work_wire_type (str): The type of work wire(s), can be ``"zeroed"`` or ``"borrowed"``.
 
     Returns:
         (function or :class:`~.operation.Operator`): If an Operator is provided, returns a
@@ -318,7 +321,13 @@ def ctrl(
             f"to the lenght of control ({len(control)})"
         )
 
-    res = CtrlCallable(f, control, control_values=control_values, work_wires=work_wires)
+    res = CtrlCallable(
+        f,
+        control,
+        control_values=control_values,
+        work_wires=work_wires,
+        work_wire_type=work_wire_type,
+    )
     return res() if isinstance(f, Operator) else res
 
 
@@ -523,11 +532,12 @@ class HybridAdjoint(HybridOp):
 class CtrlCallable:
     """Callable wrapper to produce a ctrl instance."""
 
-    def __init__(self, target, control, control_values, work_wires):
+    def __init__(self, target, control, control_values, work_wires, work_wire_type="borrowed"):
         self.target = target
         self.control_wires = control
         self.control_values = control_values
         self.work_wires = work_wires
+        self.work_wire_type = work_wire_type
 
         if isinstance(target, Operator):
             # Case 1. Support an initialized operation as the base target
@@ -548,7 +558,11 @@ class CtrlCallable:
         if self.single_op:
             base_op = self.target if self.instantiated else self.target(*args, **kwargs)
             return create_controlled_op(
-                base_op, self.control_wires, self.control_values, self.work_wires
+                base_op,
+                self.control_wires,
+                self.control_values,
+                self.work_wires,
+                work_wire_type=self.work_wire_type,
             )
 
         tracing_artifacts = self.trace_body(args, kwargs)
@@ -558,6 +572,7 @@ class CtrlCallable:
             control_wires=self.control_wires,
             control_values=self.control_values,
             work_wires=self.work_wires,
+            work_wire_type=self.work_wire_type,
         )
 
     def trace_body(self, args, kwargs):
@@ -589,9 +604,17 @@ class CtrlCallable:
 class HybridCtrl(HybridOp):
     """Catalyst quantum ctrl operation support for both operations and callables"""
 
-    def __init__(self, *tracing_artifacts, control_wires, control_values=None, work_wires=None):
+    def __init__(
+        self,
+        *tracing_artifacts,
+        control_wires,
+        control_values=None,
+        work_wires=None,
+        work_wire_type="borrowed",
+    ):
         self._control_wires = qml.wires.Wires(control_wires)
         self._work_wires = qml.wires.Wires([] if work_wires is None else work_wires)
+        self._work_wire_type = work_wire_type
         if control_values is None:
             self._control_values = [True] * len(self._control_wires)
         elif isinstance(control_values, (int, bool)):
@@ -617,6 +640,7 @@ class HybridCtrl(HybridOp):
             self._control_wires,
             self._control_values,
             self._work_wires,
+            self._work_wire_type,
         )
 
     @property
@@ -645,6 +669,11 @@ class HybridCtrl(HybridOp):
         """Optional wires that can be used in the expansion of this op."""
         return self._work_wires
 
+    @property
+    def work_wire_type(self):
+        """The type of work wires provided"""
+        return self._work_wire_type
+
     def map_wires(self, wire_map):
         """Map wires to new wires according to wire_map"""
         new_ops = []
@@ -661,6 +690,7 @@ def ctrl_distribute(
     control_wires: List[Any],
     control_values: List[Any],
     work_wires: Optional[List[Any]] = None,
+    work_wire_type: str = "borrowed",
 ) -> QuantumTape:
     """Distribute the quantum control operation, described by ``control_wires`` and
     ``control_values``, over all the operations on the nested quantum tape.
@@ -683,11 +713,21 @@ def ctrl_distribute(
     for op in tape.operations:
         if has_nested_tapes(op):
             if isinstance(op, HybridCtrl):
+                # For nested HybridCtrl, resolve the combined work_wire_type first.
+                # This is the same as the logic in PennyLane:
+                # `pennylane/ops/op_math/controlled.py:create_controlled_op`
+                combined_work_wire_type = resolve_work_wire_type(
+                    qml.wires.Wires(work_wires) if work_wires is not None else qml.wires.Wires([]),
+                    work_wire_type,
+                    op.work_wires,
+                    op.work_wire_type,
+                )
                 nested_ops = ctrl_distribute(
                     op.regions[0].quantum_tape,
                     control_wires + op.control_wires,
                     control_values + op.control_values,
                     work_wires + op.work_wires,
+                    combined_work_wire_type,
                 )
                 new_ops.extend(nested_ops)
             else:
@@ -700,7 +740,11 @@ def ctrl_distribute(
 
                     with trace_manager:
                         nested_ops = ctrl_distribute(
-                            region.quantum_tape, control_wires, control_values, work_wires
+                            region.quantum_tape,
+                            control_wires,
+                            control_values,
+                            work_wires,
+                            work_wire_type,
                         )
                         region.quantum_tape = QuantumTape(
                             nested_ops, region.quantum_tape.measurements
@@ -713,6 +757,7 @@ def ctrl_distribute(
                 control=control_wires,
                 control_values=control_values,
                 work_wires=work_wires,
+                work_wire_type=work_wire_type,
             )
             new_ops.append(create_adjoint_op(ctrl_op, lazy=True))
         else:
@@ -721,6 +766,7 @@ def ctrl_distribute(
                 control=control_wires,
                 control_values=control_values,
                 work_wires=work_wires,
+                work_wire_type=work_wire_type,
             )
             new_ops.append(ctrl_op)
     return new_ops

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -543,7 +543,9 @@ class TestCatalystOnlyControlled:
         assert op.hyperparameters["work_wire_type"] == work_wire_type
         assert op.work_wire_type == work_wire_type
 
-    @pytest.mark.xfail(reason="Disable due to circular dependency between Catalyst and PennyLane")
+    @pytest.mark.xfail(
+        strict=False, reason="Disable due to circular dependency between Catalyst and PennyLane"
+    )
     @pytest.mark.parametrize("work_wire_type", ["zeroed", "borrowed"])
     def test_qctrl_work_wire_type_callable(self, work_wire_type):
         """Test that work_wire_type is preserved on a Controlled op when wrapping a callable"""

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -497,6 +497,71 @@ class TestCatalystOnlyControlled:
         assert new_qctrl._control_wires == [1]  # pylint: disable=protected-access
         assert new_qctrl.regions[0].quantum_tape.operations[0].wires == Wires([0])
 
+    @pytest.mark.parametrize("work_wire_type", ["zeroed", "borrowed"])
+    def test_qctrl_work_wire_type_operator(self, work_wire_type):
+        """Test that work_wire_type is preserved on a Controlled op inside qjit"""
+        x_wires = [0, 1, 2, 3]
+        output = [4, 5, 6, 7]
+        work_wires = [-1, 8, 9, 10, 11, 12]
+
+        @qjit
+        def func():
+            return PL_ctrl(
+                qml.SemiAdder(
+                    x_wires=x_wires,
+                    y_wires=output,
+                    work_wires=work_wires[1:len(output)],
+                ),
+                control=work_wires[:1],
+                work_wires=work_wires[len(output):],
+                work_wire_type=work_wire_type,
+            )
+
+        op = func()
+        assert op.hyperparameters["work_wire_type"] == work_wire_type
+        assert op.work_wire_type == work_wire_type
+        assert op.control_wires == Wires([-1])
+        assert op.work_wires == Wires([11, 12])
+
+        @qjit
+        def func_native():
+            return C_ctrl(
+                qml.SemiAdder(
+                    x_wires=x_wires,
+                    y_wires=output,
+                    work_wires=work_wires[1 : len(output)],
+                ),
+                control=work_wires[:1],
+                work_wires=work_wires[len(output) :],
+                work_wire_type=work_wire_type,
+            )
+
+        op = func_native()
+        assert op.hyperparameters["work_wire_type"] == work_wire_type
+        assert op.work_wire_type == work_wire_type
+
+    @pytest.mark.parametrize("work_wire_type", ["zeroed", "borrowed"])
+    def test_qctrl_work_wire_type_callable(self, work_wire_type):
+        """Test that work_wire_type is preserved on a Controlled op when wrapping a callable"""
+        x_wires = [0, 1, 2, 3]
+        output = [4, 5, 6, 7]
+        work_wires = [-1, 8, 9, 10, 11]
+
+        def _func():
+            qml.SemiAdder(x_wires=x_wires, y_wires=output, work_wires=work_wires[1:len(output)])
+
+        hybrid_ctrl = C_ctrl(
+            _func,
+            control=work_wires[:1],
+            work_wires=work_wires[len(output):],
+            work_wire_type=work_wire_type,
+        )()
+        assert hybrid_ctrl.work_wire_type == work_wire_type
+
+        decomposed = hybrid_ctrl.decomposition()
+        assert len(decomposed) == 1
+        assert decomposed[0].hyperparameters["work_wire_type"] == work_wire_type
+
     def test_control_outside_qjit(self):
         """Test that the Catalyst control function can be used without jitting."""
 

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -289,7 +289,7 @@ class TestControlled:
         def native_controlled():
             qml.ctrl(
                 qml.QubitUnitary(
-                    jnp.array(  # pyright: ignore[reportArgumentType]
+                    jnp.array(
                         [
                             [0.70710678 + 0.0j, 0.70710678 + 0.0j],
                             [0.70710678 + 0.0j, -0.70710678 + 0.0j],

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -289,7 +289,7 @@ class TestControlled:
         def native_controlled():
             qml.ctrl(
                 qml.QubitUnitary(
-                    jnp.array(
+                    jnp.array(  # pyright: ignore[reportArgumentType]
                         [
                             [0.70710678 + 0.0j, 0.70710678 + 0.0j],
                             [0.70710678 + 0.0j, -0.70710678 + 0.0j],
@@ -497,6 +497,7 @@ class TestCatalystOnlyControlled:
         assert new_qctrl._control_wires == [1]  # pylint: disable=protected-access
         assert new_qctrl.regions[0].quantum_tape.operations[0].wires == Wires([0])
 
+    @pytest.mark.xfail(reason="Disable due to circular dependency between Catalyst and PennyLane")
     @pytest.mark.parametrize("work_wire_type", ["zeroed", "borrowed"])
     def test_qctrl_work_wire_type_operator(self, work_wire_type):
         """Test that work_wire_type is preserved on a Controlled op inside qjit"""
@@ -540,6 +541,7 @@ class TestCatalystOnlyControlled:
         assert op.hyperparameters["work_wire_type"] == work_wire_type
         assert op.work_wire_type == work_wire_type
 
+    @pytest.mark.xfail(reason="Disable due to circular dependency between Catalyst and PennyLane")
     @pytest.mark.parametrize("work_wire_type", ["zeroed", "borrowed"])
     def test_qctrl_work_wire_type_callable(self, work_wire_type):
         """Test that work_wire_type is preserved on a Controlled op when wrapping a callable"""

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -503,9 +503,11 @@ class TestCatalystOnlyControlled:
     @pytest.mark.parametrize("work_wire_type", ["zeroed", "borrowed"])
     def test_qctrl_work_wire_type_operator(self, work_wire_type):
         """Test that work_wire_type is preserved on a Controlled op inside qjit"""
-        x_wires = [0, 1, 2, 3]
-        output = [4, 5, 6, 7]
-        work_wires = [-1, 8, 9, 10, 11, 12]
+        c_wire = 0
+        x_wires = [1, 2, 3]
+        output = [4, 5, 6]
+        work_wires_add = [7, 8]
+        work_wires_ctrl = [9]
 
         @qjit
         def func():
@@ -513,18 +515,18 @@ class TestCatalystOnlyControlled:
                 qml.SemiAdder(
                     x_wires=x_wires,
                     y_wires=output,
-                    work_wires=work_wires[1 : len(output)],
+                    work_wires=work_wires_add,
                 ),
-                control=work_wires[:1],
-                work_wires=work_wires[len(output) :],
+                control=c_wire,
+                work_wires=work_wires_ctrl,
                 work_wire_type=work_wire_type,
             )
 
         op = func()
         assert op.hyperparameters["work_wire_type"] == work_wire_type
         assert op.work_wire_type == work_wire_type
-        assert op.control_wires == Wires([-1])
-        assert op.work_wires == Wires([11, 12])
+        assert op.control_wires == Wires([0])
+        assert op.work_wires == Wires([9])
 
         @qjit
         def func_native():
@@ -532,10 +534,10 @@ class TestCatalystOnlyControlled:
                 qml.SemiAdder(
                     x_wires=x_wires,
                     y_wires=output,
-                    work_wires=work_wires[1 : len(output)],
+                    work_wires=work_wires_add,
                 ),
-                control=work_wires[:1],
-                work_wires=work_wires[len(output) :],
+                control=c_wire,
+                work_wires=work_wires_ctrl,
                 work_wire_type=work_wire_type,
             )
 

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -551,19 +551,16 @@ class TestCatalystOnlyControlled:
     @pytest.mark.parametrize("work_wire_type", ["zeroed", "borrowed"])
     def test_qctrl_work_wire_type_callable(self, work_wire_type):
         """Test that work_wire_type is preserved on a Controlled op when wrapping a callable"""
-        x_wires = [0, 1, 2, 3]
-        output = [4, 5, 6, 7]
-        work_wires = [-1, 8, 9, 10, 11]
+        c_wire = 0
+        x_wires = [1, 2, 3]
+        output = [4, 5, 6]
+        work_wires_add = [7, 8]
+        work_wires_ctrl = [9]
 
         def _func():
-            qml.SemiAdder(x_wires=x_wires, y_wires=output, work_wires=work_wires[1 : len(output)])
+            qml.SemiAdder(x_wires=x_wires, y_wires=output, work_wires=work_wires_add)
 
-        hybrid_ctrl = C_ctrl(
-            _func,
-            control=work_wires[:1],
-            work_wires=work_wires[len(output) :],
-            work_wire_type=work_wire_type,
-        )()
+        hybrid_ctrl = C_ctrl(_func, control=c_wire, work_wires=work_wires_ctrl, work_wire_type=work_wire_type)()
         assert hybrid_ctrl.work_wire_type == work_wire_type
 
         decomposed = hybrid_ctrl.decomposition()

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -560,7 +560,9 @@ class TestCatalystOnlyControlled:
         def _func():
             qml.SemiAdder(x_wires=x_wires, y_wires=output, work_wires=work_wires_add)
 
-        hybrid_ctrl = C_ctrl(_func, control=c_wire, work_wires=work_wires_ctrl, work_wire_type=work_wire_type)()
+        hybrid_ctrl = C_ctrl(
+            _func, control=c_wire, work_wires=work_wires_ctrl, work_wire_type=work_wire_type
+        )()
         assert hybrid_ctrl.work_wire_type == work_wire_type
 
         decomposed = hybrid_ctrl.decomposition()

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -458,9 +458,7 @@ class TestCatalystOnlyControlled:
 
         assert circuit(0.1) == qml.wires.Wires([1, 0, 3])
 
-    @pytest.mark.xfail(
-        strict=False, reason="ctrl.wires fails in control-flow branches is not supported"
-    )
+    @pytest.mark.xfail(reason="ctrl.wires fails in control-flow branches is not supported")
     def test_qctrl_wires_controlflow(self, backend):
         """Test the wires property of HybridCtrl with control flow branches"""
 

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -458,7 +458,9 @@ class TestCatalystOnlyControlled:
 
         assert circuit(0.1) == qml.wires.Wires([1, 0, 3])
 
-    @pytest.mark.xfail(reason="ctrl.wires fails in control-flow branches is not supported")
+    @pytest.mark.xfail(
+        strict=False, reason="ctrl.wires fails in control-flow branches is not supported"
+    )
     def test_qctrl_wires_controlflow(self, backend):
         """Test the wires property of HybridCtrl with control flow branches"""
 
@@ -497,7 +499,9 @@ class TestCatalystOnlyControlled:
         assert new_qctrl._control_wires == [1]  # pylint: disable=protected-access
         assert new_qctrl.regions[0].quantum_tape.operations[0].wires == Wires([0])
 
-    @pytest.mark.xfail(reason="Disable due to circular dependency between Catalyst and PennyLane")
+    @pytest.mark.xfail(
+        strict=False, reason="Disable due to circular dependency between Catalyst and PennyLane"
+    )
     @pytest.mark.parametrize("work_wire_type", ["zeroed", "borrowed"])
     def test_qctrl_work_wire_type_operator(self, work_wire_type):
         """Test that work_wire_type is preserved on a Controlled op inside qjit"""

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -510,10 +510,10 @@ class TestCatalystOnlyControlled:
                 qml.SemiAdder(
                     x_wires=x_wires,
                     y_wires=output,
-                    work_wires=work_wires[1:len(output)],
+                    work_wires=work_wires[1 : len(output)],
                 ),
                 control=work_wires[:1],
-                work_wires=work_wires[len(output):],
+                work_wires=work_wires[len(output) :],
                 work_wire_type=work_wire_type,
             )
 
@@ -548,12 +548,12 @@ class TestCatalystOnlyControlled:
         work_wires = [-1, 8, 9, 10, 11]
 
         def _func():
-            qml.SemiAdder(x_wires=x_wires, y_wires=output, work_wires=work_wires[1:len(output)])
+            qml.SemiAdder(x_wires=x_wires, y_wires=output, work_wires=work_wires[1 : len(output)])
 
         hybrid_ctrl = C_ctrl(
             _func,
             control=work_wires[:1],
-            work_wires=work_wires[len(output):],
+            work_wires=work_wires[len(output) :],
             work_wire_type=work_wire_type,
         )()
         assert hybrid_ctrl.work_wire_type == work_wire_type


### PR DESCRIPTION
**Context:**

The `work_wire_type` is not preserved in qjit. That's because the `catalyst.ctrl` didn't take in `work_wire_type`.

**Description of the Change:**

Add a `work_wire_type` parameter to `catalyst.ctrl` and propagate it through the call path.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
closes https://github.com/PennyLaneAI/catalyst/issues/2709
[sc-116955]
[sc-116989]