### PR TITLE
`qml` -> `qp` in `doc`

### DIFF
--- a/doc/_templates/autosummary/base.rst
+++ b/doc/_templates/autosummary/base.rst
@@ -1,4 +1,4 @@
-{{ fullname | replace("pennylane", "qml") | escape | underline}}
+{{ fullname | replace("pennylane", "qp") | escape | underline}}
 
 .. currentmodule:: {{ module }}
 

--- a/doc/_templates/autosummary/class.rst
+++ b/doc/_templates/autosummary/class.rst
@@ -1,4 +1,4 @@
-{{ fullname | replace("pennylane", "qml") }}
+{{ fullname | replace("pennylane", "qp") }}
 {{ underline }}
 
 .. autoclass:: {{ fullname }}

--- a/doc/_templates/autosummary/class_no_inherited.rst
+++ b/doc/_templates/autosummary/class_no_inherited.rst
@@ -1,4 +1,4 @@
-{{ fullname | replace("pennylane", "qml") }}
+{{ fullname | replace("pennylane", "qp") }}
 {{ underline }}
 
 .. autoclass:: {{ fullname }}

--- a/doc/_templates/autosummary/module.rst
+++ b/doc/_templates/autosummary/module.rst
@@ -1,4 +1,4 @@
-{{ fullname | replace("pennylane", "qml") | escape | underline}}
+{{ fullname | replace("pennylane", "qp") | escape | underline}}
 
 .. automodule:: {{ fullname }}
 

--- a/doc/code/dialects/MBQC/MBQCOps.md
+++ b/doc/code/dialects/MBQC/MBQCOps.md
@@ -26,7 +26,7 @@ the basis vector is aligned for a rotation angle of 0, and the second character 
 the other axis that forms the plane. For instance, the measurement basis defined by the XY
 plane with a rotation angle of 0 is the Pauli-X basis, with orthonormal basis vector |+> and
 |->, which point along the +x and -x axes of the Bloch sphere, respectively. For more
-details, see the documentation for the [`qml.ftqc.measure_arbitrary_basis()`
+details, see the documentation for the [`qp.ftqc.measure_arbitrary_basis()`
 ](https://docs.pennylane.ai/en/stable/code/api/pennylane.ftqc.measure_arbitrary_basis.html)
 function.
 

--- a/doc/dev/arch/frontend.puml
+++ b/doc/dev/arch/frontend.puml
@@ -19,7 +19,7 @@ Boundary(_frontend_, "Frontend / Compiler Driver", "Python", "Python code tracer
   Container(_codegen_, "CodeGen", "LLVM", "Object code generation & linking")
 }
 
-Container_Ext(_qml_, "OpQueue", "PennyLane", "")
+Container_Ext(_qp_, "OpQueue", "PennyLane", "")
 Container_Ext(_jaxcore_, "Tracer", "jax.core", "")
 Container_Ext(_jaxlib_, "MLIR Bindings", "jaxlib", "")
 Container_Ext(_quantumopt_, "Compiler Libraries", "quantum-opt", "Catalyst MLIR dialects and passes")
@@ -32,7 +32,7 @@ Rel_R(_mlirgen_, _core_, "mlir", "")
 Rel_R(_core_, _codegen_, "llvmir", "")
 Rel_R(_codegen_, _so_, " ", "")
 
-Rel_D(_tracing_, _qml_, "uses", "", $tags="action")
+Rel_D(_tracing_, _qp_, "uses", "", $tags="action")
 Rel_D(_tracing_, _jaxcore_, "uses", "", $tags="action")
 Rel_D(_mlirgen_, _jaxlib_, "uses", "", $tags="action")
 Rel_D(_core_, _quantumopt_, "uses","", $tags="action")

--- a/doc/dev/architecture.rst
+++ b/doc/dev/architecture.rst
@@ -109,7 +109,7 @@ with abstract arguments called *tracers*. Calling operations from the tracing li
 data structure. Note that JAX's tracing contexts can be nested to allow scoped region capture,
 which is relevant when tracing control flow operations.
 
-During the tracing of quantum functions (``qml.qnode``), PennyLane's queuing context is activated to
+During the tracing of quantum functions (``qp.qnode``), PennyLane's queuing context is activated to
 build a ``QuantumTape`` data structure that records all quantum operations. Nested queuing contexts
 are leveraged to allow for scoped operation capture, including control flow operations which are
 themselves captured as pseudo-quantum operations on the tape.

--- a/doc/dev/autograph.rst
+++ b/doc/dev/autograph.rst
@@ -38,25 +38,25 @@ To enable AutoGraph in Catalyst, simply pass ``autograph=True`` to the ``@qjit``
 
 .. code-block:: python
 
-    dev = qml.device("lightning.qubit", wires=4)
+    dev = qp.device("lightning.qubit", wires=4)
 
     @qjit(autograph=True)
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def cost(weights, data):
-        qml.AngleEmbedding(data, wires=range(4))
+        qp.AngleEmbedding(data, wires=range(4))
 
         for x in weights:
 
             for j, p in enumerate(x):
                 if p > 0:
-                    qml.RX(p, wires=j)
+                    qp.RX(p, wires=j)
                 elif p < 0:
-                    qml.RY(p, wires=j)
+                    qp.RY(p, wires=j)
 
             for j in range(4):
-                qml.CNOT(wires=[j, jnp.mod((j + 1), 4)])
+                qp.CNOT(wires=[j, jnp.mod((j + 1), 4)])
 
-        return qml.expval(qml.PauliZ(0) + qml.PauliZ(3))
+        return qp.expval(qp.PauliZ(0) + qp.PauliZ(3))
 
 >>> weights = jnp.linspace(-1, 1, 20).reshape([5, 4])
 >>> data = jnp.ones([4])
@@ -69,9 +69,9 @@ AutoGraph, but instead using :func:`~.cond` and :func:`~.for_loop`:
 .. code-block:: python
 
     @qjit(autograph=False)
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def cost(weights, data):
-        qml.AngleEmbedding(data, wires=range(4))
+        qp.AngleEmbedding(data, wires=range(4))
 
         def layer_loop(i):
             x = weights[i]
@@ -79,22 +79,22 @@ AutoGraph, but instead using :func:`~.cond` and :func:`~.for_loop`:
 
                 @cond(x[j] > 0)
                 def trainable_gate():
-                    qml.RX(x[j], wires=j)
+                    qp.RX(x[j], wires=j)
 
                 @trainable_gate.else_if(x[j] < 0)
                 def trainable_gate():
-                    qml.RY(x[j], wires=j)
+                    qp.RY(x[j], wires=j)
 
                 trainable_gate()
 
             def cnot_loop(j):
-                qml.CNOT(wires=[j, jnp.mod((j + 1), 4)])
+                qp.CNOT(wires=[j, jnp.mod((j + 1), 4)])
 
             for_loop(0, 4, 1)(wire_loop)()
             for_loop(0, 4, 1)(cnot_loop)()
 
         for_loop(0, jnp.shape(weights)[0], 1)(layer_loop)()
-        return qml.expval(qml.PauliZ(0) + qml.PauliZ(3))
+        return qp.expval(qp.PauliZ(0) + qp.PauliZ(3))
 
 >>> cost(weights, data)
 Array(0.30455313, dtype=float64)
@@ -200,13 +200,13 @@ compile-time information:
 
 .. code-block:: python
 
-    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    @qp.qnode(qp.device("lightning.qubit", wires=1))
     def f(switch: bool):
 
         if switch:
-            return qml.expval(qml.PauliY(0))
+            return qp.expval(qp.PauliY(0))
 
-        return qml.expval(qml.PauliZ(0))
+        return qp.expval(qp.PauliZ(0))
 
 >>> qjit(autograph=True)(f)
 TypeError: Conditional requires a consistent return structure across all branches!
@@ -362,15 +362,15 @@ fallback to Python, and the loop will be unrolled at compile-time:
 
 .. code-block:: python
 
-    dev = qml.device("lightning.qubit", wires=1)
+    dev = qp.device("lightning.qubit", wires=1)
 
     @qjit(autograph=True)
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def f():
         params = ["0", "1", "2"]
         for x in params:
-            qml.RY(int(x) * jnp.pi / 4, wires=0)
-        return qml.expval(qml.PauliZ(0))
+            qp.RY(int(x) * jnp.pi / 4, wires=0)
+        return qp.expval(qp.PauliZ(0))
 
 >>> f()
 Array(-0.70710678, dtype=float64)
@@ -395,13 +395,13 @@ Indexing arrays within a for loop will generally work, but care must be taken.
 
 For example, using a for loop with static bounds to index a JAX array is straightforward:
 
->>> dev = qml.device("lightning.qubit", wires=3)
+>>> dev = qp.device("lightning.qubit", wires=3)
 >>> @qjit(autograph=True)
-... @qml.qnode(dev)
+... @qp.qnode(dev)
 ... def f(x):
 ...     for i in range(3):
-...         qml.RX(x[i], wires=i)
-...     return qml.expval(qml.PauliZ(0))
+...         qp.RX(x[i], wires=i)
+...     return qp.expval(qp.PauliZ(0))
 >>> weights = jnp.array([0.1, 0.2, 0.3])
 >>> f(weights)
 Array(0.99500417, dtype=float64)
@@ -415,12 +415,12 @@ or dynamic variable, but an object that can be converted to a JAX array
 and fallback to Python to evaluate the loop at compile-time:
 
 >>> @qjit(autograph=True)
-... @qml.qnode(dev)
+... @qp.qnode(dev)
 ... def f():
 ...     x = [0.1, 0.2, 0.3]
 ...     for i in range(3):
-...         qml.RX(x[i], wires=i)
-...     return qml.expval(qml.PauliZ(0))
+...         qp.RX(x[i], wires=i)
+...     return qp.expval(qp.PauliZ(0))
 Warning: If you intended for the conversion to happen, make sure that the(now dynamic) loop variable is not used in tracing-incompatible ways,
 for instance by indexing a Python list with it. In that case, the list should be wrapped into an array.
 To understand different types of JAX tracing errors, please refer to the guide at: https://jax.readthedocs.io/en/latest/errors.html
@@ -436,12 +436,12 @@ To allow AutoGraph conversion to work in this case, simply convert the list to
 a JAX array:
 
 >>> @qjit(autograph=True)
-... @qml.qnode(dev)
+... @qp.qnode(dev)
 ... def f():
 ...     x = jnp.array([0.1, 0.2, 0.3])
 ...     for i in range(3):
-...         qml.RX(x[i], wires=i)
-...     return qml.expval(qml.PauliZ(0))
+...         qp.RX(x[i], wires=i)
+...     return qp.expval(qp.PauliZ(0))
 >>> f()
 Array(0.99500417, dtype=float64)
 
@@ -452,12 +452,12 @@ loop. However, AutoGraph will continue to fallback to Python for interpreting
 the for loop:
 
 >>> @qjit(autograph=True)
-... @qml.qnode(dev)
+... @qp.qnode(dev)
 ... def f():
 ...     x = ["0.1", "0.2", "0.3"]
 ...     for i in range(3):
-...         qml.RX(float(x[i]), wires=i)
-...     return qml.expval(qml.PauliZ(0))
+...         qp.RX(float(x[i]), wires=i)
+...     return qp.expval(qp.PauliZ(0))
 Warning: If you intended for the conversion to happen, make sure that the(now dynamic) loop variable is not used in tracing-incompatible ways,
 for instance by indexing a Python list with it. In that case, the list should be wrapped into an array.
 To understand different types of JAX tracing errors, please refer to the guide at: https://jax.readthedocs.io/en/latest/errors.html
@@ -508,12 +508,12 @@ the size of the loop is set by a dynamic runtime variable) will also work, as lo
 as the object indexed is a JAX array:
 
 >>> @qjit(autograph=True)
-... @qml.qnode(dev)
+... @qp.qnode(dev)
 ... def f(n):
 ...     x = jnp.array([0.0, 1 / 4 * jnp.pi, 2 / 4 * jnp.pi])
 ...     for i in range(n):
-...         qml.RY(x[i], wires=0)
-...     return qml.expval(qml.PauliZ(0))
+...         qp.RY(x[i], wires=0)
+...     return qp.expval(qp.PauliZ(0))
 >>> f(2)
 Array(0.70710678, dtype=float64)
 >>> f(3)
@@ -527,12 +527,12 @@ In this case, AutoGraph will raise a warning, but the compilation of the functio
 will ultimately fail:
 
 >>> @qjit(autograph=True)
-... @qml.qnode(dev)
+... @qp.qnode(dev)
 ... def f(n):
 ...     x = [0.0, 1 / 4 * jnp.pi, 2 / 4 * jnp.pi]
 ...     for i in range(n):
-...         qml.RY(x[i], wires=0)
-...     return qml.expval(qml.PauliZ(0))
+...         qp.RY(x[i], wires=0)
+...     return qp.expval(qp.PauliZ(0))
 TracerIntegerConversionError: The __index__() method was called on traced array with shape int64[].
 See https://jax.readthedocs.io/en/latest/errors.html#jax.errors.TracerIntegerConversionError
 
@@ -679,25 +679,25 @@ of multiple measurements. For example,
 
 .. code-block:: python
 
-    dev = qml.device("lightning.qubit", wires=2)
+    dev = qp.device("lightning.qubit", wires=2)
 
     @qjit(autograph=True)
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def circuit():
-        qml.RX(0.1, wires=0)
-        qml.RY(0.5, wires=1)
+        qp.RX(0.1, wires=0)
+        qp.RY(0.5, wires=1)
 
         m1 = measure(0)
         m2 = measure(1)
 
         if m1 and not m2:
-            qml.Hadamard(wires=1)
+            qp.Hadamard(wires=1)
         elif m1 and m2:
-            qml.RX(0.5, wires=1)
+            qp.RX(0.5, wires=1)
         else:
-            qml.RY(0.5, wires=1)
+            qp.RY(0.5, wires=1)
 
-        return qml.expval(qml.PauliZ(1))
+        return qp.expval(qp.PauliZ(1))
 
 >>> circuit()
 Array(0.87758256, dtype=float64)
@@ -796,14 +796,14 @@ that all parts of our program control flow *are* being captured, we can set
 ``autograph_strict_conversion``:
 
 >>> catalyst.autograph_strict_conversion = True
->>> dev = qml.device("lightning.qubit", wires=1)
+>>> dev = qp.device("lightning.qubit", wires=1)
 >>> @qjit(autograph=True)
-... @qml.qnode(dev)
+... @qp.qnode(dev)
 ... def f():
 ...     params = ["0", "1", "2"]
 ...     for x in params:
-...         qml.RY(int(x) * jnp.pi / 4, wires=0)
-...     return qml.expval(qml.PauliZ(0))
+...         qp.RY(int(x) * jnp.pi / 4, wires=0)
+...     return qp.expval(qp.PauliZ(0))
 AutoGraphError: Could not convert the iteration target ['0', '1', '2'] to array while processing the following with AutoGraph:
   File "<ipython-input-44-dbae11e6d745>", line 7, in f
     for x in params:
@@ -814,12 +814,12 @@ silence AutoGraph warnings; this can be done via ``autograph_ignore_fallbacks``:
 >>> catalyst.autograph_strict_conversion = False
 >>> catalyst.autograph_ignore_fallbacks = True
 >>> @qjit(autograph=True)
-... @qml.qnode(dev)
+... @qp.qnode(dev)
 ... def f():
 ...     x = ["0.1", "0.2", "0.3"]
 ...     for i in range(3):
-...         qml.RX(float(x[i]), wires=i)
-...     return qml.expval(qml.PauliZ(0))
+...         qp.RX(float(x[i]), wires=i)
+...     return qp.expval(qp.PauliZ(0))
 >>> f()
 Array(0.99500417, dtype=float64)
 
@@ -900,7 +900,7 @@ function with ``autograph=True``:
           num += 1. / fac
       return num
 
-    @qml.qjit(autograph=True)
+    @qp.qjit(autograph=True)
     def g(x: float, N: int):
 
       for i in range(N):
@@ -920,7 +920,7 @@ within a qjit-compiled function via the context manager syntax:
 
 .. code-block:: python
 
-    @qml.qjit(autograph=True)
+    @qp.qjit(autograph=True)
     def g(x: float, N: int):
 
       for i in range(N):
@@ -939,7 +939,7 @@ if defined within function ``g``:
 
 .. code-block:: python
 
-    @qml.qjit(autograph=True, static_argnums=1)
+    @qp.qjit(autograph=True, static_argnums=1)
     def g(x: float, N: int):
 
         def approximate_e(n):

--- a/doc/dev/custom_devices.rst
+++ b/doc/dev/custom_devices.rst
@@ -87,7 +87,7 @@ as a string of device specifications and options, represented in Python dictiona
 An example could be some noise parameter or other configurable behaviour: ``"{'noise': 0.5}"``.
 
 Note that these parameters are automatically initialized in the frontend if the library is
-provided as a PennyLane plugin device (see :func:`qml.device() <pennylane.device>`).
+provided as a PennyLane plugin device (see :func:`qp.device() <pennylane.device>`).
 
 The destructor of ``CustomDevice`` will be automatically called by the runtime.
 
@@ -121,7 +121,7 @@ Integration with Python devices
 
 There are two things that are needed in order to integrate with PennyLane devices:
 
-* Adding a ``get_c_interface`` method to your ``qml.devices.Device`` class.
+* Adding a ``get_c_interface`` method to your ``qp.devices.Device`` class.
 * Adding a ``config_filepath`` class variable pointing to your configuration file. This file should
   be a `toml file <https://toml.io/en/>`_ with fields that describe what gates and features are
   supported by your device.
@@ -143,7 +143,7 @@ The Pennylane device API allows you to build a QJIT compatible device in a simpl
 
 .. code-block:: python
 
-    class CustomDevice(qml.devices.Device):
+    class CustomDevice(qp.devices.Device):
         """Custom Device"""
 
         config_filepath = pathlib.Path("absolute/path/to/configuration/file.toml")
@@ -163,7 +163,7 @@ The Pennylane device API allows you to build a QJIT compatible device in a simpl
             """Your normal definitions"""
 
     @qjit
-    @qml.qnode(CustomDevice(wires=1))
+    @qp.qnode(CustomDevice(wires=1))
     def f():
         return measure(0)
 
@@ -295,7 +295,7 @@ of the ``QuantumDevice`` constructor to variables. For example:
 
 .. code-block:: python
 
-    class CustomDevice(qml.devices.Device):
+    class CustomDevice(qp.devices.Device):
         """Custom Device"""
 
         config_filepath = pathlib.Path("absolute/path/to/configuration/file.toml")

--- a/doc/dev/debugging.rst
+++ b/doc/dev/debugging.rst
@@ -152,7 +152,7 @@ passing them to the ``@qjit`` decorator. E.g. if you want to disable inlining
         ]
 
      @qjit(pipelines=my_pipelines, keep_intermediate=True)
