### PR TITLE
Add an option to `make frontend` for not unintalling current environment's PL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ RT_BUILD_DIR ?= $(MK_DIR)/runtime/build
 OQC_BUILD_DIR ?= $(MK_DIR)/frontend/catalyst/third_party/oqc/src/build
 ENZYME_BUILD_DIR ?= $(MK_DIR)/mlir/Enzyme/build
 COVERAGE_REPORT ?= term-missing
+UNINSTALL_PL ?= ON
 ENABLE_OPENQASM ?= ON
 ENABLE_OQD ?= OFF
 TEST_BACKEND ?= "lightning.qubit"
@@ -118,9 +119,11 @@ catalyst: runtime dialects plugin frontend oqc
 .PHONY: frontend
 frontend:
 	@echo "install Catalyst Frontend"
+ifeq ($(UNINSTALL_PL),ON)
 	# Uninstall pennylane before updating Catalyst, since pip will not replace two development
 	# versions of a package with the same version tag (e.g. 0.38-dev0).
 	$(PYTHON) -m pip uninstall -y pennylane
+endif
 	$(PYTHON) -m pip install -e . --extra-index-url https://test.pypi.org/simple $(PIP_VERBOSE_FLAG)
 	$(PYTHON) -m catalyst.utils.precompile_decomposition_rules
 	rm -r frontend/pennylane_catalyst.egg-info

--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,10 @@ ifeq ($(UNINSTALL_PL),ON)
 	# Uninstall pennylane before updating Catalyst, since pip will not replace two development
 	# versions of a package with the same version tag (e.g. 0.38-dev0).
 	$(PYTHON) -m pip uninstall -y pennylane
-endif
 	$(PYTHON) -m pip install -e . --extra-index-url https://test.pypi.org/simple $(PIP_VERBOSE_FLAG)
+else
+	$(PYTHON) -m pip install -e . --no-deps
+endif
 	$(PYTHON) -m catalyst.utils.precompile_decomposition_rules
 	rm -r frontend/pennylane_catalyst.egg-info
 


### PR DESCRIPTION
**Context:**
During development, it is often the case that people will need their local environment to be on a specific PennyLane branch, instead of a nightly package on testpypi. In these cases, `make frontend` uninstalling the environment's current PL is very frustrating.

**Description of the Change:**
Add an option to `make frontend` to keep the local environment's current PL package.

**Benefits:**
Better development experience.
