### PR TITLE
Fix build failures with clang + GCC ≤ 13 libstdc++ due to broken range views

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -12,11 +12,17 @@
 
 <h3>Internal changes ⚙️</h3>
 
-- Update RC nightly builds to read version number from the `_version.py` file 
+* Update RC nightly builds to read version number from the `_version.py` file 
   [(#2797)](https://github.com/PennyLaneAI/catalyst/pull/2797)
+
+* Fix build failures when using clang with GCC ≤ 13 libstdc++ by replacing
+  `std::views::filter`/`std::views::transform` with `std::copy_if`/`std::transform`
+  [(#2801)](https://github.com/PennyLaneAI/catalyst/pull/2801)
 
 <h3>Documentation 📝</h3>
 
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
+
+Mehrdad Malekmohammadi,

--- a/mlir/include/Driver/DefaultPipelines/DefaultPipelines.h
+++ b/mlir/include/Driver/DefaultPipelines/DefaultPipelines.h
@@ -211,12 +211,11 @@ PassNames getLLVMDialectLoweringStage(bool asyncQNodes = false)
     PassNames ret;
     std::copy_if(pipelineList[4].passNames.begin(), pipelineList[4].passNames.end(),
                  std::back_inserter(ret), [&asyncQNodes](const auto &passName) {
-                     return asyncQNodes ||
-                            (passName != "qnode-to-async-lowering" &&
-                             passName != "async-func-to-async-runtime" &&
-                             passName != "async-to-async-runtime" &&
-                             passName != "convert-async-to-llvm" &&
-                             passName != "add-exception-handling");
+                     return asyncQNodes || (passName != "qnode-to-async-lowering" &&
+                                            passName != "async-func-to-async-runtime" &&
+                                            passName != "async-to-async-runtime" &&
+                                            passName != "convert-async-to-llvm" &&
+                                            passName != "add-exception-handling");
                  });
     return ret;
 }

--- a/mlir/include/Driver/DefaultPipelines/DefaultPipelines.h
+++ b/mlir/include/Driver/DefaultPipelines/DefaultPipelines.h
@@ -14,8 +14,8 @@
 
 #pragma once
 
+#include <algorithm>
 #include <numeric>
-#include <ranges>
 #include <string>
 #include <vector>
 
@@ -176,11 +176,12 @@ PipelineNames getPipelineNames()
 
 PassNames getQuantumCompilationStage(bool disableAssertion = true)
 {
-    auto &&ret =
-        pipelineList[0].passNames | std::views::filter([&disableAssertion](const auto &passName) {
-            return (!disableAssertion && (passName == "disable-assertion")) ? false : true;
-        });
-    return PassNames{ret.begin(), ret.end()};
+    PassNames ret;
+    std::copy_if(pipelineList[0].passNames.begin(), pipelineList[0].passNames.end(),
+                 std::back_inserter(ret), [&disableAssertion](const auto &passName) {
+                     return !(!disableAssertion && (passName == "disable-assertion"));
+                 });
+    return ret;
 }
 
 PassNames getHLOLoweringStage() { return pipelineList[1].passNames; }
@@ -194,29 +195,30 @@ PassNames getBufferizationStage(bool asyncQNodes = false)
         "function-boundary-type-conversion=identity-layout-map " +
         "unknown-type-conversion=identity-layout-map" + (asyncQNodes ? " copy-before-write" : "") +
         "}";
-    auto &&ret = pipelineList[3].passNames |
-                 std::views::transform([&bufferizationOptions](const auto &passName) {
-                     if (passName == "one-shot-bufferize") {
-                         return passName + bufferizationOptions;
-                     }
-                     return passName;
-                 });
-    return PassNames{ret.begin(), ret.end()};
+    PassNames ret;
+    std::transform(pipelineList[3].passNames.begin(), pipelineList[3].passNames.end(),
+                   std::back_inserter(ret), [&bufferizationOptions](const auto &passName) {
+                       if (passName == "one-shot-bufferize") {
+                           return passName + bufferizationOptions;
+                       }
+                       return passName;
+                   });
+    return ret;
 }
 
 PassNames getLLVMDialectLoweringStage(bool asyncQNodes = false)
 {
-    auto &&ret =
-        pipelineList[4].passNames | std::views::filter([&asyncQNodes](const auto &passName) {
-            return (!asyncQNodes &&
-                    (passName == "qnode-to-async-lowering" ||
-                     passName == "async-func-to-async-runtime" ||
-                     passName == "async-to-async-runtime" || passName == "convert-async-to-llvm" ||
-                     passName == "add-exception-handling"))
-                       ? false
-                       : true;
-        });
-    return PassNames{ret.begin(), ret.end()};
+    PassNames ret;
+    std::copy_if(pipelineList[4].passNames.begin(), pipelineList[4].passNames.end(),
+                 std::back_inserter(ret), [&asyncQNodes](const auto &passName) {
+                     return asyncQNodes ||
+                            (passName != "qnode-to-async-lowering" &&
+                             passName != "async-func-to-async-runtime" &&
+                             passName != "async-to-async-runtime" &&
+                             passName != "convert-async-to-llvm" &&
+                             passName != "add-exception-handling");
+                 });
+    return ret;
 }
 
 } // namespace driver

--- a/mlir/unittests/DecompGraphSolver/Test_DecompGraphSolver.cpp
+++ b/mlir/unittests/DecompGraphSolver/Test_DecompGraphSolver.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <iostream>
 
 #include "DGBuilder.hpp"


### PR DESCRIPTION
**Context:**
`DefaultPipelines.h` recent changes use `std::views::filter` and `std::views::transform` via the | pipe syntax which fails when compiling from source using clang with GCC 12 or GCC 13's `libstdc++`.

**Description of the Change:**
replaced those methods with `std::copy_if` and  `std::transform` from `<algorithm>` to dodge these failures.  

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-119527]