### PR TITLE
`qml` -> `qp` in `utils`

### DIFF
--- a/frontend/catalyst/utils/exceptions.py
+++ b/frontend/catalyst/utils/exceptions.py
@@ -38,6 +38,6 @@ class PlxprCaptureCFCompatibilityError(Exception):
         message = (
             f"catalyst.{control_flow_type} is not supported with PennyLane's capture enabled. "
             "For compatibility with program capture, please use the corresponding "
-            f"qml.{control_flow_type} instead. See the documentation for more information."
+            f"qp.{control_flow_type} instead. See the documentation for more information."
         )
         super().__init__(message)


### PR DESCRIPTION
**Context:**
In order to reposition PennyLane and Catalyst for general quantum computing (rather than quantum machine learning) PennyLane will be imported as `qp` (rather than `qml`). These changes will be made per-module in Catalyst.

**Description of the Change:**
Update references to PennyLane in `utils`.

**Benefits:**
Improve user perception of the uses of PennyLane + Catalyst.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-117380]