### PR TITLE
Make a header for QubitIndex

### DIFF
--- a/mlir/include/Quantum/Utils/QubitIndex.h
+++ b/mlir/include/Quantum/Utils/QubitIndex.h
@@ -1,0 +1,81 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <variant>
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Value.h"
+
+namespace catalyst {
+namespace quantum {
+
+/// A struct to represent qubit indices in quantum operations.
+///
+/// This struct provides a way to handle qubit indices that can be either:
+/// - A runtime Value (for dynamic indices computed at runtime)
+/// - An IntegerAttr (for compile-time constant indices)
+/// - Invalid/uninitialized (represented by std::monostate)
+/// And a qreg value to represent the qreg that the index belongs to
+///
+/// The struct uses std::variant to ensure only one type is active at a time,
+/// preventing invalid states.
+///
+/// Example usage:
+///   QubitIndex dynamicIdx(operandValue, qreg);         // Runtime qubit index
+///   QubitIndex staticIdx(IntegerAttr::get(...), qreg); // Compile-time constant
+///   QubitIndex invalidIdx;                             // Uninitialized state
+///
+///   if (dynamicIdx) {                                  // Check if valid
+///     if (dynamicIdx.isValue()) {                      // Check if runtime value
+///       Value idx = dynamicIdx.getValue();             // Get the Value
+///     }
+///   }
+///
+/// Typical construction site: building a QubitIndex from a quantum.extract op,
+/// where the index may be either a dynamic SSA Value or a static IntegerAttr:
+///
+///   if (auto extractOp = qubit.getDefiningOp<quantum::ExtractOp>()) {
+///       if (Value idx = extractOp.getIdx()) {
+///           return QubitIndex(idx, extractOp.getQreg());
+///       }
+///       if (IntegerAttr idxAttr = extractOp.getIdxAttrAttr()) {
+///           return QubitIndex(idxAttr, extractOp.getQreg());
+///       }
+///   }
+class QubitIndex {
+  private:
+    // use monostate to represent the invalid index
+    std::variant<std::monostate, mlir::Value, mlir::IntegerAttr> index;
+    mlir::Value qreg;
+
+  public:
+    QubitIndex() : index(std::monostate()), qreg(nullptr) {}
+    QubitIndex(mlir::Value val, mlir::Value qreg) : index(val), qreg(qreg) {}
+    QubitIndex(mlir::IntegerAttr attr, mlir::Value qreg) : index(attr), qreg(qreg) {}
+
+    bool isValue() const { return std::holds_alternative<mlir::Value>(index); }
+    bool isAttr() const { return std::holds_alternative<mlir::IntegerAttr>(index); }
+    operator bool() const { return isValue() || isAttr(); }
+    mlir::Value getReg() const { return qreg; }
+    mlir::Value getValue() const { return isValue() ? std::get<mlir::Value>(index) : nullptr; }
+    mlir::IntegerAttr getAttr() const
+    {
+        return isAttr() ? std::get<mlir::IntegerAttr>(index) : nullptr;
+    }
+};
+
+} // namespace quantum
+} // namespace catalyst

--- a/mlir/include/Quantum/Utils/QubitIndex.h
+++ b/mlir/include/Quantum/Utils/QubitIndex.h
@@ -16,8 +16,12 @@
 
 #include <variant>
 
+#include "llvm/ADT/STLExtras.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Value.h"
+
+#include "Quantum/IR/QuantumInterfaces.h"
+#include "Quantum/IR/QuantumOps.h"
 
 namespace catalyst {
 namespace quantum {
@@ -76,6 +80,55 @@ class QubitIndex {
         return isAttr() ? std::get<mlir::IntegerAttr>(index) : nullptr;
     }
 };
+
+/// Trace a qubit SSA value back to the quantum.extract that produced it and
+/// return the corresponding QubitIndex (with the originating qreg).
+///
+/// The walk follows the def chain backward through:
+///   - quantum.extract  -> terminate, build QubitIndex from its index operand
+///                         (dynamic Value or static IntegerAttr) and its qreg
+///   - QuantumGate ops  -> step to the qubit operand at the same result position
+///   - quantum.measure  -> step to the input qubit
+///
+/// Returns an invalid (default-constructed) QubitIndex if the chain ends in
+/// some other defining op or a block argument.
+inline QubitIndex getExtractIndex(mlir::Value qubit)
+{
+    while (qubit) {
+        if (auto extractOp = qubit.getDefiningOp<quantum::ExtractOp>()) {
+            if (mlir::Value idx = extractOp.getIdx()) {
+                return QubitIndex(idx, extractOp.getQreg());
+            }
+            if (mlir::IntegerAttr idxAttr = extractOp.getIdxAttrAttr()) {
+                return QubitIndex(idxAttr, extractOp.getQreg());
+            }
+        }
+
+        if (auto gate = mlir::dyn_cast_or_null<quantum::QuantumGate>(qubit.getDefiningOp())) {
+            auto qubitOperands = gate.getQubitOperands();
+            auto qubitResults = gate.getQubitResults();
+            auto it =
+                llvm::find_if(qubitResults, [&](mlir::Value result) { return result == qubit; });
+
+            if (it != qubitResults.end()) {
+                size_t resultIndex = std::distance(qubitResults.begin(), it);
+                if (resultIndex < qubitOperands.size()) {
+                    qubit = qubitOperands[resultIndex];
+                    continue;
+                }
+            }
+        }
+        else if (auto measureOp =
+                     mlir::dyn_cast_or_null<quantum::MeasureOp>(qubit.getDefiningOp())) {
+            qubit = measureOp.getInQubit();
+            continue;
+        }
+
+        break;
+    }
+
+    return QubitIndex();
+}
 
 } // namespace quantum
 } // namespace catalyst

