### PR TITLE
Remove XFail from work wire type tests

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.238
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.45.0-dev84
+pennylane=0.45.0-dev86
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -34,4 +34,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.45.0-dev21
 pennylane-lightning==0.45.0-dev21
-pennylane==0.45.0-dev84
+pennylane==0.45.0-dev86

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -497,9 +497,6 @@ class TestCatalystOnlyControlled:
         assert new_qctrl._control_wires == [1]  # pylint: disable=protected-access
         assert new_qctrl.regions[0].quantum_tape.operations[0].wires == Wires([0])
 
-    @pytest.mark.xfail(
-        strict=False, reason="Disable due to circular dependency between Catalyst and PennyLane"
-    )
     @pytest.mark.parametrize("work_wire_type", ["zeroed", "borrowed"])
     def test_qctrl_work_wire_type_operator(self, work_wire_type):
         """Test that work_wire_type is preserved on a Controlled op inside qjit"""
@@ -545,9 +542,6 @@ class TestCatalystOnlyControlled:
         assert op.hyperparameters["work_wire_type"] == work_wire_type
         assert op.work_wire_type == work_wire_type
 
-    @pytest.mark.xfail(
-        strict=False, reason="Disable due to circular dependency between Catalyst and PennyLane"
-    )
     @pytest.mark.parametrize("work_wire_type", ["zeroed", "borrowed"])
     def test_qctrl_work_wire_type_callable(self, work_wire_type):
         """Test that work_wire_type is preserved on a Controlled op when wrapping a callable"""


### PR DESCRIPTION
**Context:**

Due to the circular dependency between Pennylane and Catalyst, we added xfails on `fixed work wire type`'s tests to merge the following two PRs. Now, both PRs have been merged, we're good to remove these XFails from our tests.

https://github.com/PennyLaneAI/pennylane/pull/9328
https://github.com/PennyLaneAI/catalyst/pull/2710

**Description of the Change:**

Remove xfails

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-116955]
[sc-116989]