### PR TITLE
[qref 2.5.2] Small follow-ups to the ref-to-v MLIR pass

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -707,7 +707,7 @@
   [(#2674)](https://github.com/PennyLaneAI/catalyst/pull/2674)
   [(#2642)](https://github.com/PennyLaneAI/catalyst/pull/2642)
   [(#2692)](https://github.com/PennyLaneAI/catalyst/pull/2692)
-  [(#????)](https://github.com/PennyLaneAI/catalyst/pull/????)
+  [(#2721)](https://github.com/PennyLaneAI/catalyst/pull/2721)
 
   Unlike qubit (or qreg) SSA values in the `Quantum` dialect, a qubit (or qreg) reference SSA value
   in the `QRef` dialect is allowed to be used multiple times. The operands of gates and observables

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -537,7 +537,7 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* Fixed a bug where the `work_wire_type` argument of `qml.ctrl` was silently dropped inside `@qjit` functions. 
+* Fixed a bug where the `work_wire_type` argument of `qml.ctrl` was silently dropped inside `@qjit` functions.
   The parameter is now threaded through `catalyst.ctrl`, `CtrlCallable`, `HybridCtrl`, and
   `ctrl_distribute`, with the default value being `"borrowed"`.
   [(#2710)](https://github.com/PennyLaneAI/catalyst/pull/2710)
@@ -707,6 +707,7 @@
   [(#2674)](https://github.com/PennyLaneAI/catalyst/pull/2674)
   [(#2642)](https://github.com/PennyLaneAI/catalyst/pull/2642)
   [(#2692)](https://github.com/PennyLaneAI/catalyst/pull/2692)
+  [(#????)](https://github.com/PennyLaneAI/catalyst/pull/????)
 
   Unlike qubit (or qreg) SSA values in the `Quantum` dialect, a qubit (or qreg) reference SSA value
   in the `QRef` dialect is allowed to be used multiple times. The operands of gates and observables
@@ -999,7 +1000,7 @@
   from the `quantum` dialect into the QEC Logical (`qecl`) dialect.
   [(#2589)](https://github.com/PennyLaneAI/catalyst/pull/2589)
 
-* An experimental compiler pass `inject-noise-to-qecl` has been added to inject noise operations  
+* An experimental compiler pass `inject-noise-to-qecl` has been added to inject noise operations
   into the QEC Logical (`qecl`) layer to validate QEC protocols under development.
   [(#2705)](https://github.com/PennyLaneAI/catalyst/pull/2705)
 

--- a/mlir/lib/QRef/Transforms/value_semantics_conversion.cpp
+++ b/mlir/lib/QRef/Transforms/value_semantics_conversion.cpp
@@ -132,6 +132,11 @@ DenseI32ArrayAttr getResultSegmentSizes(IRRewriter &builder, qref::QuantumGate r
  */
 bool isQrefSubroutine(func::FuncOp f)
 {
+    // quantum.node is not a subroutine
+    if (f->hasAttrOfType<UnitAttr>("quantum.node")) {
+        return false;
+    }
+
     // If has a qref argument, definitely is a qref subroutine
     if (llvm::any_of(f.getArgumentTypes(), llvm::IsaPred<qref::QubitType, qref::QuregType>)) {
         return true;
@@ -1166,10 +1171,6 @@ void handleAdjoint(IRRewriter &builder, qref::AdjointOp rAdjointOp, QubitValueTr
     SetVector<Value> rValuesUsedByRegion;
     collectNecessaryRegionRValues(rAdjointOp.getRegion(), rValuesUsedByRegion);
 
-    if (rValuesUsedByRegion.size() == 0) {
-        return;
-    }
-
     quantum::AdjointOp vAdjointOp;
     {
         // 1. Send in the vValues from above as arguments
@@ -1610,6 +1611,11 @@ void handleSubroutine(IRRewriter &builder, func::FuncOp f,
                "qref.bit Values must have no uses after the semantic conversion");
         builder.eraseOp(getOp);
     });
+    f.walk([&](qref::AllocOp allocOp) {
+        assert(allocOp.use_empty() &&
+               "qref.reg Values must have no uses after the semantic conversion");
+        builder.eraseOp(allocOp);
+    });
 
     // Nuke all old qref arguments
     f.front().eraseArguments(
@@ -1789,6 +1795,12 @@ struct ValueSemanticsConversionPass
                 assert(getOp.use_empty() &&
                        "qref.bit Values must have no uses after the semantic conversion");
                 builder.eraseOp(getOp);
+            });
+
+            targetFunc.walk([&](qref::AllocOp allocOp) {
+                assert(allocOp.use_empty() &&
+                       "qref.reg Values must have no uses after the semantic conversion");
+                builder.eraseOp(allocOp);
             });
         }
     }


### PR DESCRIPTION
**Context:**
3 small fixes to the reference-to-value semantics conversion pass.

**Description of the Change:**
1. `qref.alloc` ops are cleaned at the end of the conversion explicitly, instead of relying on the canonicalizer
2. Functions explicitly marked with `quantum.node` attribute will not be mistakenly classified as qref subroutines
3. `qref.adjoint` ops will always be handled, regardless of whether it uses any quantum values from outside. This is because unlike the scf regioned operations, `qref.adjoint` is a quantum operation itself, so it will never be "purely classical".  

**Benefits:**
Correctness