### PR TITLE
PBC Depth: Support depth for ppm-specs on static `scf.for`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -39,11 +39,14 @@
   [(#2863)](https://github.com/PennyLaneAI/catalyst/pull/2863)
 
 * The ``depth`` field reported by :func:`~.passes.ppm_specs` is now the **worst-case quantum
-  depth** across ``scf.if`` and ``scf.index_switch`` branches:
-  ``depth(region) = layers_outside_branch + Σ max(depth(branch_i))``. Previously branches
-  were counted sequentially.
+  depth** across ``scf.if`` and ``scf.index_switch`` branches, and across statically bounded
+  ``scf.for`` loops: ``depth(region) = layers_outside_branch + Σ max(depth(branch_i))`` for 
+  branches and ``depth(scf.for) = N * depth(body)`` for static for loops. 
+  Previously branches were counted sequentially and any PBC op inside ``scf.for`` 
+  produced an error. ``scf.while`` and dynamically-bounded ``scf.for`` still produce an error.
   [(#2876)](https://github.com/PennyLaneAI/catalyst/pull/2876)
   [(#2877)](https://github.com/PennyLaneAI/catalyst/pull/2877)
+  [(#XXXX)](https://github.com/PennyLaneAI/catalyst/pull/XXXX)
 
 * The `--decompose-lowering` pass can now handle cases where the decomposed gate act on qubit values
   extracted from different quantum register SSA values, as long as all these quantum register values

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -46,7 +46,7 @@
   produced an error. ``scf.while`` and dynamically-bounded ``scf.for`` still produce an error.
   [(#2876)](https://github.com/PennyLaneAI/catalyst/pull/2876)
   [(#2877)](https://github.com/PennyLaneAI/catalyst/pull/2877)
-  [(#XXXX)](https://github.com/PennyLaneAI/catalyst/pull/XXXX)
+  [(#2879)](https://github.com/PennyLaneAI/catalyst/pull/2879)
 
 * The `--decompose-lowering` pass can now handle cases where the decomposed gate act on qubit values
   extracted from different quantum register SSA values, as long as all these quantum register values

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -38,12 +38,11 @@
   longer requires an explicit pipeline and no longer mixes MLIR into the JSON output.
   [(#2863)](https://github.com/PennyLaneAI/catalyst/pull/2863)
 
-* The ``depth`` field reported by :func:`~.passes.ppm_specs` is now the **worst-case quantum
-  depth** across ``scf.if`` and ``scf.index_switch`` branches, and across statically bounded
-  ``scf.for`` loops: ``depth(region) = layers_outside_branch + Σ max(depth(branch_i))`` for 
-  branches and ``depth(scf.for) = N * depth(body)`` for static for loops. 
-  Previously branches were counted sequentially and any PBC op inside ``scf.for`` 
-  produced an error. ``scf.while`` and dynamically-bounded ``scf.for`` still produce an error.
+* The ``depth`` field reported by :func:`~.passes.ppm_specs` is now the worst-case depth
+  across ``scf.if`` and ``scf.index_switch`` branches (taking the maximum over all branches)
+  and across statically-bounded ``scf.for`` loops (multiplied by the trip count).
+  Previously, branches were counted sequentially and PBC ops inside ``scf.for`` produced an
+  error. ``scf.while`` and dynamically-bounded ``scf.for`` still produce an error.
   [(#2876)](https://github.com/PennyLaneAI/catalyst/pull/2876)
   [(#2877)](https://github.com/PennyLaneAI/catalyst/pull/2877)
   [(#2879)](https://github.com/PennyLaneAI/catalyst/pull/2879)

--- a/mlir/include/Catalyst/Utils/SCFUtils.h
+++ b/mlir/include/Catalyst/Utils/SCFUtils.h
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Operation.h"
 
 using namespace mlir;
@@ -31,5 +32,9 @@ bool isOpInWhileOp(Operation *op);
 // Note: if the input op is not inside any for loop operations,
 // this method returns 1, since there would be just one "iteration".
 int64_t countStaticForloopIterations(Operation *op);
+
+// Returns the static trip count of a single for loop if all three bounds are
+// arith.constant ops, or -1 if any bound is dynamic.
+int64_t countStaticForOpIterations(scf::ForOp forOp);
 
 } // namespace catalyst

--- a/mlir/include/PBC/Utils/PBCLayer.h
+++ b/mlir/include/PBC/Utils/PBCLayer.h
@@ -62,6 +62,9 @@ class PBCLayerContext {
     // Worst-case depth of an `scf.index_switch`: `max(depth(default), depth(case_i))`
     mlir::FailureOr<int64_t> switchWorstCaseDepth(mlir::scf::IndexSwitchOp switchOp,
                                                   bool onlyOnDisjointQubit);
+    // Worst-case depth of a static `scf.for`: `N * depth(body)`.
+    // Returns failure if the trip count is dynamic.
+    mlir::FailureOr<int64_t> forWorstCaseDepth(mlir::scf::ForOp forOp, bool onlyOnDisjointQubit);
 };
 
 class PBCLayer {

--- a/mlir/lib/Catalyst/Utils/SCFUtils.cpp
+++ b/mlir/lib/Catalyst/Utils/SCFUtils.cpp
@@ -46,6 +46,31 @@ bool isOpInIfOp(Operation *op) { return hasAncestorOfType<scf::IfOp>(op); }
 // Returns true if an operation is nested in a scf.while operation at any depth.
 bool isOpInWhileOp(Operation *op) { return hasAncestorOfType<scf::WhileOp>(op); }
 
+// Returns the static trip count of `forOp` if all three bounds are
+// arith.constant ops, or -1 if any bound is dynamic.
+int64_t countStaticForOpIterations(scf::ForOp forOp)
+{
+    Operation *lowerBoundOp = forOp.getLowerBound().getDefiningOp();
+    if (!lowerBoundOp || !isa<arith::ConstantOp>(lowerBoundOp)) {
+        return -1;
+    }
+    int64_t l = getIntFromArithConstantOp(cast<arith::ConstantOp>(lowerBoundOp));
+
+    Operation *upperBoundOp = forOp.getUpperBound().getDefiningOp();
+    if (!upperBoundOp || !isa<arith::ConstantOp>(upperBoundOp)) {
+        return -1;
+    }
+    int64_t u = getIntFromArithConstantOp(cast<arith::ConstantOp>(upperBoundOp));
+
+    Operation *stepOp = forOp.getStep().getDefiningOp();
+    if (!stepOp || !isa<arith::ConstantOp>(stepOp)) {
+        return -1;
+    }
+    int64_t s = getIntFromArithConstantOp(cast<arith::ConstantOp>(stepOp));
+
+    return getNumIterations(l, u, s);
+}
+
 // Given an op in a for loop body with a static number of start, end and step,
 // compute the number of iterations that will be executed by the for loop.
 // Returns -1 if any of the above for loop information is not static.
@@ -60,31 +85,12 @@ int64_t countStaticForloopIterations(Operation *op)
 
     Operation *parent = op->getParentOp();
     while (parent) {
-        if (isa<scf::ForOp>(parent)) {
-            scf::ForOp forOp = cast<scf::ForOp>(parent);
-
-            Operation *lowerBoundOp = forOp.getLowerBound().getDefiningOp();
-            if (!lowerBoundOp || !isa<arith::ConstantOp>(lowerBoundOp)) {
-                // Dynamic
+        if (auto forOp = dyn_cast<scf::ForOp>(parent)) {
+            int64_t iterations = countStaticForOpIterations(forOp);
+            if (iterations == -1) {
                 return -1;
             }
-            int64_t l = getIntFromArithConstantOp(cast<arith::ConstantOp>(lowerBoundOp));
-
-            Operation *upperBoundOp = forOp.getUpperBound().getDefiningOp();
-            if (!upperBoundOp || !isa<arith::ConstantOp>(upperBoundOp)) {
-                // Dynamic
-                return -1;
-            }
-            int64_t u = getIntFromArithConstantOp(cast<arith::ConstantOp>(upperBoundOp));
-
-            Operation *stepOp = forOp.getStep().getDefiningOp();
-            if (!stepOp || !isa<arith::ConstantOp>(stepOp)) {
-                // Dynamic
-                return -1;
-            }
-            int64_t s = getIntFromArithConstantOp(cast<arith::ConstantOp>(stepOp));
-
-            count *= getNumIterations(l, u, s);
+            count *= iterations;
         }
         parent = parent->getParentOp();
     }

--- a/mlir/lib/PBC/Utils/PBCLayer.cpp
+++ b/mlir/lib/PBC/Utils/PBCLayer.cpp
@@ -19,6 +19,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 
+#include "Catalyst/Utils/SCFUtils.h"
 #include "PBC/IR/PBCOpInterfaces.h"
 #include "PBC/IR/PBCOps.h"
 #include "PBC/Utils/PauliStringWrapper.h"
@@ -71,6 +72,21 @@ FailureOr<int64_t> PBCLayerContext::switchWorstCaseDepth(scf::IndexSwitchOp swit
     return maxDepth;
 }
 
+FailureOr<int64_t> PBCLayerContext::forWorstCaseDepth(scf::ForOp forOp, bool onlyOnDisjointQubit)
+{
+    int64_t iterations = countStaticForOpIterations(forOp);
+    if (iterations == -1) {
+        return forOp.emitOpError(
+            "worst-case depth is not available when there are dynamically sized for loops");
+    }
+
+    FailureOr<int64_t> bodyDepth = computeWorstCaseDepth(forOp.getBody(), onlyOnDisjointQubit);
+    if (failed(bodyDepth)) {
+        return failure();
+    }
+    return iterations * (*bodyDepth);
+}
+
 FailureOr<int64_t> PBCLayerContext::computeWorstCaseDepth(Block *block, bool onlyOnDisjointQubit)
 {
     int64_t depth = 0;
@@ -84,9 +100,9 @@ FailureOr<int64_t> PBCLayerContext::computeWorstCaseDepth(Block *block, bool onl
     };
 
     for (Operation &op : *block) {
-        if (isa<scf::ForOp>(&op) || isa<scf::WhileOp>(&op)) {
+        if (isa<scf::WhileOp>(&op)) {
             return op.emitOpError(
-                "worst-case depth is not available when PBC ops are inside scf.for or scf.while");
+                "worst-case depth is not available when PBC ops are inside scf.while");
         }
         if (auto ifOp = dyn_cast<scf::IfOp>(&op)) {
             flushLayer();
@@ -105,6 +121,16 @@ FailureOr<int64_t> PBCLayerContext::computeWorstCaseDepth(Block *block, bool onl
                 return failure();
             }
             depth += *branchDepth;
+            continue;
+        }
+
+        if (auto forOp = dyn_cast<scf::ForOp>(&op)) {
+            flushLayer();
+            FailureOr<int64_t> loopDepth = forWorstCaseDepth(forOp, onlyOnDisjointQubit);
+            if (failed(loopDepth)) {
+                return failure();
+            }
+            depth += *loopDepth;
             continue;
         }
 

--- a/mlir/test/PBC/PPMSpecsTest.mlir
+++ b/mlir/test/PBC/PPMSpecsTest.mlir
@@ -631,9 +631,12 @@ func.func public @test_switch_default_only_branch_depth(%arg : index, %q : !quan
 
 // -----
 
-// Counts are still emitted even when depth analysis fails (here, scf.for blocks depth).
+// Static for-loop: depth = N * depth(body). Z-axis PPR + Z-axis PPM commute,
+// so each iteration is a single layer.
 
 // CHECK-DAG: "static_for_loop"
+// CHECK-DAG: "depth": 5
+// CHECK-DAG: "depth_type": 0
 // CHECK-DAG: "max_weight_pi4": 1
 // CHECK-DAG: "num_of_ppm": 5
 // CHECK-DAG: "pi4_ppr": 5
@@ -642,7 +645,6 @@ func.func public @static_for_loop(%arg0: !quantum.bit) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
 
-    // expected-error@+1 {{worst-case depth is not available when PBC ops are inside scf.for or scf.while}}
     %q = scf.for %iter = %c0 to %c5 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
       %out_qubits = pbc.ppr ["Z"](4) %arg1 : !quantum.bit
       %mres, %out_qubits_1 = pbc.ppm ["Z"] %out_qubits : i1, !quantum.bit
@@ -655,6 +657,8 @@ func.func public @static_for_loop(%arg0: !quantum.bit) {
 // -----
 
 // CHECK-DAG: "static_for_loop_bigstep"
+// CHECK-DAG: "depth": 3
+// CHECK-DAG: "depth_type": 0
 // CHECK-DAG: "max_weight_pi4": 1
 // CHECK-DAG: "num_of_ppm": 3
 // CHECK-DAG: "pi4_ppr": 3
@@ -664,7 +668,6 @@ func.func public @static_for_loop_bigstep(%arg0: !quantum.bit) {
     %c2 = arith.constant 2 : index
     // COM: should be 3 iterations (0,2,4)
 
-    // expected-error@+1 {{worst-case depth is not available when PBC ops are inside scf.for or scf.while}}
     %q = scf.for %iter = %c0 to %c5 step %c2 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
       %out_qubits = pbc.ppr ["Z"](4) %arg1 : !quantum.bit
       %mres, %out_qubits_1 = pbc.ppm ["Z"] %out_qubits : i1, !quantum.bit
@@ -676,7 +679,15 @@ func.func public @static_for_loop_bigstep(%arg0: !quantum.bit) {
 
 // -----
 
+// Nested static for-loop. Inner body = 1 layer (Z PPR + Z PPM commute).
+// Inner depth = 5 * 1 = 5. Outer body = inner (5) + 1 outer Z PPR (commutes with the
+// final Z PPM in the inner body? no, inner body was yielded; outer PPR is on the yielded
+// qubit -> a fresh layer after the loop). Outer body depth = 5 + 1 = 6.
+// Outer total = 6 * 6 = 36.
+
 // CHECK-DAG: "static_for_loop_nested"
+// CHECK-DAG: "depth": 36
+// CHECK-DAG: "depth_type": 0
 // CHECK-DAG: "max_weight_pi4": 1
 // CHECK-DAG: "max_weight_pi8": 1
 // CHECK-DAG: "num_of_ppm": 30
@@ -688,7 +699,6 @@ func.func public @static_for_loop_nested(%arg0: !quantum.bit) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
 
-    // expected-error@+1 {{worst-case depth is not available when PBC ops are inside scf.for or scf.while}}
     %q = scf.for %iter = %c0 to %c6 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
 
         %q_inner = scf.for %iter_inner = %c0 to %c5 step %c1 iter_args(%arg1_inner = %arg1) -> (!quantum.bit) {
@@ -706,13 +716,18 @@ func.func public @static_for_loop_nested(%arg0: !quantum.bit) {
 
 // -----
 
-func.func public @test_if_in_for_errors(%arg0: !quantum.bit) {
+// scf.if inside scf.for: outer trip count 2, inner body = scf.if (max(then, else) = 1).
+// Outer body depth = 1. Outer total = 2 * 1 = 2.
+
+// CHECK-DAG: "test_if_in_for_depth"
+// CHECK-DAG: "depth": 2
+// CHECK-DAG: "depth_type": 0
+func.func public @test_if_in_for_depth(%arg0: !quantum.bit) {
     %c0 = arith.constant 0 : index
     %c2 = arith.constant 2 : index
     %c1 = arith.constant 1 : index
     %cond = arith.constant 0 : i1
 
-    // expected-error@+1 {{worst-case depth is not available when PBC ops are inside scf.for or scf.while}}
     %q = scf.for %iter = %c0 to %c2 step %c1 iter_args(%arg1 = %arg0) -> (!quantum.bit) {
       %r = scf.if %cond -> (!quantum.bit) {
         %p = pbc.ppr ["Z"](4) %arg1 : !quantum.bit


### PR DESCRIPTION
**Context:**
Following #2876 and #2877, the --ppm-specs pass still errored when any PBC op appeared inside `scf.for`.

**Description of the Change:**
In this PR, static `scf.for` loops (all three bounds are arith.constant) contribute to worst-case depth as:
`depth(scf.for, static N) = N × depth(body)`

Dynamic-bound `scf.for` and `scf.while` still error. `scf.while` is intentionally out of scope. its trip count is data-dependent.

**Related GitHub Issues:**
Follows up #2876  (worst-case depth across scf.if), #2877 (scf.index_switch), and #2863  (original depth/depth_type fields).