### PR TITLE
Conservative array casting in conditional

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -126,6 +126,9 @@
   - `qecp.dealloc_cb`, which deallocates a single physical codeblock.
     [(#2867)](https://github.com/PennyLaneAI/catalyst/pull/2867)
 
+* More conservative casting to tracer arrays in conditionals to preserve constant (static) values
+  better. This can be useful for optimizations that depend on values being static.
+  [(#2892)](https://github.com/PennyLaneAI/catalyst/pull/2892)
 
 
 <h3>Documentation 📝</h3>

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -810,7 +810,10 @@ class CondCallable:
 
         if not self._is_any_boolean(pred):
             try:
-                pred = jnp.astype(pred, bool, copy=False)
+                if isinstance(pred, jax.core.Tracer):
+                    pred = jnp.astype(pred, bool, copy=False)
+                else:
+                    pred = bool(pred)
             except TypeError as e:
                 raise TypeError(
                     "Conditional predicates are required to be of bool, integer or float type"

--- a/frontend/catalyst/api_extensions/control_flow.py
+++ b/frontend/catalyst/api_extensions/control_flow.py
@@ -814,9 +814,9 @@ class CondCallable:
                     pred = jnp.astype(pred, bool, copy=False)
                 else:
                     pred = bool(pred)
-            except TypeError as e:
+            except (TypeError, ValueError) as e:
                 raise TypeError(
-                    "Conditional predicates are required to be of bool, integer or float type"
+                    "Conditional predicates are required to be cast-able to bool."
                 ) from e
 
         return pred

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -1079,34 +1079,8 @@ class TestCondPredicateConversion:
 
         assert workflow(3) == 9
 
-    def test_string_conversion_failed(self, capture_mode):
-        """Test failure at converting string to bool using Autograph."""
-
-        if capture_mode:
-            pytest.skip("works with program capture.")
-
-        @qjit(autograph=True, capture=capture_mode)
-        def workflow(x):
-            n = "fail"
-
-            if n:
-                y = x**2
-            else:
-                y = 0
-
-            return y
-
-        with pytest.raises(
-            TypeError,
-            match="Conditional predicates are required to be of bool, integer or float type",
-        ):
-            workflow(3)
-
-    def test_string_conversion_capture_works(self, capture_mode):
-        """Test that truthy values in conditionals work when capture is enabled."""
-
-        if not capture_mode:
-            pytest.skip("only works with program capture.")
+    def test_string_conversion_works(self, capture_mode):
+        """Test that truthy values in conditionals work."""
 
         @qjit(autograph=True, capture=capture_mode)
         def workflow(x):


### PR DESCRIPTION
In the context of JAX tracing, casting values to arrays automatically converts them to tracers, which means this value, and everything it interacts with, is now considered a dynamic program value. Being more conservative in this casting process, thus ensuring that static values remain static for longer, can be beneficial, e.g. for trace-time optimizations. This is especially true given that this is generally a one-way process, i.e. it is much easier to make a static value dynamic, than a dynamic value static.

[sc-121161]