### PR TITLE
Fix that pass-plugin path never be forwarded

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -348,9 +348,6 @@ endif
 ifeq ($(ENABLE_OQD), ON)
 	COVERAGE_FILE=$(MK_DIR)/.coverage.pytest $(ASAN_COMMAND) $(PYTHON) -m pytest frontend/test/test_oqd/oqd $(PYTEST_FLAGS) --cov=catalyst --cov-append --tb=native --cov-report=
 endif
-	$(MAKE) plugin-wheel
-	$(PYTHON) -m pip install --force-reinstall --no-deps $(MK_DIR)/standalone_plugin_wheel/dist/*.whl
-	COVERAGE_FILE=$(MK_DIR)/.coverage.pytest $(ASAN_COMMAND) $(PYTHON) -m pytest standalone_plugin_wheel/standalone_plugin/test $(PYTEST_FLAGS) --cov=catalyst --cov-append --tb=native --cov-report=
 	$(ASAN_COMMAND) $(MAKE) lit-coverage
 	$(PYTHON) -m coverage combine --data-file=$(MK_DIR)/.coverage.combined $(MK_DIR)/.coverage.lit $(MK_DIR)/.coverage.pytest
 	@echo "=== Generating final coverage report with format: $(COVERAGE_REPORT) ==="

--- a/Makefile
+++ b/Makefile
@@ -348,6 +348,9 @@ endif
 ifeq ($(ENABLE_OQD), ON)
 	COVERAGE_FILE=$(MK_DIR)/.coverage.pytest $(ASAN_COMMAND) $(PYTHON) -m pytest frontend/test/test_oqd/oqd $(PYTEST_FLAGS) --cov=catalyst --cov-append --tb=native --cov-report=
 endif
+	$(MAKE) plugin-wheel
+	$(PYTHON) -m pip install --force-reinstall --no-deps $(MK_DIR)/standalone_plugin_wheel/dist/*.whl
+	COVERAGE_FILE=$(MK_DIR)/.coverage.pytest $(ASAN_COMMAND) $(PYTHON) -m pytest standalone_plugin_wheel/standalone_plugin/test $(PYTEST_FLAGS) --cov=catalyst --cov-append --tb=native --cov-report=
 	$(ASAN_COMMAND) $(MAKE) lit-coverage
 	$(PYTHON) -m coverage combine --data-file=$(MK_DIR)/.coverage.combined $(MK_DIR)/.coverage.lit $(MK_DIR)/.coverage.pytest
 	@echo "=== Generating final coverage report with format: $(COVERAGE_REPORT) ==="

--- a/doc/releases/changelog-0.15.0.md
+++ b/doc/releases/changelog-0.15.0.md
@@ -693,6 +693,10 @@ codes only.
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a bug where the `path_to_plugin` never be forwarded in :func:`~.passes.apply_pass_plugin`. The plugin path is now registered with the compiler during tracing.
+  [(#2790)](https://github.com/PennyLaneAI/catalyst/pull/2790)
+
+
 * Refactored all passes in `catalyst.passes.builtin_passes.py` to be `pennylane.transforms.core.Transform` objects
   rather than decorators. This allows them to be used as standard transforms, enabling full compatibility with
   `pennylane.CompilePipeline`.

--- a/frontend/catalyst/passes/pass_api.py
+++ b/frontend/catalyst/passes/pass_api.py
@@ -190,7 +190,14 @@ def apply_pass_plugin(path_to_plugin: str | Path, pass_name: str, *flags, **valu
         raise FileNotFoundError(f"File '{path_to_plugin}' does not exist.")
 
     def decorator(obj):
-        return transform(pass_name=pass_name)(obj, *flags, **valued_options)
+        transformed = transform(pass_name=pass_name)(obj, *flags, **valued_options)
+
+        def wrapper(*args, **kwargs):
+            if EvaluationContext.is_tracing():
+                EvaluationContext.add_plugin(path_to_plugin)
+            return transformed(*args, **kwargs)
+
+        return wrapper
 
     return decorator
 

--- a/frontend/catalyst/passes/pass_api.py
+++ b/frontend/catalyst/passes/pass_api.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 from copy import copy
+from functools import wraps
 from importlib.metadata import entry_points
 from pathlib import Path
 from typing import TypeAlias
-from functools import wraps
 
 from pennylane.transforms.core import BoundTransform, CompilePipeline, transform
 

--- a/frontend/catalyst/passes/pass_api.py
+++ b/frontend/catalyst/passes/pass_api.py
@@ -16,6 +16,7 @@ from copy import copy
 from importlib.metadata import entry_points
 from pathlib import Path
 from typing import TypeAlias
+from functools import wraps
 
 from pennylane.transforms.core import BoundTransform, CompilePipeline, transform
 
@@ -192,6 +193,7 @@ def apply_pass_plugin(path_to_plugin: str | Path, pass_name: str, *flags, **valu
     def decorator(obj):
         transformed = transform(pass_name=pass_name)(obj, *flags, **valued_options)
 
+        @wraps(transformed)
         def wrapper(*args, **kwargs):
             if EvaluationContext.is_tracing():
                 EvaluationContext.add_plugin(path_to_plugin)

--- a/standalone_plugin_wheel/standalone_plugin/test/test_mlir_plugin.py
+++ b/standalone_plugin_wheel/standalone_plugin/test/test_mlir_plugin.py
@@ -72,7 +72,7 @@ def test_standalone_plugin_no_preregistration():
 
 
 @pytest.mark.skipif(not have_standalone_plugin, reason="Standalone Plugin is not installed")
-def test_standalone_plugin_no_preregistration():
+def test_standalone_plugin_no_preregistration_run():
     """Execute the standalone plugin"""
 
     @apply_pass_plugin(plugin, "standalone-switch-bar-foo")

--- a/standalone_plugin_wheel/standalone_plugin/test/test_mlir_plugin.py
+++ b/standalone_plugin_wheel/standalone_plugin/test/test_mlir_plugin.py
@@ -72,6 +72,26 @@ def test_standalone_plugin_no_preregistration():
 
 
 @pytest.mark.skipif(not have_standalone_plugin, reason="Standalone Plugin is not installed")
+def test_standalone_plugin_no_preregistration():
+    """Execute the standalone plugin"""
+
+    @apply_pass_plugin(plugin, "standalone-switch-bar-foo")
+    @qp.qnode(qp.device("lightning.qubit", wires=0))
+    def qnode():
+        return qp.state()
+
+    @qp.qjit
+    def module():
+        return qnode()
+
+    module()
+
+    # It would be nice if we were able to combine lit tests with
+    # pytest
+    assert "standalone-switch-bar-foo" in module.mlir
+
+
+@pytest.mark.skipif(not have_standalone_plugin, reason="Standalone Plugin is not installed")
 def test_standalone_entry_point():
     """Generate MLIR for the standalone plugin via entry-point"""
 


### PR DESCRIPTION
**Context:**

Decorator in `apply_pass_plugin` only passes `pass_name` into `transform(...)`, and the `path_to_plugin` is never forwarded.

**Description of the Change:**

Add a wrapper to ensure the `EvaluationContext.add_plugin(path_to_plugin)` be executed before transform. 

TODO:
~- [ ] Add tests~ We already have the tests in `standalone_plugin_wheel/standalone_plugin/test/test_mlir_plugin.py`
- [x] Changelog

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
https://github.com/PennyLaneAI/catalyst/issues/2540
[sc-112983]
