### PR TITLE
Remove rt_decoder from build targets

### DIFF
--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -336,7 +336,7 @@ jobs:
               -DENABLE_OQD=OFF \
               -DMLIR_INCLUDE_DIRS="$GITHUB_WORKSPACE/mlir/llvm-project/mlir/include"
 
-        cmake --build $GITHUB_WORKSPACE/runtime-build --target rt_capi rt_rsdecomp rt_decoder rtd_openqasm rtd_null_qubit
+        cmake --build $GITHUB_WORKSPACE/runtime-build --target rt_capi rt_rsdecomp rtd_openqasm rtd_null_qubit
 
     - name: Build OQC-Runtime
       run: |

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -359,7 +359,7 @@ jobs:
               -DENABLE_OQD=OFF \
               -DMLIR_INCLUDE_DIRS="$GITHUB_WORKSPACE/mlir/llvm-project/mlir/include"
 
-        cmake --build $GITHUB_WORKSPACE/runtime-build --target rt_capi rt_rsdecomp rt_decoder rtd_openqasm rtd_null_qubit
+        cmake --build $GITHUB_WORKSPACE/runtime-build --target rt_capi rt_rsdecomp rtd_openqasm rtd_null_qubit
 
     # Build OQC-Runtime
     - name: Build OQC-Runtime

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -329,7 +329,7 @@ jobs:
               -DENABLE_OQD=OFF \
               -DMLIR_INCLUDE_DIRS="$GITHUB_WORKSPACE/mlir/llvm-project/mlir/include"
 
-        cmake --build $GITHUB_WORKSPACE/runtime-build --target rt_capi rt_rsdecomp rt_decoder rtd_openqasm rtd_null_qubit
+        cmake --build $GITHUB_WORKSPACE/runtime-build --target rt_capi rt_rsdecomp rtd_openqasm rtd_null_qubit
 
     - name: Error log on failure
       if: failure() && steps.runtime-build.outcome == 'failure'

--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,6 @@ wheel:
 	cp $(RT_BUILD_DIR)/lib/liblapacke.* $(MK_DIR)/frontend/catalyst/lib || true  # optional
 	cp $(RT_BUILD_DIR)/lib/librt_capi.* $(MK_DIR)/frontend/catalyst/lib
 	cp $(RT_BUILD_DIR)/lib/librt_rsdecomp.* $(MK_DIR)/frontend/catalyst/lib
-	cp $(RT_BUILD_DIR)/lib/librt_decoder.* $(MK_DIR)/frontend/catalyst/lib
 	cp $(RT_BUILD_DIR)/lib/backend/*.toml $(MK_DIR)/frontend/catalyst/lib/backend
 	cp $(OQC_BUILD_DIR)/librtd_oqc* $(MK_DIR)/frontend/catalyst/lib
 	cp $(OQC_BUILD_DIR)/oqc_python_module.so $(MK_DIR)/frontend/catalyst/lib

--- a/doc/dev/debugging.rst
+++ b/doc/dev/debugging.rst
@@ -119,7 +119,7 @@ Will print out something close to the following:
             -Wl,-rpath,mlir/llvm-project/build/lib -Lmlir/llvm-project/build/lib \
             -Wl,-rpath,frontend/catalyst/utils/../../../runtime/build/lib -Lfrontend/catalyst/utils/../../../runtime/build/lib \
             -Wl,-rpath,frontend/catalyst/utils -Lfrontend/catalyst/utils \
-            -lrt_capi -lpthread -lmlir_c_runner_utils -llapacke.3 -lcustom_calls -lmlir_async_runtime -lrt_rsdecomp -lrt_decoder -lrt_OQD_capi \
+            -lrt_capi -lpthread -lmlir_c_runner_utils -llapacke.3 -lcustom_calls -lmlir_async_runtime -lrt_rsdecomp -lrt_OQD_capi \
             circuit.o -o circuit.so
 
 Pass Pipelines

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -173,7 +173,7 @@ class LinkerDriver:
             "-lcustom_calls",
             "-lmlir_async_runtime",
             "-lrt_rsdecomp",
-            "-lrt_decoder",
+            # "-lrt_decoder",  TODO: Re-enable when stringop-overflow warning on arm64 is resolved
         ]
 
         # If OQD runtime capi is built, link to it as well


### PR DESCRIPTION
**Context:** PR #2772 added the new LUT decoder runtime lib, `rt_decoder`, as a build target. However, on Linux arm64 builds, this triggers a `stringop-overflow` compiler warning (promoted to error). See here for example: https://github.com/PennyLaneAI/catalyst/actions/runs/25882806007/job/76067179962.

[sc-119884]

**Description of the Change:** This is a difficult compiler warning to debug as it only appears on Linux arm64 builds. Therefore as a stopgap measure while we work on a proper fix, this PR removes `rt_decoder` from the build targets to unblock the wheels builds.