-     @qml.qnode(dev)
+     @qp.qnode(dev)
      def circuit():
         ...
 
@@ -209,7 +209,7 @@ Compilation Steps
 
 The compilation process of a QJITed quantum function moves through various stages of the compilation pipeline including:
 
-- **Quantum Tape**: the quantum record of hybrid quantum programs in a single ``qml.QNode``
+- **Quantum Tape**: the quantum record of hybrid quantum programs in a single ``qp.QNode``
 - **JAXPR**: the graph data structure maintained by `JAX <https://github.com/google/jax>`_ for the classical & quantum parts of the compiled program
 - **MLIR**: a novel compiler framework and intermediate representation
 - **StableHLO + Quantum Dialect**: Lowering to `StableHLO <https://github.com/openxla/stablehlo>`_ is the first stage inside MLIR after leaving JAXPR.
@@ -224,12 +224,12 @@ In the following example, we also compile ahead-of-time so that there is no requ
 .. code-block:: python
 
     @qjit(keep_intermediate=True)
-    @qml.qnode(qml.device("lightning.qubit", wires=2))
+    @qp.qnode(qp.device("lightning.qubit", wires=2))
     def circuit(x: float, y: float):
         theta = jnp.sin(x) + y
-        qml.RY(theta, wires=0)
-        qml.CNOT(wires=[0,1])
-        return qml.state()
+        qp.RY(theta, wires=0)
+        qp.CNOT(wires=[0,1])
+        return qp.state()
 
     print(circuit.jaxpr)
 

--- a/doc/dev/devices.rst
+++ b/doc/dev/devices.rst
@@ -80,7 +80,7 @@ Supported backend devices include:
       simulator with many novel optimizations including hybrid stabilizer simulation. To use this
       device with Catalyst, make sure to install the
       `PennyLane-Qrack plugin <https://pennylane-qrack.readthedocs.io/en/latest/>`__, and check out
-      the `QJIT compilation with Qrack and Catalyst tutorial <https://pennylane.ai/qp/demos/qrack/>`__.
+      the `QJIT compilation with Qrack and Catalyst tutorial <https://pennylane.ai/qml/demos/qrack/>`__.
 
       See the `Catalyst configuration file <https://github.com/unitaryfund/pennylane-qrack/blob/master/pennylane_qrack/QrackDeviceConfig.toml>`__
       for natively supported instructions.

--- a/doc/dev/devices.rst
+++ b/doc/dev/devices.rst
@@ -80,7 +80,7 @@ Supported backend devices include:
       simulator with many novel optimizations including hybrid stabilizer simulation. To use this
       device with Catalyst, make sure to install the
       `PennyLane-Qrack plugin <https://pennylane-qrack.readthedocs.io/en/latest/>`__, and check out
-      the `QJIT compilation with Qrack and Catalyst tutorial <https://pennylane.ai/qml/demos/qrack/>`__.
+      the `QJIT compilation with Qrack and Catalyst tutorial <https://pennylane.ai/qp/demos/qrack/>`__.
 
       See the `Catalyst configuration file <https://github.com/unitaryfund/pennylane-qrack/blob/master/pennylane_qrack/QrackDeviceConfig.toml>`__
       for natively supported instructions.
@@ -99,7 +99,7 @@ Supported backend devices include:
           os.environ["OQC_PASSWORD"] = "your_password"
           os.environ["OQC_URL"] = "oqc_url"
 
