### PR TITLE
Drop quantum.node from caller in split-multiple-tapes

### DIFF
--- a/doc/releases/changelog-0.15.0.md
+++ b/doc/releases/changelog-0.15.0.md
@@ -697,7 +697,10 @@ codes only.
   the `quantum.node` attribute. Downstream, the `resource-analysis` pass then misidentified
   the empty wrapper as an additional qnode, causing an empty column in `qp.specs` at MLIR levels.
   [(#2793)](https://github.com/PennyLaneAI/catalyst/pull/2793)
-
+* Fixed a bug in the `split-multiple-tapes` pass where the post-split classical wrapper kept
+  the `quantum.node` attribute. Downstream, the `resource-analysis` pass would identify
+  the empty wrapper as an additional qnode, causing `qp.specs` to return invalid results at MLIR levels.
+  [(#2793)](https://github.com/PennyLaneAI/catalyst/pull/2793)
 * Refactored all passes in `catalyst.passes.builtin_passes.py` to be `pennylane.transforms.core.Transform` objects
   rather than decorators. This allows them to be used as standard transforms, enabling full compatibility with
   `pennylane.CompilePipeline`.

--- a/doc/releases/changelog-0.15.0.md
+++ b/doc/releases/changelog-0.15.0.md
@@ -693,6 +693,11 @@ codes only.
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a bug in the `split-multiple-tapes` pass where the post-split classical wrapper kept
+  the `quantum.node` attribute. Downstream, the `resource-analysis` pass then misidentified
+  the empty wrapper as an additional qnode, causing an empty column in `qp.specs` at MLIR levels.
+  [(#2793)](https://github.com/PennyLaneAI/catalyst/pull/2793)
+
 * Refactored all passes in `catalyst.passes.builtin_passes.py` to be `pennylane.transforms.core.Transform` objects
   rather than decorators. This allows them to be used as standard transforms, enabling full compatibility with
   `pennylane.CompilePipeline`.

--- a/mlir/lib/Quantum/Transforms/SplitMultipleTapes.cpp
+++ b/mlir/lib/Quantum/Transforms/SplitMultipleTapes.cpp
@@ -323,6 +323,11 @@ struct SplitMultipleTapesPass : public impl::SplitMultipleTapesPassBase<SplitMul
                 outlinedfunc->moveAfter(func);
                 outlinedfunc->setAttrs(OutlinedFuncAttrs);
             }
+
+            // The caller function is now a classical wrapper calling the outlined
+            // tape functions, so it must drop `quantum.node`
+            // (matches split_non_commuting and split_to_single_terms).
+            func->removeAttr("quantum.node");
         }
     } // runOnOperation()
 };

--- a/mlir/test/Quantum/SplitMultipleTapesTest.mlir
+++ b/mlir/test/Quantum/SplitMultipleTapesTest.mlir
@@ -122,8 +122,6 @@ module @circuit_twotapes_module {
 }
 
 // CHECK: module @circuit_twotapes_module {
-// Both classical wrappers must lose `quantum.node` (verified via the literal
-// attribute lists below); both outlined tape functions must keep it.
 // CHECK: func.func private @circuit_twotapes(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>} {
 // CHECK: func.call @circuit_twotapes_tape_0(%arg1, %cst_0)
 // CHECK: func.call @circuit_twotapes_tape_1(%arg1, %arg0, %cst)
@@ -202,7 +200,6 @@ module @circuit_twotapes_module {
 }
 
 // CHECK: module @circuit_twotapes_module {
-// Wrapper must lose `quantum.node`; outlined tape functions keep it.
 // CHECK: func.func private @circuit_twotapes(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>} {
 // CHECK: func.call @circuit_twotapes_tape_0_0(%arg1, %cst_0)
 // CHECK: func.call @circuit_twotapes_tape_1(%arg1, %arg0, %cst)
@@ -270,7 +267,6 @@ module @circuit_twotapes_module {
 }
 
 // CHECK: module @circuit_twotapes_module {
-// Wrapper must lose `quantum.node`; outlined tape functions keep it.
 // CHECK: func.func private @circuit_twotapes(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>} {
 // CHECK: func.call @circuit_twotapes_tape_0(%arg1, %cst_0)
 // CHECK: func.call @circuit_twotapes_tape_1(%arg1, %arg0, %cst)
@@ -328,7 +324,6 @@ module @circuit_twotapes_module {
 }
 
 // CHECK: module @circuit_twotapes_module {
-// Wrapper must lose `quantum.node`; outlined tape functions keep it.
 // CHECK: func.func private @circuit_twotapes(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>} {
 // CHECK: func.call @circuit_twotapes_tape_0(%arg1, %cst_0)
 // CHECK: func.call @circuit_twotapes_tape_1(%arg1, %arg0, %cst, {{%.+}})

--- a/mlir/test/Quantum/SplitMultipleTapesTest.mlir
+++ b/mlir/test/Quantum/SplitMultipleTapesTest.mlir
@@ -46,11 +46,12 @@ module @circuit_twotapes_module {
 }
 
 // CHECK: module @circuit_twotapes_module {
-// CHECK: func.func private @circuit_twotapes
+// CHECK: func.func private @circuit_twotapes(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>} {
 // CHECK: func.call @circuit_twotapes_tape_0(%arg1, %cst_0)
 // CHECK: func.call @circuit_twotapes_tape_1(%arg1, %arg0, %cst)
 // CHECK: {{%.+}} = stablehlo.subtract {{%.+}}, {{%.+}} : tensor<f64>
 
+// Outlined tape functions MUST keep the `quantum.node` attribute.
 // CHECK: func.func private @circuit_twotapes_tape_0(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>, quantum.node}
 // CHECK: quantum.device
 // CHECK: {{%.+}} = stablehlo.add %arg0, %arg1 : tensor<f64>
@@ -121,7 +122,9 @@ module @circuit_twotapes_module {
 }
 
 // CHECK: module @circuit_twotapes_module {
-// CHECK: func.func private @circuit_twotapes
+// Both classical wrappers must lose `quantum.node` (verified via the literal
+// attribute lists below); both outlined tape functions must keep it.
+// CHECK: func.func private @circuit_twotapes(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>} {
 // CHECK: func.call @circuit_twotapes_tape_0(%arg1, %cst_0)
 // CHECK: func.call @circuit_twotapes_tape_1(%arg1, %arg0, %cst)
 // CHECK: {{%.+}} = stablehlo.subtract {{%.+}}, {{%.+}} : tensor<f64>
@@ -141,7 +144,7 @@ module @circuit_twotapes_module {
 // CHECK-DAG: return [[retMult]] : tensor<f64>
 // CHECK-DAG: }
 
-// CHECK: func.func private @circuit_twotapes_doppleganger
+// CHECK: func.func private @circuit_twotapes_doppleganger(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>} {
 // CHECK: func.call @circuit_twotapes_doppleganger_tape_0(%arg1, %cst_0)
 // CHECK: func.call @circuit_twotapes_doppleganger_tape_1(%arg1, %arg0, %cst)
 // CHECK: {{%.+}} = stablehlo.subtract {{%.+}}, {{%.+}} : tensor<f64>
@@ -199,7 +202,8 @@ module @circuit_twotapes_module {
 }
 
 // CHECK: module @circuit_twotapes_module {
-// CHECK: func.func private @circuit_twotapes
+// Wrapper must lose `quantum.node`; outlined tape functions keep it.
+// CHECK: func.func private @circuit_twotapes(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>} {
 // CHECK: func.call @circuit_twotapes_tape_0_0(%arg1, %cst_0)
 // CHECK: func.call @circuit_twotapes_tape_1(%arg1, %arg0, %cst)
 // CHECK: {{%.+}} = stablehlo.subtract {{%.+}}, {{%.+}} : tensor<f64>
@@ -266,7 +270,8 @@ module @circuit_twotapes_module {
 }
 
 // CHECK: module @circuit_twotapes_module {
-// CHECK: func.func private @circuit_twotapes
+// Wrapper must lose `quantum.node`; outlined tape functions keep it.
+// CHECK: func.func private @circuit_twotapes(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>} {
 // CHECK: func.call @circuit_twotapes_tape_0(%arg1, %cst_0)
 // CHECK: func.call @circuit_twotapes_tape_1(%arg1, %arg0, %cst)
 // CHECK: {{%.+}} = scf.execute_region
@@ -323,7 +328,8 @@ module @circuit_twotapes_module {
 }
 
 // CHECK: module @circuit_twotapes_module {
-// CHECK: func.func private @circuit_twotapes
+// Wrapper must lose `quantum.node`; outlined tape functions keep it.
+// CHECK: func.func private @circuit_twotapes(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>} {
 // CHECK: func.call @circuit_twotapes_tape_0(%arg1, %cst_0)
 // CHECK: func.call @circuit_twotapes_tape_1(%arg1, %arg0, %cst, {{%.+}})
 // CHECK: {{%.+}} = stablehlo.subtract {{%.+}}, {{%.+}} : tensor<f64>
@@ -380,7 +386,8 @@ module @circuit_twotapes_module {
 }
 
 // CHECK: module @circuit_twotapes_module {
-// CHECK: func.func private @circuit_twotapes
+// Wrapper must lose `quantum.node`; outlined tape functions keep it.
+// CHECK: func.func private @circuit_twotapes(%arg0: tensor<f64>, %arg1: tensor<f64>) -> tensor<f64> attributes {diff_method = "parameter-shift", llvm.linkage = #llvm.linkage<internal>} {
 // CHECK: {{%.+}}:2 = func.call @circuit_twotapes_tape_0(%arg1, %cst)
 // CHECK: func.call @circuit_twotapes_tape_1(%arg1, %arg0, {{%.+}}#1)
 // CHECK: {{%.+}} = stablehlo.subtract {{%.+}}#0, {{%.+}} : tensor<f64>


### PR DESCRIPTION
**Context:**
SplitMultipleTapesPass outlines each tape into its own qnode function and turns the original into a classical wrapper. Per Catalyst's qnode contract the wrapper must drop quantum.node (see [qnode-transform-guide](https://github.com/PennyLaneAI/catalyst/blob/main/frontend/catalyst/python_interface/transforms/qnode-transform-guide.md)).

Downstream, the `resource-analysis` pass then misidentified the empty wrapper as an additional qnode, surfacing as a spurious empty column in `qp.specs` at MLIR levels. The wrapper now drops the attribute, matching `split-non-commuting` and `split-to-single-terms`.

**Description of the Change:**
- Remove `quantum.node` in `SpliMultipleTapes.cpp`.

Before fix:
```mlir
module @module_circuit {
    // BUG: wrapper is now classical but still marked `qnode`
    func @circuit() attributes {qnode} {
        a = call @circuit_tape_0()
        b = call @circuit_tape_1()
        return a, b
    }
    func @circuit_tape_0() attributes {qnode} { device; gates_a; a = MeasurementProcessA; device_release; return a }
    func @circuit_tape_1() attributes {qnode} { device; gates_b; b = MeasurementProcessB; device_release; return b }
}

```
After fix:

```mlir
module @module_circuit {
    // wrapper is now classical, no `qnode`
    func @circuit() {
        a = call @circuit_tape_0()
        b = call @circuit_tape_1()
        return a, b
    }
    func @circuit_tape_0() attributes {qnode} { device; gates_a; a = MeasurementProcessA; device_release; return a }
    func @circuit_tape_1() attributes {qnode} { device; gates_b; b = MeasurementProcessB; device_release; return b }
}
```

[sc-118570]