### PR TITLE
fix: build libcustom_calls for arm64 only on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -371,6 +371,7 @@ elif system_platform == "Darwin":
         ],
         extra_compile_args=["-std=c++20"],
         define_macros=Py_LIMITED_API_macros,
+        extra_link_args=["-arch", "arm64"],
     )
     cmdclass = {"build_ext": CustomBuildExtMacos}
 


### PR DESCRIPTION
## Summary

Fixes #2907

Add `-arch arm64` to linker args for the `libcustom_calls` extension on macOS. Previously, the extension was built as a universal2 binary (supporting both arm64 and x86_64), causing the wheel to be incorrectly tagged as universal2.

## Changes

- **setup.py** — Added `extra_link_args=["-arch", "arm64"]` to the macOS `libcustom_calls` extension

## Impact

Before: `libcustom_calls` built as universal2 → wheel tagged as `macosx_14_0_universal2`

After: `libcustom_calls` built for arm64 only → wheel tagged as `macosx_14_0_arm64`

This matches all other binary artifacts in the Catalyst build and eliminates:
- The rename step during wheel publishing
- Unused x86 code in the library

## Test plan

- [ ] Build wheel on macOS arm64: `make wheel`
- [ ] Verify wheel tag: `python -m zipfile -l dist/*.whl | grep macosx`
- [ ] Verify library architecture: `file frontend/catalyst/utils/libcustom_calls.so`
- [ ] Run `delocate-wheel --require-archs=arm64` without warnings

## Notes

This is a minimal, targeted fix. The change only affects the linker args for the `libcustom_calls` extension on macOS. Other extensions (CMake-built) are already architecture-specific.

---