-          dev = qml.device("oqc.cloud", backend="lucy", shots=2012, wires=2)
+          dev = qp.device("oqc.cloud", backend="lucy", shots=2012, wires=2)
 
       See the `Catalyst configuration file <https://github.com/PennyLaneAI/catalyst/blob/main/frontend/catalyst/third_party/oqc/src/oqc.toml>`__
       for natively supported instructions.

--- a/doc/dev/jax_integration.rst
+++ b/doc/dev/jax_integration.rst
@@ -77,18 +77,18 @@ and only apply outside of QNodes:
 
 .. code-block:: python
 
-    dev = qml.device("lightning.qubit", wires=4, shots=10)
+    dev = qp.device("lightning.qubit", wires=4, shots=10)
 
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def circuit(x):
         N = x.shape[0]
 
         @catalyst.for_loop(0, N, 1)
         def loop_fn(i):
-            qml.RX(x[i], wires=i)
+            qp.RX(x[i], wires=i)
 
         loop_fn()
-        return [qml.expval(qml.PauliZ(i)) for i in range(N)]
+        return [qp.expval(qp.PauliZ(i)) for i in range(N)]
 
     @qjit
     def fn(x):
@@ -168,12 +168,12 @@ Compiled functions remain JAX compatible, and you can call JAX transformations
 on them, such as ``jax.grad`` and ``jax.vmap``. You can even call ``jax.jit``
 on functions that call qjit-compiled functions:
 
->>> dev = qml.device("lightning.qubit", wires=2)
+>>> dev = qp.device("lightning.qubit", wires=2)
 >>> @qjit
-... @qml.qnode(dev)
+... @qp.qnode(dev)
 ... def circuit(x):
-...     qml.RX(x, wires=0)
-...     return qml.expval(qml.PauliZ(0))
+...     qp.RX(x, wires=0)
+...     return qp.expval(qp.PauliZ(0))
 >>> @jax.jit
 ... def workflow(y):
 ...     return jax.grad(circuit)(jnp.sin(y))
@@ -213,10 +213,10 @@ If they are applied to quantum processing, an error will occur:
 
 >>> @qjit
 ... def f(x):
-...     @qml.qnode(dev)
+...     @qp.qnode(dev)
 ...     def g(y):
-...         qml.RX(y, wires=0)
-...         return qml.expval(qml.PauliX(0))
+...         qp.RX(y, wires=0)
+...         return qp.expval(qp.PauliX(0))
 ...     return jax.grad(lambda y: g(y) ** 2)(x)
 >>> f(0.4)
 NotImplementedError: must override
@@ -226,10 +226,10 @@ quantum-classical processing:
 
 >>> @qjit
 ... def f(x):
-...     @qml.qnode(dev)
+...     @qp.qnode(dev)
 ...     def g(y):
-...         qml.RX(y, wires=0)
-...         return qml.expval(qml.PauliZ(0))
+...         qp.RX(y, wires=0)
+...         return qp.expval(qp.PauliZ(0))
 ...     return grad(lambda y: g(y) ** 2)(x)
 >>> f(0.4)
 Array(-0.71735609, dtype=float64)

--- a/doc/dev/plugins.rst
+++ b/doc/dev/plugins.rst
@@ -352,11 +352,11 @@ See for example:
     from standalone import getStandalonePluginAbsolutePath
 
     @apply_pass_plugin(getStandalonePluginAbsolutePath(), "standalone-switch-bar-foo")
-    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    @qp.qnode(qp.device("lightning.qubit", wires=1))
     def qnode():
-        return qml.state()
+        return qp.state()
 
-    @qml.qjit(target="mlir")
+    @qp.qjit(target="mlir")
     def module():
         return qnode()
 
