### PR TITLE
Skip generating the `apply_t` subroutine clifford-only circuits

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -133,6 +133,7 @@
 * The experimental compiler pass `convert-quantum-to-qecl` has been extended to lower
   `quantum.custom "T"` gates to the `qecl` layer as a subroutine using a magic state.
   [(#2870)](https://github.com/PennyLaneAI/catalyst/pull/2870)
+  [(#2917)](https://github.com/PennyLaneAI/catalyst/pull/2917)
 
 * The reference semantics Pauli Product Measurement operation `pbc.ref.ppm` was added.
   [(#2773)](https://github.com/PennyLaneAI/catalyst/pull/2773)

--- a/frontend/catalyst/python_interface/transforms/qecl/convert_quantum_to_qecl.py
+++ b/frontend/catalyst/python_interface/transforms/qecl/convert_quantum_to_qecl.py
@@ -623,8 +623,17 @@ class ConvertQuantumToQecLogicalPass(ModulePass):
 
         module_block = op.regions[0].blocks.first
         assert module_block is not None, "Module has no block"
-        t_subroutine = self.create_t_subroutine()
-        module_block.add_op(t_subroutine)
+
+        # The apply_T subroutine is built from `qecl.fabricate`.
+        # only emit it when the circuit actually contains a T gate.
+        has_t_gate = any(
+            isinstance(inner, quantum.CustomOp) and inner.gate_name.data == "T"
+            for inner in op.walk()
+        )
+        t_subroutine = None
+        if has_t_gate:
+            t_subroutine = self.create_t_subroutine()
+            module_block.add_op(t_subroutine)
 
         PatternRewriteWalker(
             GreedyRewritePatternApplier(

--- a/frontend/catalyst/python_interface/transforms/qecl/convert_quantum_to_qecl.py
+++ b/frontend/catalyst/python_interface/transforms/qecl/convert_quantum_to_qecl.py
@@ -624,7 +624,6 @@ class ConvertQuantumToQecLogicalPass(ModulePass):
         module_block = op.regions[0].blocks.first
         assert module_block is not None, "Module has no block"
 
-        # The apply_T subroutine is built from `qecl.fabricate`.
         # only emit it when the circuit actually contains a T gate.
         has_t_gate = any(
             isinstance(inner, quantum.CustomOp) and inner.gate_name.data == "T"

--- a/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
+++ b/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
@@ -670,6 +670,29 @@ class TestGatePattern:
         """
         run_filecheck(program, quantum_to_qecl_pipeline_k_1)
 
+    def test_no_apply_t_subroutine_for_clifford_circuit(
+        self, run_filecheck, quantum_to_qecl_pipeline_k_1
+    ):
+        """Test that the `apply_T` magic-state subroutine is NOT emitted for a Clifford-only
+        circuit (one with no T gates).
+
+        """
+        program = """
+        builtin.module @module_circuit {
+            func.func @test_func() attributes {quantum.node} {
+                // CHECK: qecl.hadamard
+                %0 = "test.op"() : () -> !qecl.codeblock<1>
+                %1 = builtin.unrealized_conversion_cast %0 : !qecl.codeblock<1> to !quantum.bit
+                %2 = quantum.custom "Hadamard"() %1 : !quantum.bit
+                %3 = "test.op"(%2) : (!quantum.bit) -> !quantum.bit  // To prevent DCE
+                return
+            }
+            // CHECK-NOT: @apply_T
+            // CHECK-NOT: qecl.fabricate
+        }
+        """
+        run_filecheck(program, quantum_to_qecl_pipeline_k_1)
+
     def test_gate_cnot_k_1(self, run_filecheck, quantum_to_qecl_pipeline_k_1):
         """Test that CNOT gates (`quantum.custom "CNOT"() ops) are converted to their corresponding
         `qecl.cnot` ops for k = 1.


### PR DESCRIPTION
**Context:**
Currently, the `Apply_T` subroutine is generated even if the circuit consists of only clifford gates, which results in a redundant function in the IR. 

**Description of the Change:**
skip generating the circuit if it clifford-only.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
