### PR TITLE
Update tests that were affected by Pennylane deprecation/removal v0.46

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.238
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.45.0
+pennylane=0.46.0.dev9
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.238
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.46.0.dev9
+pennylane=0.46.0.dev11
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -32,6 +32,6 @@ lxml_html_clean
 
 # Pre-install PL development wheels
 --extra-index-url https://test.pypi.org/simple/
-pennylane-lightning-kokkos==0.45.0-dev44
-pennylane-lightning==0.45.0-dev44
-pennylane==0.45.0-dev94
+pennylane-lightning-kokkos==0.45.0
+pennylane-lightning==0.45.0
+pennylane==0.46.0.dev9

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -34,4 +34,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.45.0
 pennylane-lightning==0.45.0
-pennylane==0.46.0.dev9
+pennylane==0.46.0.dev11

--- a/frontend/test/pytest/from_plxpr/test_capture_integration.py
+++ b/frontend/test/pytest/from_plxpr/test_capture_integration.py
@@ -88,15 +88,6 @@ def is_single_qubit_fusion_applied(mlir):
     )
 
 
-def is_controlled_pushed_back(mlir, non_controlled_string, controlled_string):
-    """Check in the MLIR if the controlled gate got pushed after the non-controlled one"""
-    non_controlled_pos = mlir.find(non_controlled_string)
-    assert non_controlled_pos > 0
-
-    remaining_mlir = mlir[non_controlled_pos + len(non_controlled_string) :]
-    return controlled_string in remaining_mlir
-
-
 def is_amplitude_embedding_merged_and_decomposed(mlir):
     """Check in the MLIR if the amplitude embeddings got merged and decomposed"""
     return (
@@ -1472,53 +1463,6 @@ class TestCapture:
             qp.Rot(0.4, 0.5, 0.6, wires=0)
             qp.RZ(0.1, wires=0)
             qp.RZ(0.4, wires=0)
-            return qp.expval(qp.PauliZ(0))
-
-        assert jnp.allclose(circuit(), capture_result)
-
-    def test_transform_commute_controlled_workflow(self, backend):
-        """Test the integration for a circuit with a 'commute_controlled' transform."""
-
-        # Capture enabled
-
-        qp.capture.enable()
-
-        @qjit
-        @partial(qp.transforms.commute_controlled, direction="left")
-        @qp.qnode(qp.device(backend, wires=3))
-        def captured_circuit():
-            qp.CNOT(wires=[0, 2])
-            qp.PauliX(wires=2)
-            qp.RX(0.2, wires=2)
-            qp.Toffoli(wires=[0, 1, 2])
-            qp.CRX(0.1, wires=[0, 1])
-            qp.PauliX(wires=1)
-            return qp.expval(qp.PauliZ(0))
-
-        capture_result = captured_circuit()
-
-        capture_mlir = captured_circuit.mlir
-        assert is_controlled_pushed_back(
-            capture_mlir, 'quantum.custom "RX"', 'quantum.custom "CNOT"'
-        )
-        assert is_controlled_pushed_back(
-            capture_mlir, 'quantum.custom "PauliX"', 'quantum.custom "CRX"'
-        )
-
-        qp.capture.disable()
-
-        # Capture disabled
-
-        @qjit
-        @partial(qp.transforms.commute_controlled, direction="left")
-        @qp.qnode(qp.device(backend, wires=3))
-        def circuit():
-            qp.CNOT(wires=[0, 2])
-            qp.PauliX(wires=2)
-            qp.RX(0.2, wires=2)
-            qp.Toffoli(wires=[0, 1, 2])
-            qp.CRX(0.1, wires=[0, 1])
-            qp.PauliX(wires=1)
             return qp.expval(qp.PauliZ(0))
 
         assert jnp.allclose(circuit(), capture_result)

--- a/frontend/test/pytest/test_adjoint.py
+++ b/frontend/test/pytest/test_adjoint.py
@@ -1082,19 +1082,6 @@ class TestAdjointOperation:
         for angle1, angle2 in zip(angles, reversed(base_angles)):
             assert angle1 == -angle2
 
-    @pytest.mark.parametrize(
-        "base, basis",
-        (
-            (qp.RX(1.234, wires=0), "X"),
-            (qp.PauliY("a"), "Y"),
-            (qp.PhaseShift(4.56, wires="b"), "Z"),
-            (qp.SX(-1), "X"),
-        ),
-    )
-    def test_basis_property(self, base, basis):
-        op = adjoint(base)
-        assert op.basis == basis
-
     def test_control_wires(self):
         """Test the control_wires of an adjoint are the same as the base op."""
         op = adjoint(qp.CNOT(wires=("a", "b")))

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -901,6 +901,19 @@ class TestControlledProperties:
         op = C_ctrl(DummyOp(1), 0)
         assert op.has_diagonalizing_gates is value
 
+    @pytest.mark.parametrize("value", ("_ops", "_measurements"))
+    def test_queue_cateogry(self, value):
+        """Test that `catalyst.ctrl` defers `_queue_category` to base operator."""
+
+        class DummyOp(Operator):
+            """DummyOp"""
+
+            num_wires = 1
+            _queue_category = value
+
+        op = C_ctrl(DummyOp(1), 0)
+        assert op._queue_category == "_ops"
+
     @pytest.mark.parametrize("value", (True, False))
     def test_is_verified_hermitian(self, value):
         """Test that `catalyst.ctrl` defers `is_verified_hermitian` to base operator."""

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -901,19 +901,6 @@ class TestControlledProperties:
         op = C_ctrl(DummyOp(1), 0)
         assert op.has_diagonalizing_gates is value
 
-    @pytest.mark.parametrize("value", ("_ops", "_measurements"))
-    def test_queue_cateogry(self, value):
-        """Test that `catalyst.ctrl` defers `_queue_category` to base operator."""
-
-        class DummyOp(Operator):
-            """DummyOp"""
-
-            num_wires = 1
-            _queue_category = value
-
-        op = C_ctrl(DummyOp(1), 0)
-        assert op._queue_category == value
-
     @pytest.mark.parametrize("value", (True, False))
     def test_is_verified_hermitian(self, value):
         """Test that `catalyst.ctrl` defers `is_verified_hermitian` to base operator."""

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -1141,19 +1141,6 @@ class TestControlledOperationProperties:
         op = C_ctrl(base, 2)
         assert op.grad_method == gm
 
-    def test_basis(self):
-        """Test that controlled mimics the basis attribute of the base op."""
-
-        class DummyOp(Operation):
-            """DummyOp"""
-
-            num_wires = 1
-            basis = "Z"
-
-        base = DummyOp(1)
-        op = C_ctrl(base, 2)
-        assert op.basis == "Z"
-
     @pytest.mark.parametrize(
         "base, expected",
         [

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -901,17 +901,10 @@ class TestControlledProperties:
         op = C_ctrl(DummyOp(1), 0)
         assert op.has_diagonalizing_gates is value
 
-    @pytest.mark.parametrize("value", ("_ops", "_measurements"))
-    def test_queue_cateogry(self, value):
-        """Test that `catalyst.ctrl` defers `_queue_category` to base operator."""
+    def test_queue_cateogry(self):
+        """Test that C_ctrl always returns '_ops' for _queue_category."""
 
-        class DummyOp(Operator):
-            """DummyOp"""
-
-            num_wires = 1
-            _queue_category = value
-
-        op = C_ctrl(DummyOp(1), 0)
+        op = C_ctrl(qp.PauliX(1), 0)
         assert op._queue_category == "_ops"
 
     @pytest.mark.parametrize("value", (True, False))

--- a/frontend/test/test_oqd/oqd/test_openapl_generation.py
+++ b/frontend/test/test_oqd/oqd/test_openapl_generation.py
@@ -323,7 +323,7 @@ class TestComplexCircuits:
         stats = profile_openapl(oqd_dev.openapl_file_name)
         assert stats["num_ions"] == 2
         assert stats["num_parallel_protocols"] == 42
-        assert stats["num_beams"] == 128
+        assert stats["num_beams"] == 104
         assert stats["num_transitions"] == 8
         assert stats["num_levels"] == 8
 

--- a/frontend/test/test_oqd/oqd/test_openapl_generation.py
+++ b/frontend/test/test_oqd/oqd/test_openapl_generation.py
@@ -322,7 +322,7 @@ class TestComplexCircuits:
 
         stats = profile_openapl(oqd_dev.openapl_file_name)
         assert stats["num_ions"] == 2
-        assert stats["num_parallel_protocols"] == 54
+        assert stats["num_parallel_protocols"] == 42
         assert stats["num_beams"] == 128
         assert stats["num_transitions"] == 8
         assert stats["num_levels"] == 8


### PR DESCRIPTION
It's causing trouble after any breaking changes from Pennylane: https://github.com/PennyLaneAI/catalyst/actions/runs/25914582605/job/76167967768#step:25:306
Now it's updated to reflect the actual logic from Pennylane side without assuming mocked base class property will always be used.

Also,
 - [x] bumped the dep versions of Pennylane and Lightning.
 - [x] fixed other tests that are using deprecated `op.basis` API
 - [x] fixed two OQD tests that have fewer decomposed gates now after we improved the `BasisState` decomps

[sc-119833]