@@ -403,11 +403,11 @@ After this, the user will be able to use your pass with the :func:`~.passes.appl
 .. code-block:: python
 
     @apply_pass("standalone.standalone-switch-bar-foo")
-    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    @qp.qnode(qp.device("lightning.qubit", wires=1))
     def qnode():
-        return qml.state()
+        return qp.state()
 
-    @qml.qjit(target="mlir")
+    @qp.qjit(target="mlir")
     def module():
         return qnode()
 
@@ -422,11 +422,11 @@ For example:
     from standalone import SwitchBarToFoo
 
     @SwitchBarToFoo
-    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    @qp.qnode(qp.device("lightning.qubit", wires=1))
     def qnode():
-        return qml.state()
+        return qp.state()
 
-    @qml.qjit(target="mlir")
+    @qp.qjit(target="mlir")
     def module():
         return qnode()
 

--- a/doc/dev/quick_start.rst
+++ b/doc/dev/quick_start.rst
@@ -30,7 +30,7 @@ provided by JAX.
 .. code-block:: python
 
     from catalyst import qjit, measure, cond, for_loop, while_loop, grad
-    import pennylane as qml
+    import pennylane as qp
     from jax import numpy as jnp
 
 Constructing the QNode
@@ -51,14 +51,14 @@ Let's start learning more about Catalyst by running a simple circuit.
 
 .. code-block:: python
 
-    @qml.qnode(qml.device("lightning.qubit", wires=2))
+    @qp.qnode(qp.device("lightning.qubit", wires=2))
     def circuit(theta):
-        qml.Hadamard(wires=0)
-        qml.RX(theta, wires=1)
-        qml.CNOT(wires=[0,1])
-        return qml.expval(qml.PauliZ(wires=1))
+        qp.Hadamard(wires=0)
+        qp.RX(theta, wires=1)
+        qp.CNOT(wires=[0,1])
+        return qp.expval(qp.PauliZ(wires=1))
 
-In PennyLane, the :func:`qml.qnode() <pennylane.qnode>` decorator creates a device specific quantum function. For each quantum
+In PennyLane, the :func:`qp.qnode() <pennylane.qnode>` decorator creates a device specific quantum function. For each quantum
 function, we can specify the number of wires.
 
 The :func:`.qjit` decorator can be used to jit a workflow of quantum functions:
@@ -76,12 +76,12 @@ For example, the following circuit can be jitted with wires as arguments:
 .. code-block:: python
 
     @qjit
-    @qml.qnode(qml.device("lightning.qubit", wires=5))
+    @qp.qnode(qp.device("lightning.qubit", wires=5))
     def circuit(arg0, arg1, arg2):
-        qml.RX(arg0, wires=[arg1 + 1])
-        qml.RY(arg0, wires=[arg2])
-        qml.CNOT(wires=[arg1, arg2])
-        return qml.probs(wires=[arg1 + 1])
+        qp.RX(arg0, wires=[arg1 + 1])
+        qp.RY(arg0, wires=[arg2])
+        qp.CNOT(wires=[arg1, arg2])
+        return qp.probs(wires=[arg1 + 1])
 
 >>> circuit(jnp.pi / 3, 1, 2)
 Array([0.625, 0.375], dtype=float64)
@@ -91,16 +91,16 @@ Operations
 ----------
 Catalyst allows you to use :doc:`quantum operations <introduction/operations>`
 available in PennyLane either via native support by the runtime or PennyLane's decomposition rules.
-The :func:`qml.adjoint() <pennylane.adjoint>` and :func:`qml.ctrl() <pennylane.ctrl>` functions in
+The :func:`qp.adjoint() <pennylane.adjoint>` and :func:`qp.ctrl() <pennylane.ctrl>` functions in
 PennyLane are also supported via the decomposition mechanism in Catalyst. For example,
 
 .. code-block:: python
 
-    @qml.qnode(qml.device("lightning.qubit", wires=2))
+    @qp.qnode(qp.device("lightning.qubit", wires=2))
     def circuit():
-        qml.Rot(0.3, 0.4, 0.5, wires=0)
-        qml.adjoint(qml.SingleExcitation(jnp.pi / 3, wires=[0, 1]))
-        return qml.state()
+        qp.Rot(0.3, 0.4, 0.5, wires=0)
+        qp.adjoint(qp.SingleExcitation(jnp.pi / 3, wires=[0, 1]))
+        return qp.state()
 
 In addition, you can qjit most :doc:`PennyLane templates <introduction/templates>` to easily construct and evaluate
 more complex quantum circuits.
@@ -112,7 +112,7 @@ more complex quantum circuits.
    decompose quite differently).
    However, Catalyst's decomposition logic will differ in the following cases:
 
-   1. For devices without native controlled gates support (e.g., ``lightning.kokkos`` and ``lightning.gpu``), all :class:`qml.Controlled <pennylane.ops.op_math.Controlled>` operations will decompose to :class:`qml.QubitUnitary <pennylane.QubitUnitary>` operations.
+   1. For devices without native controlled gates support (e.g., ``lightning.kokkos`` and ``lightning.gpu``), all :class:`qp.Controlled <pennylane.ops.op_math.Controlled>` operations will decompose to :class:`qp.QubitUnitary <pennylane.QubitUnitary>` operations.
    2. The set of operations supported by Catalyst itself can in some instances lead to additional decompositions compared to the device itself.
 
 
@@ -121,21 +121,21 @@ Observables
 The Catalyst has support for :doc:`PennyLane observables <introduction/operations>`.
 
 For example, the following circuit is a QJIT compatible function that calculates the expectation value of
-a tensor product of a :class:`qml.PauliX <pennylane.PauliX>`, :class:`qml.Hadamard <pennylane.Hadamard>` and :class:`qml.Hermitian <pennylane.Hermitian>` observables.
+a tensor product of a :class:`qp.PauliX <pennylane.PauliX>`, :class:`qp.Hadamard <pennylane.Hadamard>` and :class:`qp.Hermitian <pennylane.Hermitian>` observables.
 
 .. code-block:: python
 
-    @qml.qnode(qml.device("lightning.qubit", wires=3))
+    @qp.qnode(qp.device("lightning.qubit", wires=3))
     def circuit(x, y):
-        qml.RX(x, 0)
-        qml.RX(y, 1)
-        qml.CNOT([0, 2])
-        qml.CNOT([1, 2])
+        qp.RX(x, 0)
+        qp.RX(y, 1)
+        qp.CNOT([0, 2])
+        qp.CNOT([1, 2])
         h_matrix = jnp.array(
             [[complex(1.0, 0.0), complex(2.0, 0.0)],
             [complex(2.0, 0.0), complex(-1.0, 0.0)]]
         )
-        return qml.expval(qml.PauliX(0) @ qml.Hadamard(1) @ qml.Hermitian(h_matrix, 2))
+        return qp.expval(qp.PauliX(0) @ qp.Hadamard(1) @ qp.Hermitian(h_matrix, 2))
 
 .. _measurements:
 
@@ -148,22 +148,22 @@ are supported in Catalyst, although not all features are supported for all measu
    :widths: 25 75
    :header-rows: 0
 
-   * - :func:`qml.expval() <pennylane.expval>`
+   * - :func:`qp.expval() <pennylane.expval>`
      - The expectation value of observables is supported analytically as well as with finite-shots.
-   * - :func:`qml.var() <pennylane.var>`
+   * - :func:`qp.var() <pennylane.var>`
      - The variance of observables is supported analytically as well as with finite-shots.
-   * - :func:`qml.sample() <pennylane.sample>`
+   * - :func:`qp.sample() <pennylane.sample>`
      - Samples in the computational basis only are supported.
-   * - :func:`qml.counts() <pennylane.counts>`
+   * - :func:`qp.counts() <pennylane.counts>`
      - Sample counts in the computational basis only are supported.
-   * - :func:`qml.probs() <pennylane.probs>`
+   * - :func:`qp.probs() <pennylane.probs>`
      - The probabilities is supported in the computational basis as well as with finite-shots.
-   * - :func:`qml.state() <pennylane.state>`
+   * - :func:`qp.state() <pennylane.state>`
      - The state in the computational basis only is supported.
    * - :func:`.measure`
      - The projective mid-circuit measurement is supported via its own operation in Catalyst.
 
-For both :func:`qml.sample() <pennylane.sample>` and :func:`qml.counts() <pennylane.counts>` omitting the wires
+For both :func:`qp.sample() <pennylane.sample>` and :func:`qp.counts() <pennylane.counts>` omitting the wires
 parameters produces samples on all declared qubits in the same format as in PennyLane.
 
 Counts are returned a bit differently, namely as a pair of arrays representing a dictionary from basis states
@@ -174,17 +174,17 @@ float data type. This way they are compatible with eigenvalue sampling, but this
 .. code-block:: python
 
     @qjit
-    @qml.qnode(qml.device("lightning.qubit", wires=2, shots=1000))
+    @qp.qnode(qp.device("lightning.qubit", wires=2, shots=1000))
     def counts():
-        qml.Rot(0.1, 0.2, 0.3, wires=[0])
-        return qml.counts(wires=[0])
+        qp.Rot(0.1, 0.2, 0.3, wires=[0])
+        return qp.counts(wires=[0])
     basis_states, counts = counts()
 
 >>> {format(int(state), '01b'): count for state, count in zip(basis_states, counts)}
 {'0': 985, '1': 15}
 
 You can specify the number of shots to be used in sample-based measurements when you create a device.
-:func:`qml.sample() <pennylane.sample>` and :func:`qml.counts() <pennylane.counts>` will
+:func:`qp.sample() <pennylane.sample>` and :func:`qp.counts() <pennylane.counts>` will
 automatically use the device's ``shots`` parameter when performing measurements.
 In the following example, the number of shots is set to :math:`500` in the device instantiation.
 
@@ -195,18 +195,18 @@ In the following example, the number of shots is set to :math:`500` in the devic
 .. code-block:: python
 
     @qjit
-    @qml.qnode(qml.device("lightning.qubit", wires=3, shots=500))
+    @qp.qnode(qp.device("lightning.qubit", wires=3, shots=500))
     def circuit(params):
-        qml.RX(params[0], wires=0)
-        qml.RX(params[1], wires=1)
-        qml.RZ(params[2], wires=2)
+        qp.RX(params[0], wires=0)
+        qp.RX(params[1], wires=1)
+        qp.RZ(params[2], wires=2)
         return (
-            qml.sample(),
-            qml.counts(),
-            qml.expval(qml.PauliZ(0)),
-            qml.var(qml.PauliZ(0)),
-            qml.probs(wires=[0, 1]),
-            qml.state(),
+            qp.sample(),
+            qp.counts(),
+            qp.expval(qp.PauliZ(0)),
+            qp.var(qp.PauliZ(0)),
+            qp.probs(wires=[0, 1]),
+            qp.state(),
         )
 
 >>> circuit([0.3, 0.5, 0.7])
@@ -233,7 +233,7 @@ requires a list of wires that the measurement process acts on.
 
 .. important::
 
-    The :func:`qml.measure() <pennylane.measure>` function is **not** QJIT compatible and :func:`.measure` from Catalyst should be used instead:
+    The :func:`qp.measure() <pennylane.measure>` function is **not** QJIT compatible and :func:`.measure` from Catalyst should be used instead:
 
     .. code-block:: python
 
@@ -244,9 +244,9 @@ In the following example, ``m`` will be equal to ``True`` if wire :math:`0` is r
 .. code-block:: python
 
     @qjit
-    @qml.qnode(qml.device("lightning.qubit", wires=2))
+    @qp.qnode(qp.device("lightning.qubit", wires=2))
     def circuit(x):
-        qml.RX(x, wires=0)
+        qp.RX(x, wires=0)
         m = measure(wires=0)
         return m
 
@@ -270,12 +270,12 @@ the quantum function is executed. For example, ``circuit`` is compiled as early 
 .. code-block:: python
 
     @qjit
-    @qml.qnode(qml.device("lightning.qubit", wires=2))
+    @qp.qnode(qp.device("lightning.qubit", wires=2))
     def circuit(theta):
-        qml.Hadamard(wires=0)
-        qml.RX(theta, wires=1)
-        qml.CNOT(wires=[0,1])
-        return qml.expval(qml.PauliZ(wires=1))
+        qp.Hadamard(wires=0)
+        qp.RX(theta, wires=1)
+        qp.CNOT(wires=[0,1])
+        return qp.expval(qp.PauliZ(wires=1))
 
 >>> circuit(0.5)  # the first call, compilation occurs here
 Array(0., dtype=float64)
@@ -298,12 +298,12 @@ and data type of a tensor:
     from jax.core import ShapedArray
 
     @qjit  # compilation happens at definition
-    @qml.qnode(qml.device("lightning.qubit", wires=2))
+    @qp.qnode(qp.device("lightning.qubit", wires=2))
     def circuit(x: complex, z: ShapedArray(shape=(3,), dtype=jnp.float64)):
         theta = jnp.abs(x)
-        qml.RY(theta, wires=0)
-        qml.Rot(z[0], z[1], z[2], wires=0)
-        return qml.state()
+        qp.RY(theta, wires=0)
+        qp.Rot(z[0], z[1], z[2], wires=0)
+        return qp.state()
 
 >>> circuit(0.2j, jnp.array([0.3, 0.6, 0.9]))  # calls precompiled function
 Array([0.75634905-0.52801002j, 0. +0.j,
@@ -498,10 +498,10 @@ This decorator accepts the function to differentiate, a differentiation strategy
 
     @qjit
     def workflow(x):
-        @qml.qnode(qml.device("lightning.qubit", wires=1))
+        @qp.qnode(qp.device("lightning.qubit", wires=1))
         def circuit(x):
-            qml.RX(jnp.pi * x, wires=0)
-            return qml.expval(qml.PauliY(0))
+            qp.RX(jnp.pi * x, wires=0)
+            return qp.expval(qp.PauliY(0))
 
         g = grad(circuit)
         return g(x)
@@ -544,10 +544,10 @@ also feasible.
 
     @qjit
     def workflow(params):
-        @qml.qnode(qml.device("lightning.qubit", wires=1))
+        @qp.qnode(qp.device("lightning.qubit", wires=1))
         def circuit(params):
-            qml.RX(params[0] * params[1], wires=0)
-            return qml.expval(qml.PauliY(0))
+            qp.RX(params[0] * params[1], wires=0)
+            return qp.expval(qp.PauliY(0))
 
         return grad(circuit, argnums=0)(params)
 
@@ -561,11 +561,11 @@ decorator to compute Jacobian matrices of general hybrid functions with multiple
 
     @qjit
     def workflow(x):
-        @qml.qnode(qml.device("lightning.qubit", wires=1))
+        @qp.qnode(qp.device("lightning.qubit", wires=1))
         def circuit(x):
-            qml.RX(jnp.pi * x[0], wires=0)
-            qml.RY(x[1], wires=0)
-            return qml.probs()
+            qp.RX(jnp.pi * x[0], wires=0)
+            qp.RY(x[1], wires=0)
+            return qp.probs()
 
         g = jacobian(circuit, method="auto")
         return g(x)
@@ -601,13 +601,13 @@ the value of ``value_and_grad`` argument. To optimize params iteratively, you la
     import optax
     from jax.lax import fori_loop
 
-    dev = qml.device("lightning.qubit", wires=1)
+    dev = qp.device("lightning.qubit", wires=1)
 
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def circuit(param):
-        qml.Hadamard(0)
-        qml.RY(param, wires=0)
-        return qml.expval(qml.PauliZ(0))
+        qp.Hadamard(0)
+        qp.RY(param, wires=0)
+        return qp.expval(qp.PauliZ(0))
 
     @qjit
     def workflow():
@@ -651,15 +651,15 @@ function:
 
 .. code-block:: python
 
-    dev = qml.device("lightning.qubit", wires=1)
+    dev = qp.device("lightning.qubit", wires=1)
 
     @qjit
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def circuit(x):
-      qml.RX(jnp.pi * x[0], wires=0)
-      qml.RY(x[1] ** 2, wires=0)
-      qml.RX(x[1] * x[2], wires=0)
-      return qml.probs(wires=0)
+      qp.RX(jnp.pi * x[0], wires=0)
+      qp.RY(x[1] ** 2, wires=0)
+      qp.RX(x[1] * x[2], wires=0)
+      return qp.probs(wires=0)
 
     @jax.jit
     def cost_fn(weights):

--- a/doc/dev/sharp_bits.rst
+++ b/doc/dev/sharp_bits.rst
@@ -268,18 +268,18 @@ size of the input argument determines the number of qubits and gates used:
 
 .. code-block:: python
 
-    dev = qml.device("lightning.qubit", wires=4)
+    dev = qp.device("lightning.qubit", wires=4)
 
     @qjit
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def circuit(x):
         print("Tracing occurring")
 
         def loop_fn(i):
-            qml.RX(x[i], wires=i)
+            qp.RX(x[i], wires=i)
 
         for_loop(0, x.shape[0], 1)(loop_fn)()
-        return qml.expval(qml.PauliZ(0))
+        return qp.expval(qp.PauliZ(0))
 
 This will run correctly, but tracing and recompilation will occur with every
 function execution:
@@ -296,13 +296,13 @@ To be explicitly warned about recompilation, you can use ahead-of-time
 directly:
 
 >>> @qjit
-... @qml.qnode(dev)
+... @qp.qnode(dev)
 ... def circuit(x: jax.core.ShapedArray((3,), dtype=np.float64)):
 ...     print("Tracing occurring")
 ...     def loop_fn(i):
-...         qml.RX(x[i], wires=i)
+...         qp.RX(x[i], wires=i)
 ...     for_loop(0, x.shape[0], 1)(loop_fn)()
-...     return qml.expval(qml.PauliZ(0))
+...     return qp.expval(qp.PauliZ(0))
 Tracing occurring
 
 Note that compilation now happens on **function definition**. We can execute
@@ -397,25 +397,25 @@ circuit, are measuring an expectation value, and are optimizing the result:
     import numpy as np
     import jax
 
-    dev = qml.device("default.qubit", wires=4)
+    dev = qp.device("default.qubit", wires=4)
 
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def cost(weights, data):
-        qml.AngleEmbedding(data, wires=range(4))
+        qp.AngleEmbedding(data, wires=range(4))
 
         for x in weights:
             # each trainable layer
             for i in range(4):
                 # for each wire
                 if x[i] > 0:
-                    qml.RX(x[i], wires=i)
+                    qp.RX(x[i], wires=i)
                 elif x[i] < 0:
-                    qml.RY(x[i], wires=i)
+                    qp.RY(x[i], wires=i)
 
             for i in range(4):
-                qml.CNOT(wires=[i, (i + 1) % 4])
+                qp.CNOT(wires=[i, (i + 1) % 4])
 
-        return qml.expval(qml.PauliZ(0) + qml.PauliZ(3))
+        return qp.expval(qp.PauliZ(0) + qp.PauliZ(3))
 
     weights = jnp.array(2 * np.random.random([5, 4]) - 1)
     data = jnp.array(np.random.random([4]))
@@ -445,12 +445,12 @@ it using Catalyst:
 
 .. code-block:: python
 
-    dev = qml.device("lightning.qubit", wires=4)
+    dev = qp.device("lightning.qubit", wires=4)
 
     @qjit
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def cost(weights, data):
-        qml.AngleEmbedding(data, wires=range(4))
+        qp.AngleEmbedding(data, wires=range(4))
 
         def layer_loop(i):
             x = weights[i]
@@ -458,23 +458,23 @@ it using Catalyst:
 
                 @cond(x[j] > 0)
                 def trainable_gate():
-                    qml.RX(x[j], wires=j)
+                    qp.RX(x[j], wires=j)
 
                 @trainable_gate.else_if(x[j] < 0)
                 def negative_gate():
-                    qml.RY(x[j], wires=j)
+                    qp.RY(x[j], wires=j)
 
                 trainable_gate.otherwise(lambda: None)
                 trainable_gate()
 
             def cnot_loop(j):
-                qml.CNOT(wires=[j, jnp.mod((j + 1), 4)])
+                qp.CNOT(wires=[j, jnp.mod((j + 1), 4)])
 
             for_loop(0, 4, 1)(wire_loop)()
             for_loop(0, 4, 1)(cnot_loop)()
 
         for_loop(0, jnp.shape(weights)[0], 1)(layer_loop)()
-        return qml.expval(qml.PauliZ(0) + qml.PauliZ(3))
+        return qp.expval(qp.PauliZ(0) + qp.PauliZ(3))
 
     opt = optax.sgd(learning_rate=0.4)
 
@@ -547,10 +547,10 @@ If they are applied to quantum processing, an error will occur:
 
 >>> @qjit
 ... def f(x):
-...     @qml.qnode(dev)
+...     @qp.qnode(dev)
 ...     def g(y):
-...         qml.RX(y, wires=0)
-...         return qml.expval(qml.PauliX(0))
+...         qp.RX(y, wires=0)
+...         return qp.expval(qp.PauliX(0))
 ...     return jax.grad(lambda y: g(y) ** 2)(x)
 >>> f(0.4)
 NotImplementedError: must override
@@ -560,10 +560,10 @@ quantum-classical processing:
 
 >>> @qjit
 ... def f(x):
-...     @qml.qnode(dev)
+...     @qp.qnode(dev)
 ...     def g(y):
-...         qml.RX(y, wires=0)
-...         return qml.expval(qml.PauliZ(0))
+...         qp.RX(y, wires=0)
+...         return qp.expval(qp.PauliZ(0))
 ...     return grad(lambda y: g(y) ** 2)(x)
 >>> f(0.4)
 Array(-0.71735609, dtype=float64)
@@ -577,9 +577,9 @@ Inspecting and drawing circuits
 
 A useful tool for debugging quantum algorithms is the ability to draw them. Currently,
 :func:`@qjit <~.qjit>` compiled QNodes can be used as input to
-:func:`qml.draw <pennylane.draw>`, with the following caveats:
+:func:`qp.draw <pennylane.draw>`, with the following caveats:
 
-- The ``qml.draw()`` function will only accept plain QNodes as input, *or* QNodes that have been qjit-compiled. It will not accept arbitrary hybrid functions (that may contain QNodes).
+- The ``qp.draw()`` function will only accept plain QNodes as input, *or* QNodes that have been qjit-compiled. It will not accept arbitrary hybrid functions (that may contain QNodes).
 
 - The :func:`catalyst.measure` function is not supported in drawn QNodes
 
@@ -593,25 +593,25 @@ For example,
 .. code-block:: python
 
     @qjit
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def circuit(x):
         def measurement_loop(i, y):
-            qml.RX(y, wires=0)
-            qml.RY(y ** 2, wires=1)
-            qml.CNOT(wires=[0, 1])
+            qp.RX(y, wires=0)
+            qp.RY(y ** 2, wires=1)
+            qp.CNOT(wires=[0, 1])
 
             @cond(y < 0.5)
             def cond_gate():
-                qml.CRX(y * jnp.exp(- y ** 2), wires=[0, 1])
+                qp.CRX(y * jnp.exp(- y ** 2), wires=[0, 1])
 
             cond_gate()
 
             return y * 2
 
         for_loop(0, 3, step=1)(measurement_loop)(x)
-        return qml.expval(qml.PauliZ(0))
+        return qp.expval(qp.PauliZ(0))
 
->>> print(qml.draw(circuit)(0.3))
+>>> print(qp.draw(circuit)(0.3))
 0: ──RX(0.30)─╭●─╭●─────────RX(0.60)─╭●──RX(1.20)─╭●─┤  <Z>
 1: ──RY(0.09)─╰X─╰RX(0.27)──RY(0.36)─╰X──RY(1.44)─╰X─┤
 
@@ -681,7 +681,7 @@ when working with classical control in Catalyst.
 Compatibility with PennyLane transforms
 ---------------------------------------
 
-PennyLane provides a wide variety of :doc:`transforms <code/qml_transforms>`
+PennyLane provides a wide variety of :doc:`transforms <code/qp_transforms>`
 that convert a circuit to one or more circuits.
 
 Currently, most PennyLane transforms will work with Catalyst as long as
@@ -690,16 +690,16 @@ variables. This includes transforms that generate many circuits,
 
 .. code-block:: python
 
-    import pennylane as qml
+    import pennylane as qp
 
-    dev = qml.device("lightning.qubit", wires=1)
+    dev = qp.device("lightning.qubit", wires=1)
 
-    @qml.qjit
-    @qml.transforms.split_non_commuting
-    @qml.qnode(dev)
+    @qp.qjit
+    @qp.transforms.split_non_commuting
+    @qp.qnode(dev)
     def circuit(x):
-        qml.RX(x,wires=0)
-        return [qml.expval(qml.PauliY(0)), qml.expval(qml.PauliZ(0))]
+        qp.RX(x,wires=0)
+        return [qp.expval(qp.PauliY(0)), qp.expval(qp.PauliZ(0))]
 
 >>> circuit(0.4)
 (Array(-0.38941834, dtype=float64), Array(0.92106099, dtype=float64))
@@ -708,13 +708,13 @@ as well as transforms that simply map the circuit to another:
 
 .. code-block:: python
 
-    @qml.qjit
-    @qml.transforms.merge_rotations
-    @qml.qnode(dev)
+    @qp.qjit
+    @qp.transforms.merge_rotations
+    @qp.qnode(dev)
     def circuit(x):
-        qml.RX(x, wires=0)
-        qml.RX(x ** 2, wires=0)
-        return qml.expval(qml.PauliZ(0))
+        qp.RX(x, wires=0)
+        qp.RX(x ** 2, wires=0)
+        return qp.expval(qp.PauliZ(0))
 
 >>> circuit(0.5)
 Array(0.73168887, dtype=float64)
@@ -763,31 +763,31 @@ Consider the following example that includes ``cancel_inverses``,
 
 .. code-block:: python
 
-    @qml.transform
+    @qp.transform
     def tape_transform(tape):
         return [tape,], lambda x: x[0]
 
-    dev = qml.device("lightning.qubit", wires=3)
+    dev = qp.device("lightning.qubit", wires=3)
 
-    @qml.qjit
+    @qp.qjit
     @tape_transform # applied as a tape transform
-    @qml.transforms.cancel_inverses(recursive=True) # applied as a tape transform
-    @qml.transforms.merge_rotations # applied as a tape transform
-    @qml.qnode(device=dev)
+    @qp.transforms.cancel_inverses(recursive=True) # applied as a tape transform
+    @qp.transforms.merge_rotations # applied as a tape transform
+    @qp.qnode(device=dev)
     def circuit(theta):
-        qml.CZ(wires=[0, 2])
-        qml.X(2)
-        qml.S(wires=0)
+        qp.CZ(wires=[0, 2])
+        qp.X(2)
+        qp.S(wires=0)
 
-        qml.CNOT(wires=[0, 1])
+        qp.CNOT(wires=[0, 1])
 
-        qml.H(0)
-        qml.H(0)
+        qp.H(0)
+        qp.H(0)
 
-        qml.RX(theta, wires=1)
-        qml.RX(theta, wires=1)
+        qp.RX(theta, wires=1)
+        qp.RX(theta, wires=1)
 
-        return qml.expval(qml.Z(0))
+        return qp.expval(qp.Z(0))
 
 >>> circuit(0.1)
 Array(1., dtype=float64)
@@ -803,27 +803,27 @@ However, if we were to swap ``cancel_inverses`` and ``tape_transform``,
 
 .. code-block:: python
 
-    dev = qml.device("lightning.qubit", wires=3)
+    dev = qp.device("lightning.qubit", wires=3)
 
-    @qml.qjit
-    @qml.transforms.cancel_inverses(recursive=True) # applied as an MLIR pass
+    @qp.qjit
+    @qp.transforms.cancel_inverses(recursive=True) # applied as an MLIR pass
     @tape_transform # applied as a tape transform
-    @qml.transforms.merge_rotations # applied as a tape transform
-    @qml.qnode(device=dev)
+    @qp.transforms.merge_rotations # applied as a tape transform
+    @qp.qnode(device=dev)
     def circuit(theta):
-        qml.CZ(wires=[0, 2])
-        qml.X(2)
-        qml.S(wires=0)
+        qp.CZ(wires=[0, 2])
+        qp.X(2)
+        qp.S(wires=0)
 
-        qml.CNOT(wires=[0, 1])
+        qp.CNOT(wires=[0, 1])
 
-        qml.H(0)
-        qml.H(0)
+        qp.H(0)
+        qp.H(0)
 
-        qml.RX(theta, wires=1)
-        qml.RX(theta, wires=1)
+        qp.RX(theta, wires=1)
+        qp.RX(theta, wires=1)
 
-        return qml.expval(qml.Z(0))
+        return qp.expval(qp.Z(0))
 
 In addition to this internal discrepancy, an error will now be raised since the
 MLIR implementation of ``cancel_inverses`` does not support the ``recursive``
@@ -845,7 +845,7 @@ variables will fail, since decompositions are applied at compile time:
 
 .. code-block:: python
 
-    class RXX(qml.operation.Operation):
+    class RXX(qp.operation.Operation):
         num_params = 1
         num_wires = 2
 
@@ -854,20 +854,20 @@ variables will fail, since decompositions are applied at compile time:
             ops = []
 
             if theta == 0.3:
-                ops.append(qml.PauliRot(theta / 2 * 2, 'XX', wires=wires))
+                ops.append(qp.PauliRot(theta / 2 * 2, 'XX', wires=wires))
             else:
-                ops.append(qml.PauliRot(theta / 2 * 2, 'XX', wires=wires))
+                ops.append(qp.PauliRot(theta / 2 * 2, 'XX', wires=wires))
 
             return ops
 
-    dev = qml.device("lightning.qubit", wires=2)
+    dev = qp.device("lightning.qubit", wires=2)
 
     @qjit
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def circuit(theta):
         RXX(theta, wires=[0, 1])
-        qml.Hadamard(1)
-        return qml.expval(qml.PauliZ(0))
+        qp.Hadamard(1)
+        return qp.expval(qp.PauliZ(0))
 
 >>> circuit(0.3)
 TracerBoolConversionError: Attempted boolean conversion of traced array with shape bool[]..
@@ -877,33 +877,33 @@ Instead, Catalyst control flow (such as :func:`~.cond` and :func:`.for_loop`) mu
 
 .. code-block:: python
 
-    class RXX(qml.operation.Operation):
+    class RXX(qp.operation.Operation):
         num_params = 1
         num_wires = 2
 
         def compute_decomposition(self, *params, wires=None):
             theta = params[0]
 
-            with qml.tape.QuantumTape() as tape:
+            with qp.tape.QuantumTape() as tape:
 
                 @cond(params[0] == 0.3)
                 def branch_fn():
-                    qml.PauliRot(theta, 'XX', wires=wires)
+                    qp.PauliRot(theta, 'XX', wires=wires)
 
                 @branch_fn.otherwise
                 def branch_fn():
-                    qml.PauliRot(theta / 2 * 2, 'XX', wires=wires)
+                    qp.PauliRot(theta / 2 * 2, 'XX', wires=wires)
 
                 branch_fn()
 
             return tape.operations
 
     @qjit
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def circuit(theta):
         RXX(theta, wires=[0, 1])
-        qml.Hadamard(1)
-        return qml.expval(qml.PauliZ(0))
+        qp.Hadamard(1)
+        return qp.expval(qp.PauliZ(0))
 
 >>> circuit(0.3)
 Array(0.95533649, dtype=float64)
@@ -920,7 +920,7 @@ the decomposition as follows:
 
     from catalyst import run_autograph
 
-    class RXX(qml.operation.Operation):
+    class RXX(qp.operation.Operation):
         num_params = 1
         num_wires = 2
 
@@ -930,11 +930,11 @@ the decomposition as follows:
             @run_autograph
             def f(params):
                 if params[0] == 0.3:
-                    qml.PauliRot(theta, 'XX', wires=wires)
+                    qp.PauliRot(theta, 'XX', wires=wires)
                 else:
-                    qml.PauliRot(theta / 2 * 2, 'XX', wires=wires)
+                    qp.PauliRot(theta / 2 * 2, 'XX', wires=wires)
 
-            with qml.tape.QuantumTape() as tape:
+            with qp.tape.QuantumTape() as tape:
                 f(params)
 
             return tape.operations
@@ -952,18 +952,18 @@ function, and can be used as follows:
 
 .. code-block:: python
 
-    dev = qml.device("lightning.qubit", wires=1)
+    dev = qp.device("lightning.qubit", wires=1)
 
     @qjit
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def f():
-        qml.PauliX(0)
-        qml.PauliX(0)
-        qml.Hadamard(0)
-        return qml.state()
+        qp.PauliX(0)
+        qp.PauliX(0)
+        qp.Hadamard(0)
+        return qp.state()
 
     # Explicitly accessing the QNode for PenneLane transforms, which takes in a QNode and returns a QNode
-    g = qml.transforms.cancel_inverses(f.original_function)
+    g = qp.transforms.cancel_inverses(f.original_function)
 
 
 >>> f
@@ -972,22 +972,22 @@ function, and can be used as follows:
 <QNode: device='<lightning.qubit device (wires=1) at ...>', ...>
 >>> g
 <QNode: device='<lightning.qubit device (wires=1) at ...>', ...>
->>> qml.matrix(f.original_function)()
+>>> qp.matrix(f.original_function)()
 [[ 0.70710678  0.70710678]
  [ 0.70710678 -0.70710678]]
 
 
-Note that some PennyLane functions may be able to extract the QNode automatically, like ``qml.draw`` and ``qml.matrix``:
+Note that some PennyLane functions may be able to extract the QNode automatically, like ``qp.draw`` and ``qp.matrix``:
 
->>> qml.matrix(f)()
+>>> qp.matrix(f)()
 [[ 0.70710678  0.70710678]
  [ 0.70710678 -0.70710678]]
->>> qml.draw(f)()
+>>> qp.draw(f)()
 0: ──X──X──H─┤  State
 >>> g = qjit(g)   # Compile the transformed QNode again with qjit
 >>> g
 <catalyst.jit.QJIT object at ...>
->>> qml.draw(g)()
+>>> qp.draw(g)()
 0: ──H─┤  State
 
 But in general, you will need to pass in the QNode explicitly.
@@ -1012,7 +1012,7 @@ For example, consider the following, where we pass arbitrarily nested lists or
 dictionaries as input to the compiled function:
 
 >>> f = qjit(lambda *args: args)
->>> x = qml.RX(0.4, wires=0)
+>>> x = qp.RX(0.4, wires=0)
 >>> y = {"apple": (True, jnp.array([0.1, 0.2, 0.3]))}
 >>> f(x, y)
 (RX(Array(0.4, dtype=float64), wires=[0]),
@@ -1206,35 +1206,35 @@ a single QNode, allowing the measurement type to alter based on some condition:
 
 .. code-block:: python
 
-    dev = qml.device("default.qubit", wires=2, shots=10)
+    dev = qp.device("default.qubit", wires=2, shots=10)
 
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def circuit(x, sample=False):
-        qml.RX(x, wires=0)
+        qp.RX(x, wires=0)
 
         if sample:
-            return qml.sample(wires=0)
+            return qp.sample(wires=0)
 
-        return qml.expval(qml.PauliZ(0))
+        return qp.expval(qp.PauliZ(0))
 
 This pattern is currently not supported in Catalyst, and will lead to an error:
 
 .. code-block:: python
 
-    dev = qml.device("lightning.qubit", wires=2, shots=10)
+    dev = qp.device("lightning.qubit", wires=2, shots=10)
 
     @qjit
-    @qml.qnode(dev)
+    @qp.qnode(dev)
     def circuit(x, sample=False):
-        qml.RX(x, wires=0)
+        qp.RX(x, wires=0)
 
         @cond(sample)
         def measure_fn():
-            return qml.sample(wires=0)
+            return qp.sample(wires=0)
 
         @measure_fn.otherwise
         def expval():
-            return qml.expval(qml.PauliZ(0))
+            return qp.expval(qp.PauliZ(0))
 
         return measure_fn()
 
@@ -1245,10 +1245,10 @@ It is recommended for now to create separate QNodes if different measurement sta
 returned, or alternatively using a single return statement with multiple measurements:
 
 >>> @qjit
-... @qml.qnode(dev)
+... @qp.qnode(dev)
 ... def circuit(x):
-...     qml.RX(x, wires=0)
-...     return {"samples": qml.sample(), "expval": qml.expval(qml.PauliZ(0))}
+...     qp.RX(x, wires=0)
+...     return {"samples": qp.sample(), "expval": qp.expval(qp.PauliZ(0))}
 >>> circuit(0.3)
 {'expval': Array(1., dtype=float64),
  'samples': Array([[0, 0],
@@ -1311,11 +1311,11 @@ Compatibility with broadcasting
 Catalyst does not currently support passing multi-dimensional arrays
 as quantum operator parameters ('parameter broadcasting'):
 
->>> @qml.qnode(dev)
+>>> @qp.qnode(dev)
 ... def circuit(x):
-...     qml.RX(x, wires=0)
-...     qml.RY(0.1, wires=0)
-...     return qml.expval(qml.PauliZ(0))
+...     qp.RX(x, wires=0)
+...     qp.RY(0.1, wires=0)
+...     return qp.expval(qp.PauliZ(0))
 >>> circuit(jnp.array([0.1, 0.2]))
 Array([0.99003329, 0.97517033], dtype=float64)
 >>> qjit(circuit)(jnp.array([0.1, 0.2]))
@@ -1334,9 +1334,9 @@ Note that ``jax.vmap`` cannot be used within a qjit-compiled function:
 NotImplementedError: Batching rule for 'qinst' not implemented
 
 In addition, shot-vectors are currently only supported in a limited manner;
-shot-vectors work with :func:`qml.sample <pennylane.sample>`, but not other
-measurement processes such as :func:`qml.expval <pennylane.expval>` and
-:func:`qml.probs <pennylane.probs>`.
+shot-vectors work with :func:`qp.sample <pennylane.sample>`, but not other
+measurement processes such as :func:`qp.expval <pennylane.expval>` and
+:func:`qp.probs <pennylane.probs>`.
 
 Functionality differences from PennyLane
 ----------------------------------------
@@ -1354,12 +1354,12 @@ Currently, however, this is not the case for the following functionalities.
   intermediate decompositions that have the same overall cost. This phenomenon
   is not an issue, except for in cases where intermediate gates are not
   executable with ``qjit`` present. An example of such a gate is
-  ``qml.PauliRot``; if an intermediate decomposition is chosen that includes
-  a ``qml.PauliRot`` instance, Catalyst cannot execute the program. If this
+  ``qp.PauliRot``; if an intermediate decomposition is chosen that includes
+  a ``qp.PauliRot`` instance, Catalyst cannot execute the program. If this
   behaviour is encountered, this can be counteracted by adding a prohibitively
-  large penalty to the graph solution should it encounter a ``qml.PauliRot``
+  large penalty to the graph solution should it encounter a ``qp.PauliRot``
   instance (e.g.,
-  ``qml.transforms.decomopose(..., gate_set={..., qml.PauliRot: 100_000})``).
+  ``qp.transforms.decomopose(..., gate_set={..., qp.PauliRot: 100_000})``).
 
 - **Measurement behaviour**: :func:`catalyst.measure` currently behaves
   differently from its PennyLane counterpart :func:`pennylane.measure`.
@@ -1373,76 +1373,76 @@ Currently, however, this is not the case for the following functionalities.
     be post-selected on the outcome that was measured. The post-selected
     measurement will change with every execution.
 
-- **Dynamic wire allocation behaviour**: The ``qml.allocate()`` function currently
+- **Dynamic wire allocation behaviour**: The ``qp.allocate()`` function currently
   behaves differently when Catalyst is present or not. In particular:
 
-  - The ``state`` and ``restored`` keyword arguments of ``qml.allocate()`` are
+  - The ``state`` and ``restored`` keyword arguments of ``qp.allocate()`` are
     ignored in Catalyst. The reason is that the only supported mode is to always allocate in the
     zero state.
 
   - Related to the above point, in PennyLane, dynamic wire allocations do not
     increase the total number of wires used in the circuit. This is because
     PennyLane treats the number of wires during device initialization (the
-    ``qml.device("...", wires=N)``) as the device capacity. Briefly, when
-    ``qml.allocate()`` is encountered, PennyLane looks into the pool of existing
+    ``qp.device("...", wires=N)``) as the device capacity. Briefly, when
+    ``qp.allocate()`` is encountered, PennyLane looks into the pool of existing
     wires and chooses a suitable set of wires that is currently unused as the
     result of the allocation, instead of requesting additional wires from the
     device. However, Catalyst treats device wires as completely separate from
-    wires that are requested via ``qml.allocate``; they are two separate pools
-    of memory, where wires requested with ``qml.allocate`` are in addition to
-    initial ones from ``qml.device``. If the pool of wires from ``device`` is
-    called "device" and the pool of wires from ``qml.allocate`` is called
-    "dynamic", future calls to ``qml.allocate`` can reuse wires from the
+    wires that are requested via ``qp.allocate``; they are two separate pools
+    of memory, where wires requested with ``qp.allocate`` are in addition to
+    initial ones from ``qp.device``. If the pool of wires from ``device`` is
+    called "device" and the pool of wires from ``qp.allocate`` is called
+    "dynamic", future calls to ``qp.allocate`` can reuse wires from the
     dynamic pool, but not from the device pool.
 
   - Dynamically allocated wires cannot be used in quantum adjoints yet.
 
   .. code-block:: python
 
-    qml.capture.enable()
+    qp.capture.enable()
 
-    @qml.qjit
-    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    @qp.qjit
+    @qp.qnode(qp.device("lightning.qubit", wires=1))
     def circuit():
-        with qml.allocate(1) as q:
-            qml.adjoint(qml.X)(wires=q[0])
-        return qml.probs(wires=[0])
+        with qp.allocate(1) as q:
+            qp.adjoint(qp.X)(wires=q[0])
+        return qp.probs(wires=[0])
 
   >>> print(circuit())
   NotImplementedError: Dynamically allocated wires cannot be used in quantum adjoints yet.
 
-  - Usage of ``qml.allocate()`` with Catalyst prohibits returning any terminal measurement
-    *except for* ``qml.probs``. This is due to a bug in Lightning.
-    Other measurement types (``qml.sample``, ``qml.expval``, ``qml.var``, etc.)
+  - Usage of ``qp.allocate()`` with Catalyst prohibits returning any terminal measurement
+    *except for* ``qp.probs``. This is due to a bug in Lightning.
+    Other measurement types (``qp.sample``, ``qp.expval``, ``qp.var``, etc.)
     will be supported in the future after the underlying bug is fixed.
 
   .. code-block:: python
 
-    qml.capture.enable()
+    qp.capture.enable()
 
     @qjit
-    @qml.qnode(qml.device("lightning.qubit", wires=3, shots=10))
+    @qp.qnode(qp.device("lightning.qubit", wires=3, shots=10))
     def circuit():
-        with qml.allocate(2) as qs:
-            qml.X(qs[1])
-        return qml.sample(wires=[0, 1])
+        with qp.allocate(2) as qs:
+            qp.X(qs[1])
+        return qp.sample(wires=[0, 1])
 
   >>> circuit()
-  CompileError: Only probability measurements (qml.probs) are currently supported
+  CompileError: Only probability measurements (qp.probs) are currently supported
   when dynamic allocations are present in the program. Other measurement
-  types (qml.sample, qml.expval, qml.var, ...etc) will be supported
+  types (qp.sample, qp.expval, qp.var, ...etc) will be supported
   in a future release after the underlying bug is fixed.
 
   .. code-block:: python
 
-    qml.capture.enable()
+    qp.capture.enable()
 
-    @qml.qjit
-    @qml.qnode(qml.device("lightning.qubit", wires=1))
+    @qp.qjit
+    @qp.qnode(qp.device("lightning.qubit", wires=1))
     def circuit():
-        with qml.allocate(1) as q:
-            qml.X(q[0])
-        return qml.probs(wires=[0])
+        with qp.allocate(1) as q:
+            qp.X(q[0])
+        return qp.probs(wires=[0])
 
   >>> circuit()
   Array([1., 0.], dtype=float64)

--- a/doc/dev/sharp_bits.rst
+++ b/doc/dev/sharp_bits.rst
@@ -681,7 +681,7 @@ when working with classical control in Catalyst.
 Compatibility with PennyLane transforms
 ---------------------------------------
 
-PennyLane provides a wide variety of :doc:`transforms <code/qp_transforms>`
+PennyLane provides a wide variety of :doc:`transforms <code/qml_transforms>`
 that convert a circuit to one or more circuits.
 
 Currently, most PennyLane transforms will work with Catalyst as long as

--- a/doc/dev/transforms.rst
+++ b/doc/dev/transforms.rst
@@ -37,13 +37,13 @@ Let's look at a simple example starting in Python:
 .. code-block:: python
 
     def circuit(x: complex):
-        qml.Hadamard(wires=0)
+        qp.Hadamard(wires=0)
 
         A = np.array([[1, 0], [0, np.exp(x)]])
-        qml.QubitUnitary(A, wires=0)
+        qp.QubitUnitary(A, wires=0)
 
         B = np.array([[1, 0], [0, np.exp(2*x)]])
-        qml.QubitUnitary(B, wires=0)
+        qp.QubitUnitary(B, wires=0)
 
         return measure(0)
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -98,12 +98,12 @@ Catalyst
    :caption: Examples
    :hidden:
 
-    Magic State Distillation <https://pennylane.ai/qp/demos/tutorial_magic_state_distillation>
-    Variational Quantum Eigensolver <https://pennylane.ai/qp/demos/tutorial_how_to_quantum_just_in_time_compile_vqe_catalyst>
-    QML Optimization with Optax <https://pennylane.ai/qp/demos/tutorial_How_to_optimize_QML_model_using_JAX_catalyst_and_Optax>
-    Shor's Algorithm <https://pennylane.ai/qp/demos/tutorial_shors_algorithm_catalyst>
-    Catalyst and Lightning GPU <https://pennylane.ai/qp/demos/how_to_catalyst_lightning_gpu>
-    Grover's Algorithm <https://pennylane.ai/qp/demos/tutorial_qjit_compile_grovers_algorithm_with_catalyst>
+    Magic State Distillation <https://pennylane.ai/qml/demos/tutorial_magic_state_distillation>
+    Variational Quantum Eigensolver <https://pennylane.ai/qml/demos/tutorial_how_to_quantum_just_in_time_compile_vqe_catalyst>
+    QML Optimization with Optax <https://pennylane.ai/qml/demos/tutorial_How_to_optimize_QML_model_using_JAX_catalyst_and_Optax>
+    Shor's Algorithm <https://pennylane.ai/qml/demos/tutorial_shors_algorithm_catalyst>
+    Catalyst and Lightning GPU <https://pennylane.ai/qml/demos/how_to_catalyst_lightning_gpu>
+    Grover's Algorithm <https://pennylane.ai/qml/demos/tutorial_qjit_compile_grovers_algorithm_with_catalyst>
     
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -98,12 +98,12 @@ Catalyst
    :caption: Examples
    :hidden:
 
-    Magic State Distillation <https://pennylane.ai/qml/demos/tutorial_magic_state_distillation>
-    Variational Quantum Eigensolver <https://pennylane.ai/qml/demos/tutorial_how_to_quantum_just_in_time_compile_vqe_catalyst>
-    QML Optimization with Optax <https://pennylane.ai/qml/demos/tutorial_How_to_optimize_QML_model_using_JAX_catalyst_and_Optax>
-    Shor's Algorithm <https://pennylane.ai/qml/demos/tutorial_shors_algorithm_catalyst>
-    Catalyst and Lightning GPU <https://pennylane.ai/qml/demos/how_to_catalyst_lightning_gpu>
-    Grover's Algorithm <https://pennylane.ai/qml/demos/tutorial_qjit_compile_grovers_algorithm_with_catalyst>
+    Magic State Distillation <https://pennylane.ai/qp/demos/tutorial_magic_state_distillation>
+    Variational Quantum Eigensolver <https://pennylane.ai/qp/demos/tutorial_how_to_quantum_just_in_time_compile_vqe_catalyst>
+    QML Optimization with Optax <https://pennylane.ai/qp/demos/tutorial_How_to_optimize_QML_model_using_JAX_catalyst_and_Optax>
+    Shor's Algorithm <https://pennylane.ai/qp/demos/tutorial_shors_algorithm_catalyst>
+    Catalyst and Lightning GPU <https://pennylane.ai/qp/demos/how_to_catalyst_lightning_gpu>
+    Grover's Algorithm <https://pennylane.ai/qp/demos/tutorial_qjit_compile_grovers_algorithm_with_catalyst>
     
 
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -1033,7 +1033,8 @@
 <h3>Documentation 📝</h3>
 
 * The `qp` alias as in `import pennylane as qp` has been updated to `qp` in our source code and documentation.
-  [(#2739)](https://github.com/PennyLaneAI/catalyst/pull/2738)
+  [(#2748)](https://github.com/PennyLaneAI/catalyst/pull/2748)
+
 
 * The "Compatibility with PennyLane transforms" section of the
   :doc:`Sharp bits and debugging tips <../dev/sharp_bits>` document has been updated to describe

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -19,16 +19,16 @@
   With this new MLIR pass, one shot execution mode is now available when capture is enabled.
 
   ```python
