### PR TITLE
Decompose lowering pass can handle a null decomp rule

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -14,11 +14,16 @@
   argument is at an arbitrary position in the argument list.
   [(#2836)](https://github.com/PennyLaneAI/catalyst/pull/2836)
 
+* The `--decompose-lowering` pass can now handle null decomposition rules, which are rule functions
+  that do not have any quantum values as arguments or results. Gates with null decomposition rules
+  are simply removed.
+  [(#????)](https://github.com/PennyLaneAI/catalyst/pull/????)
+
 <h3>Breaking changes 💔</h3>
 
 * Catalyst's xDSL dependencies have been updated to `xdsl` 0.63.0 and `xdsl-jax` 0.5.2.
   [(#2840)](https://github.com/PennyLaneAI/catalyst/pull/2840)
-  
+
 * Removes support for `Transform.plxpr_transform` from the `qp.qjit(capture=True)` capture pipeline.
   All transforms must now have a MLIR or XDSL implementation and a corresponding `pass_name`.
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -17,7 +17,7 @@
 * The `--decompose-lowering` pass can now handle null decomposition rules, which are rule functions
   that do not have any quantum values as arguments or results. Gates with null decomposition rules
   are simply removed.
-  [(#????)](https://github.com/PennyLaneAI/catalyst/pull/????)
+  [(#2855)](https://github.com/PennyLaneAI/catalyst/pull/2855)
 
 <h3>Breaking changes 💔</h3>
 

--- a/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <llvm/ADT/STLExtras.h>
 #define DEBUG_TYPE "decompose-lowering"
 
 #include "llvm/ADT/StringMap.h"

--- a/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <llvm/ADT/STLExtras.h>
 #define DEBUG_TYPE "decompose-lowering"
 
 #include "llvm/ADT/StringMap.h"
@@ -60,6 +61,21 @@ struct DLCustomOpPattern : public OpRewritePattern<CustomOp> {
             return failure();
         }
         func::FuncOp decompFunc = it->second;
+
+        // For null decomp rules, the signature will not have any quantum values
+        // This is a deviation from the standard decomp func signature, so we deal with it
+        // separately
+        if (!llvm::any_of(llvm::concat<const Type>(decompFunc.getFunctionType().getInputs(),
+                                                   decompFunc.getFunctionType().getResults()),
+                          [](const mlir::Type t) {
+                              return isa<quantum::QuregType, quantum::QubitType>(t);
+                          })) {
+            for (auto [inQubit, outQubit] :
+                 llvm::zip_equal(op.getQubitOperands(), op.getQubitResults())) {
+                rewriter.replaceAllUsesWith(outQubit, inQubit);
+            }
+            return success();
+        }
 
         // Here is the assumption that the decomposition function must have at least one input and
         // one result

--- a/mlir/test/Quantum/DecomposeLoweringTest.mlir
+++ b/mlir/test/Quantum/DecomposeLoweringTest.mlir
@@ -670,7 +670,7 @@ module @null_decomp_rule{
     return
   }
 
-  // CHECK-NOT: func.func private @my_cnot
+  // CHECK-NOT: func.func private @null_decomp
   func.func private @null_decomp() attributes {target_gate = "PauliX"} {
     return
   }

--- a/mlir/test/Quantum/DecomposeLoweringTest.mlir
+++ b/mlir/test/Quantum/DecomposeLoweringTest.mlir
@@ -651,3 +651,27 @@ module @qreg_at_not_first_arg {
     return %7 : !quantum.reg
   }
 }
+
+// -----
+
+module @null_decomp_rule{
+  func.func public @test_null_decomp_rule() attributes {quantum.node} {
+    // CHECK: [[reg:%.+]] = quantum.alloc( 1)
+    // CHECK: [[q0:%.+]] = quantum.extract [[reg]][ 0]
+    %0 = quantum.alloc( 1) : !quantum.reg
+    %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+
+    // CHECK-NOT: PauliX
+    // CHECK: quantum.custom "Hadamard"() [[q0]] : !quantum.bit
+    %2 = quantum.custom "PauliX"() %1 : !quantum.bit
+    %3 = quantum.custom "Hadamard"() %2 : !quantum.bit
+    %4 = quantum.insert %0[ 0], %3 : !quantum.reg, !quantum.bit
+    quantum.dealloc %4 : !quantum.reg
+    return
+  }
+
+  // CHECK-NOT: func.func private @my_cnot
+  func.func private @null_decomp() attributes {target_gate = "PauliX"} {
+    return
+  }
+}


### PR DESCRIPTION
**Context:**
The decompose lowering pass makes certain assumptions about the signature of the decomp rule. In particular, it assumes that the signature has either qreg or qubit values.

This is a natural assumption. However, a special kind of decomp rules are the null rules, which is just empty. These rule functions will not have quantum types in their signature. 

**Description of the Change:**
In decompose lowering pass, if the decomp rule has no quantum values in the function signature, simply replace qubit operands of the quantum gate op with the qubit results. 

**Benefits:**
Null decomp rule works. 

