### PR TITLE
PBC Depth: Support depth for ppm-specs across `scf.index_switch` branches 

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -43,7 +43,7 @@
   ``depth(region) = layers_outside_branch + Σ max(depth(branch_i))``. Previously branches
   were counted sequentially.
   [(#2876)](https://github.com/PennyLaneAI/catalyst/pull/2876)
-  [(#XXXX)](https://github.com/PennyLaneAI/catalyst/pull/XXXX)
+  [(#2877)](https://github.com/PennyLaneAI/catalyst/pull/2877)
 
 * The `--decompose-lowering` pass can now handle cases where the decomposed gate act on qubit values
   extracted from different quantum register SSA values, as long as all these quantum register values

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -38,12 +38,14 @@
   longer requires an explicit pipeline and no longer mixes MLIR into the JSON output.
   [(#2863)](https://github.com/PennyLaneAI/catalyst/pull/2863)
 
-* The ``depth`` field reported by :func:`~.passes.ppm_specs` is now the **worst-case quantum
-  depth** across ``scf.if`` and ``scf.index_switch`` branches:
-  ``depth(region) = layers_outside_branch + max(depth(branch_i))``. Previously branches
-  were counted sequentially.
+* The ``depth`` field reported by :func:`~.passes.ppm_specs` is now the worst-case depth
+  across ``scf.if`` and ``scf.index_switch`` branches (taking the maximum over all branches)
+  and across statically-bounded ``scf.for`` loops (multiplied by the trip count).
+  Previously, branches were counted sequentially and PBC ops inside ``scf.for`` produced an
+  error. ``scf.while`` and dynamically-bounded ``scf.for`` still produce an error.
   [(#2876)](https://github.com/PennyLaneAI/catalyst/pull/2876)
   [(#2877)](https://github.com/PennyLaneAI/catalyst/pull/2877)
+  [(#2879)](https://github.com/PennyLaneAI/catalyst/pull/2879)
 
 * The `--decompose-lowering` pass can now handle cases where the decomposed gate act on qubit values
   extracted from different quantum register SSA values, as long as all these quantum register values

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -38,6 +38,11 @@
   longer requires an explicit pipeline and no longer mixes MLIR into the JSON output.
   [(#2863)](https://github.com/PennyLaneAI/catalyst/pull/2863)
 
+* The ``depth`` field reported by :func:`~.passes.ppm_specs` is now the **worst-case quantum
+  depth** across ``scf.if`` branches: ``depth(region) = layers_outside_if + Σ max(depth(then),
+  depth(else))``. Previously THEN and ELSE were counted sequentially.
+  [(#2876)](https://github.com/PennyLaneAI/catalyst/pull/2876)
+
 * The `--decompose-lowering` pass can now handle cases where the decomposed gate act on qubit values
   extracted from different quantum register SSA values, as long as all these quantum register values
   trace back to the same allocation.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -40,7 +40,7 @@
 
 * The ``depth`` field reported by :func:`~.passes.ppm_specs` is now the **worst-case quantum
   depth** across ``scf.if`` and ``scf.index_switch`` branches:
-  ``depth(region) = layers_outside_branch + Σ max(depth(branch_i))``. Previously branches
+  ``depth(region) = layers_outside_branch + max(depth(branch_i))``. Previously branches
   were counted sequentially.
   [(#2876)](https://github.com/PennyLaneAI/catalyst/pull/2876)
   [(#2877)](https://github.com/PennyLaneAI/catalyst/pull/2877)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -39,9 +39,11 @@
   [(#2863)](https://github.com/PennyLaneAI/catalyst/pull/2863)
 
 * The ``depth`` field reported by :func:`~.passes.ppm_specs` is now the **worst-case quantum
-  depth** across ``scf.if`` branches: ``depth(region) = layers_outside_if + Σ max(depth(then),
-  depth(else))``. Previously THEN and ELSE were counted sequentially.
+  depth** across ``scf.if`` and ``scf.index_switch`` branches:
+  ``depth(region) = layers_outside_branch + Σ max(depth(branch_i))``. Previously branches
+  were counted sequentially.
   [(#2876)](https://github.com/PennyLaneAI/catalyst/pull/2876)
+  [(#XXXX)](https://github.com/PennyLaneAI/catalyst/pull/XXXX)
 
 * The `--decompose-lowering` pass can now handle cases where the decomposed gate act on qubit values
   extracted from different quantum register SSA values, as long as all these quantum register values

--- a/mlir/include/Catalyst/Utils/SCFUtils.h
+++ b/mlir/include/Catalyst/Utils/SCFUtils.h
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Operation.h"
 
 using namespace mlir;
@@ -31,5 +32,9 @@ bool isOpInWhileOp(Operation *op);
 // Note: if the input op is not inside any for loop operations,
 // this method returns 1, since there would be just one "iteration".
 int64_t countStaticForloopIterations(Operation *op);
+
+// Returns the static trip count of a single for loop if all three bounds are
+// arith.constant ops, or -1 if any bound is dynamic.
+int64_t countStaticForOpIterations(scf::ForOp forOp);
 
 } // namespace catalyst

--- a/mlir/include/PBC/Utils/PBCLayer.h
+++ b/mlir/include/PBC/Utils/PBCLayer.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "llvm/ADT/SetVector.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 
 #include "PBC/IR/PBCDialect.h"
 #include "PBC/IR/PBCOpInterfaces.h"
@@ -49,6 +50,15 @@ class PBCLayerContext {
     // Returns op lists only; operand/result bookkeeping is deferred until layer construction.
     llvm::SmallVector<std::vector<PBCOpInterface>> groupLayers(mlir::Operation *root,
                                                                bool onlyOnDisjointQubit = false);
+
+    // Worst-case PBC layer depth across `scf.if` branches within `block`
+    // (typically a function body's entry block). `scf.for` / `scf.while` are not supported yet.
+    mlir::FailureOr<int64_t> computeWorstCaseDepth(mlir::Block *block,
+                                                   bool onlyOnDisjointQubit = false);
+
+  private:
+    // Worst-case depth of an `scf.if`: `max(depth(then), depth(else))`
+    mlir::FailureOr<int64_t> ifWorstCaseDepth(mlir::scf::IfOp ifOp, bool onlyOnDisjointQubit);
 };
 
 class PBCLayer {

--- a/mlir/include/PBC/Utils/PBCLayer.h
+++ b/mlir/include/PBC/Utils/PBCLayer.h
@@ -63,6 +63,9 @@ class PBCLayerContext {
     // Worst-case depth of an `scf.index_switch`: `max(depth(default), depth(case_i))`
     mlir::FailureOr<int64_t> switchWorstCaseDepth(mlir::scf::IndexSwitchOp switchOp,
                                                   bool onlyOnDisjointQubit);
+    // Worst-case depth of a static `scf.for`: `N * depth(body)`.
+    // Returns failure if the trip count is dynamic.
+    mlir::FailureOr<int64_t> forWorstCaseDepth(mlir::scf::ForOp forOp, bool onlyOnDisjointQubit);
 };
 
 class PBCLayer {

--- a/mlir/include/PBC/Utils/PBCLayer.h
+++ b/mlir/include/PBC/Utils/PBCLayer.h
@@ -59,6 +59,9 @@ class PBCLayerContext {
   private:
     // Worst-case depth of an `scf.if`: `max(depth(then), depth(else))`
     mlir::FailureOr<int64_t> ifWorstCaseDepth(mlir::scf::IfOp ifOp, bool onlyOnDisjointQubit);
+    // Worst-case depth of an `scf.index_switch`: `max(depth(default), depth(case_i))`
+    mlir::FailureOr<int64_t> switchWorstCaseDepth(mlir::scf::IndexSwitchOp switchOp,
+                                                  bool onlyOnDisjointQubit);
 };
 
 class PBCLayer {

--- a/mlir/lib/Catalyst/Utils/SCFUtils.cpp
+++ b/mlir/lib/Catalyst/Utils/SCFUtils.cpp
@@ -46,6 +46,31 @@ bool isOpInIfOp(Operation *op) { return hasAncestorOfType<scf::IfOp>(op); }
 // Returns true if an operation is nested in a scf.while operation at any depth.
 bool isOpInWhileOp(Operation *op) { return hasAncestorOfType<scf::WhileOp>(op); }
 
+// Returns the static trip count of `forOp` if all three bounds are
+// arith.constant ops, or -1 if any bound is dynamic.
+int64_t countStaticForOpIterations(scf::ForOp forOp)
+{
+    Operation *lowerBoundOp = forOp.getLowerBound().getDefiningOp();
+    if (!lowerBoundOp || !isa<arith::ConstantOp>(lowerBoundOp)) {
+        return -1;
+    }
+    int64_t l = getIntFromArithConstantOp(cast<arith::ConstantOp>(lowerBoundOp));
+
+    Operation *upperBoundOp = forOp.getUpperBound().getDefiningOp();
+    if (!upperBoundOp || !isa<arith::ConstantOp>(upperBoundOp)) {
+        return -1;
+    }
+    int64_t u = getIntFromArithConstantOp(cast<arith::ConstantOp>(upperBoundOp));
+
+    Operation *stepOp = forOp.getStep().getDefiningOp();
+    if (!stepOp || !isa<arith::ConstantOp>(stepOp)) {
+        return -1;
+    }
+    int64_t s = getIntFromArithConstantOp(cast<arith::ConstantOp>(stepOp));
+
+    return getNumIterations(l, u, s);
+}
+
 // Given an op in a for loop body with a static number of start, end and step,
 // compute the number of iterations that will be executed by the for loop.
 // Returns -1 if any of the above for loop information is not static.
@@ -60,31 +85,12 @@ int64_t countStaticForloopIterations(Operation *op)
 
     Operation *parent = op->getParentOp();
     while (parent) {
-        if (isa<scf::ForOp>(parent)) {
-            scf::ForOp forOp = cast<scf::ForOp>(parent);
-
-            Operation *lowerBoundOp = forOp.getLowerBound().getDefiningOp();
-            if (!lowerBoundOp || !isa<arith::ConstantOp>(lowerBoundOp)) {
-                // Dynamic
+        if (auto forOp = dyn_cast<scf::ForOp>(parent)) {
+            int64_t iterations = countStaticForOpIterations(forOp);
+            if (iterations == -1) {
                 return -1;
             }
-            int64_t l = getIntFromArithConstantOp(cast<arith::ConstantOp>(lowerBoundOp));
-
-            Operation *upperBoundOp = forOp.getUpperBound().getDefiningOp();
-            if (!upperBoundOp || !isa<arith::ConstantOp>(upperBoundOp)) {
-                // Dynamic
-                return -1;
-            }
-            int64_t u = getIntFromArithConstantOp(cast<arith::ConstantOp>(upperBoundOp));
-
-            Operation *stepOp = forOp.getStep().getDefiningOp();
-            if (!stepOp || !isa<arith::ConstantOp>(stepOp)) {
-                // Dynamic
-                return -1;
-            }
-            int64_t s = getIntFromArithConstantOp(cast<arith::ConstantOp>(stepOp));
-
-            count *= getNumIterations(l, u, s);
+            count *= iterations;
         }
         parent = parent->getParentOp();
     }

--- a/mlir/lib/PBC/Transforms/CountPPMSpecs.cpp
+++ b/mlir/lib/PBC/Transforms/CountPPMSpecs.cpp
@@ -43,9 +43,9 @@ namespace pbc {
 struct CountPPMSpecsPass : public impl::CountPPMSpecsPassBase<CountPPMSpecsPass> {
     using CountPPMSpecsPassBase::CountPPMSpecsPassBase;
 
-    LogicalResult
-    countLogicalQubit(Operation *op,
-                      llvm::DenseMap<StringRef, llvm::DenseMap<StringRef, int>> &PPMSpecs)
+    using PPMSpecsType = llvm::DenseMap<StringRef, llvm::DenseMap<StringRef, int>>;
+
+    LogicalResult countLogicalQubit(Operation *op, PPMSpecsType &PPMSpecs)
     {
         uint64_t numQubits = cast<quantum::AllocOp>(op).getNqubitsAttr().value_or(0);
 
@@ -58,12 +58,10 @@ struct CountPPMSpecsPass : public impl::CountPPMSpecsPassBase<CountPPMSpecsPass>
         return success();
     }
 
-    LogicalResult countPPM(pbc::PPMeasurementOp op,
-                           llvm::DenseMap<StringRef, llvm::DenseMap<StringRef, int>> &PPMSpecs)
+    LogicalResult countPPM(pbc::PPMeasurementOp op, PPMSpecsType &PPMSpecs)
     {
-        if (isOpInIfOp(op) || isOpInWhileOp(op)) {
-            return op->emitOpError(
-                "PPM statistics is not available when there are conditionals or while loops.");
+        if (isOpInWhileOp(op)) {
+            return op->emitOpError("PPM statistics is not available when there are while loops.");
         }
 
         auto parentFuncOp = op->getParentOfType<func::FuncOp>();
@@ -81,13 +79,11 @@ struct CountPPMSpecsPass : public impl::CountPPMSpecsPassBase<CountPPMSpecsPass>
         return success();
     }
 
-    LogicalResult countPPR(pbc::PPRotationOp op,
-                           llvm::DenseMap<StringRef, llvm::DenseMap<StringRef, int>> &PPMSpecs,
+    LogicalResult countPPR(pbc::PPRotationOp op, PPMSpecsType &PPMSpecs,
                            llvm::BumpPtrAllocator &stringAllocator)
     {
-        if (isOpInIfOp(op) || isOpInWhileOp(op)) {
-            return op->emitOpError(
-                "PPM statistics is not available when there are conditionals or while loops.");
+        if (isOpInWhileOp(op)) {
+            return op->emitOpError("PPR statistics is not available when there are while loops.");
         }
 
         int8_t rotationKind = op.getRotationKind();
@@ -117,10 +113,47 @@ struct CountPPMSpecsPass : public impl::CountPPMSpecsPassBase<CountPPMSpecsPass>
         return success();
     }
 
+    // Worst-case PBC layer depth for a single function, treating scf.if as
+    // a barrier whose contribution is `max(depth(then), depth(else))`.
+    // depth_type:
+    //   depth-0: any commuting PPMs may share a layer, even on overlapping qubits.
+    //   depth-1: only PPMs on non-overlapping qubits may share a layer.
+    LogicalResult computeFuncDepth(func::FuncOp funcOp, bool onlyDisjointQubit,
+                                   PPMSpecsType &PPMSpecs)
+    {
+        if (!funcOp.getBody()
+                 .walk([&](PBCOpInterface) { return WalkResult::interrupt(); })
+                 .wasInterrupted()) {
+            return success();
+        }
+
+        PBCLayerContext layerContext;
+        FailureOr<int64_t> depth =
+            layerContext.computeWorstCaseDepth(&funcOp.getBody().front(), onlyDisjointQubit);
+        if (failed(depth)) {
+            return failure();
+        }
+
+        StringRef funcName = funcOp.getName();
+        PPMSpecs[funcName]["depth_type"] = onlyDisjointQubit ? 1 : 0;
+        PPMSpecs[funcName]["depth"] = static_cast<int>(*depth);
+        return success();
+    }
+
+    LogicalResult computeAllFuncDepth(bool onlyDisjointQubit, PPMSpecsType &PPMSpecs)
+    {
+        WalkResult wr = getOperation()->walk([&](func::FuncOp funcOp) {
+            return failed(computeFuncDepth(funcOp, onlyDisjointQubit, PPMSpecs))
+                       ? WalkResult::interrupt()
+                       : WalkResult::advance();
+        });
+        return wr.wasInterrupted() ? failure() : success();
+    }
+
     LogicalResult printSpecs(bool onlyDisjointQubit)
     {
         llvm::BumpPtrAllocator stringAllocator;
-        llvm::DenseMap<StringRef, llvm::DenseMap<StringRef, int>> PPMSpecs;
+        PPMSpecsType PPMSpecs;
 
         // Walk over all operations in the IR (could be ModuleOp or FuncOp)
         WalkResult wr = getOperation()->walk([&](Operation *op) {
@@ -158,32 +191,14 @@ struct CountPPMSpecsPass : public impl::CountPPMSpecsPassBase<CountPPMSpecsPass>
             return failure();
         }
 
-        // Count depth using the same layer grouping as partition-layers.
-        PBCLayerContext layerContext;
-        auto groupLayers = layerContext.groupLayers(getOperation(), onlyDisjointQubit);
-
-        if (!groupLayers.empty() && !groupLayers.front().empty()) {
-            auto funcOp =
-                groupLayers.front().front().getOperation()->getParentOfType<func::FuncOp>();
-            if (!funcOp) {
-                return groupLayers.front().front().emitOpError(
-                    "expected PBC op to be nested in func.func");
-            }
-            StringRef funcName = funcOp.getName();
-
-            // depth_type:
-            // depth-0: Depth calculated by allowing any commuting logical PPMs to be computed
-            // together, even with overlapping support.
-            // depth-1: Depth calculated by allowing only PPMs with non-overlapping support to be
-            // computed together.
-            PPMSpecs[funcName]["depth_type"] = onlyDisjointQubit ? 1 : 0;
-            PPMSpecs[funcName]["depth"] = groupLayers.size();
-        }
+        // Compute depth, but still emit JSON even if depth analysis fails for some
+        // functions (counts may have succeeded). Pass failure is reported at the end.
+        LogicalResult depthResult = computeAllFuncDepth(onlyDisjointQubit, PPMSpecs);
 
         json PPMSpecsJson = PPMSpecs;
         llvm::outs() << PPMSpecsJson.dump(4)
                      << "\n"; // dump(4) makes an indent with 4 spaces when printing JSON
-        return success();
+        return depthResult;
     }
 
     void runOnOperation() final

--- a/mlir/lib/PBC/Utils/CMakeLists.txt
+++ b/mlir/lib/PBC/Utils/CMakeLists.txt
@@ -33,4 +33,4 @@ target_compile_options(PBCUtils PRIVATE
     -fexceptions     # Enable exceptions
 )
 
-target_link_libraries(PBCUtils PRIVATE libstim ExternalStablehloLib)
+target_link_libraries(PBCUtils PRIVATE libstim ExternalStablehloLib MLIRSCFDialect)

--- a/mlir/lib/PBC/Utils/PBCLayer.cpp
+++ b/mlir/lib/PBC/Utils/PBCLayer.cpp
@@ -84,20 +84,18 @@ FailureOr<int64_t> PBCLayerContext::computeWorstCaseDepth(Block *block, bool onl
     };
 
     for (Operation &op : *block) {
+        if (isa<scf::ForOp>(&op) || isa<scf::WhileOp>(&op)) {
+            return op.emitOpError(
+                "worst-case depth is not available when PBC ops are inside scf.for or scf.while");
+        }
         if (auto ifOp = dyn_cast<scf::IfOp>(&op)) {
             flushLayer();
             FailureOr<int64_t> branchDepth = ifWorstCaseDepth(ifOp, onlyOnDisjointQubit);
             if (failed(branchDepth)) {
                 return failure();
             }
-
             depth += *branchDepth;
             continue;
-        }
-
-        if (isa<scf::ForOp>(&op) || isa<scf::WhileOp>(&op)) {
-            return op.emitOpError(
-                "worst-case depth is not available when PBC ops are inside scf.for or scf.while");
         }
 
         if (auto switchOp = dyn_cast<scf::IndexSwitchOp>(&op)) {

--- a/mlir/lib/PBC/Utils/PBCLayer.cpp
+++ b/mlir/lib/PBC/Utils/PBCLayer.cpp
@@ -139,10 +139,10 @@ FailureOr<int64_t> PBCLayerContext::computeWorstCaseDepth(Block *block, bool onl
 
         flushLayer();
         FailureOr<int64_t> innerDepth = computeWorstCaseDepth(&region.front(), onlyOnDisjointQubit);
-
         if (failed(innerDepth)) {
             return failure();
         }
+
         depth += *innerDepth;
     }
 

--- a/mlir/lib/PBC/Utils/PBCLayer.cpp
+++ b/mlir/lib/PBC/Utils/PBCLayer.cpp
@@ -19,6 +19,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 
+#include "Catalyst/Utils/SCFUtils.h"
 #include "PBC/IR/PBCOpInterfaces.h"
 #include "PBC/IR/PBCOps.h"
 #include "PBC/Utils/PauliStringWrapper.h"
@@ -71,6 +72,21 @@ FailureOr<int64_t> PBCLayerContext::switchWorstCaseDepth(scf::IndexSwitchOp swit
     return maxDepth;
 }
 
+FailureOr<int64_t> PBCLayerContext::forWorstCaseDepth(scf::ForOp forOp, bool onlyOnDisjointQubit)
+{
+    int64_t iterations = countStaticForOpIterations(forOp);
+    if (iterations == -1) {
+        return forOp.emitOpError(
+            "worst-case depth is not available when there are dynamically sized for loops");
+    }
+
+    FailureOr<int64_t> bodyDepth = computeWorstCaseDepth(forOp.getBody(), onlyOnDisjointQubit);
+    if (failed(bodyDepth)) {
+        return failure();
+    }
+    return iterations * (*bodyDepth);
+}
+
 FailureOr<int64_t> PBCLayerContext::computeWorstCaseDepth(Block *block, bool onlyOnDisjointQubit)
 {
     int64_t depth = 0;
@@ -84,9 +100,9 @@ FailureOr<int64_t> PBCLayerContext::computeWorstCaseDepth(Block *block, bool onl
     };
 
     for (Operation &op : *block) {
-        if (isa<scf::ForOp>(&op) || isa<scf::WhileOp>(&op)) {
+        if (isa<scf::WhileOp>(&op)) {
             return op.emitOpError(
-                "worst-case depth is not available when PBC ops are inside scf.for or scf.while");
+                "worst-case depth is not available when PBC ops are inside scf.while");
         }
         if (auto ifOp = dyn_cast<scf::IfOp>(&op)) {
             flushLayer();
@@ -105,6 +121,16 @@ FailureOr<int64_t> PBCLayerContext::computeWorstCaseDepth(Block *block, bool onl
                 return failure();
             }
             depth += *branchDepth;
+            continue;
+        }
+
+        if (auto forOp = dyn_cast<scf::ForOp>(&op)) {
+            flushLayer();
+            FailureOr<int64_t> loopDepth = forWorstCaseDepth(forOp, onlyOnDisjointQubit);
+            if (failed(loopDepth)) {
+                return failure();
+            }
+            depth += *loopDepth;
             continue;
         }
 

--- a/mlir/lib/PBC/Utils/PBCLayer.cpp
+++ b/mlir/lib/PBC/Utils/PBCLayer.cpp
@@ -14,17 +14,116 @@
 
 #include "PBC/Utils/PBCLayer.h"
 
+#include <algorithm>
+
 #include "llvm/ADT/STLExtras.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 
 #include "PBC/IR/PBCOpInterfaces.h"
 #include "PBC/IR/PBCOps.h"
 #include "PBC/Utils/PauliStringWrapper.h"
 #include "Quantum/IR/QuantumOps.h" // for quantum.extract op
 
-using namespace catalyst::pbc;
+using namespace mlir;
 
 namespace catalyst {
 namespace pbc {
+
+FailureOr<int64_t> PBCLayerContext::ifWorstCaseDepth(scf::IfOp ifOp, bool onlyOnDisjointQubit)
+{
+    FailureOr<int64_t> thenDepth =
+        computeWorstCaseDepth(&ifOp.getThenRegion().front(), onlyOnDisjointQubit);
+    if (failed(thenDepth)) {
+        return failure();
+    }
+
+    int64_t elseDepth = 0;
+    if (!ifOp.getElseRegion().empty()) {
+        FailureOr<int64_t> elseD =
+            computeWorstCaseDepth(&ifOp.getElseRegion().front(), onlyOnDisjointQubit);
+        if (failed(elseD)) {
+            return failure();
+        }
+        elseDepth = *elseD;
+    }
+    return std::max(*thenDepth, elseDepth);
+}
+
+FailureOr<int64_t> PBCLayerContext::computeWorstCaseDepth(Block *block, bool onlyOnDisjointQubit)
+{
+    int64_t depth = 0;
+    PBCLayer layer(this);
+
+    auto flushLayer = [&]() {
+        if (!layer.empty()) {
+            depth += 1;
+            layer = PBCLayer(this);
+        }
+    };
+
+    for (Operation &op : *block) {
+        if (auto ifOp = dyn_cast<scf::IfOp>(&op)) {
+            flushLayer();
+            FailureOr<int64_t> branchDepth = ifWorstCaseDepth(ifOp, onlyOnDisjointQubit);
+            if (failed(branchDepth)) {
+                return failure();
+            }
+
+            depth += *branchDepth;
+            continue;
+        }
+
+        if (isa<scf::ForOp>(&op) || isa<scf::WhileOp>(&op)) {
+            return op.emitOpError(
+                "worst-case depth is not available when PBC ops are inside scf.for or scf.while");
+        }
+
+        if (isa<scf::IndexSwitchOp>(&op)) {
+            return op.emitOpError(
+                "worst-case depth is not available when PBC ops are inside scf.index_switch");
+        }
+
+        if (auto pbcOp = dyn_cast<PBCOpInterface>(&op)) {
+            if (!layer.insert(pbcOp, onlyOnDisjointQubit)) {
+                flushLayer();
+                bool inserted = layer.insert(pbcOp, onlyOnDisjointQubit);
+                assert(inserted && "PBCLayer::insert must accept any op into an empty layer");
+            }
+            continue;
+        }
+
+        // plain ops
+        if (op.getNumRegions() == 0) {
+            continue;
+        }
+
+        // multi-region ops
+        if (op.getNumRegions() != 1) {
+            return op.emitOpError(
+                "worst-case depth cannot analyze operations with multiple regions");
+        }
+
+        // Recurse into the op's single-block region body (e.g. quantum.adjoint)
+        Region &region = op.getRegion(0);
+        if (region.empty()) {
+            continue;
+        }
+        if (!region.hasOneBlock()) {
+            return op.emitOpError("worst-case depth cannot analyze regions with multiple blocks");
+        }
+
+        flushLayer();
+        FailureOr<int64_t> innerDepth = computeWorstCaseDepth(&region.front(), onlyOnDisjointQubit);
+
+        if (failed(innerDepth)) {
+            return failure();
+        }
+        depth += *innerDepth;
+    }
+
+    flushLayer();
+    return depth;
+}
 
 // Partition PBC ops into layer groups using commutation/disjoint-qubit rules.
 // Only op membership is recorded; operand/result bookkeeping is deferred until

--- a/mlir/lib/PBC/Utils/PBCLayer.cpp
+++ b/mlir/lib/PBC/Utils/PBCLayer.cpp
@@ -49,6 +49,28 @@ FailureOr<int64_t> PBCLayerContext::ifWorstCaseDepth(scf::IfOp ifOp, bool onlyOn
     return std::max(*thenDepth, elseDepth);
 }
 
+FailureOr<int64_t> PBCLayerContext::switchWorstCaseDepth(scf::IndexSwitchOp switchOp,
+                                                         bool onlyOnDisjointQubit)
+{
+    FailureOr<int64_t> defaultDepth =
+        computeWorstCaseDepth(&switchOp.getDefaultBlock(), onlyOnDisjointQubit);
+    if (failed(defaultDepth)) {
+        return failure();
+    }
+
+    int64_t maxDepth = *defaultDepth;
+
+    for (unsigned i = 0, n = switchOp.getNumCases(); i < n; ++i) {
+        FailureOr<int64_t> caseDepth =
+            computeWorstCaseDepth(&switchOp.getCaseBlock(i), onlyOnDisjointQubit);
+        if (failed(caseDepth)) {
+            return failure();
+        }
+        maxDepth = std::max(maxDepth, *caseDepth);
+    }
+    return maxDepth;
+}
+
 FailureOr<int64_t> PBCLayerContext::computeWorstCaseDepth(Block *block, bool onlyOnDisjointQubit)
 {
     int64_t depth = 0;
@@ -78,9 +100,14 @@ FailureOr<int64_t> PBCLayerContext::computeWorstCaseDepth(Block *block, bool onl
                 "worst-case depth is not available when PBC ops are inside scf.for or scf.while");
         }
 
-        if (isa<scf::IndexSwitchOp>(&op)) {
-            return op.emitOpError(
-                "worst-case depth is not available when PBC ops are inside scf.index_switch");
+        if (auto switchOp = dyn_cast<scf::IndexSwitchOp>(&op)) {
+            flushLayer();
+            FailureOr<int64_t> branchDepth = switchWorstCaseDepth(switchOp, onlyOnDisjointQubit);
+            if (failed(branchDepth)) {
+                return failure();
+            }
+            depth += *branchDepth;
+            continue;
         }
 
         if (auto pbcOp = dyn_cast<PBCOpInterface>(&op)) {

--- a/mlir/test/PBC/PPMSpecsTest.mlir
+++ b/mlir/test/PBC/PPMSpecsTest.mlir
@@ -631,9 +631,12 @@ func.func public @test_switch_default_only_branch_depth(%arg : index, %q : !quan
 
 // -----
 
-// Counts are still emitted even when depth analysis fails (here, scf.for blocks depth).
+// Static for-loop: depth = N * depth(body). Z-axis PPR + Z-axis PPM commute,
+// so each iteration is a single layer.
 
 // CHECK-DAG: "static_for_loop"
+// CHECK-DAG: "depth": 5
+// CHECK-DAG: "depth_type": 0
 // CHECK-DAG: "max_weight_pi4": 1
 // CHECK-DAG: "num_of_ppm": 5
 // CHECK-DAG: "pi4_ppr": 5
@@ -642,7 +645,6 @@ func.func public @static_for_loop(%arg0: !quantum.bit) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
 
-    // expected-error@+1 {{worst-case depth is not available when PBC ops are inside scf.for or scf.while}}
     %q = scf.for %iter = %c0 to %c5 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
       %out_qubits = pbc.ppr ["Z"](4) %arg1 : !quantum.bit
       %mres, %out_qubits_1 = pbc.ppm ["Z"] %out_qubits : i1, !quantum.bit
@@ -655,6 +657,8 @@ func.func public @static_for_loop(%arg0: !quantum.bit) {
 // -----
 
 // CHECK-DAG: "static_for_loop_bigstep"
+// CHECK-DAG: "depth": 3
+// CHECK-DAG: "depth_type": 0
 // CHECK-DAG: "max_weight_pi4": 1
 // CHECK-DAG: "num_of_ppm": 3
 // CHECK-DAG: "pi4_ppr": 3
@@ -664,7 +668,6 @@ func.func public @static_for_loop_bigstep(%arg0: !quantum.bit) {
     %c2 = arith.constant 2 : index
     // COM: should be 3 iterations (0,2,4)
 
-    // expected-error@+1 {{worst-case depth is not available when PBC ops are inside scf.for or scf.while}}
     %q = scf.for %iter = %c0 to %c5 step %c2 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
       %out_qubits = pbc.ppr ["Z"](4) %arg1 : !quantum.bit
       %mres, %out_qubits_1 = pbc.ppm ["Z"] %out_qubits : i1, !quantum.bit
@@ -676,7 +679,15 @@ func.func public @static_for_loop_bigstep(%arg0: !quantum.bit) {
 
 // -----
 
+// Nested static for-loop. Inner body = 1 layer (Z PPR + Z PPM commute).
+// Inner depth = 5 * 1 = 5. Outer body = inner (5) + 1 outer Z PPR (commutes with the
+// final Z PPM in the inner body? no, inner body was yielded; outer PPR is on the yielded
+// qubit -> a fresh layer after the loop). Outer body depth = 5 + 1 = 6.
+// Outer total = 6 * 6 = 36.
+
 // CHECK-DAG: "static_for_loop_nested"
+// CHECK-DAG: "depth": 36
+// CHECK-DAG: "depth_type": 0
 // CHECK-DAG: "max_weight_pi4": 1
 // CHECK-DAG: "max_weight_pi8": 1
 // CHECK-DAG: "num_of_ppm": 30
@@ -688,7 +699,6 @@ func.func public @static_for_loop_nested(%arg0: !quantum.bit) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
 
-    // expected-error@+1 {{worst-case depth is not available when PBC ops are inside scf.for or scf.while}}
     %q = scf.for %iter = %c0 to %c6 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
 
         %q_inner = scf.for %iter_inner = %c0 to %c5 step %c1 iter_args(%arg1_inner = %arg1) -> (!quantum.bit) {
@@ -706,13 +716,18 @@ func.func public @static_for_loop_nested(%arg0: !quantum.bit) {
 
 // -----
 
-func.func public @test_if_in_for_errors(%arg0: !quantum.bit) {
+// scf.if inside scf.for: outer trip count 2, inner body = scf.if (max(then, else) = 1).
+// Outer body depth = 1. Outer total = 2 * 1 = 2.
+
+// CHECK-DAG: "test_if_in_for_depth"
+// CHECK-DAG: "depth": 2
+// CHECK-DAG: "depth_type": 0
+func.func public @test_if_in_for_depth(%arg0: !quantum.bit) {
     %c0 = arith.constant 0 : index
     %c2 = arith.constant 2 : index
     %c1 = arith.constant 1 : index
     %cond = arith.constant 0 : i1
 
-    // expected-error@+1 {{worst-case depth is not available when PBC ops are inside scf.for or scf.while}}
     %q = scf.for %iter = %c0 to %c2 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
       %r = scf.if %cond -> (!quantum.bit) {
         %p = pbc.ppr ["Z"](4) %arg1 : !quantum.bit

--- a/mlir/test/PBC/PPMSpecsTest.mlir
+++ b/mlir/test/PBC/PPMSpecsTest.mlir
@@ -324,85 +324,6 @@ func.func public @game_of_surface_code(%arg0: !quantum.bit, %arg1: !quantum.bit,
 
 // -----
 
-//CHECK: {
-//CHECK:     "static_for_loop": {
-//CHECK:         "max_weight_pi4": 1,
-//CHECK:         "num_of_ppm": 5,
-//CHECK:         "pi4_ppr": 5
-//CHECK:     }
-//CHECK: }
-func.func public @static_for_loop(%arg0: !quantum.bit) {
-    %c5 = arith.constant 5 : index
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-
-    %q = scf.for %iter = %c0 to %c5 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
-      %out_qubits = pbc.ppr ["Z"](4) %arg1 : !quantum.bit
-      %mres, %out_qubits_1 = pbc.ppm ["Z"] %out_qubits : i1, !quantum.bit
-      scf.yield %out_qubits_1 : !quantum.bit
-    }
-
-    return
-}
-
-// -----
-
-//CHECK: {
-//CHECK:     "static_for_loop_bigstep": {
-//CHECK:         "max_weight_pi4": 1,
-//CHECK:         "num_of_ppm": 3,
-//CHECK:         "pi4_ppr": 3
-//CHECK:     }
-//CHECK: }
-func.func public @static_for_loop_bigstep(%arg0: !quantum.bit) {
-    %c5 = arith.constant 5 : index
-    %c0 = arith.constant 0 : index
-    %c2 = arith.constant 2 : index
-    // COM: should be 3 iterations (0,2,4)
-
-    %q = scf.for %iter = %c0 to %c5 step %c2 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
-      %out_qubits = pbc.ppr ["Z"](4) %arg1 : !quantum.bit
-      %mres, %out_qubits_1 = pbc.ppm ["Z"] %out_qubits : i1, !quantum.bit
-      scf.yield %out_qubits_1 : !quantum.bit
-    }
-
-    return
-}
-
-// -----
-
-//CHECK: {
-//CHECK:     "static_for_loop_nested": {
-//CHECK:         "max_weight_pi4": 1,
-//CHECK:         "max_weight_pi8": 1,
-//CHECK:         "num_of_ppm": 30,
-//CHECK:         "pi4_ppr": 30,
-//CHECK:         "pi8_ppr": 6
-//CHECK:     }
-//CHECK: }
-func.func public @static_for_loop_nested(%arg0: !quantum.bit) {
-    %c5 = arith.constant 5 : index
-    %c6 = arith.constant 6 : index
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-
-    %q = scf.for %iter = %c0 to %c6 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
-
-        %q_inner = scf.for %iter_inner = %c0 to %c5 step %c1 iter_args(%arg1_inner = %arg1) -> (!quantum.bit) {
-          %out_qubits_inner = pbc.ppr ["Z"](4) %arg1_inner : !quantum.bit
-          %mres, %out_qubits_inner_1 = pbc.ppm ["Z"] %out_qubits_inner : i1, !quantum.bit
-          scf.yield %out_qubits_inner_1 : !quantum.bit
-        }
-
-        %out_qubits = pbc.ppr ["Z"](8) %q_inner : !quantum.bit
-        scf.yield %out_qubits : !quantum.bit
-    }
-
-    return
-}
-
-// -----
-
 func.func public @dynamic_for_loop_error(%arg0: !quantum.bit, %c: index) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
@@ -419,20 +340,6 @@ func.func public @dynamic_for_loop_error(%arg0: !quantum.bit, %c: index) {
 
 // -----
 
-func.func public @cond_error(%arg0: !quantum.bit, %b: i1) {
-    %out_qubits = scf.if %b -> !quantum.bit {
-        %out_qubits_t = pbc.ppr ["Z"](4) %arg0 : !quantum.bit
-        // expected-error@above {{PPM statistics is not available when there are conditionals or while loops.}}
-        scf.yield %out_qubits_t : !quantum.bit
-    } else {
-        scf.yield %arg0 : !quantum.bit
-    }
-
-    return
-}
-
-// -----
-
 func.func public @while_error(%arg0: !quantum.bit, %b: i1) {
 
     %q = scf.while (%in_qubit = %arg0) : (!quantum.bit) -> (!quantum.bit) {
@@ -440,7 +347,7 @@ func.func public @while_error(%arg0: !quantum.bit, %b: i1) {
     } do {
         ^bb0(%in_qubit: !quantum.bit):
         %out_qubits = pbc.ppr ["Z"](4) %in_qubit : !quantum.bit
-        // expected-error@above {{PPM statistics is not available when there are conditionals or while loops.}}
+        // expected-error@above {{PPR statistics is not available when there are while loops.}}
         scf.yield %out_qubits : !quantum.bit
     }
 
@@ -549,4 +456,231 @@ func.func @test_disjoint_qubit_specs(%qr0 : !quantum.bit, %qr1 : !quantum.bit, %
     %m4, %4:5 = pbc.ppm ["Z", "X", "Y", "Y", "Y"] %2#0, %2#1, %3#0, %3#1, %1 : i1, !quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit
 
     func.return
+}
+
+// -----
+
+// CHECK-DAG: "test_if_worst_case_depth"
+// CHECK-DAG: "depth": 3
+// CHECK-DAG: "depth_type": 0
+
+// CHECK-DISJOINT-DAG: "test_if_worst_case_depth"
+// CHECK-DISJOINT-DAG: "depth": 3
+// CHECK-DISJOINT-DAG: "depth_type": 1
+func.func public @test_if_worst_case_depth(%b : i1, %q0 : !quantum.bit) {
+    %m, %out = pbc.ppm ["Z"] %q0 : i1, !quantum.bit
+    %r = scf.if %b -> (!quantum.bit) {
+        %a = pbc.ppr ["Z"](4) %out : !quantum.bit
+        %p2 = pbc.ppr ["X"](4) %a : !quantum.bit
+        scf.yield %p2 : !quantum.bit
+    } else {
+        %c = pbc.ppr ["Y"](4) %out : !quantum.bit
+        scf.yield %c : !quantum.bit
+    }
+    func.return
+}
+
+// -----
+
+// CHECK-DAG: "test_if_balanced_branches"
+// CHECK-DAG: "depth": 2
+// CHECK-DAG: "depth_type": 0
+
+// CHECK-DISJOINT-DAG: "test_if_balanced_branches"
+// CHECK-DISJOINT-DAG: "depth": 2
+// CHECK-DISJOINT-DAG: "depth_type": 1
+func.func public @test_if_balanced_branches(%b : i1, %q0 : !quantum.bit, %q1 : !quantum.bit, %q2 : !quantum.bit) {
+    %m, %out:3 = pbc.ppm ["X", "X", "Y"] %q0, %q1, %q2 : i1, !quantum.bit, !quantum.bit, !quantum.bit
+    %r:2 = scf.if %b -> (!quantum.bit, !quantum.bit) {
+        %a:2 = pbc.ppr ["Y", "X"](4) %out#0, %out#1 : !quantum.bit, !quantum.bit
+        scf.yield %a#0, %a#1 : !quantum.bit, !quantum.bit
+    } else {
+        %c:2 = pbc.ppr ["X", "X"](4) %out#0, %out#1 : !quantum.bit, !quantum.bit
+        scf.yield %c#0, %c#1 : !quantum.bit, !quantum.bit
+    }
+    func.return
+}
+
+// -----
+
+// CHECK-DAG: "test_if_no_else_branch_depth"
+// CHECK-DAG: "depth": 2
+// CHECK-DAG: "depth_type": 0
+
+// CHECK-DISJOINT-DAG: "test_if_no_else_branch_depth"
+// CHECK-DISJOINT-DAG: "depth": 2
+// CHECK-DISJOINT-DAG: "depth_type": 1
+func.func public @test_if_no_else_branch_depth(%b : i1, %q : !quantum.bit) {
+    %m, %out = pbc.ppm ["Z"] %q : i1, !quantum.bit
+    %r = scf.if %b -> (!quantum.bit) {
+        %p = pbc.ppr ["X"](4) %out : !quantum.bit
+        scf.yield %p : !quantum.bit
+    } else {
+        scf.yield %out : !quantum.bit
+    }
+    func.return
+}
+
+// -----
+
+// An scf.if barrier must prevent merging adjacent PBC ops on the
+// same qubit into one layer. Expect 3 layers: PPR | max(if) | PPR (= 1 + 1 + 1).
+
+// CHECK-DAG: "test_if_adjacent_ppr_barrier"
+// CHECK-DAG: "depth": 3
+// CHECK-DAG: "depth_type": 0
+
+// CHECK-DISJOINT-DAG: "test_if_adjacent_ppr_barrier"
+// CHECK-DISJOINT-DAG: "depth": 3
+// CHECK-DISJOINT-DAG: "depth_type": 1
+func.func public @test_if_adjacent_ppr_barrier(%b : i1, %q : !quantum.bit) {
+    %before = pbc.ppr ["Z"](4) %q : !quantum.bit
+    %r = scf.if %b -> (!quantum.bit) {
+        %inner = pbc.ppr ["X"](4) %before : !quantum.bit
+        scf.yield %inner : !quantum.bit
+    } else {
+        scf.yield %before : !quantum.bit
+    }
+    %after = pbc.ppr ["Z"](4) %r : !quantum.bit
+    func.return
+}
+
+// -----
+
+// CHECK-DAG: "test_nested_if_worst_case_depth"
+// CHECK-DAG: "depth": 3
+// CHECK-DAG: "depth_type": 0
+
+// CHECK-DISJOINT-DAG: "test_nested_if_worst_case_depth"
+// CHECK-DISJOINT-DAG: "depth": 3
+// CHECK-DISJOINT-DAG: "depth_type": 1
+func.func public @test_nested_if_worst_case_depth(%b0 : i1, %b1 : i1, %q0 : !quantum.bit) {
+    %m, %out = pbc.ppm ["Z"] %q0 : i1, !quantum.bit
+    %u = scf.if %b0 -> (!quantum.bit) {
+        %v = scf.if %b1 -> (!quantum.bit) {
+            %x = pbc.ppr ["Z"](4) %out : !quantum.bit
+            %y = pbc.ppr ["X"](4) %x : !quantum.bit
+            scf.yield %y : !quantum.bit
+        } else {
+            %z = pbc.ppr ["Y"](4) %out : !quantum.bit
+            scf.yield %z : !quantum.bit
+        }
+        scf.yield %v : !quantum.bit
+    } else {
+        scf.yield %out : !quantum.bit
+    }
+    func.return
+}
+
+// -----
+
+// Counts are still emitted even when depth analysis fails (here, scf.for blocks depth).
+
+// CHECK-DAG: "static_for_loop"
+// CHECK-DAG: "max_weight_pi4": 1
+// CHECK-DAG: "num_of_ppm": 5
+// CHECK-DAG: "pi4_ppr": 5
+func.func public @static_for_loop(%arg0: !quantum.bit) {
+    %c5 = arith.constant 5 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+
+    // expected-error@+1 {{worst-case depth is not available when PBC ops are inside scf.for or scf.while}}
+    %q = scf.for %iter = %c0 to %c5 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
+      %out_qubits = pbc.ppr ["Z"](4) %arg1 : !quantum.bit
+      %mres, %out_qubits_1 = pbc.ppm ["Z"] %out_qubits : i1, !quantum.bit
+      scf.yield %out_qubits_1 : !quantum.bit
+    }
+
+    return
+}
+
+// -----
+
+// CHECK-DAG: "static_for_loop_bigstep"
+// CHECK-DAG: "max_weight_pi4": 1
+// CHECK-DAG: "num_of_ppm": 3
+// CHECK-DAG: "pi4_ppr": 3
+func.func public @static_for_loop_bigstep(%arg0: !quantum.bit) {
+    %c5 = arith.constant 5 : index
+    %c0 = arith.constant 0 : index
+    %c2 = arith.constant 2 : index
+    // COM: should be 3 iterations (0,2,4)
+
+    // expected-error@+1 {{worst-case depth is not available when PBC ops are inside scf.for or scf.while}}
+    %q = scf.for %iter = %c0 to %c5 step %c2 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
+      %out_qubits = pbc.ppr ["Z"](4) %arg1 : !quantum.bit
+      %mres, %out_qubits_1 = pbc.ppm ["Z"] %out_qubits : i1, !quantum.bit
+      scf.yield %out_qubits_1 : !quantum.bit
+    }
+
+    return
+}
+
+// -----
+
+// CHECK-DAG: "static_for_loop_nested"
+// CHECK-DAG: "max_weight_pi4": 1
+// CHECK-DAG: "max_weight_pi8": 1
+// CHECK-DAG: "num_of_ppm": 30
+// CHECK-DAG: "pi4_ppr": 30
+// CHECK-DAG: "pi8_ppr": 6
+func.func public @static_for_loop_nested(%arg0: !quantum.bit) {
+    %c5 = arith.constant 5 : index
+    %c6 = arith.constant 6 : index
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+
+    // expected-error@+1 {{worst-case depth is not available when PBC ops are inside scf.for or scf.while}}
+    %q = scf.for %iter = %c0 to %c6 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
+
+        %q_inner = scf.for %iter_inner = %c0 to %c5 step %c1 iter_args(%arg1_inner = %arg1) -> (!quantum.bit) {
+          %out_qubits_inner = pbc.ppr ["Z"](4) %arg1_inner : !quantum.bit
+          %mres, %out_qubits_inner_1 = pbc.ppm ["Z"] %out_qubits_inner : i1, !quantum.bit
+          scf.yield %out_qubits_inner_1 : !quantum.bit
+        }
+
+        %out_qubits = pbc.ppr ["Z"](8) %q_inner : !quantum.bit
+        scf.yield %out_qubits : !quantum.bit
+    }
+
+    return
+}
+
+// -----
+
+func.func public @test_if_in_for_errors(%arg0: !quantum.bit) {
+    %c0 = arith.constant 0 : index
+    %c2 = arith.constant 2 : index
+    %c1 = arith.constant 1 : index
+    %cond = arith.constant 0 : i1
+
+    // expected-error@+1 {{worst-case depth is not available when PBC ops are inside scf.for or scf.while}}
+    %q = scf.for %iter = %c0 to %c2 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
+      %r = scf.if %cond -> (!quantum.bit) {
+        %p = pbc.ppr ["Z"](4) %arg1 : !quantum.bit
+        scf.yield %p : !quantum.bit
+      } else {
+        scf.yield %arg1 : !quantum.bit
+      }
+      scf.yield %r : !quantum.bit
+    }
+
+    return
+}
+
+// -----
+
+func.func public @test_index_switch_depth_error(%idx: index, %arg0: !quantum.bit) {
+    // expected-error@+1 {{worst-case depth is not available when PBC ops are inside scf.index_switch}}
+    %q = scf.index_switch %idx -> !quantum.bit
+    case 0 {
+        %p = pbc.ppr ["Z"](4) %arg0 : !quantum.bit
+        scf.yield %p : !quantum.bit
+    }
+    default {
+        scf.yield %arg0 : !quantum.bit
+    }
+
+    return
 }

--- a/mlir/test/PBC/PPMSpecsTest.mlir
+++ b/mlir/test/PBC/PPMSpecsTest.mlir
@@ -574,6 +574,63 @@ func.func public @test_nested_if_worst_case_depth(%b0 : i1, %b1 : i1, %q0 : !qua
 
 // -----
 
+// scf.index_switch: depth = layers_outside + max(default, case_0, case_1, ...)
+// Outside = 1 PPM. default = 1 PPR. case 0 = 2 non-commuting PPRs (Z then X).
+// case 1 = 1 PPR. Expect depth = 1 + max(1, 2, 1) = 3.
+
+// CHECK-DAG: "test_switch_worst_case_depth"
+// CHECK-DAG: "depth": 3
+// CHECK-DAG: "depth_type": 0
+
+// CHECK-DISJOINT-DAG: "test_switch_worst_case_depth"
+// CHECK-DISJOINT-DAG: "depth": 3
+// CHECK-DISJOINT-DAG: "depth_type": 1
+func.func public @test_switch_worst_case_depth(%arg : index, %q0 : !quantum.bit) {
+    %m, %out = pbc.ppm ["Z"] %q0 : i1, !quantum.bit
+    %r = scf.index_switch %arg -> !quantum.bit
+    case 0 {
+        %a = pbc.ppr ["Z"](4) %out : !quantum.bit
+        %b = pbc.ppr ["X"](4) %a : !quantum.bit
+        scf.yield %b : !quantum.bit
+    }
+    case 1 {
+        %c = pbc.ppr ["Y"](4) %out : !quantum.bit
+        scf.yield %c : !quantum.bit
+    }
+    default {
+        %d = pbc.ppr ["X"](4) %out : !quantum.bit
+        scf.yield %d : !quantum.bit
+    }
+    func.return
+}
+
+// -----
+
+// scf.index_switch with default having a PPR and a case with 0 PBC ops.
+// Outside = 1 PPM. default = 1 PPR. case 0 = 0 layers. Expect depth = 1 + max(1, 0) = 2.
+
+// CHECK-DAG: "test_switch_default_only_branch_depth"
+// CHECK-DAG: "depth": 2
+// CHECK-DAG: "depth_type": 0
+
+// CHECK-DISJOINT-DAG: "test_switch_default_only_branch_depth"
+// CHECK-DISJOINT-DAG: "depth": 2
+// CHECK-DISJOINT-DAG: "depth_type": 1
+func.func public @test_switch_default_only_branch_depth(%arg : index, %q : !quantum.bit) {
+    %m, %out = pbc.ppm ["Z"] %q : i1, !quantum.bit
+    %r = scf.index_switch %arg -> !quantum.bit
+    case 0 {
+        scf.yield %out : !quantum.bit
+    }
+    default {
+        %d = pbc.ppr ["X"](4) %out : !quantum.bit
+        scf.yield %d : !quantum.bit
+    }
+    func.return
+}
+
+// -----
+
 // Counts are still emitted even when depth analysis fails (here, scf.for blocks depth).
 
 // CHECK-DAG: "static_for_loop"
@@ -669,18 +726,3 @@ func.func public @test_if_in_for_errors(%arg0: !quantum.bit) {
     return
 }
 
-// -----
-
-func.func public @test_index_switch_depth_error(%idx: index, %arg0: !quantum.bit) {
-    // expected-error@+1 {{worst-case depth is not available when PBC ops are inside scf.index_switch}}
-    %q = scf.index_switch %idx -> !quantum.bit
-    case 0 {
-        %p = pbc.ppr ["Z"](4) %arg0 : !quantum.bit
-        scf.yield %p : !quantum.bit
-    }
-    default {
-        scf.yield %arg0 : !quantum.bit
-    }
-
-    return
-}


### PR DESCRIPTION
**Context:**
This PR extends the worst-case depth analysis in `--ppm-specs` (introduced in #2876) to also handle `scf.index_switch`. Catalyst emits `scf.index_switch` from the user-facing catalyst.switch primitive and from the gridsynth PPR-basis decomposition. Previously, a function containing any of these would fail the depth analysis with worst-case depth is not available when PBC ops are inside scf.index_switch.

**Description of the Change:**
This PR implement to support switch-case op for worst-case depth analysis.
A switch is a multi-way scf.if. The worst-case depth across all branches (default + cases) is:
`depth(switch) = max(depth(default), depth(case_0), ..., depth(case_{N-1}))`

For example:
```
pbc.ppm ["Z"]                        # 1 layer
scf.index_switch:
  case 0: pbc.ppr ["Z"](4)           # 2 non-commuting PPRs
          pbc.ppr ["X"](4)           #   -> 2 layers
  case 1: pbc.ppr ["Y"](4)           # 1 layer
  default: pbc.ppr ["X"](4)          # 1 layer
```
Reported depth is now 1 + max(2, 1, 1) = 3 same shape as the scf.if case in the previous PR, just with N+1 regions.

**Related GitHub Issues:**
Follows up #2876  (worst-case depth across scf.if), which built on #2863 .

[sc-120053]