-  dev = qml.device("lightning.qubit", wires=2)
+  dev = qp.device("lightning.qubit", wires=2)
 
   @qjit(capture=True)
-  @qml.transform(pass_name="dynamic-one-shot")
-  @qml.qnode(dev, shots=10)
+  @qp.transform(pass_name="dynamic-one-shot")
+  @qp.qnode(dev, shots=10)
   def circuit():
-      qml.Hadamard(wires=0)
-      m_0 = qml.measure(0)
-      m_1 = qml.measure(1)
-      return qml.sample([m_0, m_1]), qml.expval(m_0), qml.probs(op=[m_0,m_1]), qml.counts(wires=0)
+      qp.Hadamard(wires=0)
+      m_0 = qp.measure(0)
+      m_1 = qp.measure(1)
+      return qp.sample([m_0, m_1]), qp.expval(m_0), qp.probs(op=[m_0,m_1]), qp.counts(wires=0)
   ```
 
   ```pycon
@@ -67,16 +67,16 @@
   :func:`pennylane.specs` and :func:`catalyst.draw`. Now, such circuits can be executed:
 
   ```python
-  import pennylane as qml
+  import pennylane as qp
 
-  @qml.qjit(capture=True)
-  @qml.transforms.decompose_arbitrary_ppr
-  @qml.transforms.to_ppr
-  @qml.qnode(qml.device("lightning.qubit", wires=3))
+  @qp.qjit(capture=True)
+  @qp.transforms.decompose_arbitrary_ppr
+  @qp.transforms.to_ppr
+  @qp.qnode(qp.device("lightning.qubit", wires=3))
   def circuit():
-      qml.PauliRot(0.123, pauli_word="XXY", wires=[0, 1, 2])
-      qml.pauli_measure("XYZ", wires=[0, 1, 2])
-      return qml.probs([0, 1])
+      qp.PauliRot(0.123, pauli_word="XXY", wires=[0, 1, 2])
+      qp.pauli_measure("XYZ", wires=[0, 1, 2])
+      return qp.probs([0, 1])
   ```
 
   ```
@@ -86,13 +86,13 @@
 
 * Added `capture` keyword argument to the `@qjit` decorator for per-function control over
   PennyLane's program capture frontend. This allows selective use of the new capture-based
-  compilation pathway without affecting the global `qml.capture.enabled()` state. The parameter
+  compilation pathway without affecting the global `qp.capture.enabled()` state. The parameter
   accepts `"global"` (default, defer to global state), `True` (force capture on), or `False`
   (force capture off). This enables safe testing and gradual migration to the capture system.
   [(#2457)](https://github.com/PennyLaneAI/catalyst/pull/2457)
 
-* Mid-circuit measurements (`qml.measure`) are now supported on the OQD backend.
-  A `qml.measure` call is lowered to an OpenAPL's `MeasurePulse` for fluorescence detection,
+* Mid-circuit measurements (`qp.measure`) are now supported on the OQD backend.
+  A `qp.measure` call is lowered to an OpenAPL's `MeasurePulse` for fluorescence detection,
   which is executed by the trapped-ion hardware at runtime.
   [(#2508)](https://github.com/PennyLaneAI/catalyst/pull/2508)
 
@@ -117,11 +117,11 @@
   oqd_dev = OQDDevice(backend="default", wires=1, openapl_file_name="out.json")
 
   @qjit(pipelines=OQD_PIPELINES)
-  @qml.set_shots(10)
-  @qml.qnode(oqd_dev)
+  @qp.set_shots(10)
+  @qp.qnode(oqd_dev)
   def circuit():
-      qml.measure(wires=0)
-      return qml.counts(wires=0)
+      qp.measure(wires=0)
+      return qp.counts(wires=0)
 
   circuit()
   ```
