### PR TITLE
Register all `QuantumGate`s to the MLIR graph

### DIFF
--- a/doc/releases/changelog-0.15.0.md
+++ b/doc/releases/changelog-0.15.0.md
@@ -266,6 +266,7 @@ codes only.
   [(#2711)](https://github.com/PennyLaneAI/catalyst/pull/2711)
   [(#2765)](https://github.com/PennyLaneAI/catalyst/pull/2765)
   [(#2722)](https://github.com/PennyLaneAI/catalyst/pull/2722)
+  [(#2795)](https://github.com/PennyLaneAI/catalyst/pull/2795)
 
   The framework is interfaced with a new `graph_decomposition` pass decorator
   with key capabilities:

--- a/frontend/test/pytest/from_plxpr/test_decompose_transform.py
+++ b/frontend/test/pytest/from_plxpr/test_decompose_transform.py
@@ -468,13 +468,12 @@ class TestGraphDecomposition:
         """Test that the graph correctly registers non-custom ops."""
 
         with pytest.raises(CompileError):
-
             @qp.qjit
             @graph_decomposition(gate_set={qp.X})
             @qp.qnode(qp.device("lightning.qubit", wires=2))
             def circuit(x: float, y: float):
                 qp.PauliRot(0.1, "ZZ", wires=[0, 1])
-                return
+                return qml.state()
 
             circuit()
 

--- a/frontend/test/pytest/from_plxpr/test_decompose_transform.py
+++ b/frontend/test/pytest/from_plxpr/test_decompose_transform.py
@@ -468,6 +468,7 @@ class TestGraphDecomposition:
         """Test that the graph correctly registers non-custom ops."""
 
         with pytest.raises(CompileError):
+
             @qp.qjit
             @graph_decomposition(gate_set={qp.X})
             @qp.qnode(qp.device("lightning.qubit", wires=2))

--- a/frontend/test/pytest/from_plxpr/test_decompose_transform.py
+++ b/frontend/test/pytest/from_plxpr/test_decompose_transform.py
@@ -31,6 +31,7 @@ from pennylane_lightning.lightning_qubit.lightning_qubit import (
     stopping_condition as lightning_stopping_condition,
 )
 
+from catalyst import CompileError
 from catalyst.jax_primitives import decomposition_rule
 from catalyst.passes import graph_decomposition
 
@@ -462,6 +463,20 @@ class TestGraphDecomposition:
             qp.CRX(1.7, wires=[0, 1])
             qp.CRX(-7.2, wires=[0, 1])
             return qp.state()
+
+    def test_non_custom_op(self):
+        """Test that the graph correctly registers non-custom ops."""
+
+        with pytest.raises(CompileError):
+
+            @qp.qjit
+            @graph_decomposition(gate_set={qp.X})
+            @qp.qnode(qp.device("lightning.qubit", wires=2))
+            def circuit(x: float, y: float):
+                qp.PauliRot(0.1, "ZZ", wires=[0, 1])
+                return
+
+            circuit()
 
 
 class TestPlxPRDecomposition:

--- a/frontend/test/pytest/from_plxpr/test_decompose_transform.py
+++ b/frontend/test/pytest/from_plxpr/test_decompose_transform.py
@@ -474,7 +474,7 @@ class TestGraphDecomposition:
             @qp.qnode(qp.device("lightning.qubit", wires=2))
             def circuit(x: float, y: float):
                 qp.PauliRot(0.1, "ZZ", wires=[0, 1])
-                return qml.state()
+                return qp.state()
 
             circuit()
 

--- a/mlir/lib/Quantum/Transforms/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/graph_decomposition.cpp
@@ -272,14 +272,26 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
 
     void getOperators(std::vector<OperatorNode> &operators)
     {
-        getOperation().walk([&](CustomOp op) {
+        getOperation().walk([&](quantum::QuantumGate op) {
             OperatorNode node;
-            node.name = op.getGateName().str();
-            auto inQubits = op.getInQubits();
-            node.numWires = inQubits.size();
-            auto inParams = op.getParams();
-            node.numParams = inParams.size();
-            node.adjoint = op.getAdjoint();
+            node.numWires = op.getQubitOperands().size();
+            node.adjoint = op.getAdjointFlag();
+
+            if (auto customOp = llvm::dyn_cast<quantum::CustomOp>(op.getOperation())) {
+                node.name = customOp.getGateName().str();
+            }
+            else {
+                node.name = op->getName().stripDialect().str();
+            }
+
+            if (auto paramOp =
+                    llvm::dyn_cast<catalyst::quantum::ParametrizedGate>(op.getOperation())) {
+                node.numParams = paramOp.getAllParams().size();
+            }
+            else {
+                node.numParams = 0;
+            }
+
             operators.push_back(node);
         });
     }

--- a/mlir/lib/Quantum/Transforms/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/graph_decomposition.cpp
@@ -279,7 +279,8 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
 
             if (auto customOp = llvm::dyn_cast<quantum::CustomOp>(op.getOperation())) {
                 node.name = customOp.getGateName().str();
-            } else {
+            }
+            else {
                 std::string name = op->getName().stripDialect().str();
                 if (name == "gphase") {
                     name = "GlobalPhase";
@@ -290,7 +291,8 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
             if (auto paramOp =
                     llvm::dyn_cast<catalyst::quantum::ParametrizedGate>(op.getOperation())) {
                 node.numParams = paramOp.getAllParams().size();
-            } else {
+            }
+            else {
                 node.numParams = 0;
             }
 

--- a/mlir/lib/Quantum/Transforms/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/graph_decomposition.cpp
@@ -274,7 +274,7 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
     {
         getOperation().walk([&](quantum::QuantumGate op) {
             OperatorNode node;
-            node.numWires = op.getQubitOperands().size();
+            node.numWires = op.getNonCtrlQubitOperands().size();
             node.adjoint = op.getAdjointFlag();
 
             if (auto customOp = llvm::dyn_cast<quantum::CustomOp>(op.getOperation())) {

--- a/mlir/lib/Quantum/Transforms/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/graph_decomposition.cpp
@@ -279,8 +279,7 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
 
             if (auto customOp = llvm::dyn_cast<quantum::CustomOp>(op.getOperation())) {
                 node.name = customOp.getGateName().str();
-            }
-            else {
+            } else {
                 std::string name = op->getName().stripDialect().str();
                 if (name == "gphase") {
                     name = "GlobalPhase";
@@ -291,8 +290,7 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
             if (auto paramOp =
                     llvm::dyn_cast<catalyst::quantum::ParametrizedGate>(op.getOperation())) {
                 node.numParams = paramOp.getAllParams().size();
-            }
-            else {
+            } else {
                 node.numParams = 0;
             }
 

--- a/mlir/lib/Quantum/Transforms/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/graph_decomposition.cpp
@@ -281,7 +281,11 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
                 node.name = customOp.getGateName().str();
             }
             else {
-                node.name = op->getName().stripDialect().str();
+                std::string name = op->getName().stripDialect().str();
+                if (name == "gphase") {
+                    name = "GlobalPhase";
+                }
+                node.name = name;
             }
 
             if (auto paramOp =

--- a/mlir/test/Quantum/GraphDecomposition/TestFailedDecomp.mlir
+++ b/mlir/test/Quantum/GraphDecomposition/TestFailedDecomp.mlir
@@ -17,6 +17,7 @@
 func.func @circuit(%q0: !quantum.bit, %q1: !quantum.bit, %q2: !quantum.bit) {
     %pi = arith.constant 3.14 : f64
     %out:3 = quantum.paulirot ["X", "Z", "Y"](%pi) %q0, %q1, %q2 : !quantum.bit, !quantum.bit, !quantum.bit
-    // CHECK: GraphSolverFailedError: Decomposition rule not found for operator 'paulirot
+    // CHECK: GraphSolverFailedError
+    // CHECK: Decomposition rule not found for operator 'paulirot
     return
 }

--- a/mlir/test/Quantum/GraphDecomposition/TestFailedDecomp.mlir
+++ b/mlir/test/Quantum/GraphDecomposition/TestFailedDecomp.mlir
@@ -1,0 +1,22 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RUN: not --crash quantum-opt --split-input-file --pass-pipeline='builtin.module( graph-decomposition{gate-set=PauliX=1.0 bytecode-rules="%BYTECODE_PATH"})' %s 2>&1 | FileCheck %s
+
+func.func @circuit(%q0: !quantum.bit, %q1: !quantum.bit, %q2: !quantum.bit) {
+    %pi = arith.constant 3.14 : f64
+    %out:3 = quantum.paulirot ["X", "Z", "Y"](%pi) %q0, %q1, %q2 : !quantum.bit, !quantum.bit, !quantum.bit
+    // CHECK: GraphSolverFailedError: Decomposition rule not found for operator 'paulirot
+    return
+}

--- a/mlir/test/Quantum/GraphDecomposition/TestMultiDecomp.mlir
+++ b/mlir/test/Quantum/GraphDecomposition/TestMultiDecomp.mlir
@@ -14,7 +14,7 @@
 
 // RUN: quantum-opt --split-input-file --pass-pipeline='builtin.module(graph-decomposition{gate-set=RX=1.0,GlobalPhase=1.0 bytecode-rules="%BYTECODE_PATH"})' %s | FileCheck %s --check-prefixes FIRST
 
-// RUN: quantum-opt --split-input-file --pass-pipeline='builtin.module(graph-decomposition{gate-set=RX=1.0,GlobalPhase=1.0 bytecode-rules="%BYTECODE_PATH"},graph-decomposition{gate-set=RZ=1.0,RY=1.0,GlobalPhase=1.0 bytecode-rules="%BYTECODE_PATH"})' %s | FileCheck %s --check-prefixes SECOND
+// RUN: quantum-opt --split-input-file --pass-pipeline='builtin.module(graph-decomposition{gate-set=RX=1.0,GlobalPhase=1.0 bytecode-rules="%BYTECODE_PATH"},graph-decomposition{gate-set=RZ=1.0,RY=1.0,gphase=1.0 bytecode-rules="%BYTECODE_PATH"})' %s | FileCheck %s --check-prefixes SECOND
 
 func.func @circuit() -> !quantum.bit {
     %0 = quantum.alloc(2) : !quantum.reg

--- a/mlir/test/Quantum/GraphDecomposition/TestMultiDecomp.mlir
+++ b/mlir/test/Quantum/GraphDecomposition/TestMultiDecomp.mlir
@@ -14,7 +14,7 @@
 
 // RUN: quantum-opt --split-input-file --pass-pipeline='builtin.module(graph-decomposition{gate-set=RX=1.0,GlobalPhase=1.0 bytecode-rules="%BYTECODE_PATH"})' %s | FileCheck %s --check-prefixes FIRST
 
-// RUN: quantum-opt --split-input-file --pass-pipeline='builtin.module(graph-decomposition{gate-set=RX=1.0,GlobalPhase=1.0 bytecode-rules="%BYTECODE_PATH"},graph-decomposition{gate-set=RZ=1.0,RY=1.0,gphase=1.0 bytecode-rules="%BYTECODE_PATH"})' %s | FileCheck %s --check-prefixes SECOND
+// RUN: quantum-opt --split-input-file --pass-pipeline='builtin.module(graph-decomposition{gate-set=RX=1.0,GlobalPhase=1.0 bytecode-rules="%BYTECODE_PATH"},graph-decomposition{gate-set=RZ=1.0,RY=1.0,GlobalPhase=1.0 bytecode-rules="%BYTECODE_PATH"})' %s | FileCheck %s --check-prefixes SECOND
 
 func.func @circuit() -> !quantum.bit {
     %0 = quantum.alloc(2) : !quantum.reg


### PR DESCRIPTION
**Context:**
The current MLIR graph registers only `quantum.custom` operations, meaning that gates like `quantum.paulirot`, `quantum.multirz` etc are ignored. This allows examples like the following:

```python
@qp.qjit
@graph_decomposition(gate_set={qp.X})
@qp.qnode(qp.device("lightning.qubit", wires=2))
def circuit(x: float, y: float):
    qp.PauliRot(0.1, "ZZ", wires=[0, 1])
    return
```

Users would expect this to fail, since a `ZZ` `paulirot` can't be decomposed to `X`, but it passes the graph since it is unregistered.

**Description of the Change:**
Registers all `QuantumGate` operations to the graph.

**Benefits:**
Improved graph behaviour.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-118714]