### PR TITLE
Adjoint lowering pass can handle control flow with arbitrary quantum operands

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -36,6 +36,10 @@
   trace back to the same allocation.
   [(#2861)](https://github.com/PennyLaneAI/catalyst/pull/2861)
 
+* The `--adjoint-lowering` pass can now handle adjoint operations containing control flow operations
+  that have multiple quantum operands, of either quantum register or qubit type.
+  [(#2868)](https://github.com/PennyLaneAI/catalyst/pull/2868)
+
 <h3>Breaking changes 💔</h3>
 
 * Catalyst's xDSL dependencies have been updated to `xdsl` 0.63.0 and `xdsl-jax` 0.5.2.

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -613,41 +613,58 @@ class AdjointGenerator {
 
     void visitOperation(scf::IndexSwitchOp switchOp, OpBuilder &builder)
     {
-        std::optional<Value> qureg = getQuantumReg(switchOp.getResults());
-        if (!qureg.has_value()) {
+        SmallVector<Value> yieldedQValues = getQuantumValues(switchOp.getResults());
+        if (yieldedQValues.empty()) {
+            // This operation is purely classical
             return;
         }
 
         Value tape = cache.controlFlowTapes.at(switchOp.getOperation());
         Value index = ListPopOp::create(builder, switchOp.getLoc(), tape);
-        Value reversedResult = remappedValues.lookup(getQuantumReg(switchOp.getResults()).value());
 
-        auto findRootQuregInRegion = [&](Region &region) {
+        SmallVector<Value> reversedResults;
+        for (auto v : getQuantumValues(switchOp.getResults())) {
+            reversedResults.push_back(remappedValues.lookup(v));
+        }
+
+        auto findRootQvaluesInRegion = [&](Region &region) -> SetVector<Value> {
+            SetVector<Value> qvalues;
             for (Operation &innerOp : region.getOps()) {
                 for (Value operand : innerOp.getOperands()) {
-                    if (isa<quantum::QuregType>(operand.getType())) {
-                        return operand;
+                    bool isDefinedFromOutsideRegion =
+                        operand.getParentRegion()->isProperAncestor(&region);
+                    if (isa<quantum::QuregType, quantum::QubitType>(operand.getType()) &&
+                        isDefinedFromOutsideRegion) {
+                        qvalues.insert(operand);
                     }
                 }
             }
-            llvm_unreachable("failed to find qureg in scf.index_switch region");
+            assert(!qvalues.empty() && "failed to find quantum values in scf.index_switch region");
+            return qvalues;
         };
 
-        auto newSwitchOp = scf::IndexSwitchOp::create(builder, switchOp.getLoc(),
-                                                      TypeRange{reversedResult.getType()}, index,
-                                                      switchOp.getCases(), switchOp.getNumCases());
+        auto newSwitchOp =
+            scf::IndexSwitchOp::create(builder, switchOp.getLoc(), TypeRange{reversedResults},
+                                       index, switchOp.getCases(), switchOp.getNumCases());
 
         auto fillRegion = [&](Region &oldRegion, Region &newRegion) {
             OpBuilder::InsertionGuard guard(builder);
             newRegion.push_back(new Block());
             builder.setInsertionPointToStart(&newRegion.front());
 
-            std::optional<Value> yieldedQureg =
-                getQuantumReg(oldRegion.front().getTerminator()->getOperands());
-            remappedValues.map(yieldedQureg.value(), reversedResult);
+            for (auto [qvalue, reversedResult] :
+                 llvm::zip_equal(getQuantumValues(oldRegion.front().getTerminator()->getOperands()),
+                                 reversedResults)) {
+                remappedValues.map(qvalue, reversedResult);
+            }
+
             generateImpl(oldRegion, builder);
-            scf::YieldOp::create(builder, switchOp.getLoc(),
-                                 remappedValues.lookup(findRootQuregInRegion(oldRegion)));
+
+            SmallVector<Value> yields;
+            for (auto v : findRootQvaluesInRegion(oldRegion)) {
+                yields.push_back(remappedValues.lookup(v));
+            }
+            scf::YieldOp::create(builder, switchOp.getLoc(), yields);
         };
 
         // Case regions:
@@ -659,8 +676,10 @@ class AdjointGenerator {
         // Default region:
         fillRegion(switchOp.getDefaultRegion(), newSwitchOp.getDefaultRegion());
 
-        Value startingQureg = findRootQuregInRegion(switchOp.getDefaultRegion());
-        remappedValues.map(startingQureg, newSwitchOp.getResult(0));
+        int res_idx = 0;
+        for (auto v : findRootQvaluesInRegion(switchOp.getDefaultRegion())) {
+            remappedValues.map(v, newSwitchOp.getResult(res_idx++));
+        }
     }
 
   private:

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -547,10 +547,11 @@ class AdjointGenerator {
         SetVector<Value> startingThenQvalues = findOldestQvaluesInRegion(ifOp.getThenRegion());
         SetVector<Value> startingElseQvalues = findOldestQvaluesInRegion(ifOp.getElseRegion());
 
-        int res_idx = 0;
-        for (auto [t, e] : llvm::zip_equal(startingThenQvalues, startingElseQvalues)) {
+        for (auto [idx, pair] :
+             llvm::enumerate(llvm::zip_equal(startingThenQvalues, startingElseQvalues))) {
+            auto [t, e] = pair;
             assert(t == e && "Expected the same input quantum values for both scf.if branches");
-            remappedValues.map(t, reversedIf.getResult(res_idx++));
+            remappedValues.map(t, reversedIf.getResult(idx));
         }
     }
 
@@ -666,9 +667,9 @@ class AdjointGenerator {
         // Default region:
         fillRegion(switchOp.getDefaultRegion(), newSwitchOp.getDefaultRegion());
 
-        int res_idx = 0;
-        for (auto v : findRootQvaluesInRegion(switchOp.getDefaultRegion())) {
-            remappedValues.map(v, newSwitchOp.getResult(res_idx++));
+        for (auto [idx, v] :
+             llvm::enumerate(findRootQvaluesInRegion(switchOp.getDefaultRegion()))) {
+            remappedValues.map(v, newSwitchOp.getResult(idx));
         }
     }
 

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -157,16 +157,6 @@ class AdjointGenerator {
         return dynamicWire;
     }
 
-    std::optional<Value> getQuantumReg(ValueRange values)
-    {
-        for (Value value : values) {
-            if (isa<quantum::QuregType>(value.getType())) {
-                return value;
-            }
-        }
-        return std::nullopt;
-    }
-
     SmallVector<Value> getQuantumValues(ValueRange values)
     {
         SmallVector<Value> qvalues;

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -566,9 +566,9 @@ class AdjointGenerator {
 
     void visitOperation(scf::WhileOp whileOp, OpBuilder &builder)
     {
-        std::optional<Value> yieldedQureg =
-            getQuantumReg(whileOp.getAfter().front().getTerminator()->getOperands());
-        if (!yieldedQureg.has_value()) {
+        SmallVector<Value> yieldedQValues =
+            getQuantumValues(whileOp.getAfter().front().getTerminator()->getOperands());
+        if (yieldedQValues.empty()) {
             // This operation is purely classical
             return;
         }
@@ -578,23 +578,37 @@ class AdjointGenerator {
         Value c0 = index::ConstantOp::create(builder, whileOp.getLoc(), 0);
         Value c1 = index::ConstantOp::create(builder, whileOp.getLoc(), 1);
 
-        Value iterArgInit = remappedValues.lookup(getQuantumReg(whileOp.getResults()).value());
+        SmallVector<Value> iterArgsInit;
+        for (auto v : getQuantumValues(whileOp.getResults())) {
+            iterArgsInit.push_back(remappedValues.lookup(v));
+        }
+
         auto replacedWhile = scf::ForOp::create(
             builder, whileOp.getLoc(), /*start=*/c0, /*stop=*/numIterations, /*step=*/c1,
-            iterArgInit,
+            iterArgsInit,
             /*bodyBuilder=*/
             [&](OpBuilder &bodyBuilder, Location loc, Value iv, ValueRange iterArgs) {
                 OpBuilder::InsertionGuard insertionGuard(builder);
                 builder.restoreInsertionPoint(bodyBuilder.saveInsertionPoint());
 
-                remappedValues.map(yieldedQureg.value(), iterArgs[0]);
+                for (auto [qvalue, iterArg] : llvm::zip_equal(yieldedQValues, iterArgs)) {
+                    remappedValues.map(qvalue, iterArg);
+                }
+
                 generateImpl(whileOp.getAfter(), builder);
-                scf::YieldOp::create(
-                    builder, loc,
-                    remappedValues.lookup(
-                        getQuantumReg(whileOp.getAfter().front().getArguments()).value()));
+
+                SmallVector<Value> yields;
+                for (auto v : getQuantumValues(whileOp.getAfter().front().getArguments())) {
+                    yields.push_back(remappedValues.lookup(v));
+                }
+
+                scf::YieldOp::create(builder, loc, yields);
             });
-        remappedValues.map(getQuantumReg(whileOp.getInits()).value(), replacedWhile.getResult(0));
+
+        for (auto [newWhileResult, initArg] :
+             llvm::zip_equal(replacedWhile.getResults(), getQuantumValues(whileOp.getInits()))) {
+            remappedValues.map(initArg, newWhileResult);
+        }
     }
 
     void visitOperation(scf::IndexSwitchOp switchOp, OpBuilder &builder)

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -15,12 +15,11 @@
 #define DEBUG_TYPE "adjoint"
 
 #include <algorithm>
-#include <iterator>
 #include <queue>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Errc.h"
 #include "mlir/Dialect/Complex/IR/Complex.h"
@@ -30,6 +29,7 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/IRMapping.h"
+#include "mlir/IR/Value.h"
 #include "mlir/IR/Verifier.h"
 #include "mlir/Transforms/DialectConversion.h"
 
@@ -164,6 +164,17 @@ class AdjointGenerator {
             }
         }
         return std::nullopt;
+    }
+
+    SmallVector<Value> getQuantumValues(ValueRange values)
+    {
+        SmallVector<Value> qvalues;
+        for (Value value : values) {
+            if (isa<quantum::QuregType, quantum::QubitType>(value.getType())) {
+                qvalues.push_back(value);
+            }
+        }
+        return qvalues;
     }
 
     void visitOperation(quantum::QuantumGate gate, OpBuilder &builder)
@@ -438,9 +449,9 @@ class AdjointGenerator {
 
     void visitOperation(scf::ForOp forOp, OpBuilder &builder)
     {
-        std::optional<Value> yieldedQureg =
-            getQuantumReg(forOp.getBody()->getTerminator()->getOperands());
-        if (!yieldedQureg.has_value()) {
+        SmallVector<Value> yieldedQValues =
+            getQuantumValues(forOp.getBody()->getTerminator()->getOperands());
+        if (yieldedQValues.empty()) {
             // This operation is purely classical
             return;
         }
@@ -452,20 +463,35 @@ class AdjointGenerator {
         Value stop = ListPopOp::create(builder, forOp.getLoc(), tape);
         Value start = ListPopOp::create(builder, forOp.getLoc(), tape);
 
-        Value reversedResult = remappedValues.lookup(getQuantumReg(forOp.getResults()).value());
+        SmallVector<Value> reversedResults;
+        for (auto v : getQuantumValues(forOp.getResults())) {
+            reversedResults.push_back(remappedValues.lookup(v));
+        }
+
         auto replacedFor = scf::ForOp::create(
-            builder, forOp.getLoc(), start, stop, step, /*iterArgsInit=*/reversedResult,
+            builder, forOp.getLoc(), start, stop, step, /*iterArgsInit=*/reversedResults,
             [&](OpBuilder &bodyBuilder, Location loc, Value iv, ValueRange iterArgs) {
                 OpBuilder::InsertionGuard insertionGuard(builder);
                 builder.restoreInsertionPoint(bodyBuilder.saveInsertionPoint());
 
-                remappedValues.map(yieldedQureg.value(), iterArgs[0]);
+                for (auto [qvalue, iterArg] : llvm::zip_equal(yieldedQValues, iterArgs)) {
+                    remappedValues.map(qvalue, iterArg);
+                }
+
                 generateImpl(forOp.getBodyRegion(), builder);
-                scf::YieldOp::create(
-                    builder, loc,
-                    remappedValues.lookup(getQuantumReg(forOp.getRegionIterArgs()).value()));
+
+                SmallVector<Value> yields;
+                for (auto v : getQuantumValues(forOp.getRegionIterArgs())) {
+                    yields.push_back(remappedValues.lookup(v));
+                }
+
+                scf::YieldOp::create(builder, loc, yields);
             });
-        remappedValues.map(getQuantumReg(forOp.getInitArgs()).value(), replacedFor.getResult(0));
+
+        for (auto [newForResult, initArg] :
+             llvm::zip_equal(replacedFor.getResults(), getQuantumValues(forOp.getInitArgs()))) {
+            remappedValues.map(initArg, newForResult);
+        }
     }
 
     void visitOperation(scf::IfOp ifOp, OpBuilder &builder)

--- a/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointPatterns.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Errc.h"
@@ -496,8 +497,8 @@ class AdjointGenerator {
 
     void visitOperation(scf::IfOp ifOp, OpBuilder &builder)
     {
-        std::optional<Value> qureg = getQuantumReg(ifOp.getResults());
-        if (!qureg.has_value()) {
+        SmallVector<Value> yieldedQValues = getQuantumValues(ifOp.getResults());
+        if (yieldedQValues.empty()) {
             // This operation is purely classical
             return;
         }
@@ -505,41 +506,62 @@ class AdjointGenerator {
         Value tape = cache.controlFlowTapes.at(ifOp);
         Value condition = ListPopOp::create(builder, ifOp.getLoc(), tape);
         condition = index::CastSOp::create(builder, ifOp.getLoc(), builder.getI1Type(), condition);
-        Value reversedResult = remappedValues.lookup(getQuantumReg(ifOp.getResults()).value());
 
-        // The quantum register is captured from outside rather than passed in through a
+        SmallVector<Value> reversedResults;
+        for (auto v : getQuantumValues(ifOp.getResults())) {
+            reversedResults.push_back(remappedValues.lookup(v));
+        }
+
+        // The quantum values are captured from outside rather than passed in through a
         // basic block argument. We thus need to traverse the region to look for it.
-        auto findOldestQuregInRegion = [&](Region &region) {
+        auto findOldestQvaluesInRegion = [&](Region &region) -> SetVector<Value> {
+            SetVector<Value> qvalues;
             for (Operation &innerOp : region.getOps()) {
                 for (Value operand : innerOp.getOperands()) {
-                    if (isa<quantum::QuregType>(operand.getType())) {
-                        return operand;
+                    bool isDefinedFromOutsideRegion =
+                        operand.getParentRegion()->isProperAncestor(&region);
+                    if (isa<quantum::QuregType, quantum::QubitType>(operand.getType()) &&
+                        isDefinedFromOutsideRegion) {
+                        qvalues.insert(operand);
                     }
                 }
             }
-            llvm_unreachable("failed to find qureg in scf.if region");
+            assert(!qvalues.empty() && "failed to find quantum values in scf.if region");
+            return qvalues;
         };
+
         auto getRegionBuilder = [&](Region &oldRegion) {
             return [&](OpBuilder &bodyBuilder, Location loc) {
                 OpBuilder::InsertionGuard insertionGuard(builder);
                 builder.restoreInsertionPoint(bodyBuilder.saveInsertionPoint());
 
-                std::optional<Value> yieldedQureg =
-                    getQuantumReg(oldRegion.front().getTerminator()->getOperands());
-                remappedValues.map(yieldedQureg.value(), reversedResult);
+                for (auto [qvalue, reversedResult] : llvm::zip_equal(
+                         getQuantumValues(oldRegion.front().getTerminator()->getOperands()),
+                         reversedResults)) {
+                    remappedValues.map(qvalue, reversedResult);
+                }
+
                 generateImpl(oldRegion, builder);
-                scf::YieldOp::create(builder, loc,
-                                     remappedValues.lookup(findOldestQuregInRegion(oldRegion)));
+
+                SmallVector<Value> yields;
+                for (auto v : findOldestQvaluesInRegion(oldRegion)) {
+                    yields.push_back(remappedValues.lookup(v));
+                }
+                scf::YieldOp::create(builder, loc, yields);
             };
         };
         auto reversedIf = scf::IfOp::create(builder, ifOp.getLoc(), condition,
                                             getRegionBuilder(ifOp.getThenRegion()),
                                             getRegionBuilder(ifOp.getElseRegion()));
-        Value startingThenQureg = findOldestQuregInRegion(ifOp.getThenRegion());
-        Value startingElseQureg = findOldestQuregInRegion(ifOp.getElseRegion());
-        assert(startingThenQureg == startingElseQureg &&
-               "Expected the same input register for both scf.if branches");
-        remappedValues.map(startingThenQureg, reversedIf.getResult(0));
+
+        SetVector<Value> startingThenQvalues = findOldestQvaluesInRegion(ifOp.getThenRegion());
+        SetVector<Value> startingElseQvalues = findOldestQvaluesInRegion(ifOp.getElseRegion());
+
+        int res_idx = 0;
+        for (auto [t, e] : llvm::zip_equal(startingThenQvalues, startingElseQvalues)) {
+            assert(t == e && "Expected the same input quantum values for both scf.if branches");
+            remappedValues.map(t, reversedIf.getResult(res_idx++));
+        }
     }
 
     void visitOperation(scf::WhileOp whileOp, OpBuilder &builder)

--- a/mlir/test/Quantum/AdjointTest.mlir
+++ b/mlir/test/Quantum/AdjointTest.mlir
@@ -352,6 +352,153 @@ func.func private @param_ordering(%0: !quantum.reg) -> !quantum.reg {
 
 // -----
 
+// Test adjoint of scf.for
+
+  func.func public @adjoint_for_loop() {
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %c0 = arith.constant 0 : index
+
+    // CHECK: [[reg:%.+]] = quantum.alloc( 2) : !quantum.reg
+    // CHECK: [[q0:%.+]] = quantum.extract [[reg]][ 0] : !quantum.reg -> !quantum.bit
+    // CHECK: [[q1:%.+]] = quantum.extract [[reg]][ 1] : !quantum.reg -> !quantum.bit
+    %0 = quantum.alloc( 2) : !quantum.reg
+    %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+    %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+
+    // CHECK-NOT: quantum.adjoint
+    %3:2 = quantum.adjoint(%1, %2) : !quantum.bit, !quantum.bit {
+    ^bb0(%arg1: !quantum.bit, %arg2: !quantum.bit):
+
+      // CHECK: [[for_out:%.+]]:2 = scf.for
+      // CHECK-SAME: iter_args(%arg1 = [[q0]], %arg2 = [[q1]]) -> (!quantum.bit, !quantum.bit) {
+      // CHECK:   [[gate2:%.+]]:2 = quantum.custom "gate2"() %arg1, %arg2 adj : !quantum.bit, !quantum.bit
+      // CHECK:   [[gate1:%.+]]:2 = quantum.custom "gate1"() [[gate2]]#0, [[gate2]]#1 adj : !quantum.bit, !quantum.bit
+      // CHECK:   scf.yield [[gate1]]#0, [[gate1]]#1 : !quantum.bit, !quantum.bit
+      // CHECK: }
+      %8:2 = scf.for %arg3 = %c0 to %c4 step %c1 iter_args(%arg5 = %arg1, %arg6 = %arg2) -> (!quantum.bit, !quantum.bit) {
+        %out_qubits:2 = quantum.custom "gate1"() %arg5, %arg6 : !quantum.bit, !quantum.bit
+        %out_qubits_0:2 = quantum.custom "gate2"() %out_qubits#0, %out_qubits#1 : !quantum.bit, !quantum.bit
+        scf.yield %out_qubits_0#0, %out_qubits_0#1 : !quantum.bit, !quantum.bit
+      }
+
+      quantum.yield %8#0, %8#1 : !quantum.bit, !quantum.bit
+    }
+
+    // CHECK: [[insert0:%.+]] = quantum.insert [[reg]][ 0], [[for_out]]#0 : !quantum.reg, !quantum.bit
+    // CHECK: [[insert1:%.+]] = quantum.insert [[insert0]][ 1], [[for_out]]#1 : !quantum.reg, !quantum.bit
+    // CHECK: quantum.dealloc [[insert1]]
+    %4 = quantum.insert %0[ 0], %3#0 : !quantum.reg, !quantum.bit
+    %5 = quantum.insert %4[ 1], %3#1 : !quantum.reg, !quantum.bit
+    quantum.dealloc %5 : !quantum.reg
+    return
+  }
+
+// -----
+
+// Test adjoint of scf.while
+
+  func.func public @adjoint_while_loop() {
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %c0 = arith.constant 0 : index
+
+    // CHECK: [[reg:%.+]] = quantum.alloc( 2) : !quantum.reg
+    // CHECK: [[q0:%.+]] = quantum.extract [[reg]][ 0] : !quantum.reg -> !quantum.bit
+    // CHECK: [[q1:%.+]] = quantum.extract [[reg]][ 1] : !quantum.reg -> !quantum.bit
+    %0 = quantum.alloc( 2) : !quantum.reg
+    %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+    %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+
+    // CHECK-NOT: quantum.adjoint
+    %3:2 = quantum.adjoint(%1, %2) : !quantum.bit, !quantum.bit {
+    ^bb0(%arg1: !quantum.bit, %arg2: !quantum.bit):
+
+      // COM: while loops are converted into a pre-run with empty `do` block to compute the number
+      // COM: of iterations in runtime, and then a for loop with the gates.
+      // CHECK: memref.alloca() : memref<index>
+      // CHECK: scf.while
+      // CHECK: memref.store
+
+      // CHECK: memref.load {{%.+}}[] : memref
+      // CHECK: [[for_out:%.+]]:2 = scf.for
+      // CHECK-SAME: iter_args(%arg1 = [[q0]], %arg2 = [[q1]]) -> (!quantum.bit, !quantum.bit) {
+      // CHECK:   [[gate2:%.+]]:2 = quantum.custom "gate2"() %arg1, %arg2 adj : !quantum.bit, !quantum.bit
+      // CHECK:   [[gate1:%.+]]:2 = quantum.custom "gate1"() [[gate2]]#0, [[gate2]]#1 adj : !quantum.bit, !quantum.bit
+      // CHECK:   scf.yield [[gate1]]#0, [[gate1]]#1 : !quantum.bit, !quantum.bit
+      // CHECK: }
+      %6:2 = scf.while (%arg3 = %arg1, %arg4 = %arg2) : (!quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit) {
+          %7 = arith.constant true
+          scf.condition(%7) %arg3, %arg4 : !quantum.bit, !quantum.bit
+      } do {
+          ^bb0(%arg3: !quantum.bit, %arg4: !quantum.bit):
+          %out_qubits:2 = quantum.custom "gate1"() %arg3, %arg4 : !quantum.bit, !quantum.bit
+          %out_qubits_0:2 = quantum.custom "gate2"() %out_qubits#0, %out_qubits#1 : !quantum.bit, !quantum.bit
+          scf.yield %out_qubits_0#0, %out_qubits_0#1 : !quantum.bit, !quantum.bit
+      }
+
+      quantum.yield %6#0, %6#1 : !quantum.bit, !quantum.bit
+    }
+
+    // CHECK: [[insert0:%.+]] = quantum.insert [[reg]][ 0], [[for_out]]#0 : !quantum.reg, !quantum.bit
+    // CHECK: [[insert1:%.+]] = quantum.insert [[insert0]][ 1], [[for_out]]#1 : !quantum.reg, !quantum.bit
+    // CHECK: quantum.dealloc [[insert1]]
+    %4 = quantum.insert %0[ 0], %3#0 : !quantum.reg, !quantum.bit
+    %5 = quantum.insert %4[ 1], %3#1 : !quantum.reg, !quantum.bit
+    quantum.dealloc %5 : !quantum.reg
+    return
+  }
+
+// -----
+
+// Test adjoint of scf.if
+
+  func.func public @adjoint_if(%arg0: i1) {
+
+    // CHECK: [[reg:%.+]] = quantum.alloc( 2) : !quantum.reg
+    // CHECK: [[q0:%.+]] = quantum.extract [[reg]][ 0] : !quantum.reg -> !quantum.bit
+    // CHECK: [[q1:%.+]] = quantum.extract [[reg]][ 1] : !quantum.reg -> !quantum.bit
+    %0 = quantum.alloc( 2) : !quantum.reg
+    %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+    %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+
+    // CHECK-NOT: quantum.adjoint
+    %3:2 = quantum.adjoint(%1, %2) : !quantum.bit, !quantum.bit {
+    ^bb0(%arg1: !quantum.bit, %arg2: !quantum.bit):
+
+      // CHECK: [[if_out:%.+]]:2 = scf.if {{%.+}} -> (!quantum.bit, !quantum.bit) {
+      // CHECK:   [[gate2:%.+]]:2 = quantum.custom "gate2"() [[q0]], [[q1]] adj : !quantum.bit, !quantum.bit
+      // CHECK:   [[gate1:%.+]]:2 = quantum.custom "gate1"() [[gate2]]#0, [[gate2]]#1 adj : !quantum.bit, !quantum.bit
+      // CHECK:   scf.yield [[gate1]]#0, [[gate1]]#1 : !quantum.bit, !quantum.bit
+      // CHECK: } else {
+      // CHECK:   [[gate4:%.+]]:2 = quantum.custom "gate4"() [[q0]], [[q1]] adj : !quantum.bit, !quantum.bit
+      // CHECK:   [[gate3:%.+]]:2 = quantum.custom "gate3"() [[gate4]]#0, [[gate4]]#1 adj : !quantum.bit, !quantum.bit
+      // CHECK:   scf.yield [[gate3]]#0, [[gate3]]#1 : !quantum.bit, !quantum.bit
+      // CHECK: }
+      %8:2 = scf.if %arg0 -> (!quantum.bit, !quantum.bit) {
+        %out_qubits:2 = quantum.custom "gate1"() %arg1, %arg2 : !quantum.bit, !quantum.bit
+        %out_qubits_0:2 = quantum.custom "gate2"() %out_qubits#0, %out_qubits#1 : !quantum.bit, !quantum.bit
+        scf.yield %out_qubits_0#0, %out_qubits_0#1 : !quantum.bit, !quantum.bit
+      } else {
+        %out_qubits:2 = quantum.custom "gate3"() %arg1, %arg2 : !quantum.bit, !quantum.bit
+        %out_qubits_0:2 = quantum.custom "gate4"() %out_qubits#0, %out_qubits#1 : !quantum.bit, !quantum.bit
+        scf.yield %out_qubits_0#0, %out_qubits_0#1 : !quantum.bit, !quantum.bit
+      }
+
+      quantum.yield %8#0, %8#1 : !quantum.bit, !quantum.bit
+    }
+
+    // CHECK: [[insert0:%.+]] = quantum.insert [[reg]][ 0], [[if_out]]#0 : !quantum.reg, !quantum.bit
+    // CHECK: [[insert1:%.+]] = quantum.insert [[insert0]][ 1], [[if_out]]#1 : !quantum.reg, !quantum.bit
+    // CHECK: quantum.dealloc [[insert1]]
+    %4 = quantum.insert %0[ 0], %3#0 : !quantum.reg, !quantum.bit
+    %5 = quantum.insert %4[ 1], %3#1 : !quantum.reg, !quantum.bit
+    quantum.dealloc %5 : !quantum.reg
+    return
+  }
+
+// -----
+
 // Test adjoint of scf.index_switch
 
 // CHECK: func.func private @switch_branch_callee.adjoint(%arg0: !quantum.reg) -> !quantum.reg


### PR DESCRIPTION
**Context:**
Recently we extended the `quantum.adjoint` operation to handle arbitrary quantum operand structures (as opposed to being restricted to have a single qreg arg) #2590

In adjoint lowering pass, when the adjoint region contains other control flow regions, the code is still assuming the control flow regions have a single qreg argument (at index `0`).

**Description of the Change:**
Update adjoint lowering pass's control flow part to deal with arbitrary quantum operand structure.

**Benefits:**
Adjoint lowering pass works with more general programs.
In particular, those generated by the ref-to-value semantics conversion will in general have unconstrained quantum operand structures on control flow ops.

