### PR TITLE
Remove missing docs reference

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -192,6 +192,9 @@
 
 <h3>Documentation 📝</h3>
 
+* Remove reference to missing docs section "decomposition-rules."
+  [(#2913)](https://github.com/PennyLaneAI/catalyst/pull/2913)
+
 <h3>Contributors ✍️</h3>
 
 This release contains contributions from (in alphabetical order):

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -192,7 +192,7 @@
 
 <h3>Documentation 📝</h3>
 
-* Remove reference to missing docs section "decomposition-rules."
+* A broken link was removed in the [Compiler Core](https://docs.pennylane.ai/projects/catalyst/en/stable/modules/mlir.html) documentation page. The link referred to where precompiled decomposition rules were implemented, which has since been refactored.
   [(#2913)](https://github.com/PennyLaneAI/catalyst/pull/2913)
 
 <h3>Contributors ✍️</h3>

--- a/mlir/README.rst
+++ b/mlir/README.rst
@@ -25,10 +25,6 @@ Contents
 This module contains out-of-tree dialect definitions for the MLIR compiler framework, and the
 directory structure generally follows the recommended practices from the upstream project:
 
-- `decomposition-rules <https://github.com/PennyLaneAI/catalyst/tree/main/mlir/decomposition-rules>`_:
-    This contains the utilities for and results of pre-compiling the decomposition rules defined in 
-    PennyLane, for use with the graph decomposition system.
-
 - `include <https://github.com/PennyLaneAI/catalyst/tree/main/mlir/include>`_:
     This contains declarative definitions of new IR objects such as custom dialects, types, and
     operations in the form of TableGen (``.td``) files. TableGen is a small language used by MLIR to


### PR DESCRIPTION
**Context:**
An MLIR docs section was added as part of the initial precompile-decomp-rules PR, but the logic was moved during review & refactor. This left the docs out-of-date.

**Description of the Change:**
Removes the reference to the missing docs section.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-121382]