### PR TITLE
Add a `qecp-to-qauntum` skeleton pass

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -2,6 +2,10 @@
 
 <h3>New features since last release</h3>
 
+* A new, experimental compiler pass `convert-qecp-to-quantum` has been added to lower operations
+  from the QEC Physical (`qecp`) dialect into the Quantum (`quantum`) dialect.
+  [(#2822)](https://github.com/PennyLaneAI/catalyst/pull/2822)
+
 <h3>Improvements 🛠</h3>
 
 <h3>Breaking changes 💔</h3>
@@ -20,3 +24,4 @@
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):
+Shuli Shu,

--- a/frontend/catalyst/python_interface/transforms/qecp/__init__.py
+++ b/frontend/catalyst/python_interface/transforms/qecp/__init__.py
@@ -19,6 +19,7 @@ from .convert_qecl_noise_to_qec_noise import (
     convert_qecl_noise_to_qecp_noise_pass,
 )
 from .convert_qecl_to_qecp import ConvertQecLogicalToQecPhysicalPass, convert_qecl_to_qecp_pass
+from .convert_qecp_to_quantum import ConvertQecPhysicalToQuantumPass, convert_qecp_to_quantum_pass
 
 __all__ = [
     # Passes
@@ -26,4 +27,6 @@ __all__ = [
     "convert_qecl_to_qecp_pass",
     "ConvertQECLNoiseOpToQECPNoisePass",
     "convert_qecl_noise_to_qecp_noise_pass",
+    "ConvertQecPhysicalToQuantumPass",
+    "convert_qecp_to_quantum_pass",
 ]

--- a/frontend/catalyst/python_interface/transforms/qecp/convert_qecp_to_quantum.py
+++ b/frontend/catalyst/python_interface/transforms/qecp/convert_qecp_to_quantum.py
@@ -1,0 +1,54 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""QEC Physical to Quantum dialect conversion.
+
+This module contains the implementation of the xDSL convert-qecp-to-quantum dialect-conversion pass.
+"""
+
+from dataclasses import dataclass
+
+from xdsl.context import Context
+from xdsl.dialects import builtin
+from xdsl.passes import ModulePass
+from xdsl.pattern_rewriter import (
+    GreedyRewritePatternApplier,
+    PatternRewriteWalker,
+)
+
+from catalyst.python_interface.pass_api import compiler_transform
+
+
+@dataclass(frozen=True)
+class ConvertQecPhysicalToQuantumPass(ModulePass):
+    """
+    Convert QEC physical instructions to Quantum instructions.
+    """
+
+    name = "convert-qecp-to-quantum"
+
+    # pylint: disable=unused-argument
+    def apply(self, ctx: Context, op: builtin.ModuleOp) -> None:
+        """Apply the convert-qecp-to-quantum pass."""
+
+        PatternRewriteWalker(
+            GreedyRewritePatternApplier(
+                [
+                    # To add more patterns
+                ]
+            )
+        ).rewrite_module(op)
+
+
+convert_qecp_to_quantum_pass = compiler_transform(ConvertQecPhysicalToQuantumPass)

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_qecp_to_quantum.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_qecp_to_quantum.py
@@ -1,0 +1,24 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the convert-qecp-to-quantum xDSL dialect-conversion pass."""
+
+import pytest
+
+# from catalyst.python_interface.transforms.qecp.convert_qecp_to_quantum import (
+#     ConvertQecPhysicalToQuantumPass,
+#     convert_qecp_to_quantum_pass,
+# )
+
+pytestmark = pytest.mark.xdsl


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new functions and code must be clearly commented and documented.

- [x] Ensure that code is properly formatted by running `make format`.
      The latest version of black and `clang-format-20` are used in CI/CD to check formatting.

- [x] All new features must include a unit test.
      Integration and frontend tests should be added to [`frontend/test`](../frontend/test/),
      Quantum dialect and MLIR tests should be added to [`mlir/test`](../mlir/test/), and
      Runtime tests should be added to [`runtime/tests`](../runtime/tests/).

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

In preparation to build a prototype QEC compilation pipeline, this PR adds a skeleton pass to lower a program in a QEC physical representation toaquantum representation.

[sc-119280]

**Description of the Change:**

This PR adds a skeleton `convert-qecp-to-quantum` dialect-conversion pass, implemented in xDSL. It contains no rewrite patterns at the moment; these will be added in subsequent PRs.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
