### PR TITLE
Update pl-compat-workflow for precompiled decomp rules

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -132,12 +132,12 @@ jobs:
         DIALECTS_BUILD_DIR="$(pwd)/quantum-build" \
         ENABLE_OPENQASM=ON \
         make runtime dialects plugin
-        echo "PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum" >> $GITHUB_ENV
-        echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
-        echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
-        echo "CATALYST_BIN_DIR=$(pwd)/quantum-build/bin" >> $GITHUB_ENV
-        echo "CATALYST_LIB_DIR=$(pwd)/quantum-build/lib" >> $GITHUB_ENV
-        chmod +x $(pwd)/quantum-build/bin/catalyst  # artifact upload does not preserve permissions
+        PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum \
+        RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib \
+        MLIR_LIB_DIR=$(pwd)/llvm-build/lib \
+        CATALYST_BIN_DIR=$(pwd)/quantum-build/bin \
+        CATALYST_LIB_DIR=$(pwd)/quantum-build/lib \
+        chmod +x $(pwd)/quantum-build/bin/catalyst  # artifact upload does not preserve permissions \
         make frontend oqc
 
 

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -118,6 +118,15 @@ jobs:
         sudo apt-get install -y graphviz
         pip install pennylane-catalyst
 
+    - name: Add Frontend Dependencies to PATH
+      if: ${{ inputs.catalyst == 'latest' }}
+      run: |
+        echo "PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum" >> $GITHUB_ENV
+        echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
+        echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
+        echo "CATALYST_BIN_DIR=$(pwd)/quantum-build/bin" >> $GITHUB_ENV
+        echo "CATALYST_LIB_DIR=$(pwd)/quantum-build/lib" >> $GITHUB_ENV
+
     - name: Install Catalyst (latest)
       if: ${{ inputs.catalyst == 'latest' }}
       run: |
@@ -135,11 +144,6 @@ jobs:
         
         chmod +x $(pwd)/quantum-build/bin/catalyst  # artifact upload does not preserve permissions
         
-        PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum \
-        RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib \
-        MLIR_LIB_DIR=$(pwd)/llvm-build/lib \
-        CATALYST_BIN_DIR=$(pwd)/quantum-build/bin \
-        CATALYST_LIB_DIR=$(pwd)/quantum-build/lib \
         make frontend oqc
 
 

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -140,11 +140,7 @@ jobs:
         ENZYME_BUILD_DIR="$(pwd)/enzyme-build" \
         DIALECTS_BUILD_DIR="$(pwd)/quantum-build" \
         ENABLE_OPENQASM=ON \
-        make runtime dialects plugin
-        
-        chmod +x $(pwd)/quantum-build/bin/catalyst  # artifact upload does not preserve permissions
-        
-        make frontend oqc
+        make catalyst
 
     - name: Install Catalyst (release-candidate)
       if: ${{ inputs.catalyst == 'release-candidate' }}

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -132,13 +132,15 @@ jobs:
         DIALECTS_BUILD_DIR="$(pwd)/quantum-build" \
         ENABLE_OPENQASM=ON \
         make runtime dialects plugin
+        
+        chmod +x $(pwd)/quantum-build/bin/catalyst  # artifact upload does not preserve permissions
+        
         PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum \
         RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib \
         MLIR_LIB_DIR=$(pwd)/llvm-build/lib \
         CATALYST_BIN_DIR=$(pwd)/quantum-build/bin \
         CATALYST_LIB_DIR=$(pwd)/quantum-build/lib \
-        chmod +x $(pwd)/quantum-build/bin/catalyst  # artifact upload does not preserve permissions \
-        make frontend oqc
+        make frontend oqc \
 
 
     - name: Install Catalyst (release-candidate)

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -140,7 +140,7 @@ jobs:
         MLIR_LIB_DIR=$(pwd)/llvm-build/lib \
         CATALYST_BIN_DIR=$(pwd)/quantum-build/bin \
         CATALYST_LIB_DIR=$(pwd)/quantum-build/lib \
-        make frontend oqc \
+        make frontend oqc
 
 
     - name: Install Catalyst (release-candidate)

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -112,6 +112,16 @@ jobs:
         key: ${{ runner.os }}-ccache-${{ github.run_id }}
         restore-keys: ${{ runner.os }}-ccache-
 