@@ -142,7 +142,7 @@
   ```python
   import os
   import numpy as np
-  import pennylane as qml
+  import pennylane as qp
 
   from catalyst import qjit
   from catalyst.third_party.oqd import OQDDevice, OQDDevicePipeline
@@ -159,14 +159,14 @@
       shots=4,
       wires=1
   )
-  qml.capture.enable()
+  qp.capture.enable()
 
   # Compile to LLVM IR only
-  @qml.qnode(oqd_dev)
+  @qp.qnode(oqd_dev)
   def circuit():
       x = np.pi / 2
-      qml.RX(x, wires=0)
-      return qml.counts(wires=0)
+      qp.RX(x, wires=0)
+      return qp.counts(wires=0)
 
   compiled_circuit = QJIT(circuit, CompileOptions(link=False, pipelines=OQD_PIPELINES))
 
@@ -372,7 +372,7 @@
 
 <h3>Improvements 🛠</h3>
 
-* `qml.for_loop` and `qml.while_loop` now support dynamic shapes with program capture `qjit(capture=True)`.
+* `qp.for_loop` and `qp.while_loop` now support dynamic shapes with program capture `qjit(capture=True)`.
   [(#2603)](https://github.com/PennyLaneAI/catalyst/pull/2603/)
   [(#2651)](https://github.com/PennyLaneAI/catalyst/pull/2651)
 
@@ -394,7 +394,7 @@
   [(#2590)](https://github.com/PennyLaneAI/catalyst/pull/2590)
   [(#2610)](https://github.com/PennyLaneAI/catalyst/pull/2610)
 
-* `qml.value_and_grad` can now be used with program capture `qml.qjit(capture=True)`.
+* `qp.value_and_grad` can now be used with program capture `qp.qjit(capture=True)`.
   [(#2587)](https://github.com/PennyLaneAI/catalyst/pull/2587)
 
 * Catalyst with program capture now supports device preprocessing. Currently, preprocessing transforms
@@ -412,11 +412,11 @@
 * The tape transform :func:`~.device.decomposition.catalyst_decompose` now accepts the optional
   keyword arguments ``target_gates``, ``num_work_wires``, ``fixed_decomps``, and ``alt_decomps``,
   which all are passed to the used PennyLane decomposition function
-  ``qml.devices.preprocess.decompose`` and used if the graph-based decomposition system is enabled.
+  ``qp.devices.preprocess.decompose`` and used if the graph-based decomposition system is enabled.
   [(#2501)](https://github.com/PennyLaneAI/catalyst/pull/2501)
 
-* Catalyst with program capture can now be used with the new `qml.templates.Subroutine` class and the associated
-  `qml.capture.subroutine` upstreamed from `catalyst.jax_primitives.subroutine`.
+* Catalyst with program capture can now be used with the new `qp.templates.Subroutine` class and the associated
+  `qp.capture.subroutine` upstreamed from `catalyst.jax_primitives.subroutine`.
   [(#2396)](https://github.com/PennyLaneAI/catalyst/pull/2396)
   [(#2493)](https://github.com/PennyLaneAI/catalyst/pull/2493)
 
@@ -430,7 +430,7 @@
   including the conditional and multiplexed variants.
 
 * `null.qubit` resource tracking is now able to track measurements and observables. This output
-  is also reflected in `qml.specs`.
+  is also reflected in `qp.specs`.
   [(#2446)](https://github.com/PennyLaneAI/catalyst/pull/2446)
 
 * The default mcm_method for the finite-shots setting (dynamic one-shot) no longer silently falls
@@ -446,7 +446,7 @@
   length and the number of qubit operands are the same, and that all of the Pauli words are legal.
   [(#2405)](https://github.com/PennyLaneAI/catalyst/pull/2405)
 
-* `qml.vjp`  and `qml.jvp` can now be used with Catalyst and program capture.
+* `qp.vjp`  and `qp.jvp` can now be used with Catalyst and program capture.
   [(#2279)](https://github.com/PennyLaneAI/catalyst/pull/2279)
   [(#2316)](https://github.com/PennyLaneAI/catalyst/pull/2316)
 
@@ -501,11 +501,11 @@
   accept QNodes as the input. Now, the input must always be a :class:`~.QJIT` object.
   [(#2542)](https://github.com/PennyLaneAI/catalyst/pull/2542)
 
-* `catalyst.from_plxpr.register_transforms` as a way to access MLIR passes from Python has been removed in favour of the new unified transforms API. MLIR passes can be accessed from Python using `qml.transform(pass_name="some-pass-name")`.
+* `catalyst.from_plxpr.register_transforms` as a way to access MLIR passes from Python has been removed in favour of the new unified transforms API. MLIR passes can be accessed from Python using `qp.transform(pass_name="some-pass-name")`.
   [(#2509)](https://github.com/PennyLaneAI/catalyst/pull/2509)
   [(#2680)](https://github.com/PennyLaneAI/catalyst/pull/2680)
 
-* `catalyst.jax_primitives.subroutine` has been moved to `qml.capture.subroutine`.
+* `catalyst.jax_primitives.subroutine` has been moved to `qp.capture.subroutine`.
   [(#2396)](https://github.com/PennyLaneAI/catalyst/pull/2396)
 
 * The `StableHLO` dialect has been removed from Catalyst's Python interface module.
@@ -540,7 +540,7 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* Fixed a bug where the `work_wire_type` argument of `qml.ctrl` was silently dropped inside `@qjit` functions.
+* Fixed a bug where the `work_wire_type` argument of `qp.ctrl` was silently dropped inside `@qjit` functions.
   The parameter is now threaded through `catalyst.ctrl`, `CtrlCallable`, `HybridCtrl`, and
   `ctrl_distribute`, with the default value being `"borrowed"`.
   [(#2710)](https://github.com/PennyLaneAI/catalyst/pull/2710)
@@ -648,7 +648,7 @@
   are able to just inherit the base behaviour from `PlxprInterpreter`.
   [(#2706)](https://github.com/PennyLaneAI/catalyst/pull/2706)
 
-* The legacy frontend no longer registers `qml.allocate()` and `qml.deallocate()` onto the qjit device
+* The legacy frontend no longer registers `qp.allocate()` and `qp.deallocate()` onto the qjit device
   capabilities, since dynamic qubit allocation is only implemented for the capture frontend.
   [(#2696)](https://github.com/PennyLaneAI/catalyst/pull/2696)
 
@@ -694,7 +694,7 @@
 * Update nightly RC builds to be triggered by Lightning.
   [(#2491)](https://github.com/PennyLaneAI/catalyst/pull/2491)
 
-* Updated integration tests to match changes to the PennyLane `qml.specs` frontend made in https://github.com/PennyLaneAI/pennylane/pull/9088 and https://github.com/PennyLaneAI/pennylane/pull/9091.
+* Updated integration tests to match changes to the PennyLane `qp.specs` frontend made in https://github.com/PennyLaneAI/pennylane/pull/9088 and https://github.com/PennyLaneAI/pennylane/pull/9091.
   [(#2513)](https://github.com/PennyLaneAI/catalyst/pull/2513)
   [(#2533)](https://github.com/PennyLaneAI/catalyst/pull/2533)
 
@@ -847,16 +847,16 @@
   Consider the following example:
 
   ```python
