### PR TITLE
Test cleanup

### DIFF
--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -615,8 +615,9 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
             # the same as the decorator arguments
             closure_vars = inspect.getclosurevars(fn)
             decorator_kwargs = {
-                "id": closure_vars.nonlocals["id"],
-                "lazy": closure_vars.nonlocals["lazy"],
+                k: v
+                for k, v in closure_vars.nonlocals.items()
+                if k in ("id", "lazy")
             }
 
             # Convert the original function with autograph

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -615,9 +615,8 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
             # the same as the decorator arguments
             closure_vars = inspect.getclosurevars(fn)
             decorator_kwargs = {
-                k: v
-                for k, v in closure_vars.nonlocals.items()
-                if k in ("id", "lazy")
+                "id": closure_vars.nonlocals["id"],
+                "lazy": closure_vars.nonlocals["lazy"],
             }
 
             # Convert the original function with autograph

--- a/frontend/test/pytest/test_specs.py
+++ b/frontend/test/pytest/test_specs.py
@@ -265,21 +265,21 @@ class TestPassByPassSpecs:
 
         no_passes = qjit(simple_circuit, capture=capture_mode)
         with pytest.raises(
-            check=ValueError,
+            ValueError,
             match=r"The 'level' argument to .*\.specs for QJIT'd QNodes is out of "
             "bounds, got -5.",
         ):
             qp.specs(no_passes, level=-5)()
 
         with pytest.raises(
-            check=ValueError,
+            ValueError,
             match=r"The 'level' argument to .*\.specs for QJIT'd "
             "QNodes is out of bounds, got 10.",
         ):
             qp.specs(no_passes, level=10)()
 
         with pytest.raises(
-            check=ValueError,
+            ValueError,
             match=r"The 'level' argument to .*\.specs for QJIT'd "
             "QNodes is out of bounds, got 10.",
         ):

--- a/frontend/test/pytest/test_verification.py
+++ b/frontend/test/pytest/test_verification.py
@@ -712,7 +712,7 @@ class TestMeasurementTypeValidation:
             """A custom measurement (not supported on lightning.qubit)"""
 
             def __init__(self, obs=None, wires=None):
-                super().__init__(obs=obs, wires=wires, eigvals=None, id=None)
+                super().__init__(obs=obs, wires=wires, eigvals=None)
 
             def process_samples(self, samples, wire_order, shot_range, bin_size):
                 """overwrite ABC method"""


### PR DESCRIPTION
1. `pytest.raises` use error type as the first positional arg instead of `check=` kwarg. `check` won't work if pytest upgrades to a newer version.
2. `id` has been removed on Pennylane side; caused two of the failures in https://github.com/PennyLaneAI/catalyst/actions/runs/25856613784/job/75975962909
   - [x] test_unsupported_measurement_types_rejected

[sc-119766]