### PR TITLE
Emit error when decomposing PauliRot

### DIFF
--- a/frontend/catalyst/from_plxpr/decompose.py
+++ b/frontend/catalyst/from_plxpr/decompose.py
@@ -276,6 +276,9 @@ def _create_decomposition_rule(
             with a variable number of wires (e.g., MultiRZ, GlobalPhase).
     """
 
+    if op_name == "PauliRot":
+        raise NotImplementedError("Decomposition of PauliRot is not supported in Catalyst.")
+
     sig_func = inspect.signature(func)
     type_hints = get_type_hints(func)
 


### PR DESCRIPTION
Emit an error when decomposing a PauliRot.

Proper fix here: https://github.com/PennyLaneAI/catalyst/pull/2803