### PR TITLE
fix: 2 improvements across 2 files

### DIFF
--- a/.github/workflows/set_nightly_version.py
+++ b/.github/workflows/set_nightly_version.py
@@ -29,7 +29,7 @@ with open(version_file_path, "r+", encoding="UTF-8") as f:
     version_line = lines[-1]
     assert "__version__ = " in version_line
 
-    pattern = r"(\d+).(\d+).(\d+)-dev(\d+)"
+    pattern = r"^(\d+)\.(\d+)\.(\d+)-dev(\d+)$"
     match = re.search(pattern, version_line)
     assert match
 

--- a/bin/utils.py
+++ b/bin/utils.py
@@ -34,9 +34,9 @@ def get_cpp_files_from_path(path, ignore_patterns=None, use_gitignore=True, head
     path = Path(path)
     files_rel = set()  # file paths relative to path
 
-    exts = HEADERFILE_EXT
+    exts = list(HEADERFILE_EXT)
     if not header_only:
-        exts += SRCFILE_EXT
+        exts.extend(SRCFILE_EXT)
     for ext in exts:
         for file_path in path.rglob(f"*.{ext}"):
             files_rel.add(file_path.relative_to(path))


### PR DESCRIPTION
## Summary

fix: 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `bin/utils.py:L40`

The function `get_cpp_files_from_path` assigns `exts = HEADERFILE_EXT` and then does `exts += SRCFILE_EXT` when `header_only` is false. Because `exts` references the global list, this permanently mutates `HEADERFILE_EXT`, causing later calls (including `header_only=True`) to incorrectly include source files.

## Solution

Use a copy when building the extension list, e.g. `exts = list(HEADERFILE_EXT)` and then `exts.extend(SRCFILE_EXT)`.

## Changes

- `bin/utils.py` (modified)
- `.github/workflows/set_nightly_version.py` (modified)