### PR TITLE
bump PL dev12 and fix test failures

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.238
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.46.0.dev11
+pennylane=0.46.0.dev12
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -34,4 +34,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.45.0
 pennylane-lightning==0.45.0
-pennylane==0.46.0.dev11
+pennylane==0.46.0.dev12

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -598,7 +598,9 @@ class TestCond:
             return res
 
         if capture_mode:
-            with pytest.raises(ValueError, match="Mismatch in output abstract values"):
+            with pytest.raises(
+                ValueError, match="Mismatch in number of output variables in false branch"
+            ):
                 qjit(g, capture=capture_mode)
         else:
             with pytest.raises(
@@ -613,7 +615,7 @@ class TestCond:
 
         if capture_mode:
             with pytest.raises(
-                ValueError, match="Mismatch in number of output variables in false branch"
+                ValueError, match="Mismatch in number of output variables in elif branch"
             ):
                 qjit(h, capture=capture_mode)
         else:

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -612,7 +612,9 @@ class TestCond:
             return res
 
         if capture_mode:
-            with pytest.raises(ValueError, match="Mismatch in output abstract values"):
+            with pytest.raises(
+                ValueError, match="Mismatch in number of output variables in false branch"
+            ):
                 qjit(h, capture=capture_mode)
         else:
             with pytest.raises(

--- a/frontend/test/pytest/test_quantum_control.py
+++ b/frontend/test/pytest/test_quantum_control.py
@@ -1096,23 +1096,23 @@ class TestControlledMiscMethods:
         # different control wires
         op1 = C_ctrl(base, (1, 2), [0, 1])
         op2 = C_ctrl(base, (2, 1), [0, 1])
-        assert op1.hash != op2.hash
+        assert hash(op1) != hash(op2)
 
         # different control values
         op3 = C_ctrl(base, (1, 2), [1, 0])
-        assert op1.hash != op3.hash
-        assert op2.hash != op3.hash
+        assert hash(op1) != hash(op3)
+        assert hash(op2) != hash(op3)
 
         # all variations on default control_values
         op4 = C_ctrl(base, (1, 2))
         op5 = C_ctrl(base, (1, 2), [True, True])
         op6 = C_ctrl(base, (1, 2), [1, 1])
-        assert op4.hash == op5.hash
-        assert op4.hash == op6.hash
+        assert hash(op4) == hash(op5)
+        assert hash(op4) == hash(op6)
 
         # work wires
         op7 = C_ctrl(base, (1, 2), [0, 1], work_wires="aux")
-        assert op7.hash != op1.hash
+        assert hash(op7) != hash(op1)
 
 
 class TestControlledOperationProperties:


### PR DESCRIPTION
Fixing https://github.com/PennyLaneAI/catalyst/actions/runs/26159251434/job/76946605862

## Changes

1. https://github.com/PennyLaneAI/pennylane/pull/9494 changed the mismatch type of `cond` (now, within the same test, `cond` dropped the `AbstractOperator` outvar so comes across number mismatch)
2. use Python `hash()` instead of `op.hash` as the latter is [being deprecated](https://github.com/PennyLaneAI/pennylane/pull/9488)

[sc-120115]