### PR TITLE
Add swap operation to quantum and qred dialects 

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -297,6 +297,7 @@
 
 * Register manupulation API has been added to the quantum dialect.
   [(#2654)](https://github.com/PennyLaneAI/catalyst/pull/2654)
+  [(#2770)](https://github.com/PennyLaneAI/catalyst/pull/2770)
 
 * A new native-MLIR graph-based decomposition framework is now available. This system
   migrates the graph-decomposition logic from Python into the Catalyst compiler as a

--- a/mlir/include/QRef/IR/QRefOps.td
+++ b/mlir/include/QRef/IR/QRefOps.td
@@ -158,6 +158,29 @@ def GetOp : Memory_Op<"get", [NoMemoryEffect]> {
     let hasFolder = 1;
 }
 
+def SwapOp : Memory_Op<"swap"> {
+    let summary = "Exchange a qubit at a register position with a standalone qubit.";
+    let description = [{
+        Exchanges the qubit at the given register position with the standalone
+        qubit. Both `qreg[idx]` and the referent of `qubit` are mutated in
+        place: after the op, each refers to what the other did before. No SSA
+        results are produced.
+    }];
+
+    let arguments = (ins
+        QuregRefType:$qreg,
+        Optional<I64>:$idx,
+        OptionalAttr<ConfinedAttr<I64Attr, [IntNonNegative]>>:$idx_attr,
+        QubitRefType:$qubit
+    );
+
+    let assemblyFormat = [{
+        $qreg `[` ($idx^):($idx_attr)? `]` `,` $qubit attr-dict `:` type($qreg) `,` type($qubit)
+    }];
+
+    let hasVerifier = 1;
+}
+
 // -----
 
 class Gate_Op<string mnemonic, list<Trait> traits = []> :

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -241,6 +241,34 @@ def InsertOp : Memory_Op<"insert", [NoMemoryEffect]> {
     let hasFolder = 1;
 }
 
+def SwapOp : Memory_Op<"swap", [NoMemoryEffect]> {
+    let summary = "Exchange a qubit at a register position with a standalone qubit.";
+    let description = [{
+        Writes the incoming qubit into the register at the given index and returns
+        both the updated register and the qubit that previously occupied that slot.
+        The input register and qubit are consumed; the result is a new register
+        value and the displaced qubit value.
+    }];
+
+    let arguments = (ins
+        QuregType:$in_qreg,
+        Optional<I64>:$idx,
+        OptionalAttr<ConfinedAttr<I64Attr, [IntNonNegative]>>:$idx_attr,
+        QubitType:$in_qubit
+    );
+
+    let results = (outs
+        QuregType:$out_qreg,
+        QubitType:$out_qubit
+    );
+
+    let assemblyFormat = [{
+        $in_qreg `[` ($idx^):($idx_attr)? `]` `,` $in_qubit attr-dict `:` type($in_qreg) `,` type($in_qubit)
+    }];
+
+    let hasVerifier = 1;
+}
+
 // -----
 
 class Gate_Op<string mnemonic, list<Trait> traits = []> :

--- a/mlir/lib/QRef/IR/QRefOps.cpp
+++ b/mlir/lib/QRef/IR/QRefOps.cpp
@@ -215,6 +215,17 @@ LogicalResult AllocOp::verify()
     return success();
 }
 
+LogicalResult SwapOp::verify()
+{
+    if (!(getIdx() || getIdxAttr().has_value())) {
+        return emitOpError() << "expected op to have a non-null index";
+    }
+    if (getIdx() && getIdxAttr().has_value()) {
+        return emitOpError() << "must have a single index";
+    }
+    return success();
+}
+
 LogicalResult CustomOp::verify()
 {
     if (getQubits().size() == 0) {

--- a/mlir/lib/Quantum/IR/QuantumOps.cpp
+++ b/mlir/lib/Quantum/IR/QuantumOps.cpp
@@ -228,6 +228,17 @@ LogicalResult InsertOp::verify()
     return success();
 }
 
+LogicalResult SwapOp::verify()
+{
+    if (!(getIdx() || getIdxAttr().has_value())) {
+        return emitOpError() << "expected op to have a non-null index";
+    }
+    if (getIdx() && getIdxAttr().has_value()) {
+        return emitOpError() << "must have a single index";
+    }
+    return success();
+}
+
 static LogicalResult verifyObservable(Value obs, std::optional<size_t> &numQubits)
 {
     if (auto compOp = obs.getDefiningOp<ComputationalBasisOp>()) {

--- a/mlir/test/QRef/UnitTests.mlir
+++ b/mlir/test/QRef/UnitTests.mlir
@@ -64,6 +64,19 @@ func.func @test_get(%arg0 : !qref.reg<10>, %arg1: i64) {
 
 // -----
 
+func.func @test_swap(%arg0 : !qref.reg<10>, %q : !qref.bit, %arg1 : i64) {
+
+    // Static
+    qref.swap %arg0[3], %q : !qref.reg<10>, !qref.bit
+
+    // Dynamic
+    qref.swap %arg0[%arg1], %q : !qref.reg<10>, !qref.bit
+
+    return
+}
+
+// -----
+
 func.func @test_set_state(%arg0 : tensor<2xcomplex<f64>>, %q0: !qref.bit) {
     qref.set_state(%arg0) %q0 : tensor<2xcomplex<f64>>, !qref.bit
     return

--- a/mlir/test/QRef/VerifierTests.mlir
+++ b/mlir/test/QRef/VerifierTests.mlir
@@ -241,3 +241,20 @@ func.func @test_mbqc_graph_state_prep_invalid_size() {
     %graph_reg = qref.mbqc.graph_state_prep (%adj_matrix : tensor<1xi1>) [init "Hadamard", entangle "CZ"] : !qref.reg<4>
     func.return
 }
+
+// -----
+
+func.func @test_swap_no_index(%r : !qref.reg<4>, %q : !qref.bit) {
+    // expected-error@+1 {{expected op to have a non-null index}}
+    "qref.swap"(%r, %q) : (!qref.reg<4>, !qref.bit) -> ()
+    return
+}
+
+// -----
+
+func.func @test_swap_negative_index(%q : !qref.bit) {
+    %r = qref.alloc(4) : !qref.reg<4>
+    // expected-error @+1 {{failed to satisfy constraint: 64-bit signless integer attribute whose value is non-negative}}
+    qref.swap %r[-1], %q : !qref.reg<4>, !qref.bit
+    return
+}

--- a/mlir/test/Quantum/SwapTest.mlir
+++ b/mlir/test/Quantum/SwapTest.mlir
@@ -1,0 +1,33 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RUN: quantum-opt --split-input-file %s | quantum-opt | FileCheck %s
+
+// CHECK-LABEL: @test_swap_static
+func.func @test_swap_static(%q_extra : !quantum.bit) -> (!quantum.reg, !quantum.bit) {
+    %r = quantum.alloc(4) : !quantum.reg
+    // CHECK: %{{.*}}, %{{.*}} = quantum.swap %{{.*}}[ 1], %{{.*}} : !quantum.reg, !quantum.bit
+    %r1, %q_displaced = quantum.swap %r[1], %q_extra : !quantum.reg, !quantum.bit
+    return %r1, %q_displaced : !quantum.reg, !quantum.bit
+}
+
+// -----
+
+// CHECK-LABEL: @test_swap_dynamic
+func.func @test_swap_dynamic(%q_extra : !quantum.bit, %i : i64) -> (!quantum.reg, !quantum.bit) {
+    %r = quantum.alloc(4) : !quantum.reg
+    // CHECK: %{{.*}}, %{{.*}} = quantum.swap %{{.*}}[%{{.*}}], %{{.*}} : !quantum.reg, !quantum.bit
+    %r1, %q_displaced = quantum.swap %r[%i], %q_extra : !quantum.reg, !quantum.bit
+    return %r1, %q_displaced : !quantum.reg, !quantum.bit
+}

--- a/mlir/test/Quantum/VerifierTest.mlir
+++ b/mlir/test/Quantum/VerifierTest.mlir
@@ -50,6 +50,23 @@ quantum.dealloc %r1 : !quantum.reg
 
 // -----
 
+func.func @test_swap_no_index(%r : !quantum.reg, %q : !quantum.bit) -> (!quantum.reg, !quantum.bit) {
+    // expected-error@+1 {{expected op to have a non-null index}}
+    %r1, %q_displaced = "quantum.swap"(%r, %q) : (!quantum.reg, !quantum.bit) -> (!quantum.reg, !quantum.bit)
+    return %r1, %q_displaced : !quantum.reg, !quantum.bit
+}
+
+// -----
+
+func.func @test_swap_negative_index(%q : !quantum.bit) {
+    %r = quantum.alloc(4) : !quantum.reg
+    // expected-error @+1 {{failed to satisfy constraint: 64-bit signless integer attribute whose value is non-negative}}
+    %r1, %q_displaced = quantum.swap %r[-1], %q : !quantum.reg, !quantum.bit
+    return
+}
+
+// -----
+
 ///////////
 // Gates //
 ///////////


### PR DESCRIPTION
**Context:**
Catalyst's IR has no mean for moving qubits between registers. As part of the enhanced registers's design register manipulation API, this PR adds the swap op in both qref and quantum dialects, with op definitions only for now.

**Description of the Change:**
Added `quantum.swap` and `qref.swap`

**Benefits:**
Enables software-level qubit relocation in the IR

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-116151]