### PR TITLE
Replace Op strings with Op types in decompose.py

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -52,6 +52,10 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a bug in `DecompRuleInterpreter.cleanup` by replacing fragile string-based operator
+  checks with strict type-based checking.
+  [(#2873)](https://github.com/PennyLaneAI/catalyst/pull/2873)
+
 * Fixed a bug where using `keep_intermediate=True` with `target="mlir"` resulted in an empty workspace
   folder being created and the files printed outside in the main directory.
   [(#2807)](https://github.com/PennyLaneAI/catalyst/pull/2807)
@@ -127,6 +131,7 @@
 
 This release contains contributions from (in alphabetical order):
 
+Ali Asadi,
 Joey Carter,
 Yushao Chen,
 Lillian Frederiksen,

--- a/frontend/catalyst/from_plxpr/decompose.py
+++ b/frontend/catalyst/from_plxpr/decompose.py
@@ -237,14 +237,17 @@ class DecompRuleInterpreter(qp.capture.PlxprInterpreter):
                     requires_copy=requires_copy,
                     pauli_word=pauli_word,
                 )
-            elif not any(
-                keyword in getattr(op.op, "name", "")
-                for keyword in (
-                    "Adjoint",
-                    "Controlled",
-                    "TemporaryAND",
-                    "ChangeOpBasis",
-                    "Prod",
+            elif not (
+                (op_type := getattr(op.op, "op_type", None)) is not None
+                and issubclass(
+                    op_type,
+                    (
+                        qp.ops.Adjoint,
+                        qp.ops.Controlled,
+                        qp.ops.ChangeOpBasis,
+                        qp.ops.Prod,
+                        qp.TemporaryAND,
+                    ),
                 )
             ):  # pragma: no cover
                 # Note that the graph-decomposition returns abstracted rules

--- a/frontend/catalyst/from_plxpr/decompose.py
+++ b/frontend/catalyst/from_plxpr/decompose.py
@@ -255,7 +255,7 @@ class DecompRuleInterpreter(qp.capture.PlxprInterpreter):
                 # These abstracted rules cannot be captured and lowered.
                 # We use MLIR AdjointOp and ControlledOp primitives
                 # to deal with decomposition of symbolic operations at PLxPR.
-                raise ValueError(f"Could not capture {op} without the number of wires.")
+                raise ValueError(f"Could not capture {op.op.name} without the number of wires.")
 
 
 # pylint: disable=too-many-arguments, too-many-positional-arguments

--- a/frontend/catalyst/from_plxpr/decompose.py
+++ b/frontend/catalyst/from_plxpr/decompose.py
@@ -249,7 +249,7 @@ class DecompRuleInterpreter(qp.capture.PlxprInterpreter):
                         qp.TemporaryAND,
                     ),
                 )
-            ):  # pragma: no cover
+            ):
                 # Note that the graph-decomposition returns abstracted rules
                 # for Adjoint and Controlled operations, so we skip them here.
                 # These abstracted rules cannot be captured and lowered.

--- a/frontend/catalyst/from_plxpr/decompose.py
+++ b/frontend/catalyst/from_plxpr/decompose.py
@@ -255,7 +255,7 @@ class DecompRuleInterpreter(qp.capture.PlxprInterpreter):
                 # These abstracted rules cannot be captured and lowered.
                 # We use MLIR AdjointOp and ControlledOp primitives
                 # to deal with decomposition of symbolic operations at PLxPR.
-                raise ValueError(f"Could not capture {op.op.name} without the number of wires.")
+                raise ValueError(f"Could not capture {op.op} without the number of wires.")
 
 
 # pylint: disable=too-many-arguments, too-many-positional-arguments

--- a/frontend/test/pytest/from_plxpr/test_decompose_transform.py
+++ b/frontend/test/pytest/from_plxpr/test_decompose_transform.py
@@ -1086,6 +1086,55 @@ class TestPlxPRDecomposition:
         assert qp.math.allclose(r2, np.cos(1.2))
         qp.decomposition.disable_graph()
 
+    def test_unknown_op_in_solution_raises(self):
+        """An op that ends up in the decomposition graph solution but is
+        neither in the captured circuit nor in ``COMPILER_OPS_FOR_DECOMPOSITION``
+        and is not a symbolic op must raise a clear ValueError so the user knows the
+        wire count cannot be inferred.
+        """
+
+        class _UnknownOp(qp.operation.Operation):
+            num_wires = 1
+            num_params = 0
+            name = "_UnknownOp"
+
+        def _unknown_resources():
+            return {qp.resource_rep(qp.PauliX): 1}
+
+        @qp.register_resources(_unknown_resources)
+        def _unknown_decomp(wires):
+            qp.PauliX(wires)
+
+        qp.add_decomps(_UnknownOp, _unknown_decomp)
+
+        def _rx_resources():
+            return {qp.resource_rep(_UnknownOp): 1}
+
+        @qp.register_resources(_rx_resources)
+        def _rx_decomp(phi, wires):
+            _UnknownOp(wires=wires)
+
+        qp.decomposition.enable_graph()
+
+        @qp.qjit(capture=True)
+        @qp.decompose(
+            gate_set={"PauliX"},
+            fixed_decomps={qp.RX: _rx_decomp},
+        )
+        @qp.qnode(qp.device("null.qubit", wires=1))
+        def f(phi):
+            qp.RX(phi, 0)
+            return qp.state()
+
+        try:
+            with pytest.raises(
+                ValueError,
+                match=r"Could not capture _UnknownOp without the number of wires\.",
+            ):
+                f(0.5)
+        finally:
+            qp.decomposition.disable_graph()
+
     def test_symbolic_controlled_op_is_skipped(self):
         """Symbolic Controlled ops produced by ``qml.ctrl`` must be skipped when
         iterating the decomposition graph solution.

--- a/frontend/test/pytest/from_plxpr/test_decompose_transform.py
+++ b/frontend/test/pytest/from_plxpr/test_decompose_transform.py
@@ -15,7 +15,7 @@
 This module tests the decompose transformation.
 """
 
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines, too-many-public-methods
 
 from contextlib import nullcontext as does_not_raise
 from functools import partial

--- a/frontend/test/pytest/from_plxpr/test_decompose_transform.py
+++ b/frontend/test/pytest/from_plxpr/test_decompose_transform.py
@@ -24,6 +24,7 @@ import numpy as np
 import pennylane as qp
 import pytest
 from jax.core import ShapedArray
+from pennylane.decomposition import controlled_resource_rep
 from pennylane.exceptions import DecompositionError, DecompositionWarning
 from pennylane.typing import TensorLike
 from pennylane.wires import WiresLike
@@ -1083,6 +1084,39 @@ class TestPlxPRDecomposition:
         r1, r2 = c()
         assert qp.math.allclose(r1, np.cos(0.5))
         assert qp.math.allclose(r2, np.cos(1.2))
+        qp.decomposition.disable_graph()
+
+    def test_symbolic_controlled_op_is_skipped(self):
+        """Symbolic Controlled ops produced by ``qml.ctrl`` must be skipped when
+        iterating the decomposition graph solution.
+        """
+        qp.decomposition.enable_graph()
+
+        def _resources():
+            return {
+                controlled_resource_rep(
+                    qp.BasisEmbedding, {"num_wires": 1}, num_control_wires=1
+                ): 1,
+                qp.resource_rep(qp.GlobalPhase): 1,
+            }
+
+        @qp.register_resources(_resources)
+        def my_rz(phi, wires):
+            qp.GlobalPhase(phi / 2)
+            qp.ctrl(qp.BasisEmbedding, control=wires)([1], wires=[1])
+
+        @qp.qjit(capture=True)
+        @qp.decompose(
+            gate_set={"CNOT", "PauliX", "GlobalPhase", "MultiControlledX"},
+            fixed_decomps={qp.RZ: my_rz},
+        )
+        @qp.qnode(qp.device("null.qubit", wires=2))
+        def f(phi):
+            qp.RZ(phi, 0)
+            return qp.state()
+
+        resources = qp.specs(f, level="device")(0.123).resources.gate_types
+        assert resources == {"BasisState": 1, "GlobalPhase": 1}
         qp.decomposition.disable_graph()
 
 

--- a/frontend/test/pytest/from_plxpr/test_decompose_transform.py
+++ b/frontend/test/pytest/from_plxpr/test_decompose_transform.py
@@ -1111,7 +1111,7 @@ class TestPlxPRDecomposition:
             return {qp.resource_rep(_UnknownOp): 1}
 
         @qp.register_resources(_rx_resources)
-        def _rx_decomp(phi, wires):
+        def _rx_decomp(_, wires):
             _UnknownOp(wires=wires)
 
         qp.decomposition.enable_graph()


### PR DESCRIPTION
**Context:**
Replace Op strings with Op types in decompose.py

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-120705]
Fixes #2875
