### PR TITLE
Add qecp.t op

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -125,6 +125,8 @@
     [(#2867)](https://github.com/PennyLaneAI/catalyst/pull/2867)
   - `qecp.dealloc_cb`, which deallocates a single physical codeblock.
     [(#2867)](https://github.com/PennyLaneAI/catalyst/pull/2867)
+  - `qecp.t`, which performs a T gate on a single physical qubit.
+    [(#2888)](https://github.com/PennyLaneAI/catalyst/pull/2888)
 
 
 

--- a/frontend/catalyst/python_interface/dialects/qecp.py
+++ b/frontend/catalyst/python_interface/dialects/qecp.py
@@ -686,6 +686,9 @@ class SOp(SingleQubitPhysicalGateOp):
 class TOp(SingleQubitPhysicalGateOp):
     """A physical T gate operation."""
 
+    def __init__(self, in_qubit: QecPhysicalQubitSSAValue | Operation):
+        super().__init__(in_qubit)
+
     name = "qecp.t"
 
 
@@ -932,6 +935,7 @@ QecPhysical = Dialect(
         PauliYOp,
         PauliZOp,
         HadamardOp,
+        TOp,
         RotOp,
         SOp,
         CnotOp,

--- a/frontend/catalyst/python_interface/dialects/qecp.py
+++ b/frontend/catalyst/python_interface/dialects/qecp.py
@@ -683,6 +683,13 @@ class SOp(SingleQubitPhysicalGateOp):
 
 
 @irdl_op_definition
+class TOp(SingleQubitPhysicalGateOp):
+    """A physical T gate operation."""
+
+    name = "qecp.t"
+
+
+@irdl_op_definition
 class CnotOp(IRDLOperation):
     """A physical CNOT gate operation."""
 

--- a/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
@@ -348,7 +348,6 @@ class TestQecPhysicalOps:
         assert len(t_op.result_types) == 1
         assert t_op.result_types[0] == qubit.type
 
-
     @pytest.mark.parametrize(
         "qubit",
         [

--- a/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
@@ -82,6 +82,7 @@ expected_ops_names = {
     "PauliZOp": "qecp.z",
     "HadamardOp": "qecp.hadamard",
     "SOp": "qecp.s",
+    "TOp": "qecp.t",
     "RotOp": "qecp.rot",
     "CnotOp": "qecp.cnot",
     "MeasureOp": "qecp.measure",
@@ -339,6 +340,22 @@ class TestQecPhysicalOps:
             create_ssa_value(qecp.QecPhysicalQubitType("aux")),
         ],
     )
+    def test_qecp_op_constructor_t(self, qubit):
+        """Test the constructor of the qecp.t op."""
+        t_op = qecp.TOp(qubit)
+        assert len(t_op.operands) == 1
+        assert t_op.operand_types[0] == qubit.type
+        assert len(t_op.result_types) == 1
+        assert t_op.result_types[0] == qubit.type
+
+
+    @pytest.mark.parametrize(
+        "qubit",
+        [
+            create_ssa_value(qecp.QecPhysicalQubitType("data")),
+            create_ssa_value(qecp.QecPhysicalQubitType("aux")),
+        ],
+    )
     @pytest.mark.parametrize(
         "phi, theta, omega",
         [
@@ -535,26 +552,31 @@ def test_assembly_format(run_filecheck, pretty_print):
     %qd5 = qecp.hadamard %qd4 : !qecp.qubit<data>
     %qa5 = qecp.hadamard %qa4 : !qecp.qubit<aux>
 
-    // CHECK: [[qd6:%.+]] = qecp.s [[qd5]] : !qecp.qubit<data>
-    // CHECK: [[qa6:%.+]] = qecp.s [[qa5]] : !qecp.qubit<aux>
-    %qd6 = qecp.s %qd5 : !qecp.qubit<data>
-    %qa6 = qecp.s %qa5 : !qecp.qubit<aux>
+    // CHECK: [[qd6:%.+]] = qecp.t [[qd5]] : !qecp.qubit<data>
+    // CHECK: [[qa6:%.+]] = qecp.t [[qa5]] : !qecp.qubit<aux>
+    %qd6 = qecp.t %qd5 : !qecp.qubit<data>
+    %qa6 = qecp.t %qa5 : !qecp.qubit<aux>
 
-    // CHECK: [[qd7:%.+]] = qecp.s [[qd6]] adj : !qecp.qubit<data>
-    // CHECK: [[qa7:%.+]] = qecp.s [[qa6]] adj : !qecp.qubit<aux>
-    %qd7 = qecp.s %qd6 adj : !qecp.qubit<data>
-    %qa7 = qecp.s %qa6 adj : !qecp.qubit<aux>
+    // CHECK: [[qd7:%.+]] = qecp.s [[qd6]] : !qecp.qubit<data>
+    // CHECK: [[qa7:%.+]] = qecp.s [[qa6]] : !qecp.qubit<aux>
+    %qd7 = qecp.s %qd6 : !qecp.qubit<data>
+    %qa7 = qecp.s %qa6 : !qecp.qubit<aux>
+
+    // CHECK: [[qd8:%.+]] = qecp.s [[qd7]] adj : !qecp.qubit<data>
+    // CHECK: [[qa8:%.+]] = qecp.s [[qa7]] adj : !qecp.qubit<aux>
+    %qd8 = qecp.s %qd7 adj : !qecp.qubit<data>
+    %qa8 = qecp.s %qa7 adj : !qecp.qubit<aux>
 
     // CHECK: [[phi:%.+]] = "test.op"() : () -> f64
     // CHECK: [[theta:%.+]] = "test.op"() : () -> f64
     // CHECK: [[omega:%.+]] = "test.op"() : () -> f64
-    // CHECK: [[qd8:%.+]] = qecp.rot([[phi:%.+]], [[theta:%.+]], [[omega:%.+]]) [[qd7]] : !qecp.qubit<data>
-    // CHECK: [[qa8:%.+]] = qecp.rot([[phi:%.+]], [[theta:%.+]], [[omega:%.+]]) [[qa7]] : !qecp.qubit<aux>
+    // CHECK: [[qd9:%.+]] = qecp.rot([[phi:%.+]], [[theta:%.+]], [[omega:%.+]]) [[qd8]] : !qecp.qubit<data>
+    // CHECK: [[qa9:%.+]] = qecp.rot([[phi:%.+]], [[theta:%.+]], [[omega:%.+]]) [[qa8]] : !qecp.qubit<aux>
     %phi = "test.op"() : () -> f64
     %theta = "test.op"() : () -> f64
     %omega = "test.op"() : () -> f64
-    %qd8 = qecp.rot(%phi, %theta, %omega) %qd7 : !qecp.qubit<data>
-    %qa8 = qecp.rot(%phi, %theta, %omega) %qa7 : !qecp.qubit<aux>
+    %qd9 = qecp.rot(%phi, %theta, %omega) %qd8 : !qecp.qubit<data>
+    %qa9 = qecp.rot(%phi, %theta, %omega) %qa8 : !qecp.qubit<aux>
 
     // CHECK: [[qd10:%.+]] = "test.op"() : () -> !qecp.qubit<data>
     // CHECK: [[qd20:%.+]] = "test.op"() : () -> !qecp.qubit<data>
@@ -582,10 +604,10 @@ def test_assembly_format(run_filecheck, pretty_print):
     %row_idx = "test.op"() : () -> tensor<8xi32>
     %col_ptr = "test.op"() : () -> tensor<6xi32>
 
-    // CHECK: [[mres0:%.+]], [[qd9:%.+]] = qecp.measure [[qd8]] : i1, !qecp.qubit<data>
-    // CHECK: [[mres1:%.+]], [[qa9:%.+]] = qecp.measure [[qa8]] : i1, !qecp.qubit<aux>
-    %mres0, %qd9 = qecp.measure %qd8 : i1, !qecp.qubit<data>
-    %mres1, %qa9 = qecp.measure %qa8 : i1, !qecp.qubit<aux>
+    // CHECK: [[mres0:%.+]], [[qd10:%.+]] = qecp.measure [[qd9]] : i1, !qecp.qubit<data>
+    // CHECK: [[mres1:%.+]], [[qa10:%.+]] = qecp.measure [[qa9]] : i1, !qecp.qubit<aux>
+    %mres0, %qd10 = qecp.measure %qd9 : i1, !qecp.qubit<data>
+    %mres1, %qa10 = qecp.measure %qa9 : i1, !qecp.qubit<aux>
 
     // CHECK: [[tgraph:%.+]] = qecp.assemble_tanner [[row_idx]], [[col_ptr]] : tensor<8xi32>, tensor<6xi32> -> !qecp.tanner_graph<8, 6, i32>
     %tgraph = qecp.assemble_tanner %row_idx, %col_ptr : tensor<8xi32>, tensor<6xi32> -> !qecp.tanner_graph<8, 6, i32>

--- a/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_qecp_dialect.py
@@ -605,8 +605,8 @@ def test_assembly_format(run_filecheck, pretty_print):
 
     // CHECK: [[mres0:%.+]], [[qd10:%.+]] = qecp.measure [[qd9]] : i1, !qecp.qubit<data>
     // CHECK: [[mres1:%.+]], [[qa10:%.+]] = qecp.measure [[qa9]] : i1, !qecp.qubit<aux>
-    %mres0, %qd10 = qecp.measure %qd9 : i1, !qecp.qubit<data>
-    %mres1, %qa10 = qecp.measure %qa9 : i1, !qecp.qubit<aux>
+    %mres0, %qd13 = qecp.measure %qd9 : i1, !qecp.qubit<data>
+    %mres1, %qa13 = qecp.measure %qa9 : i1, !qecp.qubit<aux>
 
     // CHECK: [[tgraph:%.+]] = qecp.assemble_tanner [[row_idx]], [[col_ptr]] : tensor<8xi32>, tensor<6xi32> -> !qecp.tanner_graph<8, 6, i32>
     %tgraph = qecp.assemble_tanner %row_idx, %col_ptr : tensor<8xi32>, tensor<6xi32> -> !qecp.tanner_graph<8, 6, i32>

--- a/mlir/include/QecPhysical/IR/QecPhysicalOps.td
+++ b/mlir/include/QecPhysical/IR/QecPhysicalOps.td
@@ -278,6 +278,10 @@ def HadamardOp : SingleQubitPhysicalGate_Op<"hadamard", [AllTypesMatch<["in_qubi
     let summary = "A physical Hadamard gate operation.";
 }
 
+def TOp : SingleQubitPhysicalGate_Op<"t", [AllTypesMatch<["in_qubit", "out_qubit"]>]> {
+    let summary = "A physical T gate operation.";
+}
+
 def SOp : SingleQubitPhysicalGate_Op<"s", [AllTypesMatch<["in_qubit", "out_qubit"]>]> {
     let summary = "A physical S (π/2 phase) gate operation.";
 }

--- a/mlir/test/QecPhysical/DialectTest.mlir
+++ b/mlir/test/QecPhysical/DialectTest.mlir
@@ -177,6 +177,14 @@ func.func @test_gate_op_hadamard(%arg0 : !qecp.qubit<data>, %arg1 : !qecp.qubit<
 
 // -----
 
+func.func @test_gate_op_t(%arg0 : !qecp.qubit<data>, %arg1 : !qecp.qubit<aux>) {
+    %0 = qecp.t %arg0 : !qecp.qubit<data>
+    %1 = qecp.t %arg1 : !qecp.qubit<aux>
+    func.return
+}
+
+// -----
+
 func.func @test_gate_op_s(%arg0 : !qecp.qubit<data>, %arg1 : !qecp.qubit<aux>) {
     %0 = qecp.s %arg0 : !qecp.qubit<data>
     %1 = qecp.s %0 adj : !qecp.qubit<data>


### PR DESCRIPTION
**Context:**

To facilitate creating magic states on codeblocks in the QECP layer, we want to be able to apply a physical T gate on a single qubit within the codeblock

**Description of the Change:**

We add a `qecp.t` op
