### PR TITLE
Prepare for Catalyst RC v0.15.0 (update lightning dev)

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -12,4 +12,4 @@ pennylane=0.45.0-dev94
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'
-lightning=0.45.0-dev43
+lightning=0.45.0-dev44

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -32,6 +32,6 @@ lxml_html_clean
 
 # Pre-install PL development wheels
 --extra-index-url https://test.pypi.org/simple/
-pennylane-lightning-kokkos==0.45.0-dev43
-pennylane-lightning==0.45.0-dev43
+pennylane-lightning-kokkos==0.45.0-dev44
+pennylane-lightning==0.45.0-dev44
 pennylane==0.45.0-dev94


### PR DESCRIPTION
lightning=0.45.0-dev43 is broken during uploading, so using dev44 instead.
