### PR TITLE
Small follow up to ref semantics ops in mbqc and pbc

### DIFF
--- a/mlir/lib/QRef/Transforms/value_semantics_conversion.cpp
+++ b/mlir/lib/QRef/Transforms/value_semantics_conversion.cpp
@@ -680,7 +680,8 @@ void _getNecessaryRegionRValuesImpl(Region &r, SetVector<Value> &necessaryRegion
     llvm::SmallDenseSet<Value, 8> rQregsTakenIn;
 
     r.walk([&](Operation *op) {
-        if (!isa<qref::QRefDialect>(op->getDialect()) && !isa<func::CallOp>(op)) {
+        if (!isa<qref::QRefDialect>(op->getDialect()) &&
+            !isa<func::CallOp, mbqc::RefMeasureInBasisOp, pbc::RefPPMeasurementOp>(op)) {
             return;
         }
         if (isa<qref::GetOp>(op)) {


### PR DESCRIPTION
**Context:**
Forgot to register them as quantum gates when collecting closure qref values from inside regions.

