### PR TITLE
Improve docstrings of ``disentangle_cnot/swap`` and ``parity_synth`` passes

### DIFF
--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -514,13 +514,11 @@ def parity_synth_setup_inputs():
     .. code-block:: python
 
         import pennylane as qp
-        from catalyst.python_interface import Compiler
-        import catalyst
 
         dev = qp.device("lightning.qubit", wires=2)
 
         @qp.qjit(capture=True)
-        @catalyst.passes.parity_synth
+        @qp.transforms.parity_synth
         @qp.qnode(dev)
         def circuit(x: float, y: float, z: float):
             qp.CNOT((0, 1))

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -268,7 +268,12 @@ diagonalize_measurements = qp.transform(
 
 
 def disentangle_cnot_setup_inputs():
-    r"""A peephole optimization for replacing ``CNOT`` gates with single-qubit gates.
+    r"""A relaxed peephole optimization for replacing ``CNOT`` gates with single-qubit gates.
+
+    The optimizations that this pass performs are found in
+    `arXiv:2012.07711 <https://arxiv.org/pdf/2012.07711>`, specifically TABLE I. The patterns
+    therein represent functional equivalencies to applying a ``CNOT`` gate on certain two-qubit
+    input states.
 
     .. note::
 
@@ -327,8 +332,12 @@ disentangle_cnot = qp.transform(
 
 
 def disentangle_swap_setup_inputs():
-    r"""A peephole optimization for replacing ``SWAP`` gates with simpler gates (``PauliX`` and
-    ``CNOT``).
+    r"""A relaxed peephole optimization for replacing ``SWAP`` gates with single-qubit gates.
+
+    The optimizations that this pass performs are found in
+    `arXiv:2012.07711 <https://arxiv.org/pdf/2012.07711>`, specifically TABLE VI. The patterns
+    therein represent functional equivalencies to applying a ``SWAP`` gate on certain two-qubit
+    input states.
 
     .. note::
 

--- a/frontend/catalyst/passes/builtin_passes.py
+++ b/frontend/catalyst/passes/builtin_passes.py
@@ -271,7 +271,7 @@ def disentangle_cnot_setup_inputs():
     r"""A relaxed peephole optimization for replacing ``CNOT`` gates with single-qubit gates.
 
     The optimizations that this pass performs are found in
-    `arXiv:2012.07711 <https://arxiv.org/pdf/2012.07711>`, specifically TABLE I. The patterns
+    `arXiv:2012.07711 <https://arxiv.org/pdf/2012.07711>`_, specifically TABLE I. The patterns
     therein represent functional equivalencies to applying a ``CNOT`` gate on certain two-qubit
     input states.
 
@@ -335,7 +335,7 @@ def disentangle_swap_setup_inputs():
     r"""A relaxed peephole optimization for replacing ``SWAP`` gates with single-qubit gates.
 
     The optimizations that this pass performs are found in
-    `arXiv:2012.07711 <https://arxiv.org/pdf/2012.07711>`, specifically TABLE VI. The patterns
+    `arXiv:2012.07711 <https://arxiv.org/pdf/2012.07711>`_, specifically TABLE VI. The patterns
     therein represent functional equivalencies to applying a ``SWAP`` gate on certain two-qubit
     input states.
 


### PR DESCRIPTION
**Context:** Internal discussions with @paul0403, @lillian542, and others informed us that we should have more context in these docstrings to better explain what the ``disentangle_cnot/swap`` transforms do. Additionally, ``parity_synth``'s docstring should just use the ``pennylane`` frontend.

**Description of the Change:** Adds a reference to https://arxiv.org/pdf/2012.07711 in both docstrings, along with a bit more explanation. Ammend code example in ``parity_synth``

**Benefits:** It is more clear what these transforms do.

**Possible Drawbacks:**

**Related GitHub Issues:**
