### PR TITLE
Bump PL version to 0.45.0.dev89

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.238
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.45.0-dev86
+pennylane=0.45.0-dev89
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -34,4 +34,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.45.0-dev21
 pennylane-lightning==0.45.0-dev21
-pennylane==0.45.0-dev86
+pennylane==0.45.0-dev89

--- a/frontend/test/pytest/test_specs.py
+++ b/frontend/test/pytest/test_specs.py
@@ -267,22 +267,19 @@ class TestPassByPassSpecs:
         no_passes = qjit(simple_circuit, capture=capture_mode)
         with pytest.raises(
             check=ValueError,
-            match="The 'level' argument to qml.specs for QJIT'd QNodes is out of "
-            "bounds, got -5.",
+            match="The 'level' argument to qp.specs for QJIT'd QNodes is out of " "bounds, got -5.",
         ):
             qp.specs(no_passes, level=-5)()
 
         with pytest.raises(
             check=ValueError,
-            match="The 'level' argument to qml.specs for QJIT'd "
-            "QNodes is out of bounds, got 10.",
+            match="The 'level' argument to qp.specs for QJIT'd " "QNodes is out of bounds, got 10.",
         ):
             qp.specs(no_passes, level=10)()
 
         with pytest.raises(
             check=ValueError,
-            match="The 'level' argument to qml.specs for QJIT'd "
-            "QNodes is out of bounds, got 10.",
+            match="The 'level' argument to qp.specs for QJIT'd " "QNodes is out of bounds, got 10.",
         ):
             qp.specs(no_passes, level=[10, 11])()
 
@@ -1225,7 +1222,7 @@ class TestMarkerIntegration:
 
         with pytest.warns(
             UserWarning,
-            match="The 'level' argument to qml.specs for QJIT'd QNodes has been sorted to be "
+            match="The 'level' argument to qp.specs for QJIT'd QNodes has been sorted to be "
             "in ascending order with no duplicate levels.",
         ):
             actual = qp.specs(simple_circuit, level=["m0", "m1", "m1-duplicate"])()


### PR DESCRIPTION
**Context:**
Bump PL version for something needed in the reference semantics work (https://github.com/PennyLaneAI/pennylane/pull/9336)

I wanted to separate this bump so that any potential issues can be dealt with separately, instead of being squashed into the already big reference semantics PR.