### PR TITLE
Add support for conversion of dataclasses to MLIR dict attributes

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1002,6 +1002,10 @@
 * A number of deprecation warnings have been fixed in the compiler python interface.
   [(#2621)](https://github.com/PennyLaneAI/catalyst/pull/2621)
 
+* Python `dataclass` objects can now be converted to MLIR dictionary attributes, allowing them to be
+  used as xDSL pass options, for example.
+  [(#2719)](https://github.com/PennyLaneAI/catalyst/pull/2719)
+
 <h3>Documentation 📝</h3>
 
 * The "Compatibility with PennyLane transforms" section of the

--- a/frontend/catalyst/jax_extras/lowering.py
+++ b/frontend/catalyst/jax_extras/lowering.py
@@ -233,12 +233,12 @@ def get_mlir_attribute_from_pyval(value):
                 named_attrs[k] = get_mlir_attribute_from_pyval(v)
             attr = ir.DictAttr.get(named_attrs)
 
+        case _ if dataclasses.is_dataclass(value):
+            attr = get_mlir_attribute_from_pyval(dataclasses.asdict(value))
+
         case _:
-            if dataclasses.is_dataclass(value):
-                attr = get_mlir_attribute_from_pyval(dataclasses.asdict(value))
-            else:
-                raise CompileError(
-                    f"Cannot convert Python type {type(value)} to an MLIR attribute."
-                )
+            raise CompileError(
+                f"Cannot convert Python type {type(value)} to an MLIR attribute."
+            )
 
     return attr

--- a/frontend/catalyst/jax_extras/lowering.py
+++ b/frontend/catalyst/jax_extras/lowering.py
@@ -209,7 +209,7 @@ def get_mlir_attribute_from_pyval(value):
                 attr = ir.IntegerAttr.get(ir.IntegerType.get_signless(64), value)
             else:
                 raise CompileError(textwrap.dedent("""
-                    Large interger attributes currently not supported in MLIR,
+                    Large integer attributes currently not supported in MLIR,
                     see https://github.com/llvm/llvm-project/issues/128072
                     """))
 

--- a/frontend/catalyst/jax_extras/lowering.py
+++ b/frontend/catalyst/jax_extras/lowering.py
@@ -237,8 +237,6 @@ def get_mlir_attribute_from_pyval(value):
             attr = get_mlir_attribute_from_pyval(dataclasses.asdict(value))
 
         case _:
-            raise CompileError(
-                f"Cannot convert Python type {type(value)} to an MLIR attribute."
-            )
+            raise CompileError(f"Cannot convert Python type {type(value)} to an MLIR attribute.")
 
     return attr

--- a/frontend/catalyst/jax_extras/lowering.py
+++ b/frontend/catalyst/jax_extras/lowering.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import textwrap
 
@@ -233,6 +234,11 @@ def get_mlir_attribute_from_pyval(value):
             attr = ir.DictAttr.get(named_attrs)
 
         case _:
-            raise CompileError(f"Cannot convert Python type {type(value)} to an MLIR attribute.")
+            if dataclasses.is_dataclass(value):
+                attr = get_mlir_attribute_from_pyval(dataclasses.asdict(value))
+            else:
+                raise CompileError(
+                    f"Cannot convert Python type {type(value)} to an MLIR attribute."
+                )
 
     return attr

--- a/frontend/test/pytest/test_jax_integration.py
+++ b/frontend/test/pytest/test_jax_integration.py
@@ -616,29 +616,29 @@ class TestJAXMLIRAttributeGetter:
 
         # pylint: disable=missing-class-docstring
         @dataclass
-        class Foo:
+        class MyOptions:
             a: bool = True
             b: int = 42
             c: float = 1 / 137
             d: str = "yellow submarine"
 
         with ctx, loc:
-            foo = Foo()
-            attr = get_mlir_attribute_from_pyval(foo)
+            options = MyOptions()
+            attr = get_mlir_attribute_from_pyval(options)
 
             assert isinstance(attr, ir.DictAttr)
 
             assert isinstance(attr["a"], ir.BoolAttr)
-            assert attr["a"].value == foo.a
+            assert attr["a"].value == options.a
 
             assert isinstance(attr["b"], ir.IntegerAttr)
-            assert attr["b"].value == foo.b
+            assert attr["b"].value == options.b
 
             assert isinstance(attr["c"], ir.FloatAttr)
-            assert attr["c"].value == foo.c
+            assert attr["c"].value == options.c
 
             assert isinstance(attr["d"], ir.StringAttr)
-            assert attr["d"].value == foo.d
+            assert attr["d"].value == options.d
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_jax_integration.py
+++ b/frontend/test/pytest/test_jax_integration.py
@@ -15,6 +15,7 @@
 """Test QJIT compatibility with JAX transformations such as jax.jit and jax.grad."""
 
 import textwrap
+from dataclasses import dataclass
 from functools import partial
 
 import jax
@@ -601,12 +602,43 @@ class TestJAXMLIRAttributeGetter:
         with pytest.raises(
             CompileError,
             match=textwrap.dedent("""
-            Large interger attributes currently not supported in MLIR,
+            Large integer attributes currently not supported in MLIR,
             see https://github.com/llvm/llvm-project/issues/128072
             """),
         ):
             with ctx, loc:
                 _ = get_mlir_attribute_from_pyval(2**100)
+
+    def test_dataclass_attr(self):
+        """
+        Test that a dataclass is convertible to an MLIR dictionary attribute.
+        """
+
+        # pylint: disable=missing-class-docstring
+        @dataclass
+        class Foo:
+            a: bool = True
+            b: int = 42
+            c: float = 1 / 137
+            d: str = "yellow submarine"
+
+        with ctx, loc:
+            foo = Foo()
+            attr = get_mlir_attribute_from_pyval(foo)
+
+            assert isinstance(attr, ir.DictAttr)
+
+            assert isinstance(attr["a"], ir.BoolAttr)
+            assert attr["a"].value == foo.a
+
+            assert isinstance(attr["b"], ir.IntegerAttr)
+            assert attr["b"].value == foo.b
+
+            assert isinstance(attr["c"], ir.FloatAttr)
+            assert attr["c"].value == foo.c
+
+            assert isinstance(attr["d"], ir.StringAttr)
+            assert attr["d"].value == foo.d
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_jax_integration.py
+++ b/frontend/test/pytest/test_jax_integration.py
@@ -15,7 +15,7 @@
 """Test QJIT compatibility with JAX transformations such as jax.jit and jax.grad."""
 
 import textwrap
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import partial
 
 import jax
@@ -620,7 +620,9 @@ class TestJAXMLIRAttributeGetter:
             a: bool = True
             b: int = 42
             c: float = 1 / 137
-            d: str = "yellow submarine"
+            d: str = "Yellow Submarine"
+            e: list = field(default_factory=lambda: ["John", "Paul", "George", "Ringo"])
+            f: dict = field(default_factory=lambda: {"one": 1, "two": 2})
 
         with ctx, loc:
             options = MyOptions()
@@ -639,6 +641,17 @@ class TestJAXMLIRAttributeGetter:
 
             assert isinstance(attr["d"], ir.StringAttr)
             assert attr["d"].value == options.d
+
+            assert isinstance(attr["e"], ir.ArrayAttr)
+            assert len(attr["e"]) == len(options.e)
+            for attr_val, options_val in zip(attr["e"], options.e):
+                assert attr_val.value == options_val
+
+            assert isinstance(attr["f"], ir.DictAttr)
+            assert len(attr["f"]) == len(options.f)
+            for attr_val, (options_key, options_val) in zip(attr["f"], options.f.items()):
+                assert attr_val.name == options_key
+                assert attr_val.attr.value == options_val
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The function [`get_mlir_attribute_from_pyval()`](https://github.com/PennyLaneAI/catalyst/blob/1b067e0f29f76148ebdb55a5fa2697c7d39ecc80/frontend/catalyst/jax_extras/lowering.py#L191-L236), which converts Python types to MLIR attributes, does not currently support Python `dataclass`es. A `dataclass` is easily convertible to a `dict` object via [`dataclasses.asdict()`](https://docs.python.org/3/library/dataclasses.html#dataclasses.asdict), therefore we can easily support the conversion of a `dataclass` object to an MLIR dictionary attribute.

Having this conversion is particularly useful for developers who wish to use a `dataclass` object as an xDSL pass option.

[sc-117368]