### PR TITLE
Fix keep_intermediate workspace for target="mlir" + mlir_opt

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -14,7 +14,7 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* Fixed a bug where keep_intermediate=True isused with target="mlir" resulted in an emptyworkspace
+* Fixed a bug where using `keep_intermediate=True` with `target="mlir"` resulted in an empty workspace
   folder being created and the files printed outside in the main directory.
   [(#2807)](https://github.com/PennyLaneAI/catalyst/pull/2807)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -14,6 +14,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a bug where keep_intermediate=True isused with target="mlir" resulted in an emptyworkspace
+  folder being created and the files printed outside in the main directory.
+  [(#2807)](https://github.com/PennyLaneAI/catalyst/pull/2807)
+
 <h3>Internal changes ⚙️</h3>
 
 - Update RC nightly builds to read version number from the `_version.py` file 

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -387,7 +387,11 @@ def to_llvmir(*args, stdin=None, options: Optional[CompileOptions] = None):
 
 
 def to_mlir_opt(
-    *args, stdin=None, options: Optional[CompileOptions] = None, using_python_compiler=False
+    *args,
+    stdin=None,
+    options: Optional[CompileOptions] = None,
+    using_python_compiler=False,
+    workspace=None,
 ):
     """echo ${input} | catalyst --tool=opt *args *opts -"""
     # Check if we need to use the Python interface for xDSL passes
@@ -404,6 +408,8 @@ def to_mlir_opt(
         return _quantum_opt(*args, stdin=stdin)
 
     opts = _options_to_cli_flags(options)
+    if workspace is not None:
+        opts += [("--workspace", str(workspace))]
     return _quantum_opt(*opts, *args, stdin=stdin)
 
 

--- a/frontend/catalyst/jit.py
+++ b/frontend/catalyst/jit.py
@@ -635,8 +635,16 @@ class QJIT(CatalystCallable):
             print_generic_op_form=using_python_compiler,
             enable_debug_info=self.compile_options.use_nameloc,
         )
+        if self.compile_options.keep_intermediate and self.workspace:
+            module_name = str(self.mlir_module.operation.attributes["sym_name"]).replace('"', "")
+            initial_ir_file = os.path.join(str(self.workspace), f"0_{module_name}.mlir")
+            with open(initial_ir_file, "w", encoding="utf-8") as f:
+                f.write(self.mlir)
         return to_mlir_opt(
-            stdin=stdin, options=self.compile_options, using_python_compiler=using_python_compiler
+            stdin=stdin,
+            options=self.compile_options,
+            using_python_compiler=using_python_compiler,
+            workspace=self.workspace,
         )
 
     @debug_logger

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -930,6 +930,9 @@ class TestDefaultAvailableIR:
             qp.H(0)
             return qp.state()
 
+        # Create tmp workspaces for intermediates to avoid CI race conditions
+        circuit.use_cwd_for_workspace = False
+
         _ = circuit.mlir_opt
 
         workspace_files = os.listdir(str(circuit.workspace))

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -919,7 +919,7 @@ class TestDefaultAvailableIR:
         mlir_opt = f.mlir_opt
         assert mlir_opt
         assert not "__catalyst__qis__Hadamard" in mlir_opt
-        
+
     def test_mlir_opt_with_keep_intermediate(self, backend):
         """Test that keep_intermediate with target='mlir' writes the initial IR and
         pipeline output files into the workspace when mlir_opt is accessed."""

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import random
 import warnings
 from functools import partial
@@ -918,6 +919,23 @@ class TestDefaultAvailableIR:
         mlir_opt = f.mlir_opt
         assert mlir_opt
         assert not "__catalyst__qis__Hadamard" in mlir_opt
+        
+    def test_mlir_opt_with_keep_intermediate(self, backend):
+        """Test that keep_intermediate with target='mlir' writes the initial IR and
+        pipeline output files into the workspace when mlir_opt is accessed."""
+
+        @qjit(target="mlir", keep_intermediate=True)
+        @qp.qnode(qp.device(backend, wires=1))
+        def circuit():
+            qp.H(0)
+            return qp.state()
+
+        _ = circuit.mlir_opt
+
+        workspace_files = os.listdir(str(circuit.workspace))
+        assert any(f.startswith("0_") and f.endswith(".mlir") for f in workspace_files)
+        assert any("After" in f and f.endswith(".mlir") for f in workspace_files)
+        circuit.workspace.cleanup()
 
     def test_jaxpr_target(self, backend):
         """Test no mlir is generated for jaxpr target."""


### PR DESCRIPTION
**Context:**
When `keep_intermediate=True` isused with `target="mlir"`, the workspace folder is created but remained empty and the files are printed outside in the main directory. This is due to the fact that `to_mlir_opt` invokes `quantum-opt` without `--workspace`.

**Description of the Change:**
pass workspace to quantum_opt when using `qjit.mlir_opt `

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-119526]