### PR TITLE
PR3: Install RC PL and Lightning when on RC branch

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -12,4 +12,4 @@ pennylane=0.45.0-dev94
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'
-lightning=0.45.0-dev43
+lightning=0.45.0-dev44

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -31,7 +31,14 @@ matplotlib==3.10.0
 lxml_html_clean
 
 # Pre-install PL development wheels
---extra-index-url https://test.pypi.org/simple/
-pennylane-lightning-kokkos==0.45.0-dev43
-pennylane-lightning==0.45.0-dev43
-pennylane==0.45.0-dev94
+# --extra-index-url https://test.pypi.org/simple/
+# pennylane-lightning-kokkos==0.45.0-dev43
+# pennylane-lightning==0.45.0-dev43
+# pennylane==0.45.0-dev94
+
+# If targeting RC branch, we must install latest RC packages from TestPyPI
+# Revert when merging RC branch back to main, and uncomment the above regular requirements
+--pre --extra-index-url https://test.pypi.org/simple/
+pennylane-lightning-kokkos>=0.45.0rc0,<=0.45.0
+pennylane-lightning>=0.45.0rc0,<=0.45.0
+pennylane>=0.45.0rc0,<=0.45.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -39,6 +39,6 @@ lxml_html_clean
 # If targeting RC branch, we must install latest RC packages from TestPyPI
 # Revert when merging RC branch back to main, and uncomment the above regular requirements
 --pre --extra-index-url https://test.pypi.org/simple/
-pennylane-lightning-kokkos>=0.45.0rc0,<=0.45.0
-pennylane-lightning>=0.45.0rc0,<=0.45.0
+pennylane-lightning-kokkos>=0.45.0rc2,<=0.45.0
+pennylane-lightning>=0.45.0rc2,<=0.45.0
 pennylane>=0.45.0rc0,<=0.45.0

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,12 @@ else:
     lightning_dep = f"pennylane-lightning>={lq_min_release}"
     kokkos_dep = ""
 
+# If targeting RC branch, we must install latest RC packages from TestPyPI
+# Revert when merging RC branch back to main
+pennylane_dep = f"pennylane>=0.45.0rc0,<=0.45.0"
+lightning_dep = f"pennylane-lightning>=0.45.0rc0,<=0.45.0"
+kokkos_dep = f"pennylane-lightning-kokkos>=0.45.0rc0,<=0.45.0"
+
 requirements = [
     pennylane_dep,
     lightning_dep,

--- a/setup.py
+++ b/setup.py
@@ -124,8 +124,8 @@ else:
 # If targeting RC branch, we must install latest RC packages from TestPyPI
 # Revert when merging RC branch back to main
 pennylane_dep = f"pennylane>=0.45.0rc0,<=0.45.0"
-lightning_dep = f"pennylane-lightning>=0.45.0rc0,<=0.45.0"
-kokkos_dep = f"pennylane-lightning-kokkos>=0.45.0rc0,<=0.45.0"
+lightning_dep = f"pennylane-lightning>=0.45.0rc2,<=0.45.0"
+kokkos_dep = f"pennylane-lightning-kokkos>=0.45.0rc2,<=0.45.0"
 
 requirements = [
     pennylane_dep,


### PR DESCRIPTION
Context:
In setup.py, we install RC PL and Lightning packages. This only occurs for the rc branch.
For PRs targeting RC branch as base, locally make frontend will now automatically install RC PL and Lightning!

Note that starting from the previous release, we sync all versioning from testpypi. There will be no more git-based installations.

Note that when merging rc branch back to main after the release, this PR must be reverted for .dep_versions to take back control of the versions.