### PR TITLE
Split lowering rules out of jax_primitives.py

### DIFF
--- a/frontend/catalyst/jax_extras/lowering.py
+++ b/frontend/catalyst/jax_extras/lowering.py
@@ -126,7 +126,7 @@ def custom_lower_jaxpr_to_module(
     # Create a keepalives list that will be mutated during the lowering.
     keepalives = []
     host_callbacks = []
-    custom_lowering_rules = get_custom_lowering_rules()
+    custom_lowering_rules = tuple(get_custom_lowering_rules().items())
     lowering_params = LoweringParameters(override_lowering_rules=custom_lowering_rules)
     ctx = ModuleContext(
         backend=None,

--- a/frontend/catalyst/jax_extras/lowering.py
+++ b/frontend/catalyst/jax_extras/lowering.py
@@ -15,9 +15,7 @@
 
 from __future__ import annotations
 
-import dataclasses
 import logging
-import textwrap
 
 import jax
 from jax._src import core
@@ -39,6 +37,7 @@ from jaxlib.mlir.dialects.func import FuncOp
 
 import catalyst
 from catalyst.logging import debug_logger
+from catalyst.primitive_lowering_rules import get_custom_lowering_rules
 from catalyst.utils.exceptions import CompileError
 from catalyst.utils.patching import Patcher
 
@@ -129,7 +128,7 @@ def custom_lower_jaxpr_to_module(
     # Create a keepalives list that will be mutated during the lowering.
     keepalives = []
     host_callbacks = []
-    custom_lowering_rules = catalyst.jax_primitives.CUSTOM_LOWERING_RULES
+    custom_lowering_rules = get_custom_lowering_rules()
     lowering_params = LoweringParameters(override_lowering_rules=custom_lowering_rules)
     ctx = ModuleContext(
         backend=None,
@@ -187,56 +186,3 @@ def custom_lower_jaxpr_to_module(
                 worklist += [*op.body.operations]
 
     return ctx.module, ctx.context
-
-
-def get_mlir_attribute_from_pyval(value):
-    """
-    Given a value of any type, construct an mlir attribute of corresponding type.
-
-    We set up the context and location outside because recursive calls to this function
-    will segfault if multiple `Context()`s are instantiated.
-    """
-
-    attr = None
-    match value:
-        case bool():
-            attr = ir.BoolAttr.get(value)
-
-        case int():
-            if -9223372036854775808 <= value < 0:  # 2**63
-                attr = ir.IntegerAttr.get(ir.IntegerType.get_signed(64), value)
-            elif 0 <= value < 18446744073709551616:  # = 2**64
-                attr = ir.IntegerAttr.get(ir.IntegerType.get_signless(64), value)
-            else:
-                raise CompileError(textwrap.dedent("""
-                    Large integer attributes currently not supported in MLIR,
-                    see https://github.com/llvm/llvm-project/issues/128072
-                    """))
-
-        case float():
-            attr = ir.FloatAttr.get(ir.F64Type.get(), value)
-
-        case str():
-            attr = ir.StringAttr.get(value)
-
-        case list() | tuple():
-            element_attrs = [get_mlir_attribute_from_pyval(elem) for elem in value]
-            attr = ir.ArrayAttr.get(element_attrs)
-
-        case dict():
-            named_attrs = {}
-            for k, v in value.items():
-                if not isinstance(k, str):
-                    raise CompileError(
-                        f"Dictionary keys for MLIR DictionaryAttr must be strings, got: {type(k)}"
-                    )
-                named_attrs[k] = get_mlir_attribute_from_pyval(v)
-            attr = ir.DictAttr.get(named_attrs)
-
-        case _ if dataclasses.is_dataclass(value):
-            attr = get_mlir_attribute_from_pyval(dataclasses.asdict(value))
-
-        case _:
-            raise CompileError(f"Cannot convert Python type {type(value)} to an MLIR attribute.")
-
-    return attr

--- a/frontend/catalyst/jax_extras/lowering.py
+++ b/frontend/catalyst/jax_extras/lowering.py
@@ -35,10 +35,8 @@ from jax.interpreters.mlir import (
 from jaxlib.mlir.dialects.builtin import ModuleOp
 from jaxlib.mlir.dialects.func import FuncOp
 
-import catalyst
 from catalyst.logging import debug_logger
 from catalyst.primitive_lowering_rules import get_custom_lowering_rules
-from catalyst.utils.exceptions import CompileError
 from catalyst.utils.patching import Patcher
 
 # pylint: disable=protected-access

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -566,7 +566,7 @@ def _unitary_abstract_eval(matrix, *qubits, qubits_len=0, ctrl_len=0, adjoint=Fa
 #
 # pauli rot operation
 #
-# pylint: disable=unused-variable
+# pylint: disable=unused-variable,too-many-arguments
 @pauli_rot_p.def_abstract_eval
 def _pauli_rot_abstract_eval(
     *qubits_and_ctrl_qubits,

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -16,135 +16,22 @@ of quantum operations, measurements, and observables to JAXPR.
 """
 
 import functools
-import sys
 from dataclasses import dataclass
 from enum import Enum
-from itertools import chain
-from typing import Iterable, List, Union
+from typing import List, Union
 
 import jax
-import numpy as np
 import pennylane as qml
-from jax._src import core, source_info_util, util
+from jax._src import core
 from jax._src.core import pytype_aval_mappings
 from jax._src.interpreters import partial_eval as pe
-from jax._src.lax.lax import _merge_dyn_shape, _nary_lower_hlo, cos_p, sin_p
+from jax._src.lax.lax import _merge_dyn_shape
 from jax._src.lib.mlir import ir
-from jax._src.lib.mlir.dialects import hlo
-from jax._src.pjit import _pjit_lowering
 from jax.core import AbstractValue
-from jax.extend.core import Primitive
+from jax.extend.core import ClosedJaxpr, Primitive
 from jax.interpreters import mlir
-from jax.tree_util import PyTreeDef, tree_unflatten
-from jaxlib.mlir._mlir_libs import _mlir as _ods_cext
-from jaxlib.mlir.dialects.arith import (
-    AddIOp,
-    CeilDivSIOp,
-    ConstantOp,
-    ExtUIOp,
-    IndexCastOp,
-    MulIOp,
-    SubIOp,
-)
-from jaxlib.mlir.dialects.func import FunctionType
-from jaxlib.mlir.dialects.scf import ConditionOp, ForOp, IfOp, IndexSwitchOp, WhileOp, YieldOp
-from jaxlib.mlir.dialects.stablehlo import ConstantOp as StableHLOConstantOp
-from jaxlib.mlir.dialects.stablehlo import ConvertOp as StableHLOConvertOp
 
-# TODO: remove after jax v0.7.2 upgrade
-# Mock _ods_cext.globals.register_traceback_file_exclusion due to API conflicts between
-# Catalyst's MLIR version and the MLIR version used by JAX. The current JAX version has not
-# yet updated to the latest MLIR, causing compatibility issues. This workaround will be removed
-# once JAX updates to a compatible MLIR version
-# pylint: disable=ungrouped-imports
-from catalyst.jax_extras.patches import mock_attributes
-from catalyst.utils.patching import Patcher
-
-with Patcher(
-    (
-        _ods_cext,
-        "globals",
-        mock_attributes(
-            # pylint: disable=c-extension-no-member
-            _ods_cext.globals,
-            {"register_traceback_file_exclusion": lambda x: None},
-        ),
-    ),
-):
-    from mlir_quantum.dialects.catalyst import (
-        AssertionOp,
-        CallbackCallOp,
-        CallbackOp,
-        PrintOp,
-    )
-    from mlir_quantum.dialects.gradient import (
-        CustomGradOp,
-        ForwardOp,
-        GradOp,
-        JVPOp,
-        ReverseOp,
-        ValueAndGradOp,
-        VJPOp,
-    )
-    from mlir_quantum.dialects.mbqc import MeasureInBasisOp
-    from mlir_quantum.dialects.mitigation import ZneOp
-    from mlir_quantum.dialects.pbc import PPMeasurementOp
-    from mlir_quantum.dialects.quantum import (
-        AdjointOp,
-        AllocOp,
-        ComputationalBasisOp,
-        CountsOp,
-        CustomOp,
-        DeallocOp,
-        DeallocQubitOp,
-        DeviceInitOp,
-        DeviceReleaseOp,
-        ExpvalOp,
-        ExtractOp,
-        GlobalPhaseOp,
-        HamiltonianOp,
-        HermitianOp,
-        InsertOp,
-        MCMObsOp,
-        MeasureOp,
-        MultiRZOp,
-        NamedObsOp,
-        NumQubitsOp,
-        PauliRotOp,
-        PCPhaseOp,
-        ProbsOp,
-        QubitUnitaryOp,
-        SampleOp,
-        SetBasisStateOp,
-        SetStateOp,
-        StateOp,
-        TensorOp,
-        VarianceOp,
-    )
-    from mlir_quantum.dialects.quantum import YieldOp as QYieldOp
-
-    from catalyst.jax_primitives_utils import (
-        ApplyRegisteredPassOp,
-        cache,
-        create_call_op,
-        get_cached,
-        get_call_jaxpr,
-        get_symbolref,
-        lower_callable,
-        lower_jaxpr,
-    )
-
-from pennylane.capture.primitives import for_loop_prim as pl_for_loop_prim
-from pennylane.capture.primitives import jacobian_prim as pl_jac_prim
-from pennylane.capture.primitives import jvp_prim as pl_jvp_prim
-from pennylane.capture.primitives import quantum_subroutine_prim
-from pennylane.capture.primitives import value_and_grad_prim as pl_value_and_grad_prim
-from pennylane.capture.primitives import vjp_prim as pl_vjp_prim
-from pennylane.capture.primitives import while_loop_prim as pl_while_loop_prim
-
-from catalyst.compiler import get_lib_path
-from catalyst.jax_extras import (
-    ClosedJaxpr,
+from catalyst.jax_extras.tracing import (
     DynshapePrimitive,
     cond_expansion_strategy,
     for_loop_expansion_strategy,
@@ -153,8 +40,6 @@ from catalyst.jax_extras import (
     while_loop_expansion_strategy,
 )
 from catalyst.utils.calculate_grad_shape import Signature, calculate_grad_shape
-from catalyst.utils.extra_bindings import FromElementsOp, TensorExtractOp
-from catalyst.utils.types import convert_shaped_arrays_to_tensors
 
 # pylint: disable=unused-argument,too-many-lines,too-many-statements,protected-access
 
@@ -471,88 +356,6 @@ def _python_callback_abstract_eval(*avals, callback, custom_grad, results_aval):
     return results_aval
 
 
-@python_callback_p.def_impl
-def _python_callback_def_impl(*avals, callback, custom_grad, results_aval):  # pragma: no cover
-    """Concrete evaluation"""
-    raise NotImplementedError()
-
-
-def _python_callback_lowering(
-    jax_ctx: mlir.LoweringRuleContext, *args, callback, custom_grad, results_aval
-):
-    """Callback lowering"""
-
-    sys.path.append(get_lib_path("runtime", "RUNTIME_LIB_DIR"))
-    # pylint: disable=import-outside-toplevel
-    import catalyst_callback_registry as registry  # type: ignore[import-not-found]
-
-    callback_id = registry.register(callback)
-
-    params_ty = [arg.type for arg in args]
-    results_ty = list(convert_shaped_arrays_to_tensors(results_aval))
-    fn_ty = FunctionType.get(inputs=params_ty, results=results_ty)
-    fn_ty_attr = ir.TypeAttr.get(fn_ty)
-    cache_key = (callback_id, *params_ty, *results_ty)
-    if callbackOp := get_cached(jax_ctx, cache_key):
-        symbol = callbackOp.sym_name.value
-        symbol_attr = ir.FlatSymbolRefAttr.get(symbol)
-        return CallbackCallOp(results_ty, symbol_attr, args).results
-
-    module = jax_ctx.module_context.module
-    ip = module.body
-    attrs = [fn_ty_attr, callback_id, len(args), len(results_ty)]
-    with ir.InsertionPoint(ip):
-        # TODO: Name mangling for callbacks
-        name = callback.__name__
-        callbackOp = CallbackOp(f"callback_{name}_{callback_id}", *attrs)
-
-    cache(jax_ctx, cache_key, callbackOp)
-    symbol = callbackOp.sym_name.value
-    symbol_attr = ir.FlatSymbolRefAttr.get(symbol)
-    retval = CallbackCallOp(results_ty, symbol_attr, args).results
-
-    if not custom_grad:
-        return retval
-
-    assert custom_grad._fwd and custom_grad._bwd
-    fwd = custom_grad._fwd
-    rev = custom_grad._bwd
-    fwd_jaxpr = custom_grad._fwd_jaxpr
-    rev_jaxpr = custom_grad._bwd_jaxpr
-    mlir_fwd = lower_callable(jax_ctx, fwd, fwd_jaxpr)
-    mlir_rev = lower_callable(jax_ctx, rev, rev_jaxpr)
-    sym_fwd = mlir_fwd.sym_name.value + ".fwd"
-
-    argc = len(args)
-    resc = len(results_ty)
-    len_tape = len(mlir_fwd.type.results) - resc
-
-    # args_ty = inputs and cotangents since they are shadows
-    args_ty = [arg.type for arg in args]
-    # results_ty = output and cotangent
-    output_ty = results_ty
-    # the tape is found in the mlir_fwd.type
-    tape_ty = mlir_fwd.type.results[-len_tape:] if len_tape > 0 else []
-
-    fn_fwd_ty = FunctionType.get(inputs=args_ty, results=output_ty + tape_ty)
-    fn_rev_ty = FunctionType.get(inputs=output_ty + tape_ty, results=args_ty)
-
-    fwd_fn_ty_attr = ir.TypeAttr.get(fn_fwd_ty)
-    fwd_callee_attr = ir.FlatSymbolRefAttr.get(mlir_fwd.sym_name.value)
-    sym_rev = mlir_rev.sym_name.value + ".rev"
-    rev_fn_ty_attr = ir.TypeAttr.get(fn_rev_ty)
-    rev_callee_attr = ir.FlatSymbolRefAttr.get(mlir_rev.sym_name.value)
-
-    with ir.InsertionPoint(ip):
-        forward = ForwardOp(sym_fwd, fwd_fn_ty_attr, fwd_callee_attr, argc, resc, len_tape)
-        reverse = ReverseOp(sym_rev, rev_fn_ty_attr, rev_callee_attr, argc, resc, len_tape)
-        fwd_sym_attr = ir.FlatSymbolRefAttr.get(forward.sym_name.value)
-        rev_sym_attr = ir.FlatSymbolRefAttr.get(reverse.sym_name.value)
-        CustomGradOp(symbol_attr, fwd_sym_attr, rev_sym_attr)
-
-    return retval
-
-
 #
 # print
 #
@@ -567,74 +370,11 @@ def _print_def_impl(*args, string=None, memref=False):  # pragma: no cover
     return ()
 
 
-def _print_lowering(jax_ctx: mlir.LoweringRuleContext, *args, string=None, memref=False):
-    val = args[0] if args else None
-    return PrintOp(val=val, const_val=None, print_descriptor=memref).results
-
-
-#
-# module
-#
-@quantum_kernel_p.def_impl
-def _quantum_kernel_def_impl(*args, call_jaxpr, qnode, pipelines=None):  # pragma: no cover
-    raise NotImplementedError()
-
-
-def _quantum_kernel_lowering(ctx, *args, call_jaxpr, qnode, pipelines=None):
-    """Lower's qnodes to moduleOp
-
-    Args:
-      ctx: LoweringRuleContext
-      *args: List[mlir.Value] corresponding to argument values
-      qnode: qml.Qnode
-      call_jaxpr: jaxpr representing fn
-    Returns:
-      List[mlir.Value] corresponding
-    """
-    assert isinstance(qnode, qml.QNode), "This function expects qnodes"
-    pipelines = pipelines or ()
-
-    func_op = lower_callable(ctx, qnode, call_jaxpr, pipelines)
-    call_op = create_call_op(ctx, func_op, *args)
-    return call_op.results
-
-
-@func_p.def_impl
-def _func_def_impl(*args, call_jaxpr, fn):  # pragma: no cover
-    raise NotImplementedError()
-
-
-def _func_lowering(ctx, *args, call_jaxpr, fn):
-    """Lower a quantum function into MLIR in a two step process.
-    The first step is the compilation of the definition of the function fn.
-    The second step is compiling a call to function fn.
-
-    Args:
-      ctx: the MLIR context
-      args: list of arguments or abstract arguments to the function
-      name: name of the function
-      call_jaxpr: the jaxpr representation of the fn
-      fn: the function being compiled
-    """
-    func_op = lower_callable(ctx, fn, call_jaxpr)
-    call_op = create_call_op(ctx, func_op, *args)
-    return call_op.results
-
-
 #
 # Decomp rule
 #
 @decomprule_p.def_abstract_eval
 def _decomposition_rule_abstract(*, pyfun, func_jaxpr, is_qreg=False, num_params=None, **params):
-    return ()
-
-
-def _decomposition_rule_lowering(ctx, *, pyfun, func_jaxpr, **params):
-    """Lower a quantum decomposition rule into MLIR in a single step process.
-    The step is the compilation of the definition of the function fn.
-    """
-
-    lower_callable(ctx, pyfun, func_jaxpr, **params)
     return ()
 
 
@@ -655,11 +395,6 @@ class GradParams:
     with_value: bool = False  # if true it calls value_and_grad instead of grad
 
 
-@grad_p.def_impl
-def _grad_def_impl(ctx, *args, jaxpr, fn, grad_params):  # pragma: no cover
-    raise NotImplementedError()
-
-
 @grad_p.def_abstract_eval
 def _grad_abstract(*args, jaxpr, fn, grad_params):
     """This function is called with abstract arguments for tracing."""
@@ -670,97 +405,8 @@ def _grad_abstract(*args, jaxpr, fn, grad_params):
     return tuple(transformed_signature.get_results())
 
 
-def _grad_lowering(ctx, *args, jaxpr, fn, grad_params):
-    """Lowering function to gradient.
-    Args:
-        ctx: the MLIR context
-        args: the points in the function in which we are to calculate the derivative
-        jaxpr: the jaxpr representation of the grad op
-        fn (GradCallable): the function to be differentiated
-        method: the method used for differentiation
-        h: the difference for finite difference. May be None when fn is not finite difference.
-        argnums: argument indices which define over which arguments to
-            differentiate.
-    """
-    consts = []
-    offset = len(args) - len(jaxpr.consts)
-    for i, jax_array_or_tracer in enumerate(jaxpr.consts):
-        if isinstance(jax_array_or_tracer, jax._src.interpreters.partial_eval.DynamicJaxprTracer):
-            # There are some cases where this value cannot be converted into
-            # a jax.numpy.array.
-            # in that case we get it from the arguments.
-            consts.append(args[offset + i])
-        else:
-            # ``ir.DenseElementsAttr.get()`` constructs a dense elements attribute from an array of
-            # element values. This doesn't support ``jaxlib.xla_extension.Array``, so we have to
-            # cast such constants to numpy array types.
-            const = jax_array_or_tracer
-            const_type = ir.RankedTensorType.get(const.shape, mlir.dtype_to_ir_type(const.dtype))
-            nparray = np.asarray(const)
-            attr = ir.DenseElementsAttr.get(nparray, type=const_type)
-            constval = StableHLOConstantOp(attr).results
-            consts.append(constval)
-
-    method, h, argnums = grad_params.method, grad_params.h, grad_params.expanded_argnums
-    mlir_ctx = ctx.module_context.context
-    finiteDiffParam = None
-    if h:
-        f64 = ir.F64Type.get(mlir_ctx)
-        finiteDiffParam = ir.FloatAttr.get(f64, h)
-    offset = len(jaxpr.consts)
-    new_argnums = [num + offset for num in argnums]
-    argnum_numpy = np.array(new_argnums)
-    diffArgIndices = ir.DenseIntElementsAttr.get(argnum_numpy)
-    func_op = lower_jaxpr(ctx, jaxpr, (method, h, *argnums))
-    symbol_ref = get_symbolref(ctx, func_op)
-    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
-    flat_output_types = util.flatten(output_types)
-
-    len_args = len(args)
-    index = len_args - len(consts)
-    args_and_consts = consts + list(args[:index])
-
-    return GradOp(
-        flat_output_types,
-        ir.StringAttr.get(method),
-        symbol_ref,
-        mlir.flatten_ir_values(args_and_consts),
-        diffArgIndices=diffArgIndices,
-        finiteDiffParam=finiteDiffParam,
-    ).results
-
-
-# pylint: disable=too-many-arguments
-def _capture_grad_lowering(ctx, *args, argnums, jaxpr, n_consts, method, h, fn, scalar_out):
-    mlir_ctx = ctx.module_context.context
-    f64 = ir.F64Type.get(mlir_ctx)
-    finiteDiffParam = ir.FloatAttr.get(f64, h)
-
-    new_argnums = [num + n_consts for num in argnums]
-    argnum_numpy = np.array(new_argnums)
-    diffArgIndices = ir.DenseIntElementsAttr.get(argnum_numpy)
-    func_op = lower_jaxpr(ctx, jaxpr, (method, h, *new_argnums), fn=fn)
-    symbol_ref = get_symbolref(ctx, func_op)
-    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
-    flat_output_types = util.flatten(output_types)
-
-    return GradOp(
-        flat_output_types,
-        ir.StringAttr.get(method),
-        symbol_ref,
-        mlir.flatten_ir_values(args),
-        diffArgIndices=diffArgIndices,
-        finiteDiffParam=finiteDiffParam,
-    ).results
-
-
 # value_and_grad
 #
-@value_and_grad_p.def_impl
-def _value_and_grad_def_impl(ctx, *args, jaxpr, fn, grad_params):  # pragma: no cover
-    raise NotImplementedError()
-
-
 @value_and_grad_p.def_abstract_eval
 def _value_and_grad_abstract(*args, jaxpr, fn, grad_params):  # pylint: disable=unused-argument
     """This function is called with abstract arguments for tracing.
@@ -773,183 +419,14 @@ def _value_and_grad_abstract(*args, jaxpr, fn, grad_params):  # pylint: disable=
     return tuple(jaxpr.out_avals + transformed_signature.get_results())
 
 
-def _value_and_grad_lowering(ctx, *args, jaxpr, fn, grad_params):
-    """
-    Returns:
-        MLIR results
-    """
-    consts = []
-    offset = len(args) - len(jaxpr.consts)
-    for i, jax_array_or_tracer in enumerate(jaxpr.consts):
-        if not isinstance(
-            jax_array_or_tracer, jax._src.interpreters.partial_eval.DynamicJaxprTracer
-        ):
-            # ``ir.DenseElementsAttr.get()`` constructs a dense elements attribute from an array of
-            # element values. This doesn't support ``jaxlib.xla_extension.Array``, so we have to
-            # cast such constants to numpy array types.
-            const = jax_array_or_tracer
-            const_type = ir.RankedTensorType.get(const.shape, mlir.dtype_to_ir_type(const.dtype))
-            nparray = np.asarray(const)
-            attr = ir.DenseElementsAttr.get(nparray, type=const_type)
-            constval = StableHLOConstantOp(attr).results
-            consts.append(constval)
-        else:
-            # There are some cases where this value cannot be converted into
-            # a jax.numpy.array.
-            # in that case we get it from the arguments.
-            consts.append(args[offset + i])
-
-    len_args = len(args)
-    index = len_args - len(consts)
-    args = list(args[0:index])
-    method, h, argnums = grad_params.method, grad_params.h, grad_params.expanded_argnums
-    mlir_ctx = ctx.module_context.context
-    new_argnums = np.array([len(jaxpr.consts) + num for num in argnums])
-
-    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
-    flat_output_types = util.flatten(output_types)
-
-    constants = consts
-
-    consts_and_args = constants + args
-    func_call_jaxpr = get_call_jaxpr(jaxpr)
-    func_args = consts_and_args[: len(func_call_jaxpr.invars)]
-    val_result_types = flat_output_types[: len(flat_output_types) - len(argnums)]
-    gradient_result_types = flat_output_types[len(flat_output_types) - len(argnums) :]
-
-    func_op = lower_jaxpr(ctx, jaxpr, (method, h, *argnums))
-
-    symbol_ref = get_symbolref(ctx, func_op)
-    return ValueAndGradOp(
-        val_result_types,
-        gradient_result_types,
-        ir.StringAttr.get(method),
-        symbol_ref,
-        mlir.flatten_ir_values(func_args),
-        diffArgIndices=ir.DenseIntElementsAttr.get(new_argnums),
-        finiteDiffParam=ir.FloatAttr.get(ir.F64Type.get(mlir_ctx), h) if h else None,
-    ).results
-
-
-def _capture_value_and_grad_lowering(ctx, *args, jaxpr, fn, h, method, argnums):
-    """
-    Returns:
-        MLIR results
-    """
-    mlir_ctx = ctx.module_context.context
-    new_argnums = np.array(argnums)
-
-    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
-    flat_output_types = util.flatten(output_types)
-
-    val_result_types = flat_output_types[: len(flat_output_types) - len(argnums)]
-    gradient_result_types = flat_output_types[len(flat_output_types) - len(argnums) :]
-
-    func_op = lower_jaxpr(ctx, jaxpr, (method, h, *argnums), fn=fn)
-
-    symbol_ref = get_symbolref(ctx, func_op)
-    return ValueAndGradOp(
-        val_result_types,
-        gradient_result_types,
-        ir.StringAttr.get(method),
-        symbol_ref,
-        mlir.flatten_ir_values(args),
-        diffArgIndices=ir.DenseIntElementsAttr.get(new_argnums),
-        finiteDiffParam=ir.FloatAttr.get(ir.F64Type.get(mlir_ctx), h) if h else None,
-    ).results
-
-
 #
 # vjp/jvp
 #
-@jvp_p.def_impl
-def _jvp_def_impl(ctx, *args, jaxpr, fn, grad_params):  # pragma: no cover
-    raise NotImplementedError()
-
-
 @jvp_p.def_abstract_eval
 def _jvp_abstract(*args, jaxpr, fn, grad_params):  # pylint: disable=unused-argument
     """This function is called with abstract arguments for tracing.
     Note: argument names must match these of `_jvp_lowering`."""
     return jaxpr.out_avals + jaxpr.out_avals
-
-
-def _jvp_lowering(ctx, *args, jaxpr, fn, grad_params):
-    """
-    Returns:
-        MLIR results
-    """
-    args = list(args)
-    method, h, argnums = grad_params.method, grad_params.h, grad_params.expanded_argnums
-    mlir_ctx = ctx.module_context.context
-    new_argnums = np.array([len(jaxpr.consts) + num for num in argnums])
-
-    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
-    flat_output_types = util.flatten(output_types)
-    constants = [
-        StableHLOConstantOp(ir.DenseElementsAttr.get(np.asarray(const))).results
-        for const in jaxpr.consts
-    ]
-    consts_and_args = constants + args
-    func_call_jaxpr = get_call_jaxpr(jaxpr)
-    func_args = consts_and_args[: len(func_call_jaxpr.invars)]
-    tang_args = consts_and_args[len(func_call_jaxpr.invars) :]
-
-    func_op = lower_jaxpr(ctx, jaxpr, (method, h, *argnums))
-
-    assert (
-        len(flat_output_types) % 2 == 0
-    ), f"The total number of result tensors is expected to be even, not {len(flat_output_types)}"
-    symbol_ref = get_symbolref(ctx, func_op)
-    return JVPOp(
-        flat_output_types[: len(flat_output_types) // 2],
-        flat_output_types[len(flat_output_types) // 2 :],
-        ir.StringAttr.get(method),
-        symbol_ref,
-        mlir.flatten_ir_values(func_args),
-        mlir.flatten_ir_values(tang_args),
-        diffArgIndices=ir.DenseIntElementsAttr.get(new_argnums),
-        finiteDiffParam=ir.FloatAttr.get(ir.F64Type.get(mlir_ctx), h) if h else None,
-    ).results
-
-
-def _capture_jvp_lowering(ctx, *args, jaxpr, fn, method, argnums, h):
-    """
-    Returns:
-        MLIR results
-    """
-    args = list(args)
-    mlir_ctx = ctx.module_context.context
-    n_params = len(jaxpr.invars)
-    array_argnums = np.array(argnums)
-
-    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
-    flat_output_types = util.flatten(output_types)
-
-    func_result_types = flat_output_types[: len(flat_output_types) - len(argnums)]
-    jvp_result_types = flat_output_types[len(flat_output_types) - len(argnums) :]
-
-    func_args = args[:n_params]
-    d_args = args[n_params:]
-
-    func_op = lower_jaxpr(ctx, jaxpr, (method, h, *argnums), fn=fn)
-
-    symbol_ref = get_symbolref(ctx, func_op)
-    return JVPOp(
-        func_result_types,
-        jvp_result_types,
-        ir.StringAttr.get(method),
-        symbol_ref,
-        mlir.flatten_ir_values(func_args),
-        mlir.flatten_ir_values(d_args),
-        diffArgIndices=ir.DenseIntElementsAttr.get(array_argnums),
-        finiteDiffParam=ir.FloatAttr.get(ir.F64Type.get(mlir_ctx), h) if h else None,
-    ).results
-
-
-@vjp_p.def_impl
-def _vjp_def_impl(ctx, *args, jaxpr, fn, grad_params):  # pragma: no cover
-    raise NotImplementedError()
 
 
 @vjp_p.def_abstract_eval
@@ -959,86 +436,9 @@ def _vjp_abstract(*args, jaxpr, fn, grad_params):
     return jaxpr.out_avals + [jaxpr.in_avals[i] for i in grad_params.expanded_argnums]
 
 
-def _vjp_lowering(ctx, *args, jaxpr, fn, grad_params):
-    """
-    Returns:
-        MLIR results
-    """
-    args = list(args)
-    method, h, argnums = grad_params.method, grad_params.h, grad_params.expanded_argnums
-    mlir_ctx = ctx.module_context.context
-    new_argnums = np.array([len(jaxpr.consts) + num for num in argnums])
-
-    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
-    flat_output_types = util.flatten(output_types)
-    constants = [
-        StableHLOConstantOp(ir.DenseElementsAttr.get(np.asarray(const))).results
-        for const in jaxpr.consts
-    ]
-    consts_and_args = constants + args
-    func_call_jaxpr = get_call_jaxpr(jaxpr)
-    func_args = consts_and_args[: len(func_call_jaxpr.invars)]
-    cotang_args = consts_and_args[len(func_call_jaxpr.invars) :]
-    func_result_types = flat_output_types[: len(flat_output_types) - len(argnums)]
-    vjp_result_types = flat_output_types[len(flat_output_types) - len(argnums) :]
-
-    func_op = lower_jaxpr(ctx, jaxpr, (method, h, *argnums))
-
-    symbol_ref = get_symbolref(ctx, func_op)
-    return VJPOp(
-        func_result_types,
-        vjp_result_types,
-        ir.StringAttr.get(method),
-        symbol_ref,
-        mlir.flatten_ir_values(func_args),
-        mlir.flatten_ir_values(cotang_args),
-        diffArgIndices=ir.DenseIntElementsAttr.get(new_argnums),
-        finiteDiffParam=ir.FloatAttr.get(ir.F64Type.get(mlir_ctx), h) if h else None,
-    ).results
-
-
-def _capture_vjp_lowering(ctx, *args, jaxpr, fn, method, argnums, h):
-    """
-    Returns:
-        MLIR results
-    """
-    args = list(args)
-    mlir_ctx = ctx.module_context.context
-    n_params = len(jaxpr.invars)
-    new_argnums = np.array(argnums)
-
-    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
-    flat_output_types = util.flatten(output_types)
-    func_args = args[:n_params]
-    cotang_args = args[n_params:]
-    func_result_types = flat_output_types[: len(flat_output_types) - len(argnums)]
-    vjp_result_types = flat_output_types[len(flat_output_types) - len(argnums) :]
-
-    func_op = lower_jaxpr(ctx, jaxpr, (method, h, *argnums), fn=fn)
-
-    symbol_ref = get_symbolref(ctx, func_op)
-    return VJPOp(
-        func_result_types,
-        vjp_result_types,
-        ir.StringAttr.get(method),
-        symbol_ref,
-        mlir.flatten_ir_values(func_args),
-        mlir.flatten_ir_values(cotang_args),
-        diffArgIndices=ir.DenseIntElementsAttr.get(new_argnums),
-        finiteDiffParam=ir.FloatAttr.get(ir.F64Type.get(mlir_ctx), h) if h else None,
-    ).results
-
-
 #
 # zne
 #
-
-
-@zne_p.def_impl
-def _zne_def_impl(ctx, *args, folding, jaxpr, fn):  # pragma: no cover
-    raise NotImplementedError()
-
-
 @zne_p.def_abstract_eval
 def _zne_abstract_eval(*args, folding, jaxpr, fn):  # pylint: disable=unused-argument
     shape = list(args[-1].shape)
@@ -1047,80 +447,11 @@ def _zne_abstract_eval(*args, folding, jaxpr, fn):  # pylint: disable=unused-arg
     return core.ShapedArray(shape, jaxpr.out_avals[0].dtype)
 
 
-def _folding_attribute(ctx, folding):
-    ctx = ctx.module_context.context
-    return ir.OpaqueAttr.get(
-        "mitigation",
-        ("folding " + Folding(folding).name.lower()).encode("utf-8"),
-        ir.NoneType.get(ctx),
-        ctx,
-    )
-
-
-def _zne_lowering(ctx, *args, folding, jaxpr, fn):
-    """Lowering function to the ZNE opearation.
-    Args:
-        ctx: the MLIR context
-        args: the arguments with scale factors as last
-        jaxpr: the jaxpr representation of the circuit
-        fn: the function to be mitigated
-    """
-    func_op = lower_jaxpr(ctx, jaxpr)
-    symbol_ref = get_symbolref(ctx, func_op)
-    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
-    flat_output_types = util.flatten(output_types)
-    num_folds = args[-1]
-
-    constants = []
-    for const in jaxpr.consts:
-        const_type = ir.RankedTensorType.get(const.shape, mlir.dtype_to_ir_type(const.dtype))
-        nparray = np.asarray(const)
-        if const.dtype == bool:
-            nparray = np.packbits(nparray, bitorder="little")
-        attr = ir.DenseElementsAttr.get(nparray, type=const_type)
-        constantVals = StableHLOConstantOp(attr).results
-        constants.append(constantVals)
-
-    args_and_consts = constants + list(args[0:-1])
-
-    return ZneOp(
-        flat_output_types,
-        symbol_ref,
-        mlir.flatten_ir_values(args_and_consts),
-        _folding_attribute(ctx, folding),
-        num_folds,
-    ).results
-
-
 #
 # device_init
 #
 @device_init_p.def_abstract_eval
 def _device_init_abstract_eval(shots, auto_qubit_management, rtd_lib, rtd_name, rtd_kwargs):
-    return ()
-
-
-# pylint: disable=too-many-arguments, too-many-positional-arguments
-def _device_init_lowering(
-    jax_ctx: mlir.LoweringRuleContext,
-    shots: ir.Value,
-    auto_qubit_management,
-    rtd_lib,
-    rtd_name,
-    rtd_kwargs,
-):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    shots_value = TensorExtractOp(ir.IntegerType.get_signless(64, ctx), shots, []).result
-    DeviceInitOp(
-        ir.StringAttr.get(rtd_lib),
-        ir.StringAttr.get(rtd_name),
-        ir.StringAttr.get(rtd_kwargs),
-        shots=shots_value,
-        auto_qubit_management=auto_qubit_management,
-    )
-
     return ()
 
 
@@ -1132,11 +463,6 @@ def _device_release_abstract_eval():
     return ()
 
 
-def _device_release_lowering(jax_ctx: mlir.LoweringRuleContext):
-    DeviceReleaseOp()  # end of qnode
-    return ()
-
-
 #
 # num_qubits_p
 #
@@ -1145,67 +471,20 @@ def _num_qubits_abstract_eval():
     return core.ShapedArray((), jax.numpy.int64)
 
 
-def _num_qubits_lowering(jax_ctx: mlir.LoweringRuleContext):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    result_type = ir.IntegerType.get_signless(64, ctx)
-    nqubits = NumQubitsOp(result_type).result
-
-    result_from_elements_op = ir.RankedTensorType.get((), result_type)
-    from_elements_op = FromElementsOp(result_from_elements_op, nqubits)
-    return from_elements_op.results
-
-
 #
 # qalloc
 #
-@qalloc_p.def_impl
-def _qalloc_def_impl(ctx, size_value):  # pragma: no cover
-    raise NotImplementedError()
-
-
 @qalloc_p.def_abstract_eval
 def _qalloc_abstract_eval(size):
     """This function is called with abstract arguments for tracing."""
     return AbstractQreg()
 
 
-def _qalloc_lowering(jax_ctx: mlir.LoweringRuleContext, size_value: ir.Value):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    qreg_type = ir.OpaqueType.get("quantum", "reg", ctx)
-    if isinstance(size_value.owner, ir.Operation) and size_value.owner.name == "stablehlo.constant":
-        size_value_attr = size_value.owner.attributes["value"]
-        assert ir.DenseIntElementsAttr.isinstance(size_value_attr)
-        size = ir.DenseIntElementsAttr(size_value_attr)[0]
-        assert size >= 0
-
-        size_attr = ir.IntegerAttr.get(ir.IntegerType.get_signless(64, ctx), size)
-        return AllocOp(qreg_type, nqubits_attr=size_attr).results
-    else:
-        size_value = extract_scalar(size_value, "qalloc")
-        return AllocOp(qreg_type, nqubits=size_value).results
-
-
 #
 # qdealloc
 #
-@qdealloc_p.def_impl
-def _qdealloc_def_impl(ctx, size_value):  # pragma: no cover
-    raise NotImplementedError()
-
-
 @qdealloc_p.def_abstract_eval
 def _qdealloc_abstract_eval(qreg):
-    return ()
-
-
-def _qdealloc_lowering(jax_ctx: mlir.LoweringRuleContext, qreg):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-    DeallocOp(qreg)
     return ()
 
 
@@ -1217,21 +496,9 @@ def _qdealloc_qb_abstract_eval(qubit):
     return ()
 
 
-def _qdealloc_qb_lowering(jax_ctx: mlir.LoweringRuleContext, qubit):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-    DeallocQubitOp(qubit)
-    return ()
-
-
 #
 # qextract
 #
-@qextract_p.def_impl
-def _qextract_def_impl(ctx, qreg, qubit_idx):  # pragma: no cover
-    raise NotImplementedError()
-
-
 @qextract_p.def_abstract_eval
 def _qextract_abstract_eval(qreg, qubit_idx):
     """This function is called with abstract arguments for tracing."""
@@ -1239,64 +506,15 @@ def _qextract_abstract_eval(qreg, qubit_idx):
     return AbstractQbit()
 
 
-def _qextract_lowering(jax_ctx: mlir.LoweringRuleContext, qreg: ir.Value, qubit_idx: ir.Value):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    assert ir.OpaqueType.isinstance(qreg.type), qreg.type
-    assert ir.OpaqueType(qreg.type).dialect_namespace == "quantum"
-    assert ir.OpaqueType(qreg.type).data == "reg"
-
-    qubit_idx = extract_scalar(qubit_idx, "wires", "index")
-    if not ir.IntegerType.isinstance(qubit_idx.type):
-        raise TypeError(f"Operator wires expected to be integers, got {qubit_idx.type}!")
-
-    if ir.IntegerType(qubit_idx.type).width < 64:
-        qubit_idx = ExtUIOp(ir.IntegerType.get_signless(64), qubit_idx).result
-    elif not ir.IntegerType(qubit_idx.type).width == 64:
-        raise TypeError(f"Operator wires expected to be 64-bit integers, got {qubit_idx.type}!")
-
-    qubit_type = ir.OpaqueType.get("quantum", "bit", ctx)
-    return ExtractOp(qubit_type, qreg, idx=qubit_idx).results
-
-
 #
 # qinsert
 #
-@qinsert_p.def_impl
-def _qinsert_def_impl(ctx, qreg_old, qubit_idx, qubit):  # pragma: no cover
-    raise NotImplementedError()
-
-
 @qinsert_p.def_abstract_eval
 def _qinsert_abstract_eval(qreg_old, qubit_idx, qubit):
     """This function is called with abstract arguments for tracing."""
     assert isinstance(qreg_old, AbstractQreg)
     assert isinstance(qubit, AbstractQbit)
     return AbstractQreg()
-
-
-def _qinsert_lowering(
-    jax_ctx: mlir.LoweringRuleContext, qreg_old: ir.Value, qubit_idx: ir.Value, qubit: ir.Value
-):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    assert ir.OpaqueType.isinstance(qreg_old.type)
-    assert ir.OpaqueType(qreg_old.type).dialect_namespace == "quantum"
-    assert ir.OpaqueType(qreg_old.type).data == "reg"
-
-    qubit_idx = extract_scalar(qubit_idx, "wires", "index")
-    if not ir.IntegerType.isinstance(qubit_idx.type):
-        raise TypeError(f"Operator wires expected to be integers, got {qubit_idx.type}!")
-
-    if ir.IntegerType(qubit_idx.type).width < 64:
-        qubit_idx = ExtUIOp(ir.IntegerType.get_signless(64), qubit_idx).result
-    elif not ir.IntegerType(qubit_idx.type).width == 64:
-        raise TypeError(f"Operator wires expected to be 64-bit integers, got {qubit_idx.type}!")
-
-    qreg_type = ir.OpaqueType.get("quantum", "reg", ctx)
-    return InsertOp(qreg_type, qreg_old, qubit, idx=qubit_idx).results
 
 
 #
@@ -1314,44 +532,6 @@ def _gphase_abstract_eval(*qubits_or_params, ctrl_len=0, adjoint=False):
         qubit = ctrl_qubits[idx]
         assert isinstance(qubit, AbstractQbit)
     return (AbstractQbit(),) * (ctrl_len)
-
-
-@gphase_p.def_impl
-def _gphase_def_impl(*args, **kwargs):
-    """Not implemented"""
-    raise NotImplementedError()
-
-
-def _gphase_lowering(
-    jax_ctx: mlir.LoweringRuleContext, *qubits_or_params, ctrl_len=0, adjoint=False
-):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    param = qubits_or_params[0]
-    ctrl_qubits = qubits_or_params[1 : 1 + ctrl_len]
-    ctrl_values = qubits_or_params[1 + ctrl_len :]
-
-    param = safe_cast_to_f64(param, "GlobalPhase")
-    param = extract_scalar(param, "GlobalPhase")
-
-    assert ir.F64Type.isinstance(
-        param.type
-    ), "Only scalar double parameters are allowed for quantum gates!"
-
-    ctrl_values_i1 = []
-    for v in ctrl_values:
-        p = TensorExtractOp(ir.IntegerType.get_signless(1), v, []).result
-        ctrl_values_i1.append(p)
-
-    GlobalPhaseOp(
-        angle=param,
-        out_ctrl_qubits=[qubit.type for qubit in ctrl_qubits],
-        in_ctrl_qubits=ctrl_qubits,
-        in_ctrl_values=ctrl_values_i1,
-        adjoint=adjoint,
-    )
-    return ctrl_qubits
 
 
 #
@@ -1372,94 +552,6 @@ def _qinst_abstract_eval(
     return (AbstractQbit(),) * (qubits_len + ctrl_len)
 
 
-@qinst_p.def_impl
-def _qinst_def_impl(*args, **kwargs):  # pragma: no cover
-    raise NotImplementedError()
-
-
-# pylint: disable=too-many-arguments
-def _qinst_lowering(
-    jax_ctx: mlir.LoweringRuleContext,
-    *qubits_or_params,
-    op=None,
-    qubits_len=0,
-    params_len=0,
-    ctrl_len=0,
-    adjoint=False,
-):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    qubits = qubits_or_params[:qubits_len]
-    params = qubits_or_params[qubits_len : qubits_len + params_len]
-    ctrl_qubits = qubits_or_params[qubits_len + params_len : qubits_len + params_len + ctrl_len]
-    ctrl_values = qubits_or_params[qubits_len + params_len + ctrl_len :]
-
-    for qubit in qubits:
-        assert ir.OpaqueType.isinstance(qubit.type)
-        assert ir.OpaqueType(qubit.type).dialect_namespace == "quantum"
-        assert ir.OpaqueType(qubit.type).data == "bit"
-
-    float_params = []
-    for p in params:
-        p = safe_cast_to_f64(p, op)
-        p = extract_scalar(p, op)
-
-        assert ir.F64Type.isinstance(
-            p.type
-        ), "Only scalar double parameters are allowed for quantum gates!"
-
-        float_params.append(p)
-
-    ctrl_values_i1 = []
-    for v in ctrl_values:
-        p = TensorExtractOp(ir.IntegerType.get_signless(1), v, []).result
-        ctrl_values_i1.append(p)
-
-    name_attr = ir.StringAttr.get(op)
-    name_str = str(name_attr)
-    name_str = name_str.replace('"', "")
-
-    if name_str == "MultiRZ":
-        assert len(float_params) == 1, "MultiRZ takes one float parameter"
-        float_param = float_params[0]
-        return MultiRZOp(
-            out_qubits=[qubit.type for qubit in qubits],
-            out_ctrl_qubits=[qubit.type for qubit in ctrl_qubits],
-            theta=float_param,
-            in_qubits=qubits,
-            in_ctrl_qubits=ctrl_qubits,
-            in_ctrl_values=ctrl_values_i1,
-            adjoint=adjoint,
-        ).results
-
-    if name_str == "PCPhase":
-        assert len(float_params) == 2, "PCPhase takes two float parameters"
-        float_param = float_params[0]
-        dim_param = float_params[1]
-        return PCPhaseOp(
-            out_qubits=[qubit.type for qubit in qubits],
-            out_ctrl_qubits=[qubit.type for qubit in ctrl_qubits],
-            theta=float_param,
-            dim=dim_param,
-            in_qubits=qubits,
-            in_ctrl_qubits=ctrl_qubits,
-            in_ctrl_values=ctrl_values_i1,
-            adjoint=adjoint,
-        ).results
-
-    return CustomOp(
-        out_qubits=[qubit.type for qubit in qubits],
-        out_ctrl_qubits=[qubit.type for qubit in ctrl_qubits],
-        params=float_params,
-        in_qubits=qubits,
-        gate_name=name_attr,
-        in_ctrl_qubits=ctrl_qubits,
-        in_ctrl_values=ctrl_values_i1,
-        adjoint=adjoint,
-    ).results
-
-
 #
 # qubit unitary operation
 #
@@ -1469,70 +561,6 @@ def _unitary_abstract_eval(matrix, *qubits, qubits_len=0, ctrl_len=0, adjoint=Fa
         qubit = qubits[idx]
         assert isinstance(qubit, AbstractQbit)
     return (AbstractQbit(),) * (qubits_len + ctrl_len)
-
-
-@unitary_p.def_impl
-def _unitary_def_impl(*args, **kwargs):  # pragma: no cover
-    raise NotImplementedError()
-
-
-def _unitary_lowering(
-    jax_ctx: mlir.LoweringRuleContext,
-    matrix: ir.Value,
-    *qubits_or_controlled: tuple,
-    qubits_len=0,
-    ctrl_len=0,
-    adjoint=False,
-):
-    qubits = qubits_or_controlled[:qubits_len]
-    ctrl_qubits = qubits_or_controlled[qubits_len : qubits_len + ctrl_len]
-    ctrl_values = qubits_or_controlled[qubits_len + ctrl_len :]
-
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    for q in qubits:
-        assert ir.OpaqueType.isinstance(q.type)
-        assert ir.OpaqueType(q.type).dialect_namespace == "quantum"
-        assert ir.OpaqueType(q.type).data == "bit"
-
-    matrix_type = matrix.type
-    is_tensor = ir.RankedTensorType.isinstance(matrix_type)
-    shape = ir.RankedTensorType(matrix_type).shape if is_tensor else None
-    is_2d_tensor = len(shape) == 2 if is_tensor else False
-    if not is_2d_tensor:
-        raise TypeError("QubitUnitary must be a 2 dimensional tensor.")
-
-    possibly_complex_type = ir.RankedTensorType(matrix_type).element_type
-    is_complex = ir.ComplexType.isinstance(possibly_complex_type)
-    is_f64_type = False
-
-    if is_complex:
-        complex_type = ir.ComplexType(possibly_complex_type)
-        possibly_f64_type = complex_type.element_type
-        is_f64_type = ir.F64Type.isinstance(possibly_f64_type)
-
-    is_complex_f64_type = is_complex and is_f64_type
-    if not is_complex_f64_type:
-        f64_type = ir.F64Type.get()
-        complex_f64_type = ir.ComplexType.get(f64_type)
-        tensor_complex_f64_type = ir.RankedTensorType.get(shape, complex_f64_type)
-        matrix = StableHLOConvertOp(tensor_complex_f64_type, matrix).result
-
-    ctrl_values_i1 = []
-    for v in ctrl_values:
-        p = TensorExtractOp(ir.IntegerType.get_signless(1), v, []).result
-        ctrl_values_i1.append(p)
-
-    return QubitUnitaryOp(
-        out_qubits=[q.type for q in qubits],
-        out_ctrl_qubits=[q.type for q in ctrl_qubits],
-        matrix=matrix,
-        in_qubits=qubits,
-        in_ctrl_qubits=ctrl_qubits,
-        in_ctrl_values=ctrl_values_i1,
-        adjoint=adjoint,
-    ).results
 
 
 #
@@ -1560,60 +588,6 @@ def _pauli_rot_abstract_eval(
     return (AbstractQbit(),) * (qubits_len + ctrl_len)
 
 
-@pauli_rot_p.def_impl
-def _pauli_rot_def_impl(*args, **kwargs):  # pragma: no cover
-    raise NotImplementedError()
-
-
-# pylint: disable=unused-argument
-def _pauli_rot_lowering(
-    jax_ctx: mlir.LoweringRuleContext,
-    *qubits_and_params: tuple,
-    pauli_word=None,
-    qubits_len=0,
-    params_len=0,
-    ctrl_len=0,
-    adjoint=False,
-):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    qubits = qubits_and_params[:qubits_len]
-    params = qubits_and_params[qubits_len : qubits_len + params_len]
-    ctrl_qubits = qubits_and_params[qubits_len + params_len : qubits_len + params_len + ctrl_len]
-    ctrl_values = qubits_and_params[qubits_len + params_len + ctrl_len :]
-
-    for q in qubits:
-        assert ir.OpaqueType.isinstance(q.type)
-        assert ir.OpaqueType(q.type).dialect_namespace == "quantum"
-        assert ir.OpaqueType(q.type).data == "bit"
-
-    assert params_len == 1 and params[0] is not None
-    angle = params[0]
-    angle = safe_cast_to_f64(angle, "PauliRot")
-    angle = extract_scalar(angle, "PauliRot")
-    assert ir.F64Type.isinstance(angle.type)
-    assert pauli_word is not None
-
-    pauli_word = ir.ArrayAttr.get([ir.StringAttr.get(p) for p in pauli_word])
-
-    ctrl_values_i1 = []
-    for v in ctrl_values:
-        p = TensorExtractOp(ir.IntegerType.get_signless(1), v, []).result
-        ctrl_values_i1.append(p)
-
-    return PauliRotOp(
-        out_qubits=[qubit.type for qubit in qubits],
-        out_ctrl_qubits=[qubit.type for qubit in ctrl_qubits],
-        angle=angle,
-        pauli_product=pauli_word,
-        adjoint=adjoint,
-        in_qubits=qubits,
-        in_ctrl_qubits=ctrl_qubits,
-        in_ctrl_values=ctrl_values_i1,
-    ).results
-
-
 #
 # pauli measure operation
 #
@@ -1625,50 +599,6 @@ def _pauli_measure_abstract_eval(*qubits, pauli_word=None, qubits_len=0, adjoint
     return (core.ShapedArray((), bool),) + (AbstractQbit(),) * (qubits_len)
 
 
-@pauli_measure_p.def_impl
-def _pauli_measure_def_impl(*args, **kwargs):  # pragma: no cover
-    raise NotImplementedError()
-
-
-def _pauli_measure_lowering(
-    jax_ctx: mlir.LoweringRuleContext,
-    *qubits: tuple,
-    pauli_word=None,
-    qubits_len=0,
-):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    qubits = qubits[:qubits_len]
-    for q in qubits:
-        assert ir.OpaqueType.isinstance(q.type)
-        assert ir.OpaqueType(q.type).dialect_namespace == "quantum"
-        assert ir.OpaqueType(q.type).data == "bit"
-
-    assert pauli_word is not None
-
-    if not all(p in ["I", "X", "Y", "Z"] for p in pauli_word):
-        raise ValueError("Only Pauli words consisting of 'I', 'X', 'Y', and 'Z' are allowed.")
-
-    pauli_word = ir.ArrayAttr.get([ir.StringAttr.get(p) for p in pauli_word])
-
-    result_type = ir.IntegerType.get_signless(1)
-
-    ppm_results = PPMeasurementOp(
-        out_qubits=[q.type for q in qubits],
-        mres=result_type,
-        pauli_product=pauli_word,
-        in_qubits=qubits,
-    ).results
-
-    result, *out_qubits = ppm_results  # First element is the measurement result
-
-    result_type = ir.RankedTensorType.get((), result.type)
-    from_elements_op = FromElementsOp(result_type, result)
-
-    return (from_elements_op.results[0],) + tuple(out_qubits)
-
-
 #
 # measure
 #
@@ -1676,37 +606,6 @@ def _pauli_measure_lowering(
 def _measure_abstract_eval(qubit, postselect: int = None):
     assert isinstance(qubit, AbstractQbit)
     return core.ShapedArray((), bool), qubit
-
-
-@measure_p.def_impl
-def _measure_def_impl(ctx, qubit, postselect: int = None):  # pragma: no cover
-    raise NotImplementedError()
-
-
-def _measure_lowering(jax_ctx: mlir.LoweringRuleContext, qubit: ir.Value, postselect: int = None):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    assert ir.OpaqueType.isinstance(qubit.type)
-    assert ir.OpaqueType(qubit.type).dialect_namespace == "quantum"
-    assert ir.OpaqueType(qubit.type).data == "bit"
-
-    # Prepare postselect attribute
-    if postselect is not None:
-        i32_type = ir.IntegerType.get_signless(32, ctx)
-        postselect = ir.IntegerAttr.get(i32_type, postselect)
-
-    result_type = ir.IntegerType.get_signless(1)
-
-    result, new_qubit = MeasureOp(result_type, qubit.type, qubit, postselect=postselect).results
-
-    result_from_elements_op = ir.RankedTensorType.get((), result.type)
-    from_elements_op = FromElementsOp(result_from_elements_op, result)
-
-    return (
-        from_elements_op.results[0],
-        new_qubit,
-    )
 
 
 #
@@ -1718,68 +617,6 @@ def _measure_in_basis_abstract_eval(
 ):
     assert isinstance(qubit, AbstractQbit)
     return core.ShapedArray((), bool), qubit
-
-
-@measure_in_basis_p.def_impl
-def _measure_in_basis_def_impl(
-    ctx, angle: float, qubit: AbstractQbit, plane: MeasurementPlane, postselect: int = None
-):  # pragma: no cover
-    raise NotImplementedError()
-
-
-def _measurement_plane_attribute(ctx, plane: MeasurementPlane):
-    return ir.OpaqueAttr.get(
-        "mbqc",
-        ("measurement_plane " + MeasurementPlane(plane).name).encode("utf-8"),
-        ir.NoneType.get(ctx),
-        ctx,
-    )
-
-
-def _measure_in_basis_lowering(
-    jax_ctx: mlir.LoweringRuleContext,
-    angle: float,
-    qubit: ir.Value,
-    plane: MeasurementPlane,
-    postselect: int = None,
-):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    assert ir.OpaqueType.isinstance(qubit.type)
-    assert ir.OpaqueType(qubit.type).dialect_namespace == "quantum"
-    assert ir.OpaqueType(qubit.type).data == "bit"
-
-    angle = safe_cast_to_f64(angle, "angle")
-    angle = extract_scalar(angle, "angle")
-
-    assert ir.F64Type.isinstance(
-        angle.type
-    ), "Only scalar double parameters are allowed for quantum gates!"
-
-    # Prepare postselect attribute
-    if postselect is not None:
-        i32_type = ir.IntegerType.get_signless(32, ctx)
-        postselect = ir.IntegerAttr.get(i32_type, postselect)
-
-    result_type = ir.IntegerType.get_signless(1)
-
-    result, new_qubit = MeasureInBasisOp(
-        result_type,
-        qubit.type,
-        qubit,
-        plane=_measurement_plane_attribute(ctx, plane),
-        angle=angle,
-        postselect=postselect,
-    ).results
-
-    result_from_elements_op = ir.RankedTensorType.get((), result.type)
-    from_elements_op = FromElementsOp(result_from_elements_op, result)
-
-    return (
-        from_elements_op.results[0],
-        new_qubit,
-    )
 
 
 #
@@ -1798,68 +635,13 @@ def _compbasis_abstract_eval(*qubits_or_qreg, qreg_available=False):
         return AbstractObs(len(qubits), compbasis_p)
 
 
-@compbasis_p.def_impl
-def _compbasis_def_impl(ctx, *qubits_or_qreg, qreg_available):  # pragma: no cover
-    raise NotImplementedError()
-
-
-def _compbasis_lowering(
-    jax_ctx: mlir.LoweringRuleContext, *qubits_or_qreg: tuple, qreg_available=False
-):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    result_type = ir.OpaqueType.get("quantum", "obs")
-
-    if qreg_available:
-        qreg = qubits_or_qreg[0]
-        assert ir.OpaqueType.isinstance(qreg.type)
-        assert ir.OpaqueType(qreg.type).dialect_namespace == "quantum"
-        assert ir.OpaqueType(qreg.type).data == "reg"
-        return ComputationalBasisOp(result_type, [], qreg=qreg).results
-
-    else:
-        qubits = qubits_or_qreg
-        for qubit in qubits:
-            assert ir.OpaqueType.isinstance(qubit.type)
-            assert ir.OpaqueType(qubit.type).dialect_namespace == "quantum"
-            assert ir.OpaqueType(qubit.type).data == "bit"
-
-        return ComputationalBasisOp(result_type, qubits).results
-
-
 #
 # named observable
 #
-@namedobs_p.def_impl
-def _namedobs_def_impl(qubit, kind):  # pragma: no cover
-    raise NotImplementedError()
-
-
 @namedobs_p.def_abstract_eval
 def _namedobs_abstract_eval(qubit, kind):
     assert isinstance(qubit, AbstractQbit)
     return AbstractObs()
-
-
-def _named_obs_attribute(ctx, kind: str):
-    return ir.OpaqueAttr.get(
-        "quantum", ("named_observable " + kind).encode("utf-8"), ir.NoneType.get(ctx), ctx
-    )
-
-
-def _named_obs_lowering(jax_ctx: mlir.LoweringRuleContext, qubit: ir.Value, kind: str):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    assert ir.OpaqueType.isinstance(qubit.type)
-    assert ir.OpaqueType(qubit.type).dialect_namespace == "quantum"
-    assert ir.OpaqueType(qubit.type).data == "bit"
-
-    obsId = _named_obs_attribute(ctx, kind)
-    result_type = ir.OpaqueType.get("quantum", "obs", ctx)
-
-    return NamedObsOp(result_type, qubit, obsId).results
 
 
 #
@@ -1868,18 +650,6 @@ def _named_obs_lowering(jax_ctx: mlir.LoweringRuleContext, qubit: ir.Value, kind
 @mcmobs_p.def_abstract_eval
 def _mcmobs_abstract_eval(*mcms):
     return AbstractObs(len(mcms), mcmobs_p)
-
-
-def _mcm_obs_lowering(jax_ctx: mlir.LoweringRuleContext, *mcms: list[ir.Value]):
-    ctx = jax_ctx.module_context.context
-    result_type = ir.OpaqueType.get("quantum", "obs", ctx)
-    tensor_i1_type = ir.RankedTensorType.get([], ir.IntegerType.get_signless(1))
-
-    extracted = []
-    for mcm in mcms:
-        convert_op = StableHLOConvertOp(tensor_i1_type, mcm)
-        extracted.append(extract_scalar(convert_op.result, "mcmobs"))
-    return MCMObsOp(result_type, extracted).results
 
 
 #
@@ -1892,42 +662,14 @@ def _hermitian_abstract_eval(matrix, *qubits):
     return AbstractObs()
 
 
-@hermitian_p.def_impl
-def _hermitian_def_impl(ctx, matrix, *qubits):  # pragma: no cover
-    raise NotImplementedError()
-
-
-def _hermitian_lowering(jax_ctx: mlir.LoweringRuleContext, matrix: ir.Value, *qubits: tuple):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    result_type = ir.OpaqueType.get("quantum", "obs", ctx)
-
-    return HermitianOp(result_type, matrix, qubits).results
-
-
 #
 # tensor observable
 #
-@tensorobs_p.def_impl
-def _tensorobs_def_impl(ctx, *terms):  # pragma: no cover
-    raise NotImplementedError()
-
-
 @tensorobs_p.def_abstract_eval
 def _tensorobs_abstract_eval(*terms):
     for o in terms:
         assert isinstance(o, AbstractObs)
     return AbstractObs()
-
-
-def _tensor__obs_lowering(jax_ctx: mlir.LoweringRuleContext, *terms: tuple):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    result_type = ir.OpaqueType.get("quantum", "obs")
-
-    return TensorOp(result_type, terms).results
 
 
 #
@@ -1938,22 +680,6 @@ def _hamiltonian_abstract_eval(coeffs, *terms):
     for o in terms:
         assert isinstance(o, AbstractObs)
     return AbstractObs()
-
-
-@hamiltonian_p.def_impl
-def _hamiltonian_def_impl(ctx, coeffs, *terms):  # pragma: no cover
-    raise NotImplementedError()
-
-
-def _hamiltonian_lowering(jax_ctx: mlir.LoweringRuleContext, coeffs: ir.Value, *terms: tuple):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    coeffs = safe_cast_to_f64(coeffs, "Hamiltonian", "coefficient")
-
-    result_type = ir.OpaqueType.get("quantum", "obs", ctx)
-
-    return HamiltonianOp(result_type, coeffs, terms).results
 
 
 #
@@ -2032,32 +758,6 @@ def sample_staging_rule(jaxpr_trace, _src, obs, *dynamic_shape, static_shape):
 pe.custom_staging_rules[sample_p] = sample_staging_rule
 
 
-@sample_p.def_impl
-def _sample_def_impl(ctx, obs, *dynamic_shape, static_shape):  # pragma: no cover
-    raise NotImplementedError()
-
-
-def _sample_lowering(
-    jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, *dynamic_shape, static_shape
-):
-    # result shape of sample op is (shots, number_of_qubits)
-    # The static_shape argument contains the static dimensions, and None for dynamic dimensions
-
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-    f64_type = ir.F64Type.get()
-
-    # Replace Nones in static_shape with dynamic mlir dimensions
-    result_shape = tuple(ir.ShapedType.get_dynamic_size() if d is None else d for d in static_shape)
-    result_type = ir.RankedTensorType.get(result_shape, f64_type)
-
-    dynamic_shape = list(dynamic_shape)
-    for i, dyn_dim in enumerate(dynamic_shape):
-        dynamic_shape[i] = extract_scalar(dyn_dim, f"sample_dyn_dim_{i}")
-
-    return SampleOp(result_type, obs, dynamic_shape=dynamic_shape).results
-
-
 #
 # counts measurement
 #
@@ -2088,38 +788,6 @@ def counts_staging_rule(jaxpr_trace, _src, obs, *dynamic_shape, static_shape):
 pe.custom_staging_rules[counts_p] = counts_staging_rule
 
 
-@counts_p.def_impl
-def _counts_def_impl(ctx, obs, *dynamic_shape, static_shape):  # pragma: no cover
-    raise NotImplementedError()
-
-
-def _counts_lowering(
-    jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, *dynamic_shape, static_shape
-):
-    # Note: result shape of counts op is (tensor<Nxf64>, tensor<Nxi64>)
-    # where N = 2**number_of_qubits
-    # This means even with dynamic shots, result shape is still static.
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    i64_type = ir.IntegerType.get_signless(64, ctx)
-    f64_type = ir.F64Type.get()
-
-    # Replace Nones in static_shape with dynamic mlir dimensions
-    shape = tuple(ir.ShapedType.get_dynamic_size() if d is None else d for d in static_shape)
-    eigvals_type = ir.RankedTensorType.get(shape, f64_type)
-    counts_type = ir.RankedTensorType.get(shape, i64_type)
-
-    if static_shape[0] is None:
-        # dynamic num_qubits, pass the SSA value to the op
-        dyn_shape = extract_scalar(dynamic_shape[0], "counts_size")
-    else:
-        # static num_qubits already in the shape, no need to pass another operand
-        dyn_shape = None
-
-    return CountsOp(eigvals_type, counts_type, obs, dynamic_shape=dyn_shape).results
-
-
 #
 # expval measurement
 #
@@ -2129,27 +797,6 @@ def _expval_abstract_eval(obs, shape=None):
     return core.ShapedArray((), jax.numpy.float64)
 
 
-@expval_p.def_impl
-def _expval_def_impl(ctx, obs, shape=None):  # pragma: no cover
-    raise NotImplementedError()
-
-
-def _expval_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shape=None):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    assert ir.OpaqueType.isinstance(obs.type)
-    assert ir.OpaqueType(obs.type).dialect_namespace == "quantum"
-    assert ir.OpaqueType(obs.type).data == "obs"
-
-    result_type = ir.F64Type.get()
-
-    mres = ExpvalOp(result_type, obs).result
-    result_from_elements_op = ir.RankedTensorType.get((), result_type)
-    from_elements_op = FromElementsOp(result_from_elements_op, mres)
-    return from_elements_op.results
-
-
 #
 # var measurement
 #
@@ -2157,27 +804,6 @@ def _expval_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shape=Non
 def _var_abstract_eval(obs, shape=None):
     assert isinstance(obs, AbstractObs)
     return core.ShapedArray((), jax.numpy.float64)
-
-
-@var_p.def_impl
-def _var_def_impl(ctx, obs, shape=None):  # pragma: no cover
-    raise NotImplementedError()
-
-
-def _var_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shape=None):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    assert ir.OpaqueType.isinstance(obs.type)
-    assert ir.OpaqueType(obs.type).dialect_namespace == "quantum"
-    assert ir.OpaqueType(obs.type).data == "obs"
-
-    result_type = ir.F64Type.get()
-
-    mres = VarianceOp(result_type, obs).result
-    result_from_elements_op = ir.RankedTensorType.get((), result_type)
-    from_elements_op = FromElementsOp(result_from_elements_op, mres)
-    return from_elements_op.results
 
 
 #
@@ -2198,30 +824,6 @@ def probs_staging_rule(jaxpr_trace, _src, obs, *dynamic_shape, static_shape):
 
 
 pe.custom_staging_rules[probs_p] = probs_staging_rule
-
-
-@probs_p.def_impl
-def _probs_def_impl(ctx, obs, *dynamic_shape, static_shape):  # pragma: no cover
-    raise NotImplementedError()
-
-
-def _probs_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, *dynamic_shape, static_shape):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    f64_type = ir.F64Type.get()
-
-    # Replace Nones in static_shape with dynamic mlir dimensions
-    result_shape = tuple(ir.ShapedType.get_dynamic_size() if d is None else d for d in static_shape)
-    result_type = ir.RankedTensorType.get(result_shape, f64_type)
-
-    if static_shape[0] is None:
-        # dynamic sv_length, pass the SSA value to the op
-        dyn_shape = extract_scalar(dynamic_shape[0], "probs_sv_length")
-    else:
-        # static sv_length already in the shape, no need to pass another operand
-        dyn_shape = None
-    return ProbsOp(result_type, obs, dynamic_shape=dyn_shape).results
 
 
 #
@@ -2252,30 +854,6 @@ def state_staging_rule(jaxpr_trace, _src, obs, *dynamic_shape, static_shape):
 pe.custom_staging_rules[state_p] = state_staging_rule
 
 
-@state_p.def_impl
-def _state_def_impl(ctx, obs, *dynamic_shape, static_shape):  # pragma: no cover
-    raise NotImplementedError()
-
-
-def _state_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, *dynamic_shape, static_shape):
-    ctx = jax_ctx.module_context.context
-    ctx.allow_unregistered_dialects = True
-
-    c64_type = ir.ComplexType.get(ir.F64Type.get())
-
-    # Replace Nones in static_shape with dynamic mlir dimensions
-    result_shape = tuple(ir.ShapedType.get_dynamic_size() if d is None else d for d in static_shape)
-    result_type = ir.RankedTensorType.get(result_shape, c64_type)
-
-    if static_shape[0] is None:
-        # dynamic sv_length, pass the SSA value to the op
-        dyn_shape = extract_scalar(dynamic_shape[0], "state_sv_length")
-    else:
-        # static sv_length already in the shape, no need to pass another operand
-        dyn_shape = None
-    return StateOp(result_type, obs, dynamic_shape=dyn_shape).results
-
-
 #
 # cond
 #
@@ -2289,81 +867,6 @@ def _cond_abstract_eval(*args, branch_jaxprs, num_implicit_outputs: int, **kwarg
         num_implicit_inputs=None,
     )
     return out_type
-
-
-@cond_p.def_impl
-def _cond_def_impl(ctx, *preds_and_branch_args_plus_consts, branch_jaxprs):  # pragma: no cover
-    raise NotImplementedError()
-
-
-def _cond_lowering(
-    jax_ctx: mlir.LoweringRuleContext,
-    *preds_and_branch_args_plus_consts: tuple,
-    branch_jaxprs: List[core.ClosedJaxpr],
-    num_implicit_outputs: int,
-):
-    result_types = [mlir.aval_to_ir_types(a)[0] for a in jax_ctx.avals_out]
-    num_preds = len(branch_jaxprs) - 1
-    preds = preds_and_branch_args_plus_consts[:num_preds]
-    branch_args_plus_consts = preds_and_branch_args_plus_consts[num_preds:]
-    flat_args_plus_consts = mlir.flatten_ir_values(branch_args_plus_consts)
-
-    # recursively lower if-else chains to nested IfOps
-    def emit_branches(preds, branch_jaxprs, ip):
-        # ip is an MLIR InsertionPoint. This allows recursive calls to emit their Operations inside
-        # the 'else' blocks of preceding IfOps.
-        with ip:
-            pred_extracted = TensorExtractOp(ir.IntegerType.get_signless(1), preds[0], []).result
-            if_op_scf = IfOp(pred_extracted, result_types, hasElse=True)
-            true_jaxpr = branch_jaxprs[0]
-            if_block = if_op_scf.then_block
-
-            # if block
-            source_info_util.extend_name_stack("if")
-            if_ctx = jax_ctx.replace(name_stack=jax_ctx.name_stack.extend("if"))
-            with ir.InsertionPoint(if_block):
-                # recursively generate the mlir for the if block
-                out, _ = mlir.jaxpr_subcomp(
-                    if_ctx.module_context,
-                    true_jaxpr.jaxpr,
-                    if_ctx.name_stack,
-                    mlir.TokenSet(),
-                    [mlir.ir_constant(c) for c in true_jaxpr.consts],  # is never hit in our tests
-                    *flat_args_plus_consts,
-                    dim_var_values=jax_ctx.dim_var_values,
-                    const_lowering=jax_ctx.const_lowering,
-                )
-
-                YieldOp(out)
-
-            # else block
-            source_info_util.extend_name_stack("else")
-            else_ctx = jax_ctx.replace(name_stack=jax_ctx.name_stack.extend("else"))
-            else_block = if_op_scf.else_block
-            if len(preds) == 1:
-                # Base case: reached the otherwise block
-                otherwise_jaxpr = branch_jaxprs[-1]
-                with ir.InsertionPoint(else_block):
-                    out, _ = mlir.jaxpr_subcomp(
-                        else_ctx.module_context,
-                        otherwise_jaxpr.jaxpr,
-                        else_ctx.name_stack,
-                        mlir.TokenSet(),
-                        [mlir.ir_constants(c) for c in otherwise_jaxpr.consts],
-                        *flat_args_plus_consts,
-                        dim_var_values=jax_ctx.dim_var_values,
-                        const_lowering=jax_ctx.const_lowering,
-                    )
-
-                    YieldOp(out)
-            else:
-                with ir.InsertionPoint(else_block) as else_ip:
-                    child_if_op = emit_branches(preds[1:], branch_jaxprs[1:], else_ip)
-                    YieldOp(child_if_op.results)
-            return if_op_scf
-
-    head_if_op = emit_branches(preds, branch_jaxprs, jax_ctx.module_context.ip.current)
-    return head_if_op.results
 
 
 #
@@ -2380,71 +883,6 @@ def _switch_p_abstract_eval(*args, branch_jaxprs, num_implicit_outputs: int, **k
     )
 
     return out_type
-
-
-@switch_p.def_impl
-def _switch_def_impl(*args, **kwargs):  # pragma: no cover
-    raise NotImplementedError()
-
-
-def _switch_lowering(
-    jax_ctx,
-    *index_and_cases_and_branch_args_plus_consts: tuple,
-    branch_jaxprs: List[core.ClosedJaxpr],
-    num_implicit_outputs: int,
-):
-    result_types = [mlir.aval_to_ir_types(outvar)[0] for outvar in branch_jaxprs[0].out_avals]
-
-    index = index_and_cases_and_branch_args_plus_consts[0]
-    # the last branch is default and does not have a case
-    cases = index_and_cases_and_branch_args_plus_consts[1 : len(branch_jaxprs)]
-    branch_args_plus_consts = index_and_cases_and_branch_args_plus_consts[len(branch_jaxprs) :]
-    flat_args_plus_consts = mlir.flatten_ir_values(branch_args_plus_consts)
-
-    index = _cast_to_index(index)
-
-    # enumerate branches so that branch indices and "cases" line up properly
-    cases = ir.DenseI64ArrayAttr.get(
-        [case.owner.attributes["value"].get_splat_value().value for case in cases]
-    )
-
-    scf_switch_op = IndexSwitchOp(result_types, index, cases, len(branch_jaxprs) - 1)
-
-    # construct switch branches
-    for i in range(len(branch_jaxprs) - 1):
-        with ir.InsertionPoint(scf_switch_op.caseRegions[i].blocks.append()):
-            branch_ctx = jax_ctx.replace(name_stack=jax_ctx.name_stack.extend(f"branch {i}"))
-            branch_jaxpr = branch_jaxprs[i]
-            out, _ = mlir.jaxpr_subcomp(
-                branch_ctx.module_context,
-                branch_jaxpr.jaxpr,
-                branch_ctx.name_stack,
-                mlir.TokenSet(),
-                [mlir.ir_constant(const) for const in branch_jaxpr.consts],
-                *flat_args_plus_consts,
-                dim_var_values=jax_ctx.dim_var_values,
-                const_lowering=jax_ctx.const_lowering,
-            )
-
-            YieldOp(out)
-
-    with ir.InsertionPoint(scf_switch_op.defaultRegion.blocks.append()):
-        branch_ctx = jax_ctx.replace(name_stack=jax_ctx.name_stack.extend("default branch"))
-        branch_jaxpr = branch_jaxprs[-1]
-        out, _ = mlir.jaxpr_subcomp(
-            branch_ctx.module_context,
-            branch_jaxpr.jaxpr,
-            branch_ctx.name_stack,
-            mlir.TokenSet(),
-            [mlir.ir_constant(const) for const in branch_jaxpr.consts],
-            *flat_args_plus_consts,
-            dim_var_values=jax_ctx.dim_var_values,
-            const_lowering=jax_ctx.const_lowering,
-        )
-
-        YieldOp(out)
-
-    return scf_switch_op.results
 
 
 #
@@ -2470,169 +908,6 @@ def _while_loop_abstract_eval(
     )
 
 
-@while_p.def_impl
-def _while_loop_def_impl(
-    ctx,
-    *iter_args_plus_consts,
-    cond_jaxpr,
-    body_jaxpr,
-    cond_nconsts,
-    body_nconsts,
-    num_implicit_inputs,
-    preserve_dimensions,
-):  # pragma: no cover
-    raise NotImplementedError()
-
-
-def _while_loop_lowering(
-    jax_ctx: mlir.LoweringRuleContext,
-    *iter_args_plus_consts: tuple,
-    cond_jaxpr: core.ClosedJaxpr,
-    body_jaxpr: core.ClosedJaxpr,
-    cond_nconsts: int,
-    body_nconsts: int,
-    num_implicit_inputs: int,
-    preserve_dimensions: bool,
-):
-    loop_carry_types_plus_consts = [mlir.aval_to_ir_types(a)[0] for a in jax_ctx.avals_in]
-    flat_args_plus_consts = mlir.flatten_ir_values(iter_args_plus_consts)
-    assert [val.type for val in flat_args_plus_consts] == loop_carry_types_plus_consts
-
-    # split the argument list into 3 separate groups
-    # 1) the constants used in the condition function
-    # 2) the constants used in the body function
-    # 3) the normal arguments which are not constants
-    cond_consts = flat_args_plus_consts[:cond_nconsts]
-    body_consts = flat_args_plus_consts[cond_nconsts : cond_nconsts + body_nconsts]
-    loop_args = flat_args_plus_consts[cond_nconsts + body_nconsts :]
-
-    # remove const types from abstract parameter types list
-    loop_carry_types = loop_carry_types_plus_consts[cond_nconsts + body_nconsts :]
-    assert loop_carry_types == [mlir.aval_to_ir_types(a)[0] for a in jax_ctx.avals_out], (
-        loop_carry_types,
-        [mlir.aval_to_ir_types(a)[0] for a in jax_ctx.avals_out],
-    )
-
-    while_op_scf = WhileOp(loop_carry_types, loop_args)
-
-    # cond block
-    cond_block = while_op_scf.regions[0].blocks.append(*loop_carry_types)
-    name_stack = jax_ctx.name_stack.extend("while")
-    cond_ctx = jax_ctx.replace(name_stack=name_stack.extend("cond"))
-    with ir.InsertionPoint(cond_block):
-        cond_args = [cond_block.arguments[i] for i in range(len(loop_carry_types))]
-        params = cond_consts + cond_args
-
-        # recursively generate the mlir for the while cond
-        (pred,), _ = mlir.jaxpr_subcomp(
-            cond_ctx.module_context,
-            cond_jaxpr.jaxpr,
-            cond_ctx.name_stack,
-            mlir.TokenSet(),
-            [mlir.ir_constants(c) for c in cond_jaxpr.consts],
-            *params,
-            dim_var_values=jax_ctx.dim_var_values,
-            const_lowering=jax_ctx.const_lowering,
-        )
-
-        pred_extracted = TensorExtractOp(ir.IntegerType.get_signless(1), pred, []).result
-        ConditionOp(pred_extracted, cond_args)
-
-    # body block
-    body_block = while_op_scf.regions[1].blocks.append(*loop_carry_types)
-    body_ctx = jax_ctx.replace(name_stack=name_stack.extend("body"))
-    with ir.InsertionPoint(body_block):
-        body_args = [body_block.arguments[i] for i in range(len(loop_carry_types))]
-        params = body_consts + body_args
-
-        # recursively generate the mlir for the while body
-        out, _ = mlir.jaxpr_subcomp(
-            body_ctx.module_context,
-            body_jaxpr.jaxpr,
-            body_ctx.name_stack,
-            mlir.TokenSet(),
-            [mlir.ir_constants(c) for c in cond_jaxpr.consts],
-            *params,
-            dim_var_values=jax_ctx.dim_var_values,
-            const_lowering=jax_ctx.const_lowering,
-        )
-
-        YieldOp(out)
-
-    return while_op_scf.results
-
-
-def _pl_while_loop_lowering(
-    jax_ctx: mlir.LoweringRuleContext,
-    *plxpr_invals,
-    jaxpr_body_fn,
-    jaxpr_cond_fn,
-    body_slice,
-    cond_slice,
-    args_slice,
-):
-    body_consts = plxpr_invals[slice(*body_slice)]
-    cond_consts = plxpr_invals[slice(*cond_slice)]
-    args = plxpr_invals[slice(*args_slice)]
-
-    all_args_types = [mlir.aval_to_ir_types(a)[0] for a in jax_ctx.avals_in]
-    args_types = all_args_types[slice(*args_slice)]
-
-    while_op_scf = WhileOp(args_types, args)
-
-    # cond block
-    cond_block = while_op_scf.regions[0].blocks.append(*args_types)
-    name_stack = jax_ctx.name_stack.extend("while")
-    cond_ctx = jax_ctx.replace(name_stack=name_stack.extend("cond"))
-    with ir.InsertionPoint(cond_block):
-        cond_args = tuple(cond_block.arguments[i] for i in range(len(args)))
-        params = cond_consts + cond_args
-        new_cond_jaxpr = jaxpr_cond_fn.replace(
-            constvars=(), invars=jaxpr_cond_fn.constvars + jaxpr_cond_fn.invars
-        )
-
-        # recursively generate the mlir for the while cond
-        (pred,), _ = mlir.jaxpr_subcomp(
-            cond_ctx.module_context,
-            new_cond_jaxpr,
-            cond_ctx.name_stack,
-            mlir.TokenSet(),
-            [],
-            *params,
-            dim_var_values=jax_ctx.dim_var_values,
-            const_lowering=jax_ctx.const_lowering,
-        )
-
-        pred_extracted = TensorExtractOp(ir.IntegerType.get_signless(1), pred, []).result
-        ConditionOp(pred_extracted, cond_args)
-
-    # body block
-    body_block = while_op_scf.regions[1].blocks.append(*args_types)
-    body_ctx = jax_ctx.replace(name_stack=name_stack.extend("body"))
-    with ir.InsertionPoint(body_block):
-        body_args = tuple(body_block.arguments[-len(args) :])
-        params = body_consts + body_args
-
-        new_body_jaxpr = jaxpr_body_fn.replace(
-            constvars=(), invars=jaxpr_body_fn.constvars + jaxpr_body_fn.invars
-        )
-
-        # recursively generate the mlir for the while body
-        out, _ = mlir.jaxpr_subcomp(
-            body_ctx.module_context,
-            new_body_jaxpr,
-            body_ctx.name_stack,
-            mlir.TokenSet(),
-            [],
-            *params,
-            dim_var_values=jax_ctx.dim_var_values,
-            const_lowering=jax_ctx.const_lowering,
-        )
-        YieldOp(out)
-
-    return while_op_scf.results
-
-
 #
 # for loop
 #
@@ -2651,204 +926,17 @@ def _for_loop_abstract_eval(
     )
 
 
-# pylint: disable=too-many-arguments
-@for_p.def_impl
-def _for_loop_def_impl(
-    ctx,
-    lower_bound,
-    upper_bound,
-    step,
-    *iter_args_plus_consts,
-    body_jaxpr,
-    num_implicit_inputs=0,
-    body_nconsts,
-    preserve_dimensions,
-):  # pragma: no cover
-    raise NotImplementedError()
-
-
-# pylint: disable=too-many-arguments
-def _for_loop_lowering(
-    jax_ctx: mlir.LoweringRuleContext,
-    *iter_args_plus_consts: tuple,
-    body_jaxpr: core.ClosedJaxpr,
-    body_nconsts: int,
-    apply_reverse_transform: bool,
-    num_implicit_inputs: int,
-    preserve_dimensions,
-):
-    body_consts = iter_args_plus_consts[:body_nconsts]
-    body_implicits = iter_args_plus_consts[body_nconsts : body_nconsts + num_implicit_inputs]
-    lower_bound = iter_args_plus_consts[body_nconsts + num_implicit_inputs + 0]
-    upper_bound = iter_args_plus_consts[body_nconsts + num_implicit_inputs + 1]
-    step = iter_args_plus_consts[body_nconsts + num_implicit_inputs + 2]
-    loop_index = iter_args_plus_consts[body_nconsts + num_implicit_inputs + 3]
-    loop_args = [*body_implicits, *iter_args_plus_consts[body_nconsts + num_implicit_inputs + 4 :]]
-
-    loop_index_type = ir.RankedTensorType(loop_index.type).element_type
-
-    all_param_types_plus_consts = [mlir.aval_to_ir_types(a)[0] for a in jax_ctx.avals_in]
-    assert [lower_bound.type, upper_bound.type, step.type] == all_param_types_plus_consts[
-        body_nconsts + num_implicit_inputs : body_nconsts + num_implicit_inputs + 3
-    ]
-    assert [val.type for val in body_consts] == all_param_types_plus_consts[:body_nconsts]
-
-    result_types = [v.type for v in loop_args]
-    assert result_types == [
-        mlir.aval_to_ir_types(a)[0] for a in jax_ctx.avals_out
-    ], f"\n{result_types=} doesn't match \n{jax_ctx.avals_out=}"
-
-    lower_bound, upper_bound, step = map(_cast_to_index, (lower_bound, upper_bound, step))
-
-    if apply_reverse_transform:
-        zero_np = np.array(0)
-        one_np = np.array(1)
-        zero_attr = ir.DenseIntElementsAttr.get(zero_np)
-        one_attr = ir.DenseIntElementsAttr.get(one_np)
-        zero_tensor = StableHLOConstantOp(zero_attr)
-        one_tensor = StableHLOConstantOp(one_attr)
-        ctx = jax_ctx.module_context.context
-        i64_type = ir.IntegerType.get_signless(64, ctx)
-        zero_i64 = TensorExtractOp(i64_type, zero_tensor, []).result
-        one_i64 = TensorExtractOp(i64_type, one_tensor, []).result
-        zero = IndexCastOp(ir.IndexType.get(), zero_i64).result
-        one = IndexCastOp(ir.IndexType.get(), one_i64).result
-
-        start_val, stop_val, step_val = lower_bound, upper_bound, step
-
-        # Iterate from 0 to the number of iterations (ceil((stop - start) / step))
-        distance = SubIOp(stop_val, start_val)
-        num_iterations = CeilDivSIOp(distance.result, step_val)
-        lower_bound, upper_bound, step = zero, num_iterations, one
-
-    for_op_scf = ForOp(lower_bound, upper_bound, step, iter_args=loop_args)
-
-    name_stack = jax_ctx.name_stack.extend("for")
-    body_block = for_op_scf.body
-    body_ctx = jax_ctx.replace(name_stack=name_stack.extend("body"))
-
-    with ir.InsertionPoint(body_block):
-        body_args = list(body_block.arguments)
-
-        # Convert the index type iteration variable expected by MLIR to tensor<i64> expected by JAX.
-        if apply_reverse_transform:
-            # iv = start + normalized_iv * step
-            body_args[0] = AddIOp(start_val, MulIOp(body_args[0], step_val))
-
-        body_args[0] = IndexCastOp(loop_index_type, body_args[0]).result
-        result_from_elements_op = ir.RankedTensorType.get((), loop_index_type)
-        from_elements_op = FromElementsOp(result_from_elements_op, body_args[0])
-        body_args[0] = from_elements_op.result
-
-        # Re-order arguments in accordance with jax dynamic API convensions
-        consts = body_consts
-        loop_iter = body_args[0]
-        implicit_args = body_args[1 : num_implicit_inputs + 1]
-        explicit_args = body_args[num_implicit_inputs + 1 :]
-        loop_params = (*consts, *implicit_args, loop_iter, *explicit_args)
-
-        # Recursively generate the mlir for the loop body
-        out, _ = mlir.jaxpr_subcomp(
-            body_ctx.module_context,
-            body_jaxpr.jaxpr,
-            body_ctx.name_stack,
-            mlir.TokenSet(),
-            [mlir.ir_constants(c) for c in body_jaxpr.consts],
-            *loop_params,
-            dim_var_values=jax_ctx.dim_var_values,
-            const_lowering=jax_ctx.const_lowering,
-        )
-        YieldOp(out)
-
-    return for_op_scf.results
-
-
-# pylint: disable=too-many-arguments
-def _pl_for_loop_lowering(
-    jax_ctx: mlir.LoweringRuleContext,
-    start,
-    stop,
-    step,
-    *plxpr_invals,
-    jaxpr_body_fn,
-    consts_slice,
-    args_slice,
-    abstract_shapes_slice,
-):
-    body_consts = plxpr_invals[slice(*consts_slice)]
-    abstract_shapes = plxpr_invals[slice(*abstract_shapes_slice)]
-    args = plxpr_invals[slice(*args_slice)]
-
-    # need later to cast index back to original type
-    start_type = ir.RankedTensorType(start.type).element_type
-
-    start, stop, step = map(_cast_to_index, (start, stop, step))
-    # slicing out index, as passed to block independently
-    loop_args = abstract_shapes + args
-    for_op_scf = ForOp(start, stop, step, iter_args=loop_args)
-
-    name_stack = jax_ctx.name_stack.extend("for")
-    body_block = for_op_scf.body
-    body_ctx = jax_ctx.replace(name_stack=name_stack.extend("body"))
-
-    with ir.InsertionPoint(body_block):
-        # index -> i32 -> tensor<i32>
-        index = body_block.arguments[0]
-        scalar_index = IndexCastOp(start_type, index).result
-        new_dtype = ir.RankedTensorType.get((), start_type)
-        tensor_index = FromElementsOp(new_dtype, scalar_index).result
-
-        inner_shapes = body_block.arguments[1 : len(abstract_shapes) + 1]
-        inner_args = body_block.arguments[len(abstract_shapes) + 1 :]
-        loop_params = (*body_consts, *inner_shapes, tensor_index, *inner_args)
-        new_jaxpr = jaxpr_body_fn.replace(
-            constvars=(), invars=jaxpr_body_fn.constvars + jaxpr_body_fn.invars
-        )
-
-        # Recursively generate the mlir for the loop body
-        out, _ = mlir.jaxpr_subcomp(
-            body_ctx.module_context,
-            new_jaxpr,
-            body_ctx.name_stack,
-            mlir.TokenSet(),
-            [],
-            *loop_params,
-            dim_var_values=jax_ctx.dim_var_values,
-            const_lowering=jax_ctx.const_lowering,
-        )
-        YieldOp(out)
-
-    return for_op_scf.results
-
-
 #
 # assert
 #
-@assert_p.def_impl
-def _assert_def_impl(ctx, assertion, error):  # pragma: no cover
-    raise NotImplementedError()
-
-
 @assert_p.def_abstract_eval
 def _assert_abstract(assertion, error):
-    return ()
-
-
-def _assert_lowering(jax_ctx: mlir.LoweringRuleContext, assertion, error):
-    assertion_mlir = TensorExtractOp(ir.IntegerType.get_signless(1), assertion, []).result
-    AssertionOp(assertion=assertion_mlir, error=error)
     return ()
 
 
 #
 # state_prep
 #
-@set_state_p.def_impl
-def set_state_impl(ctx, *qubits_or_params):  # pragma: no cover
-    """Concrete evaluation"""
-    raise NotImplementedError()
-
-
 @set_state_p.def_abstract_eval
 def set_state_abstract(*qubits_or_params):
     """Abstract evaluation"""
@@ -2857,24 +945,9 @@ def set_state_abstract(*qubits_or_params):
     return (AbstractQbit(),) * qubits_length
 
 
-def _set_state_lowering(jax_ctx: mlir.LoweringRuleContext, *qubits_or_params):
-    """Lowering of set state"""
-    qubits_or_params = list(qubits_or_params)
-    param = qubits_or_params.pop()
-    qubits = qubits_or_params
-    out_qubits = [qubit.type for qubit in qubits]
-    return SetStateOp(out_qubits, param, qubits).results
-
-
 #
 # set_basis_state
 #
-@set_basis_state_p.def_impl
-def set_basis_state_impl(ctx, *qubits_or_params):  # pragma: no cover
-    """Concrete evaluation"""
-    raise NotImplementedError()
-
-
 @set_basis_state_p.def_abstract_eval
 def set_basis_state_abstract(*qubits_or_params):
     """Abstract evaluation"""
@@ -2883,233 +956,12 @@ def set_basis_state_abstract(*qubits_or_params):
     return (AbstractQbit(),) * qubits_length
 
 
-def _set_basis_state_lowering(jax_ctx: mlir.LoweringRuleContext, *qubits_or_params):
-    """Lowering of set basis state"""
-    qubits_or_params = list(qubits_or_params)
-    param = qubits_or_params.pop()
-    qubits = qubits_or_params
-    out_qubits = [qubit.type for qubit in qubits]
-    return SetBasisStateOp(out_qubits, param, qubits).results
-
-
 #
 # adjoint
 #
-@adjoint_p.def_impl
-def _adjoint_def_impl(ctx, *args, args_tree, jaxpr):  # pragma: no cover
-    raise NotImplementedError()
-
-
 @adjoint_p.def_abstract_eval
 def _adjoint_abstract(*args, args_tree, jaxpr):
     return jaxpr.out_avals[-1:]
-
-
-def _adjoint_lowering(
-    jax_ctx: mlir.LoweringRuleContext,
-    *args: Iterable[ir.Value],
-    args_tree: PyTreeDef,
-    jaxpr: core.ClosedJaxpr,
-) -> ir.Value:
-    """The JAX bind handler performing the Jaxpr -> MLIR adjoint lowering by taking the `jaxpr`
-    expression to be lowered and all its already lowered arguments as MLIR value references. The Jax
-    requires all the arguments to be passed as a single list of positionals, thus we pass indices of
-    the argument groups. The handler returns the resulting MLIR Value."""
-
-    # [1] - MLIR Value of constans, classical and quantum arguments [2] - JAXPR types of constans,
-    # classical and quantum arguments [3] - Build a body of the adjoint operator. We pass constants
-    # and classical arguments as-is, but substitute the quantum arguments with the arguments of the
-    # block.
-
-    ctx = jax_ctx.module_context.context
-    consts, cargs, qargs = tree_unflatten(args_tree, args)  # [1]
-    _, _, aqargs = tree_unflatten(args_tree, jax_ctx.avals_in)  # [2]
-
-    assert len(qargs) == 1, "We currently expect exactly one quantum register argument"
-    output_types = util.flatten(map(mlir.aval_to_ir_types, jax_ctx.avals_out))
-    assert len(output_types) == 1 and output_types[0] == ir.OpaqueType.get(
-        "quantum", "reg", ctx
-    ), f"Expected a single result of quantum.register type, got: {output_types}"
-
-    # Build an adjoint operation with a single-block region.
-    op = AdjointOp(output_types, qargs)
-    adjoint_block = op.regions[0].blocks.append(*[mlir.aval_to_ir_types(a)[0] for a in aqargs])
-    with ir.InsertionPoint(adjoint_block):
-        source_info_util.extend_name_stack("adjoint")
-        out, _ = mlir.jaxpr_subcomp(
-            jax_ctx.module_context,
-            jaxpr.jaxpr,
-            jax_ctx.name_stack.extend("adjoint"),
-            mlir.TokenSet(),
-            [mlir.ir_constants(c) for c in jaxpr.consts],
-            *list(chain(consts, cargs, adjoint_block.arguments)),
-            dim_var_values=jax_ctx.dim_var_values,
-            const_lowering=jax_ctx.const_lowering,
-        )
-
-        QYieldOp([out[-1]])
-
-    # Need to manually add adjoint lowering pass for PPR, since that pipeline is not
-    # end-to-end yet.
-    # TODO: remove this manual addition when PPR is end-to-end, or when PPR has its own
-    # pipeline registered.
-
-    if any(_op.name == "pbc.ppr" for _op in adjoint_block.operations):
-
-        def adjoint_pass_injector(_op: ir.Operation) -> ir.WalkResult:
-            if _op.name == "transform.named_sequence":
-                with ir.InsertionPoint.at_block_begin(_op.regions[0].blocks[0]):
-                    ApplyRegisteredPassOp(
-                        result=ir.OpaqueType.get("transform", 'op<"builtin.module">'),
-                        target=_op.regions[0].blocks[0].arguments[0],  # just insert at beginning
-                        pass_name="adjoint-lowering",
-                        options={},
-                        dynamic_options={},
-                    )
-                return ir.WalkResult.INTERRUPT
-            return ir.WalkResult.ADVANCE
-
-        op.parent.parent.walk(adjoint_pass_injector, walk_order=ir.WalkOrder.PRE_ORDER)
-
-    return op.results
-
-
-def safe_cast_to_f64(value, op, kind="parameter"):
-    """Utility function to allow upcasting from integers and floats, while preventing downcasting
-    from larger bitwidths or complex numbers."""
-    assert ir.RankedTensorType.isinstance(value.type)
-
-    baseType = ir.RankedTensorType(value.type).element_type
-    if ir.ComplexType.isinstance(baseType) or (
-        ir.FloatType.isinstance(baseType) and ir.FloatType(baseType).width > 64
-    ):
-        raise TypeError(
-            f"Operator {op} expected a float64 {kind}, got {baseType}.\n"
-            "If you didn't specify this operator directly, it may have come from the decomposition "
-            "of a non-Unitary operator, such as an exponential with real exponent."
-        )
-
-    shape = ir.RankedTensorType(value.type).shape
-    if not ir.F64Type.isinstance(baseType):
-        targetBaseType = ir.F64Type.get()
-        targetTensorType = ir.RankedTensorType.get(shape, targetBaseType)
-        value = StableHLOConvertOp(targetTensorType, value).result
-
-    return value
-
-
-def _cast_to_index(p):
-    p = TensorExtractOp(
-        ir.RankedTensorType(p.type).element_type, p, []
-    ).result  # tensor<i64> -> i64
-    p = IndexCastOp(ir.IndexType.get(), p).result  # i64 -> index
-    return p
-
-
-def extract_scalar(value, op, kind="parameter"):
-    """Utility function to extract real scalars from scalar tensors or one-element 1-D tensors."""
-    assert ir.RankedTensorType.isinstance(value.type)
-
-    baseType = ir.RankedTensorType(value.type).element_type
-    shape = ir.RankedTensorType(value.type).shape
-    if shape == []:
-        value = TensorExtractOp(baseType, value, []).result
-    elif shape == [1]:
-        c0 = ConstantOp(ir.IndexType.get(), 0)
-        value = TensorExtractOp(baseType, value, [c0]).result
-    else:
-        raise TypeError(f"Operator {op} expected a scalar {kind}, got tensor of shape {shape}")
-
-    return value
-
-
-# TODO: remove these patches after https://github.com/jax-ml/jax/pull/23886
-def _sin_lowering2(ctx, x, accuracy):
-    """Use hlo.sine lowering instead of the new sin lowering from jax 0.4.28"""
-    return _nary_lower_hlo(hlo.sine, ctx, x, accuracy=accuracy)
-
-
-def _cos_lowering2(ctx, x, accuracy):
-    """Use hlo.cosine lowering instead of the new cosine lowering from jax 0.4.28"""
-    return _nary_lower_hlo(hlo.cosine, ctx, x, accuracy=accuracy)
-
-
-def subroutine_lowering(*args, **kwargs):
-    """This is just a method that forwards arguments to _pjit_lowering
-
-    Even though we could register the `pjit_p` lowering directly, this makes the code origin
-    apparent in stack traces and similar use cases.
-    """
-    try:
-        retval = _pjit_lowering(*args, **kwargs)
-    except NotImplementedError as e:
-        if "MLIR translation rule for primitive" in str(e):
-            msg = str(e) + """
-                This error sometimes occurs when using quantum operations
-                inside subroutines but calling them outside a qnode
-            """
-            raise NotImplementedError(msg) from e
-        raise e
-
-    return retval
-
-
-CUSTOM_LOWERING_RULES = (
-    (zne_p, _zne_lowering),
-    (device_init_p, _device_init_lowering),
-    (device_release_p, _device_release_lowering),
-    (qalloc_p, _qalloc_lowering),
-    (qdealloc_p, _qdealloc_lowering),
-    (qdealloc_qb_p, _qdealloc_qb_lowering),
-    (qextract_p, _qextract_lowering),
-    (qinsert_p, _qinsert_lowering),
-    (qinst_p, _qinst_lowering),
-    (num_qubits_p, _num_qubits_lowering),
-    (gphase_p, _gphase_lowering),
-    (unitary_p, _unitary_lowering),
-    (pauli_rot_p, _pauli_rot_lowering),
-    (pauli_measure_p, _pauli_measure_lowering),
-    (measure_p, _measure_lowering),
-    (compbasis_p, _compbasis_lowering),
-    (namedobs_p, _named_obs_lowering),
-    (mcmobs_p, _mcm_obs_lowering),
-    (hermitian_p, _hermitian_lowering),
-    (tensorobs_p, _tensor__obs_lowering),
-    (hamiltonian_p, _hamiltonian_lowering),
-    (sample_p, _sample_lowering),
-    (counts_p, _counts_lowering),
-    (expval_p, _expval_lowering),
-    (var_p, _var_lowering),
-    (probs_p, _probs_lowering),
-    (state_p, _state_lowering),
-    (cond_p, _cond_lowering),
-    (switch_p, _switch_lowering),
-    (while_p, _while_loop_lowering),
-    (for_p, _for_loop_lowering),
-    (pl_for_loop_prim, _pl_for_loop_lowering),
-    (grad_p, _grad_lowering),
-    (pl_jac_prim, _capture_grad_lowering),
-    (pl_vjp_prim, _capture_vjp_lowering),
-    (pl_jvp_prim, _capture_jvp_lowering),
-    (pl_value_and_grad_prim, _capture_value_and_grad_lowering),
-    (pl_while_loop_prim, _pl_while_loop_lowering),
-    (func_p, _func_lowering),
-    (jvp_p, _jvp_lowering),
-    (vjp_p, _vjp_lowering),
-    (adjoint_p, _adjoint_lowering),
-    (print_p, _print_lowering),
-    (assert_p, _assert_lowering),
-    (python_callback_p, _python_callback_lowering),
-    (value_and_grad_p, _value_and_grad_lowering),
-    (set_state_p, _set_state_lowering),
-    (set_basis_state_p, _set_basis_state_lowering),
-    (sin_p, _sin_lowering2),
-    (cos_p, _cos_lowering2),
-    (quantum_kernel_p, _quantum_kernel_lowering),
-    (quantum_subroutine_prim, subroutine_lowering),
-    (measure_in_basis_p, _measure_in_basis_lowering),
-    (decomprule_p, _decomposition_rule_lowering),
-)
 
 
 def _scalar_abstractify(t):

--- a/frontend/catalyst/jax_primitives_utils.py
+++ b/frontend/catalyst/jax_primitives_utils.py
@@ -14,7 +14,9 @@
 """This module contains some helper functions for translating JAX primitives to MLIR."""
 
 import copy
+import dataclasses
 import functools
+import textwrap
 
 import pennylane as qml
 from jax._src import core, util
@@ -26,8 +28,61 @@ from mlir_quantum.dialects._transform_ops_gen import ApplyRegisteredPassOp, Name
 from mlir_quantum.dialects.catalyst import LaunchKernelOp
 from pennylane.transforms.core import BoundTransform
 
-from catalyst.jax_extras.lowering import get_mlir_attribute_from_pyval
 from catalyst.passes import PassPlugin
+from catalyst.utils.exceptions import CompileError
+
+
+def get_mlir_attribute_from_pyval(value):
+    """
+    Given a value of any type, construct an mlir attribute of corresponding type.
+
+    We set up the context and location outside because recursive calls to this function
+    will segfault if multiple `Context()`s are instantiated.
+    """
+
+    attr = None
+    match value:
+        case bool():
+            attr = ir.BoolAttr.get(value)
+
+        case int():
+            if -9223372036854775808 <= value < 0:  # 2**63
+                attr = ir.IntegerAttr.get(ir.IntegerType.get_signed(64), value)
+            elif 0 <= value < 18446744073709551616:  # = 2**64
+                attr = ir.IntegerAttr.get(ir.IntegerType.get_signless(64), value)
+            else:
+                raise CompileError(textwrap.dedent("""
+                    Large integer attributes currently not supported in MLIR,
+                    see https://github.com/llvm/llvm-project/issues/128072
+                    """))
+
+        case float():
+            attr = ir.FloatAttr.get(ir.F64Type.get(), value)
+
+        case str():
+            attr = ir.StringAttr.get(value)
+
+        case list() | tuple():
+            element_attrs = [get_mlir_attribute_from_pyval(elem) for elem in value]
+            attr = ir.ArrayAttr.get(element_attrs)
+
+        case dict():
+            named_attrs = {}
+            for k, v in value.items():
+                if not isinstance(k, str):
+                    raise CompileError(
+                        f"Dictionary keys for MLIR DictionaryAttr must be strings, got: {type(k)}"
+                    )
+                named_attrs[k] = get_mlir_attribute_from_pyval(v)
+            attr = ir.DictAttr.get(named_attrs)
+
+        case _ if dataclasses.is_dataclass(value):
+            attr = get_mlir_attribute_from_pyval(dataclasses.asdict(value))
+
+        case _:
+            raise CompileError(f"Cannot convert Python type {type(value)} to an MLIR attribute.")
+
+    return attr
 
 
 def _all_expval(call_jaxpr: core.ClosedJaxpr) -> bool:

--- a/frontend/catalyst/passes/pass_api.py
+++ b/frontend/catalyst/passes/pass_api.py
@@ -19,7 +19,7 @@ from typing import TypeAlias
 
 from pennylane.transforms.core import BoundTransform, CompilePipeline, transform
 
-from catalyst.jax_extras.lowering import get_mlir_attribute_from_pyval
+# from catalyst.jax_primitives_utils import get_mlir_attribute_from_pyval
 from catalyst.tracing.contexts import EvaluationContext
 
 PipelineDict: TypeAlias = dict[str, dict[str, str]]
@@ -230,24 +230,6 @@ class Pass:
             EvaluationContext.add_plugin(path)
 
         self.name = name
-
-    def get_options(self):
-        """
-        Build a dictionary mapping option names to MLIR attributes.
-        ApplyRegisteredPassOp expects options to be a dictionary from strings to attributes.
-        See https://github.com/llvm/llvm-project/pull/143159
-        """
-        options_dict = {}
-        for option in self.options:
-            options_dict[str(option)] = get_mlir_attribute_from_pyval(True)
-
-        for option, value in self.valued_options.items():
-            # MLIR options are either CamelCase
-            # or spinal-case (kebab-case) which is not allowed in python
-            mlir_option = str(option).replace("_", "-")
-            options_dict[mlir_option] = get_mlir_attribute_from_pyval(value)
-
-        return options_dict
 
     def __repr__(self):
         return (

--- a/frontend/catalyst/passes/pass_api.py
+++ b/frontend/catalyst/passes/pass_api.py
@@ -19,7 +19,6 @@ from typing import TypeAlias
 
 from pennylane.transforms.core import BoundTransform, CompilePipeline, transform
 
-# from catalyst.jax_primitives_utils import get_mlir_attribute_from_pyval
 from catalyst.tracing.contexts import EvaluationContext
 
 PipelineDict: TypeAlias = dict[str, dict[str, str]]

--- a/frontend/catalyst/primitive_lowering_rules.py
+++ b/frontend/catalyst/primitive_lowering_rules.py
@@ -213,7 +213,7 @@ def register_lowering(primitive: Primitive):
     """
 
     def decorator(f: Callable) -> Callable:
-        global CUSTOM_LOWERING_RULES
+        global CUSTOM_LOWERING_RULES  # pylint: disable=global-statement
         CUSTOM_LOWERING_RULES += ((primitive, f),)
         return f
 

--- a/frontend/catalyst/primitive_lowering_rules.py
+++ b/frontend/catalyst/primitive_lowering_rules.py
@@ -197,7 +197,7 @@ from catalyst.utils.types import convert_shaped_arrays_to_tensors
 # pylint: disable=unused-argument,too-many-lines,too-many-statements,protected-access
 
 
-CUSTOM_LOWERING_RULES = ()
+CUSTOM_LOWERING_RULES = {}
 
 
 def get_custom_lowering_rules():
@@ -213,8 +213,7 @@ def register_lowering(primitive: Primitive):
     """
 
     def decorator(f: Callable) -> Callable:
-        global CUSTOM_LOWERING_RULES  # pylint: disable=global-statement
-        CUSTOM_LOWERING_RULES += ((primitive, f),)
+        CUSTOM_LOWERING_RULES[primitive] = f
         return f
 
     return decorator

--- a/frontend/catalyst/primitive_lowering_rules.py
+++ b/frontend/catalyst/primitive_lowering_rules.py
@@ -1,0 +1,2010 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module contains the lowering rules for all JAX primitives used by Catalyst."""
+
+import sys
+from itertools import chain
+from typing import Callable, Iterable, List
+
+import jax
+import numpy as np
+import pennylane as qp
+from jax._src import core, source_info_util, util
+from jax._src.lax.lax import _nary_lower_hlo, cos_p, sin_p
+from jax._src.lib.mlir import ir
+from jax._src.lib.mlir.dialects import hlo
+from jax._src.pjit import _pjit_lowering
+from jax.extend.core import Primitive
+from jax.interpreters import mlir
+from jax.tree_util import PyTreeDef, tree_unflatten
+from jaxlib.mlir._mlir_libs import _mlir as _ods_cext
+from jaxlib.mlir.dialects.arith import (
+    AddIOp,
+    CeilDivSIOp,
+    ConstantOp,
+    ExtUIOp,
+    IndexCastOp,
+    MulIOp,
+    SubIOp,
+)
+from jaxlib.mlir.dialects.func import FunctionType
+from jaxlib.mlir.dialects.scf import ConditionOp, ForOp, IfOp, IndexSwitchOp, WhileOp, YieldOp
+from jaxlib.mlir.dialects.stablehlo import ConstantOp as StableHLOConstantOp
+from jaxlib.mlir.dialects.stablehlo import ConvertOp as StableHLOConvertOp
+from pennylane.capture.primitives import for_loop_prim as pl_for_loop_prim
+from pennylane.capture.primitives import jacobian_prim as pl_jac_prim
+from pennylane.capture.primitives import jvp_prim as pl_jvp_prim
+from pennylane.capture.primitives import quantum_subroutine_prim
+from pennylane.capture.primitives import value_and_grad_prim as pl_value_and_grad_prim
+from pennylane.capture.primitives import vjp_prim as pl_vjp_prim
+from pennylane.capture.primitives import while_loop_prim as pl_while_loop_prim
+
+# TODO: remove after jax v0.7.2 upgrade
+# Mock _ods_cext.globals.register_traceback_file_exclusion due to API conflicts between
+# Catalyst's MLIR version and the MLIR version used by JAX. The current JAX version has not
+# yet updated to the latest MLIR, causing compatibility issues. This workaround will be removed
+# once JAX updates to a compatible MLIR version
+# pylint: disable=ungrouped-imports
+from catalyst.jax_extras.patches import mock_attributes
+from catalyst.jax_primitives import (
+    Folding,
+    MeasurementPlane,
+    adjoint_p,
+    assert_p,
+    compbasis_p,
+    cond_p,
+    counts_p,
+    decomprule_p,
+    device_init_p,
+    device_release_p,
+    expval_p,
+    for_p,
+    func_p,
+    gphase_p,
+    grad_p,
+    hamiltonian_p,
+    hermitian_p,
+    jvp_p,
+    mcmobs_p,
+    measure_in_basis_p,
+    measure_p,
+    namedobs_p,
+    num_qubits_p,
+    pauli_measure_p,
+    pauli_rot_p,
+    print_p,
+    probs_p,
+    python_callback_p,
+    qalloc_p,
+    qdealloc_p,
+    qdealloc_qb_p,
+    qextract_p,
+    qinsert_p,
+    qinst_p,
+    quantum_kernel_p,
+    sample_p,
+    set_basis_state_p,
+    set_state_p,
+    state_p,
+    switch_p,
+    tensorobs_p,
+    unitary_p,
+    value_and_grad_p,
+    var_p,
+    vjp_p,
+    while_p,
+    zne_p,
+)
+from catalyst.utils.patching import Patcher
+
+with Patcher(
+    (
+        _ods_cext,
+        "globals",
+        mock_attributes(
+            # pylint: disable=c-extension-no-member
+            _ods_cext.globals,
+            {"register_traceback_file_exclusion": lambda x: None},
+        ),
+    ),
+):
+    from mlir_quantum.dialects.catalyst import (
+        AssertionOp,
+        CallbackCallOp,
+        CallbackOp,
+        PrintOp,
+    )
+    from mlir_quantum.dialects.gradient import (
+        CustomGradOp,
+        ForwardOp,
+        GradOp,
+        JVPOp,
+        ReverseOp,
+        ValueAndGradOp,
+        VJPOp,
+    )
+    from mlir_quantum.dialects.mbqc import MeasureInBasisOp
+    from mlir_quantum.dialects.mitigation import ZneOp
+    from mlir_quantum.dialects.pbc import PPMeasurementOp
+    from mlir_quantum.dialects.quantum import (
+        AdjointOp,
+        AllocOp,
+        ComputationalBasisOp,
+        CountsOp,
+        CustomOp,
+        DeallocOp,
+        DeallocQubitOp,
+        DeviceInitOp,
+        DeviceReleaseOp,
+        ExpvalOp,
+        ExtractOp,
+        GlobalPhaseOp,
+        HamiltonianOp,
+        HermitianOp,
+        InsertOp,
+        MCMObsOp,
+        MeasureOp,
+        MultiRZOp,
+        NamedObsOp,
+        NumQubitsOp,
+        PauliRotOp,
+        PCPhaseOp,
+        ProbsOp,
+        QubitUnitaryOp,
+        SampleOp,
+        SetBasisStateOp,
+        SetStateOp,
+        StateOp,
+        TensorOp,
+        VarianceOp,
+    )
+    from mlir_quantum.dialects.quantum import YieldOp as QYieldOp
+
+    from catalyst.jax_primitives_utils import (
+        ApplyRegisteredPassOp,
+        cache,
+        create_call_op,
+        get_cached,
+        get_call_jaxpr,
+        get_symbolref,
+        lower_callable,
+        lower_jaxpr,
+    )
+
+from pennylane.capture.primitives import for_loop_prim as pl_for_loop_prim
+from pennylane.capture.primitives import jacobian_prim as pl_jac_prim
+from pennylane.capture.primitives import jvp_prim as pl_jvp_prim
+from pennylane.capture.primitives import quantum_subroutine_prim
+from pennylane.capture.primitives import value_and_grad_prim as pl_value_and_grad_prim
+from pennylane.capture.primitives import vjp_prim as pl_vjp_prim
+from pennylane.capture.primitives import while_loop_prim as pl_while_loop_prim
+
+from catalyst.compiler import get_lib_path
+from catalyst.utils.extra_bindings import FromElementsOp, TensorExtractOp
+from catalyst.utils.types import convert_shaped_arrays_to_tensors
+
+# pylint: disable=unused-argument,too-many-lines,too-many-statements,protected-access
+
+
+CUSTOM_LOWERING_RULES = ()
+
+
+def get_custom_lowering_rules():
+    return CUSTOM_LOWERING_RULES
+
+
+def register_lowering(primitive: Primitive):
+    """
+    Registers a lowering rule for a custom primitive.
+    """
+
+    def decorator(f: Callable) -> Callable:
+        global CUSTOM_LOWERING_RULES
+        CUSTOM_LOWERING_RULES += ((primitive, f),)
+        return f
+
+    return decorator
+
+
+@register_lowering(python_callback_p)
+def _python_callback_lowering(
+    jax_ctx: mlir.LoweringRuleContext, *args, callback, custom_grad, results_aval
+):
+    """Callback lowering"""
+
+    sys.path.append(get_lib_path("runtime", "RUNTIME_LIB_DIR"))
+    # pylint: disable=import-outside-toplevel
+    import catalyst_callback_registry as registry  # type: ignore[import-not-found]
+
+    callback_id = registry.register(callback)
+
+    params_ty = [arg.type for arg in args]
+    results_ty = list(convert_shaped_arrays_to_tensors(results_aval))
+    fn_ty = FunctionType.get(inputs=params_ty, results=results_ty)
+    fn_ty_attr = ir.TypeAttr.get(fn_ty)
+    cache_key = (callback_id, *params_ty, *results_ty)
+    if callbackOp := get_cached(jax_ctx, cache_key):
+        symbol = callbackOp.sym_name.value
+        symbol_attr = ir.FlatSymbolRefAttr.get(symbol)
+        return CallbackCallOp(results_ty, symbol_attr, args).results
+
+    module = jax_ctx.module_context.module
+    ip = module.body
+    attrs = [fn_ty_attr, callback_id, len(args), len(results_ty)]
+    with ir.InsertionPoint(ip):
+        # TODO: Name mangling for callbacks
+        name = callback.__name__
+        callbackOp = CallbackOp(f"callback_{name}_{callback_id}", *attrs)
+
+    cache(jax_ctx, cache_key, callbackOp)
+    symbol = callbackOp.sym_name.value
+    symbol_attr = ir.FlatSymbolRefAttr.get(symbol)
+    retval = CallbackCallOp(results_ty, symbol_attr, args).results
+
+    if not custom_grad:
+        return retval
+
+    assert custom_grad._fwd and custom_grad._bwd
+    fwd = custom_grad._fwd
+    rev = custom_grad._bwd
+    fwd_jaxpr = custom_grad._fwd_jaxpr
+    rev_jaxpr = custom_grad._bwd_jaxpr
+    mlir_fwd = lower_callable(jax_ctx, fwd, fwd_jaxpr)
+    mlir_rev = lower_callable(jax_ctx, rev, rev_jaxpr)
+    sym_fwd = mlir_fwd.sym_name.value + ".fwd"
+
+    argc = len(args)
+    resc = len(results_ty)
+    len_tape = len(mlir_fwd.type.results) - resc
+
+    # args_ty = inputs and cotangents since they are shadows
+    args_ty = [arg.type for arg in args]
+    # results_ty = output and cotangent
+    output_ty = results_ty
+    # the tape is found in the mlir_fwd.type
+    tape_ty = mlir_fwd.type.results[-len_tape:] if len_tape > 0 else []
+
+    fn_fwd_ty = FunctionType.get(inputs=args_ty, results=output_ty + tape_ty)
+    fn_rev_ty = FunctionType.get(inputs=output_ty + tape_ty, results=args_ty)
+
+    fwd_fn_ty_attr = ir.TypeAttr.get(fn_fwd_ty)
+    fwd_callee_attr = ir.FlatSymbolRefAttr.get(mlir_fwd.sym_name.value)
+    sym_rev = mlir_rev.sym_name.value + ".rev"
+    rev_fn_ty_attr = ir.TypeAttr.get(fn_rev_ty)
+    rev_callee_attr = ir.FlatSymbolRefAttr.get(mlir_rev.sym_name.value)
+
+    with ir.InsertionPoint(ip):
+        forward = ForwardOp(sym_fwd, fwd_fn_ty_attr, fwd_callee_attr, argc, resc, len_tape)
+        reverse = ReverseOp(sym_rev, rev_fn_ty_attr, rev_callee_attr, argc, resc, len_tape)
+        fwd_sym_attr = ir.FlatSymbolRefAttr.get(forward.sym_name.value)
+        rev_sym_attr = ir.FlatSymbolRefAttr.get(reverse.sym_name.value)
+        CustomGradOp(symbol_attr, fwd_sym_attr, rev_sym_attr)
+
+    return retval
+
+
+@register_lowering(print_p)
+def _print_lowering(jax_ctx: mlir.LoweringRuleContext, *args, string=None, memref=False):
+    val = args[0] if args else None
+    return PrintOp(val=val, const_val=None, print_descriptor=memref).results
+
+
+@register_lowering(quantum_kernel_p)
+def _quantum_kernel_lowering(ctx, *args, call_jaxpr, qnode, pipelines=None):
+    """Lower's qnodes to moduleOp
+
+    Args:
+      ctx: LoweringRuleContext
+      *args: List[mlir.Value] corresponding to argument values
+      qnode: qml.Qnode
+      call_jaxpr: jaxpr representing fn
+    Returns:
+      List[mlir.Value] corresponding
+    """
+    assert isinstance(qnode, qp.QNode), "This function expects qnodes"
+    pipelines = pipelines or ()
+
+    func_op = lower_callable(ctx, qnode, call_jaxpr, pipelines)
+    call_op = create_call_op(ctx, func_op, *args)
+    return call_op.results
+
+
+@register_lowering(func_p)
+def _func_lowering(ctx, *args, call_jaxpr, fn):
+    """Lower a quantum function into MLIR in a two step process.
+    The first step is the compilation of the definition of the function fn.
+    The second step is compiling a call to function fn.
+
+    Args:
+      ctx: the MLIR context
+      args: list of arguments or abstract arguments to the function
+      name: name of the function
+      call_jaxpr: the jaxpr representation of the fn
+      fn: the function being compiled
+    """
+    func_op = lower_callable(ctx, fn, call_jaxpr)
+    call_op = create_call_op(ctx, func_op, *args)
+    return call_op.results
+
+
+@register_lowering(decomprule_p)
+def _decomposition_rule_lowering(ctx, *, pyfun, func_jaxpr, **params):
+    """Lower a quantum decomposition rule into MLIR in a single step process.
+    The step is the compilation of the definition of the function fn.
+    """
+
+    lower_callable(ctx, pyfun, func_jaxpr, **params)
+    return ()
+
+
+@register_lowering(grad_p)
+def _grad_lowering(ctx, *args, jaxpr, fn, grad_params):
+    """Lowering function to gradient.
+    Args:
+        ctx: the MLIR context
+        args: the points in the function in which we are to calculate the derivative
+        jaxpr: the jaxpr representation of the grad op
+        fn (GradCallable): the function to be differentiated
+        method: the method used for differentiation
+        h: the difference for finite difference. May be None when fn is not finite difference.
+        argnums: argument indices which define over which arguments to
+            differentiate.
+    """
+    consts = []
+    offset = len(args) - len(jaxpr.consts)
+    for i, jax_array_or_tracer in enumerate(jaxpr.consts):
+        if isinstance(jax_array_or_tracer, jax._src.interpreters.partial_eval.DynamicJaxprTracer):
+            # There are some cases where this value cannot be converted into
+            # a jax.numpy.array.
+            # in that case we get it from the arguments.
+            consts.append(args[offset + i])
+        else:
+            # ``ir.DenseElementsAttr.get()`` constructs a dense elements attribute from an array of
+            # element values. This doesn't support ``jaxlib.xla_extension.Array``, so we have to
+            # cast such constants to numpy array types.
+            const = jax_array_or_tracer
+            const_type = ir.RankedTensorType.get(const.shape, mlir.dtype_to_ir_type(const.dtype))
+            nparray = np.asarray(const)
+            attr = ir.DenseElementsAttr.get(nparray, type=const_type)
+            constval = StableHLOConstantOp(attr).results
+            consts.append(constval)
+
+    method, h, argnums = grad_params.method, grad_params.h, grad_params.expanded_argnums
+    mlir_ctx = ctx.module_context.context
+    finiteDiffParam = None
+    if h:
+        f64 = ir.F64Type.get(mlir_ctx)
+        finiteDiffParam = ir.FloatAttr.get(f64, h)
+    offset = len(jaxpr.consts)
+    new_argnums = [num + offset for num in argnums]
+    argnum_numpy = np.array(new_argnums)
+    diffArgIndices = ir.DenseIntElementsAttr.get(argnum_numpy)
+    func_op = lower_jaxpr(ctx, jaxpr, (method, h, *argnums))
+    symbol_ref = get_symbolref(ctx, func_op)
+    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
+    flat_output_types = util.flatten(output_types)
+
+    len_args = len(args)
+    index = len_args - len(consts)
+    args_and_consts = consts + list(args[:index])
+
+    return GradOp(
+        flat_output_types,
+        ir.StringAttr.get(method),
+        symbol_ref,
+        mlir.flatten_ir_values(args_and_consts),
+        diffArgIndices=diffArgIndices,
+        finiteDiffParam=finiteDiffParam,
+    ).results
+
+
+# pylint: disable=too-many-arguments
+@register_lowering(pl_jac_prim)
+def _capture_grad_lowering(ctx, *args, argnums, jaxpr, n_consts, method, h, fn, scalar_out):
+    mlir_ctx = ctx.module_context.context
+    f64 = ir.F64Type.get(mlir_ctx)
+    finiteDiffParam = ir.FloatAttr.get(f64, h)
+
+    new_argnums = [num + n_consts for num in argnums]
+    argnum_numpy = np.array(new_argnums)
+    diffArgIndices = ir.DenseIntElementsAttr.get(argnum_numpy)
+    func_op = lower_jaxpr(ctx, jaxpr, (method, h, *new_argnums), fn=fn)
+    symbol_ref = get_symbolref(ctx, func_op)
+    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
+    flat_output_types = util.flatten(output_types)
+
+    return GradOp(
+        flat_output_types,
+        ir.StringAttr.get(method),
+        symbol_ref,
+        mlir.flatten_ir_values(args),
+        diffArgIndices=diffArgIndices,
+        finiteDiffParam=finiteDiffParam,
+    ).results
+
+
+@register_lowering(value_and_grad_p)
+def _value_and_grad_lowering(ctx, *args, jaxpr, fn, grad_params):
+    """
+    Returns:
+        MLIR results
+    """
+    consts = []
+    offset = len(args) - len(jaxpr.consts)
+    for i, jax_array_or_tracer in enumerate(jaxpr.consts):
+        if not isinstance(
+            jax_array_or_tracer, jax._src.interpreters.partial_eval.DynamicJaxprTracer
+        ):
+            # ``ir.DenseElementsAttr.get()`` constructs a dense elements attribute from an array of
+            # element values. This doesn't support ``jaxlib.xla_extension.Array``, so we have to
+            # cast such constants to numpy array types.
+            const = jax_array_or_tracer
+            const_type = ir.RankedTensorType.get(const.shape, mlir.dtype_to_ir_type(const.dtype))
+            nparray = np.asarray(const)
+            attr = ir.DenseElementsAttr.get(nparray, type=const_type)
+            constval = StableHLOConstantOp(attr).results
+            consts.append(constval)
+        else:
+            # There are some cases where this value cannot be converted into
+            # a jax.numpy.array.
+            # in that case we get it from the arguments.
+            consts.append(args[offset + i])
+
+    len_args = len(args)
+    index = len_args - len(consts)
+    args = list(args[0:index])
+    method, h, argnums = grad_params.method, grad_params.h, grad_params.expanded_argnums
+    mlir_ctx = ctx.module_context.context
+    new_argnums = np.array([len(jaxpr.consts) + num for num in argnums])
+
+    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
+    flat_output_types = util.flatten(output_types)
+
+    constants = consts
+
+    consts_and_args = constants + args
+    func_call_jaxpr = get_call_jaxpr(jaxpr)
+    func_args = consts_and_args[: len(func_call_jaxpr.invars)]
+    val_result_types = flat_output_types[: len(flat_output_types) - len(argnums)]
+    gradient_result_types = flat_output_types[len(flat_output_types) - len(argnums) :]
+
+    func_op = lower_jaxpr(ctx, jaxpr, (method, h, *argnums))
+
+    symbol_ref = get_symbolref(ctx, func_op)
+    return ValueAndGradOp(
+        val_result_types,
+        gradient_result_types,
+        ir.StringAttr.get(method),
+        symbol_ref,
+        mlir.flatten_ir_values(func_args),
+        diffArgIndices=ir.DenseIntElementsAttr.get(new_argnums),
+        finiteDiffParam=ir.FloatAttr.get(ir.F64Type.get(mlir_ctx), h) if h else None,
+    ).results
+
+
+@register_lowering(pl_value_and_grad_prim)
+def _capture_value_and_grad_lowering(ctx, *args, jaxpr, fn, h, method, argnums):
+    """
+    Returns:
+        MLIR results
+    """
+    mlir_ctx = ctx.module_context.context
+    new_argnums = np.array(argnums)
+
+    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
+    flat_output_types = util.flatten(output_types)
+
+    val_result_types = flat_output_types[: len(flat_output_types) - len(argnums)]
+    gradient_result_types = flat_output_types[len(flat_output_types) - len(argnums) :]
+
+    func_op = lower_jaxpr(ctx, jaxpr, (method, h, *argnums), fn=fn)
+
+    symbol_ref = get_symbolref(ctx, func_op)
+    return ValueAndGradOp(
+        val_result_types,
+        gradient_result_types,
+        ir.StringAttr.get(method),
+        symbol_ref,
+        mlir.flatten_ir_values(args),
+        diffArgIndices=ir.DenseIntElementsAttr.get(new_argnums),
+        finiteDiffParam=ir.FloatAttr.get(ir.F64Type.get(mlir_ctx), h) if h else None,
+    ).results
+
+
+@register_lowering(jvp_p)
+def _jvp_lowering(ctx, *args, jaxpr, fn, grad_params):
+    """
+    Returns:
+        MLIR results
+    """
+    args = list(args)
+    method, h, argnums = grad_params.method, grad_params.h, grad_params.expanded_argnums
+    mlir_ctx = ctx.module_context.context
+    new_argnums = np.array([len(jaxpr.consts) + num for num in argnums])
+
+    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
+    flat_output_types = util.flatten(output_types)
+    constants = [
+        StableHLOConstantOp(ir.DenseElementsAttr.get(np.asarray(const))).results
+        for const in jaxpr.consts
+    ]
+    consts_and_args = constants + args
+    func_call_jaxpr = get_call_jaxpr(jaxpr)
+    func_args = consts_and_args[: len(func_call_jaxpr.invars)]
+    tang_args = consts_and_args[len(func_call_jaxpr.invars) :]
+
+    func_op = lower_jaxpr(ctx, jaxpr, (method, h, *argnums))
+
+    assert (
+        len(flat_output_types) % 2 == 0
+    ), f"The total number of result tensors is expected to be even, not {len(flat_output_types)}"
+    symbol_ref = get_symbolref(ctx, func_op)
+    return JVPOp(
+        flat_output_types[: len(flat_output_types) // 2],
+        flat_output_types[len(flat_output_types) // 2 :],
+        ir.StringAttr.get(method),
+        symbol_ref,
+        mlir.flatten_ir_values(func_args),
+        mlir.flatten_ir_values(tang_args),
+        diffArgIndices=ir.DenseIntElementsAttr.get(new_argnums),
+        finiteDiffParam=ir.FloatAttr.get(ir.F64Type.get(mlir_ctx), h) if h else None,
+    ).results
+
+
+@register_lowering(pl_jvp_prim)
+def _capture_jvp_lowering(ctx, *args, jaxpr, fn, method, argnums, h):
+    """
+    Returns:
+        MLIR results
+    """
+    args = list(args)
+    mlir_ctx = ctx.module_context.context
+    n_params = len(jaxpr.invars)
+    array_argnums = np.array(argnums)
+
+    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
+    flat_output_types = util.flatten(output_types)
+
+    func_result_types = flat_output_types[: len(flat_output_types) - len(argnums)]
+    jvp_result_types = flat_output_types[len(flat_output_types) - len(argnums) :]
+
+    func_args = args[:n_params]
+    d_args = args[n_params:]
+
+    func_op = lower_jaxpr(ctx, jaxpr, (method, h, *argnums), fn=fn)
+
+    symbol_ref = get_symbolref(ctx, func_op)
+    return JVPOp(
+        func_result_types,
+        jvp_result_types,
+        ir.StringAttr.get(method),
+        symbol_ref,
+        mlir.flatten_ir_values(func_args),
+        mlir.flatten_ir_values(d_args),
+        diffArgIndices=ir.DenseIntElementsAttr.get(array_argnums),
+        finiteDiffParam=ir.FloatAttr.get(ir.F64Type.get(mlir_ctx), h) if h else None,
+    ).results
+
+
+@register_lowering(vjp_p)
+def _vjp_lowering(ctx, *args, jaxpr, fn, grad_params):
+    """
+    Returns:
+        MLIR results
+    """
+    args = list(args)
+    method, h, argnums = grad_params.method, grad_params.h, grad_params.expanded_argnums
+    mlir_ctx = ctx.module_context.context
+    new_argnums = np.array([len(jaxpr.consts) + num for num in argnums])
+
+    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
+    flat_output_types = util.flatten(output_types)
+    constants = [
+        StableHLOConstantOp(ir.DenseElementsAttr.get(np.asarray(const))).results
+        for const in jaxpr.consts
+    ]
+    consts_and_args = constants + args
+    func_call_jaxpr = get_call_jaxpr(jaxpr)
+    func_args = consts_and_args[: len(func_call_jaxpr.invars)]
+    cotang_args = consts_and_args[len(func_call_jaxpr.invars) :]
+    func_result_types = flat_output_types[: len(flat_output_types) - len(argnums)]
+    vjp_result_types = flat_output_types[len(flat_output_types) - len(argnums) :]
+
+    func_op = lower_jaxpr(ctx, jaxpr, (method, h, *argnums))
+
+    symbol_ref = get_symbolref(ctx, func_op)
+    return VJPOp(
+        func_result_types,
+        vjp_result_types,
+        ir.StringAttr.get(method),
+        symbol_ref,
+        mlir.flatten_ir_values(func_args),
+        mlir.flatten_ir_values(cotang_args),
+        diffArgIndices=ir.DenseIntElementsAttr.get(new_argnums),
+        finiteDiffParam=ir.FloatAttr.get(ir.F64Type.get(mlir_ctx), h) if h else None,
+    ).results
+
+
+@register_lowering(pl_vjp_prim)
+def _capture_vjp_lowering(ctx, *args, jaxpr, fn, method, argnums, h):
+    """
+    Returns:
+        MLIR results
+    """
+    args = list(args)
+    mlir_ctx = ctx.module_context.context
+    n_params = len(jaxpr.invars)
+    new_argnums = np.array(argnums)
+
+    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
+    flat_output_types = util.flatten(output_types)
+    func_args = args[:n_params]
+    cotang_args = args[n_params:]
+    func_result_types = flat_output_types[: len(flat_output_types) - len(argnums)]
+    vjp_result_types = flat_output_types[len(flat_output_types) - len(argnums) :]
+
+    func_op = lower_jaxpr(ctx, jaxpr, (method, h, *argnums), fn=fn)
+
+    symbol_ref = get_symbolref(ctx, func_op)
+    return VJPOp(
+        func_result_types,
+        vjp_result_types,
+        ir.StringAttr.get(method),
+        symbol_ref,
+        mlir.flatten_ir_values(func_args),
+        mlir.flatten_ir_values(cotang_args),
+        diffArgIndices=ir.DenseIntElementsAttr.get(new_argnums),
+        finiteDiffParam=ir.FloatAttr.get(ir.F64Type.get(mlir_ctx), h) if h else None,
+    ).results
+
+
+# pylint: disable=too-many-arguments, too-many-positional-arguments
+@register_lowering(device_init_p)
+def _device_init_lowering(
+    jax_ctx: mlir.LoweringRuleContext,
+    shots: ir.Value,
+    auto_qubit_management,
+    rtd_lib,
+    rtd_name,
+    rtd_kwargs,
+):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    shots_value = TensorExtractOp(ir.IntegerType.get_signless(64, ctx), shots, []).result
+    DeviceInitOp(
+        ir.StringAttr.get(rtd_lib),
+        ir.StringAttr.get(rtd_name),
+        ir.StringAttr.get(rtd_kwargs),
+        shots=shots_value,
+        auto_qubit_management=auto_qubit_management,
+    )
+
+    return ()
+
+
+@register_lowering(device_release_p)
+def _device_release_lowering(jax_ctx: mlir.LoweringRuleContext):
+    DeviceReleaseOp()  # end of qnode
+    return ()
+
+
+@register_lowering(qalloc_p)
+def _qalloc_lowering(jax_ctx: mlir.LoweringRuleContext, size_value: ir.Value):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    qreg_type = ir.OpaqueType.get("quantum", "reg", ctx)
+    if isinstance(size_value.owner, ir.Operation) and size_value.owner.name == "stablehlo.constant":
+        size_value_attr = size_value.owner.attributes["value"]
+        assert ir.DenseIntElementsAttr.isinstance(size_value_attr)
+        size = ir.DenseIntElementsAttr(size_value_attr)[0]
+        assert size >= 0
+
+        size_attr = ir.IntegerAttr.get(ir.IntegerType.get_signless(64, ctx), size)
+        return AllocOp(qreg_type, nqubits_attr=size_attr).results
+    else:
+        size_value = extract_scalar(size_value, "qalloc")
+        return AllocOp(qreg_type, nqubits=size_value).results
+
+
+@register_lowering(qdealloc_p)
+def _qdealloc_lowering(jax_ctx: mlir.LoweringRuleContext, qreg):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+    DeallocOp(qreg)
+    return ()
+
+
+@register_lowering(qdealloc_qb_p)
+def _qdealloc_qb_lowering(jax_ctx: mlir.LoweringRuleContext, qubit):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+    DeallocQubitOp(qubit)
+    return ()
+
+
+@register_lowering(num_qubits_p)
+def _num_qubits_lowering(jax_ctx: mlir.LoweringRuleContext):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    result_type = ir.IntegerType.get_signless(64, ctx)
+    nqubits = NumQubitsOp(result_type).result
+
+    result_from_elements_op = ir.RankedTensorType.get((), result_type)
+    from_elements_op = FromElementsOp(result_from_elements_op, nqubits)
+    return from_elements_op.results
+
+
+@register_lowering(qextract_p)
+def _qextract_lowering(jax_ctx: mlir.LoweringRuleContext, qreg: ir.Value, qubit_idx: ir.Value):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    assert ir.OpaqueType.isinstance(qreg.type), qreg.type
+    assert ir.OpaqueType(qreg.type).dialect_namespace == "quantum"
+    assert ir.OpaqueType(qreg.type).data == "reg"
+
+    qubit_idx = extract_scalar(qubit_idx, "wires", "index")
+    if not ir.IntegerType.isinstance(qubit_idx.type):
+        raise TypeError(f"Operator wires expected to be integers, got {qubit_idx.type}!")
+
+    if ir.IntegerType(qubit_idx.type).width < 64:
+        qubit_idx = ExtUIOp(ir.IntegerType.get_signless(64), qubit_idx).result
+    elif not ir.IntegerType(qubit_idx.type).width == 64:
+        raise TypeError(f"Operator wires expected to be 64-bit integers, got {qubit_idx.type}!")
+
+    qubit_type = ir.OpaqueType.get("quantum", "bit", ctx)
+    return ExtractOp(qubit_type, qreg, idx=qubit_idx).results
+
+
+@register_lowering(qinsert_p)
+def _qinsert_lowering(
+    jax_ctx: mlir.LoweringRuleContext, qreg_old: ir.Value, qubit_idx: ir.Value, qubit: ir.Value
+):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    assert ir.OpaqueType.isinstance(qreg_old.type)
+    assert ir.OpaqueType(qreg_old.type).dialect_namespace == "quantum"
+    assert ir.OpaqueType(qreg_old.type).data == "reg"
+
+    qubit_idx = extract_scalar(qubit_idx, "wires", "index")
+    if not ir.IntegerType.isinstance(qubit_idx.type):
+        raise TypeError(f"Operator wires expected to be integers, got {qubit_idx.type}!")
+
+    if ir.IntegerType(qubit_idx.type).width < 64:
+        qubit_idx = ExtUIOp(ir.IntegerType.get_signless(64), qubit_idx).result
+    elif not ir.IntegerType(qubit_idx.type).width == 64:
+        raise TypeError(f"Operator wires expected to be 64-bit integers, got {qubit_idx.type}!")
+
+    qreg_type = ir.OpaqueType.get("quantum", "reg", ctx)
+    return InsertOp(qreg_type, qreg_old, qubit, idx=qubit_idx).results
+
+
+@register_lowering(gphase_p)
+def _gphase_lowering(
+    jax_ctx: mlir.LoweringRuleContext, *qubits_or_params, ctrl_len=0, adjoint=False
+):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    param = qubits_or_params[0]
+    ctrl_qubits = qubits_or_params[1 : 1 + ctrl_len]
+    ctrl_values = qubits_or_params[1 + ctrl_len :]
+
+    param = safe_cast_to_f64(param, "GlobalPhase")
+    param = extract_scalar(param, "GlobalPhase")
+
+    assert ir.F64Type.isinstance(
+        param.type
+    ), "Only scalar double parameters are allowed for quantum gates!"
+
+    ctrl_values_i1 = []
+    for v in ctrl_values:
+        p = TensorExtractOp(ir.IntegerType.get_signless(1), v, []).result
+        ctrl_values_i1.append(p)
+
+    GlobalPhaseOp(
+        angle=param,
+        out_ctrl_qubits=[qubit.type for qubit in ctrl_qubits],
+        in_ctrl_qubits=ctrl_qubits,
+        in_ctrl_values=ctrl_values_i1,
+        adjoint=adjoint,
+    )
+    return ctrl_qubits
+
+
+# pylint: disable=too-many-arguments
+@register_lowering(qinst_p)
+def _qinst_lowering(
+    jax_ctx: mlir.LoweringRuleContext,
+    *qubits_or_params,
+    op=None,
+    qubits_len=0,
+    params_len=0,
+    ctrl_len=0,
+    adjoint=False,
+):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    qubits = qubits_or_params[:qubits_len]
+    params = qubits_or_params[qubits_len : qubits_len + params_len]
+    ctrl_qubits = qubits_or_params[qubits_len + params_len : qubits_len + params_len + ctrl_len]
+    ctrl_values = qubits_or_params[qubits_len + params_len + ctrl_len :]
+
+    for qubit in qubits:
+        assert ir.OpaqueType.isinstance(qubit.type)
+        assert ir.OpaqueType(qubit.type).dialect_namespace == "quantum"
+        assert ir.OpaqueType(qubit.type).data == "bit"
+
+    float_params = []
+    for p in params:
+        p = safe_cast_to_f64(p, op)
+        p = extract_scalar(p, op)
+
+        assert ir.F64Type.isinstance(
+            p.type
+        ), "Only scalar double parameters are allowed for quantum gates!"
+
+        float_params.append(p)
+
+    ctrl_values_i1 = []
+    for v in ctrl_values:
+        p = TensorExtractOp(ir.IntegerType.get_signless(1), v, []).result
+        ctrl_values_i1.append(p)
+
+    name_attr = ir.StringAttr.get(op)
+    name_str = str(name_attr)
+    name_str = name_str.replace('"', "")
+
+    if name_str == "MultiRZ":
+        assert len(float_params) == 1, "MultiRZ takes one float parameter"
+        float_param = float_params[0]
+        return MultiRZOp(
+            out_qubits=[qubit.type for qubit in qubits],
+            out_ctrl_qubits=[qubit.type for qubit in ctrl_qubits],
+            theta=float_param,
+            in_qubits=qubits,
+            in_ctrl_qubits=ctrl_qubits,
+            in_ctrl_values=ctrl_values_i1,
+            adjoint=adjoint,
+        ).results
+
+    if name_str == "PCPhase":
+        assert len(float_params) == 2, "PCPhase takes two float parameters"
+        float_param = float_params[0]
+        dim_param = float_params[1]
+        return PCPhaseOp(
+            out_qubits=[qubit.type for qubit in qubits],
+            out_ctrl_qubits=[qubit.type for qubit in ctrl_qubits],
+            theta=float_param,
+            dim=dim_param,
+            in_qubits=qubits,
+            in_ctrl_qubits=ctrl_qubits,
+            in_ctrl_values=ctrl_values_i1,
+            adjoint=adjoint,
+        ).results
+
+    return CustomOp(
+        out_qubits=[qubit.type for qubit in qubits],
+        out_ctrl_qubits=[qubit.type for qubit in ctrl_qubits],
+        params=float_params,
+        in_qubits=qubits,
+        gate_name=name_attr,
+        in_ctrl_qubits=ctrl_qubits,
+        in_ctrl_values=ctrl_values_i1,
+        adjoint=adjoint,
+    ).results
+
+
+@register_lowering(unitary_p)
+def _unitary_lowering(
+    jax_ctx: mlir.LoweringRuleContext,
+    matrix: ir.Value,
+    *qubits_or_controlled: tuple,
+    qubits_len=0,
+    ctrl_len=0,
+    adjoint=False,
+):
+    qubits = qubits_or_controlled[:qubits_len]
+    ctrl_qubits = qubits_or_controlled[qubits_len : qubits_len + ctrl_len]
+    ctrl_values = qubits_or_controlled[qubits_len + ctrl_len :]
+
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    for q in qubits:
+        assert ir.OpaqueType.isinstance(q.type)
+        assert ir.OpaqueType(q.type).dialect_namespace == "quantum"
+        assert ir.OpaqueType(q.type).data == "bit"
+
+    matrix_type = matrix.type
+    is_tensor = ir.RankedTensorType.isinstance(matrix_type)
+    shape = ir.RankedTensorType(matrix_type).shape if is_tensor else None
+    is_2d_tensor = len(shape) == 2 if is_tensor else False
+    if not is_2d_tensor:
+        raise TypeError("QubitUnitary must be a 2 dimensional tensor.")
+
+    possibly_complex_type = ir.RankedTensorType(matrix_type).element_type
+    is_complex = ir.ComplexType.isinstance(possibly_complex_type)
+    is_f64_type = False
+
+    if is_complex:
+        complex_type = ir.ComplexType(possibly_complex_type)
+        possibly_f64_type = complex_type.element_type
+        is_f64_type = ir.F64Type.isinstance(possibly_f64_type)
+
+    is_complex_f64_type = is_complex and is_f64_type
+    if not is_complex_f64_type:
+        f64_type = ir.F64Type.get()
+        complex_f64_type = ir.ComplexType.get(f64_type)
+        tensor_complex_f64_type = ir.RankedTensorType.get(shape, complex_f64_type)
+        matrix = StableHLOConvertOp(tensor_complex_f64_type, matrix).result
+
+    ctrl_values_i1 = []
+    for v in ctrl_values:
+        p = TensorExtractOp(ir.IntegerType.get_signless(1), v, []).result
+        ctrl_values_i1.append(p)
+
+    return QubitUnitaryOp(
+        out_qubits=[q.type for q in qubits],
+        out_ctrl_qubits=[q.type for q in ctrl_qubits],
+        matrix=matrix,
+        in_qubits=qubits,
+        in_ctrl_qubits=ctrl_qubits,
+        in_ctrl_values=ctrl_values_i1,
+        adjoint=adjoint,
+    ).results
+
+
+# pylint: disable=unused-argument
+@register_lowering(pauli_rot_p)
+def _pauli_rot_lowering(
+    jax_ctx: mlir.LoweringRuleContext,
+    *qubits_and_params: tuple,
+    pauli_word=None,
+    qubits_len=0,
+    params_len=0,
+    ctrl_len=0,
+    adjoint=False,
+):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    qubits = qubits_and_params[:qubits_len]
+    params = qubits_and_params[qubits_len : qubits_len + params_len]
+    ctrl_qubits = qubits_and_params[qubits_len + params_len : qubits_len + params_len + ctrl_len]
+    ctrl_values = qubits_and_params[qubits_len + params_len + ctrl_len :]
+
+    for q in qubits:
+        assert ir.OpaqueType.isinstance(q.type)
+        assert ir.OpaqueType(q.type).dialect_namespace == "quantum"
+        assert ir.OpaqueType(q.type).data == "bit"
+
+    assert params_len == 1 and params[0] is not None
+    angle = params[0]
+    angle = safe_cast_to_f64(angle, "PauliRot")
+    angle = extract_scalar(angle, "PauliRot")
+    assert ir.F64Type.isinstance(angle.type)
+    assert pauli_word is not None
+
+    pauli_word = ir.ArrayAttr.get([ir.StringAttr.get(p) for p in pauli_word])
+
+    ctrl_values_i1 = []
+    for v in ctrl_values:
+        p = TensorExtractOp(ir.IntegerType.get_signless(1), v, []).result
+        ctrl_values_i1.append(p)
+
+    return PauliRotOp(
+        out_qubits=[qubit.type for qubit in qubits],
+        out_ctrl_qubits=[qubit.type for qubit in ctrl_qubits],
+        angle=angle,
+        pauli_product=pauli_word,
+        adjoint=adjoint,
+        in_qubits=qubits,
+        in_ctrl_qubits=ctrl_qubits,
+        in_ctrl_values=ctrl_values_i1,
+    ).results
+
+
+@register_lowering(pauli_measure_p)
+def _pauli_measure_lowering(
+    jax_ctx: mlir.LoweringRuleContext,
+    *qubits: tuple,
+    pauli_word=None,
+    qubits_len=0,
+):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    qubits = qubits[:qubits_len]
+    for q in qubits:
+        assert ir.OpaqueType.isinstance(q.type)
+        assert ir.OpaqueType(q.type).dialect_namespace == "quantum"
+        assert ir.OpaqueType(q.type).data == "bit"
+
+    assert pauli_word is not None
+
+    if not all(p in ["I", "X", "Y", "Z"] for p in pauli_word):
+        raise ValueError("Only Pauli words consisting of 'I', 'X', 'Y', and 'Z' are allowed.")
+
+    pauli_word = ir.ArrayAttr.get([ir.StringAttr.get(p) for p in pauli_word])
+
+    result_type = ir.IntegerType.get_signless(1)
+
+    ppm_results = PPMeasurementOp(
+        out_qubits=[q.type for q in qubits],
+        mres=result_type,
+        pauli_product=pauli_word,
+        in_qubits=qubits,
+    ).results
+
+    result, *out_qubits = ppm_results  # First element is the measurement result
+
+    result_type = ir.RankedTensorType.get((), result.type)
+    from_elements_op = FromElementsOp(result_type, result)
+
+    return (from_elements_op.results[0],) + tuple(out_qubits)
+
+
+@register_lowering(measure_p)
+def _measure_lowering(jax_ctx: mlir.LoweringRuleContext, qubit: ir.Value, postselect: int = None):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    assert ir.OpaqueType.isinstance(qubit.type)
+    assert ir.OpaqueType(qubit.type).dialect_namespace == "quantum"
+    assert ir.OpaqueType(qubit.type).data == "bit"
+
+    # Prepare postselect attribute
+    if postselect is not None:
+        i32_type = ir.IntegerType.get_signless(32, ctx)
+        postselect = ir.IntegerAttr.get(i32_type, postselect)
+
+    result_type = ir.IntegerType.get_signless(1)
+
+    result, new_qubit = MeasureOp(result_type, qubit.type, qubit, postselect=postselect).results
+
+    result_from_elements_op = ir.RankedTensorType.get((), result.type)
+    from_elements_op = FromElementsOp(result_from_elements_op, result)
+
+    return (
+        from_elements_op.results[0],
+        new_qubit,
+    )
+
+
+@register_lowering(measure_in_basis_p)
+def _measure_in_basis_lowering(
+    jax_ctx: mlir.LoweringRuleContext,
+    angle: float,
+    qubit: ir.Value,
+    plane: MeasurementPlane,
+    postselect: int = None,
+):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    assert ir.OpaqueType.isinstance(qubit.type)
+    assert ir.OpaqueType(qubit.type).dialect_namespace == "quantum"
+    assert ir.OpaqueType(qubit.type).data == "bit"
+
+    angle = safe_cast_to_f64(angle, "angle")
+    angle = extract_scalar(angle, "angle")
+
+    assert ir.F64Type.isinstance(
+        angle.type
+    ), "Only scalar double parameters are allowed for quantum gates!"
+
+    # Prepare postselect attribute
+    if postselect is not None:
+        i32_type = ir.IntegerType.get_signless(32, ctx)
+        postselect = ir.IntegerAttr.get(i32_type, postselect)
+
+    result_type = ir.IntegerType.get_signless(1)
+
+    result, new_qubit = MeasureInBasisOp(
+        result_type,
+        qubit.type,
+        qubit,
+        plane=ir.OpaqueAttr.get(
+            "mbqc",
+            ("measurement_plane " + MeasurementPlane(plane).name).encode("utf-8"),
+            ir.NoneType.get(ctx),
+            ctx,
+        ),
+        angle=angle,
+        postselect=postselect,
+    ).results
+
+    result_from_elements_op = ir.RankedTensorType.get((), result.type)
+    from_elements_op = FromElementsOp(result_from_elements_op, result)
+
+    return (
+        from_elements_op.results[0],
+        new_qubit,
+    )
+
+
+@register_lowering(compbasis_p)
+def _compbasis_lowering(
+    jax_ctx: mlir.LoweringRuleContext, *qubits_or_qreg: tuple, qreg_available=False
+):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    result_type = ir.OpaqueType.get("quantum", "obs")
+
+    if qreg_available:
+        qreg = qubits_or_qreg[0]
+        assert ir.OpaqueType.isinstance(qreg.type)
+        assert ir.OpaqueType(qreg.type).dialect_namespace == "quantum"
+        assert ir.OpaqueType(qreg.type).data == "reg"
+        return ComputationalBasisOp(result_type, [], qreg=qreg).results
+
+    else:
+        qubits = qubits_or_qreg
+        for qubit in qubits:
+            assert ir.OpaqueType.isinstance(qubit.type)
+            assert ir.OpaqueType(qubit.type).dialect_namespace == "quantum"
+            assert ir.OpaqueType(qubit.type).data == "bit"
+
+        return ComputationalBasisOp(result_type, qubits).results
+
+
+@register_lowering(namedobs_p)
+def _named_obs_lowering(jax_ctx: mlir.LoweringRuleContext, qubit: ir.Value, kind: str):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    assert ir.OpaqueType.isinstance(qubit.type)
+    assert ir.OpaqueType(qubit.type).dialect_namespace == "quantum"
+    assert ir.OpaqueType(qubit.type).data == "bit"
+
+    obsId = ir.OpaqueAttr.get(
+        "quantum", ("named_observable " + kind).encode("utf-8"), ir.NoneType.get(ctx), ctx
+    )
+    result_type = ir.OpaqueType.get("quantum", "obs", ctx)
+
+    return NamedObsOp(result_type, qubit, obsId).results
+
+
+@register_lowering(mcmobs_p)
+def _mcm_obs_lowering(jax_ctx: mlir.LoweringRuleContext, *mcms: list[ir.Value]):
+    ctx = jax_ctx.module_context.context
+    result_type = ir.OpaqueType.get("quantum", "obs", ctx)
+    tensor_i1_type = ir.RankedTensorType.get([], ir.IntegerType.get_signless(1))
+
+    extracted = []
+    for mcm in mcms:
+        convert_op = StableHLOConvertOp(tensor_i1_type, mcm)
+        extracted.append(extract_scalar(convert_op.result, "mcmobs"))
+    return MCMObsOp(result_type, extracted).results
+
+
+@register_lowering(hermitian_p)
+def _hermitian_lowering(jax_ctx: mlir.LoweringRuleContext, matrix: ir.Value, *qubits: tuple):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    result_type = ir.OpaqueType.get("quantum", "obs", ctx)
+
+    return HermitianOp(result_type, matrix, qubits).results
+
+
+@register_lowering(tensorobs_p)
+def _tensor__obs_lowering(jax_ctx: mlir.LoweringRuleContext, *terms: tuple):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    result_type = ir.OpaqueType.get("quantum", "obs")
+
+    return TensorOp(result_type, terms).results
+
+
+@register_lowering(hamiltonian_p)
+def _hamiltonian_lowering(jax_ctx: mlir.LoweringRuleContext, coeffs: ir.Value, *terms: tuple):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    coeffs = safe_cast_to_f64(coeffs, "Hamiltonian", "coefficient")
+
+    result_type = ir.OpaqueType.get("quantum", "obs", ctx)
+
+    return HamiltonianOp(result_type, coeffs, terms).results
+
+
+@register_lowering(sample_p)
+def _sample_lowering(
+    jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, *dynamic_shape, static_shape
+):
+    # result shape of sample op is (shots, number_of_qubits)
+    # The static_shape argument contains the static dimensions, and None for dynamic dimensions
+
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+    f64_type = ir.F64Type.get()
+
+    # Replace Nones in static_shape with dynamic mlir dimensions
+    result_shape = tuple(ir.ShapedType.get_dynamic_size() if d is None else d for d in static_shape)
+    result_type = ir.RankedTensorType.get(result_shape, f64_type)
+
+    dynamic_shape = list(dynamic_shape)
+    for i, dyn_dim in enumerate(dynamic_shape):
+        dynamic_shape[i] = extract_scalar(dyn_dim, f"sample_dyn_dim_{i}")
+
+    return SampleOp(result_type, obs, dynamic_shape=dynamic_shape).results
+
+
+@register_lowering(counts_p)
+def _counts_lowering(
+    jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, *dynamic_shape, static_shape
+):
+    # Note: result shape of counts op is (tensor<Nxf64>, tensor<Nxi64>)
+    # where N = 2**number_of_qubits
+    # This means even with dynamic shots, result shape is still static.
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    i64_type = ir.IntegerType.get_signless(64, ctx)
+    f64_type = ir.F64Type.get()
+
+    # Replace Nones in static_shape with dynamic mlir dimensions
+    shape = tuple(ir.ShapedType.get_dynamic_size() if d is None else d for d in static_shape)
+    eigvals_type = ir.RankedTensorType.get(shape, f64_type)
+    counts_type = ir.RankedTensorType.get(shape, i64_type)
+
+    if static_shape[0] is None:
+        # dynamic num_qubits, pass the SSA value to the op
+        dyn_shape = extract_scalar(dynamic_shape[0], "counts_size")
+    else:
+        # static num_qubits already in the shape, no need to pass another operand
+        dyn_shape = None
+
+    return CountsOp(eigvals_type, counts_type, obs, dynamic_shape=dyn_shape).results
+
+
+@register_lowering(expval_p)
+def _expval_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shape=None):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    assert ir.OpaqueType.isinstance(obs.type)
+    assert ir.OpaqueType(obs.type).dialect_namespace == "quantum"
+    assert ir.OpaqueType(obs.type).data == "obs"
+
+    result_type = ir.F64Type.get()
+
+    mres = ExpvalOp(result_type, obs).result
+    result_from_elements_op = ir.RankedTensorType.get((), result_type)
+    from_elements_op = FromElementsOp(result_from_elements_op, mres)
+    return from_elements_op.results
+
+
+@register_lowering(var_p)
+def _var_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, shape=None):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    assert ir.OpaqueType.isinstance(obs.type)
+    assert ir.OpaqueType(obs.type).dialect_namespace == "quantum"
+    assert ir.OpaqueType(obs.type).data == "obs"
+
+    result_type = ir.F64Type.get()
+
+    mres = VarianceOp(result_type, obs).result
+    result_from_elements_op = ir.RankedTensorType.get((), result_type)
+    from_elements_op = FromElementsOp(result_from_elements_op, mres)
+    return from_elements_op.results
+
+
+@register_lowering(probs_p)
+def _probs_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, *dynamic_shape, static_shape):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    f64_type = ir.F64Type.get()
+
+    # Replace Nones in static_shape with dynamic mlir dimensions
+    result_shape = tuple(ir.ShapedType.get_dynamic_size() if d is None else d for d in static_shape)
+    result_type = ir.RankedTensorType.get(result_shape, f64_type)
+
+    if static_shape[0] is None:
+        # dynamic sv_length, pass the SSA value to the op
+        dyn_shape = extract_scalar(dynamic_shape[0], "probs_sv_length")
+    else:
+        # static sv_length already in the shape, no need to pass another operand
+        dyn_shape = None
+    return ProbsOp(result_type, obs, dynamic_shape=dyn_shape).results
+
+
+@register_lowering(state_p)
+def _state_lowering(jax_ctx: mlir.LoweringRuleContext, obs: ir.Value, *dynamic_shape, static_shape):
+    ctx = jax_ctx.module_context.context
+    ctx.allow_unregistered_dialects = True
+
+    c64_type = ir.ComplexType.get(ir.F64Type.get())
+
+    # Replace Nones in static_shape with dynamic mlir dimensions
+    result_shape = tuple(ir.ShapedType.get_dynamic_size() if d is None else d for d in static_shape)
+    result_type = ir.RankedTensorType.get(result_shape, c64_type)
+
+    if static_shape[0] is None:
+        # dynamic sv_length, pass the SSA value to the op
+        dyn_shape = extract_scalar(dynamic_shape[0], "state_sv_length")
+    else:
+        # static sv_length already in the shape, no need to pass another operand
+        dyn_shape = None
+    return StateOp(result_type, obs, dynamic_shape=dyn_shape).results
+
+
+@register_lowering(cond_p)
+def _cond_lowering(
+    jax_ctx: mlir.LoweringRuleContext,
+    *preds_and_branch_args_plus_consts: tuple,
+    branch_jaxprs: List[core.ClosedJaxpr],
+    num_implicit_outputs: int,
+):
+    result_types = [mlir.aval_to_ir_types(a)[0] for a in jax_ctx.avals_out]
+    num_preds = len(branch_jaxprs) - 1
+    preds = preds_and_branch_args_plus_consts[:num_preds]
+    branch_args_plus_consts = preds_and_branch_args_plus_consts[num_preds:]
+    flat_args_plus_consts = mlir.flatten_ir_values(branch_args_plus_consts)
+
+    # recursively lower if-else chains to nested IfOps
+    def emit_branches(preds, branch_jaxprs, ip):
+        # ip is an MLIR InsertionPoint. This allows recursive calls to emit their Operations inside
+        # the 'else' blocks of preceding IfOps.
+        with ip:
+            pred_extracted = TensorExtractOp(ir.IntegerType.get_signless(1), preds[0], []).result
+            if_op_scf = IfOp(pred_extracted, result_types, hasElse=True)
+            true_jaxpr = branch_jaxprs[0]
+            if_block = if_op_scf.then_block
+
+            # if block
+            source_info_util.extend_name_stack("if")
+            if_ctx = jax_ctx.replace(name_stack=jax_ctx.name_stack.extend("if"))
+            with ir.InsertionPoint(if_block):
+                # recursively generate the mlir for the if block
+                out, _ = mlir.jaxpr_subcomp(
+                    if_ctx.module_context,
+                    true_jaxpr.jaxpr,
+                    if_ctx.name_stack,
+                    mlir.TokenSet(),
+                    [mlir.ir_constant(c) for c in true_jaxpr.consts],  # is never hit in our tests
+                    *flat_args_plus_consts,
+                    dim_var_values=jax_ctx.dim_var_values,
+                    const_lowering=jax_ctx.const_lowering,
+                )
+
+                YieldOp(out)
+
+            # else block
+            source_info_util.extend_name_stack("else")
+            else_ctx = jax_ctx.replace(name_stack=jax_ctx.name_stack.extend("else"))
+            else_block = if_op_scf.else_block
+            if len(preds) == 1:
+                # Base case: reached the otherwise block
+                otherwise_jaxpr = branch_jaxprs[-1]
+                with ir.InsertionPoint(else_block):
+                    out, _ = mlir.jaxpr_subcomp(
+                        else_ctx.module_context,
+                        otherwise_jaxpr.jaxpr,
+                        else_ctx.name_stack,
+                        mlir.TokenSet(),
+                        [mlir.ir_constants(c) for c in otherwise_jaxpr.consts],
+                        *flat_args_plus_consts,
+                        dim_var_values=jax_ctx.dim_var_values,
+                        const_lowering=jax_ctx.const_lowering,
+                    )
+
+                    YieldOp(out)
+            else:
+                with ir.InsertionPoint(else_block) as else_ip:
+                    child_if_op = emit_branches(preds[1:], branch_jaxprs[1:], else_ip)
+                    YieldOp(child_if_op.results)
+            return if_op_scf
+
+    head_if_op = emit_branches(preds, branch_jaxprs, jax_ctx.module_context.ip.current)
+    return head_if_op.results
+
+
+@register_lowering(switch_p)
+def _switch_lowering(
+    jax_ctx,
+    *index_and_cases_and_branch_args_plus_consts: tuple,
+    branch_jaxprs: List[core.ClosedJaxpr],
+    num_implicit_outputs: int,
+):
+    result_types = [mlir.aval_to_ir_types(outvar)[0] for outvar in branch_jaxprs[0].out_avals]
+
+    index = index_and_cases_and_branch_args_plus_consts[0]
+    # the last branch is default and does not have a case
+    cases = index_and_cases_and_branch_args_plus_consts[1 : len(branch_jaxprs)]
+    branch_args_plus_consts = index_and_cases_and_branch_args_plus_consts[len(branch_jaxprs) :]
+    flat_args_plus_consts = mlir.flatten_ir_values(branch_args_plus_consts)
+
+    index = _cast_to_index(index)
+
+    # enumerate branches so that branch indices and "cases" line up properly
+    cases = ir.DenseI64ArrayAttr.get(
+        [case.owner.attributes["value"].get_splat_value().value for case in cases]
+    )
+
+    scf_switch_op = IndexSwitchOp(result_types, index, cases, len(branch_jaxprs) - 1)
+
+    # construct switch branches
+    for i in range(len(branch_jaxprs) - 1):
+        with ir.InsertionPoint(scf_switch_op.caseRegions[i].blocks.append()):
+            branch_ctx = jax_ctx.replace(name_stack=jax_ctx.name_stack.extend(f"branch {i}"))
+            branch_jaxpr = branch_jaxprs[i]
+            out, _ = mlir.jaxpr_subcomp(
+                branch_ctx.module_context,
+                branch_jaxpr.jaxpr,
+                branch_ctx.name_stack,
+                mlir.TokenSet(),
+                [mlir.ir_constant(const) for const in branch_jaxpr.consts],
+                *flat_args_plus_consts,
+                dim_var_values=jax_ctx.dim_var_values,
+                const_lowering=jax_ctx.const_lowering,
+            )
+
+            YieldOp(out)
+
+    with ir.InsertionPoint(scf_switch_op.defaultRegion.blocks.append()):
+        branch_ctx = jax_ctx.replace(name_stack=jax_ctx.name_stack.extend("default branch"))
+        branch_jaxpr = branch_jaxprs[-1]
+        out, _ = mlir.jaxpr_subcomp(
+            branch_ctx.module_context,
+            branch_jaxpr.jaxpr,
+            branch_ctx.name_stack,
+            mlir.TokenSet(),
+            [mlir.ir_constant(const) for const in branch_jaxpr.consts],
+            *flat_args_plus_consts,
+            dim_var_values=jax_ctx.dim_var_values,
+            const_lowering=jax_ctx.const_lowering,
+        )
+
+        YieldOp(out)
+
+    return scf_switch_op.results
+
+
+@register_lowering(while_p)
+def _while_loop_lowering(
+    jax_ctx: mlir.LoweringRuleContext,
+    *iter_args_plus_consts: tuple,
+    cond_jaxpr: core.ClosedJaxpr,
+    body_jaxpr: core.ClosedJaxpr,
+    cond_nconsts: int,
+    body_nconsts: int,
+    num_implicit_inputs: int,
+    preserve_dimensions: bool,
+):
+    loop_carry_types_plus_consts = [mlir.aval_to_ir_types(a)[0] for a in jax_ctx.avals_in]
+    flat_args_plus_consts = mlir.flatten_ir_values(iter_args_plus_consts)
+    assert [val.type for val in flat_args_plus_consts] == loop_carry_types_plus_consts
+
+    # split the argument list into 3 separate groups
+    # 1) the constants used in the condition function
+    # 2) the constants used in the body function
+    # 3) the normal arguments which are not constants
+    cond_consts = flat_args_plus_consts[:cond_nconsts]
+    body_consts = flat_args_plus_consts[cond_nconsts : cond_nconsts + body_nconsts]
+    loop_args = flat_args_plus_consts[cond_nconsts + body_nconsts :]
+
+    # remove const types from abstract parameter types list
+    loop_carry_types = loop_carry_types_plus_consts[cond_nconsts + body_nconsts :]
+    assert loop_carry_types == [mlir.aval_to_ir_types(a)[0] for a in jax_ctx.avals_out], (
+        loop_carry_types,
+        [mlir.aval_to_ir_types(a)[0] for a in jax_ctx.avals_out],
+    )
+
+    while_op_scf = WhileOp(loop_carry_types, loop_args)
+
+    # cond block
+    cond_block = while_op_scf.regions[0].blocks.append(*loop_carry_types)
+    name_stack = jax_ctx.name_stack.extend("while")
+    cond_ctx = jax_ctx.replace(name_stack=name_stack.extend("cond"))
+    with ir.InsertionPoint(cond_block):
+        cond_args = [cond_block.arguments[i] for i in range(len(loop_carry_types))]
+        params = cond_consts + cond_args
+
+        # recursively generate the mlir for the while cond
+        (pred,), _ = mlir.jaxpr_subcomp(
+            cond_ctx.module_context,
+            cond_jaxpr.jaxpr,
+            cond_ctx.name_stack,
+            mlir.TokenSet(),
+            [mlir.ir_constants(c) for c in cond_jaxpr.consts],
+            *params,
+            dim_var_values=jax_ctx.dim_var_values,
+            const_lowering=jax_ctx.const_lowering,
+        )
+
+        pred_extracted = TensorExtractOp(ir.IntegerType.get_signless(1), pred, []).result
+        ConditionOp(pred_extracted, cond_args)
+
+    # body block
+    body_block = while_op_scf.regions[1].blocks.append(*loop_carry_types)
+    body_ctx = jax_ctx.replace(name_stack=name_stack.extend("body"))
+    with ir.InsertionPoint(body_block):
+        body_args = [body_block.arguments[i] for i in range(len(loop_carry_types))]
+        params = body_consts + body_args
+
+        # recursively generate the mlir for the while body
+        out, _ = mlir.jaxpr_subcomp(
+            body_ctx.module_context,
+            body_jaxpr.jaxpr,
+            body_ctx.name_stack,
+            mlir.TokenSet(),
+            [mlir.ir_constants(c) for c in cond_jaxpr.consts],
+            *params,
+            dim_var_values=jax_ctx.dim_var_values,
+            const_lowering=jax_ctx.const_lowering,
+        )
+
+        YieldOp(out)
+
+    return while_op_scf.results
+
+
+@register_lowering(pl_while_loop_prim)
+def _pl_while_loop_lowering(
+    jax_ctx: mlir.LoweringRuleContext,
+    *plxpr_invals,
+    jaxpr_body_fn,
+    jaxpr_cond_fn,
+    body_slice,
+    cond_slice,
+    args_slice,
+):
+    body_consts = plxpr_invals[slice(*body_slice)]
+    cond_consts = plxpr_invals[slice(*cond_slice)]
+    args = plxpr_invals[slice(*args_slice)]
+
+    all_args_types = [mlir.aval_to_ir_types(a)[0] for a in jax_ctx.avals_in]
+    args_types = all_args_types[slice(*args_slice)]
+
+    while_op_scf = WhileOp(args_types, args)
+
+    # cond block
+    cond_block = while_op_scf.regions[0].blocks.append(*args_types)
+    name_stack = jax_ctx.name_stack.extend("while")
+    cond_ctx = jax_ctx.replace(name_stack=name_stack.extend("cond"))
+    with ir.InsertionPoint(cond_block):
+        cond_args = tuple(cond_block.arguments[i] for i in range(len(args)))
+        params = cond_consts + cond_args
+        new_cond_jaxpr = jaxpr_cond_fn.replace(
+            constvars=(), invars=jaxpr_cond_fn.constvars + jaxpr_cond_fn.invars
+        )
+
+        # recursively generate the mlir for the while cond
+        (pred,), _ = mlir.jaxpr_subcomp(
+            cond_ctx.module_context,
+            new_cond_jaxpr,
+            cond_ctx.name_stack,
+            mlir.TokenSet(),
+            [],
+            *params,
+            dim_var_values=jax_ctx.dim_var_values,
+            const_lowering=jax_ctx.const_lowering,
+        )
+
+        pred_extracted = TensorExtractOp(ir.IntegerType.get_signless(1), pred, []).result
+        ConditionOp(pred_extracted, cond_args)
+
+    # body block
+    body_block = while_op_scf.regions[1].blocks.append(*args_types)
+    body_ctx = jax_ctx.replace(name_stack=name_stack.extend("body"))
+    with ir.InsertionPoint(body_block):
+        body_args = tuple(body_block.arguments[-len(args) :])
+        params = body_consts + body_args
+
+        new_body_jaxpr = jaxpr_body_fn.replace(
+            constvars=(), invars=jaxpr_body_fn.constvars + jaxpr_body_fn.invars
+        )
+
+        # recursively generate the mlir for the while body
+        out, _ = mlir.jaxpr_subcomp(
+            body_ctx.module_context,
+            new_body_jaxpr,
+            body_ctx.name_stack,
+            mlir.TokenSet(),
+            [],
+            *params,
+            dim_var_values=jax_ctx.dim_var_values,
+            const_lowering=jax_ctx.const_lowering,
+        )
+        YieldOp(out)
+
+    return while_op_scf.results
+
+
+# pylint: disable=too-many-arguments
+@register_lowering(for_p)
+def _for_loop_lowering(
+    jax_ctx: mlir.LoweringRuleContext,
+    *iter_args_plus_consts: tuple,
+    body_jaxpr: core.ClosedJaxpr,
+    body_nconsts: int,
+    apply_reverse_transform: bool,
+    num_implicit_inputs: int,
+    preserve_dimensions,
+):
+    body_consts = iter_args_plus_consts[:body_nconsts]
+    body_implicits = iter_args_plus_consts[body_nconsts : body_nconsts + num_implicit_inputs]
+    lower_bound = iter_args_plus_consts[body_nconsts + num_implicit_inputs + 0]
+    upper_bound = iter_args_plus_consts[body_nconsts + num_implicit_inputs + 1]
+    step = iter_args_plus_consts[body_nconsts + num_implicit_inputs + 2]
+    loop_index = iter_args_plus_consts[body_nconsts + num_implicit_inputs + 3]
+    loop_args = [*body_implicits, *iter_args_plus_consts[body_nconsts + num_implicit_inputs + 4 :]]
+
+    loop_index_type = ir.RankedTensorType(loop_index.type).element_type
+
+    all_param_types_plus_consts = [mlir.aval_to_ir_types(a)[0] for a in jax_ctx.avals_in]
+    assert [lower_bound.type, upper_bound.type, step.type] == all_param_types_plus_consts[
+        body_nconsts + num_implicit_inputs : body_nconsts + num_implicit_inputs + 3
+    ]
+    assert [val.type for val in body_consts] == all_param_types_plus_consts[:body_nconsts]
+
+    result_types = [v.type for v in loop_args]
+    assert result_types == [
+        mlir.aval_to_ir_types(a)[0] for a in jax_ctx.avals_out
+    ], f"\n{result_types=} doesn't match \n{jax_ctx.avals_out=}"
+
+    lower_bound, upper_bound, step = map(_cast_to_index, (lower_bound, upper_bound, step))
+
+    if apply_reverse_transform:
+        zero_np = np.array(0)
+        one_np = np.array(1)
+        zero_attr = ir.DenseIntElementsAttr.get(zero_np)
+        one_attr = ir.DenseIntElementsAttr.get(one_np)
+        zero_tensor = StableHLOConstantOp(zero_attr)
+        one_tensor = StableHLOConstantOp(one_attr)
+        ctx = jax_ctx.module_context.context
+        i64_type = ir.IntegerType.get_signless(64, ctx)
+        zero_i64 = TensorExtractOp(i64_type, zero_tensor, []).result
+        one_i64 = TensorExtractOp(i64_type, one_tensor, []).result
+        zero = IndexCastOp(ir.IndexType.get(), zero_i64).result
+        one = IndexCastOp(ir.IndexType.get(), one_i64).result
+
+        start_val, stop_val, step_val = lower_bound, upper_bound, step
+
+        # Iterate from 0 to the number of iterations (ceil((stop - start) / step))
+        distance = SubIOp(stop_val, start_val)
+        num_iterations = CeilDivSIOp(distance.result, step_val)
+        lower_bound, upper_bound, step = zero, num_iterations, one
+
+    for_op_scf = ForOp(lower_bound, upper_bound, step, iter_args=loop_args)
+
+    name_stack = jax_ctx.name_stack.extend("for")
+    body_block = for_op_scf.body
+    body_ctx = jax_ctx.replace(name_stack=name_stack.extend("body"))
+
+    with ir.InsertionPoint(body_block):
+        body_args = list(body_block.arguments)
+
+        # Convert the index type iteration variable expected by MLIR to tensor<i64> expected by JAX.
+        if apply_reverse_transform:
+            # iv = start + normalized_iv * step
+            body_args[0] = AddIOp(start_val, MulIOp(body_args[0], step_val))
+
+        body_args[0] = IndexCastOp(loop_index_type, body_args[0]).result
+        result_from_elements_op = ir.RankedTensorType.get((), loop_index_type)
+        from_elements_op = FromElementsOp(result_from_elements_op, body_args[0])
+        body_args[0] = from_elements_op.result
+
+        # Re-order arguments in accordance with jax dynamic API convensions
+        consts = body_consts
+        loop_iter = body_args[0]
+        implicit_args = body_args[1 : num_implicit_inputs + 1]
+        explicit_args = body_args[num_implicit_inputs + 1 :]
+        loop_params = (*consts, *implicit_args, loop_iter, *explicit_args)
+
+        # Recursively generate the mlir for the loop body
+        out, _ = mlir.jaxpr_subcomp(
+            body_ctx.module_context,
+            body_jaxpr.jaxpr,
+            body_ctx.name_stack,
+            mlir.TokenSet(),
+            [mlir.ir_constants(c) for c in body_jaxpr.consts],
+            *loop_params,
+            dim_var_values=jax_ctx.dim_var_values,
+            const_lowering=jax_ctx.const_lowering,
+        )
+        YieldOp(out)
+
+    return for_op_scf.results
+
+
+# pylint: disable=too-many-arguments
+@register_lowering(pl_for_loop_prim)
+def _pl_for_loop_lowering(
+    jax_ctx: mlir.LoweringRuleContext,
+    start,
+    stop,
+    step,
+    *plxpr_invals,
+    jaxpr_body_fn,
+    consts_slice,
+    args_slice,
+    abstract_shapes_slice,
+):
+    body_consts = plxpr_invals[slice(*consts_slice)]
+    abstract_shapes = plxpr_invals[slice(*abstract_shapes_slice)]
+    args = plxpr_invals[slice(*args_slice)]
+
+    # need later to cast index back to original type
+    start_type = ir.RankedTensorType(start.type).element_type
+
+    start, stop, step = map(_cast_to_index, (start, stop, step))
+    # slicing out index, as passed to block independently
+    loop_args = abstract_shapes + args
+    for_op_scf = ForOp(start, stop, step, iter_args=loop_args)
+
+    name_stack = jax_ctx.name_stack.extend("for")
+    body_block = for_op_scf.body
+    body_ctx = jax_ctx.replace(name_stack=name_stack.extend("body"))
+
+    with ir.InsertionPoint(body_block):
+        # index -> i32 -> tensor<i32>
+        index = body_block.arguments[0]
+        scalar_index = IndexCastOp(start_type, index).result
+        new_dtype = ir.RankedTensorType.get((), start_type)
+        tensor_index = FromElementsOp(new_dtype, scalar_index).result
+
+        inner_shapes = body_block.arguments[1 : len(abstract_shapes) + 1]
+        inner_args = body_block.arguments[len(abstract_shapes) + 1 :]
+        loop_params = (*body_consts, *inner_shapes, tensor_index, *inner_args)
+        new_jaxpr = jaxpr_body_fn.replace(
+            constvars=(), invars=jaxpr_body_fn.constvars + jaxpr_body_fn.invars
+        )
+
+        # Recursively generate the mlir for the loop body
+        out, _ = mlir.jaxpr_subcomp(
+            body_ctx.module_context,
+            new_jaxpr,
+            body_ctx.name_stack,
+            mlir.TokenSet(),
+            [],
+            *loop_params,
+            dim_var_values=jax_ctx.dim_var_values,
+            const_lowering=jax_ctx.const_lowering,
+        )
+        YieldOp(out)
+
+    return for_op_scf.results
+
+
+@register_lowering(assert_p)
+def _assert_lowering(jax_ctx: mlir.LoweringRuleContext, assertion, error):
+    assertion_mlir = TensorExtractOp(ir.IntegerType.get_signless(1), assertion, []).result
+    AssertionOp(assertion=assertion_mlir, error=error)
+    return ()
+
+
+@register_lowering(set_state_p)
+def _set_state_lowering(jax_ctx: mlir.LoweringRuleContext, *qubits_or_params):
+    qubits_or_params = list(qubits_or_params)
+    param = qubits_or_params.pop()
+    qubits = qubits_or_params
+    out_qubits = [qubit.type for qubit in qubits]
+    return SetStateOp(out_qubits, param, qubits).results
+
+
+@register_lowering(set_basis_state_p)
+def _set_basis_state_lowering(jax_ctx: mlir.LoweringRuleContext, *qubits_or_params):
+    qubits_or_params = list(qubits_or_params)
+    param = qubits_or_params.pop()
+    qubits = qubits_or_params
+    out_qubits = [qubit.type for qubit in qubits]
+    return SetBasisStateOp(out_qubits, param, qubits).results
+
+
+@register_lowering(adjoint_p)
+def _adjoint_lowering(
+    jax_ctx: mlir.LoweringRuleContext,
+    *args: Iterable[ir.Value],
+    args_tree: PyTreeDef,
+    jaxpr: core.ClosedJaxpr,
+) -> ir.Value:
+    """The JAX bind handler performing the Jaxpr -> MLIR adjoint lowering by taking the `jaxpr`
+    expression to be lowered and all its already lowered arguments as MLIR value references. The Jax
+    requires all the arguments to be passed as a single list of positionals, thus we pass indices of
+    the argument groups. The handler returns the resulting MLIR Value."""
+
+    # [1] - MLIR Value of constans, classical and quantum arguments [2] - JAXPR types of constans,
+    # classical and quantum arguments [3] - Build a body of the adjoint operator. We pass constants
+    # and classical arguments as-is, but substitute the quantum arguments with the arguments of the
+    # block.
+
+    ctx = jax_ctx.module_context.context
+    consts, cargs, qargs = tree_unflatten(args_tree, args)  # [1]
+    _, _, aqargs = tree_unflatten(args_tree, jax_ctx.avals_in)  # [2]
+
+    assert len(qargs) == 1, "We currently expect exactly one quantum register argument"
+    output_types = util.flatten(map(mlir.aval_to_ir_types, jax_ctx.avals_out))
+    assert len(output_types) == 1 and output_types[0] == ir.OpaqueType.get(
+        "quantum", "reg", ctx
+    ), f"Expected a single result of quantum.register type, got: {output_types}"
+
+    # Build an adjoint operation with a single-block region.
+    op = AdjointOp(output_types, qargs)
+    adjoint_block = op.regions[0].blocks.append(*[mlir.aval_to_ir_types(a)[0] for a in aqargs])
+    with ir.InsertionPoint(adjoint_block):
+        source_info_util.extend_name_stack("adjoint")
+        out, _ = mlir.jaxpr_subcomp(
+            jax_ctx.module_context,
+            jaxpr.jaxpr,
+            jax_ctx.name_stack.extend("adjoint"),
+            mlir.TokenSet(),
+            [mlir.ir_constants(c) for c in jaxpr.consts],
+            *list(chain(consts, cargs, adjoint_block.arguments)),
+            dim_var_values=jax_ctx.dim_var_values,
+            const_lowering=jax_ctx.const_lowering,
+        )
+
+        QYieldOp([out[-1]])
+
+    # Need to manually add adjoint lowering pass for PPR, since that pipeline is not
+    # end-to-end yet.
+    # TODO: remove this manual addition when PPR is end-to-end, or when PPR has its own
+    # pipeline registered.
+
+    if any(_op.name == "pbc.ppr" for _op in adjoint_block.operations):
+
+        def adjoint_pass_injector(_op: ir.Operation) -> ir.WalkResult:
+            if _op.name == "transform.named_sequence":
+                with ir.InsertionPoint.at_block_begin(_op.regions[0].blocks[0]):
+                    ApplyRegisteredPassOp(
+                        result=ir.OpaqueType.get("transform", 'op<"builtin.module">'),
+                        target=_op.regions[0].blocks[0].arguments[0],  # just insert at beginning
+                        pass_name="adjoint-lowering",
+                        options={},
+                        dynamic_options={},
+                    )
+                return ir.WalkResult.INTERRUPT
+            return ir.WalkResult.ADVANCE
+
+        op.parent.parent.walk(adjoint_pass_injector, walk_order=ir.WalkOrder.PRE_ORDER)
+
+    return op.results
+
+
+@register_lowering(zne_p)
+def _zne_lowering(ctx, *args, folding, jaxpr, fn):
+    """Lowering function to the ZNE opearation.
+    Args:
+        ctx: the MLIR context
+        args: the arguments with scale factors as last
+        jaxpr: the jaxpr representation of the circuit
+        fn: the function to be mitigated
+    """
+    func_op = lower_jaxpr(ctx, jaxpr)
+    symbol_ref = get_symbolref(ctx, func_op)
+    output_types = list(map(mlir.aval_to_ir_types, ctx.avals_out))
+    flat_output_types = util.flatten(output_types)
+    num_folds = args[-1]
+
+    constants = []
+    for const in jaxpr.consts:
+        const_type = ir.RankedTensorType.get(const.shape, mlir.dtype_to_ir_type(const.dtype))
+        nparray = np.asarray(const)
+        if const.dtype == bool:
+            nparray = np.packbits(nparray, bitorder="little")
+        attr = ir.DenseElementsAttr.get(nparray, type=const_type)
+        constantVals = StableHLOConstantOp(attr).results
+        constants.append(constantVals)
+
+    args_and_consts = constants + list(args[0:-1])
+
+    return ZneOp(
+        flat_output_types,
+        symbol_ref,
+        mlir.flatten_ir_values(args_and_consts),
+        ir.OpaqueAttr.get(
+            "mitigation",
+            ("folding " + Folding(folding).name.lower()).encode("utf-8"),
+            ir.NoneType.get(ctx.module_context.context),
+            ctx.module_context.context,
+        ),
+        num_folds,
+    ).results
+
+
+@register_lowering(quantum_subroutine_prim)
+def subroutine_lowering(*args, **kwargs):
+    """This is just a method that forwards arguments to _pjit_lowering
+
+    Even though we could register the `pjit_p` lowering directly, this makes the code origin
+    apparent in stack traces and similar use cases.
+    """
+    try:
+        retval = _pjit_lowering(*args, **kwargs)
+    except NotImplementedError as e:
+        if "MLIR translation rule for primitive" in str(e):
+            msg = str(e) + """
+                This error sometimes occurs when using quantum operations
+                inside subroutines but calling them outside a qnode
+            """
+            raise NotImplementedError(msg) from e
+        raise e
+
+    return retval
+
+
+# TODO: remove these patches after https://github.com/jax-ml/jax/pull/23886
+@register_lowering(sin_p)
+def _sin_lowering2(ctx, x, accuracy):
+    """Use hlo.sine lowering instead of the new sin lowering from jax 0.4.28"""
+    return _nary_lower_hlo(hlo.sine, ctx, x, accuracy=accuracy)
+
+
+@register_lowering(cos_p)
+def _cos_lowering2(ctx, x, accuracy):
+    """Use hlo.cosine lowering instead of the new cosine lowering from jax 0.4.28"""
+    return _nary_lower_hlo(hlo.cosine, ctx, x, accuracy=accuracy)
+
+
+def extract_scalar(value, op, kind="parameter"):
+    """Utility function to extract real scalars from scalar tensors or one-element 1-D tensors."""
+    assert ir.RankedTensorType.isinstance(value.type)
+
+    baseType = ir.RankedTensorType(value.type).element_type
+    shape = ir.RankedTensorType(value.type).shape
+    if shape == []:
+        value = TensorExtractOp(baseType, value, []).result
+    elif shape == [1]:
+        c0 = ConstantOp(ir.IndexType.get(), 0)
+        value = TensorExtractOp(baseType, value, [c0]).result
+    else:
+        raise TypeError(f"Operator {op} expected a scalar {kind}, got tensor of shape {shape}")
+
+    return value
+
+
+def safe_cast_to_f64(value, op, kind="parameter"):
+    """Utility function to allow upcasting from integers and floats, while preventing downcasting
+    from larger bitwidths or complex numbers."""
+    assert ir.RankedTensorType.isinstance(value.type)
+
+    baseType = ir.RankedTensorType(value.type).element_type
+    if ir.ComplexType.isinstance(baseType) or (
+        ir.FloatType.isinstance(baseType) and ir.FloatType(baseType).width > 64
+    ):
+        raise TypeError(
+            f"Operator {op} expected a float64 {kind}, got {baseType}.\n"
+            "If you didn't specify this operator directly, it may have come from the decomposition "
+            "of a non-Unitary operator, such as an exponential with real exponent."
+        )
+
+    shape = ir.RankedTensorType(value.type).shape
+    if not ir.F64Type.isinstance(baseType):
+        targetBaseType = ir.F64Type.get()
+        targetTensorType = ir.RankedTensorType.get(shape, targetBaseType)
+        value = StableHLOConvertOp(targetTensorType, value).result
+
+    return value
+
+
+def _cast_to_index(p):
+    p = TensorExtractOp(
+        ir.RankedTensorType(p.type).element_type, p, []
+    ).result  # tensor<i64> -> i64
+    p = IndexCastOp(ir.IndexType.get(), p).result  # i64 -> index
+    return p

--- a/frontend/catalyst/primitive_lowering_rules.py
+++ b/frontend/catalyst/primitive_lowering_rules.py
@@ -201,6 +201,9 @@ CUSTOM_LOWERING_RULES = ()
 
 
 def get_custom_lowering_rules():
+    """
+    Get the custom lowering rules registry.
+    """
     return CUSTOM_LOWERING_RULES
 
 

--- a/frontend/catalyst/tracing/type_signatures.py
+++ b/frontend/catalyst/tracing/type_signatures.py
@@ -28,7 +28,7 @@ from jax._src.pjit import _flat_axes_specs
 from jax.core import AbstractValue
 from jax.tree_util import tree_flatten, tree_unflatten
 
-from catalyst.jax_extras import get_aval2
+from catalyst.jax_extras.patches import get_aval2
 from catalyst.utils.exceptions import CompileError
 from catalyst.utils.patching import Patcher
 

--- a/frontend/catalyst/utils/types.py
+++ b/frontend/catalyst/utils/types.py
@@ -20,8 +20,7 @@ import numpy as np
 from jax import numpy as jnp
 from jax._src.core import shaped_abstractify
 from jax._src.lib.mlir import ir
-
-from catalyst.jax_extras import ShapedArray
+from jax.core import ShapedArray
 
 
 def convert_shaped_arrays_to_tensors(sarrays: Sequence[ShapedArray]):

--- a/frontend/test/pytest/from_plxpr/test_from_plxpr.py
+++ b/frontend/test/pytest/from_plxpr/test_from_plxpr.py
@@ -26,12 +26,12 @@ from catalyst import qjit
 from catalyst.from_plxpr import from_plxpr
 from catalyst.jax_primitives import (
     adjoint_p,
-    get_call_jaxpr,
     qalloc_p,
     qextract_p,
     qinsert_p,
     qinst_p,
 )
+from catalyst.jax_primitives_utils import get_call_jaxpr
 
 pytestmark = pytest.mark.usefixtures("disable_capture")
 

--- a/frontend/test/pytest/test_jax_integration.py
+++ b/frontend/test/pytest/test_jax_integration.py
@@ -25,7 +25,7 @@ import pytest
 from jax.interpreters.mlir import ir
 
 from catalyst import for_loop, measure, qjit
-from catalyst.jax_extras.lowering import get_mlir_attribute_from_pyval
+from catalyst.jax_primitives_utils import get_mlir_attribute_from_pyval
 from catalyst.jit import JAX_QJIT
 from catalyst.utils.exceptions import CompileError
 

--- a/frontend/test/pytest/test_jax_primitives.py
+++ b/frontend/test/pytest/test_jax_primitives.py
@@ -25,7 +25,7 @@ from jax import make_jaxpr
 from jax._src.lib.mlir import ir
 from jax.interpreters.mlir import ir_constant, make_ir_context
 
-from catalyst.jax_primitives import (
+from catalyst.primitive_lowering_rules import (
     _qextract_lowering,
     _qinsert_lowering,
     extract_scalar,

--- a/frontend/test/pytest/test_mlir_plugin_interface.py
+++ b/frontend/test/pytest/test_mlir_plugin_interface.py
@@ -23,6 +23,7 @@ from jax.interpreters.mlir import ir
 
 import catalyst
 from catalyst import qjit
+from catalyst.jax_primitives_utils import _lowered_options
 
 
 def test_path_does_not_exists():
@@ -70,27 +71,27 @@ def test_pass_plugin_can_aot_compile():
         assert example.mlir
 
 
-def test_get_options():
+def test_lower_options():
     """
-    Test get_options from Pass
+    Test lower_options util function
 
     ApplyRegisteredPassOp expects options to be a dictionary from strings to attributes.
     See https://github.com/llvm/llvm-project/pull/143159
     """
     with ir.Context(), ir.Location.unknown():
-        options = catalyst.passes.Pass("example-pass", "single-option").get_options()
-        assert isinstance(options, dict)
+        options = _lowered_options(catalyst.passes.Pass("example-pass", "single-option"))
+        assert isinstance(options, ir.DictAttr)
         assert isinstance(options["single-option"], ir.BoolAttr)
         assert options["single-option"].value == True
 
-        options = catalyst.passes.Pass("example-pass", "an-option", "bn-option").get_options()
-        assert isinstance(options, dict)
+        options = _lowered_options(catalyst.passes.Pass("example-pass", "an-option", "bn-option"))
+        assert isinstance(options, ir.DictAttr)
         assert isinstance(options["an-option"], ir.BoolAttr)
         assert options["an-option"].value == True
         assert isinstance(options["bn-option"], ir.BoolAttr)
         assert options["bn-option"].value == True
 
-        options = catalyst.passes.Pass("example-pass", option=True).get_options()
-        assert isinstance(options, dict)
+        options = _lowered_options(catalyst.passes.Pass("example-pass", option=True))
+        assert isinstance(options, ir.DictAttr)
         assert isinstance(options["option"], ir.BoolAttr)
         assert options["option"].value == True


### PR DESCRIPTION
**Context:**
The `jax_primitives.py` file was getting too heavy.

**Description of the Change:**
Split the lowering rules out into their own file, `primitive_lowering_rules.py`.
Remove all `NotImplementedError()` on the primitives' unused `def_impl`.
Slightly improve import structure.
Delete a unused function `catalyst.Pass.get_options()`. 

**Benefits:**
Better organization.

