### PR TITLE
Add mark-entry-points pass to annotate nested-module entry functions

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -87,6 +87,10 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* A new compiler pass `mark-entry-points` has been added, which annotates externally-callable
+  entry functions with the `catalyst.entry_point` attribute.
+  [(#2899)](https://github.com/PennyLaneAI/catalyst/pull/2899)
+
 * Removed the internal ``mlir_specs`` function which was the old backend for :func:`qp.specs`. The resource analysis pass replaces its use.
   [(#2841)](https://github.com/PennyLaneAI/catalyst/pull/2841)
 

--- a/frontend/catalyst/utils/gen_mlir.py
+++ b/frontend/catalyst/utils/gen_mlir.py
@@ -75,4 +75,3 @@ def inject_functions(module, ctx, seed):
     teardown_module = gen_teardown(ctx)
     teardown_func = teardown_module.body.operations[0]
     module.body.append(teardown_func)
-

--- a/frontend/catalyst/utils/gen_mlir.py
+++ b/frontend/catalyst/utils/gen_mlir.py
@@ -64,6 +64,7 @@ def inject_functions(module, ctx, seed):
     """
     # Add C interface for the quantum function and annonate it as the main entry_point.
     mlir_qfunc = module.body.operations[0]
+    assert isinstance(mlir_qfunc, FuncOp)
     mlir_qfunc.attributes["catalyst.entry_point"] = ir.UnitAttr.get(context=ctx)
     mlir_qfunc.attributes["llvm.emit_c_interface"] = ir.UnitAttr.get(context=ctx)
 
@@ -75,4 +76,3 @@ def inject_functions(module, ctx, seed):
     teardown_func = teardown_module.body.operations[0]
     module.body.append(teardown_func)
 
-    assert isinstance(mlir_qfunc, FuncOp)

--- a/frontend/catalyst/utils/gen_mlir.py
+++ b/frontend/catalyst/utils/gen_mlir.py
@@ -62,8 +62,10 @@ def inject_functions(module, ctx, seed):
     """
     This function appends functions to the input module.
     """
-    # Add C interface for the quantum function.
-    module.body.operations[0].attributes["llvm.emit_c_interface"] = ir.UnitAttr.get(context=ctx)
+    # Add C interface for the quantum function and annonate it as the main entry_point.
+    mlir_qfunc = module.body.operations[0]
+    mlir_qfunc.attributes["catalyst.entry_point"] = ir.UnitAttr.get(context=ctx)
+    mlir_qfunc.attributes["llvm.emit_c_interface"] = ir.UnitAttr.get(context=ctx)
 
     setup_module = gen_setup(ctx, seed)
     setup_func = setup_module.body.operations[0]
@@ -73,5 +75,4 @@ def inject_functions(module, ctx, seed):
     teardown_func = teardown_module.body.operations[0]
     module.body.append(teardown_func)
 
-    mlir_qfunc = module.body.operations[0]
     assert isinstance(mlir_qfunc, FuncOp)

--- a/frontend/test/lit/test_function_attributes.py
+++ b/frontend/test/lit/test_function_attributes.py
@@ -31,7 +31,7 @@ def qnode(x):
 
 @qjit(target="mlir")
 # The entry point has no internal linkage.
-# CHECK-DAG: func.func public @jit_workload(%arg0: tensor<f64>) -> tensor<4xcomplex<f64>> attributes {llvm.emit_c_interface} {
+# CHECK-DAG: func.func public @jit_workload(%arg0: tensor<f64>) -> tensor<4xcomplex<f64>> attributes {catalyst.entry_point, llvm.emit_c_interface} {
 def workload(x: float):
     y = x * qp.numpy.pi  # pylint: disable=no-member
     return qnode(y)

--- a/mlir/include/Catalyst/Transforms/Passes.td
+++ b/mlir/include/Catalyst/Transforms/Passes.td
@@ -143,6 +143,16 @@ def ApplyTransformSequencePass : Pass<"apply-transform-sequence"> {
     let summary = "Apply the passes scheduled with the transform dialect.";
 }
 
+def MarkEntryPointsPass : Pass<"mark-entry-points", "mlir::ModuleOp"> {
+    let summary = "Mark externally-callable entries on nested modules.";
+    let description = [{
+        Annotate functions inside any nested module whose name is reachable 
+        from outside that module with `catalyst.entry_point`.
+    }];
+
+    let dependentDialects = ["mlir::func::FuncDialect"];
+}
+
 def InlineNestedModulePass : Pass<"inline-nested-module"> {
     let summary = "Inline nested modules with qnode attribute.";
 

--- a/mlir/include/Driver/DefaultPipelines/DefaultPipelines.h
+++ b/mlir/include/Driver/DefaultPipelines/DefaultPipelines.h
@@ -39,6 +39,9 @@ const PipelineList pipelineList{
       "split-multiple-tapes",
       // Run the transform sequence defined in the MLIR module
       "builtin.module(apply-transform-sequence)",
+      // Stamp catalyst.entry_point on host-called functions inside every
+      // nested module.
+      "mark-entry-points",
       // Nested modules are something that will be used in the future
       // for making device-specific transformations.
       // Since at the moment, nothing in the runtime is using them

--- a/mlir/lib/Catalyst/Transforms/CMakeLists.txt
+++ b/mlir/lib/Catalyst/Transforms/CMakeLists.txt
@@ -16,6 +16,7 @@ file(GLOB SRC
     GEPInboundsPass.cpp
     GEPInboundsPatterns.cpp
     InlineNestedModules.cpp
+    MarkEntryPoints.cpp
     mark_entry_point_args_non_writable.cpp
     MemrefCopyToLinalgCopyPass.cpp
     MemrefCopyToLinalgCopyPatterns.cpp

--- a/mlir/lib/Catalyst/Transforms/MarkEntryPoints.cpp
+++ b/mlir/lib/Catalyst/Transforms/MarkEntryPoints.cpp
@@ -1,0 +1,68 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "llvm/ADT/SmallSet.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Pass/Pass.h"
+
+using namespace mlir;
+
+namespace catalyst {
+
+#define GEN_PASS_DEF_MARKENTRYPOINTSPASS
+#include "Catalyst/Transforms/Passes.h.inc"
+
+namespace {
+
+struct MarkEntryPointsPass : impl::MarkEntryPointsPassBase<MarkEntryPointsPass> {
+    using MarkEntryPointsPassBase::MarkEntryPointsPassBase;
+
+    void runOnOperation() final
+    {
+        ModuleOp root = getOperation();
+        UnitAttr entryAttr = UnitAttr::get(&getContext());
+
+        // Collect leaf names referenced from outside any nested module, then
+        // stamp matching functions inside each nested module. The host's own
+        // entry is annotated by the frontend, not this pass.
+        llvm::SmallSet<StringRef, 8> exposed;
+        for (Operation &topOp : root.getBody()->getOperations()) {
+            if (isa<ModuleOp>(&topOp)) {
+                continue;
+            }
+            if (auto uses = SymbolTable::getSymbolUses(&topOp)) {
+                for (SymbolTable::SymbolUse use : *uses) {
+                    exposed.insert(use.getSymbolRef().getLeafReference().getValue());
+                }
+            }
+        }
+        for (Operation &topOp : root.getBody()->getOperations()) {
+            auto mod = dyn_cast<ModuleOp>(&topOp);
+            if (!mod) {
+                continue;
+            }
+            for (auto func : mod.getOps<func::FuncOp>()) {
+                if (exposed.contains(func.getName())) {
+                    func->setAttr("catalyst.entry_point", entryAttr);
+                }
+            }
+        }
+    }
+};
+
+} // namespace
+
+} // namespace catalyst

--- a/mlir/test/Catalyst/MarkEntryPoints.mlir
+++ b/mlir/test/Catalyst/MarkEntryPoints.mlir
@@ -1,0 +1,84 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RUN: quantum-opt %s --mark-entry-points --split-input-file | FileCheck %s
+
+// Externally-called function in a nested target module gets marked as entry-points in
+// the contataining module
+
+// CHECK-LABEL: module @case_simple
+module @case_simple {
+  func.func public @host() {
+    func.call @entry() : () -> ()
+    return
+  }
+  // CHECK: func.func private @entry()
+  // CHECK-NOT: catalyst.entry_point
+  func.func private @entry()
+
+  module @target {
+    // CHECK: func.func public @entry()
+    // CHECK-SAME: catalyst.entry_point
+    func.func public @entry() {
+      return
+    }
+    // CHECK: func.func private @helper()
+    // CHECK-NOT: catalyst.entry_point
+    func.func private @helper() {
+      return
+    }
+  }
+}
+
+// -----
+
+// Target module with no externally-referenced functions
+
+// CHECK-LABEL: module @case_orphan
+module @case_orphan {
+  func.func public @host() { return }
+
+  module @target {
+    // CHECK-NOT: catalyst.entry_point
+    func.func public @unused() { return }
+  }
+}
+
+// -----
+
+// Intra-module references don't count as "external".
+
+// CHECK-LABEL: module @case_intra_module
+module @case_intra_module {
+  func.func public @host() {
+    func.call @entry() : () -> ()
+    return
+  }
+  // CHECK: func.func private @entry()
+  // CHECK-NOT: catalyst.entry_point
+  func.func private @entry()
+
+  module @qnode {
+    // CHECK: func.func public @entry()
+    // CHECK-SAME: catalyst.entry_point
+    func.func public @entry() {
+      func.call @callee() : () -> ()
+      return
+    }
+    // CHECK: func.func private @callee()
+    // CHECK-NOT: catalyst.entry_point
+    func.func private @callee() { return }
+  }
+}
+


### PR DESCRIPTION
**Context:**
When the compiler emits nested modules, the functions that the host actually dispatches into need to be distinguishable from purely-internal helpers. Downstream passes may use this as a signal for "this function is an externally-reachable entry point". 

**Description of the Change:**
Introduces a `catalyst.entry_point` annotation marking the functions that are externally callable, produced from either:
1. frontend: for the main dispatch function
2. `MarkEntryPoints` pass for nested modules.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
