### PR TITLE
Quick fix for generic format MLIR sent into --convert-to-value-semantics

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -111,6 +111,7 @@
   [(#2757)](https://github.com/PennyLaneAI/catalyst/pull/2757)
   [(#2781)](https://github.com/PennyLaneAI/catalyst/pull/2781)
   [(#2834)](https://github.com/PennyLaneAI/catalyst/pull/2834)
+  [(#????)](https://github.com/PennyLaneAI/catalyst/pull/????)
 
 * Removed the internal ``mlir_specs`` function which was the old backend for :func:`qp.specs`. The resource analysis pass replaces its use.
   [(#2841)](https://github.com/PennyLaneAI/catalyst/pull/2841)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -111,7 +111,7 @@
   [(#2757)](https://github.com/PennyLaneAI/catalyst/pull/2757)
   [(#2781)](https://github.com/PennyLaneAI/catalyst/pull/2781)
   [(#2834)](https://github.com/PennyLaneAI/catalyst/pull/2834)
-  [(#????)](https://github.com/PennyLaneAI/catalyst/pull/????)
+  [(#2911)](https://github.com/PennyLaneAI/catalyst/pull/2911)
 
 * Removed the internal ``mlir_specs`` function which was the old backend for :func:`qp.specs`. The resource analysis pass replaces its use.
   [(#2841)](https://github.com/PennyLaneAI/catalyst/pull/2841)

--- a/frontend/catalyst/python_interface/compiler.py
+++ b/frontend/catalyst/python_interface/compiler.py
@@ -80,13 +80,14 @@ class Compiler:
 
         # JAX serializes void func.func ops with `res_attrs = []` in generic form
         # triggering an assertion in FuncToLLVM lowering.
-        # Assert that the canonicalization above has removed these empty attributes
+        # Remove empty arrays in-place so the generic printer omits them.\
         for op in xmod.walk():
             if not isinstance(op, FuncOp):
                 continue
             for key in ("res_attrs", "arg_attrs"):
                 val = op.properties.get(key)
-                assert not (isinstance(val, ArrayAttr) and len(val) == 0)
+                if isinstance(val, ArrayAttr) and len(val) == 0:
+                    del op.properties[key]
         buffer = io.StringIO()
         Printer(stream=buffer, print_generic_format=True).print_op(xmod)
 

--- a/frontend/catalyst/python_interface/compiler.py
+++ b/frontend/catalyst/python_interface/compiler.py
@@ -80,7 +80,7 @@ class Compiler:
 
         # JAX serializes void func.func ops with `res_attrs = []` in generic form
         # triggering an assertion in FuncToLLVM lowering.
-        # Remove empty arrays in-place so the generic printer omits them.\
+        # Remove empty arrays in-place so the generic printer omits them.
         for op in xmod.walk():
             if not isinstance(op, FuncOp):
                 continue

--- a/frontend/catalyst/python_interface/compiler.py
+++ b/frontend/catalyst/python_interface/compiler.py
@@ -65,6 +65,7 @@ class Compiler:
         value_semantics_mlir = (
             catalyst.python_interface.inspection.xdsl_conversion._quantum_opt_stderr(
                 '--catalyst-pipeline="pipe(canonicalize;convert-to-value-semantics;canonicalize)"',
+                "--mlir-print-op-generic",
                 stdin=str(gentxtmod),
             )
         )

--- a/mlir/lib/QRef/Transforms/value_semantics_conversion.cpp
+++ b/mlir/lib/QRef/Transforms/value_semantics_conversion.cpp
@@ -1755,47 +1755,71 @@ void handleSubroutine(IRRewriter &builder, func::FuncOp f,
 
     // Add new quantum arguments
     QubitValueTracker regionTracker;
-    for (auto rValue : rValuesUsedBySubroutine) {
-        Value newArg;
+    size_t originalNumArgs = f.getFunctionType().getNumInputs();
+    SmallVector<unsigned> indicesToInsertArgs;
+    SmallVector<Type> typesToInsertArgs;
+    SmallVector<DictionaryAttr> attrsToInsertArgs;
+    SmallVector<Location> locsToInsertArgs;
+    SmallVector<unsigned> newVargIndices;
+    size_t numNewArgsAdded = 0;
+    for (Value rValue : rValuesUsedBySubroutine) {
         if (isa<qref::QubitType>(rValue.getType())) {
-            newArg = f.getBody().front().addArgument(quantum::QubitType::get(ctx), loc);
-            regionTracker.setCurrentVQubit(rValue, newArg);
+            typesToInsertArgs.push_back(quantum::QubitType::get(ctx));
+            newVargIndices.push_back(originalNumArgs + (numNewArgsAdded++));
         }
         else if (isa<qref::QuregType>(rValue.getType())) {
-            newArg = f.getBody().front().addArgument(quantum::QuregType::get(ctx), loc);
-            regionTracker.setCurrentVQreg(rValue, newArg);
+            typesToInsertArgs.push_back(quantum::QuregType::get(ctx));
+            newVargIndices.push_back(originalNumArgs + (numNewArgsAdded++));
+        }
+
+        indicesToInsertArgs.push_back(originalNumArgs);
+        attrsToInsertArgs.push_back(DictionaryAttr::get(ctx));
+        locsToInsertArgs.push_back(loc);
+    }
+    assert(succeeded(f.insertArguments(indicesToInsertArgs, typesToInsertArgs, attrsToInsertArgs,
+                                       locsToInsertArgs)));
+    for (auto [i, rValue] : llvm::zip_equal(newVargIndices, rValuesUsedBySubroutine)) {
+        if (isa<qref::QubitType>(rValue.getType())) {
+            regionTracker.setCurrentVQubit(rValue, f.getArgument(i));
+        }
+        else if (isa<qref::QuregType>(rValue.getType())) {
+            regionTracker.setCurrentVQreg(rValue, f.getArgument(i));
         }
     }
 
+    // Convert the body
     handleRegion(builder, f.getBody(), regionTracker);
-
     addRootVValuesToRetOp(f.front().getTerminator(), rValuesUsedBySubroutine.getArrayRef(),
                           regionTracker);
 
     // Remove all old qref arguments
     eraseAllRemainingAnchorRValues(f);
-    f.front().eraseArguments(
-        [](BlockArgument arg) { return isa<qref::QubitType, qref::QuregType>(arg.getType()); });
-    f.setFunctionType(
-        FunctionType::get(ctx, f.front().getArgumentTypes(), f.getFunctionType().getResults()));
+    BitVector eraseArgsIndices(f.getNumArguments());
+    for (auto [i, argType] : llvm::enumerate(f.getArgumentTypes())) {
+        if (isa<qref::QuregType, qref::QubitType>(argType)) {
+            eraseArgsIndices.set(i);
+        }
+    }
+    assert(succeeded(f.eraseArguments(eraseArgsIndices)));
 
-    // Also need to append result attributes and update function type
+    // Add value semantics returns
     size_t originalNumResults = f.getFunctionType().getNumResults();
-    SmallVector<unsigned> indicesToInsert;
-    SmallVector<Type> typesToInsert;
-    SmallVector<DictionaryAttr> attrsToInsert;
+    SmallVector<unsigned> indicesToInsertResults;
+    SmallVector<Type> typesToInsertResults;
+    SmallVector<DictionaryAttr> attrsToInsertResults;
     for (Type retType : f.front().getTerminator()->getOperandTypes()) {
         if (isa<quantum::QuregType, quantum::QubitType>(retType)) {
-            typesToInsert.push_back(retType);
+            typesToInsertResults.push_back(retType);
         }
         else {
             continue;
         }
 
-        indicesToInsert.push_back(originalNumResults);
-        attrsToInsert.push_back(DictionaryAttr::get(ctx));
+        indicesToInsertResults.push_back(originalNumResults);
+        attrsToInsertResults.push_back(DictionaryAttr::get(ctx));
     }
-    assert(succeeded(f.insertResults(indicesToInsert, typesToInsert, attrsToInsert)));
+    assert(succeeded(
+        f.insertResults(indicesToInsertResults, typesToInsertResults, attrsToInsertResults)));
 }
 
 void handleRegion(IRRewriter &builder, Region &r, QubitValueTracker &tracker)

--- a/mlir/lib/QRef/Transforms/value_semantics_conversion.cpp
+++ b/mlir/lib/QRef/Transforms/value_semantics_conversion.cpp
@@ -1749,11 +1749,6 @@ void handleWhile(IRRewriter &builder, scf::WhileOp whileOp, QubitValueTracker &t
 void handleSubroutine(IRRewriter &builder, func::FuncOp f,
                       const SetVector<Value> &rValuesUsedBySubroutine)
 {
-    // Special: when calling this conversion pass with generic format MLIR, the input qref
-    // subroutine might have an empty `res_attr` attribtue, e.g. from JAX serialization.
-    // We just remove it, since the subroutine return signature is changing.
-    f->removeAttr("res_attrs");
-
     MLIRContext *ctx = f.getContext();
     OpBuilder::InsertionGuard guard(builder);
     Location loc = f->getLoc();
@@ -1773,8 +1768,29 @@ void handleSubroutine(IRRewriter &builder, func::FuncOp f,
     }
 
     handleRegion(builder, f.getBody(), regionTracker);
+
+    // Return new value semantics quantum results
+    // Also need to append result attributes and update function type
+    size_t originalNumResults = f.getFunctionType().getNumResults();
     addRootVValuesToRetOp(f.front().getTerminator(), rValuesUsedBySubroutine.getArrayRef(),
                           regionTracker);
+    size_t newNumResults = f.front().getTerminator()->getNumOperands();
+
+    SmallVector<Attribute> newResAttrs;
+    if (ArrayAttr existingResAttrs = f.getResAttrsAttr()) {
+        // Copy existing result attributes
+        newResAttrs.append(existingResAttrs.begin(), existingResAttrs.end());
+    }
+    else {
+        // Pad with empty ones if none existed
+        for (size_t i = 0; i < originalNumResults; i++) {
+            newResAttrs.push_back(DictionaryAttr::get(ctx));
+        }
+    }
+    for (size_t i = 0; i < (newNumResults - originalNumResults); i++) {
+        newResAttrs.push_back(DictionaryAttr::get(ctx));
+    }
+    f.setResAttrsAttr(ArrayAttr::get(ctx, newResAttrs));
 
     eraseAllRemainingAnchorRValues(f);
 

--- a/mlir/lib/QRef/Transforms/value_semantics_conversion.cpp
+++ b/mlir/lib/QRef/Transforms/value_semantics_conversion.cpp
@@ -1769,37 +1769,33 @@ void handleSubroutine(IRRewriter &builder, func::FuncOp f,
 
     handleRegion(builder, f.getBody(), regionTracker);
 
-    // Return new value semantics quantum results
-    // Also need to append result attributes and update function type
-    size_t originalNumResults = f.getFunctionType().getNumResults();
     addRootVValuesToRetOp(f.front().getTerminator(), rValuesUsedBySubroutine.getArrayRef(),
                           regionTracker);
-    size_t newNumResults = f.front().getTerminator()->getNumOperands();
 
-    SmallVector<Attribute> newResAttrs;
-    if (ArrayAttr existingResAttrs = f.getResAttrsAttr()) {
-        // Copy existing result attributes
-        newResAttrs.append(existingResAttrs.begin(), existingResAttrs.end());
-    }
-    else {
-        // Pad with empty ones if none existed
-        for (size_t i = 0; i < originalNumResults; i++) {
-            newResAttrs.push_back(DictionaryAttr::get(ctx));
-        }
-    }
-    for (size_t i = 0; i < (newNumResults - originalNumResults); i++) {
-        newResAttrs.push_back(DictionaryAttr::get(ctx));
-    }
-    f.setResAttrsAttr(ArrayAttr::get(ctx, newResAttrs));
-
+    // Remove all old qref arguments
     eraseAllRemainingAnchorRValues(f);
-
-    // Nuke all old qref arguments
     f.front().eraseArguments(
         [](BlockArgument arg) { return isa<qref::QubitType, qref::QuregType>(arg.getType()); });
+    f.setFunctionType(
+        FunctionType::get(ctx, f.front().getArgumentTypes(), f.getFunctionType().getResults()));
 
-    f.setFunctionType(FunctionType::get(ctx, f.front().getArgumentTypes(),
-                                        f.front().getTerminator()->getOperandTypes()));
+    // Also need to append result attributes and update function type
+    size_t originalNumResults = f.getFunctionType().getNumResults();
+    SmallVector<unsigned> indicesToInsert;
+    SmallVector<Type> typesToInsert;
+    SmallVector<DictionaryAttr> attrsToInsert;
+    for (Type retType : f.front().getTerminator()->getOperandTypes()) {
+        if (isa<quantum::QuregType, quantum::QubitType>(retType)) {
+            typesToInsert.push_back(retType);
+        }
+        else {
+            continue;
+        }
+
+        indicesToInsert.push_back(originalNumResults);
+        attrsToInsert.push_back(DictionaryAttr::get(ctx));
+    }
+    assert(succeeded(f.insertResults(indicesToInsert, typesToInsert, attrsToInsert)));
 }
 
 void handleRegion(IRRewriter &builder, Region &r, QubitValueTracker &tracker)

--- a/mlir/lib/QRef/Transforms/value_semantics_conversion.cpp
+++ b/mlir/lib/QRef/Transforms/value_semantics_conversion.cpp
@@ -1749,6 +1749,11 @@ void handleWhile(IRRewriter &builder, scf::WhileOp whileOp, QubitValueTracker &t
 void handleSubroutine(IRRewriter &builder, func::FuncOp f,
                       const SetVector<Value> &rValuesUsedBySubroutine)
 {
+    // Special: when calling this conversion pass with generic format MLIR, the input qref
+    // subroutine might have an empty `res_attr` attribtue, e.g. from JAX serialization We just
+    // remove it, since the subroutine return signature is changing.
+    f->removeAttr("res_attrs");
+
     MLIRContext *ctx = f.getContext();
     OpBuilder::InsertionGuard guard(builder);
     Location loc = f->getLoc();

--- a/mlir/lib/QRef/Transforms/value_semantics_conversion.cpp
+++ b/mlir/lib/QRef/Transforms/value_semantics_conversion.cpp
@@ -1750,8 +1750,8 @@ void handleSubroutine(IRRewriter &builder, func::FuncOp f,
                       const SetVector<Value> &rValuesUsedBySubroutine)
 {
     // Special: when calling this conversion pass with generic format MLIR, the input qref
-    // subroutine might have an empty `res_attr` attribtue, e.g. from JAX serialization We just
-    // remove it, since the subroutine return signature is changing.
+    // subroutine might have an empty `res_attr` attribtue, e.g. from JAX serialization.
+    // We just remove it, since the subroutine return signature is changing.
     f->removeAttr("res_attrs");
 
     MLIRContext *ctx = f.getContext();


### PR DESCRIPTION
**Context:**
JAX serializes MLIR modules to textual MLIR in generic format. For functions with no return values, such as the decomposition rules in reference semantics (since they don't return quantum values, like those in value semantics), JAX adds the `res_attrs=[]` empty result attribute to the funcop.

When such a function is sent into `--convert-to-value-semantics`, and these decomp rule funcs are converted to value semantics, the new funcs now have return values, but the result attribute is still empty, leading to a mismatch and a crash. 

**Description of the Change:**
Use func op interface's methods to handle the addition and erasure of args and results. This ensures all relavant internals (like the aforementioned attributes) are appropriately handled by API contract.

**Benefits:**
Fixes XAS benchmark.
