### PR TITLE
Add the `qecl.dealloc_cb` op

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -110,6 +110,8 @@
   - `qecl.fabricate`, which fabricates a logical codeblock in a specified initial state (typically a
     magic state).
     [(#2865)](https://github.com/PennyLaneAI/catalyst/pull/2865)
+  - `qecl.dealloc_cb`, which deallocates a single logical codeblock.
+    [(#2866)](https://github.com/PennyLaneAI/catalyst/pull/2866)
 
 <h3>Documentation 📝</h3>
 

--- a/frontend/catalyst/python_interface/dialects/qecl.py
+++ b/frontend/catalyst/python_interface/dialects/qecl.py
@@ -341,6 +341,22 @@ class FabricateOp(IRDLOperation):
 
 
 @irdl_op_definition
+class DeallocCodeblockOp(IRDLOperation):
+    """Deallocate a single logical codeblock."""
+
+    name = "qecl.dealloc_cb"
+
+    assembly_format = """
+            $codeblock attr-dict `:` type($codeblock)
+        """
+
+    codeblock = operand_def(base(LogicalCodeblockType))
+
+    def __init__(self, codeblock: LogicalCodeBlockSSAValue | Operation):
+        super().__init__(operands=(codeblock,))
+
+
+@irdl_op_definition
 class EncodeOp(IRDLOperation):
     """Encode a logical codeblock to the specified logical state."""
 
@@ -778,6 +794,7 @@ QecLogical = Dialect(
         ExtractCodeblockOp,
         InsertCodeblockOp,
         FabricateOp,
+        DeallocCodeblockOp,
         EncodeOp,
         NoiseOp,
         QecCycleOp,

--- a/frontend/test/pytest/python_interface/dialects/test_qecl_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_qecl_dialect.py
@@ -63,6 +63,7 @@ expected_ops_names = {
     "InsertCodeblockOp": "qecl.insert_block",
     "FabricateOp": "qecl.fabricate",
     "EncodeOp": "qecl.encode",
+    "DeallocCodeblockOp": "qecl.dealloc_cb",
     "NoiseOp": "qecl.noise",
     "QecCycleOp": "qecl.qec",
     "IdentityOp": "qecl.identity",
@@ -205,6 +206,11 @@ class TestQecLogicalOps:
         assert isinstance(fabricate_op.result_types[0], qecl.LogicalCodeblockType)
         assert fabricate_op.result_types[0].k == self.k
 
+    def test_qecl_op_constructor_dealloc_cb(self):
+        """Test the constructor of the qecl.dealloc_cb op."""
+        dealloc_cb_op = qecl.DeallocCodeblockOp(self._get_codeblock_value())
+        assert len(dealloc_cb_op.result_types) == 0
+
     @pytest.mark.parametrize("init_state", ["zero", qecl.LogicalCodeblockInitStateAttr("zero")])
     def test_qecl_op_constructor_encode(self, init_state):
         """Test the constructor of the qecl.encode op."""
@@ -314,6 +320,9 @@ def test_assembly_format(run_filecheck, pretty_print):
 
     // CHECK: [[magic:%.+]] = qecl.fabricate{{\s*}}[magic] : !qecl.codeblock<1>
     %magic = qecl.fabricate [magic] : !qecl.codeblock<1>
+
+    // CHECK: qecl.dealloc_cb [[magic]] : !qecl.codeblock<1>
+    qecl.dealloc_cb %magic : !qecl.codeblock<1>
 
     // CHECK: [[block1:%.+]] = qecl.encode{{\s*}}[zero] [[block0]] : !qecl.codeblock<1>
     %block1 = qecl.encode [zero] %block0 : !qecl.codeblock<1>

--- a/mlir/include/QecLogical/IR/QecLogicalOps.td
+++ b/mlir/include/QecLogical/IR/QecLogicalOps.td
@@ -139,6 +139,18 @@ def FabricateOp : QecLogical_Op<"fabricate"> {
     let hasVerifier = true;
 }
 
+def DeallocCodeblockOp : QecLogical_Op<"dealloc_cb"> {
+    let summary = "Deallocate a single logical codeblock.";
+
+    let arguments = (ins
+        LogicalCodeblockType:$codeblock
+    );
+
+    let assemblyFormat = [{
+        $codeblock attr-dict `:` qualified(type($codeblock))
+    }];
+}
+
 def EncodeOp : QecLogical_Op<"encode", [AllTypesMatch<["in_codeblock", "out_codeblock"]>]> {
     let summary = "Encode a logical codeblock to the specified logical state.";
 

--- a/mlir/test/QecLogical/DialectTest.mlir
+++ b/mlir/test/QecLogical/DialectTest.mlir
@@ -76,6 +76,13 @@ func.func @test_fabricate() {
 
 // -----
 
+func.func @test_dealloc_cb(%arg0 : !qecl.codeblock<1>) {
+    qecl.dealloc_cb %arg0 : !qecl.codeblock<1>
+    func.return
+}
+
+// -----
+
 func.func @test_encode_block(%arg0 : !qecl.codeblock<1>) {
     %0 = qecl.encode [zero] %arg0 : !qecl.codeblock<1>
     func.return


### PR DESCRIPTION
**Context:** In order to support T gates and π/8 PPMs in the experimental QEC pipeline, in #2865 we added support to represent the fabrication of magic states in the QEC logical layer. Now, we need the ability to also deallocate single logical codeblocks.

**Description of the Change:** This PR adds the `qecl.dealloc_cb` op, which deallocates a single logical codeblock. This operation is available in both MLIR and in the xDSL interface to Catalyst.

This operation is generally used in conjunction with the `qecl.fabricate` op. For example,

```mlir
%0 = qecl.fabricate [magic] : !qecl.codeblock<1>
// %1 = operations on the magic state...
qecl.dealloc_cb %1 : !qecl.codeblock<1>
```

In principle, it is also possible to deallocate a single logical codeblock extracted from a hyper-register, e.g.

 ```mlir
%0 = qecl.alloc() : !qecl.hyperreg<3 x 1>
%1 = qecl.extract %0[0] : !qecl.hyperreg<3 x 1> -> !qecl.codeblock<1>
qecl.dealloc_cb %1 : !qecl.codeblock<1>
```

However, IR patterns like this should be used with caution for now since they require careful consideration in the `qecp` layer below and in the runtime (for instance, similar patterns of single-qubit deallocation in the `quantum` dialect generally require the use of array-backed registers to allow for execution of the compiled workload).

[sc-119924]