--- a/mlir/lib/Quantum/Transforms/DecomposeLoweringImpl.hpp
+++ b/mlir/lib/Quantum/Transforms/DecomposeLoweringImpl.hpp
@@ -404,43 +404,6 @@ class BaseSignatureAnalyzer {
         signature.outQubitIndices = signature.inWireIndices;
         signature.outCtrlQubitIndices = signature.inCtrlWireIndices;
     }
-
-    QubitIndex getExtractIndex(Value qubit)
-    {
-        while (qubit) {
-            if (auto extractOp = qubit.getDefiningOp<quantum::ExtractOp>()) {
-                if (Value idx = extractOp.getIdx()) {
-                    return QubitIndex(idx, extractOp.getQreg());
-                }
-                if (IntegerAttr idxAttr = extractOp.getIdxAttrAttr()) {
-                    return QubitIndex(idxAttr, extractOp.getQreg());
-                }
-            }
-
-            if (auto gate = dyn_cast_or_null<quantum::QuantumGate>(qubit.getDefiningOp())) {
-                auto qubitOperands = gate.getQubitOperands();
-                auto qubitResults = gate.getQubitResults();
-                auto it =
-                    llvm::find_if(qubitResults, [&](Value result) { return result == qubit; });
-
-                if (it != qubitResults.end()) {
-                    size_t resultIndex = std::distance(qubitResults.begin(), it);
-                    if (resultIndex < qubitOperands.size()) {
-                        qubit = qubitOperands[resultIndex];
-                        continue;
-                    }
-                }
-            }
-            else if (auto measureOp = dyn_cast_or_null<quantum::MeasureOp>(qubit.getDefiningOp())) {
-                qubit = measureOp.getInQubit();
-                continue;
-            }
-
-            break;
-        }
-
-        return QubitIndex();
-    }
 };
 
 class CustomOpSignatureAnalyzer : public BaseSignatureAnalyzer {

--- a/mlir/lib/Quantum/Transforms/DecomposeLoweringImpl.hpp
+++ b/mlir/lib/Quantum/Transforms/DecomposeLoweringImpl.hpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <algorithm> // std::move_backward
-#include <variant>
 
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
@@ -26,52 +25,13 @@
 
 #include "Quantum/IR/QuantumOps.h"
 #include "Quantum/IR/QuantumTypes.h"
+#include "Quantum/Utils/QubitIndex.h"
 
 using namespace mlir;
 using namespace catalyst::quantum;
 
 namespace catalyst {
 namespace quantum {
-
-/// A struct to represent qubit indices in quantum operations.
-///
-/// This struct provides a way to handle qubit indices that can be either:
-/// - A runtime Value (for dynamic indices computed at runtime)
-/// - An IntegerAttr (for compile-time constant indices)
-/// - Invalid/uninitialized (represented by std::monostate)
-/// And a qreg value to represent the qreg that the index belongs to
-///
-/// The struct uses std::variant to ensure only one type is active at a time,
-/// preventing invalid states.
-///
-/// Example usage:
-///   QubitIndex dynamicIdx(operandValue);     // Runtime qubit index
-///   QubitIndex staticIdx(IntegerAttr::get(...)); // Compile-time constant
-///   QubitIndex invalidIdx;                   // Uninitialized state
-///
-///   if (dynamicIdx) {                        // Check if valid
-///     if (dynamicIdx.isValue()) {            // Check if runtime value
-///       Value idx = dynamicIdx.getValue();   // Get the Value
-///     }
-///   }
-class QubitIndex {
-  private:
-    // use monostate to represent the invalid index
-    std::variant<std::monostate, Value, IntegerAttr> index;
-    Value qreg;
-
-  public:
-    QubitIndex() : index(std::monostate()), qreg(nullptr) {}
-    QubitIndex(Value val, Value qreg) : index(val), qreg(qreg) {}
-    QubitIndex(IntegerAttr attr, Value qreg) : index(attr), qreg(qreg) {}
-
-    bool isValue() const { return std::holds_alternative<Value>(index); }
-    bool isAttr() const { return std::holds_alternative<IntegerAttr>(index); }
-    operator bool() const { return isValue() || isAttr(); }
-    Value getReg() const { return qreg; }
-    Value getValue() const { return isValue() ? std::get<Value>(index) : nullptr; }
-    IntegerAttr getAttr() const { return isAttr() ? std::get<IntegerAttr>(index) : nullptr; }
-};
 
 // The goal of this class is to analyze the signature of a custom operation to get the enough
 // information to prepare the call operands and results for replacing the op to calling the


### PR DESCRIPTION
**Context:**

QubitIndex was originally defined in the decomposition lowering pass (`DecomposeLoweringImpl.hpp`), but it is a general-purpose utility for representing a qubit index that may be either a dynamic SSA Value or a compile-time IntegerAttr, together with the qreg it belongs to. Other developers may need to reuse it for tracing the index.

**Description of the Change:**

Extract QubitIndex into its own header at `mlir/include/Quantum/Utils/QubitIndex.h`, in the `catalyst::quantum` namespace.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
