### PR TITLE
Remove stray print statement in measurements_from_samples

### DIFF
--- a/frontend/catalyst/python_interface/transforms/quantum/measurements_from_samples.py
+++ b/frontend/catalyst/python_interface/transforms/quantum/measurements_from_samples.py
@@ -128,7 +128,6 @@ class MeasurementsFromSamplesPattern(RewritePattern):
         # post-processing calls will be injected at the same point for all MPs
         # adding calls starting with the final MP ensures call order matches MP order
         for mp_op in measurement_processes[::-1]:
-            print(mp_op.name)
             match mp_op.name:
                 case "quantum.expval":
                     self.expval_and_var_to_samples(mp_op, rewriter)


### PR DESCRIPTION
**Context:**
The `measurements_from_samples` pass has a stray print statement leftover from debugging during implementation. It prints your circuit's MPs.

**Description of the Change:**
Remove stray print statement.