-  import pennylane as qml
+  import pennylane as qp
   from catalyst import qjit
   from catalyst.passes import apply_pass
 
   @qjit
   @apply_pass("split-to-single-terms")
-  @qml.qnode(qml.device("lightning.qubit", wires=3))
+  @qp.qnode(qp.device("lightning.qubit", wires=3))
   def circuit():
       # Hamiltonian H = Z(0) @ X(1) + 2*Y(2)
-      return qml.expval(qml.Z(0) @ qml.X(1) + 2 * qml.Y(2))
+      return qp.expval(qp.Z(0) @ qp.X(1) + 2 * qp.Y(2))
   ```
 
   The pass transforms the function by splitting the Hamiltonian into individual observables:
@@ -926,15 +926,15 @@
 
   Consider the following example:
   ```python
-  import pennylane as qml
+  import pennylane as qp
   from catalyst import qjit
 
   @qjit
-  @qml.transform(pass_name="split-non-commuting")(grouping_strategy="wires")
-  @qml.qnode(qml.device("lightning.qubit", wires=3))
+  @qp.transform(pass_name="split-non-commuting")(grouping_strategy="wires")
+  @qp.qnode(qp.device("lightning.qubit", wires=3))
   def circuit():
       # Hamiltonian H = Z(0) + 2 * X(0) + 3 * Identity
-      return qml.expval(qml.Z(0) + 2 * qml.X(0) + 3 * qml.Identity(2))
+      return qp.expval(qp.Z(0) + 2 * qp.X(0) + 3 * qp.Identity(2))
   ```
 
   The pass first runs `split-to-single-terms` to decompose the Hamiltonian, then splits
@@ -1032,7 +1032,7 @@
 
 <h3>Documentation 📝</h3>
 
-* The `qml` alias as in `import pennylane as qml` has been updated to `qp` in our source code and documentation.
+* The `qp` alias as in `import pennylane as qp` has been updated to `qp` in our source code and documentation.
   [(#2739)](https://github.com/PennyLaneAI/catalyst/pull/2738)
 
 * The "Compatibility with PennyLane transforms" section of the


### PR DESCRIPTION
**Context:**
In order to reposition PennyLane and Catalyst for general quantum computing (rather than quantum machine learning) PennyLane will be imported as `qp` (rather than `qml`). These changes will be made per-module in Catalyst.

**Description of the Change:**
Update references to PennyLane in `doc`.

**Benefits:**
Improve user perception of the uses of PennyLane + Catalyst.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-117693]