### PR TITLE
Delete plxpr transform integration

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -16,6 +16,9 @@
 
 * Catalyst's xDSL dependencies have been updated to `xdsl` 0.63.0 and `xdsl-jax` 0.5.2.
   [(#2840)](https://github.com/PennyLaneAI/catalyst/pull/2840)
+  
+* Removes support for `Transform.plxpr_transform` from the `qp.qjit(capture=True)` capture pipeline.
+  All transforms must now have a MLIR or XDSL implementation and a corresponding `pass_name`.
 
 <h3>Deprecations 👋</h3>
 
@@ -62,6 +65,7 @@ This release contains contributions from (in alphabetical order):
 Joey Carter,
 Yushao Chen,
 Lillian Frederiksen,
+Christina Lee,
 Mehrdad Malekmohammadi,
 Shuli Shu,
 Paul Haochen Wang.

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -444,8 +444,10 @@ def handle_transform(
         )
 
     if transform.pass_name is None:
-        raise ValueError(f"{transform} does not have a pass_name and is not supported with the "
-                         "capture frontend. Set capture=False to apply tape-only transforms with qjit.")
+        raise ValueError(
+            f"{transform} does not have a pass_name and is not supported with the "
+            "capture frontend. Set capture=False to apply tape-only transforms with qjit."
+        )
 
     # Apply the corresponding Catalyst pass counterpart
     next_eval = copy(self)

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -26,14 +26,8 @@ import jax
 import pennylane as qp
 from jax.extend.core import ClosedJaxpr, Jaxpr
 from pennylane.capture import PlxprInterpreter, qnode_prim
-from pennylane.capture.expand_transforms import ExpandTransformsInterpreter
 from pennylane.capture.primitives import transform_prim
-from pennylane.transforms import commute_controlled as pl_commute_controlled
 from pennylane.transforms import decompose as pl_decompose
-from pennylane.transforms import gridsynth as pl_gridsynth
-from pennylane.transforms import merge_amplitude_embedding as pl_merge_amplitude_embedding
-from pennylane.transforms import single_qubit_fusion as pl_single_qubit_fusion
-from pennylane.transforms import unitary_to_rot as pl_unitary_to_rot
 
 from catalyst.device import extract_backend_info
 from catalyst.from_plxpr.decompose import COMPILER_OPS_FOR_DECOMPOSITION, DecompRuleInterpreter
@@ -436,8 +430,7 @@ def handle_transform(
 
     # If the transform is a decomposition transform
     # and the graph-based decomposition is enabled
-    transform_name = getattr(transform._plxpr_transform, "__name__", None)
-    if transform_name == "decompose_plxpr_to_plxpr":
+    if transform == pl_decompose:
         use_graph = qp.decomposition.enabled_graph()
         return _handle_decompose_transform(
             self, inner_jaxpr, consts, non_const_args, pl_tkwargs, use_graph

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -367,20 +367,6 @@ def handle_qnode(
     )
 
 
-# The map below describes the parity between PL transforms and Catalyst passes.
-# PL transforms having a Catalyst pass counterpart will have a name as value,
-# otherwise their value will be None. The second value indicates if the transform
-# requires decomposition to be supported by Catalyst.
-transforms_to_passes = {
-    pl_commute_controlled: (None, False),
-    pl_decompose: (None, False),
-    pl_merge_amplitude_embedding: (None, True),
-    pl_single_qubit_fusion: (None, False),
-    pl_unitary_to_rot: (None, False),
-    pl_gridsynth: ("gridsynth", False),
-}
-
-
 def _set_decompose_lowering_state(self):
     """Set requires_decompose_lowering and decompose_tkwargs; raise if already set."""
     if not self.requires_decompose_lowering:
@@ -457,31 +443,13 @@ def handle_transform(
             self, inner_jaxpr, consts, non_const_args, pl_tkwargs, use_graph
         )
 
-    catalyst_pass_name = transform.pass_name
-    if catalyst_pass_name is None:
-        catalyst_pass_name = transforms_to_passes.get(transform, (None,))[0]
-    if catalyst_pass_name is None:
-        # Use PL's ExpandTransformsInterpreter to expand this and any embedded
-        # transform according to PL rules. It works by overriding the primitive
-        # registration, making all embedded transforms follow the PL rules
-        # from now on, hence ignoring the Catalyst pass conversion
-        def wrapper(*args):
-            return ExpandTransformsInterpreter().eval(inner_jaxpr, consts, *args)
-
-        unravelled_jaxpr = jax.make_jaxpr(wrapper)(*non_const_args)
-        final_jaxpr = transform._plxpr_transform(
-            unravelled_jaxpr.jaxpr, unravelled_jaxpr.consts, targs, pl_tkwargs, *non_const_args
-        )
-        if transforms_to_passes[transform][1]:
-            final_jaxpr = pl_decompose._plxpr_transform(
-                final_jaxpr.jaxpr, final_jaxpr.consts, targs, pl_tkwargs, *non_const_args
-            )
-
-        return copy(self).eval(final_jaxpr.jaxpr, final_jaxpr.consts, *non_const_args)
+    if transform.pass_name is None:
+        raise ValueError(f"{transform} does not have a pass_name and is not supported with the "
+                         "capture frontend. Set capture=False to apply tape-only transforms with qjit.")
 
     # Apply the corresponding Catalyst pass counterpart
     next_eval = copy(self)
-    t = qp.transform(pass_name=catalyst_pass_name)
+    t = qp.transform(pass_name=transform.pass_name)
     bound_pass = qp.transforms.core.BoundTransform(t, args=targs, kwargs=pl_tkwargs)
     next_eval._pass_pipeline.insert(0, bound_pass)
     return next_eval.eval(inner_jaxpr, consts, *non_const_args)

--- a/frontend/test/pytest/from_plxpr/test_capture_integration.py
+++ b/frontend/test/pytest/from_plxpr/test_capture_integration.py
@@ -20,7 +20,6 @@ from functools import partial
 import jax.numpy as jnp
 import pennylane as qp
 import pytest
-from jax.core import ShapedArray
 
 import catalyst
 from catalyst import qjit

--- a/frontend/test/pytest/from_plxpr/test_capture_integration.py
+++ b/frontend/test/pytest/from_plxpr/test_capture_integration.py
@@ -56,14 +56,6 @@ def has_catalyst_transforms(mlir):
     )
 
 
-def is_unitary_rotated(mlir):
-    """Check in the MLIR if a unitary was rotated"""
-    return (
-        "quantum.unitary" not in mlir
-        and mlir.count('quantum.custom "RZ"') == 2
-        and mlir.count('quantum.custom "RY"') == 1
-    )
-
 
 def is_rot_decomposed(mlir):
     """Check in the MLIR if a rot was decomposed"""
@@ -73,38 +65,20 @@ def is_rot_decomposed(mlir):
         and mlir.count('quantum.custom "RY"') == 1
     )
 
+def test_transforms_must_have_pass_name():
+    """Test that an error is raised if a transform does not have a pass_name."""
 
-def is_wire_mapped(mlir):
-    """Check in the MLIR if a wire was mapped"""
-    return "quantum.extract %0[ 0]" not in mlir and "quantum.extract %0[ 1]" in mlir
-
-
-def is_single_qubit_fusion_applied(mlir):
-    """Check in the MLIR if 'single_qubit_fusion' was applied"""
-    return (
-        mlir.count('quantum.custom "Rot"') == 1
-        and 'quantum.custom "Hadamard"' not in mlir
-        and 'quantum.custom "RZ"' not in mlir
-    )
-
-
-def is_controlled_pushed_back(mlir, non_controlled_string, controlled_string):
-    """Check in the MLIR if the controlled gate got pushed after the non-controlled one"""
-    non_controlled_pos = mlir.find(non_controlled_string)
-    assert non_controlled_pos > 0
-
-    remaining_mlir = mlir[non_controlled_pos + len(non_controlled_string) :]
-    return controlled_string in remaining_mlir
-
-
-def is_amplitude_embedding_merged_and_decomposed(mlir):
-    """Check in the MLIR if the amplitude embeddings got merged and decomposed"""
-    return (
-        "AmplitudeEmbedding" not in mlir
-        and mlir.count('quantum.custom "RY"') == 3
-        and mlir.count('quantum.custom "CNOT"') == 2
-    )
-
+    @qp.transform
+    def some_transform(tape):
+        return (tape, ), lambda res: res[0]
+    
+    @some_transform
+    @qp.qnode(qp.device('null.qubit', wires=1))
+    def c():
+        return qp.state()
+    
+    with pytest.raises(ValueError, match="<transform: some_transform> does not have a pass_name"):
+        qp.qjit(c, capture=True)()
 
 # pylint: disable=too-many-public-methods
 class TestCapture:
@@ -1258,109 +1232,6 @@ class TestCapture:
             == captured_rotations_inverses_result
         )
 
-    def test_transform_unitary_to_rot_workflow(self, backend):
-        """Test the integration for a circuit with a 'unitary_to_rot' transform."""
-
-        U = qp.Rot(1.0, 2.0, 3.0, wires=0)
-
-        # Capture enabled
-
-        qp.capture.enable()
-
-        @qjit
-        @qp.transforms.unitary_to_rot
-        @qp.qnode(qp.device(backend, wires=1))
-        def captured_circuit(U: ShapedArray([2, 2], complex)):
-            qp.QubitUnitary(U, 0)
-            return qp.expval(qp.Z(0))
-
-        capture_result = captured_circuit(U.matrix())
-        assert is_unitary_rotated(captured_circuit.mlir)
-
-        qp.capture.disable()
-
-        # Capture disabled
-
-        @qjit
-        @qp.transforms.unitary_to_rot
-        @qp.qnode(qp.device(backend, wires=1))
-        def circuit(U: ShapedArray([2, 2], complex)):
-            qp.QubitUnitary(U, 0)
-            return qp.expval(qp.Z(0))
-
-        assert jnp.allclose(circuit(U.matrix()), capture_result)
-
-    def test_mixed_transforms_workflow(self, backend):
-        """Test the integration for a circuit with a combination of 'unitary_to_rot'
-        and 'cancel_inverses' transforms."""
-
-        U = qp.Rot(1.0, 2.0, 3.0, wires=0)
-
-        # Capture enabled
-
-        qp.capture.enable()
-
-        @qp.qnode(qp.device(backend, wires=1))
-        def captured_circuit(U: ShapedArray([2, 2], complex)):
-            qp.QubitUnitary(U, 0)
-            qp.Hadamard(wires=0)
-            qp.Hadamard(wires=0)
-            return qp.expval(qp.PauliZ(0))
-
-        # Case 1: During plxpr interpretation, first comes the PL transform
-        # with Catalyst counterpart, second comes the PL transform without it
-
-        captured_inverses_unitary = qjit(
-            qp.transforms.cancel_inverses(qp.transforms.unitary_to_rot(captured_circuit)),
-        )
-        captured_inverses_unitary_result = captured_inverses_unitary(U.matrix())
-
-        # Catalyst 'cancel_inverses' should have been scheduled as a pass
-        # whereas PL 'unitary_to_rot' should have been expanded
-        capture_mlir = captured_inverses_unitary.mlir
-        assert 'transform.apply_registered_pass "cancel-inverses"' in capture_mlir
-        assert is_unitary_rotated(capture_mlir)
-
-        # Case 2: During plxpr interpretation, first comes the PL transform
-        # without Catalyst counterpart, second comes the PL transform with it
-
-        captured_unitary_inverses = qjit(
-            qp.transforms.unitary_to_rot(qp.transforms.cancel_inverses(captured_circuit)),
-        )
-        captured_unitary_inverses_result = captured_unitary_inverses(U.matrix())
-
-        # Both PL transforms should have been expaned and no Catalyst pass should have been
-        # scheduled
-        capture_mlir = captured_unitary_inverses.mlir
-        assert 'transform.apply_registered_pass "cancel-inverses"' not in capture_mlir
-        assert 'quantum.custom "Hadamard"' not in capture_mlir
-        assert is_unitary_rotated(capture_mlir)
-
-        qp.capture.disable()
-
-        # Capture disabled
-
-        @qp.qnode(qp.device(backend, wires=1))
-        def circuit(U: ShapedArray([2, 2], complex)):
-            qp.QubitUnitary(U, 0)
-            qp.Hadamard(wires=0)
-            qp.Hadamard(wires=0)
-            return qp.expval(qp.PauliZ(0))
-
-        inverses_unitary_result = qjit(
-            qp.transforms.cancel_inverses(qp.transforms.unitary_to_rot(circuit))
-        )(U.matrix())
-        unitary_inverses_result = qjit(
-            qp.transforms.unitary_to_rot(qp.transforms.cancel_inverses(circuit))
-        )(U.matrix())
-
-        assert (
-            inverses_unitary_result
-            == unitary_inverses_result
-            == captured_inverses_unitary_result
-            == captured_unitary_inverses_result
-        )
-
     def test_transform_decompose_workflow(self, backend):
         """Test the integration for a circuit with a 'decompose' transform."""
 
@@ -1436,124 +1307,6 @@ class TestCapture:
                 non_capture_result = qjit(circuit)(1.5, 2.5, 3.5)
 
         assert jnp.allclose(non_capture_result, capture_result)
-
-    def test_transform_single_qubit_fusion_workflow(self, backend):
-        """Test the integration for a circuit with a 'single_qubit_fusion' transform."""
-
-        # Capture enabled
-
-        qp.capture.enable()
-
-        @qjit
-        @qp.transforms.single_qubit_fusion
-        @qp.qnode(qp.device(backend, wires=1))
-        def captured_circuit():
-            qp.Hadamard(wires=0)
-            qp.Rot(0.1, 0.2, 0.3, wires=0)
-            qp.Rot(0.4, 0.5, 0.6, wires=0)
-            qp.RZ(0.1, wires=0)
-            qp.RZ(0.4, wires=0)
-            return qp.expval(qp.PauliZ(0))
-
-        capture_result = captured_circuit()
-
-        assert is_single_qubit_fusion_applied(captured_circuit.mlir)
-
-        qp.capture.disable()
-
-        # Capture disabled
-
-        @qjit
-        @qp.transforms.single_qubit_fusion
-        @qp.qnode(qp.device(backend, wires=1))
-        def circuit():
-            qp.Hadamard(wires=0)
-            qp.Rot(0.1, 0.2, 0.3, wires=0)
-            qp.Rot(0.4, 0.5, 0.6, wires=0)
-            qp.RZ(0.1, wires=0)
-            qp.RZ(0.4, wires=0)
-            return qp.expval(qp.PauliZ(0))
-
-        assert jnp.allclose(circuit(), capture_result)
-
-    def test_transform_commute_controlled_workflow(self, backend):
-        """Test the integration for a circuit with a 'commute_controlled' transform."""
-
-        # Capture enabled
-
-        qp.capture.enable()
-
-        @qjit
-        @partial(qp.transforms.commute_controlled, direction="left")
-        @qp.qnode(qp.device(backend, wires=3))
-        def captured_circuit():
-            qp.CNOT(wires=[0, 2])
-            qp.PauliX(wires=2)
-            qp.RX(0.2, wires=2)
-            qp.Toffoli(wires=[0, 1, 2])
-            qp.CRX(0.1, wires=[0, 1])
-            qp.PauliX(wires=1)
-            return qp.expval(qp.PauliZ(0))
-
-        capture_result = captured_circuit()
-
-        capture_mlir = captured_circuit.mlir
-        assert is_controlled_pushed_back(
-            capture_mlir, 'quantum.custom "RX"', 'quantum.custom "CNOT"'
-        )
-        assert is_controlled_pushed_back(
-            capture_mlir, 'quantum.custom "PauliX"', 'quantum.custom "CRX"'
-        )
-
-        qp.capture.disable()
-
-        # Capture disabled
-
-        @qjit
-        @partial(qp.transforms.commute_controlled, direction="left")
-        @qp.qnode(qp.device(backend, wires=3))
-        def circuit():
-            qp.CNOT(wires=[0, 2])
-            qp.PauliX(wires=2)
-            qp.RX(0.2, wires=2)
-            qp.Toffoli(wires=[0, 1, 2])
-            qp.CRX(0.1, wires=[0, 1])
-            qp.PauliX(wires=1)
-            return qp.expval(qp.PauliZ(0))
-
-        assert jnp.allclose(circuit(), capture_result)
-
-    def test_transform_merge_amplitude_embedding_workflow(self, backend):
-        """Test the integration for a circuit with a 'merge_amplitude_embedding' transform."""
-
-        # Capture enabled
-
-        qp.capture.enable()
-
-        @qjit
-        @qp.transforms.merge_amplitude_embedding
-        @qp.qnode(qp.device(backend, wires=2))
-        def captured_circuit():
-            qp.AmplitudeEmbedding(jnp.array([0.0, 1.0]), wires=0)
-            qp.AmplitudeEmbedding(jnp.array([0.0, 1.0]), wires=1)
-            return qp.expval(qp.PauliZ(0))
-
-        capture_result = captured_circuit()
-        assert is_amplitude_embedding_merged_and_decomposed(captured_circuit.mlir)
-
-        qp.capture.disable()
-
-        # Capture disabled
-
-        @qjit
-        @qp.transforms.merge_amplitude_embedding
-        @qp.qnode(qp.device(backend, wires=2))
-        def circuit():
-            qp.AmplitudeEmbedding(jnp.array([0.0, 1.0]), wires=0)
-            qp.AmplitudeEmbedding(jnp.array([0.0, 1.0]), wires=1)
-            return qp.expval(qp.PauliZ(0))
-
-        assert jnp.allclose(circuit(), capture_result)
 
     def test_shots_usage(self, backend):
         """Test the integration for a circuit using shots explicitly."""

--- a/frontend/test/pytest/from_plxpr/test_capture_integration.py
+++ b/frontend/test/pytest/from_plxpr/test_capture_integration.py
@@ -56,7 +56,6 @@ def has_catalyst_transforms(mlir):
     )
 
 