+    - name: Add Frontend Dependencies to PATH
+      if: ${{ inputs.catalyst == 'latest' }}
+      run: |
+        echo "PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum" >> $GITHUB_ENV
+        echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
+        echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
+        echo "CATALYST_BIN_DIR=$(pwd)/quantum-build/bin" >> $GITHUB_ENV
+        echo "CATALYST_LIB_DIR=$(pwd)/quantum-build/lib" >> $GITHUB_ENV
+        chmod +x $(pwd)/quantum-build/bin/catalyst  # artifact upload does not preserve permissions
+
     - name: Install Catalyst (stable)
       if: ${{ inputs.catalyst == 'stable' }}
       run: |
@@ -182,16 +192,6 @@ jobs:
       run: |
         # Do not overwrite any dependencies, just fetch rc package from TestPyPI
         pip install --no-deps --pre -U --index-url https://test.pypi.org/simple/ pennylane'>=0.44.0rc0,<=0.44.0'
-
-    - name: Add Frontend Dependencies to PATH
-      if: ${{ inputs.catalyst == 'latest' }}
-      run: |
-        echo "PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum" >> $GITHUB_ENV
-        echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
-        echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
-        echo "CATALYST_BIN_DIR=$(pwd)/quantum-build/bin" >> $GITHUB_ENV
-        echo "CATALYST_LIB_DIR=$(pwd)/quantum-build/lib" >> $GITHUB_ENV
-        chmod +x $(pwd)/quantum-build/bin/catalyst  # artifact upload does not preserve permissions
 
     - name: Run Frontend Tests
       run: |

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -112,16 +112,6 @@ jobs:
         key: ${{ runner.os }}-ccache-${{ github.run_id }}
         restore-keys: ${{ runner.os }}-ccache-
 
-    - name: Add Frontend Dependencies to PATH
-      if: ${{ inputs.catalyst == 'latest' }}
-      run: |
-        echo "PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum" >> $GITHUB_ENV
-        echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
-        echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
-        echo "CATALYST_BIN_DIR=$(pwd)/quantum-build/bin" >> $GITHUB_ENV
-        echo "CATALYST_LIB_DIR=$(pwd)/quantum-build/lib" >> $GITHUB_ENV
-        chmod +x $(pwd)/quantum-build/bin/catalyst  # artifact upload does not preserve permissions
-
     - name: Install Catalyst (stable)
       if: ${{ inputs.catalyst == 'stable' }}
       run: |
@@ -141,7 +131,15 @@ jobs:
         ENZYME_BUILD_DIR="$(pwd)/enzyme-build" \
         DIALECTS_BUILD_DIR="$(pwd)/quantum-build" \
         ENABLE_OPENQASM=ON \
-        make catalyst
+        make runtime dialects plugin
+        echo "PYTHONPATH=$PYTHONPATH:$(pwd)/quantum-build/python_packages/quantum" >> $GITHUB_ENV
+        echo "RUNTIME_LIB_DIR=$(pwd)/runtime-build/lib" >> $GITHUB_ENV
+        echo "MLIR_LIB_DIR=$(pwd)/llvm-build/lib" >> $GITHUB_ENV
+        echo "CATALYST_BIN_DIR=$(pwd)/quantum-build/bin" >> $GITHUB_ENV
+        echo "CATALYST_LIB_DIR=$(pwd)/quantum-build/lib" >> $GITHUB_ENV
+        chmod +x $(pwd)/quantum-build/bin/catalyst  # artifact upload does not preserve permissions
+        make frontend oqc
+
 
     - name: Install Catalyst (release-candidate)
       if: ${{ inputs.catalyst == 'release-candidate' }}

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -146,7 +146,6 @@ jobs:
         
         make frontend oqc
 
