### PR TITLE
Fix/prod id removed from pl

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -27,6 +27,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Fixed ``KeyError`` in autograph when using ``qp.prod`` as a decorator with PennyLane >= 0.45.
+  [(#2844)](https://github.com/PennyLaneAI/catalyst/pull/2844)
+
 * Update RC nightly builds to read version number from the `_version.py` file
   [(#2797)](https://github.com/PennyLaneAI/catalyst/pull/2797)
 
@@ -50,6 +53,7 @@
 This release contains contributions from (in alphabetical order):
 
 Joey Carter,
+Yushao Chen,
 Lillian Frederiksen,
 Mehrdad Malekmohammadi,
 Shuli Shu,

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -615,8 +615,9 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
             # the same as the decorator arguments
             closure_vars = inspect.getclosurevars(fn)
             decorator_kwargs = {
-                "id": closure_vars.nonlocals["id"],
-                "lazy": closure_vars.nonlocals["lazy"],
+                k: v
+                for k, v in closure_vars.nonlocals.items()
+                if k in ("id", "lazy")
             }
 
             # Convert the original function with autograph

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -615,9 +615,7 @@ def converted_call(fn, args, kwargs, caller_fn_scope=None, options=None):
             # the same as the decorator arguments
             closure_vars = inspect.getclosurevars(fn)
             decorator_kwargs = {
-                k: v
-                for k, v in closure_vars.nonlocals.items()
-                if k in ("id", "lazy")
+                "lazy": closure_vars.nonlocals["lazy"],
             }
 
             # Convert the original function with autograph


### PR DESCRIPTION
Context: Pennylane removed `id` for multiple classes: https://github.com/PennyLaneAI/pennylane/pull/9467

To fix one of the failures in https://github.com/PennyLaneAI/catalyst/actions/runs/25856613784/job/75975962909

[sc-119766]