### PR TITLE
Read version from file in rc branch check

### DIFF
--- a/.github/workflows/build-nightly-release-candidate.yaml
+++ b/.github/workflows/build-nightly-release-candidate.yaml
@@ -19,7 +19,7 @@ jobs:
       run: |
         VERSION=$(sed -n 's/^__version__ = "\(.*\)"/\1/p' frontend/catalyst/_version.py)
         IFS=. read MAJ MIN PAT <<< "${VERSION%.dev[0-9]*}"
-        RC_BRANCH="v${MAJ}.$((MIN-1)).${PAT}-rc0"
+        RC_BRANCH="v${MAJ}.$((MIN-1)).0-rc0"
         if git ls-remote --exit-code origin "refs/heads/$RC_BRANCH"; then
           echo "branch_exists=true" >> $GITHUB_OUTPUT
           echo "rc_branch=$RC_BRANCH" >> $GITHUB_OUTPUT 

--- a/.github/workflows/build-nightly-release-candidate.yaml
+++ b/.github/workflows/build-nightly-release-candidate.yaml
@@ -19,7 +19,7 @@ jobs:
       run: |
         VERSION=$(sed -n 's/^__version__ = "\(.*\)"/\1/p' frontend/catalyst/_version.py)
         IFS=. read MAJ MIN PAT <<< "${VERSION%.dev[0-9]*}"
-        RC_BRANCH="v${MAJ}.$((MIN-1)).0-rc0"
+        RC_BRANCH="v${MAJ}.$((MIN-1)).0-rc"
         if git ls-remote --exit-code origin "refs/heads/$RC_BRANCH"; then
           echo "branch_exists=true" >> $GITHUB_OUTPUT
           echo "rc_branch=$RC_BRANCH" >> $GITHUB_OUTPUT 

--- a/.github/workflows/build-nightly-release-candidate.yaml
+++ b/.github/workflows/build-nightly-release-candidate.yaml
@@ -18,8 +18,8 @@ jobs:
       id: check_rc
       run: |
         VERSION=$(sed -n 's/^__version__ = "\(.*\)"/\1/p' frontend/catalyst/_version.py)
-        IFS=. read MAJ MIN PAT <<< "${VERSION%.dev[0-9]*}"
-        RC_BRANCH="v${MAJ}.$((MIN-1)).0-rc"
+        IFS=. read MAJ MIN PAT <<< "${VERSION%[-.]dev[0-9]*}"
+        RC_BRANCH="v${MAJ}.$((MIN-1)).${PAT}-rc"
         if git ls-remote --exit-code origin "refs/heads/$RC_BRANCH"; then
           echo "branch_exists=true" >> $GITHUB_OUTPUT
           echo "rc_branch=$RC_BRANCH" >> $GITHUB_OUTPUT 

--- a/.github/workflows/build-nightly-release-candidate.yaml
+++ b/.github/workflows/build-nightly-release-candidate.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Check for RC branch
       id: check_rc
       run: |
-        VERSION=$(python setup.py --version)
+        VERSION=$(sed -n 's/^__version__ = "\(.*\)"/\1/p' frontend/catalyst/_version.py)
         IFS=. read MAJ MIN PAT <<< "${VERSION%.dev[0-9]*}"
         RC_BRANCH="v${MAJ}.$((MIN-1)).${PAT}-rc0"
         if git ls-remote --exit-code origin "refs/heads/$RC_BRANCH"; then
@@ -104,6 +104,7 @@ jobs:
 
   trigger-pennylane-rc-release:
     name: Trigger PennyLane RC release workflow
+    if: ${{ always() && !cancelled() }}
     needs: [upload]
     runs-on: ubuntu-24.04
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -12,6 +12,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+- Update RC nightly builds to read version number from the `_version.py` file 
+  [(#2797)](https://github.com/PennyLaneAI/catalyst/pull/2797)
+
 <h3>Documentation 📝</h3>
 
 <h3>Contributors ✍️</h3>


### PR DESCRIPTION
**Context:**
Catalyst's rc branch check VERSION=$(python setup.py --version) now normalizes the version name causing it to [miss the rc branch](https://github.com/PennyLaneAI/catalyst/actions/runs/25437561485/job/74619547774#step:3:14).

**Description of the Change:**
- Change rc_branch check to read from version file.
- Add trigger for pennylane build even if catalyst build fails

**Benefits:**
RC branch check works

**Possible Drawbacks:**
None

**Related GitHub Issues:**
