### PR TITLE
Improve package exclusion for autograph

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -40,6 +40,10 @@
   that have multiple quantum operands, of either quantum register or qubit type.
   [(#2868)](https://github.com/PennyLaneAI/catalyst/pull/2868)
 
+* Exclude more packages from AutoGraph conversion, since converting code unintentionally can lead
+  to tracing errors.
+  [(#2891)](https://github.com/PennyLaneAI/catalyst/pull/2891)
+
 <h3>Breaking changes 💔</h3>
 
 * Catalyst's xDSL dependencies have been updated to `xdsl` 0.63.0 and `xdsl-jax` 0.5.2.

--- a/frontend/catalyst/autograph/ag_primitives.py
+++ b/frontend/catalyst/autograph/ag_primitives.py
@@ -510,7 +510,11 @@ def get_source_code_info(tb_frame):
 module_allowlist = (
     ag_config.DoNotConvert("pennylane"),
     ag_config.DoNotConvert("catalyst"),
+    ag_config.DoNotConvert("autoray"),
+    ag_config.DoNotConvert("numpy"),
     ag_config.DoNotConvert("optax"),
+    ag_config.DoNotConvert("pyscf"),
+    ag_config.DoNotConvert("tqdm"),
     ag_config.DoNotConvert("jax"),
     *ag_config.CONVERSION_RULES,
 )


### PR DESCRIPTION
Typically we only want to convert user code with autograph, rarely library code. Autograph has a heuristics based exclusion mechanism to prevent source code from being converted unnecessarily. This is particularly important for Catalyst because it aggressively converts program elements into compilable versions, whereas TF is more selective (e.g., a loop is only converted if the target of the loop is `tf.range`, never a regular `range`).

Ultimately we might want to make autograph conversion more opt-in on an instance-by-instance basis, but for now excluding more packages that we know might be used in catalyst programs will improve robustness.

[sc-121161]