### PR TITLE
Add constant index folder to qref.get op

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -708,6 +708,7 @@
   [(#2642)](https://github.com/PennyLaneAI/catalyst/pull/2642)
   [(#2692)](https://github.com/PennyLaneAI/catalyst/pull/2692)
   [(#2721)](https://github.com/PennyLaneAI/catalyst/pull/2721)
+  [(#2723)](https://github.com/PennyLaneAI/catalyst/pull/2723)
 
   Unlike qubit (or qreg) SSA values in the `Quantum` dialect, a qubit (or qreg) reference SSA value
   in the `QRef` dialect is allowed to be used multiple times. The operands of gates and observables

--- a/mlir/include/QRef/IR/QRefOps.td
+++ b/mlir/include/QRef/IR/QRefOps.td
@@ -153,6 +153,8 @@ def GetOp : Memory_Op<"get", [NoMemoryEffect]> {
     let assemblyFormat = [{
         $qreg `[` ($idx^):($idx_attr)? `]` attr-dict `:` type(operands) `->` type(results)
     }];
+
+    let hasFolder = 1;
 }
 
 // -----

--- a/mlir/lib/QRef/IR/QRefOps.cpp
+++ b/mlir/lib/QRef/IR/QRefOps.cpp
@@ -154,6 +154,31 @@ LogicalResult DeallocQubitOp::canonicalize(DeallocQubitOp deallocQb,
     return failure();
 }
 
+template <typename IndexingOp> LogicalResult foldConstantIndexingOp(IndexingOp op, Attribute idx)
+{
+    // Prefer using an attribute when the index is constant.
+    bool hasNoIdxAttr = !op.getIdxAttr().has_value();
+    bool isConstantIdx = isa_and_nonnull<IntegerAttr>(idx);
+    if (hasNoIdxAttr && isConstantIdx) {
+        auto constantIdx = cast<IntegerAttr>(idx);
+        op.setIdxAttr(constantIdx.getValue().getSExtValue());
+
+        // Remove the dynamic Value
+        op.getIdxMutable().clear();
+        return success();
+    }
+    return failure();
+}
+
+OpFoldResult GetOp::fold(FoldAdaptor adaptor)
+{
+    if (succeeded(foldConstantIndexingOp(*this, adaptor.getIdx()))) {
+        return getResult();
+    }
+    // Returning nullptr tells the caller the op was unchanged.
+    return nullptr;
+}
+
 //===----------------------------------------------------------------------===//
 // QRef op verifiers.
 //===----------------------------------------------------------------------===//

--- a/mlir/test/QRef/CanonicalizationTest.mlir
+++ b/mlir/test/QRef/CanonicalizationTest.mlir
@@ -107,6 +107,21 @@ func.func @test_get_no_user_fold(%r: !qref.reg<3>) {
 
 // -----
 
+// CHECK-LABEL: test_get_constant_index
+func.func @test_get_constant_index(%r: !qref.reg<3>) -> (!qref.bit, !qref.bit) {
+    // CHECK: qref.get %arg0[ 0] : !qref.reg<3> -> !qref.bit
+    %0 = arith.constant 0 : i64
+    %q0 = qref.get %r[%0] : !qref.reg<3>, i64 -> !qref.bit
+
+    // CHECK: qref.get %arg0[ 1] : !qref.reg<3> -> !qref.bit
+    %1 = stablehlo.constant dense<1> : tensor<i64>
+    %extracted = tensor.extract %1[] : tensor<i64>
+    %q1 = qref.get %r[%extracted] : !qref.reg<3>, i64 -> !qref.bit
+    return %q0, %q1 : !qref.bit, !qref.bit
+}
+
+// -----
+
 // CHECK-LABEL: test_get_cse
 func.func @test_get_cse(%r: !qref.reg<3>, %i: i64) {
     // CHECK: [[q0:%.+]] = qref.get %arg0[ 0] : !qref.reg<3> -> !qref.bit

--- a/mlir/test/QRef/CanonicalizationTest.mlir
+++ b/mlir/test/QRef/CanonicalizationTest.mlir
@@ -115,6 +115,7 @@ func.func @test_get_constant_index(%r: !qref.reg<3>) -> (!qref.bit, !qref.bit) {
     %q0 = qref.get %r[%0] : !qref.reg<3>, i64 -> !qref.bit
 
     // CHECK-NOT: stablehlo.constant
+    // CHECK-NOT: tensor.extract
     // CHECK: [[q1:%.+]] = qref.get %arg0[ 1] : !qref.reg<3> -> !qref.bit
     %1 = stablehlo.constant dense<1> : tensor<i64>
     %extracted = tensor.extract %1[] : tensor<i64>

--- a/mlir/test/QRef/CanonicalizationTest.mlir
+++ b/mlir/test/QRef/CanonicalizationTest.mlir
@@ -109,14 +109,18 @@ func.func @test_get_no_user_fold(%r: !qref.reg<3>) {
 
 // CHECK-LABEL: test_get_constant_index
 func.func @test_get_constant_index(%r: !qref.reg<3>) -> (!qref.bit, !qref.bit) {
-    // CHECK: qref.get %arg0[ 0] : !qref.reg<3> -> !qref.bit
+    // CHECK-NOT: arith.constant
+    // CHECK: [[q0:%.+]] = qref.get %arg0[ 0] : !qref.reg<3> -> !qref.bit
     %0 = arith.constant 0 : i64
     %q0 = qref.get %r[%0] : !qref.reg<3>, i64 -> !qref.bit
 
-    // CHECK: qref.get %arg0[ 1] : !qref.reg<3> -> !qref.bit
+    // CHECK-NOT: stablehlo.constant
+    // CHECK: [[q1:%.+]] = qref.get %arg0[ 1] : !qref.reg<3> -> !qref.bit
     %1 = stablehlo.constant dense<1> : tensor<i64>
     %extracted = tensor.extract %1[] : tensor<i64>
     %q1 = qref.get %r[%extracted] : !qref.reg<3>, i64 -> !qref.bit
+
+    // CHECK: return [[q0]], [[q1]]
     return %q0, %q1 : !qref.bit, !qref.bit
 }
 


### PR DESCRIPTION
**Context:**
Like the `quantum.extract` op, the `qref.get` op can take in static attribute or dynamic SSA value as the extract index.

However I forgot to add the folder for folding dynamic indices from constant-ops into attributes.  

**Description of the Change:**
Add a folder on `qref.get` op to convert seemingly dynamic indices from constant-like operations into static attributes.
This is a mirror of [the folder on `quantum.extract`](https://github.com/PennyLaneAI/catalyst/blob/359c1d13c751824db75ad781311abbf569178767/mlir/lib/Quantum/IR/QuantumOps.cpp#L144).

**Benefits:**
When the ref-to-value conversion is judging whether a region needs some reference semantics quantum SSA values from above, it decides single qubits are needed only if the `qref.get` op in the region is indexing with a static attribute.

This folder allows more cases to work with simply taking in qubits from above, instead of entire qregs. 