-
     - name: Install Catalyst (release-candidate)
       if: ${{ inputs.catalyst == 'release-candidate' }}
       run: |

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -284,6 +284,7 @@
   [(#2531)](https://github.com/PennyLaneAI/catalyst/pull/2531)
   [(#2619)](https://github.com/PennyLaneAI/catalyst/pull/2619)
   [(#2713)](https://github.com/PennyLaneAI/catalyst/pull/2713)
+  [(#2749)](https://github.com/PennyLaneAI/catalyst/pull/2749)
 
 * Decomposition rules are lowered as private functions (instead of public).
   [(#2658)](https://github.com/PennyLaneAI/catalyst/pull/2658)

--- a/frontend/test/pytest/test_specs.py
+++ b/frontend/test/pytest/test_specs.py
@@ -267,19 +267,22 @@ class TestPassByPassSpecs:
         no_passes = qjit(simple_circuit, capture=capture_mode)
         with pytest.raises(
             check=ValueError,
-            match="The 'level' argument to qp.specs for QJIT'd QNodes is out of " "bounds, got -5.",
+            match="The 'level' argument to qml.specs for QJIT'd QNodes is out of "
+            "bounds, got -5.",
         ):
             qml.specs(no_passes, level=-5)()
 
         with pytest.raises(
             check=ValueError,
-            match="The 'level' argument to qp.specs for QJIT'd " "QNodes is out of bounds, got 10.",
+            match="The 'level' argument to qml.specs for QJIT'd "
+            "QNodes is out of bounds, got 10.",
         ):
             qml.specs(no_passes, level=10)()
 
         with pytest.raises(
             check=ValueError,
-            match="The 'level' argument to qp.specs for QJIT'd " "QNodes is out of bounds, got 10.",
+            match="The 'level' argument to qml.specs for QJIT'd "
+            "QNodes is out of bounds, got 10.",
         ):
             qml.specs(no_passes, level=[10, 11])()
 
@@ -1222,7 +1225,7 @@ class TestMarkerIntegration:
 
         with pytest.warns(
             UserWarning,
-            match="The 'level' argument to qp.specs for QJIT'd QNodes has been sorted to be "
+            match="The 'level' argument to qml.specs for QJIT'd QNodes has been sorted to be "
             "in ascending order with no duplicate levels.",
         ):
             actual = qml.specs(simple_circuit, level=["m0", "m1", "m1-duplicate"])()

--- a/frontend/test/pytest/test_specs.py
+++ b/frontend/test/pytest/test_specs.py
@@ -267,22 +267,19 @@ class TestPassByPassSpecs:
         no_passes = qjit(simple_circuit, capture=capture_mode)
         with pytest.raises(
             check=ValueError,
-            match="The 'level' argument to qml.specs for QJIT'd QNodes is out of "
-            "bounds, got -5.",
+            match="The 'level' argument to qp.specs for QJIT'd QNodes is out of " "bounds, got -5.",
         ):
             qml.specs(no_passes, level=-5)()
 
         with pytest.raises(
             check=ValueError,
-            match="The 'level' argument to qml.specs for QJIT'd "
-            "QNodes is out of bounds, got 10.",
+            match="The 'level' argument to qp.specs for QJIT'd " "QNodes is out of bounds, got 10.",
         ):
             qml.specs(no_passes, level=10)()
 
         with pytest.raises(
             check=ValueError,
-            match="The 'level' argument to qml.specs for QJIT'd "
-            "QNodes is out of bounds, got 10.",
+            match="The 'level' argument to qp.specs for QJIT'd " "QNodes is out of bounds, got 10.",
         ):
             qml.specs(no_passes, level=[10, 11])()
 
@@ -1225,7 +1222,7 @@ class TestMarkerIntegration:
 
         with pytest.warns(
             UserWarning,
-            match="The 'level' argument to qml.specs for QJIT'd QNodes has been sorted to be "
+            match="The 'level' argument to qp.specs for QJIT'd QNodes has been sorted to be "
             "in ascending order with no duplicate levels.",
         ):
             actual = qml.specs(simple_circuit, level=["m0", "m1", "m1-duplicate"])()


### PR DESCRIPTION
**Context:**
The introduction of precompiled decomp rules for the `graph-decomposition` pass required a change in build order for most scripts (since `make frontend` now requires a complete build of catalyst).

**Description of the Change:**
Updates the build order in `check-pl-compat.yaml` for LLL testing. The relevant workflow run is available [here](https://github.com/PennyLaneAI/catalyst/actions/runs/24900906312). NOTE: This was run with patched tests that match pennylane exceptions which have been updated from `qml` to `qp`. These changes have since been reverted in this PR to match Catalyst main ([fe24754](https://github.com/PennyLaneAI/catalyst/pull/2749/commits/fe247544964d1e864743550cc5240dda91b031fc))

**Benefits:**
LLL is tested correctly.

**Possible Drawbacks:**
N/A

**Related GitHub Issues:**
N/A
