### PR TITLE
Ensure constructors of xDSL ops with `idx_attr` produce correct attribute type

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -47,6 +47,12 @@
   [(#2780)](https://github.com/PennyLaneAI/catalyst/pull/2780)
   [(#2772)](https://github.com/PennyLaneAI/catalyst/pull/2772)
 
+* The constructors of xDSL ops that accept index attributes have been updated to ensure that the
+  resulting attribute has the correct type. These ops include `quantum.{extract, insert}`,
+  `qecl.{extract_block, insert_block, measure, <gates>}`, and
+  `qecp.{extract_block, insert_block, extract, insert}`.
+  [(#2846)](https://github.com/PennyLaneAI/catalyst/pull/2846)
+
 <h3>Documentation 📝</h3>
 
 <h3>Contributors ✍️</h3>

--- a/frontend/catalyst/python_interface/dialects/qecl.py
+++ b/frontend/catalyst/python_interface/dialects/qecl.py
@@ -251,7 +251,7 @@ class ExtractCodeblockOp(IRDLOperation):
 
         if isinstance(idx, IntegerAttr):
             operands = (hyper_reg, None)
-            properties = {"idx_attr": idx}
+            properties = {"idx_attr": IntegerAttr(idx.value.data, IndexType())}
         else:
             operands = (hyper_reg, idx)
             properties = {}
@@ -299,7 +299,7 @@ class InsertCodeblockOp(IRDLOperation):
 
         if isinstance(idx, IntegerAttr):
             operands = (in_hyper_reg, None, codeblock)
-            properties = {"idx_attr": idx}
+            properties = {"idx_attr": IntegerAttr(idx.value.data, IndexType())}
         else:
             operands = (in_hyper_reg, idx, codeblock)
             properties = {}
@@ -454,7 +454,7 @@ class SingleQubitLogicalGateOp(IRDLOperation):
 
         if isinstance(idx, IntegerAttr):
             operands = (in_codeblock, None)
-            properties["idx_attr"] = idx
+            properties["idx_attr"] = IntegerAttr(idx.value.data, IndexType())
 
         else:
             operands = (in_codeblock, idx)
@@ -725,7 +725,7 @@ class MeasureOp(IRDLOperation):
 
         if isinstance(idx, IntegerAttr):
             operands = (in_codeblock, None)
-            properties = {"idx_attr": idx}
+            properties = {"idx_attr": IntegerAttr(idx.value.data, IndexType())}
         else:
             operands = (in_codeblock, idx)
 

--- a/frontend/catalyst/python_interface/dialects/qecl.py
+++ b/frontend/catalyst/python_interface/dialects/qecl.py
@@ -655,13 +655,16 @@ class CnotOp(IRDLOperation):
 
         if isinstance(idx_ctrl, IntegerAttr) and isinstance(idx_trgt, IntegerAttr):
             operands = (in_ctrl_codeblock, None, in_trgt_codeblock, None)
-            properties = {"idx_ctrl_attr": idx_ctrl, "idx_trgt_attr": idx_trgt}
+            properties = {
+                "idx_ctrl_attr": IntegerAttr(idx_ctrl.value.data, IndexType()),
+                "idx_trgt_attr": IntegerAttr(idx_trgt.value.data, IndexType()),
+            }
         elif isinstance(idx_ctrl, IntegerAttr):
             operands = (in_ctrl_codeblock, None, in_trgt_codeblock, idx_trgt)
-            properties = {"idx_ctrl_attr": idx_ctrl}
+            properties = {"idx_ctrl_attr": IntegerAttr(idx_ctrl.value.data, IndexType())}
         elif isinstance(idx_trgt, IntegerAttr):
             operands = (in_ctrl_codeblock, idx_ctrl, in_trgt_codeblock, None)
-            properties = {"idx_trgt_attr": idx_trgt}
+            properties = {"idx_trgt_attr": IntegerAttr(idx_trgt.value.data, IndexType())}
         else:
             operands = (in_ctrl_codeblock, idx_ctrl, in_trgt_codeblock, idx_trgt)
             properties = {}

--- a/frontend/catalyst/python_interface/dialects/qecp.py
+++ b/frontend/catalyst/python_interface/dialects/qecp.py
@@ -392,7 +392,7 @@ class ExtractCodeblockOp(IRDLOperation):
 
         if isinstance(idx, IntegerAttr):
             operands = (hyper_reg, None)
-            properties = {"idx_attr": idx}
+            properties = {"idx_attr": IntegerAttr(idx.value.data, IndexType())}
         else:
             operands = (hyper_reg, idx)
             properties = {}
@@ -440,7 +440,7 @@ class InsertCodeblockOp(IRDLOperation):
 
         if isinstance(idx, IntegerAttr):
             operands = (in_hyper_reg, None, codeblock)
-            properties = {"idx_attr": idx}
+            properties = {"idx_attr": IntegerAttr(idx.value.data, IndexType())}
         else:
             operands = (in_hyper_reg, idx, codeblock)
             properties = {}
@@ -485,7 +485,7 @@ class ExtractQubitOp(IRDLOperation):
 
         if isinstance(idx, IntegerAttr):
             operands = (codeblock, None)
-            properties = {"idx_attr": idx}
+            properties = {"idx_attr": IntegerAttr(idx.value.data, IndexType())}
         else:
             operands = (codeblock, idx)
             properties = {}
@@ -537,7 +537,7 @@ class InsertQubitOp(IRDLOperation):
 
         if isinstance(idx, IntegerAttr):
             operands = (in_codeblock, None, qubit)
-            properties = {"idx_attr": idx}
+            properties = {"idx_attr": IntegerAttr(idx.value.data, IndexType())}
         else:
             operands = (in_codeblock, idx, qubit)
             properties = {}

--- a/frontend/catalyst/python_interface/dialects/quantum/operations/qubit_ops.py
+++ b/frontend/catalyst/python_interface/dialects/quantum/operations/qubit_ops.py
@@ -149,7 +149,7 @@ class ExtractOp(IRDLOperation):
 
         if isinstance(idx, IntegerAttr):
             operands = (qreg, None)
-            properties = {"idx_attr": idx}
+            properties = {"idx_attr": IntegerAttr(idx.value.data, i64)}
         else:
             operands = (qreg, idx)
             properties = {}
@@ -194,7 +194,7 @@ class InsertOp(IRDLOperation):
 
         if isinstance(idx, IntegerAttr):
             operands = (in_qreg, None, qubit)
-            properties = {"idx_attr": idx}
+            properties = {"idx_attr": IntegerAttr(idx.value.data, i64)}
         else:
             operands = (in_qreg, idx, qubit)
             properties = {}

--- a/frontend/test/pytest/python_interface/dialects/test_qecl_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_qecl_dialect.py
@@ -18,12 +18,28 @@ from typing import cast
 
 import pytest
 from xdsl.dialects import test
-from xdsl.dialects.builtin import I64, IndexType, IntegerAttr, IntegerType, UnitAttr
-from xdsl.ir import AttributeCovT, OpResult
+from xdsl.dialects.builtin import I64, IndexType, IntegerAttr, IntegerType, UnitAttr, i64
+from xdsl.ir import AttributeCovT, Operation, OpResult, SSAValue
 
 from catalyst.python_interface.dialects import qecl
 
 pytestmark = pytest.mark.xdsl
+
+
+@pytest.fixture
+def assert_valid_idx_attr(scope="module"):
+    def _validate_idx(op: Operation, idx: int | IntegerAttr | SSAValue):
+        idx_attr = op.properties.get("idx_attr")
+        if isinstance(idx, (int, IntegerAttr)):
+            assert idx_attr is not None
+            if isinstance(idx, int):
+                assert idx_attr == IntegerAttr(idx, IndexType())
+            elif isinstance(idx, IntegerAttr):
+                assert idx_attr == IntegerAttr(idx.value.data, IndexType())
+        else:
+            assert idx_attr is None
+
+    return _validate_idx
 
 
 # Test function taken from xdsl/utils/test_value.py
@@ -139,17 +155,31 @@ class TestQecLogicalOps:
         dealloc_op = qecl.DeallocOp(self._get_hyper_reg_value())
         assert len(dealloc_op.result_types) == 0
 
-    @pytest.mark.parametrize("idx", [0, IntegerAttr(0, IndexType()), create_ssa_value(IndexType())])
-    def test_qecl_op_constructor_extract_block(self, idx):
-        """Test the constructor of the qecl.extract_block op."""
+    @pytest.mark.parametrize(
+        "idx", [0, IntegerAttr(0, IndexType()), IntegerAttr(0, i64), create_ssa_value(IndexType())]
+    )
+    def test_qecl_op_constructor_extract_block(self, idx, assert_valid_idx_attr):
+        """Test the constructor of the qecl.extract_block op.
+
+        Also check that when the `idx` input is static that the `idx_attr` of the op always has type
+        `index`.
+        """
         extract_block_op = qecl.ExtractCodeblockOp(hyper_reg=self._get_hyper_reg_value(), idx=idx)
         assert len(extract_block_op.result_types) == 1
         assert isinstance(extract_block_op.result_types[0], qecl.LogicalCodeblockType)
         assert extract_block_op.result_types[0].k == self.k
 
-    @pytest.mark.parametrize("idx", [0, IntegerAttr(0, IndexType()), create_ssa_value(IndexType())])
-    def test_qecl_op_constructor_insert_block(self, idx):
-        """Test the constructor of the qecl.insert_block op."""
+        assert_valid_idx_attr(extract_block_op, idx)
+
+    @pytest.mark.parametrize(
+        "idx", [0, IntegerAttr(0, IndexType()), IntegerAttr(0, i64), create_ssa_value(IndexType())]
+    )
+    def test_qecl_op_constructor_insert_block(self, idx, assert_valid_idx_attr):
+        """Test the constructor of the qecl.insert_block op.
+
+        Also check that when the `idx` input is static that the `idx_attr` of the op always has type
+        `index`.
+        """
         insert_block_op = qecl.InsertCodeblockOp(
             in_hyper_reg=self._get_hyper_reg_value(), idx=idx, codeblock=self._get_codeblock_value()
         )
@@ -157,6 +187,8 @@ class TestQecLogicalOps:
         assert isinstance(insert_block_op.result_types[0], qecl.LogicalHyperRegisterType)
         assert insert_block_op.result_types[0].width == self.width
         assert insert_block_op.result_types[0].k == self.k
+
+        assert_valid_idx_attr(insert_block_op, idx)
 
     @pytest.mark.parametrize("init_state", ["zero", qecl.LogicalCodeblockInitStateAttr("zero")])
     def test_qecl_op_constructor_encode(self, init_state):
@@ -302,12 +334,12 @@ def test_assembly_format(run_filecheck, pretty_print):
     // CHECK: [[block11:%.+]], [[block12:%.+]] = qecl.cnot [[block_ctrl]][{{\s*}}0], [[block10]][{{\s*}}0]
     %block_ctrl = "test.op"() : () -> !qecl.codeblock<1>
     %block11, %block12 = qecl.cnot %block_ctrl[0], %block10[0] : !qecl.codeblock<1>, !qecl.codeblock<1>
-    
+
     // CHECK: [[block13:%.+]] = "test.op"() : () -> !qecl.codeblock<1>
     // CHECK: [[block14:%.+]] = qecl.noise [[block13:%.+]] : !qecl.codeblock<1>
     %block13 = "test.op"() : () -> !qecl.codeblock<1>
     %block14 = qecl.noise %block13 : !qecl.codeblock<1>
-    
+
     """
 
     run_filecheck(program, roundtrip=True, verify=True, pretty_print=pretty_print)

--- a/frontend/test/pytest/python_interface/dialects/test_qecl_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_qecl_dialect.py
@@ -26,8 +26,12 @@ from catalyst.python_interface.dialects import qecl
 pytestmark = pytest.mark.xdsl
 
 
-@pytest.fixture
-def assert_valid_idx_attr(scope="module"):
+@pytest.fixture(scope="module", name="assert_valid_idx_attr")
+def fixture_assert_valid_idx_attr():
+    """Fixture factory that returns a function to validate the `idx_attr` attribute of an xDSL
+    operation.
+    """
+
     def _validate_idx(op: Operation, idx: int | IntegerAttr | SSAValue):
         idx_attr = op.properties.get("idx_attr")
         if isinstance(idx, (int, IntegerAttr)):

--- a/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
@@ -28,11 +28,27 @@ from xdsl.dialects.builtin import (
     i32,
     i64,
 )
-from xdsl.ir import AttributeCovT, OpResult
+from xdsl.ir import AttributeCovT, Operation, OpResult, SSAValue
 
 from catalyst.python_interface.dialects import qecp
 
 pytestmark = pytest.mark.xdsl
+
+
+@pytest.fixture
+def assert_valid_idx_attr(scope="module"):
+    def _validate_idx(op: Operation, idx: int | IntegerAttr | SSAValue):
+        idx_attr = op.properties.get("idx_attr")
+        if isinstance(idx, (int, IntegerAttr)):
+            assert idx_attr is not None
+            if isinstance(idx, int):
+                assert idx_attr == IntegerAttr(idx, IndexType())
+            elif isinstance(idx, IntegerAttr):
+                assert idx_attr == IntegerAttr(idx.value.data, IndexType())
+        else:
+            assert idx_attr is None
+
+    return _validate_idx
 
 
 # Test function taken from xdsl/utils/test_value.py
@@ -197,21 +213,31 @@ class TestQecPhysicalOps:
         assert len(dealloc_aux_op.result_types) == 0
 
     @pytest.mark.parametrize(
-        "idx", [0, IntegerAttr.from_index_int_value(0), create_ssa_value(IndexType())]
+        "idx", [0, IntegerAttr(0, IndexType()), IntegerAttr(0, i64), create_ssa_value(IndexType())]
     )
-    def test_qecp_op_constructor_extract_block(self, idx):
-        """Test the constructor of the qecp.extract_block op."""
+    def test_qecp_op_constructor_extract_block(self, idx, assert_valid_idx_attr):
+        """Test the constructor of the qecp.extract_block op.
+
+        Also check that when the `idx` input is static that the `idx_attr` of the op always has type
+        `index`.
+        """
         extract_block_op = qecp.ExtractCodeblockOp(hyper_reg=self._get_hyper_reg_value(), idx=idx)
         assert len(extract_block_op.result_types) == 1
         assert isinstance(extract_block_op.result_types[0], qecp.PhysicalCodeblockType)
         assert extract_block_op.result_types[0].k == self.k
         assert extract_block_op.result_types[0].n == self.n
 
+        assert_valid_idx_attr(extract_block_op, idx)
+
     @pytest.mark.parametrize(
-        "idx", [0, IntegerAttr.from_index_int_value(0), create_ssa_value(IndexType())]
+        "idx", [0, IntegerAttr(0, IndexType()), IntegerAttr(0, i64), create_ssa_value(IndexType())]
     )
-    def test_qecp_op_constructor_insert_block(self, idx):
-        """Test the constructor of the qecp.insert_block op."""
+    def test_qecp_op_constructor_insert_block(self, idx, assert_valid_idx_attr):
+        """Test the constructor of the qecp.insert_block op.
+
+        Also check that when the `idx` input is static that the `idx_attr` of the op always has type
+        `index`.
+        """
         insert_block_op = qecp.InsertCodeblockOp(
             in_hyper_reg=self._get_hyper_reg_value(), idx=idx, codeblock=self._get_codeblock_value()
         )
@@ -221,21 +247,33 @@ class TestQecPhysicalOps:
         assert insert_block_op.result_types[0].k == self.k
         assert insert_block_op.result_types[0].n == self.n
 
+        assert_valid_idx_attr(insert_block_op, idx)
+
     @pytest.mark.parametrize(
-        "idx", [0, IntegerAttr.from_index_int_value(0), create_ssa_value(IndexType())]
+        "idx", [0, IntegerAttr(0, IndexType()), IntegerAttr(0, i64), create_ssa_value(IndexType())]
     )
-    def test_qecp_op_constructor_extract(self, idx):
-        """Test the constructor of the qecp.extract op."""
+    def test_qecp_op_constructor_extract(self, idx, assert_valid_idx_attr):
+        """Test the constructor of the qecp.extract op.
+
+        Also check that when the `idx` input is static that the `idx_attr` of the op always has type
+        `index`.
+        """
         extract_op = qecp.ExtractQubitOp(codeblock=self._get_codeblock_value(), idx=idx)
         assert len(extract_op.result_types) == 1
         assert isinstance(extract_op.result_types[0], qecp.QecPhysicalQubitType)
         assert extract_op.result_types[0].role.data == qecp.QecPhysicalQubitRole.Data
 
+        assert_valid_idx_attr(extract_op, idx)
+
     @pytest.mark.parametrize(
-        "idx", [0, IntegerAttr.from_index_int_value(0), create_ssa_value(IndexType())]
+        "idx", [0, IntegerAttr(0, IndexType()), IntegerAttr(0, i64), create_ssa_value(IndexType())]
     )
-    def test_qecp_op_constructor_insert(self, idx):
-        """Test the constructor of the qecp.insert op."""
+    def test_qecp_op_constructor_insert(self, idx, assert_valid_idx_attr):
+        """Test the constructor of the qecp.insert op.
+
+        Also check that when the `idx` input is static that the `idx_attr` of the op always has type
+        `index`.
+        """
         insert_op = qecp.InsertQubitOp(
             in_codeblock=self._get_codeblock_value(), idx=idx, qubit=self._get_qubit_data_value()
         )
@@ -243,6 +281,8 @@ class TestQecPhysicalOps:
         assert isinstance(insert_op.result_types[0], qecp.PhysicalCodeblockType)
         assert insert_op.result_types[0].k == self.k
         assert insert_op.result_types[0].n == self.n
+
+        assert_valid_idx_attr(insert_op, idx)
 
     @pytest.mark.parametrize("op", [qecp.IdentityOp, qecp.PauliXOp, qecp.PauliYOp, qecp.PauliZOp])
     @pytest.mark.parametrize(

--- a/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
@@ -35,8 +35,12 @@ from catalyst.python_interface.dialects import qecp
 pytestmark = pytest.mark.xdsl
 
 
-@pytest.fixture
-def assert_valid_idx_attr(scope="module"):
+@pytest.fixture(scope="module", name="assert_valid_idx_attr")
+def fixture_assert_valid_idx_attr():
+    """Fixture factory that returns a function to validate the `idx_attr` attribute of an xDSL
+    operation.
+    """
+
     def _validate_idx(op: Operation, idx: int | IntegerAttr | SSAValue):
         idx_attr = op.properties.get("idx_attr")
         if isinstance(idx, (int, IntegerAttr)):


### PR DESCRIPTION
**Context:** Certain xDSL ops with an `idx` attribute, such as

* `quantum.{extract, insert}`
* `qecl.{extract_block, insert_block, measure, <gate>`}
* `qecp.{extract_block, insert_block}`, etc.

can be built with incorrect types. For instance, the `qecl.extract_block` expects an integer attribute of type `index` for its `idx` attribute, however, it can be built with other integer attribute types, such as `i64`. This is normally not an issue when using the custom assembly format, since the attribute type is not displayed and can therefore be correctly interpreted during parsing. However, when using generic MLIR format, ops with the incorrect attribute would fail to parse.

**Description of the Change:** The constructors of these xDSL ops have been updated to ensure the `idx` attributes are constructed with the correct types.

[sc-119832]