### PR TITLE
Clean some unused leftover headers in pipelines.cpp

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -636,7 +636,7 @@
   nanobind extension module. This module is built during the MLIR compilation phase and discovered
   at runtime.
   [(#2259)](https://github.com/PennyLaneAI/catalyst/pull/2259)
-  [(#????)](https://github.com/PennyLaneAI/catalyst/pull/????)
+  [(#2733)](https://github.com/PennyLaneAI/catalyst/pull/2733)
 
 * Additional integration tests have been added for the pass-by-pass version of `qp.specs`.
   [(#2690)](https://github.com/PennyLaneAI/catalyst/pull/2690/)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -636,6 +636,7 @@
   nanobind extension module. This module is built during the MLIR compilation phase and discovered
   at runtime.
   [(#2259)](https://github.com/PennyLaneAI/catalyst/pull/2259)
+  [(#????)](https://github.com/PennyLaneAI/catalyst/pull/????)
 
 * Additional integration tests have been added for the pass-by-pass version of `qp.specs`.
   [(#2690)](https://github.com/PennyLaneAI/catalyst/pull/2690/)

--- a/mlir/lib/Driver/Pipelines.cpp
+++ b/mlir/lib/Driver/Pipelines.cpp
@@ -17,7 +17,6 @@
 #include "mlir/Pass/PassManager.h"
 
 #include "Driver/DefaultPipelines/DefaultPipelines.h"
-#include "Driver/Pipelines.h"
 
 #include <fmt/core.h>
 #include <fmt/ranges.h>

--- a/mlir/lib/Driver/Pipelines.cpp
+++ b/mlir/lib/Driver/Pipelines.cpp
@@ -14,42 +14,10 @@
 
 #include "Driver/Pipelines.h"
 
-#include <memory>
-
-#include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
-#include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
-#include "mlir/Conversion/BufferizationToMemRef/BufferizationToMemRef.h"
-#include "mlir/Conversion/ComplexToLLVM/ComplexToLLVM.h"
-#include "mlir/Conversion/ComplexToStandard/ComplexToStandard.h"
-#include "mlir/Conversion/IndexToLLVM/IndexToLLVM.h"
-#include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
-#include "mlir/Conversion/MathToLibm/MathToLibm.h"
-#include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
-#include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
-#include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
-#include "mlir/Conversion/TensorToLinalg/TensorToLinalgPass.h"
-#include "mlir/Dialect/Arith/Transforms/Passes.h"
-#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
-#include "mlir/Dialect/Bufferization/Transforms/Passes.h"
-#include "mlir/Dialect/Linalg/Passes.h"
-#include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Pass/PassManager.h"
-#include "mlir/Transforms/Passes.h"
-#include "stablehlo/conversions/linalg/transforms/Passes.h"
-#include "stablehlo/transforms/Passes.h"
-#include "stablehlo/transforms/optimization/Passes.h"
 
-#include "Catalyst/IR/CatalystDialect.h"
-#include "Catalyst/Transforms/Passes.h"
 #include "Driver/DefaultPipelines/DefaultPipelines.h"
 #include "Driver/Pipelines.h"
-#include "Gradient/IR/GradientDialect.h"
-#include "Gradient/Transforms/Passes.h"
-#include "Mitigation/Transforms/Passes.h"
-#include "PBC/Transforms/Passes.h"
-#include "Quantum/IR/QuantumDialect.h"
-#include "Quantum/Transforms/Passes.h"
-#include "hlo-extensions/Transforms/Passes.h"
 
 #include <fmt/core.h>
 #include <fmt/ranges.h>


### PR DESCRIPTION
**Context:**
#2259 removed the pipeline definition from `mlir/lib/Driver/pipelines.cpp`, to have a single source of truth pipeline registry :partying_face:

There are some left over dialect and pass headers that are no longer needed.

**Description of the Change:**
Delete unused headers.

**Benefits:**
Cleaner code.

