### PR TITLE
Testing and docs improvements for qecl-to-qecp pass

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -71,6 +71,7 @@
   transversal gate operations from the QEC Logical (`qecl`) dialect into the QEC
   Physical (`qecp`) dialect.
   [(#2776)](https://github.com/PennyLaneAI/catalyst/pull/2776)
+  [(#2871)](https://github.com/PennyLaneAI/catalyst/pull/2871)
 
 * The reference semantics Pauli Product Measurement operation `pbc.ref.ppm` was added.
   [(#2773)](https://github.com/PennyLaneAI/catalyst/pull/2773)
@@ -110,6 +111,8 @@
   - `qecl.fabricate`, which fabricates a logical codeblock in a specified initial state (typically a
     magic state).
     [(#2865)](https://github.com/PennyLaneAI/catalyst/pull/2865)
+
+
 
 <h3>Documentation 📝</h3>
 

--- a/frontend/catalyst/python_interface/transforms/qecp/convert_qecl_to_qecp.py
+++ b/frontend/catalyst/python_interface/transforms/qecp/convert_qecl_to_qecp.py
@@ -24,7 +24,7 @@ The convert-qecl-to-qecp pass has the following known limitations:
 
   * No support for QEC codes where the number of logical qubits per codeblock, k, is greater than 1.
   * No support for non-CSS codes
-  * Only supports lowering of transversal operations
+  * Only supports lowering of transversal gates and measurements. Does not support non-Clifford gates.
   * Only logical Pauli Z observables (computational basis) are supported for lowering `qecl.measure`
     operations.
   * Support for control flow in the user program is not fully implemented or tested

--- a/frontend/catalyst/python_interface/transforms/qecp/convert_qecl_to_qecp.py
+++ b/frontend/catalyst/python_interface/transforms/qecp/convert_qecl_to_qecp.py
@@ -28,9 +28,11 @@ The convert-qecl-to-qecp pass has the following known limitations:
   * Only logical Pauli Z observables (computational basis) are supported for lowering `qecl.measure`
     operations.
   * Support for control flow in the user program is not fully implemented or tested
-  * The generated QEC-cycles are not fault-tolerant - they don't account for potential errors in the syndrome qubits/measurements
+  * The generated QEC-cycles are not fault-tolerant - they don't account for potential errors in
+    the syndrome qubits/measurements
   * For terminal measurements, only sampling of MCMs is supported
-  * The encoding procedure to create the logical zero state in a codeblock is not optimized for efficiency
+  * The encoding procedure to create the logical zero state in a codeblock is not optimized for
+    efficiency
 """
 
 from collections.abc import Callable, Iterable

--- a/frontend/catalyst/python_interface/transforms/qecp/convert_qecl_to_qecp.py
+++ b/frontend/catalyst/python_interface/transforms/qecp/convert_qecl_to_qecp.py
@@ -33,7 +33,7 @@ The convert-qecl-to-qecp pass has the following known limitations:
   * For terminal measurements, only sampling of MCMs is supported
   * The encoding procedure to create the logical zero state in a codeblock is not optimized for
     efficiency
-  * Only thoroughly tested with the Steane code, but should be generalizable to other k=1 CSS 
+  * Only thoroughly tested with the Steane code, but should be generalizable to other k=1 CSS
     stabilizer codes.
 """
 
@@ -110,8 +110,8 @@ class HyperRegisterTypeConversion(TypeConversionPattern):
         """Type conversion rewrite pattern for physical codeblock types."""
         if typ.k.value.data != self.qec_code.k:
             raise CompileError(
-                f"Failed to convert type {typ} with QEC code '{self.qec_code}'; hyper-register has "
-                f"k = {typ.k.value.data} but QEC code has k = {self.qec_code.k}"
+                f"Failed to convert type {typ} with QEC code '{self.qec_code}'; hyper-register "
+                f"has k = {typ.k.value.data} but QEC code has k = {self.qec_code.k}"
             )
 
         return qecp.PhysicalHyperRegisterType(typ.width, typ.k, self.qec_code.n)

--- a/frontend/catalyst/python_interface/transforms/qecp/convert_qecl_to_qecp.py
+++ b/frontend/catalyst/python_interface/transforms/qecp/convert_qecl_to_qecp.py
@@ -20,11 +20,17 @@ To apply this pass, the QEC code must be know.
 Known Limitations
 -----------------
 
-The convert-qecl-to-qecp pass does not support the following cases:
+The convert-qecl-to-qecp pass has the following known limitations:
 
-  * QEC codes where the number of logical qubits per codeblock, k, is greater than 1.
+  * No support for QEC codes where the number of logical qubits per codeblock, k, is greater than 1.
+  * No support for non-CSS codes
+  * Only supports lowering of transversal operations
   * Only logical Pauli Z observables (computational basis) are supported for lowering `qecl.measure`
     operations.
+  * Support for control flow in the user program is not fully implemented or tested
+  * The generated QEC-cycles are not fault-tolerant - they don't account for potential errors in the syndrome qubits/measurements
+  * For terminal measurements, only sampling of MCMs is supported
+  * The encoding procedure to create the logical zero state in a codeblock is not optimized for efficiency
 """
 
 from collections.abc import Callable, Iterable
@@ -403,11 +409,11 @@ class ConvertQecLogicalToQecPhysicalPass(ModulePass):
         assert module_block is not None, "Module has no block"
 
         # Insert subroutines that implement the QEC protocols
-        encode_funcop = self.create_encode_subroutine()
-        module_block.add_op(encode_funcop)
+        encode_subroutine = self.create_encode_subroutine()
+        module_block.add_op(encode_subroutine)
 
-        qec_cycle_funcop = self.create_qec_cycle_subroutine()
-        module_block.add_op(qec_cycle_funcop)
+        qec_cycle_subroutine = self.create_qec_cycle_subroutine()
+        module_block.add_op(qec_cycle_subroutine)
 
         measure_subroutine = self.create_measure_subroutine()
         module_block.add_op(measure_subroutine)
@@ -415,6 +421,8 @@ class ConvertQecLogicalToQecPhysicalPass(ModulePass):
         physical_meas_decode_subroutine = self.create_physical_meas_decode_subroutine()
         module_block.add_op(physical_meas_decode_subroutine)
 
+        # 1Q gate and 2Q gate subroutines are returned as dicts storing
+        # {"gate_name": subroutine_funcop}
         transversal_gate_subroutines = (
             self.create_transversal_1Qgate_subroutines()
             | self.create_transversal_2Qgate_subroutines()
@@ -431,9 +439,9 @@ class ConvertQecLogicalToQecPhysicalPass(ModulePass):
                     DeallocationConversion(),
                     InsertBlockConversion(),
                     ExtractBlockConversion(),
-                    EncodeOpConversion(qec_code=self.qec_code, encode_subroutine=encode_funcop),
+                    EncodeOpConversion(qec_code=self.qec_code, encode_subroutine=encode_subroutine),
                     QecCycleOpConversion(
-                        qec_code=self.qec_code, qec_cycle_subroutine=qec_cycle_funcop
+                        qec_code=self.qec_code, qec_cycle_subroutine=qec_cycle_subroutine
                     ),
                     MeasureOpConversion(
                         qec_code=self.qec_code,
@@ -447,6 +455,8 @@ class ConvertQecLogicalToQecPhysicalPass(ModulePass):
                 ]
             )
         ).rewrite_module(op)
+
+    # MARK: Insert tanner graphs
 
     def insert_tanner_graph_ops_into_block(
         self, block: Block
@@ -520,8 +530,11 @@ class ConvertQecLogicalToQecPhysicalPass(ModulePass):
 
         return assemble_x_tanner_op.tanner_graph, assemble_z_tanner_op.tanner_graph
 
+    # MARK: Measure subroutine
+
     def create_measure_subroutine(self) -> func.FuncOp:
-        """Create the subroutine that performs the transversal measurement of a physical codeblock.
+        """Create the subroutine that performs the transversal measurement of a physical codeblock
+        in the computational basis. All qubits in the codeblock are measured directly.
 
         Note that this method does not insert the subroutine into the module op. Instead it returns
         the built func.FuncOp object that can then be subsequently inserted where desired.
@@ -599,9 +612,17 @@ class ConvertQecLogicalToQecPhysicalPass(ModulePass):
 
         return measure_subroutine
 
+    # MARK: Meas_decode subroutine
+
     def create_physical_meas_decode_subroutine(self) -> func.FuncOp:
         """Create the subroutine that performs the physical-measurement decoding of a transversal
-        measurement and returns the corresponding k logical measurement outcomes.
+        measurement in the computational basis, and returns the corresponding k logical measurement
+        outcomes.
+
+        The logical measurement outcome is determined by a parity check of the physical measurements
+        corresponding to the indices of the PauliZ operation - i.e. for a code where a transversal
+        Z gate is applied on indices [1, 2, 4], a logical Z measurement is determined by a parity
+        check of physical measurements at indices [1, 2, 4] of the codeblock.
 
         Note that this method does not insert the subroutine into the module op. Instead it returns
         the built func.FuncOp object that can then be subsequently inserted where desired.
@@ -670,6 +691,8 @@ class ConvertQecLogicalToQecPhysicalPass(ModulePass):
 
         return physical_meas_decode_subroutine
 
+    # MARK: Encode subroutine
+
     def create_encode_subroutine(self) -> func.FuncOp:
         """Create a subroutine that takes in a codeblock, encodes it in the zero state for
         the QEC code (based on the tanner graph), and returns the encoded codeblock. This
@@ -717,11 +740,18 @@ class ConvertQecLogicalToQecPhysicalPass(ModulePass):
 
         return funcOp
 
+    # MARK: 1Q gate subroutines
+
     def create_transversal_1Qgate_subroutines(self) -> dict[str, func.FuncOp]:
         """Create the subroutines that performs transversal 1-qubit gates on a physical codeblock.
 
+        The subroutines are built based on the gate and codeblock indices defined in the specified
+        ``QecCode``. For example, a code that specifies ``{"x": (qecp.PauliXOp, [2, 3])}`` as a
+        transversal gate will lower ``qecl.x`` to ``qecp.x`` at indices 2 and 3. The `qecp.identity`
+        operator is applied at all other indices in the codeblock.
+
         Note that this method does not insert the subroutine into the module op. Instead it returns
-        a dict of built func.FuncOp objects that can then be subsequently inserted where desired.
+        a dict containing func.FuncOp objects that can then be subsequently inserted where desired.
         """
         subroutines = {}
         single_qubit_gates = self.qec_code.transversal_1q_gates
@@ -771,11 +801,16 @@ class ConvertQecLogicalToQecPhysicalPass(ModulePass):
 
         return subroutines
 
+    # MARK: 2Q gate subroutines
+
     def create_transversal_2Qgate_subroutines(self) -> dict[str, func.FuncOp]:
-        """Create the subroutinew that performs transversal 2-qubit gates on a physical codeblock.
+        """Create the subroutines that perform transversal 2-qubit gates on a physical codeblock.
+
+        This implementation assumes the gate is applied transversally between all corresponding
+        qubit pairs in the two codeblocks.
 
         Note that this method does not insert the subroutine into the module op. Instead it returns
-        a dict of built func.FuncOp objects that can then be subsequently inserted where desired.
+        a dict containing func.FuncOp objects that can then be subsequently inserted where desired.
         """
         subroutines = {}
 
@@ -832,6 +867,8 @@ class ConvertQecLogicalToQecPhysicalPass(ModulePass):
             subroutines[gate_name] = funcOp
 
         return subroutines
+
+    # MARK: Check pattern
 
     def check_pattern(
         self,
@@ -929,6 +966,8 @@ class ConvertQecLogicalToQecPhysicalPass(ModulePass):
             )
 
         return tanner_graph, cnot_fn
+
+    # MARK: QEC cycle subroutine
 
     def create_qec_cycle_subroutine(self) -> func.FuncOp:
         """Create a subroutine that performs a cycle of QEC on an input physical codeblock.

--- a/frontend/catalyst/python_interface/transforms/qecp/convert_qecl_to_qecp.py
+++ b/frontend/catalyst/python_interface/transforms/qecp/convert_qecl_to_qecp.py
@@ -33,6 +33,8 @@ The convert-qecl-to-qecp pass has the following known limitations:
   * For terminal measurements, only sampling of MCMs is supported
   * The encoding procedure to create the logical zero state in a codeblock is not optimized for
     efficiency
+  * Only thoroughly tested with the Steane code, but should be generalizable to other k=1 CSS 
+    stabilizer codes.
 """
 
 from collections.abc import Callable, Iterable

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecl_to_qecp.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecl_to_qecp.py
@@ -569,7 +569,7 @@ class TestQecCycleLowering:
         run_filecheck(program, qecl_to_qecp_steane_pipeline)
 
 
-# MARK: TestLoweringMeasure
+# MARK: Measure
 
 
 class TestLoweringMeasure:
@@ -1015,18 +1015,61 @@ class TestLoweringTransversalGates:
         run_filecheck(program, pipeline)
 
 
-# MARK: Integration Tests with Noise
+# MARK: Integration
 
 
-# We can remove this xfail and warning filter once `convert_qecl_to_qecp_pass` is complete
-@pytest.mark.xfail(reason="The `convert_qecl_to_qecp_pass` is incomplete")
-@pytest.mark.filterwarnings("ignore:Unable to remove cast UnrealizedConversionCastOp")
-class TestQECLNoiseLoweringPassIntegration:
-    """Integration lit tests for the convert-qecl-noise-to-qecp-noise pass"""
+class TestQECPLoweringIntegration:
+    """Integration lit tests for convert-qecl-to-qecp"""
 
-    # pylint: disable=line-too-long
+    def test_circuit_ghz_to_qecp(self, run_filecheck_qjit):
+        """Test the convert-quantum-to-qecl and convert-qecl-to-qecp pass together on a
+        GHZ circuit."""
+        dev = qp.device("null.qubit", wires=3)
+
+        @qp.qjit(capture=True, target="mlir")
+        @convert_qecl_to_qecp_pass(qec_code="Steane")
+        @convert_quantum_to_qecl_pass(k=1)
+        @qp.qnode(dev, shots=1)
+        def circuit():
+            # CHECK: qecp.alloc() : !qecp.hyperreg<3 x 1 x 7>
+            # CHECK: scf.for {{.*}} {
+            # CHECK:   qecp.extract_block
+            # CHECK:   func.call @encode_zero_Steane
+            # CHECK:   qecp.insert_block
+            # CHECK:   scf.yield
+            # CHECK: }
+            # CHECK: qecp.extract_block
+            # CHECK: func.call @qec_cycle_Steane
+            # CHECK: func.call @hadamard_Steane
+            # CHECK: func.call @qec_cycle_Steane
+            # CHECK: qecp.extract_block
+            # CHECK: func.call @qec_cycle_Steane
+            # CHECK: func.call @cnot_Steane
+            # CHECK: func.call @qec_cycle_Steane
+            # CHECK: qecp.extract_block
+            # CHECK: func.call @qec_cycle_Steane
+            # CHECK: func.call @cnot_Steane
+            # CHECK: func.call @qec_cycle_Steane
+            # CHECK: func.call @measure_transversal_Steane
+            # CHECK: func.call @measure_transversal_Steane
+            # CHECK: func.call @measure_transversal_Steane
+            # CHECK: quantum.mcmobs
+            # CHECK: quantum.sample
+            # CHECK: qecp.insert_block
+            # CHECK: qecp.dealloc
+            qp.H(0)
+            qp.CNOT([0, 1])
+            qp.CNOT([1, 2])
+            m0 = qp.measure(0)
+            m1 = qp.measure(1)
+            m2 = qp.measure(2)
+            return qp.sample([m0, m1, m2])
+
+        run_filecheck_qjit(circuit)
+
     def test_convert_qecl_noise_to_qecp_noise_pass_integration(self, run_filecheck_qjit):
-        """Test the convert-qecl-noise-to-qecp-noise pass on the simplest possible, non-trivial circuit."""
+        """Test integration of the convert-qecl-noise-to-qecp-noise pass on the simplest possible,
+        non-trivial circuit."""
         dev = qp.device("null.qubit", wires=1)
 
         @qp.qjit(target="mlir", capture=True)
@@ -1035,20 +1078,18 @@ class TestQECLNoiseLoweringPassIntegration:
         @convert_quantum_to_qecl_pass(k=1)
         @qp.qnode(dev, shots=1)
         def circuit():
-            # CHECK: builtin.unrealized_conversion_cast [[codeblock:%.*]] : !qecl.codeblock<1> to !qecp.codeblock<1 x 7>
+            # CHECK: func.call @encode_zero_Steane
             # CHECK: arith.constant dense
             # CHECK: arith.constant dense
             # CHECK: func.call @noise_subroutine_code
-            # CHECK: builtin.unrealized_conversion_cast [[codeblock:%.*]] : !qecp.codeblock<1 x 7> to !qecl.codeblock<1>
-            # CHECK: qecl.qec
-            # CHECK: qecl.hadamard
+            # CHECK: func.call @qec_cycle_Steane
+            # CHECK: func.call @hadamard_Steane
             qp.H(0)
-            # CHECK: builtin.unrealized_conversion_cast [[codeblock:%.*]] : !qecl.codeblock<1> to !qecp.codeblock<1 x 7>
             # CHECK: arith.constant dense
             # CHECK: arith.constant dense
             # CHECK: func.call @noise_subroutine_code
-            # CHECK: builtin.unrealized_conversion_cast [[codeblock:%.*]] : !qecp.codeblock<1 x 7> to !qecl.codeblock<1>
-            # CHECK: qecl.qec
+            # CHECK: func.call @qec_cycle_Steane
+            # CHECK: func.call @measure_transversal_Steane
             m0 = qp.measure(0)
             return qp.sample([m0])
 


### PR DESCRIPTION
**Context:**
The `qecl-to-qecp` conversion pass was implemented piecemeal in separate PRs, with the intention of tidying up once all the pieces came together. This PR does that.

**Description of the Change:**

- Adds a more details to the Limitations section at the top of the file
- Ensures that all subroutines include a brief explanation of the lowering, or a reference to a paper the lowering is based on
- Adds test coverage for integration tests
- Small formatting changes (names variables more consistently, adds MARKs where useful)

**Benefits:**
Better testing, cleaner code and documentation, easier for us (or other people) to return to the code later and understand scope, limitations and implementation details