### PR TITLE
Add `combine_global_phase` to `passes`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -291,9 +291,10 @@
   [(#2660)](https://github.com/PennyLaneAI/catalyst/pull/2660)
 
 * A new optimization pass has been added to reduce the number of instructions in a quantum program,
-  `--merge-global-phase`, which safely combines global phase instructions for each region in the
+  `--combine-global-phase`, which safely combines global phase instructions for each region in the
   program. The xDSL version written in Python has been removed.
   [(#2604)](https://github.com/PennyLaneAI/catalyst/pull/2604)
+  [(#???)](https://github.com/PennyLaneAI/catalyst/pull/???)
 
 * A new native-MLIR graph-based decomposition framework is now available. This system
   migrates the graph-decomposition logic from Python into the Catalyst compiler as a

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -294,7 +294,7 @@
   `--combine-global-phase`, which safely combines global phase instructions for each region in the
   program. The xDSL version written in Python has been removed.
   [(#2604)](https://github.com/PennyLaneAI/catalyst/pull/2604)
-  [(#???)](https://github.com/PennyLaneAI/catalyst/pull/???)
+  [(#2777)](https://github.com/PennyLaneAI/catalyst/pull/2777)
 
 * A new native-MLIR graph-based decomposition framework is now available. This system
   migrates the graph-decomposition logic from Python into the Catalyst compiler as a

--- a/frontend/catalyst/passes/__init__.py
+++ b/frontend/catalyst/passes/__init__.py
@@ -65,6 +65,7 @@ __all__ = (
     "ppm_specs",
     "reduce_t_depth",
     "decompose_arbitrary_ppr",
+    "combine_global_phases",
     "cancel_inverses",
     "merge_rotations",
     "diagonalize_measurements",

--- a/frontend/catalyst/passes/__init__.py
+++ b/frontend/catalyst/passes/__init__.py
@@ -35,6 +35,7 @@ as load and run external MLIR passes from plugins.
 
 from catalyst.passes.builtin_passes import (
     cancel_inverses,
+    combine_global_phases,
     commute_ppr,
     decompose_arbitrary_ppr,
     diagonalize_measurements,

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -609,6 +609,111 @@ ions_decomposition = qp.transform(
 )
 
 
+def combine_global_phases_setup_inputs():  # pragma: nocover
+    r"""A quantum compilation pass that combines global phase instructions for each region in the
+    program.
+
+    Args:
+        qnode (QNode): the QNode to apply the compiler pass to
+
+    Returns:
+        :class:`QNode <pennylane.QNode>`
+
+    **Example**
+
+    In this example, the ``GlobalPhase`` gates are merged together into one ``GlobalPhase``
+    operation.
+
+    .. code-block:: python
+
+        import pennylane as qp
+        import catalyst
+        from catalyst import qjit, for_loop
+        from catalyst.passes import combine_global_phases
+        from catalyst.debug import get_compilation_stage
+
+        n = 10
+        dev = qp.device('null.qubit', wires=n)
+
+        @qjit(keep_intermediate=True, capture=True)
+        @combine_global_phases
+        @qp.qnode(dev)
+        def circuit(n):
+            qp.GlobalPhase(0.1, wires = n-1)
+            qp.X(n-1)
+            qp.GlobalPhase(0.1, wires = n-2)
+            qp.H(n-2)
+
+            @qp.for_loop(0, n)
+            def loop(i):
+                qp.GlobalPhase(0.1967, wires=i)
+                qp.GlobalPhase(0.7691, wires=i)
+
+            loop()
+
+            qp.GlobalPhase(0.1, wires=n-3)
+            qp.GlobalPhase(0.1, wires=0)
+
+            return qp.expval(qp.Z(0))
+
+    >>> circuit(n)
+    0.0
+
+    The ``GlobalPhase`` operations surrounding control flow operations will be merged, while those
+    within the control flow are merged together separately (i.e., no formal loop-boundary
+    optimizations).
+
+    Example MLIR Representation:
+
+    >>> print(get_compilation_stage(circuit, stage="QuantumCompilationStage"))
+
+    .. code-block:: mlir
+
+        . . .
+        %extracted_4 = tensor.extract %3[] : tensor<i64>
+        %5 = quantum.extract %4[%extracted_4] : !quantum.reg -> !quantum.bit
+        %out_qubits = quantum.custom "PauliX"() %5 : !quantum.bit
+        %6 = stablehlo.subtract %arg0, %c_1 : tensor<i64>
+        %extracted_5 = tensor.extract %3[] : tensor<i64>
+        %7 = quantum.insert %4[%extracted_5], %out_qubits : !quantum.reg, !quantum.bit
+        %extracted_6 = tensor.extract %6[] : tensor<i64>
+        %8 = quantum.extract %7[%extracted_6] : !quantum.reg -> !quantum.bit
+        %9 = stablehlo.subtract %arg0, %c_1 : tensor<i64>
+        %extracted_7 = tensor.extract %6[] : tensor<i64>
+        %10 = quantum.insert %7[%extracted_7], %8 : !quantum.reg, !quantum.bit
+        %extracted_8 = tensor.extract %9[] : tensor<i64>
+        %11 = quantum.extract %10[%extracted_8] : !quantum.reg -> !quantum.bit
+        %out_qubits_9 = quantum.custom "Hadamard"() %11 : !quantum.bit
+        %extracted_10 = tensor.extract %9[] : tensor<i64>
+        %12 = quantum.insert %10[%extracted_10], %out_qubits_9 : !quantum.reg, !quantum.bit
+        %extracted_11 = tensor.extract %arg0[] : tensor<i64>
+        %13 = arith.index_cast %extracted_11 : i64 to index
+        %14 = scf.for %arg1 = %c0 to %13 step %c1 iter_args(%arg2 = %12) -> (!quantum.reg) {
+        %22 = arith.index_cast %arg1 : index to i64
+        %23 = quantum.extract %arg2[%22] : !quantum.reg -> !quantum.bit
+        quantum.gphase(%cst_0)
+        %24 = quantum.insert %arg2[%22], %23 : !quantum.reg, !quantum.bit
+        scf.yield %24 : !quantum.reg
+        }
+        %15 = stablehlo.subtract %arg0, %c : tensor<i64>
+        %extracted_12 = tensor.extract %15[] : tensor<i64>
+        %16 = quantum.extract %14[%extracted_12] : !quantum.reg -> !quantum.bit
+        %extracted_13 = tensor.extract %15[] : tensor<i64>
+        %17 = quantum.insert %14[%extracted_13], %16 : !quantum.reg, !quantum.bit
+        %18 = quantum.extract %17[ 0] : !quantum.reg -> !quantum.bit
+        quantum.gphase(%cst)
+        %19 = quantum.namedobs %18[ PauliZ] : !quantum.obs
+        %20 = quantum.expval %19 : f64
+        . . .
+    """
+    return (), {}
+
+
+combine_global_phases = qp.transform(
+    pass_name="combie-global-phases", setup_inputs=combine_global_phases_setup_inputs
+)
+
+
 def gridsynth_setup_inputs(epsilon=1e-4, ppr_basis=False):
     r"""A quantum compilation pass to discretize
     single-qubit RZ and PhaseShift gates into the Clifford+T basis or the PPR basis using the Ross-Selinger Gridsynth algorithm.
@@ -1725,6 +1830,7 @@ graph_decomposition = qp.transform(
 
 __all__ = [
     "cancel_inverses",
+    "combine_global_phases",
     "disentangle_cnot",
     "disentangle_swap",
     "merge_rotations",

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -609,7 +609,7 @@ ions_decomposition = qp.transform(
 )
 
 
-def combine_global_phases_setup_inputs():  # pragma: nocover
+def combine_global_phases_setup_inputs(): 
     r"""A quantum compilation pass that combines global phase instructions for each region in the
     program.
 

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -609,7 +609,7 @@ ions_decomposition = qp.transform(
 )
 
 
-def combine_global_phases_setup_inputs(): 
+def combine_global_phases_setup_inputs():
     r"""A quantum compilation pass that combines global phase instructions for each region in the
     program.
 

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -621,8 +621,7 @@ def combine_global_phases_setup_inputs():  # pragma: nocover
 
     **Example**
 
-    In this example, the ``GlobalPhase`` gates are merged together into one ``GlobalPhase``
-    operation.
+    Consider the following example:
 
     .. code-block:: python
 
@@ -710,7 +709,7 @@ def combine_global_phases_setup_inputs():  # pragma: nocover
 
 
 combine_global_phases = qp.transform(
-    pass_name="combie-global-phases", setup_inputs=combine_global_phases_setup_inputs
+    pass_name="combine-global-phases", setup_inputs=combine_global_phases_setup_inputs
 )
 
 

--- a/frontend/test/pytest/test_builtin_passes.py
+++ b/frontend/test/pytest/test_builtin_passes.py
@@ -46,13 +46,13 @@ def assert_valid_transform(obj: Any) -> None:
     assert pipeline[0].pass_name == pass_name
 
 
-_PASS_NAME_SPECIAL_CASES = {"diagonalize_measurements": "diagonalize-final-measurements"}
 
 
 @pytest.mark.parametrize("name", builtin_passes.__all__)
 def test_pass_name_matches_variable_name(name):
     """Tests that the variable name is just the pass name but snake case."""
 
+    _PASS_NAME_SPECIAL_CASES = {"diagonalize_measurements": "diagonalize-final-measurements"}
     obj = getattr(builtin_passes, name)
     expected_pass_name = _PASS_NAME_SPECIAL_CASES.get(name, name.replace("_", "-"))
     assert obj.pass_name == expected_pass_name
@@ -66,7 +66,6 @@ def test_passes_are_valid_transforms(name):
     assert_valid_transform(obj)
 
 
-_PASSES_WITH_ARGS_KWARGS = {"graph-decomposition": ((), {"gate_set": ()})}
 
 
 @pytest.mark.parametrize("name", builtin_passes.__all__)
@@ -76,6 +75,7 @@ def test_pass_compiles_with_qjit(name):
 
     transform = getattr(builtin_passes, name)
 
+    _PASSES_WITH_ARGS_KWARGS = {"graph-decomposition": ((), {"gate_set": ()})}
     args, kwargs = _PASSES_WITH_ARGS_KWARGS.get(obj.pass_name, ((), {}))
 
     bound_obj = obj

--- a/frontend/test/pytest/test_builtin_passes.py
+++ b/frontend/test/pytest/test_builtin_passes.py
@@ -72,17 +72,17 @@ def test_pass_compiles_with_qjit(name):
     transform = getattr(builtin_passes, name)
 
     _PASSES_WITH_ARGS_KWARGS = {"graph-decomposition": ((), {"gate_set": ()})}
-    args, kwargs = _PASSES_WITH_ARGS_KWARGS.get(obj.pass_name, ((), {}))
+    args, kwargs = _PASSES_WITH_ARGS_KWARGS.get(transform.pass_name, ((), {}))
 
-    bound_obj = obj
+    bound_transform = transform
     if args or kwargs:
-        bound_obj = obj(*args, **kwargs)
+        bound_transform = transform(*args, **kwargs)
 
     @qp.qjit(target="mlir")
-    @bound_obj
+    @bound_transform
     @qp.qnode(qp.device("null.qubit", wires=1))
     def circuit():
         qp.H(0)
         return qp.expval(qp.Z(0))
 
-    assert obj.pass_name in circuit.mlir
+    assert transform.pass_name in circuit.mlir

--- a/frontend/test/pytest/test_builtin_passes.py
+++ b/frontend/test/pytest/test_builtin_passes.py
@@ -45,6 +45,18 @@ def assert_valid_transform(obj: Any) -> None:
     assert pipeline[0].pass_name == pass_name
 
 
+_PASS_NAME_SPECIAL_CASES = {"diagonalize_measurements": "diagonalize-final-measurements"}
+
+
+@pytest.mark.parametrize("name", builtin_passes.__all__)
+def test_pass_name_matches_variable_name(name):
+    """Tests that the variable name is just the pass name but snake case."""
+
+    obj = getattr(builtin_passes, name)
+    expected_pass_name = _PASS_NAME_SPECIAL_CASES.get(name, name.replace("_", "-"))
+    assert obj.pass_name == expected_pass_name
+
+
 @pytest.mark.parametrize("name", builtin_passes.__all__)
 def test_passes_are_valid_transforms(name):
     """Tests that these passes are valid transform objects."""

--- a/frontend/test/pytest/test_builtin_passes.py
+++ b/frontend/test/pytest/test_builtin_passes.py
@@ -46,8 +46,6 @@ def assert_valid_transform(obj: Any) -> None:
     assert pipeline[0].pass_name == pass_name
 
 
-
-
 @pytest.mark.parametrize("name", builtin_passes.__all__)
 def test_pass_name_matches_variable_name(name):
     """Tests that the variable name is just the pass name but snake case."""
@@ -64,8 +62,6 @@ def test_passes_are_valid_transforms(name):
 
     obj = getattr(builtin_passes, name)
     assert_valid_transform(obj)
-
-
 
 
 @pytest.mark.parametrize("name", builtin_passes.__all__)

--- a/frontend/test/pytest/test_builtin_passes.py
+++ b/frontend/test/pytest/test_builtin_passes.py
@@ -68,7 +68,8 @@ def test_passes_are_valid_transforms(name):
 
 @pytest.mark.parametrize("name", builtin_passes.__all__)
 def test_pass_compiles_with_qjit(name):
-    """Basic smoke test."""
+    """Basic smoke test to ensure proper compilation. For example, if a pass name
+    was incorrect this would fail."""
 
     obj = getattr(builtin_passes, name)
 

--- a/frontend/test/pytest/test_builtin_passes.py
+++ b/frontend/test/pytest/test_builtin_passes.py
@@ -80,4 +80,4 @@ def test_pass_compiles_with_qjit(name):
         qp.H(0)
         return qp.expval(qp.Z(0))
 
-    circuit()
+    assert name.replace("_", "-") in circuit.mlir

--- a/frontend/test/pytest/test_builtin_passes.py
+++ b/frontend/test/pytest/test_builtin_passes.py
@@ -74,7 +74,7 @@ def test_pass_compiles_with_qjit(name):
     """Basic smoke test to ensure proper compilation. For example, if a pass name
     was incorrect this would fail."""
 
-    obj = getattr(builtin_passes, name)
+    transform = getattr(builtin_passes, name)
 
     args, kwargs = _PASSES_WITH_ARGS_KWARGS.get(obj.pass_name, ((), {}))
 

--- a/frontend/test/pytest/test_builtin_passes.py
+++ b/frontend/test/pytest/test_builtin_passes.py
@@ -16,6 +16,7 @@
 import inspect
 from typing import Any
 
+import pennylane as qp
 import pytest
 from pennylane.transforms.core import CompilePipeline, Transform
 
@@ -63,3 +64,19 @@ def test_passes_are_valid_transforms(name):
 
     obj = getattr(builtin_passes, name)
     assert_valid_transform(obj)
+
+
+@pytest.mark.parametrize("name", builtin_passes.__all__)
+def test_pass_compiles_with_qjit(name):
+    """Basic smoke test."""
+
+    obj = getattr(builtin_passes, name)
+
+    @qp.qjit(target="mlir")
+    @obj
+    @qp.qnode(qp.device("null.qubit", wires=1))
+    def circuit():
+        qp.H(0)
+        return qp.expval(qp.Z(0))
+
+    circuit()

--- a/frontend/test/pytest/test_builtin_passes.py
+++ b/frontend/test/pytest/test_builtin_passes.py
@@ -78,8 +78,12 @@ def test_pass_compiles_with_qjit(name):
 
     args, kwargs = _PASSES_WITH_ARGS_KWARGS.get(obj.pass_name, ((), {}))
 
+    bound_obj = obj
+    if args or kwargs:
+        bound_obj = obj(*args, **kwargs)
+
     @qp.qjit(target="mlir")
-    @obj(*args, **kwargs)
+    @bound_obj
     @qp.qnode(qp.device("null.qubit", wires=1))
     def circuit():
         qp.H(0)

--- a/frontend/test/pytest/test_builtin_passes.py
+++ b/frontend/test/pytest/test_builtin_passes.py
@@ -66,6 +66,9 @@ def test_passes_are_valid_transforms(name):
     assert_valid_transform(obj)
 
 
+_PASSES_WITH_ARGS_KWARGS = {"graph-decomposition": ((), {"gate_set": ()})}
+
+
 @pytest.mark.parametrize("name", builtin_passes.__all__)
 def test_pass_compiles_with_qjit(name):
     """Basic smoke test to ensure proper compilation. For example, if a pass name
@@ -73,11 +76,13 @@ def test_pass_compiles_with_qjit(name):
 
     obj = getattr(builtin_passes, name)
 
+    args, kwargs = _PASSES_WITH_ARGS_KWARGS.get(obj.pass_name, ((), {}))
+
     @qp.qjit(target="mlir")
-    @obj
+    @obj(*args, **kwargs)
     @qp.qnode(qp.device("null.qubit", wires=1))
     def circuit():
         qp.H(0)
         return qp.expval(qp.Z(0))
 
-    assert name.replace("_", "-") in circuit.mlir
+    assert obj.pass_name in circuit.mlir


### PR DESCRIPTION
**Context:** https://github.com/PennyLaneAI/catalyst/pull/2604 added the pass to the CLI, but we should have the pass available in the ``passes`` module.

**Description of the Change:** Adds `combine_global_phase` to ``passes`` module.

**Benefits:** Better access for users (don't have to use the pass via ``qp.transforms(pass_name="combine-global-phases")``)

**Possible Drawbacks:**

**Related GitHub Issues:** [sc-113790](https://app.shortcut.com/xanaduai/story/113790/parity-synth-and-combine-global-phases-in-the-passes-module)
