### PR TITLE
fix: use `QuantumScript.from_queue` instead of `process_queue`

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.238
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.46.0.dev18
+pennylane=0.46.0.dev20
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -34,4 +34,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.46.0-dev10
 pennylane-lightning==0.46.0-dev10
-pennylane==0.46.0.dev18
+pennylane==0.46.0.dev20

--- a/frontend/test/pytest/test_preprocess.py
+++ b/frontend/test/pytest/test_preprocess.py
@@ -516,7 +516,7 @@ class TestPreprocessHybridOp:
             qp.RX(1.23, wires=0)
             qp.measure(0)
 
-        ops, measurements = qp.queuing.process_queue(q)
+        ops, measurements = qp.tape.qscript.process_queue(q)
         tape = qp.tape.QuantumScript(ops, measurements)
 
         capabilities = DeviceCapabilities.from_toml_file(request.node.toml_file)
@@ -537,7 +537,7 @@ class TestPreprocessHybridOp:
             qp.RX(1.23, wires=0)
             qp.measure(0)
 
-        ops, measurements = qp.queuing.process_queue(q)
+        ops, measurements = qp.tape.qscript.process_queue(q)
         subtape = qp.tape.QuantumScript(ops, measurements)
 
         region = HybridOpRegion([], subtape, [], [])

--- a/frontend/test/pytest/test_preprocess.py
+++ b/frontend/test/pytest/test_preprocess.py
@@ -516,8 +516,7 @@ class TestPreprocessHybridOp:
             qp.RX(1.23, wires=0)
             qp.measure(0)
 
-        ops, measurements = qp.tape.qscript.process_queue(q)
-        tape = qp.tape.QuantumScript(ops, measurements)
+        tape = qp.tape.QuantumScript.from_queue(q)
 
         capabilities = DeviceCapabilities.from_toml_file(request.node.toml_file)
         setattr(capabilities, "to_matrix_ops", {"S": OperatorProperties()})
@@ -537,8 +536,7 @@ class TestPreprocessHybridOp:
             qp.RX(1.23, wires=0)
             qp.measure(0)
 
-        ops, measurements = qp.tape.qscript.process_queue(q)
-        subtape = qp.tape.QuantumScript(ops, measurements)
+        subtape = qp.tape.QuantumScript.from_queue(q)
 
         region = HybridOpRegion([], subtape, [], [])
         region.trace = None


### PR DESCRIPTION
**Context:**

`process_queue` was recently moved to `pennylane/tape/qscript` which caused a breaking change here.

**Description of the Change:**

Can simply use `QuantumScript.from_queue` instead to make it simpler.

**Benefits:**

Code is more maintainable.

**Possible Drawbacks:** None identified.

[[sc-120925](https://app.shortcut.com/xanaduai/story/120925)]
