### PR TITLE
[qref 4.2] Value-to-ref conversion for adjoint ops

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -180,6 +180,7 @@
 * A new pass `--convert-to-reference-semantics` has been added. The pass takes in MLIR in value
   semantics `quantum` dialect, and converts them to reference semantics `qref` dialect.
   [(#2920)](https://github.com/PennyLaneAI/catalyst/pull/2920)
+  [(#????)](https://github.com/PennyLaneAI/catalyst/pull/????)
 
 * Removed the internal ``mlir_specs`` function which was the old backend for :func:`qp.specs`. The resource analysis pass replaces its use.
   [(#2841)](https://github.com/PennyLaneAI/catalyst/pull/2841)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -180,7 +180,7 @@
 * A new pass `--convert-to-reference-semantics` has been added. The pass takes in MLIR in value
   semantics `quantum` dialect, and converts them to reference semantics `qref` dialect.
   [(#2920)](https://github.com/PennyLaneAI/catalyst/pull/2920)
-  [(#????)](https://github.com/PennyLaneAI/catalyst/pull/????)
+  [(#2930)](https://github.com/PennyLaneAI/catalyst/pull/2930)
 
 * Removed the internal ``mlir_specs`` function which was the old backend for :func:`qp.specs`. The resource analysis pass replaces its use.
   [(#2841)](https://github.com/PennyLaneAI/catalyst/pull/2841)

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -423,7 +423,7 @@ void handleAdjoint(IRRewriter &builder, quantum::AdjointOp vAdjointOp, QubitValu
 void handleRegion(IRRewriter &builder, Region &r, QubitValueTracker &tracker)
 {
     assert(r.hasOneBlock() && "Expected region to have a single block");
-    assert(r.front().getTerminator() && "Expected region to have a terminator");
+    assert(r.front().getTerminator() && "Expected the region body to have a terminator");
 
     SmallVector<Operation *> erasureWorklist;
     r.walk<WalkOrder::PreOrder>([&](Operation *op) {

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -14,6 +14,9 @@
 
 #define DEBUG_TYPE "reference-semantics-conversion"
 
+#include "reference_semantics_conversion.h"
+
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -39,8 +42,11 @@ using namespace catalyst;
 
 namespace {
 
-void eraseAllVOps(SmallVector<Operation *> &erasureWorklist)
+void eraseAllVOps(Region &r, SmallVector<Operation *> &erasureWorklist)
 {
+    if (isa<quantum::YieldOp>(r.front().getTerminator())) {
+        erasureWorklist.push_back(r.front().getTerminator());
+    }
     for (auto op : llvm::reverse(erasureWorklist)) {
         op->erase();
     }
@@ -87,6 +93,33 @@ struct QubitValueTracker {
     llvm::DenseMap<Value, Value> qubit_map;
 }; // struct QubitValueTracker
 
+void cascadeMapAhead(Operation *vOp, QubitValueTracker &tracker)
+{
+    // Cascade the tracker for gate-like ops
+    SmallVector<Value> vQuantumOperands;
+    SmallVector<Value> vQuantumResults;
+    for (Value v : vOp->getOperands()) {
+        if (isa<quantum::QubitType, quantum::QuregType>(v.getType())) {
+            vQuantumOperands.push_back(v);
+        }
+    }
+
+    for (Value v : vOp->getResults()) {
+        if (isa<quantum::QubitType, quantum::QuregType>(v.getType())) {
+            vQuantumResults.push_back(v);
+        }
+    }
+
+    for (auto [vqo, vqr] : llvm::zip_equal(vQuantumOperands, vQuantumResults)) {
+        if (isa<quantum::QubitType>(vqo.getType())) {
+            tracker.setRQubit(vqr, tracker.getRQubit(vqo));
+        }
+        else if (isa<quantum::QuregType>(vqo.getType())) {
+            tracker.setRQreg(vqr, tracker.getRQreg(vqo));
+        }
+    }
+}
+
 template <typename OpTy>
 OpTy migrateOpToReferenceSemantics(IRRewriter &builder, Operation *vOp, QubitValueTracker &tracker)
 {
@@ -128,29 +161,7 @@ OpTy migrateOpToReferenceSemantics(IRRewriter &builder, Operation *vOp, QubitVal
 
     if (isa<quantum::QuantumOperation, quantum::MeasureOp, pbc::PPMeasurementOp,
             mbqc::MeasureInBasisOp>(vOp)) {
-        // Cascade the tracker for gate-like ops
-        SmallVector<Value> vQuantumOperands;
-        SmallVector<Value> vQuantumResults;
-        for (Value v : vOp->getOperands()) {
-            if (isa<quantum::QubitType, quantum::QuregType>(v.getType())) {
-                vQuantumOperands.push_back(v);
-            }
-        }
-
-        for (Value v : vOp->getResults()) {
-            if (isa<quantum::QubitType, quantum::QuregType>(v.getType())) {
-                vQuantumResults.push_back(v);
-            }
-        }
-
-        for (auto [vqo, vqr] : llvm::zip_equal(vQuantumOperands, vQuantumResults)) {
-            if (isa<quantum::QubitType>(vqo.getType())) {
-                tracker.setRQubit(vqr, tracker.getRQubit(vqo));
-            }
-            else if (isa<quantum::QuregType>(vqo.getType())) {
-                tracker.setRQreg(vqr, tracker.getRQreg(vqo));
-            }
-        }
+        cascadeMapAhead(vOp, tracker);
     }
 
     return cast<OpTy>(newOp);
@@ -376,6 +387,38 @@ void handleGraphStatePrep(IRRewriter &builder, mbqc::GraphStatePrepOp vGraphStat
     erasureWorklist.push_back(vGraphStatePrepOp);
 }
 
+void handleAdjoint(IRRewriter &builder, quantum::AdjointOp vAdjointOp, QubitValueTracker &tracker,
+                   SmallVector<Operation *> &erasureWorklist)
+{
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPoint(vAdjointOp);
+    Location loc = vAdjointOp->getLoc();
+
+    // Add block args to the map
+    for (auto [blockArg, operand] : llvm::zip_equal(vAdjointOp.getRegion().front().getArguments(),
+                                                    vAdjointOp->getOperands())) {
+        if (isa<quantum::QubitType>(blockArg.getType())) {
+            tracker.setRQubit(blockArg, tracker.getRQubit(operand));
+        }
+        else if (isa<quantum::QuregType>(blockArg.getType())) {
+            tracker.setRQreg(blockArg, tracker.getRQreg(operand));
+        }
+    }
+
+    // Create the rAdjoint op and handle
+    auto rAdjointOp = qref::AdjointOp::create(builder, loc);
+    builder.inlineRegionBefore(vAdjointOp.getRegion(), rAdjointOp.getRegion(),
+                               rAdjointOp.getRegion().end());
+    handleRegion(builder, rAdjointOp.getRegion(), tracker);
+    cascadeMapAhead(vAdjointOp, tracker);
+    erasureWorklist.push_back(vAdjointOp);
+
+    // Remove the moved over value semantics block args
+    rAdjointOp.getRegion().front().eraseArguments([](BlockArgument arg) {
+        return isa<quantum::QubitType, quantum::QuregType>(arg.getType());
+    });
+}
+
 void handleRegion(IRRewriter &builder, Region &r, QubitValueTracker &tracker)
 {
     SmallVector<Operation *> erasureWorklist;
@@ -405,7 +448,8 @@ void handleRegion(IRRewriter &builder, Region &r, QubitValueTracker &tracker)
                 [&](auto o) { handleMeasureInBasis(builder, o, tracker, erasureWorklist); })
             .Case<pbc::PPMeasurementOp>(
                 [&](auto o) { handlePPM(builder, o, tracker, erasureWorklist); })
-            // .Case<qref::AdjointOp>([&](auto o) { handleAdjoint(builder, o, tracker); })
+            .Case<quantum::AdjointOp>(
+                [&](auto o) { handleAdjoint(builder, o, tracker, erasureWorklist); })
             // .Case<scf::IfOp>([&](auto o) { handleIf(builder, o, tracker); })
             // .Case<scf::IndexSwitchOp>([&](auto o) { handleSwitch(builder, o, tracker); })
             // .Case<scf::ForOp>([&](auto o) { handleFor(builder, o, tracker); })
@@ -415,7 +459,7 @@ void handleRegion(IRRewriter &builder, Region &r, QubitValueTracker &tracker)
             .Default([](Operation *) {});
     });
 
-    eraseAllVOps(erasureWorklist);
+    eraseAllVOps(r, erasureWorklist);
 }
 
 } // namespace

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -393,15 +393,16 @@ void handleAdjoint(IRRewriter &builder, quantum::AdjointOp vAdjointOp, QubitValu
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPoint(vAdjointOp);
     Location loc = vAdjointOp->getLoc();
+    QubitValueTracker regionTracker = tracker;
 
     // Add block args to the map
     for (auto [blockArg, operand] : llvm::zip_equal(vAdjointOp.getRegion().front().getArguments(),
                                                     vAdjointOp->getOperands())) {
         if (isa<quantum::QubitType>(blockArg.getType())) {
-            tracker.setRQubit(blockArg, tracker.getRQubit(operand));
+            regionTracker.setRQubit(blockArg, tracker.getRQubit(operand));
         }
         else if (isa<quantum::QuregType>(blockArg.getType())) {
-            tracker.setRQreg(blockArg, tracker.getRQreg(operand));
+            regionTracker.setRQreg(blockArg, tracker.getRQreg(operand));
         }
     }
 
@@ -409,7 +410,7 @@ void handleAdjoint(IRRewriter &builder, quantum::AdjointOp vAdjointOp, QubitValu
     auto rAdjointOp = qref::AdjointOp::create(builder, loc);
     builder.inlineRegionBefore(vAdjointOp.getRegion(), rAdjointOp.getRegion(),
                                rAdjointOp.getRegion().end());
-    handleRegion(builder, rAdjointOp.getRegion(), tracker);
+    handleRegion(builder, rAdjointOp.getRegion(), regionTracker);
     cascadeMapAhead(vAdjointOp, tracker);
     erasureWorklist.push_back(vAdjointOp);
 

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -42,16 +42,6 @@ using namespace catalyst;
 
 namespace {
 
-void eraseAllVOps(Region &r, SmallVector<Operation *> &erasureWorklist)
-{
-    if (isa<quantum::YieldOp>(r.front().getTerminator())) {
-        erasureWorklist.push_back(r.front().getTerminator());
-    }
-    for (auto op : llvm::reverse(erasureWorklist)) {
-        op->erase();
-    }
-}
-
 struct QubitValueTracker {
   public:
     QubitValueTracker() = default;
@@ -463,7 +453,12 @@ void handleRegion(IRRewriter &builder, Region &r, QubitValueTracker &tracker)
             .Default([](Operation *) {});
     });
 
-    eraseAllVOps(r, erasureWorklist);
+    if (isa<quantum::YieldOp>(r.front().getTerminator())) {
+        erasureWorklist.push_back(r.front().getTerminator());
+    }
+    for (auto op : llvm::reverse(erasureWorklist)) {
+        op->erase();
+    }
 }
 
 } // namespace

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -422,6 +422,9 @@ void handleAdjoint(IRRewriter &builder, quantum::AdjointOp vAdjointOp, QubitValu
 
 void handleRegion(IRRewriter &builder, Region &r, QubitValueTracker &tracker)
 {
+    assert(r.hasOneBlock() && "Expected region to have a single block");
+    assert(r.front().getTerminator() && "Expected region to have a terminator");
+
     SmallVector<Operation *> erasureWorklist;
     r.walk<WalkOrder::PreOrder>([&](Operation *op) {
         llvm::TypeSwitch<Operation *, void>(op)

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.h
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.h
@@ -1,0 +1,81 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Region.h"
+#include "mlir/IR/Value.h"
+
+#include "MBQC/IR/MBQCOps.h"
+#include "PBC/IR/PBCOps.h"
+#include "Quantum/IR/QuantumInterfaces.h"
+#include "Quantum/IR/QuantumOps.h"
+
+using namespace mlir;
+using namespace catalyst;
+
+namespace {
+
+struct QubitValueTracker;
+
+// The main converter function
+template <typename OpTy>
+OpTy migrateOpToReferenceSemantics(IRRewriter &builder, Operation *vOp, QubitValueTracker &tracker);
+
+// Individual handlers for each op
+void handleAlloc(IRRewriter &builder, quantum::AllocOp vAllocOp, QubitValueTracker &tracker,
+                 SmallVector<Operation *> &erasureWorklist);
+void handleDealloc(IRRewriter &builder, quantum::DeallocOp vDeallocOp, QubitValueTracker &tracker,
+                   SmallVector<Operation *> &erasureWorklist);
+void handleAllocQubit(IRRewriter &builder, quantum::AllocQubitOp vAllocQbOp,
+                      QubitValueTracker &tracker, SmallVector<Operation *> &erasureWorklist);
+void handleDeallocQubit(IRRewriter &builder, quantum::DeallocQubitOp vDeallocQbOp,
+                        QubitValueTracker &tracker, SmallVector<Operation *> &erasureWorklist);
+void handleExtract(IRRewriter &builder, quantum::ExtractOp vExtractOp, QubitValueTracker &tracker,
+                   SmallVector<Operation *> &erasureWorklist);
+void handleInsert(quantum::InsertOp vInsertOp, QubitValueTracker &tracker,
+                  SmallVector<Operation *> &erasureWorklist);
+void handleGate(IRRewriter &builder, quantum::QuantumOperation vGateOp, QubitValueTracker &tracker,
+                SmallVector<Operation *> &erasureWorklist);
+void handleMeasure(IRRewriter &builder, quantum::MeasureOp vMeasureOp, QubitValueTracker &tracker,
+                   SmallVector<Operation *> &erasureWorklist);
+void handleMeasureInBasis(IRRewriter &builder, mbqc::MeasureInBasisOp vMeasureInBasisOp,
+                          QubitValueTracker &tracker, SmallVector<Operation *> &erasureWorklist);
+void handlePPM(IRRewriter &builder, pbc::PPMeasurementOp vPPMOp, QubitValueTracker &tracker,
+               SmallVector<Operation *> &erasureWorklist);
+// void handleCall(IRRewriter &builder, func::CallOp callOp, QubitValueTracker &tracker);
+void handleCompbasis(IRRewriter &builder, quantum::ComputationalBasisOp vCompbasisOp,
+                     QubitValueTracker &tracker);
+void handleNamedObs(IRRewriter &builder, quantum::NamedObsOp vNamedObsOp,
+                    QubitValueTracker &tracker);
+void handleHermitian(IRRewriter &builder, quantum::HermitianOp vHermitianOp,
+                     QubitValueTracker &tracker);
+void handleGraphStatePrep(IRRewriter &builder, mbqc::GraphStatePrepOp vGraphStatePrepOp,
+                          QubitValueTracker &tracker, SmallVector<Operation *> &erasureWorklist);
+void handleAdjoint(IRRewriter &builder, quantum::AdjointOp vAdjointOp, QubitValueTracker &tracker,
+                   SmallVector<Operation *> &erasureWorklist);
+// void handleIf(IRRewriter &builder, scf::IfOp ifOp, QubitValueTracker &tracker);
+// void handleSwitch(IRRewriter &builder, scf::IndexSwitchOp switchOp, QubitValueTracker &tracker);
+// void handleFor(IRRewriter &builder, scf::ForOp forOp, QubitValueTracker &tracker);
+// void handleWhile(IRRewriter &builder, scf::WhileOp whileOp, QubitValueTracker &tracker);
+// void handleSubroutine(IRRewriter &builder, func::FuncOp f,
+//                       const SetVector<Value> &rValuesUsedBySubroutine);
+
+// Main driver
+void handleRegion(IRRewriter &builder, Region &r, QubitValueTracker &tracker);
+} // anonymous namespace

--- a/mlir/test/Quantum/SemanticsConversion/TestFlatCircuits.mlir
+++ b/mlir/test/Quantum/SemanticsConversion/TestFlatCircuits.mlir
@@ -652,7 +652,7 @@ func.func public @test_adjoint_with_allocation(%arg0: i64) attributes {quantum.n
     %5 = quantum.insert %1[ 1], %4 : !quantum.reg, !quantum.bit
     quantum.dealloc %5 : !quantum.reg
 
-    // CHECK: [[q43:%.+]] = qref.get %0[ 3] : !qref.reg<4> -> !qref.bit
+    // CHECK: [[q43:%.+]] = qref.get [[qreg4]][ 3] : !qref.reg<4> -> !qref.bit
     %6 = quantum.extract %2[ 3] : !quantum.reg -> !quantum.bit
 
     // CHECK: qref.adjoint {

--- a/mlir/test/Quantum/SemanticsConversion/TestFlatCircuits.mlir
+++ b/mlir/test/Quantum/SemanticsConversion/TestFlatCircuits.mlir
@@ -514,7 +514,7 @@ func.func @test_dynamic_wire_index(%arg0: i64) -> f64 attributes {quantum.node} 
 // -----
 
 
-// CHECK: test_alloc_qb
+// CHECK-LABEL: test_alloc_qb
 func.func @test_alloc_qb() attributes {quantum.node} {
     // CHECK: [[qubit:%.+]] = qref.alloc_qb : !qref.bit
     // CHECK: qref.custom "X"() [[qubit]] : !qref.bit
@@ -523,5 +523,164 @@ func.func @test_alloc_qb() attributes {quantum.node} {
     %0 = quantum.alloc_qb : !quantum.bit
     %out_qubits = quantum.custom "X"() %0 : !quantum.bit
     quantum.dealloc_qb %out_qubits : !quantum.bit
+    return
+}
+
+
+// -----
+
+
+// CHECK-LABEL: test_adjoint_op
+func.func @test_adjoint_op() attributes {quantum.node} {
+    // CHECK: [[qreg:%.+]] = qref.alloc( 2) : !qref.reg<2>
+    // CHECK: [[q0:%.+]] = qref.get [[qreg]][ 0] : !qref.reg<2> -> !qref.bit
+    // CHECK: [[q1:%.+]] = qref.get [[qreg]][ 1] : !qref.reg<2> -> !qref.bit
+    %0 = quantum.alloc( 2) : !quantum.reg
+    %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+    %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+
+    // CHECK: qref.custom "CNOT"() [[q0]], [[q1]] : !qref.bit, !qref.bit
+    %3:2 = quantum.custom "CNOT"() %1, %2 : !quantum.bit, !quantum.bit
+
+    // CHECK: qref.adjoint {
+    // CHECK-NOT: ^bb
+    // CHECK:    qref.custom "Hadamard"() [[q0]] : !qref.bit
+    // CHECK:    qref.custom "CNOT"() [[q0]], [[q1]] : !qref.bit, !qref.bit
+    %4:2 = quantum.adjoint(%3#0, %3#1) : !quantum.bit, !quantum.bit {
+    ^bb0(%arg0: !quantum.bit, %arg1: !quantum.bit):
+        %out_qubits = quantum.custom "Hadamard"() %arg0 : !quantum.bit
+        %out_qubits_0:2 = quantum.custom "CNOT"() %out_qubits, %arg1 : !quantum.bit, !quantum.bit
+
+        // CHECK-NOT: quantum.yield
+        quantum.yield %out_qubits_0#0, %out_qubits_0#1 : !quantum.bit, !quantum.bit
+    }
+
+    // CHECK: qref.custom "CNOT"() [[q0]], [[q1]] : !qref.bit, !qref.bit
+    // CHECK-NOT: quantum.insert
+    %5:2 = quantum.custom "CNOT"() %4#0, %4#1 : !quantum.bit, !quantum.bit
+    %6 = quantum.insert %0[ 0], %5#0 : !quantum.reg, !quantum.bit
+    %7 = quantum.insert %6[ 1], %5#1 : !quantum.reg, !quantum.bit
+
+    // CHECK: qref.dealloc [[qreg]] : !qref.reg<2>
+    quantum.dealloc %7 : !quantum.reg
+    return
+}
+
+
+// -----
+
+
+// CHECK-LABEL: test_adjoint_op_nested
+func.func @test_adjoint_op_nested() attributes {quantum.node} {
+    // CHECK: [[qreg:%.+]] = qref.alloc( 2) : !qref.reg<2>
+    // CHECK: [[q0:%.+]] = qref.get [[qreg]][ 0] : !qref.reg<2> -> !qref.bit
+    // CHECK: [[q1:%.+]] = qref.get [[qreg]][ 1] : !qref.reg<2> -> !qref.bit
+    %0 = quantum.alloc( 2) : !quantum.reg
+    %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+    %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+
+    // CHECK: qref.adjoint {
+    // CHECK-NOT: ^bb
+    %3:2 = quantum.adjoint(%1, %2) : !quantum.bit, !quantum.bit {
+    ^bb0(%arg0: !quantum.bit, %arg1: !quantum.bit):
+
+        // CHECK: qref.custom "Hadamard"() [[q0]] : !qref.bit
+        %out_qubits = quantum.custom "Hadamard"() %arg0 : !quantum.bit
+
+        // CHECK: qref.adjoint {
+        // CHECK-NOT: ^bb
+        %6:2 = quantum.adjoint(%out_qubits, %arg1) : !quantum.bit, !quantum.bit {
+        ^bb0(%arg2: !quantum.bit, %arg3: !quantum.bit):
+
+            // CHECK: qref.custom "CNOT"() [[q0]], [[q1]] : !qref.bit, !qref.bit
+            %out_qubits_1:2 = quantum.custom "CNOT"() %arg2, %arg3 : !quantum.bit, !quantum.bit
+
+            // CHECK-NOT: quantum.yield
+            quantum.yield %out_qubits_1#0, %out_qubits_1#1 : !quantum.bit, !quantum.bit
+        }
+
+        // CHECK: qref.custom "SWAP"() [[q0]], [[q1]] : !qref.bit, !qref.bit
+        %out_qubits_0:2 = quantum.custom "SWAP"() %6#0, %6#1 : !quantum.bit, !quantum.bit
+
+        // CHECK-NOT: quantum.yield
+        quantum.yield %out_qubits_0#0, %out_qubits_0#1 : !quantum.bit, !quantum.bit
+    }
+
+    %4 = quantum.insert %0[ 0], %3#0 : !quantum.reg, !quantum.bit
+    %5 = quantum.insert %4[ 1], %3#1 : !quantum.reg, !quantum.bit
+
+    // CHECK: qref.dealloc [[qreg]] : !qref.reg<2>
+    quantum.dealloc %5 : !quantum.reg
+    return
+}
+
+
+// -----
+
+
+// CHECK-LABEL: test_adjoint_with_allocation
+func.func public @test_adjoint_with_allocation(%arg0: i64) attributes {quantum.node} {
+    // CHECK: [[qreg4:%.+]] = qref.alloc( 4) : !qref.reg<4>
+    // CHECK: [[qreg2:%.+]] = qref.alloc( 2) : !qref.reg<2>
+    %0 = quantum.alloc( 4) : !quantum.reg
+    %1 = quantum.alloc( 2) : !quantum.reg
+
+    // CHECK: qref.adjoint {
+    // CHECK:   [[q4i:%.+]] = qref.get [[qreg4]][%arg0] : !qref.reg<4>, i64 -> !qref.bit
+    // CHECK:   qref.custom "PauliX"() [[q4i]] : !qref.bit
+    // CHECK: }
+    %2 = quantum.adjoint(%0) : !quantum.reg {
+    ^bb0(%arg1: !quantum.reg):
+        %9 = quantum.extract %arg1[%arg0] : !quantum.reg -> !quantum.bit
+        %out_qubits = quantum.custom "PauliX"() %9 : !quantum.bit
+        %10 = quantum.insert %arg1[%arg0], %out_qubits : !quantum.reg, !quantum.bit
+        quantum.yield %10 : !quantum.reg
+    }
+
+
+    // CHECK: [[q21:%.+]] = qref.get [[qreg2]][ 1] : !qref.reg<2> -> !qref.bit
+    // CHECK: qref.adjoint {
+    // CHECK:   qref.custom "PauliZ"() [[q21]] : !qref.bit
+    // CHECK: }
+    // CHECK: qref.dealloc [[qreg2]] : !qref.reg<2>
+    %3 = quantum.extract %1[ 1] : !quantum.reg -> !quantum.bit
+    %4 = quantum.adjoint(%3) : !quantum.bit {
+    ^bb0(%arg1: !quantum.bit):
+        %out_qubits = quantum.custom "PauliZ"() %arg1 : !quantum.bit
+        quantum.yield %out_qubits : !quantum.bit
+    }
+    %5 = quantum.insert %1[ 1], %4 : !quantum.reg, !quantum.bit
+    quantum.dealloc %5 : !quantum.reg
+
+    // CHECK: [[q43:%.+]] = qref.get %0[ 3] : !qref.reg<4> -> !qref.bit
+    %6 = quantum.extract %2[ 3] : !quantum.reg -> !quantum.bit
+
+    // CHECK: qref.adjoint {
+    %7 = quantum.adjoint(%6) : !quantum.bit {
+    ^bb0(%arg1: !quantum.bit):
+
+        // CHECK: [[qreg_inner:%.+]] = qref.alloc( 2) : !qref.reg<2>
+        // CHECK: [[q0_inner:%.+]] = qref.get [[qreg_inner]][ 0] : !qref.reg<2> -> !qref.bit
+        %9 = quantum.alloc( 2) : !quantum.reg
+        %10 = quantum.extract %9[ 0] : !quantum.reg -> !quantum.bit
+
+        // CHECK: qref.custom "PauliX"() [[q0_inner]] : !qref.bit
+        %out_qubits = quantum.custom "PauliX"() %10 : !quantum.bit
+        %11 = quantum.insert %9[ 0], %out_qubits : !quantum.reg, !quantum.bit
+
+        // CHECK: [[q1_inner:%.+]] = qref.get [[qreg_inner]][ 1] : !qref.reg<2> -> !qref.bit
+        // CHECK: qref.custom "CNOT"() [[q43]], [[q1_inner]] : !qref.bit, !qref.bit
+        %12 = quantum.extract %11[ 1] : !quantum.reg -> !quantum.bit
+        %out_qubits_0:2 = quantum.custom "CNOT"() %arg1, %12 : !quantum.bit, !quantum.bit
+        %13 = quantum.insert %11[ 1], %out_qubits_0#1 : !quantum.reg, !quantum.bit
+
+        // CHECK: qref.dealloc [[qreg_inner]] : !qref.reg<2>
+        quantum.dealloc %13 : !quantum.reg
+        quantum.yield %out_qubits_0#0 : !quantum.bit
+    }
+    %8 = quantum.insert %2[ 3], %7 : !quantum.reg, !quantum.bit
+
+    // CHECK: qref.dealloc [[qreg4]] : !qref.reg<4>
+    quantum.dealloc %8 : !quantum.reg
     return
 }


### PR DESCRIPTION
**Context:**
Add adjoint ops to `--convert-to-reference-semantics`.

[sc-105534]