### PR TITLE
Bump Pennylane and Lightning versions prior to the release (v0.15)

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,8 +8,8 @@ enzyme=v0.0.238
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.45.0-dev94
+# pennylane=0.45.0-dev94
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'
-lightning=0.45.0-dev44
+# lightning=0.45.0-dev44

--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -487,6 +487,11 @@ jobs:
 
     - name: Install Catalyst
       run: |
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.45.0-rc0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning==0.45.0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.45.0
+        # -------------------------------------------------------------------- #
         python${{ matrix.python_version }} -m pip install dist/*.whl --extra-index-url https://test.pypi.org/simple
 
     - name: Install Standalone Plugin

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -506,6 +506,11 @@ jobs:
 
     - name: Install Catalyst
       run: |
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.45.0-rc0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning==0.45.0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.45.0
+        # -------------------------------------------------------------------- #
         python${{ matrix.python_version }} -m pip install dist/*.whl --extra-index-url https://test.pypi.org/simple
 
     - name: Install Standalone Plugin

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -487,6 +487,11 @@ jobs:
 
     - name: Install Catalyst
       run: |
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.45.0-rc0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning==0.45.0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.45.0
+        # -------------------------------------------------------------------- #
         python${{ matrix.python_version }} -m pip install dist/*.whl --extra-index-url https://test.pypi.org/simple
 
     - name: Install Standalone Plugin

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -525,6 +525,11 @@ jobs:
         python3 -m pip install oqc-qcaas-client
         # Install graphviz for testing the mlir-op-graph integration
         sudo apt-get install -y graphviz
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.45.0-rc0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning==0.45.0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.45.0
+        # -------------------------------------------------------------------- #
         make frontend
 
     - name: Verify Graphviz installation
@@ -605,6 +610,11 @@ jobs:
         sudo apt-get install -y libasan6 make
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
+        # TODO: --- remove workaround before merging to main ----------------- #
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.45.0-rc0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning==0.45.0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.45.0
+        # -------------------------------------------------------------------- #
         make frontend
 
     - name: Run Python Pytest Tests (backend=lightning.kokkos)
@@ -669,6 +679,11 @@ jobs:
         sudo apt-get install -y libasan6 make
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
         python3 -m pip install -r requirements.txt
+         # TODO: --- remove workaround before merging to main ----------------- #
+        pip install git+https://github.com/PennyLaneAI/pennylane@v0.45.0-rc0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning==0.45.0
+        pip install --extra-index-url=https://test.pypi.org/simple/ PennyLane-Lightning-Kokkos==0.45.0
+        # -------------------------------------------------------------------- #
         make frontend
 
   runtime-device-tests:

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,9 @@ frontend:
 	@echo "install Catalyst Frontend"
 	# Uninstall pennylane before updating Catalyst, since pip will not replace two development
 	# versions of a package with the same version tag (e.g. 0.38-dev0).
-	$(PYTHON) -m pip uninstall -y pennylane
+	# TODO: --- enable the following line before merging to main ------------- #
+	# $(PYTHON) -m pip uninstall -y pennylane
+	# ------------------------------------------------------------------------ #
 	$(PYTHON) -m pip install -e . --extra-index-url https://test.pypi.org/simple $(PIP_VERBOSE_FLAG)
 	$(PYTHON) -m catalyst.utils.precompile_decomposition_rules
 	rm -r frontend/pennylane_catalyst.egg-info

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -31,14 +31,7 @@ matplotlib==3.10.0
 lxml_html_clean
 
 # Pre-install PL development wheels
-# --extra-index-url https://test.pypi.org/simple/
-# pennylane-lightning-kokkos==0.45.0-dev43
-# pennylane-lightning==0.45.0-dev43
-# pennylane==0.45.0-dev94
-
-# If targeting RC branch, we must install latest RC packages from TestPyPI
-# Revert when merging RC branch back to main, and uncomment the above regular requirements
---pre --extra-index-url https://test.pypi.org/simple/
-pennylane-lightning-kokkos>=0.45.0rc2,<=0.45.0
-pennylane-lightning>=0.45.0rc2,<=0.45.0
-pennylane>=0.45.0rc0,<=0.45.0
+--extra-index-url https://test.pypi.org/simple/
+pennylane-lightning-kokkos==0.45.0
+pennylane-lightning==0.45.0
+pennylane @ git+https://github.com/pennylaneAI/pennylane@v0.45.0-rc0

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.15.0-rc2"
+__version__ = "0.15.0"

--- a/frontend/catalyst/python_interface/compiler.py
+++ b/frontend/catalyst/python_interface/compiler.py
@@ -22,6 +22,7 @@ from jaxlib.mlir.ir import Module as jaxModule
 from pennylane.typing import Callable
 from xdsl.context import Context as xContext
 from xdsl.dialects.builtin import ArrayAttr, ModuleOp
+from xdsl.dialects.func import FuncOp
 from xdsl.passes import ModulePass, PassPipeline
 from xdsl.printer import Printer
 
@@ -70,8 +71,6 @@ class Compiler:
         # JAX serialises void func.func ops with `res_attrs = []` in generic form
         # triggering an assertion in FuncToLLVM lowering.
         # Remove empty arrays in-place so the generic printer omits them.
-        from xdsl.dialects.func import FuncOp
-
         for op in xmod.walk():
             if not isinstance(op, FuncOp):
                 continue

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ jax_version = dep_versions.get("jax")
 pl_version = dep_versions.get("pennylane")
 lq_version = dep_versions.get("lightning")
 
-pl_min_release = "0.43.0"
+pl_min_release = "0.44.0"
 lq_min_release = pl_min_release
 
 if pl_version is not None:
@@ -120,12 +120,6 @@ if lq_version is not None:
 else:
     lightning_dep = f"pennylane-lightning>={lq_min_release}"
     kokkos_dep = ""
-
-# If targeting RC branch, we must install latest RC packages from TestPyPI
-# Revert when merging RC branch back to main
-pennylane_dep = f"pennylane>=0.45.0rc0,<=0.45.0"
-lightning_dep = f"pennylane-lightning>=0.45.0rc2,<=0.45.0"
-kokkos_dep = f"pennylane-lightning-kokkos>=0.45.0rc2,<=0.45.0"
 
 requirements = [
     pennylane_dep,


### PR DESCRIPTION
Bump the PennyLane and Lightning minimum versions in preparation for the Catalyst 0.14.0 release. These changes ensure we can build the wheels after the Lightning release and before the core PennyLane release.

Do not merge in this PR into the RC branch until the new version of Lightning has been released