### PR TITLE
Bump xdsl-jax to 0.5.2

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -14,6 +14,9 @@
 
 <h3>Breaking changes 💔</h3>
 
+* Catalyst's xDSL dependencies have been updated to `xdsl` 0.63.0 and `xdsl-jax` 0.5.2.
+  [(#2840)](https://github.com/PennyLaneAI/catalyst/pull/2840)
+
 <h3>Deprecations 👋</h3>
 
 <h3>Bug fixes 🐛</h3>

--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,7 @@ requirements = [
     "numpy>2.0.0",
     "scipy-openblas32>=0.3.26,!=0.3.33",  # symbol and library name
     "diastatic-malt==2.15.3",
-    "xdsl==0.59.0",
+    "xdsl==0.63.0",
     "xdsl-jax==0.5.2",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,7 @@ requirements = [
     "scipy-openblas32>=0.3.26,!=0.3.33",  # symbol and library name
     "diastatic-malt==2.15.3",
     "xdsl==0.59.0",
-    "xdsl-jax==0.5.0",
+    "xdsl-jax==0.5.2",
 ]
 
 entry_points = {


### PR DESCRIPTION
**Context:**
There was a bug in upstream xdsl-jax where 1-bit integers (`i1`) could not be parsed correctly: https://github.com/xdslproject/xdsl-jax/issues/124

It was fixed upstream and a new version was recently released.

**Description of the Change:**
Bump to new xdsl-jax version.

**Benefits:**
Original bug is fixed, unblocking various items.
