### PR TITLE
Support Operators with static named args in the decomposition graph

### DIFF
--- a/mlir/lib/Quantum/Transforms/DecompGraphSolver/DGTypes.hpp
+++ b/mlir/lib/Quantum/Transforms/DecompGraphSolver/DGTypes.hpp
@@ -41,6 +41,12 @@ namespace DecompGraph::Core {
  * can be combined and decomposed to achieve the desired target gateset while optimizing for
  * resource usage.
  *
+ * Optionally, an operator may carry a set of static named arguments (e.g.,
+ * `{"pauli_word": "X"}` for `PauliRot`) that further specialize the operator.
+ * When non-empty, static arguments participate in equality
+ * comparisons so that rules guarded on a specific value only
+ * match operator queries that carry the same value.
+ *
  * TODO: Fix the equality with wildcards for numWires and numParams
  * when adding support for operators with dynamic numbers of wires/params.
  */
@@ -49,6 +55,9 @@ struct OperatorNode {
     int numWires{-1};
     int numParams{-1};
     bool adjoint{false};
+
+    // Optional static arguments for operators that require additional data.
+    std::unordered_map<std::string, std::string> staticNamedArgs{};
 
     bool operator==(const OperatorNode &other) const
     {
@@ -59,7 +68,14 @@ struct OperatorNode {
         const bool default_params =
             (numParams == -1 || other.numParams == -1 || numParams == other.numParams);
 
-        return name == other.name && default_wires && default_params && adjoint == other.adjoint;
+        // Static arguments are optional: if either side has no static args, they
+        // are treated as matching (wildcard). When both sides provide entries, the maps must
+        // be equal element-wise for the operators to be considered equivalent.
+        const bool static_args_match = staticNamedArgs.empty() || other.staticNamedArgs.empty() ||
+                                       staticNamedArgs == other.staticNamedArgs;
+
+        return name == other.name && default_wires && default_params && adjoint == other.adjoint &&
+               static_args_match;
     }
     bool operator!=(const OperatorNode &other) const { return !(*this == other); }
 };

--- a/mlir/lib/Quantum/Transforms/DecompGraphSolver/DGUtils.hpp
+++ b/mlir/lib/Quantum/Transforms/DecompGraphSolver/DGUtils.hpp
@@ -20,6 +20,7 @@
  */
 #pragma once
 
+#include <algorithm>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
@@ -38,6 +39,17 @@ static inline auto print_op(const OperatorNode &op) -> std::string
     oss << "[p:" << op.numParams << "]";
     if (op.adjoint) {
         oss << "[adj]";
+    }
+    if (!op.staticNamedArgs.empty()) {
+        std::vector<std::string> keys;
+        keys.reserve(op.staticNamedArgs.size());
+        for (const auto &[k, _] : op.staticNamedArgs) {
+            keys.push_back(k);
+        }
+        std::sort(keys.begin(), keys.end());
+        for (const auto &k : keys) {
+            oss << "[" << k << ":" << op.staticNamedArgs.at(k) << "]";
+        }
     }
     return oss.str();
 }

--- a/mlir/unittests/DecompGraphSolver/Test_DecompGraphSolver.cpp
+++ b/mlir/unittests/DecompGraphSolver/Test_DecompGraphSolver.cpp
@@ -556,3 +556,48 @@ TEST_CASE("Test GraphSolver with empty decomposition rules", "[DecompGraph::Solv
     REQUIRE(chosen_rule.inputs.empty());
     REQUIRE(chosen_rule.totalCost == 0.0);
 }
+
+TEST_CASE("Test GraphSolver with PauliRot specialized by static argument pauli_word",
+          "[DecompGraph::Solver]")
+{
+    // Query: PauliRot[w:1][p:1][pauli_word:X] should match a rule whose output is
+    // PauliRot[w:-1][p:-1][pauli_word:X] (wildcards on wires/params, exact match on pauli_word).
+    const OperatorNode pauliRotQuery{"PauliRot", 1, 1, false, {{"pauli_word", "X"}}};
+    const OperatorNode pauliRotRuleOutput{"PauliRot", -1, -1, false, {{"pauli_word", "X"}}};
+    const OperatorNode hadamard{"Hadamard", 1, 0, false};
+    const OperatorNode multiRZ{"MultiRZ", 1, 1, false};
+
+    const WeightedGateset gateset{{{hadamard, 1.0}, {multiRZ, 1.0}}};
+
+    const std::vector<RuleNode> rules{
+        {"_pauli_rot_decomposition_X", pauliRotRuleOutput, {{hadamard, 2}, {multiRZ, 1}}},
+    };
+
+    const DecompositionGraph graph({pauliRotQuery}, gateset, rules);
+    DecompositionSolver solver(graph);
+    const auto result = solver.solve();
+
+    REQUIRE(result.find(pauliRotQuery) != result.end());
+    const auto &chosen = result.at(pauliRotQuery);
+    REQUIRE_FALSE(chosen.isBasis);
+    REQUIRE(chosen.ruleName == "_pauli_rot_decomposition_X");
+    REQUIRE(chosen.totalCost == 1.0 * 2 + 1.0 * 1);
+    REQUIRE(chosen.basisCounts.at(hadamard) == 2);
+    REQUIRE(chosen.basisCounts.at(multiRZ) == 1);
+
+    const OperatorNode pauliRotQueryY{"PauliRot", 1, 1, false, {{"pauli_word", "Y"}}};
+    REQUIRE_FALSE(pauliRotQuery == pauliRotQueryY);
+    REQUIRE(pauliRotQuery == pauliRotRuleOutput);
+}
+
+TEST_CASE("Test OperatorNode equality with staticNamedArgs", "[DecompGraph::Core]")
+{
+    const OperatorNode pauliRotX{"PauliRot", 1, 1, false, {{"pauli_word", "X"}}};
+    const OperatorNode pauliRotXWildcard{"PauliRot", -1, -1, false, {{"pauli_word", "X"}}};
+    const OperatorNode pauliRotY{"PauliRot", 1, 1, false, {{"pauli_word", "Y"}}};
+    const OperatorNode pauliRotNoArgs{"PauliRot", 1, 1, false};
+
+    REQUIRE(pauliRotX == pauliRotXWildcard);
+    REQUIRE_FALSE(pauliRotX == pauliRotY);
+    REQUIRE(pauliRotX == pauliRotNoArgs);
+}


### PR DESCRIPTION
**Context:**
Optionally, an operator may carry a set of static named arguments (e.g., `{"pauli_word": "X"}` for `qp.PauliRot`) that further specialize the operator. This PR extends the definition of `OperatorNode` in the the decomposition graph to support these optional metadata for operators in the graph. The support is guaranteed by the graph builder and the solver.  

**Description of the Change:**

**Benefits:**
- Cleaner lowering from MLIR to C++ in the `graph_decomposition` pass for Ops with static named args.

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-120980]