### PR TITLE
Update iterator to vector in DOS to avoid gcc14 stdlib strictness changes

### DIFF
--- a/mlir/lib/Quantum/Transforms/dynamic_one_shot.cpp
+++ b/mlir/lib/Quantum/Transforms/dynamic_one_shot.cpp
@@ -428,7 +428,11 @@ void editKernelMCMProbs(IRRewriter &builder, func::FuncOp oneShotKernel, quantum
     auto totalIndex =
         arith::ConstantOp::create(builder, loc, i64Type, builder.getIntegerAttr(i64Type, 0));
     Operation *loopUpdater = totalIndex;
-    for (auto [i, mcm] : llvm::enumerate(llvm::reverse(mcmobs.getMcms()))) {
+
+    // bypass C++20 issues introduced with GCC14+ and libstdcxx
+    auto mcmVec = llvm::to_vector(mcmobs.getMcms());
+
+    for (auto [i, mcm] : llvm::enumerate(llvm::reverse(mcmVec))) {
         // Power of 2 for this bit position
         auto extuiOp = arith::ExtUIOp::create(builder, loc, builder.getI64Type(), mcm);
         auto shiftSize =


### PR DESCRIPTION
**Context:** Fixes an incompatibility between LLVM iterator and GCC14+ stdlib. Missing default ctor's cause a failure due to changes in strictness. 

**Description of the Change:** Create a vector instead of using an iterator for the DOS.

**Benefits:** Will allow comp with newer GCC/stdlib variants on Linux machines (vetted against gcc14.3)

**Possible Drawbacks:** Potential for perf change in DOS due to vec creation instead of iterator use. Unlikely to show up in practice though.

**Related GitHub Issues:**
