### PR TITLE
Add the `qecp.alloc_cb` and `qecp.dealloc_cb` ops

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -112,6 +112,10 @@
     [(#2865)](https://github.com/PennyLaneAI/catalyst/pull/2865)
   - `qecl.dealloc_cb`, which deallocates a single logical codeblock.
     [(#2866)](https://github.com/PennyLaneAI/catalyst/pull/2866)
+  - `qecp.alloc_cb`, which allocates a single physical codeblock.
+    [(#2867)](https://github.com/PennyLaneAI/catalyst/pull/2867)
+  - `qecp.dealloc_cb`, which deallocates a single physical codeblock.
+    [(#2867)](https://github.com/PennyLaneAI/catalyst/pull/2867)
 
 <h3>Documentation 📝</h3>
 

--- a/frontend/catalyst/python_interface/dialects/qecp.py
+++ b/frontend/catalyst/python_interface/dialects/qecp.py
@@ -365,6 +365,38 @@ class DeallocAuxQubitOp(IRDLOperation):
 
 
 @irdl_op_definition
+class AllocCodeblockOp(IRDLOperation):
+    """Allocate a single physical codeblock."""
+
+    name = "qecp.alloc_cb"
+
+    assembly_format = """
+            attr-dict `:` type($codeblock)
+        """
+
+    codeblock = result_def(base(PhysicalCodeblockType))
+
+    def __init__(self, codeblock_type: PhysicalCodeblockType):
+        super().__init__(result_types=(codeblock_type,))
+
+
+@irdl_op_definition
+class DeallocCodeblockOp(IRDLOperation):
+    """Deallocate a single physical codeblock."""
+
+    name = "qecp.dealloc_cb"
+
+    assembly_format = """
+            $codeblock attr-dict `:` type($codeblock)
+        """
+
+    codeblock = operand_def(base(PhysicalCodeblockType))
+
+    def __init__(self, codeblock: PhysicalCodeBlockSSAValue | Operation):
+        super().__init__(operands=(codeblock,))
+
+
+@irdl_op_definition
 class ExtractCodeblockOp(IRDLOperation):
     """Extract a physical codeblock value from a hyper-register."""
 
@@ -882,6 +914,8 @@ QecPhysical = Dialect(
         DeallocOp,
         AllocAuxQubitOp,
         DeallocAuxQubitOp,
+        AllocCodeblockOp,
+        DeallocCodeblockOp,
         ExtractCodeblockOp,
         InsertCodeblockOp,
         ExtractQubitOp,

--- a/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
@@ -70,6 +70,8 @@ expected_ops_names = {
     "DeallocOp": "qecp.dealloc",
     "AllocAuxQubitOp": "qecp.alloc_aux",
     "DeallocAuxQubitOp": "qecp.dealloc_aux",
+    "AllocCodeblockOp": "qecp.alloc_cb",
+    "DeallocCodeblockOp": "qecp.dealloc_cb",
     "ExtractCodeblockOp": "qecp.extract_block",
     "InsertCodeblockOp": "qecp.insert_block",
     "ExtractQubitOp": "qecp.extract",
@@ -215,6 +217,17 @@ class TestQecPhysicalOps:
         """Test the constructor of the qecp.dealloc_aux op."""
         dealloc_aux_op = qecp.DeallocAuxQubitOp(self._get_qubit_aux_value())
         assert len(dealloc_aux_op.result_types) == 0
+
+    def test_qecp_op_constructor_alloc_cb(self):
+        """Test the constructor of the qecp.alloc_cb op."""
+        alloc_cb_op = qecp.AllocCodeblockOp(codeblock_type=qecp.PhysicalCodeblockType(k=1, n=7))
+        assert len(alloc_cb_op.result_types) == 1
+        assert isinstance(alloc_cb_op.result_types[0], qecp.PhysicalCodeblockType)
+
+    def test_qecp_op_constructor_dealloc_cb(self):
+        """Test the constructor of the qecp.dealloc_cb op."""
+        dealloc_cb_op = qecp.DeallocCodeblockOp(self._get_codeblock_value())
+        assert len(dealloc_cb_op.result_types) == 0
 
     @pytest.mark.parametrize(
         "idx", [0, IntegerAttr(0, IndexType()), IntegerAttr(0, i64), create_ssa_value(IndexType())]
@@ -474,6 +487,12 @@ def test_assembly_format(run_filecheck, pretty_print):
 
     // CHECK: qecp.dealloc_aux [[q_aux1]] : !qecp.qubit<aux>
     qecp.dealloc_aux %q_aux1 : !qecp.qubit<aux>
+
+    // CHECK: [[cb0:%.+]] = qecp.alloc_cb : !qecp.codeblock<1 x 7>
+    %cb0 = qecp.alloc_cb : !qecp.codeblock<1 x 7>
+
+    // CHECK: qecp.dealloc_cb [[cb0]] : !qecp.codeblock<1 x 7>
+    qecp.dealloc_cb %cb0 : !qecp.codeblock<1 x 7>
 
     // CHECK: [[block0:%.+]] = qecp.extract_block [[hyperreg]][{{\s*}}0] : !qecp.hyperreg<3 x 1 x 7> -> !qecp.codeblock<1 x 7>
     %block0 = qecp.extract_block %hyperreg[ 0] : !qecp.hyperreg<3 x 1 x 7> -> !qecp.codeblock<1 x 7>

--- a/mlir/include/QecPhysical/IR/QecPhysicalOps.td
+++ b/mlir/include/QecPhysical/IR/QecPhysicalOps.td
@@ -92,6 +92,34 @@ def DeallocAuxQubitOp : QecPhysical_Op<"dealloc_aux"> {
     let hasCanonicalizeMethod = 1;
 }
 
+def AllocCodeblockOp : QecPhysical_Op<"alloc_cb"> {
+    let summary = "Allocate a single physical codeblock.";
+
+    let results = (outs
+        PhysicalCodeblockType:$codeblock
+    );
+
+    let assemblyFormat = [{
+        attr-dict `:` qualified(type($codeblock))
+    }];
+
+    let hasCanonicalizeMethod = 1;
+}
+
+def DeallocCodeblockOp : QecPhysical_Op<"dealloc_cb"> {
+    let summary = "Deallocate a single physical codeblock.";
+
+    let arguments = (ins
+        PhysicalCodeblockType:$codeblock
+    );
+
+    let assemblyFormat = [{
+        $codeblock attr-dict `:` qualified(type($codeblock))
+    }];
+
+    let hasCanonicalizeMethod = 1;
+}
+
 def ExtractCodeblockOp : QecPhysical_Op<"extract_block"> {
     let summary = "Extract a physical codeblock value from a hyper-register.";
 

--- a/mlir/lib/QecPhysical/IR/QecPhysicalOps.cpp
+++ b/mlir/lib/QecPhysical/IR/QecPhysicalOps.cpp
@@ -302,6 +302,42 @@ LogicalResult DeallocAuxQubitOp::canonicalize(DeallocAuxQubitOp dealloc,
 }
 
 /**
+ * @brief Canonicalize single-physical-codeblock allocation op.
+ *
+ * Erase alloc_cb op if it has no uses.
+ */
+LogicalResult AllocCodeblockOp::canonicalize(AllocCodeblockOp alloc_cb,
+                                             mlir::PatternRewriter &rewriter)
+{
+    if (alloc_cb->use_empty()) {
+        rewriter.eraseOp(alloc_cb);
+        return success();
+    }
+
+    return failure();
+}
+
+/**
+ * @brief Canonicalize single-physical-codeblock deallocation op.
+ *
+ * Erase alloc_cb/dealloc_cb op pairs if allocated codeblock is immediately deallocated.
+ */
+LogicalResult DeallocCodeblockOp::canonicalize(DeallocCodeblockOp dealloc_cb,
+                                               mlir::PatternRewriter &rewriter)
+{
+    const auto qubit = dealloc_cb.getCodeblock();
+    if (auto alloc_cb = dyn_cast_if_present<AllocCodeblockOp>(qubit.getDefiningOp())) {
+        if (qubit.hasOneUse()) {
+            rewriter.eraseOp(dealloc_cb);
+            rewriter.eraseOp(alloc_cb);
+            return success();
+        }
+    }
+
+    return failure();
+}
+
+/**
  * @brief Canonicalize extract-codeblock op.
  *
  * Removes sequential insert-extract op pairs acting on the same index, e.g. handles the pattern:

--- a/mlir/test/QecPhysical/CanonicalizationTest.mlir
+++ b/mlir/test/QecPhysical/CanonicalizationTest.mlir
@@ -100,6 +100,49 @@ func.func @test_alloc_dealloc_aux_no_fold() {
 
 // -----
 
+// CHECK-LABEL: test_alloc_cb_dce
+func.func @test_alloc_cb_dce() {
+    // CHECK-NOT: qecp.alloc_cb
+    %cb = qecp.alloc_cb : !qecp.codeblock<1 x 7>
+    return
+}
+
+// -----
+
+// CHECK-LABEL: test_alloc_cb_no_cse
+func.func @test_alloc_cb_no_cse() -> (!qecp.codeblock<1 x 7>, !qecp.codeblock<1 x 7>) {
+    // CHECK: qecp.alloc_cb
+    // CHECK-NEXT: qecp.alloc_cb
+    %cb1 = qecp.alloc_cb : !qecp.codeblock<1 x 7>
+    %cb2 = qecp.alloc_cb : !qecp.codeblock<1 x 7>
+    return %cb1, %cb2 : !qecp.codeblock<1 x 7>, !qecp.codeblock<1 x 7>
+}
+
+// -----
+
+// CHECK-LABEL: test_alloc_dealloc_cb_fold
+func.func @test_alloc_dealloc_cb_fold() {
+    // CHECK-NOT: qecp.alloc_cb
+    // CHECK-NOT: qecp.dealloc_cb
+    %cb = qecp.alloc_cb : !qecp.codeblock<1 x 7>
+    qecp.dealloc_cb %cb : !qecp.codeblock<1 x 7>
+    return
+}
+
+// -----
+
+// CHECK-LABEL: test_alloc_dealloc_cb_no_fold
+func.func @test_alloc_dealloc_cb_no_fold() {
+    // CHECK: qecp.alloc_cb
+    // CHECK: qecp.dealloc_cb
+    %cb0 = qecp.alloc_cb : !qecp.codeblock<1 x 7>
+    %cb1 = "test.op"(%cb0) : (!qecp.codeblock<1 x 7>) -> !qecp.codeblock<1 x 7>
+    qecp.dealloc_cb %cb1 : !qecp.codeblock<1 x 7>
+    return
+}
+
+// -----
+
 // CHECK-LABEL: test_extract_insert_block_dce
 func.func @test_extract_insert_block_dce(%i : index) -> !qecp.hyperreg<3 x 1 x 7> {
     // CHECK: [[r0:%.+]] = "test.op"() : () -> !qecp.hyperreg<3 x 1 x 7>

--- a/mlir/test/QecPhysical/DialectTest.mlir
+++ b/mlir/test/QecPhysical/DialectTest.mlir
@@ -123,6 +123,20 @@ func.func @test_dealloc_aux(%arg0 : !qecp.qubit<aux>) {
 
 // -----
 
+func.func @test_alloc_cb() {
+    %0 = qecp.alloc_cb : !qecp.codeblock<1 x 7>
+    func.return
+}
+
+// -----
+
+func.func @test_dealloc_cb(%arg0 : !qecp.codeblock<1 x 7>) {
+    qecp.dealloc_cb %arg0 : !qecp.codeblock<1 x 7>
+    func.return
+}
+
+// -----
+
 func.func @test_gate_op_identity(%arg0 : !qecp.qubit<data>, %arg1 : !qecp.qubit<aux>) {
     %0 = qecp.identity %arg0 : !qecp.qubit<data>
     %1 = qecp.identity %arg1 : !qecp.qubit<aux>


### PR DESCRIPTION
**Context:** In order to support T gates and π/8 PPMs in the experimental QEC pipeline, in #2865 and #2866, we added support to represent the fabrication of magic states in the QEC logical layer and to deallocate single logical codeblocks. Now, we need the ability to also deallocate single _physical_ codeblocks in the `qecp` layer.

**Description of the Change:** This PR adds the `qecp.alloc_cb` and `qecp.dealloc_cb` ops, which allocate and deallocate a single physical codeblock, respectively. This operation is available in both MLIR and in the xDSL interface to Catalyst. For example:

```mlir
%0 = qecp.alloc_cb : !qecp.codeblock<1 x 7>
// %1 = operations on the physical codeblock...
qecp.dealloc_cb %1 : !qecp.codeblock<1 x 7>
```

[sc-119925]