### PR TITLE
Strip `-rcX` suffix and fix make wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ wheel:
 		    cp $(COPY_FLAGS) $$file $$dest_dir; \
 	    done' sh {} +
 
-	$(PYTHON) -m pip wheel --pre . -w bootstrap_dist --extra-index-url https://test.pypi.org/simple
+	$(PYTHON) -m pip wheel --pre . -w bootstrap_dist --extra-index-url https://test.pypi.org/simple 
 	$(PYTHON) -m pip install bootstrap_dist/*.whl
 
 	$(PYTHON) -m catalyst.utils.precompile_decomposition_rules

--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ wheel:
 		    cp $(COPY_FLAGS) $$file $$dest_dir; \
 	    done' sh {} +
 
-	$(PYTHON) -m pip wheel --pre . -w bootstrap_dist --extra-index-url https://test.pypi.org/simple
+	$(PYTHON) -m pip wheel --pre  . -w bootstrap_dist --extra-index-url https://test.pypi.org/simple
 	$(PYTHON) -m pip install bootstrap_dist/*.whl
 
 	$(PYTHON) -m catalyst.utils.precompile_decomposition_rules

--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ wheel:
 		    cp $(COPY_FLAGS) $$file $$dest_dir; \
 	    done' sh {} +
 
-	$(PYTHON) -m pip wheel . -w bootstrap_dist --extra-index-url https://test.pypi.org/simple
+	$(PYTHON) -m pip wheel --pre . -w bootstrap_dist --extra-index-url https://test.pypi.org/simple
 	$(PYTHON) -m pip install bootstrap_dist/*.whl
 
 	$(PYTHON) -m catalyst.utils.precompile_decomposition_rules

--- a/Makefile
+++ b/Makefile
@@ -261,7 +261,7 @@ wheel:
 		    cp $(COPY_FLAGS) $$file $$dest_dir; \
 	    done' sh {} +
 
-	$(PYTHON) -m pip wheel --pre  . -w bootstrap_dist --extra-index-url https://test.pypi.org/simple
+	$(PYTHON) -m pip wheel --pre . -w bootstrap_dist --extra-index-url https://test.pypi.org/simple
 	$(PYTHON) -m pip install bootstrap_dist/*.whl
 
 	$(PYTHON) -m catalyst.utils.precompile_decomposition_rules

--- a/frontend/catalyst/_version.py
+++ b/frontend/catalyst/_version.py
@@ -16,4 +16,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "0.15.0-rc0"
+__version__ = "0.15.0"


### PR DESCRIPTION
`--pre` is required so that PennyLane RC versions on TestPyPI  are eligible candidates. Without it, pip falls back to the latest stable PyPI release (currently 0.44.0/0.44.1), which is missing a `gast` dependency declaration that the precompile step below needs.