-
 def is_rot_decomposed(mlir):
     """Check in the MLIR if a rot was decomposed"""
     return (
@@ -65,20 +64,22 @@ def is_rot_decomposed(mlir):
         and mlir.count('quantum.custom "RY"') == 1
     )
 
+
 def test_transforms_must_have_pass_name():
     """Test that an error is raised if a transform does not have a pass_name."""
 
     @qp.transform
     def some_transform(tape):
-        return (tape, ), lambda res: res[0]
-    
+        return (tape,), lambda res: res[0]
+
     @some_transform
-    @qp.qnode(qp.device('null.qubit', wires=1))
+    @qp.qnode(qp.device("null.qubit", wires=1))
     def c():
         return qp.state()
-    
+
     with pytest.raises(ValueError, match="<transform: some_transform> does not have a pass_name"):
         qp.qjit(c, capture=True)()
+
 
 # pylint: disable=too-many-public-methods
 class TestCapture:


### PR DESCRIPTION
**Context:**

We no longer want to support or develop applying transforms to the plxpr itself. Instead, we want to force all transforms to be applied in MLIR/ XDSL with the capture pipeline.

But we still had some relatively dead code handing around to support them. This removes them.

**Description of the Change:**

Deletes some code for handling `Transform.plxpr_transform` in the conversion process from plxpr to catalyst-jaxpr.

**Benefits:**

Prunes out features we don't actually want anymore.

**Possible Drawbacks:**

This was always experimental, so if anyone is wanting it or depending on it, they are asking for this type of thing to happen.

Is a little sad to delete all the code that took so long to develop though.

**Related GitHub Issues:**

[sc-120025]
