### PR TITLE
Remove include<format> in the compiler driver

### DIFF
--- a/mlir/include/Driver/DefaultPipelines/DefaultPipelines.h
+++ b/mlir/include/Driver/DefaultPipelines/DefaultPipelines.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <format>
 #include <numeric>
 #include <ranges>
 #include <string>
@@ -190,10 +189,11 @@ PassNames getGradientLoweringStage() { return pipelineList[2].passNames; }
 
 PassNames getBufferizationStage(bool asyncQNodes = false)
 {
-    const std::string bufferizationOptions = std::format(
-        "{{{} {} {} {}{}}}", "bufferize-function-boundaries", "allow-return-allocs-from-loops",
-        "function-boundary-type-conversion=identity-layout-map",
-        "unknown-type-conversion=identity-layout-map", (asyncQNodes ? " copy-before-write" : ""));
+    const std::string bufferizationOptions =
+        std::string("{bufferize-function-boundaries ") + "allow-return-allocs-from-loops " +
+        "function-boundary-type-conversion=identity-layout-map " +
+        "unknown-type-conversion=identity-layout-map" + (asyncQNodes ? " copy-before-write" : "") +
+        "}";
     auto &&ret = pipelineList[3].passNames |
                  std::views::transform([&bufferizationOptions](const auto &passName) {
                      if (passName == "one-shot-bufferize") {


### PR DESCRIPTION
**Context:**
Removing `include<format>` from the core compiler is to ensure maximum portability and ABI stability. While `std::format` is a modern C++20 convenience, it often acts as a "gateway to linker hell" in systems like Ubuntu 22.04; its absence in older standard libs forces developers to either switch to `libc++`. As it is used in one single place, this PR rewrites the use case with C++14 compatible impl avoiding the "Undefined Symbol" and "Missing header" errors caused by using older ABI or C++ compilers.

**Related GitHub Issues:**
[sc-117824]