### PR TITLE
fix tanner graph ssa out of scope issue in qecp lowering

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -9,6 +9,7 @@
   [(#2824)](https://github.com/PennyLaneAI/catalyst/pull/2824)
   [(#2835)](https://github.com/PennyLaneAI/catalyst/pull/2835)
   [(#2839)](https://github.com/PennyLaneAI/catalyst/pull/2839)
+  [(#2849)](https://github.com/PennyLaneAI/catalyst/pull/2849)
 
 
 <h3>Improvements 🛠</h3>

--- a/frontend/catalyst/python_interface/dialects/qecp.py
+++ b/frontend/catalyst/python_interface/dialects/qecp.py
@@ -826,7 +826,7 @@ class DecodeEsmCssOp(IRDLOperation):
         esm: SSAValue[TensorType] | Operation,
         err_idx_type: TensorType,
     ):
-        operands = (tanner_graph, esm, None)
+        operands = (esm, tanner_graph, None)
         super().__init__(operands=operands, result_types=(err_idx_type,))
 
 

--- a/frontend/catalyst/python_interface/transforms/qecp/convert_qecl_to_qecp.py
+++ b/frontend/catalyst/python_interface/transforms/qecp/convert_qecl_to_qecp.py
@@ -398,13 +398,11 @@ class ConvertQecLogicalToQecPhysicalPass(ModulePass):
         module_block = op.regions[0].blocks.first
         assert module_block is not None, "Module has no block"
 
-        tanner_x, tanner_z = self.insert_tanner_graph_ops_into_block(module_block)
-
         # Insert subroutines that implement the QEC protocols
         encode_funcop = self.create_encode_subroutine()
         module_block.add_op(encode_funcop)
 
-        qec_cycle_funcop = self.create_qec_cycle_subroutine(tanner_x=tanner_x, tanner_z=tanner_z)
+        qec_cycle_funcop = self.create_qec_cycle_subroutine()
         module_block.add_op(qec_cycle_funcop)
 
         measure_subroutine = self.create_measure_subroutine()
@@ -854,14 +852,12 @@ class ConvertQecLogicalToQecPhysicalPass(ModulePass):
 
         return tanner_graph, cnot_fn
 
-    def create_qec_cycle_subroutine(
-        self, tanner_x: qecp.TannerGraphSSAValue, tanner_z: qecp.TannerGraphSSAValue
-    ) -> func.FuncOp:
+    def create_qec_cycle_subroutine(self) -> func.FuncOp:
         """Create a subroutine that performs a cycle of QEC on an input physical codeblock.
 
         The generated subroutine assumes a CSS QEC code and performs separate X and Z corrections,
-        as defined by the input X and Z Tanner graphs, `tanner_x` and `tanner_z`. Recall that
-        X-Tanner graphs define the X stabilizer components of the code, which are used to identify Z
+        as defined by this pass's X and Z Tanner graph data for the code. Recall that X-Tanner
+        graphs define the X stabilizer components of the code, which are used to identify Z
         errors, and conversely Z-Tanner graphs define the Z stabilizer components of the code, which
         are used to identify X errors.
 
@@ -872,6 +868,10 @@ class ConvertQecLogicalToQecPhysicalPass(ModulePass):
         the detected error(s) occurred. It then iterates over these codeblock indices, applies the
         respective correction, and finally returns the updated physical codeblock SSA value.
 
+        Tanner graph SSA values are produced by ``qecp.assemble_tanner`` at the start of this
+        function's entry block so the subroutine body remains isolated from the enclosing module
+        (MLIR functions are isolated from above).
+
         Note that this method does not insert the subroutine into the module op. Instead it returns
         the built func.FuncOp object that can then be subsequently inserted where desired.
         """
@@ -881,6 +881,7 @@ class ConvertQecLogicalToQecPhysicalPass(ModulePass):
         output_types = (codeblock_type,)
 
         block = Block(arg_types=input_types)
+        tanner_x, tanner_z = self.insert_tanner_graph_ops_into_block(block)
 
         with ImplicitBuilder(block):
             in_codeblock = cast(BlockArgument[qecp.PhysicalCodeblockType], block.args[0])
@@ -1013,7 +1014,7 @@ class ConvertQecLogicalToQecPhysicalPass(ModulePass):
                         assert False, f"Unknown CheckType: '{check_type}'"
 
                 insert_err_qubit_op = qecp.InsertQubitOp(
-                    in_codeblock=post_check_codeblock, idx=err_idx, qubit=corr_qubit_op.out_qubit
+                    in_codeblock=codeblock, idx=err_idx, qubit=corr_qubit_op.out_qubit
                 )
 
                 scf.YieldOp(insert_err_qubit_op.out_codeblock)
@@ -1026,7 +1027,6 @@ class ConvertQecLogicalToQecPhysicalPass(ModulePass):
 
             scf.YieldOp(out_codeblock)
 
-        # Return updated codeblock SSA value
         return for_each_err_idx_op.results[0]
 
 

--- a/frontend/catalyst/python_interface/transforms/qecp/convert_qecp_to_quantum.py
+++ b/frontend/catalyst/python_interface/transforms/qecp/convert_qecp_to_quantum.py
@@ -29,7 +29,7 @@ from typing import cast
 from xdsl import pattern_rewriter
 from xdsl.context import Context
 from xdsl.dialects import arith, builtin, func, scf
-from xdsl.dialects.builtin import IndexType, IntegerAttr, IntegerType, I64, i64
+from xdsl.dialects.builtin import I64, IndexType, IntegerAttr, IntegerType, i64
 from xdsl.ir import Attribute, SSAValue
 from xdsl.passes import ModulePass
 from xdsl.pattern_rewriter import (

--- a/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
@@ -427,8 +427,8 @@ class TestQecPhysicalOps:
             tanner_graph, esm, TensorType(IndexType(), shape=(2,))
         )
         assert len(decode_esm_css_op.operands) == 2
-        assert isinstance(decode_esm_css_op.operands[0].type, qecp.TannerGraphType)
-        assert isinstance(decode_esm_css_op.operands[1].type, TensorType)
+        assert isinstance(decode_esm_css_op.operands[0].type, TensorType)
+        assert isinstance(decode_esm_css_op.operands[1].type, qecp.TannerGraphType)
         assert len(decode_esm_css_op.result_types) == 1
         assert isinstance(decode_esm_css_op.result_types[0], TensorType)
 

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecl_to_qecp.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecl_to_qecp.py
@@ -508,13 +508,17 @@ class TestTannerGraphInsertion:
     """Unit tests for the insertion of Tanner graph ops."""
 
     def test_tanner_graph_insertion_steane(self, run_filecheck):
-        """Test that Tanner graph ops for the Steane code are correctly inserted at the beginning of
-        the module.
+        """Test that Tanner graph ops for the Steane code are emitted inside ``qec_cycle_Steane`` (not
+        at module scope), so decoded SSAs respect MLIR function isolation.
         """
 
         program = """
         // CHECK-LABEL: test_module
         builtin.module @test_module {
+        func.func @test_program()  {
+            return
+        }
+        // CHECK-LABEL: func.func private @qec_cycle_Steane
         //      CHECK: [[row_idx_x:%.+]] = arith.constant
         // CHECK-SAME:   dense<[7, 7, 8, 7, 8, 9, 7, 9, 8, 8, 9, 9, 0, 1, 2, 3, 1, 2, 4, 5, 2, 3, 5, 6]> : tensor<24xi32>
         //      CHECK: [[col_ptr_x:%.+]] = arith.constant dense<[0, 1, 3, 6, 8, 9, 11, 12, 16, 20, 24]> : tensor<11xi32>
@@ -525,10 +529,6 @@ class TestTannerGraphInsertion:
         //      CHECK: [[col_ptr_z:%.+]] = arith.constant dense<[0, 1, 3, 6, 8, 9, 11, 12, 16, 20, 24]> : tensor<11xi32>
         //      CHECK: [[tanner_z:%.+]] = qecp.assemble_tanner [[row_idx_z]], [[col_ptr_z]] :
         // CHECK-SAME:   tensor<24xi32>, tensor<11xi32> -> !qecp.tanner_graph<24, 11, i32>
-        // CHECK-LABEL: test_program
-        func.func @test_program()  {
-            return
-        }
         }
         """
         pipeline = (ConvertQecLogicalToQecPhysicalPass(qec_code=QecCode.get("Steane")),)
@@ -548,8 +548,6 @@ class TestQecCycleLowering:
         program = """
         // CHECK-LABEL: test_module
         builtin.module @test_module {
-        // CHECK: [[tanner_x:%.+]] = qecp.assemble_tanner {{.+}} -> !qecp.tanner_graph<24, 11, i32>
-        // CHECK: [[tanner_z:%.+]] = qecp.assemble_tanner {{.+}} -> !qecp.tanner_graph<24, 11, i32>
         // CHECK-LABEL: test_program
         func.func @test_program()  {
             // CHECK: [[cb0:%.+]] = "test.op"() : () -> !qecp.codeblock<1 x 7>
@@ -560,6 +558,8 @@ class TestQecCycleLowering:
             return
         }
         // CHECK-LABEL: qec_cycle_Steane([[cb0:%.+]]: !qecp.codeblock<1 x 7>) -> !qecp.codeblock<1 x 7>
+        //      CHECK: [[tanner_x:%.+]] = qecp.assemble_tanner {{.+}} -> !qecp.tanner_graph<24, 11, i32>
+        //      CHECK: [[tanner_z:%.+]] = qecp.assemble_tanner {{.+}} -> !qecp.tanner_graph<24, 11, i32>
 
         // COM: The block below takes results of X checks and performs Z corrections
         // CHECK: qecp.alloc_aux : !qecp.qubit<aux>

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecl_to_qecp.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecl_to_qecp.py
@@ -594,7 +594,7 @@ class TestQecCycleLowering:
         // CHECK:   [[cond_out_cb:%.+]] = scf.if [[cond]]
         // CHECK:     [[q0:%.+]] = qecp.extract [[cb_arg]][[[err_idx]]] : !qecp.codeblock<1 x 7> -> !qecp.qubit<data>
         // CHECK:     [[q1:%.+]] = qecp.z [[q0]] : !qecp.qubit<data>
-        // CHECK:     [[cb_arg_1:%.+]] = qecp.insert [[cb0]][[[err_idx]]], [[q1]] : !qecp.codeblock<1 x 7>, !qecp.qubit<data>
+        // CHECK:     [[cb_arg_1:%.+]] = qecp.insert [[cb_arg]][[[err_idx]]], [[q1]] : !qecp.codeblock<1 x 7>, !qecp.qubit<data>
         // CHECK:     scf.yield [[cb_arg_1]] : !qecp.codeblock<1 x 7>
         // CHECK:   } else {
         // CHECK:     scf.yield [[cb_arg]] : !qecp.codeblock<1 x 7>
@@ -631,7 +631,7 @@ class TestQecCycleLowering:
         // CHECK:   [[cond_out_cb:%.+]] = scf.if [[cond]]
         // CHECK:     [[q0:%.+]] = qecp.extract [[cb_arg]][[[err_idx]]] : !qecp.codeblock<1 x 7> -> !qecp.qubit<data>
         // CHECK:     [[q1:%.+]] = qecp.x [[q0]] : !qecp.qubit<data>
-        // CHECK:     [[cb_arg_1:%.+]] = qecp.insert [[cb0]][[[err_idx]]], [[q1]] : !qecp.codeblock<1 x 7>, !qecp.qubit<data>
+        // CHECK:     [[cb_arg_1:%.+]] = qecp.insert [[cb_arg]][[[err_idx]]], [[q1]] : !qecp.codeblock<1 x 7>, !qecp.qubit<data>
         // CHECK:     scf.yield [[cb_arg_1]] : !qecp.codeblock<1 x 7>
         // CHECK:   } else {
         // CHECK:     scf.yield [[cb_arg]] : !qecp.codeblock<1 x 7>

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecl_to_qecp.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecl_to_qecp.py
@@ -558,8 +558,8 @@ class TestQecCycleLowering:
             return
         }
         // CHECK-LABEL: qec_cycle_Steane([[cb0:%.+]]: !qecp.codeblock<1 x 7>) -> !qecp.codeblock<1 x 7>
-        //      CHECK: [[tanner_x:%.+]] = qecp.assemble_tanner {{.+}} -> !qecp.tanner_graph<24, 11, i32>
-        //      CHECK: [[tanner_z:%.+]] = qecp.assemble_tanner {{.+}} -> !qecp.tanner_graph<24, 11, i32>
+        // CHECK: [[tanner_x:%.+]] = qecp.assemble_tanner {{.+}}, {{.+}} : tensor<24xi32>, tensor<11xi32> -> !qecp.tanner_graph<24, 11, i32>
+        // CHECK: [[tanner_z:%.+]] = qecp.assemble_tanner {{.+}}, {{.+}} : tensor<24xi32>, tensor<11xi32> -> !qecp.tanner_graph<24, 11, i32>
 
         // COM: The block below takes results of X checks and performs Z corrections
         // CHECK: qecp.alloc_aux : !qecp.qubit<aux>
@@ -582,7 +582,7 @@ class TestQecCycleLowering:
         // CHECK: qecp.dealloc_aux {{.*}} : !qecp.qubit<aux>
         // CHECK: qecp.dealloc_aux {{.*}} : !qecp.qubit<aux>
         // CHECK: [[esm:%.+]] = tensor.from_elements [[m0]], [[m1]], [[m2]] : tensor<3xi1>
-        // CHECK: [[idx_t:%.+]] = qecp.decode_esm_css([[esm]] : tensor<3xi1>) [[tanner_x]] : !qecp.tanner_graph<24, 11, i32> -> tensor<1xindex>
+        // CHECK: [[idx_t:%.+]] = qecp.decode_esm_css([[tanner_x]] : !qecp.tanner_graph<24, 11, i32>) [[esm]] : tensor<3xi1> -> tensor<1xindex>
         // CHECK: [[lb:%.+]] = arith.constant 0 : index
         // CHECK: [[ub:%.+]] = arith.constant 1 : index
         // CHECK: [[st:%.+]] = arith.constant 1 : index
@@ -619,7 +619,7 @@ class TestQecCycleLowering:
         // CHECK: qecp.dealloc_aux {{.*}} : !qecp.qubit<aux>
         // CHECK: qecp.dealloc_aux {{.*}} : !qecp.qubit<aux>
         // CHECK: [[esm:%.+]] = tensor.from_elements [[m0]], [[m1]], [[m2]] : tensor<3xi1>
-        // CHECK: [[idx_t:%.+]] = qecp.decode_esm_css([[esm]] : tensor<3xi1>) [[tanner_z]] : !qecp.tanner_graph<24, 11, i32> -> tensor<1xindex>
+        // CHECK: [[idx_t:%.+]] = qecp.decode_esm_css([[tanner_z]] : !qecp.tanner_graph<24, 11, i32>) [[esm]] : tensor<3xi1>  -> tensor<1xindex>
         // CHECK: [[lb:%.+]] = arith.constant 0 : index
         // CHECK: [[ub:%.+]] = arith.constant 1 : index
         // CHECK: [[st:%.+]] = arith.constant 1 : index

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
@@ -504,6 +504,9 @@ class TestHyperRegisterLowering:
         run_filecheck(program, (ConvertQecPhysicalToQuantumPass(),))
 
 
+@pytest.mark.filterwarnings(
+    "ignore:Unable to remove cast UnrealizedConversionCastOp. Until,qecp.decode_physical_meas is in"
+)
 class TestQECPassIntegration:
     """Integration lit tests for the all qec-related pass"""
 

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
@@ -517,7 +517,7 @@ class TestQECPassIntegration:
         @convert_qecl_to_qecp_pass(qec_code="Steane", number_errors=1)
         @inject_noise_to_qecl_pass
         @convert_quantum_to_qecl_pass(k=1)
-        @qp.qnode(dev, shots=1)
+        @qp.qnode(dev, shots=1, mcm_method="one-shot")
         def ghz():
             # CHECK-NOT: qecp.alloc
             # CHECK-NOT: qecp.dealloc

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
@@ -505,7 +505,7 @@ class TestHyperRegisterLowering:
 
 
 @pytest.mark.filterwarnings(
-    "ignore:Unable to remove cast UnrealizedConversionCastOp. Until,qecp.decode_physical_meas is in"
+    "ignore:Unable to remove cast UnrealizedConversionCastOp"
 )
 class TestQECPassIntegration:
     """Integration lit tests for the all qec-related pass"""
@@ -523,6 +523,7 @@ class TestQECPassIntegration:
         def ghz():
             # CHECK: [[reg0:%.+]] = quantum.alloc(7)
             # CHECK-NEXT: [[reg0:%.+]] = func.call @encode_zero_Steane([[reg0:%.+]]) : (!quantum.reg) -> !quantum.reg
+            # CHECK: qecp.decode_physical_meas
             qp.Hadamard(0)
             qp.CNOT([0, 1])
             qp.CNOT([1, 2])

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
@@ -506,8 +506,6 @@ class TestHyperRegisterLowering:
         run_filecheck(program, (ConvertQecPhysicalToQuantumPass(),))
 
 
-@pytest.mark.xfail(reason="The 'qecp.decode_esm_css' op using value defined outside the region ")
-@pytest.mark.filterwarnings("ignore:Unable to remove cast UnrealizedConversionCastOp")
 class TestQECPassIntegration:
     """Integration lit tests for the all qec-related pass"""
 

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
@@ -504,9 +504,7 @@ class TestHyperRegisterLowering:
         run_filecheck(program, (ConvertQecPhysicalToQuantumPass(),))
 
 
-@pytest.mark.filterwarnings(
-    "ignore:Unable to remove cast UnrealizedConversionCastOp"
-)
+@pytest.mark.filterwarnings("ignore:Unable to remove cast UnrealizedConversionCastOp")
 class TestQECPassIntegration:
     """Integration lit tests for the all qec-related pass"""
 

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
@@ -519,9 +519,34 @@ class TestQECPassIntegration:
         @convert_quantum_to_qecl_pass(k=1)
         @qp.qnode(dev, shots=1)
         def ghz():
-            # CHECK: [[reg0:%.+]] = quantum.alloc(7)
-            # CHECK-NEXT: [[reg0:%.+]] = func.call @encode_zero_Steane([[reg0:%.+]]) : (!quantum.reg) -> !quantum.reg
+            # CHECK-NOT: qecp.alloc
+            # CHECK-NOT: qecp.dealloc
+            # CHECK-NOT: qecp.alloc_aux
+            # CHECK-NOT: qecp.dealloc_aux
+            # CHECK-NOT: qecp.extract_block
+            # CHECK-NOT: qecp.insert_block
+            # CHECK-NOT: qecp.insert
+            # CHECK-NOT: qecp.extract
+            # CHECK-NOT: qecp.measure
+            # CHECK-NOT: qecp.identity
+            # CHECK-NOT: qecp.x
+            # CHECK-NOT: qecp.y
+            # CHECK-NOT: qecp.z
+            # CHECK-NOT: qecp.rot
+            # CHECK-NOT: qecp.hadamard
+            # CHECK-NOT: qecp.s
+            # CHECK-NOT: qecp.cnot
+            # CHECK: quantum.alloc
             # CHECK: qecp.decode_physical_meas
+            # CHECK: quantum.dealloc
+            # CHECK: quantum.extract
+            # CHECK: quantum.insert
+            # CHECK: quantum.bit
+            # CHECK: quantum.reg
+            # CHECK: qecp.assemble_tanner
+            # CHECK: qecp.decode_esm_css
+            # CHECK: quantum.custom "Hadamard"
+            # CHECK: quantum.custom "CNOT"
             qp.Hadamard(0)
             qp.CNOT([0, 1])
             qp.CNOT([1, 2])


### PR DESCRIPTION
### Before submitting

Please complete the following checklist when submitting a PR:

- [x] All new functions and code must be clearly commented and documented.

- [x] Ensure that code is properly formatted by running `make format`.
      The latest version of black and `clang-format-20` are used in CI/CD to check formatting.

- [x] All new features must include a unit test.
      Integration and frontend tests should be added to [`frontend/test`](../frontend/test/),
      Quantum dialect and MLIR tests should be added to [`mlir/test`](../mlir/test/), and
      Runtime tests should be added to [`runtime/tests`](../runtime/tests/).

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

[sc-119843]

Current implementation inserts `qecp.assemble_tanner` operations out of the  scope of the `qeccycle` subroutine. This would lead to undefined ssa value errors when qeccycle subroutines tries to access the result of `qecp.assemble_tanner` operations. This PR moves `tanner` related operations directly to the `qeccycle` subroutine to fix the issue.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
