### PR TITLE
Dynamic one shot pass works with dynamically shaped samples

### DIFF
--- a/doc/releases/changelog-0.15.0.md
+++ b/doc/releases/changelog-0.15.0.md
@@ -55,6 +55,7 @@ codes only.
   from all shots.
   [(#2458)](https://github.com/PennyLaneAI/catalyst/pull/2458)
   [(#2573)](https://github.com/PennyLaneAI/catalyst/pull/2573)
+  [(#2786)](https://github.com/PennyLaneAI/catalyst/pull/2786)
 
   With this new MLIR pass, one shot execution mode is now available when capture is enabled.
 

--- a/frontend/test/pytest/test_mid_circuit_measurement.py
+++ b/frontend/test/pytest/test_mid_circuit_measurement.py
@@ -1256,16 +1256,41 @@ class TestDynamicOneShotMLIRPass:
         assert counts.shape == (2,)
         assert np.allclose(counts, [500, 500], atol=10)
 
-    def test_mlir_one_shot_pass_dynamic_shots(self, backend):
+    def test_mlir_one_shot_pass_dynamic_shots_sample(self, backend):
         """
         Test that the mlir implementation of --dynamic-one-shot pass can be used from frontend with
-        a dynamic number of shots.
+        a dynamic number of shots with sample terminal MP.
         """
 
         @qjit(capture=True, seed=12345)
         def workflow(shots):
             @qp.transform(pass_name="dynamic-one-shot")
-            @qp.qnode(qp.device(backend, wires=2), shots=shots)
+            @qp.set_shots(shots)
+            @qp.qnode(qp.device(backend, wires=2))
+            def circuit():
+                return qp.sample(), qp.sample(wires=[0])
+
+            return circuit()
+
+        res = workflow(37)
+        assert res[0].shape == (37, 2)
+        assert res[1].shape == (37, 1)
+
+        res = workflow(42)
+        assert res[0].shape == (42, 2)
+        assert res[1].shape == (42, 1)
+
+    def test_mlir_one_shot_pass_dynamic_shots_counts(self, backend):
+        """
+        Test that the mlir implementation of --dynamic-one-shot pass can be used from frontend with
+        a dynamic number of shots with counts terminal MP.
+        """
+
+        @qjit(capture=True, seed=12345)
+        def workflow(shots):
+            @qp.transform(pass_name="dynamic-one-shot")
+            @qp.set_shots(shots)
+            @qp.qnode(qp.device(backend, wires=2))
             def circuit():
                 qp.Hadamard(wires=0)
                 return qp.counts(all_outcomes=True)

--- a/mlir/lib/Quantum/Transforms/dynamic_one_shot.cpp
+++ b/mlir/lib/Quantum/Transforms/dynamic_one_shot.cpp
@@ -88,12 +88,9 @@ void getMPDynamicNumQubitsSizeValues(func::FuncOp qnodeFunc, llvm::SmallPtrSet<V
 
     qnodeFunc->walk([&](quantum::SampleOp sampleOp) {
         ArrayRef<int64_t> shape = cast<ShapedType>(sampleOp.getSamples().getType()).getShape();
-        if ((shape.size() == 2) && ShapedType::isDynamic(shape[1])) {
-            if (ShapedType::isDynamic(shape[0])) {
-                vals.insert(sampleOp.getDynamicShape()[1]);
-            }
-            else {
-                vals.insert(sampleOp.getDynamicShape()[0]);
+        for (auto [i, dim] : llvm::enumerate(shape)) {
+            if (ShapedType::isDynamic(dim)) {
+                vals.insert(sampleOp.getDynamicShape()[i]);
             }
         }
     });


### PR DESCRIPTION
**Context:**
In dynamic one shot pass, fix a small logic error when collecting the SSA values for the dynamic dimensions on sample ops.

I have no idea what the old logic was doing :sweat_smile: (yeah I know I wrote it)
