### PR TITLE
PBC Depth: Support depth for ppm-specs across `scf.if` branches

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -39,7 +39,7 @@
   [(#2863)](https://github.com/PennyLaneAI/catalyst/pull/2863)
 
 * The ``depth`` field reported by :func:`~.passes.ppm_specs` is now the **worst-case quantum
-  depth** across ``scf.if`` branches: ``depth(region) = layers_outside_if + Σ max(depth(then),
+  depth** across ``scf.if`` branches: ``depth(region) = layers_outside_if + max(depth(then),
   depth(else))``. Previously THEN and ELSE were counted sequentially.
   [(#2876)](https://github.com/PennyLaneAI/catalyst/pull/2876)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -38,6 +38,11 @@
   longer requires an explicit pipeline and no longer mixes MLIR into the JSON output.
   [(#2863)](https://github.com/PennyLaneAI/catalyst/pull/2863)
 
+* The ``depth`` field reported by :func:`~.passes.ppm_specs` is now the **worst-case quantum
+  depth** across ``scf.if`` branches: ``depth(region) = layers_outside_if + Σ max(depth(then),
+  depth(else))``. Previously THEN and ELSE were counted sequentially.
+  [(#2876)](https://github.com/PennyLaneAI/catalyst/pull/2876)
+
 * The `--decompose-lowering` pass can now handle cases where the decomposed gate act on qubit values
   extracted from different quantum register SSA values, as long as all these quantum register values
   trace back to the same allocation.

--- a/mlir/include/PBC/Utils/PBCLayer.h
+++ b/mlir/include/PBC/Utils/PBCLayer.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "llvm/ADT/SetVector.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 
 #include "PBC/IR/PBCDialect.h"
 #include "PBC/IR/PBCOpInterfaces.h"
@@ -49,6 +50,15 @@ class PBCLayerContext {
     // Returns op lists only; operand/result bookkeeping is deferred until layer construction.
     llvm::SmallVector<std::vector<PBCOpInterface>> groupLayers(mlir::Operation *root,
                                                                bool onlyOnDisjointQubit = false);
+
+    // Worst-case PBC layer depth across `scf.if` branches within `block`
+    // (typically a function body's entry block). `scf.for` / `scf.while` are not supported yet.
+    mlir::FailureOr<int64_t> computeWorstCaseDepth(mlir::Block *block,
+                                                   bool onlyOnDisjointQubit = false);
+
+  private:
+    // Worst-case depth of an `scf.if`: `max(depth(then), depth(else))`
+    mlir::FailureOr<int64_t> ifWorstCaseDepth(mlir::scf::IfOp ifOp, bool onlyOnDisjointQubit);
 };
 
 class PBCLayer {

--- a/mlir/lib/PBC/Transforms/CountPPMSpecs.cpp
+++ b/mlir/lib/PBC/Transforms/CountPPMSpecs.cpp
@@ -61,7 +61,7 @@ struct CountPPMSpecsPass : public impl::CountPPMSpecsPassBase<CountPPMSpecsPass>
     LogicalResult countPPM(pbc::PPMeasurementOp op, PPMSpecsType &PPMSpecs)
     {
         if (isOpInWhileOp(op)) {
-            return op->emitOpError("PPM statistics is not available when there are while loops.");
+            return op->emitOpError("PBC statistics is not available when there are while loops.");
         }
 
         auto parentFuncOp = op->getParentOfType<func::FuncOp>();
@@ -73,7 +73,7 @@ struct CountPPMSpecsPass : public impl::CountPPMSpecsPassBase<CountPPMSpecsPass>
         int64_t forLoopMultiplier = countStaticForloopIterations(op);
         if (forLoopMultiplier == -1) {
             return op->emitOpError(
-                "PPM statistics is not available when there are dynamically sized for loops.");
+                "PBC statistics is not available when there are dynamically sized for loops.");
         }
         PPMSpecs[parentFuncOp.getName()]["num_of_ppm"] += forLoopMultiplier;
         return success();
@@ -83,7 +83,7 @@ struct CountPPMSpecsPass : public impl::CountPPMSpecsPassBase<CountPPMSpecsPass>
                            llvm::BumpPtrAllocator &stringAllocator)
     {
         if (isOpInWhileOp(op)) {
-            return op->emitOpError("PPR statistics is not available when there are while loops.");
+            return op->emitOpError("PBC statistics is not available when there are while loops.");
         }
 
         int8_t rotationKind = op.getRotationKind();
@@ -103,7 +103,7 @@ struct CountPPMSpecsPass : public impl::CountPPMSpecsPassBase<CountPPMSpecsPass>
         int64_t forLoopMultiplier = countStaticForloopIterations(op);
         if (forLoopMultiplier == -1) {
             return op->emitOpError(
-                "PPM statistics is not available when there are dynamically sized for loops.");
+                "PBC statistics is not available when there are dynamically sized for loops.");
         }
         PPMSpecs[funcName][numRotationKindKey] += forLoopMultiplier;
 

--- a/mlir/lib/PBC/Transforms/CountPPMSpecs.cpp
+++ b/mlir/lib/PBC/Transforms/CountPPMSpecs.cpp
@@ -43,9 +43,9 @@ namespace pbc {
 struct CountPPMSpecsPass : public impl::CountPPMSpecsPassBase<CountPPMSpecsPass> {
     using CountPPMSpecsPassBase::CountPPMSpecsPassBase;
 
-    LogicalResult
-    countLogicalQubit(Operation *op,
-                      llvm::DenseMap<StringRef, llvm::DenseMap<StringRef, int>> &PPMSpecs)
+    using PPMSpecsType = llvm::DenseMap<StringRef, llvm::DenseMap<StringRef, int>>;
+
+    LogicalResult countLogicalQubit(Operation *op, PPMSpecsType &PPMSpecs)
     {
         uint64_t numQubits = cast<quantum::AllocOp>(op).getNqubitsAttr().value_or(0);
 
@@ -58,12 +58,10 @@ struct CountPPMSpecsPass : public impl::CountPPMSpecsPassBase<CountPPMSpecsPass>
         return success();
     }
 
-    LogicalResult countPPM(pbc::PPMeasurementOp op,
-                           llvm::DenseMap<StringRef, llvm::DenseMap<StringRef, int>> &PPMSpecs)
+    LogicalResult countPPM(pbc::PPMeasurementOp op, PPMSpecsType &PPMSpecs)
     {
-        if (isOpInIfOp(op) || isOpInWhileOp(op)) {
-            return op->emitOpError(
-                "PPM statistics is not available when there are conditionals or while loops.");
+        if (isOpInWhileOp(op)) {
+            return op->emitOpError("PPM statistics is not available when there are while loops.");
         }
 
         auto parentFuncOp = op->getParentOfType<func::FuncOp>();
@@ -81,13 +79,11 @@ struct CountPPMSpecsPass : public impl::CountPPMSpecsPassBase<CountPPMSpecsPass>
         return success();
     }
 
-    LogicalResult countPPR(pbc::PPRotationOp op,
-                           llvm::DenseMap<StringRef, llvm::DenseMap<StringRef, int>> &PPMSpecs,
+    LogicalResult countPPR(pbc::PPRotationOp op, PPMSpecsType &PPMSpecs,
                            llvm::BumpPtrAllocator &stringAllocator)
     {
-        if (isOpInIfOp(op) || isOpInWhileOp(op)) {
-            return op->emitOpError(
-                "PPM statistics is not available when there are conditionals or while loops.");
+        if (isOpInWhileOp(op)) {
+            return op->emitOpError("PPR statistics is not available when there are while loops.");
         }
 
         int8_t rotationKind = op.getRotationKind();
@@ -117,10 +113,47 @@ struct CountPPMSpecsPass : public impl::CountPPMSpecsPassBase<CountPPMSpecsPass>
         return success();
     }
 
+    // Worst-case PBC layer depth for a single function, treating scf.if as
+    // a barrier whose contribution is `max(depth(then), depth(else))`.
+    // depth_type:
+    //   depth-0: any commuting PPMs may share a layer, even on overlapping qubits.
+    //   depth-1: only PPMs on non-overlapping qubits may share a layer.
+    LogicalResult computeFuncDepth(func::FuncOp funcOp, bool onlyDisjointQubit,
+                                   PPMSpecsType &PPMSpecs)
+    {
+        if (!funcOp.getBody()
+                 .walk([&](PBCOpInterface) { return WalkResult::interrupt(); })
+                 .wasInterrupted()) {
+            return success();
+        }
+
+        PBCLayerContext layerContext;
+        FailureOr<int64_t> depth =
+            layerContext.computeWorstCaseDepth(&funcOp.getBody().front(), onlyDisjointQubit);
+        if (failed(depth)) {
+            return failure();
+        }
+
+        StringRef funcName = funcOp.getName();
+        PPMSpecs[funcName]["depth_type"] = onlyDisjointQubit ? 1 : 0;
+        PPMSpecs[funcName]["depth"] = static_cast<int>(*depth);
+        return success();
+    }
+
+    LogicalResult computeAllFuncDepth(bool onlyDisjointQubit, PPMSpecsType &PPMSpecs)
+    {
+        WalkResult wr = getOperation()->walk([&](func::FuncOp funcOp) {
+            return failed(computeFuncDepth(funcOp, onlyDisjointQubit, PPMSpecs))
+                       ? WalkResult::interrupt()
+                       : WalkResult::advance();
+        });
+        return wr.wasInterrupted() ? failure() : success();
+    }
+
     LogicalResult printSpecs(bool onlyDisjointQubit)
     {
         llvm::BumpPtrAllocator stringAllocator;
-        llvm::DenseMap<StringRef, llvm::DenseMap<StringRef, int>> PPMSpecs;
+        PPMSpecsType PPMSpecs;
 
         // Walk over all operations in the IR (could be ModuleOp or FuncOp)
         WalkResult wr = getOperation()->walk([&](Operation *op) {
@@ -158,32 +191,14 @@ struct CountPPMSpecsPass : public impl::CountPPMSpecsPassBase<CountPPMSpecsPass>
             return failure();
         }
 
-        // Count depth using the same layer grouping as partition-layers.
-        PBCLayerContext layerContext;
-        auto groupLayers = layerContext.groupLayers(getOperation(), onlyDisjointQubit);
-
-        if (!groupLayers.empty() && !groupLayers.front().empty()) {
-            auto funcOp =
-                groupLayers.front().front().getOperation()->getParentOfType<func::FuncOp>();
-            if (!funcOp) {
-                return groupLayers.front().front().emitOpError(
-                    "expected PBC op to be nested in func.func");
-            }
-            StringRef funcName = funcOp.getName();
-
-            // depth_type:
-            // depth-0: Depth calculated by allowing any commuting logical PPMs to be computed
-            // together, even with overlapping support.
-            // depth-1: Depth calculated by allowing only PPMs with non-overlapping support to be
-            // computed together.
-            PPMSpecs[funcName]["depth_type"] = onlyDisjointQubit ? 1 : 0;
-            PPMSpecs[funcName]["depth"] = groupLayers.size();
-        }
+        // Compute depth, but still emit JSON even if depth analysis fails for some
+        // functions (counts may have succeeded). Pass failure is reported at the end.
+        LogicalResult depthResult = computeAllFuncDepth(onlyDisjointQubit, PPMSpecs);
 
         json PPMSpecsJson = PPMSpecs;
         llvm::outs() << PPMSpecsJson.dump(4)
                      << "\n"; // dump(4) makes an indent with 4 spaces when printing JSON
-        return success();
+        return depthResult;
     }
 
     void runOnOperation() final

--- a/mlir/lib/PBC/Utils/CMakeLists.txt
+++ b/mlir/lib/PBC/Utils/CMakeLists.txt
@@ -33,4 +33,4 @@ target_compile_options(PBCUtils PRIVATE
     -fexceptions     # Enable exceptions
 )
 
-target_link_libraries(PBCUtils PRIVATE libstim ExternalStablehloLib)
+target_link_libraries(PBCUtils PRIVATE libstim ExternalStablehloLib MLIRSCFDialect)

--- a/mlir/lib/PBC/Utils/PBCLayer.cpp
+++ b/mlir/lib/PBC/Utils/PBCLayer.cpp
@@ -14,17 +14,116 @@
 
 #include "PBC/Utils/PBCLayer.h"
 
+#include <algorithm>
+
 #include "llvm/ADT/STLExtras.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 
 #include "PBC/IR/PBCOpInterfaces.h"
 #include "PBC/IR/PBCOps.h"
 #include "PBC/Utils/PauliStringWrapper.h"
 #include "Quantum/IR/QuantumOps.h" // for quantum.extract op
 
-using namespace catalyst::pbc;
+using namespace mlir;
 
 namespace catalyst {
 namespace pbc {
+
+FailureOr<int64_t> PBCLayerContext::ifWorstCaseDepth(scf::IfOp ifOp, bool onlyOnDisjointQubit)
+{
+    FailureOr<int64_t> thenDepth =
+        computeWorstCaseDepth(&ifOp.getThenRegion().front(), onlyOnDisjointQubit);
+    if (failed(thenDepth)) {
+        return failure();
+    }
+
+    int64_t elseDepth = 0;
+    if (!ifOp.getElseRegion().empty()) {
+        FailureOr<int64_t> elseD =
+            computeWorstCaseDepth(&ifOp.getElseRegion().front(), onlyOnDisjointQubit);
+        if (failed(elseD)) {
+            return failure();
+        }
+        elseDepth = *elseD;
+    }
+    return std::max(*thenDepth, elseDepth);
+}
+
+FailureOr<int64_t> PBCLayerContext::computeWorstCaseDepth(Block *block, bool onlyOnDisjointQubit)
+{
+    int64_t depth = 0;
+    PBCLayer layer(this);
+
+    auto flushLayer = [&]() {
+        if (!layer.empty()) {
+            depth += 1;
+            layer = PBCLayer(this);
+        }
+    };
+
+    for (Operation &op : *block) {
+        if (auto ifOp = dyn_cast<scf::IfOp>(&op)) {
+            flushLayer();
+            FailureOr<int64_t> branchDepth = ifWorstCaseDepth(ifOp, onlyOnDisjointQubit);
+            if (failed(branchDepth)) {
+                return failure();
+            }
+
+            depth += *branchDepth;
+            continue;
+        }
+
+        if (isa<scf::ForOp>(&op) || isa<scf::WhileOp>(&op)) {
+            return op.emitOpError(
+                "worst-case depth is not available when PBC ops are inside scf.for or scf.while");
+        }
+
+        if (isa<scf::IndexSwitchOp>(&op)) {
+            return op.emitOpError(
+                "worst-case depth is not available when PBC ops are inside scf.index_switch");
+        }
+
+        if (auto pbcOp = dyn_cast<PBCOpInterface>(&op)) {
+            if (!layer.insert(pbcOp, onlyOnDisjointQubit)) {
+                flushLayer();
+                bool inserted = layer.insert(pbcOp, onlyOnDisjointQubit);
+                assert(inserted && "PBCLayer::insert must accept any op into an empty layer");
+            }
+            continue;
+        }
+
+        // plain ops
+        if (op.getNumRegions() == 0) {
+            continue;
+        }
+
+        // multi-region ops
+        if (op.getNumRegions() != 1) {
+            return op.emitOpError(
+                "worst-case depth cannot analyze operations with multiple regions");
+        }
+
+        // Recurse into the op's single-block region body (e.g. quantum.adjoint)
+        Region &region = op.getRegion(0);
+        if (region.empty()) {
+            continue;
+        }
+        if (!region.hasOneBlock()) {
+            return op.emitOpError("worst-case depth cannot analyze regions with multiple blocks");
+        }
+
+        flushLayer();
+        FailureOr<int64_t> innerDepth = computeWorstCaseDepth(&region.front(), onlyOnDisjointQubit);
+
+        if (failed(innerDepth)) {
+            return failure();
+        }
+        depth += *innerDepth;
+    }
+
+    flushLayer();
+    return depth;
+}
 
 // Partition PBC ops into layer groups using commutation/disjoint-qubit rules.
 // Only op membership is recorded; operand/result bookkeeping is deferred until

--- a/mlir/test/PBC/PPMSpecsTest.mlir
+++ b/mlir/test/PBC/PPMSpecsTest.mlir
@@ -330,7 +330,7 @@ func.func public @dynamic_for_loop_error(%arg0: !quantum.bit, %c: index) {
 
     %q = scf.for %iter = %c0 to %c step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
       %out_qubits = pbc.ppr ["Z"](4) %arg1 : !quantum.bit
-      // expected-error@above {{PPM statistics is not available when there are dynamically sized for loops.}}
+      // expected-error@above {{PBC statistics is not available when there are dynamically sized for loops.}}
       %mres, %out_qubits_1 = pbc.ppm ["Z"] %out_qubits : i1, !quantum.bit
       scf.yield %out_qubits_1 : !quantum.bit
     }
@@ -347,7 +347,7 @@ func.func public @while_error(%arg0: !quantum.bit, %b: i1) {
     } do {
         ^bb0(%in_qubit: !quantum.bit):
         %out_qubits = pbc.ppr ["Z"](4) %in_qubit : !quantum.bit
-        // expected-error@above {{PPR statistics is not available when there are while loops.}}
+        // expected-error@above {{PBC statistics is not available when there are while loops.}}
         scf.yield %out_qubits : !quantum.bit
     }
 

--- a/mlir/test/PBC/PPMSpecsTest.mlir
+++ b/mlir/test/PBC/PPMSpecsTest.mlir
@@ -324,85 +324,6 @@ func.func public @game_of_surface_code(%arg0: !quantum.bit, %arg1: !quantum.bit,
 
 // -----
 
-//CHECK: {
-//CHECK:     "static_for_loop": {
-//CHECK:         "max_weight_pi4": 1,
-//CHECK:         "num_of_ppm": 5,
-//CHECK:         "pi4_ppr": 5
-//CHECK:     }
-//CHECK: }
-func.func public @static_for_loop(%arg0: !quantum.bit) {
-    %c5 = arith.constant 5 : index
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-
-    %q = scf.for %iter = %c0 to %c5 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
-      %out_qubits = pbc.ppr ["Z"](4) %arg1 : !quantum.bit
-      %mres, %out_qubits_1 = pbc.ppm ["Z"] %out_qubits : i1, !quantum.bit
-      scf.yield %out_qubits_1 : !quantum.bit
-    }
-
-    return
-}
-
-// -----
-
-//CHECK: {
-//CHECK:     "static_for_loop_bigstep": {
-//CHECK:         "max_weight_pi4": 1,
-//CHECK:         "num_of_ppm": 3,
-//CHECK:         "pi4_ppr": 3
-//CHECK:     }
-//CHECK: }
-func.func public @static_for_loop_bigstep(%arg0: !quantum.bit) {
-    %c5 = arith.constant 5 : index
-    %c0 = arith.constant 0 : index
-    %c2 = arith.constant 2 : index
-    // COM: should be 3 iterations (0,2,4)
-
-    %q = scf.for %iter = %c0 to %c5 step %c2 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
-      %out_qubits = pbc.ppr ["Z"](4) %arg1 : !quantum.bit
-      %mres, %out_qubits_1 = pbc.ppm ["Z"] %out_qubits : i1, !quantum.bit
-      scf.yield %out_qubits_1 : !quantum.bit
-    }
-
-    return
-}
-
-// -----
-
-//CHECK: {
-//CHECK:     "static_for_loop_nested": {
-//CHECK:         "max_weight_pi4": 1,
-//CHECK:         "max_weight_pi8": 1,
-//CHECK:         "num_of_ppm": 30,
-//CHECK:         "pi4_ppr": 30,
-//CHECK:         "pi8_ppr": 6
-//CHECK:     }
-//CHECK: }
-func.func public @static_for_loop_nested(%arg0: !quantum.bit) {
-    %c5 = arith.constant 5 : index
-    %c6 = arith.constant 6 : index
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-
-    %q = scf.for %iter = %c0 to %c6 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
-
-        %q_inner = scf.for %iter_inner = %c0 to %c5 step %c1 iter_args(%arg1_inner = %arg1) -> (!quantum.bit) {
-          %out_qubits_inner = pbc.ppr ["Z"](4) %arg1_inner : !quantum.bit
-          %mres, %out_qubits_inner_1 = pbc.ppm ["Z"] %out_qubits_inner : i1, !quantum.bit
-          scf.yield %out_qubits_inner_1 : !quantum.bit
-        }
-
-        %out_qubits = pbc.ppr ["Z"](8) %q_inner : !quantum.bit
-        scf.yield %out_qubits : !quantum.bit
-    }
-
-    return
-}
-
-// -----
-
 func.func public @dynamic_for_loop_error(%arg0: !quantum.bit, %c: index) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
@@ -419,20 +340,6 @@ func.func public @dynamic_for_loop_error(%arg0: !quantum.bit, %c: index) {
 
 // -----
 
-func.func public @cond_error(%arg0: !quantum.bit, %b: i1) {
-    %out_qubits = scf.if %b -> !quantum.bit {
-        %out_qubits_t = pbc.ppr ["Z"](4) %arg0 : !quantum.bit
-        // expected-error@above {{PPM statistics is not available when there are conditionals or while loops.}}
-        scf.yield %out_qubits_t : !quantum.bit
-    } else {
-        scf.yield %arg0 : !quantum.bit
-    }
-
-    return
-}
-
-// -----
-
 func.func public @while_error(%arg0: !quantum.bit, %b: i1) {
 
     %q = scf.while (%in_qubit = %arg0) : (!quantum.bit) -> (!quantum.bit) {
@@ -440,7 +347,7 @@ func.func public @while_error(%arg0: !quantum.bit, %b: i1) {
     } do {
         ^bb0(%in_qubit: !quantum.bit):
         %out_qubits = pbc.ppr ["Z"](4) %in_qubit : !quantum.bit
-        // expected-error@above {{PPM statistics is not available when there are conditionals or while loops.}}
+        // expected-error@above {{PPR statistics is not available when there are while loops.}}
         scf.yield %out_qubits : !quantum.bit
     }
 
@@ -549,4 +456,231 @@ func.func @test_disjoint_qubit_specs(%qr0 : !quantum.bit, %qr1 : !quantum.bit, %
     %m4, %4:5 = pbc.ppm ["Z", "X", "Y", "Y", "Y"] %2#0, %2#1, %3#0, %3#1, %1 : i1, !quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit
 
     func.return
+}
+
+// -----
+
+// CHECK-DAG: "test_if_worst_case_depth"
+// CHECK-DAG: "depth": 3
+// CHECK-DAG: "depth_type": 0
+
+// CHECK-DISJOINT-DAG: "test_if_worst_case_depth"
+// CHECK-DISJOINT-DAG: "depth": 3
+// CHECK-DISJOINT-DAG: "depth_type": 1
+func.func public @test_if_worst_case_depth(%b : i1, %q0 : !quantum.bit) {
+    %m, %out = pbc.ppm ["Z"] %q0 : i1, !quantum.bit
+    %r = scf.if %b -> (!quantum.bit) {
+        %a = pbc.ppr ["Z"](4) %out : !quantum.bit
+        %p2 = pbc.ppr ["X"](4) %a : !quantum.bit
+        scf.yield %p2 : !quantum.bit
+    } else {
+        %c = pbc.ppr ["Y"](4) %out : !quantum.bit
+        scf.yield %c : !quantum.bit
+    }
+    func.return
+}
+
+// -----
+
+// CHECK-DAG: "test_if_balanced_branches"
+// CHECK-DAG: "depth": 2
+// CHECK-DAG: "depth_type": 0
+
+// CHECK-DISJOINT-DAG: "test_if_balanced_branches"
+// CHECK-DISJOINT-DAG: "depth": 2
+// CHECK-DISJOINT-DAG: "depth_type": 1
+func.func public @test_if_balanced_branches(%b : i1, %q0 : !quantum.bit, %q1 : !quantum.bit, %q2 : !quantum.bit) {
+    %m, %out:3 = pbc.ppm ["X", "X", "Y"] %q0, %q1, %q2 : i1, !quantum.bit, !quantum.bit, !quantum.bit
+    %r:2 = scf.if %b -> (!quantum.bit, !quantum.bit) {
+        %a:2 = pbc.ppr ["Y", "X"](4) %out#0, %out#1 : !quantum.bit, !quantum.bit
+        scf.yield %a#0, %a#1 : !quantum.bit, !quantum.bit
+    } else {
+        %c:2 = pbc.ppr ["X", "X"](4) %out#0, %out#1 : !quantum.bit, !quantum.bit
+        scf.yield %c#0, %c#1 : !quantum.bit, !quantum.bit
+    }
+    func.return
+}
+
+// -----
+
+// CHECK-DAG: "test_if_no_else_branch_depth"
+// CHECK-DAG: "depth": 2
+// CHECK-DAG: "depth_type": 0
+
+// CHECK-DISJOINT-DAG: "test_if_no_else_branch_depth"
+// CHECK-DISJOINT-DAG: "depth": 2
+// CHECK-DISJOINT-DAG: "depth_type": 1
+func.func public @test_if_no_else_branch_depth(%b : i1, %q : !quantum.bit) {
+    %m, %out = pbc.ppm ["Z"] %q : i1, !quantum.bit
+    %r = scf.if %b -> (!quantum.bit) {
+        %p = pbc.ppr ["X"](4) %out : !quantum.bit
+        scf.yield %p : !quantum.bit
+    } else {
+        scf.yield %out : !quantum.bit
+    }
+    func.return
+}
+
+// -----
+
+// An scf.if barrier must prevent merging adjacent PBC ops on the
+// same qubit into one layer. Expect 3 layers: PPR | max(if) | PPR (= 1 + 1 + 1).
+
+// CHECK-DAG: "test_if_adjacent_ppr_barrier"
+// CHECK-DAG: "depth": 3
+// CHECK-DAG: "depth_type": 0
+
+// CHECK-DISJOINT-DAG: "test_if_adjacent_ppr_barrier"
+// CHECK-DISJOINT-DAG: "depth": 3
+// CHECK-DISJOINT-DAG: "depth_type": 1
+func.func public @test_if_adjacent_ppr_barrier(%b : i1, %q : !quantum.bit) {
+    %before = pbc.ppr ["Z"](4) %q : !quantum.bit
+    %r = scf.if %b -> (!quantum.bit) {
+        %inner = pbc.ppr ["X"](4) %before : !quantum.bit
+        scf.yield %inner : !quantum.bit
+    } else {
+        scf.yield %before : !quantum.bit
+    }
+    %after = pbc.ppr ["Z"](4) %r : !quantum.bit
+    func.return
+}
+
+// -----
+
+// CHECK-DAG: "test_nested_if_worst_case_depth"
+// CHECK-DAG: "depth": 3
+// CHECK-DAG: "depth_type": 0
+
+// CHECK-DISJOINT-DAG: "test_nested_if_worst_case_depth"
+// CHECK-DISJOINT-DAG: "depth": 3
+// CHECK-DISJOINT-DAG: "depth_type": 1
+func.func public @test_nested_if_worst_case_depth(%b0 : i1, %b1 : i1, %q0 : !quantum.bit) {
+    %m, %out = pbc.ppm ["Z"] %q0 : i1, !quantum.bit
+    %u = scf.if %b0 -> (!quantum.bit) {
+        %v = scf.if %b1 -> (!quantum.bit) {
+            %x = pbc.ppr ["Z"](4) %out : !quantum.bit
+            %y = pbc.ppr ["X"](4) %x : !quantum.bit
+            scf.yield %y : !quantum.bit
+        } else {
+            %z = pbc.ppr ["Y"](4) %out : !quantum.bit
+            scf.yield %z : !quantum.bit
+        }
+        scf.yield %v : !quantum.bit
+    } else {
+        scf.yield %out : !quantum.bit
+    }
+    func.return
+}
+
+// -----
+
+// Counts are still emitted even when depth analysis fails (here, scf.for blocks depth).
+
+// CHECK-DAG: "static_for_loop"
+// CHECK-DAG: "max_weight_pi4": 1
+// CHECK-DAG: "num_of_ppm": 5
+// CHECK-DAG: "pi4_ppr": 5
+func.func public @static_for_loop(%arg0: !quantum.bit) {
+    %c5 = arith.constant 5 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+
+    // expected-error@+1 {{worst-case depth is not available when PBC ops are inside scf.for or scf.while}}
+    %q = scf.for %iter = %c0 to %c5 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
+      %out_qubits = pbc.ppr ["Z"](4) %arg1 : !quantum.bit
+      %mres, %out_qubits_1 = pbc.ppm ["Z"] %out_qubits : i1, !quantum.bit
+      scf.yield %out_qubits_1 : !quantum.bit
+    }
+
+    return
+}
+
+// -----
+
+// CHECK-DAG: "static_for_loop_bigstep"
+// CHECK-DAG: "max_weight_pi4": 1
+// CHECK-DAG: "num_of_ppm": 3
+// CHECK-DAG: "pi4_ppr": 3
+func.func public @static_for_loop_bigstep(%arg0: !quantum.bit) {
+    %c5 = arith.constant 5 : index
+    %c0 = arith.constant 0 : index
+    %c2 = arith.constant 2 : index
+    // COM: should be 3 iterations (0,2,4)
+
+    // expected-error@+1 {{worst-case depth is not available when PBC ops are inside scf.for or scf.while}}
+    %q = scf.for %iter = %c0 to %c5 step %c2 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
+      %out_qubits = pbc.ppr ["Z"](4) %arg1 : !quantum.bit
+      %mres, %out_qubits_1 = pbc.ppm ["Z"] %out_qubits : i1, !quantum.bit
+      scf.yield %out_qubits_1 : !quantum.bit
+    }
+
+    return
+}
+
+// -----
+
+// CHECK-DAG: "static_for_loop_nested"
+// CHECK-DAG: "max_weight_pi4": 1
+// CHECK-DAG: "max_weight_pi8": 1
+// CHECK-DAG: "num_of_ppm": 30
+// CHECK-DAG: "pi4_ppr": 30
+// CHECK-DAG: "pi8_ppr": 6
+func.func public @static_for_loop_nested(%arg0: !quantum.bit) {
+    %c5 = arith.constant 5 : index
+    %c6 = arith.constant 6 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+
+    // expected-error@+1 {{worst-case depth is not available when PBC ops are inside scf.for or scf.while}}
+    %q = scf.for %iter = %c0 to %c6 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
+
+        %q_inner = scf.for %iter_inner = %c0 to %c5 step %c1 iter_args(%arg1_inner = %arg1) -> (!quantum.bit) {
+          %out_qubits_inner = pbc.ppr ["Z"](4) %arg1_inner : !quantum.bit
+          %mres, %out_qubits_inner_1 = pbc.ppm ["Z"] %out_qubits_inner : i1, !quantum.bit
+          scf.yield %out_qubits_inner_1 : !quantum.bit
+        }
+
+        %out_qubits = pbc.ppr ["Z"](8) %q_inner : !quantum.bit
+        scf.yield %out_qubits : !quantum.bit
+    }
+
+    return
+}
+
+// -----
+
+func.func public @test_if_in_for_errors(%arg0: !quantum.bit) {
+    %c0 = arith.constant 0 : index
+    %c2 = arith.constant 2 : index
+    %c1 = arith.constant 1 : index
+    %cond = arith.constant 0 : i1
+
+    // expected-error@+1 {{worst-case depth is not available when PBC ops are inside scf.for or scf.while}}
+    %q = scf.for %iter = %c0 to %c2 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
+      %r = scf.if %cond -> (!quantum.bit) {
+        %p = pbc.ppr ["Z"](4) %arg1 : !quantum.bit
+        scf.yield %p : !quantum.bit
+      } else {
+        scf.yield %arg1 : !quantum.bit
+      }
+      scf.yield %r : !quantum.bit
+    }
+
+    return
+}
+
+// -----
+
+func.func public @test_index_switch_depth_error(%idx: index, %arg0: !quantum.bit) {
+    // expected-error@+1 {{worst-case depth is not available when PBC ops are inside scf.index_switch}}
+    %q = scf.index_switch %idx -> !quantum.bit
+    case 0 {
+        %p = pbc.ppr ["Z"](4) %arg0 : !quantum.bit
+        scf.yield %p : !quantum.bit
+    }
+    default {
+        scf.yield %arg0 : !quantum.bit
+    }
+
+    return
 }


### PR DESCRIPTION
**Context:**
Today the `--ppm-specs` pass reports a depth field by using the number of layers in the PBC circuit. When a function contained an `scf.if`, the previous implmentation counted the ops in the THEN and ELSE branches sequentially, as if both branches always run. 

**Description of the Change:**
In this PR, the depth analysis the worst-case across scf.if branches:
`depth(region) = layers_outside_if + Σ max(depth(then), depth(else))`

For example:

```
pbc.ppm ["X","X","Y"]         # 1 layer
scf.if:
  then: pbc.ppr["Y","X"](4)   # 2 ops on overlapping qubits
           pbc.ppr["Z","X"](4)   # don't commute -> 2 layers
  else: pbc.ppr["X","X"](4)   # 1 layer
```
The previously reported depth was 4 (everything serialized). The correct worst-case is 3 = 1 + max(2, 1).

**Related GitHub Issues:**
* Follows up #2863, which introduced the depth / depth_type fields.

[sc-120053]
