### PR TITLE
Add `qref.operator` to Catalyst [Operator2 work]

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -266,9 +266,10 @@
   dialect. They are now accessible as `mbqc.ref.measure_in_basis` and `mbqc.ref.graph_state_prep`.
   [(#2829)](https://github.com/PennyLaneAI/catalyst/pull/2829)
 
-* A new operation has been added to the Quantum dialect to represent generic and high-level
+* A new operation has been added to the Quantum dialects to represent generic and high-level
   quantum operators, including operators with frontend-end specific data.
   [(#2883)](https://github.com/PennyLaneAI/catalyst/pull/2883)
+  [(#2943)](https://github.com/PennyLaneAI/catalyst/pull/2943)
 
 * In order to support T gates and π/8 PPRs in the experimental QEC pipeline, the following new
   operations have been added:

--- a/mlir/include/QRef/IR/QRefOps.td
+++ b/mlir/include/QRef/IR/QRefOps.td
@@ -334,6 +334,160 @@ def CustomOp : UnitaryGate_Op<"custom", [ParametrizedGate, AttrSizedOperandSegme
     let hasVerifier = 1;
 }
 
+def OperatorOp : UnitaryGate_Op<"operator", [ParametrizedGate, NoMemoryEffect,
+                                             AttrSizedOperandSegments, AttrSizedResultSegments]> {
+    let summary = "A generalized quantum operation with arbitrary input signature.";
+    let description = [{
+        The `quantum.operator` is a generic representation for arbitrary quantum operations
+        that cannot be expressed by the simpler `quantum.custom` op and don't have a dedicated
+        operation.
+        Its purpose is to represent high-level operations from frontend languages such as
+        PennyLane — in particular templates and operators parametrized by Python (or
+        frontend-language) data. The signature allows for an arbitrary number of dynamic data
+        arguments (of arbitrary MLIR type), as well as limited static data (e.g. Pauli-word
+        strings). Frontend-level data arguments are compressed into a unique identifier, since
+        in general they may not be lowerable to MLIR.
+
+        The operation has two mutually exclusive representations:
+
+        * **Qubit mode** (`in_qubits` / `out_qubits`):
+          Use this when the operator acts on a statically known set of wires. Qubits are
+          threaded through the op explicitly and can carry per-control values through
+          `in_ctrl_qubits` / `in_ctrl_values` (with matching `out_ctrl_qubits`).
+
+        * **Register mode** (`in_qreg` / `out_qreg` + index arrays):
+          Use this when the operator acts on a dynamic number of wires. The operation receives
+          one register and one or more index arrays selecting which qubits in that register
+          are targeted. Controls are expressed with matching control index/value arrays.
+
+        Besides one of the above, the operator can hold the following information:
+
+        * `op_name` — canonical operator name
+        * Operator inputs in one of several forms:
+          * `params` — dynamic operator inputs
+          * `static_data` — static inputs available to compiler passes
+          * `UID` — non-lowerable static inputs compressed into a unique ID; It can be used for
+                    equivalence checking but not much else. The decomposition rule functions
+                    (if provided) will reference the UID they were generated with.
+          * `forward_args` — dynamic inputs of operators that were themselves input to this
+                             operator; Can only be present if `UID` is also present. Usually
+                             just forwarded to decomposition functions after the params list.
+        * Optional frontend-level metadata:
+          * `param_map` — maps frontend argument names to the lowered `params` operand positions
+          * `qubit_map` — maps frontend argument names to lowered qubit/index-array positions
+
+        Examples:
+
+        A complex operator with one compilable static argument and an `adjoint`
+        modifier acting on a single qubit:
+
+        ```mlir
+        %out = quantum.operator "MyOp"(%theta: f64) adj qubits(%q)
+            static_data = {pauli_word = "XYZ", greedy = true}
+        ```
+
+        An operator with two qubit-mode controls:
+
+        ```mlir
+        %oq, %ocq:2 = quantum.operator "MyOp"() qubits(%q)
+            ctrls(%cq0, %cq1) ctrl_vals(%cv0, %cv1)
+        ```
+
+        An operator acting on a dynamic number of qubits, expressed in register mode,
+        with explicit name-to-position maps for its parameters and wire arguments:
+
+        ```mlir
+        %out_qreg = quantum.operator "MyOp"(%state: tensor<?xcomplex<f64>>)
+            quregs(%qreg) indices(%w0: tensor<?xi64>, %w1: tensor<1xi64>)
+            param_map = {state_vector = [0]}
+            qubit_map = {wires = [0], precision_wire = [1]}
+        ```
+
+        An operator carrying frontend-level data (summarized by `UID`), together with
+        extra dynamic data forwarded into those rules via `forward(...)`:
+
+        ```mlir
+        %out:3 = quantum.operator "MyOp"(%state: tensor<8xcomplex<f64>>) qubits(%q0, %q1, %q2)
+            UID(324958) forward(%phi: f64, %delta: f64)
+        ```
+    }];
+
+    let arguments = (ins
+        StringProp:$op_name,
+        Variadic<AnyType>:$params,
+        Variadic<AnyType>:$forward_args,
+
+        // traditional qubit specification
+        Variadic<QubitType>:$in_qubits,
+        Variadic<QubitType>:$in_ctrl_qubits,
+        Variadic<I1>:$in_ctrl_values,
+
+        // alternative spec for acting on a dynamic number of qubits
+        Optional<QuregType>:$in_qreg,
+        Variadic<1DTensorOf<[I64]>>:$arr_qubit_indices,
+        Optional<1DTensorOf<[I64]>>:$arr_ctrl_indices,
+        Optional<1DTensorOf<[I1]>>:$arr_ctrl_values,
+
+        // additional functionality provided by quantum.operator, being last allows the builder
+        // to use default values in the signature, so that these args are truly optional
+        UnitProp:$adjoint,
+        OptionalProp<I64Prop>:$UID,
+        DefaultValuedOptionalAttr<DictionaryAttr, "{}">:$static_data,
+        DefaultValuedOptionalAttr<I64ArrayDictAttr, "{}">:$param_map,
+        DefaultValuedOptionalAttr<I64ArrayDictAttr, "{}">:$qubit_map
+    );
+
+    let results = (outs
+        Variadic<QubitType>:$out_qubits,
+        Variadic<QubitType>:$out_ctrl_qubits,
+        Optional<QuregType>:$out_qreg
+    );
+
+    let extraClassDeclaration = extraBaseClassDeclaration # [{
+        mlir::ValueRange getAllParams() {
+            // the ODS operands must be next to each other
+            auto [start, lenParams] = getODSOperandIndexAndLength(/*params=*/1);
+            auto [_, lenForwardArgs] = getODSOperandIndexAndLength(/*forward_args=*/2);
+            return getOperands().slice(start, lenParams + lenForwardArgs);
+        }
+    }];
+
+    let hasVerifier = 1;
+    let hasCustomAssemblyFormat = 1;
+
+    let builders = [
+        // qubit mode
+        OpBuilder<(ins
+            "llvm::StringRef":$op_name,
+            "mlir::ValueRange":$params,
+            "mlir::ValueRange":$in_qubits,
+            CArg<"mlir::ValueRange", "{}">:$in_ctrl_qubits,
+            CArg<"mlir::ValueRange", "{}">:$in_ctrl_values,
+            CArg<"mlir::ValueRange", "{}">:$forward_args,
+            CArg<"bool", "false">:$adjoint,
+            CArg<"std::optional<int64_t>", "std::nullopt">:$UID,
+            CArg<"mlir::DictionaryAttr", "nullptr">:$static_data,
+            CArg<"mlir::DictionaryAttr", "nullptr">:$param_map,
+            CArg<"mlir::DictionaryAttr", "nullptr">:$qubit_map
+        )>,
+        // qureg mode
+        OpBuilder<(ins
+            "llvm::StringRef":$op_name,
+            "mlir::ValueRange":$params,
+            "mlir::Value":$in_qreg,
+            "mlir::ValueRange":$arr_qubit_indices,
+            CArg<"mlir::Value", "mlir::Value()">:$arr_ctrl_indices,
+            CArg<"mlir::Value", "mlir::Value()">:$arr_ctrl_values,
+            CArg<"mlir::ValueRange", "{}">:$forward_args,
+            CArg<"bool", "false">:$adjoint,
+            CArg<"std::optional<int64_t>", "std::nullopt">:$UID,
+            CArg<"mlir::DictionaryAttr", "nullptr">:$static_data,
+            CArg<"mlir::DictionaryAttr", "nullptr">:$param_map,
+            CArg<"mlir::DictionaryAttr", "nullptr">:$qubit_map
+        )>
+    ];
+}
+
 def PauliRotOp : UnitaryGate_Op<"paulirot", [ParametrizedGate, AttrSizedOperandSegments]> {
     let summary = "Apply a Pauli Product Rotation";
     let description = [{

--- a/mlir/include/QRef/IR/QRefOps.td
+++ b/mlir/include/QRef/IR/QRefOps.td
@@ -381,7 +381,7 @@ def OperatorOp : UnitaryGate_Op<"operator", [ParametrizedGate, AttrSizedOperandS
         modifier acting on a single qubit:
 
         ```mlir
-        %out = qref.operator "MyOp"(%theta: f64) adj qubits(%q)
+        qref.operator "MyOp"(%theta: f64) adj qubits(%q)
             static_data = {pauli_word = "XYZ", greedy = true}
         ```
 

--- a/mlir/include/QRef/IR/QRefOps.td
+++ b/mlir/include/QRef/IR/QRefOps.td
@@ -453,9 +453,9 @@ def OperatorOp : UnitaryGate_Op<"operator", [ParametrizedGate, AttrSizedOperandS
         OpBuilder<(ins
             "llvm::StringRef":$op_name,
             "mlir::ValueRange":$params,
-            "mlir::ValueRange":$in_qubits,
-            CArg<"mlir::ValueRange", "{}">:$in_ctrl_qubits,
-            CArg<"mlir::ValueRange", "{}">:$in_ctrl_values,
+            "mlir::ValueRange":$qubits,
+            CArg<"mlir::ValueRange", "{}">:$ctrl_qubits,
+            CArg<"mlir::ValueRange", "{}">:$ctrl_values,
             CArg<"mlir::ValueRange", "{}">:$forward_args,
             CArg<"bool", "false">:$adjoint,
             CArg<"std::optional<int64_t>", "std::nullopt">:$UID,
@@ -467,7 +467,7 @@ def OperatorOp : UnitaryGate_Op<"operator", [ParametrizedGate, AttrSizedOperandS
         OpBuilder<(ins
             "llvm::StringRef":$op_name,
             "mlir::ValueRange":$params,
-            "mlir::Value":$in_qreg,
+            "mlir::Value":$qreg,
             "mlir::ValueRange":$arr_qubit_indices,
             CArg<"mlir::Value", "mlir::Value()">:$arr_ctrl_indices,
             CArg<"mlir::Value", "mlir::Value()">:$arr_ctrl_values,

--- a/mlir/include/QRef/IR/QRefOps.td
+++ b/mlir/include/QRef/IR/QRefOps.td
@@ -334,12 +334,11 @@ def CustomOp : UnitaryGate_Op<"custom", [ParametrizedGate, AttrSizedOperandSegme
     let hasVerifier = 1;
 }
 
-def OperatorOp : UnitaryGate_Op<"operator", [ParametrizedGate, NoMemoryEffect,
-                                             AttrSizedOperandSegments, AttrSizedResultSegments]> {
+def OperatorOp : UnitaryGate_Op<"operator", [ParametrizedGate, AttrSizedOperandSegments]> {
     let summary = "A generalized quantum operation with arbitrary input signature.";
     let description = [{
-        The `quantum.operator` is a generic representation for arbitrary quantum operations
-        that cannot be expressed by the simpler `quantum.custom` op and don't have a dedicated
+        The `qref.operator` is a generic representation for arbitrary quantum operations
+        that cannot be expressed by the simpler `qref.custom` op and don't have a dedicated
         operation.
         Its purpose is to represent high-level operations from frontend languages such as
         PennyLane — in particular templates and operators parametrized by Python (or
@@ -350,12 +349,12 @@ def OperatorOp : UnitaryGate_Op<"operator", [ParametrizedGate, NoMemoryEffect,
 
         The operation has two mutually exclusive representations:
 
-        * **Qubit mode** (`in_qubits` / `out_qubits`):
+        * **Qubit mode** (`qubits`):
           Use this when the operator acts on a statically known set of wires. Qubits are
           threaded through the op explicitly and can carry per-control values through
-          `in_ctrl_qubits` / `in_ctrl_values` (with matching `out_ctrl_qubits`).
+          `ctrl_qubits` / `ctrl_values`.
 
-        * **Register mode** (`in_qreg` / `out_qreg` + index arrays):
+        * **Register mode** (`qreg` / `qreg` + index arrays):
           Use this when the operator acts on a dynamic number of wires. The operation receives
           one register and one or more index arrays selecting which qubits in that register
           are targeted. Controls are expressed with matching control index/value arrays.
@@ -382,14 +381,14 @@ def OperatorOp : UnitaryGate_Op<"operator", [ParametrizedGate, NoMemoryEffect,
         modifier acting on a single qubit:
 
         ```mlir
-        %out = quantum.operator "MyOp"(%theta: f64) adj qubits(%q)
+        %out = qref.operator "MyOp"(%theta: f64) adj qubits(%q)
             static_data = {pauli_word = "XYZ", greedy = true}
         ```
 
         An operator with two qubit-mode controls:
 
         ```mlir
-        %oq, %ocq:2 = quantum.operator "MyOp"() qubits(%q)
+        qref.operator "MyOp"() qubits(%q)
             ctrls(%cq0, %cq1) ctrl_vals(%cv0, %cv1)
         ```
 
@@ -397,7 +396,7 @@ def OperatorOp : UnitaryGate_Op<"operator", [ParametrizedGate, NoMemoryEffect,
         with explicit name-to-position maps for its parameters and wire arguments:
 
         ```mlir
-        %out_qreg = quantum.operator "MyOp"(%state: tensor<?xcomplex<f64>>)
+        qref.operator "MyOp"(%state: tensor<?xcomplex<f64>>)
             quregs(%qreg) indices(%w0: tensor<?xi64>, %w1: tensor<1xi64>)
             param_map = {state_vector = [0]}
             qubit_map = {wires = [0], precision_wire = [1]}
@@ -407,7 +406,7 @@ def OperatorOp : UnitaryGate_Op<"operator", [ParametrizedGate, NoMemoryEffect,
         extra dynamic data forwarded into those rules via `forward(...)`:
 
         ```mlir
-        %out:3 = quantum.operator "MyOp"(%state: tensor<8xcomplex<f64>>) qubits(%q0, %q1, %q2)
+        qref.operator "MyOp"(%state: tensor<8xcomplex<f64>>) qubits(%q0, %q1, %q2)
             UID(324958) forward(%phi: f64, %delta: f64)
         ```
     }];
@@ -418,12 +417,12 @@ def OperatorOp : UnitaryGate_Op<"operator", [ParametrizedGate, NoMemoryEffect,
         Variadic<AnyType>:$forward_args,
 
         // traditional qubit specification
-        Variadic<QubitType>:$in_qubits,
-        Variadic<QubitType>:$in_ctrl_qubits,
-        Variadic<I1>:$in_ctrl_values,
+        Variadic<QubitRefType>:$qubits,
+        Variadic<QubitRefType>:$ctrl_qubits,
+        Variadic<I1>:$ctrl_values,
 
         // alternative spec for acting on a dynamic number of qubits
-        Optional<QuregType>:$in_qreg,
+        Optional<QuregRefType>:$qreg,
         Variadic<1DTensorOf<[I64]>>:$arr_qubit_indices,
         Optional<1DTensorOf<[I64]>>:$arr_ctrl_indices,
         Optional<1DTensorOf<[I1]>>:$arr_ctrl_values,
@@ -435,12 +434,6 @@ def OperatorOp : UnitaryGate_Op<"operator", [ParametrizedGate, NoMemoryEffect,
         DefaultValuedOptionalAttr<DictionaryAttr, "{}">:$static_data,
         DefaultValuedOptionalAttr<I64ArrayDictAttr, "{}">:$param_map,
         DefaultValuedOptionalAttr<I64ArrayDictAttr, "{}">:$qubit_map
-    );
-
-    let results = (outs
-        Variadic<QubitType>:$out_qubits,
-        Variadic<QubitType>:$out_ctrl_qubits,
-        Optional<QuregType>:$out_qreg
     );
 
     let extraClassDeclaration = extraBaseClassDeclaration # [{

--- a/mlir/include/Quantum/IR/QuantumAttrDefs.td
+++ b/mlir/include/Quantum/IR/QuantumAttrDefs.td
@@ -52,9 +52,4 @@ class DictValuesOfType<string attrCppType> : AttrConstraint<
 
 def I64ArrayDictAttr : ConfinedAttr<DictionaryAttr, [DictValuesOfType<"DenseI64ArrayAttr">]>;
 
-def FunctionRefArrayAttr : TypedArrayAttrBase<FlatSymbolRefAttr,
-                                              "FlatSymbolRefArrayAttr with const builder"> {
-    let constBuilderCall = "$_builder.getArrayAttr($0)";
-}
-
 #endif // QUANTUM_ATTR_DEFS

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -17,9 +17,7 @@
 
 include "mlir/IR/OpBase.td"
 include "mlir/Dialect/Bufferization/IR/AllocationOpInterface.td"
-include "mlir/Interfaces/CallInterfaces.td"
 include "mlir/Interfaces/ControlFlowInterfaces.td"
-include "mlir/IR/SymbolInterfaces.td"
 
 include "Quantum/IR/QuantumAttrDefs.td"
 include "Quantum/IR/QuantumDialect.td"

--- a/mlir/lib/QRef/IR/QRefOps.cpp
+++ b/mlir/lib/QRef/IR/QRefOps.cpp
@@ -224,6 +224,107 @@ LogicalResult CustomOp::verify()
     return success();
 }
 
+LogicalResult OperatorOp::verify()
+{
+    const bool hasQregInput = static_cast<bool>(getInQreg());
+    const bool hasQregOutput = static_cast<bool>(getOutQreg());
+    const bool hasQregMode = hasQregInput || hasQregOutput;
+
+    const bool hasQubitInput = !getInQubits().empty();
+    const bool hasQubitOutput = !getOutQubits().empty();
+    const bool hasQubitMode = hasQubitInput || hasQubitOutput;
+
+    // Exactly one mode must be used: explicit qubits or qreg-based addressing.
+    if (hasQregMode == hasQubitMode) {
+        return emitOpError() << "must use either qubits or registers, but not both";
+    }
+
+    if (hasQregInput != hasQregOutput) {
+        return emitOpError() << "in_qreg and out_qreg must either both be present or absent";
+    }
+
+    if (!getForwardArgs().empty() && !getUID()) {
+        return emitOpError() << "forward_args can only be present when UID is provided";
+    }
+
+    const bool hasQubitControls =
+        !getInCtrlQubits().empty() || !getInCtrlValues().empty() || !getOutCtrlQubits().empty();
+    const bool hasQregControls =
+        static_cast<bool>(getArrCtrlIndices()) || static_cast<bool>(getArrCtrlValues());
+
+    if (hasQubitControls && hasQregControls) {
+        return emitOpError()
+               << "cannot mix qubit controls (in_ctrl_qubits/in_ctrl_values/out_ctrl_qubits) "
+               << "with register controls (arr_ctrl_indices/arr_ctrl_values)";
+    }
+
+    if (static_cast<bool>(getArrCtrlIndices()) != static_cast<bool>(getArrCtrlValues())) {
+        return emitOpError()
+               << "arr_ctrl_indices and arr_ctrl_values must either both be present or both absent";
+    }
+
+    if (hasQregControls) {
+        auto ctrlIndType = cast<ShapedType>(getArrCtrlIndices().getType());
+        auto ctrlValType = cast<ShapedType>(getArrCtrlValues().getType());
+        if (ctrlIndType.getShape()[0] != ctrlValType.getShape()[0]) {
+            return emitOpError() << "number of input control qubits (" << ctrlIndType.getShape()[0]
+                                 << ") and control values (" << ctrlValType.getShape()[0]
+                                 << ") must be the same";
+        }
+    }
+
+    if (getParamMapAttr()) {
+        const size_t numParams = getParams().size();
+        std::vector<bool> coveredParams(numParams, false);
+        size_t coveredCount = 0;
+        for (NamedAttribute namedAttr : getParamMap()) {
+            auto denseArray = cast<DenseI64ArrayAttr>(namedAttr.getValue());
+            for (int64_t idx : denseArray.asArrayRef()) {
+                if (idx < 0 || idx >= static_cast<int64_t>(numParams)) {
+                    return emitOpError() << "param_map index is out of bounds with respect to "
+                                            "params: "
+                                         << idx << " is not in [0, " << numParams << ")";
+                }
+                if (!coveredParams[static_cast<size_t>(idx)]) {
+                    coveredParams[static_cast<size_t>(idx)] = true;
+                    ++coveredCount;
+                }
+            }
+        }
+        if (coveredCount != numParams) {
+            return emitOpError() << "param_map must cover all params when provided: expected "
+                                 << numParams << ", got " << coveredCount;
+        }
+    }
+
+    auto qubitMap = getQubitMap();
+    if (qubitMap) {
+        const size_t numTargets = hasQregMode ? getArrQubitIndices().size() : getInQubits().size();
+        const char *boundsNoun = hasQregMode ? "index arrays" : "qubits";
+        const char *coverageNoun =
+            hasQregMode ? "index arrays in register mode" : "qubit values in qubit mode";
+
+        llvm::SmallDenseSet<int64_t> coveredTargets;
+        for (NamedAttribute namedAttr : qubitMap) {
+            auto denseArray = cast<DenseI64ArrayAttr>(namedAttr.getValue());
+            for (int64_t idx : denseArray.asArrayRef()) {
+                if (idx < 0 || idx >= static_cast<int64_t>(numTargets)) {
+                    return emitOpError()
+                           << "qubit_map index is out of bounds with respect to " << boundsNoun
+                           << ": " << idx << " is not in [0, " << numTargets << ")";
+                }
+                coveredTargets.insert(idx);
+            }
+        }
+        if (getQubitMapAttr() && coveredTargets.size() != numTargets) {
+            return emitOpError() << "qubit_map must cover all " << coverageNoun << ": expected "
+                                 << numTargets << ", got " << coveredTargets.size();
+        }
+    }
+
+    return success();
+}
+
 LogicalResult PauliRotOp::verify()
 {
     size_t pauliWordLength = getPauliProduct().size();
@@ -289,4 +390,468 @@ LogicalResult HermitianOp::verify()
 
     return success();
 }
+
+//===----------------------------------------------------------------------===//
+// Quantum op builders.
+//===----------------------------------------------------------------------===//
+
+void OperatorOp::build(OpBuilder &odsBuilder, OperationState &odsState, llvm::StringRef op_name,
+                       ValueRange params, ValueRange in_qubits, ValueRange in_ctrl_qubits,
+                       ValueRange in_ctrl_values, ValueRange forward_args, bool adjoint,
+                       std::optional<int64_t> UID, DictionaryAttr static_data,
+                       DictionaryAttr param_map, DictionaryAttr qubit_map)
+{
+    SmallVector<Type> resultTypes;
+    TypeRange qubitTypes = TypeRange(in_qubits);
+    TypeRange ctrlQubitTypes = TypeRange(in_ctrl_qubits);
+    resultTypes.append(qubitTypes.begin(), qubitTypes.end());
+    resultTypes.append(ctrlQubitTypes.begin(), ctrlQubitTypes.end());
+
+    build(odsBuilder, odsState,
+          /*resultTypes=*/resultTypes,
+          /*op_name=*/op_name,
+          /*params=*/params,
+          /*forward_args=*/forward_args,
+          /*in_qubits=*/in_qubits,
+          /*in_ctrl_qubits=*/in_ctrl_qubits,
+          /*in_ctrl_values=*/in_ctrl_values,
+          /*in_qreg=*/Value(),
+          /*arr_qubit_indices=*/ValueRange(),
+          /*arr_ctrl_indices=*/Value(),
+          /*arr_ctrl_values=*/Value(),
+          /*adjoint=*/adjoint,
+          /*UID=*/UID,
+          /*static_data=*/static_data,
+          /*param_map=*/param_map,
+          /*qubit_map=*/qubit_map);
+}
+
+void OperatorOp::build(OpBuilder &odsBuilder, OperationState &odsState, llvm::StringRef op_name,
+                       ValueRange params, Value in_qreg, ValueRange arr_qubit_indices,
+                       Value arr_ctrl_indices, Value arr_ctrl_values, ValueRange forward_args,
+                       bool adjoint, std::optional<int64_t> UID, DictionaryAttr static_data,
+                       DictionaryAttr param_map, DictionaryAttr qubit_map)
+{
+    SmallVector<Type> resultTypes = {in_qreg.getType()};
+
+    build(odsBuilder, odsState,
+          /*resultTypes=*/resultTypes,
+          /*op_name=*/op_name,
+          /*params=*/params,
+          /*forward_args=*/forward_args,
+          /*in_qubits=*/ValueRange(),
+          /*in_ctrl_qubits=*/ValueRange(),
+          /*in_ctrl_values=*/ValueRange(),
+          /*in_qreg=*/in_qreg,
+          /*arr_qubit_indices=*/arr_qubit_indices,
+          /*arr_ctrl_indices=*/arr_ctrl_indices,
+          /*arr_ctrl_values=*/arr_ctrl_values,
+          /*adjoint=*/adjoint,
+          /*UID=*/UID,
+          /*static_data=*/static_data,
+          /*param_map=*/param_map,
+          /*qubit_map=*/qubit_map);
+}
+
+//===----------------------------------------------------------------------===//
+// Quantum op printers/parsers.
+//===----------------------------------------------------------------------===//
+
+static void printDenseI64ArrayAsList(OpAsmPrinter &p, DenseI64ArrayAttr attr)
+{
+    p << "[";
+    llvm::interleaveComma(attr.asArrayRef(), p, [&](int64_t value) { p << value; });
+    p << "]";
+}
+
+static void printDictionaryWithDenseI64Lists(OpAsmPrinter &p, DictionaryAttr dict)
+{
+    p << "{";
+    llvm::interleaveComma(dict, p, [&](NamedAttribute namedAttr) {
+        p.printKeywordOrString(namedAttr.getName().strref());
+        p << " = ";
+        if (auto denseArray = dyn_cast<DenseI64ArrayAttr>(namedAttr.getValue())) {
+            printDenseI64ArrayAsList(p, denseArray);
+        }
+        else {
+            p << namedAttr.getValue();
+        }
+    });
+    p << "}";
+}
+
+void OperatorOp::print(OpAsmPrinter &p)
+{
+    // 1. Template Name
+    p << " \"" << getOpName() << "\"";
+
+    // 2. Variadic Inputs: (%arg0 : type, ...)
+    p << "(";
+    llvm::interleaveComma(llvm::zip(getParams(), getParams().getTypes()), p,
+                          [&](auto pair) { p << std::get<0>(pair) << ": " << std::get<1>(pair); });
+    p << ")";
+
+    // 3. Adjoint
+    if (getAdjoint()) {
+        p << " adj";
+    }
+
+    // 4. Qubits
+    if (!getInQubits().empty()) {
+        p << " qubits(" << getInQubits() << ")";
+    }
+
+    // 5. Attribute Dictionary
+    SmallVector<StringRef> elidedAttrs = {"static_data", "param_map", "qubit_map",
+                                          "operandSegmentSizes", "resultSegmentSizes"};
+    p.printOptionalAttrDict(getOperation()->getAttrs(), elidedAttrs);
+
+    p.increaseIndent();
+
+    // 6. Python-only data
+    if (getUID()) {
+        p.printNewline();
+        p << "UID(" << *getUID() << ")";
+        if (!getForwardArgs().empty()) {
+            p << " forward(";
+            llvm::interleaveComma(
+                llvm::zip(getForwardArgs(), getForwardArgs().getTypes()), p,
+                [&](auto pair) { p << std::get<0>(pair) << ": " << std::get<1>(pair); });
+            p << ")";
+        }
+    }
+
+    // 7. Quantum register
+    if (getInQreg()) {
+        p.printNewline();
+        p << "quregs(" << getInQreg() << ") indices(";
+        llvm::interleaveComma(
+            llvm::zip(getArrQubitIndices(), getArrQubitIndices().getTypes()), p,
+            [&](auto pair) { p << std::get<0>(pair) << ": " << std::get<1>(pair); });
+        p << ")";
+    }
+
+    // 8. Control qubits
+    if (!getInCtrlQubits().empty()) {
+        p.printNewline();
+        p << "ctrls(" << getInCtrlQubits() << ") ";
+        p << "ctrl_vals(" << getInCtrlValues() << ")";
+    }
+    else if (getArrCtrlIndices()) {
+        p.printNewline();
+        p << "ctrls(" << getArrCtrlIndices() << ": " << getArrCtrlIndices().getType() << ") ";
+        p << "ctrl_vals(" << getArrCtrlValues() << ": " << getArrCtrlValues().getType() << ")";
+    }
+
+    // 9. Compilable static data
+    if (getStaticDataAttr()) {
+        p.printNewline();
+        p << "static_data = " << getStaticData();
+    }
+
+    // 10. Optional metadata
+    if (getParamMapAttr() || getQubitMapAttr()) {
+        p.printNewline();
+    }
+    if (getParamMapAttr()) {
+        p << "param_map = ";
+        printDictionaryWithDenseI64Lists(p, getParamMap());
+    }
+    if (getParamMapAttr() && getQubitMapAttr()) {
+        p << " ";
+    }
+    if (getQubitMapAttr()) {
+        p << "qubit_map = ";
+        printDictionaryWithDenseI64Lists(p, getQubitMap());
+    }
+
+    p.decreaseIndent();
+}
+
+static ParseResult parseOperandTypePair(OpAsmParser &parser,
+                                        OpAsmParser::UnresolvedOperand &operand, Type &type)
+{
+    return failure(parser.parseOperand(operand) || parser.parseColon() || parser.parseType(type));
+}
+
+static ParseResult parseDenseI64ArrayDictionary(OpAsmParser &parser, Builder &builder,
+                                                DictionaryAttr &dict)
+{
+    NamedAttrList attrs;
+    auto parseDictEntry = [&]() -> ParseResult {
+        StringRef key;
+        SmallVector<int64_t> values;
+        auto parseArrayValue = [&]() -> ParseResult {
+            int64_t value = 0;
+            if (parser.parseInteger(value)) {
+                return failure();
+            }
+            values.push_back(value);
+            return success();
+        };
+
+        if (parser.parseKeyword(&key) || parser.parseEqual() ||
+            parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Square, parseArrayValue)) {
+            return failure();
+        }
+        attrs.append(builder.getStringAttr(key), builder.getDenseI64ArrayAttr(values));
+        return success();
+    };
+
+    if (parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Braces, parseDictEntry)) {
+        return failure();
+    }
+    dict = attrs.getDictionary(parser.getContext());
+    return success();
+}
+
+ParseResult OperatorOp::parse(OpAsmParser &parser, OperationState &result)
+{
+    Builder &builder = parser.getBuilder();
+    MLIRContext *ctx = parser.getContext();
+
+    // 1. Parse operation name string: "foo"
+    std::string opName;
+    if (parser.parseString(&opName)) {
+        return failure();
+    }
+    auto &opProperties = result.getOrAddProperties<OperatorOp::Properties>();
+    opProperties.setOpName(opName);
+
+    // 2. Parse variadic params: (%arg0: type, ...)
+    SmallVector<OpAsmParser::UnresolvedOperand> params;
+    SmallVector<Type> paramTypes;
+    auto parseParamAndType = [&]() -> ParseResult {
+        OpAsmParser::UnresolvedOperand operand;
+        Type type;
+        if (parseOperandTypePair(parser, operand, type)) {
+            return failure();
+        }
+        params.push_back(operand);
+        paramTypes.push_back(type);
+        return success();
+    };
+    if (parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Paren, parseParamAndType)) {
+        return failure();
+    }
+
+    // 3. Optional adjoint marker.
+    if (succeeded(parser.parseOptionalKeyword("adj"))) {
+        opProperties.setAdjoint(true);
+    }
+
+    SmallVector<OpAsmParser::UnresolvedOperand> inQubits;
+    SmallVector<OpAsmParser::UnresolvedOperand> forwardArgs;
+    SmallVector<Type> forwardArgTypes;
+    SmallVector<OpAsmParser::UnresolvedOperand> inCtrlQubits;
+    SmallVector<OpAsmParser::UnresolvedOperand> inCtrlValues;
+    std::optional<OpAsmParser::UnresolvedOperand> inQreg;
+    SmallVector<OpAsmParser::UnresolvedOperand> arrQubitIndices;
+    SmallVector<Type> arrQubitIndexTypes;
+    std::optional<OpAsmParser::UnresolvedOperand> arrCtrlIndices;
+    std::optional<Type> arrCtrlIndicesType;
+    std::optional<OpAsmParser::UnresolvedOperand> arrCtrlValues;
+    std::optional<Type> arrCtrlValuesType;
+
+    // 4. Optional qubit section.
+    if (succeeded(parser.parseOptionalKeyword("qubits"))) {
+        auto parseQubitOperand = [&]() -> ParseResult {
+            OpAsmParser::UnresolvedOperand operand;
+            if (parser.parseOperand(operand)) {
+                return failure();
+            }
+            inQubits.push_back(operand);
+            return success();
+        };
+        if (parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Paren, parseQubitOperand)) {
+            return failure();
+        }
+    }
+
+    // 5. Parse optional generic attr-dict that printer emits before trailing sections.
+    NamedAttrList genericAttrs;
+    if (parser.parseOptionalAttrDict(genericAttrs)) {
+        return failure();
+    }
+    result.addAttributes(genericAttrs);
+
+    // 6. Optional Python-only metadata: UID(...) [forward(...)].
+    if (succeeded(parser.parseOptionalKeyword("UID"))) {
+        int64_t uid = 0;
+        if (parser.parseLParen() || parser.parseInteger(uid) || parser.parseRParen()) {
+            return failure();
+        }
+        opProperties.setUID(uid);
+
+        if (succeeded(parser.parseOptionalKeyword("forward"))) {
+            auto parseForwardArgAndType = [&]() -> ParseResult {
+                OpAsmParser::UnresolvedOperand operand;
+                Type type;
+                if (parseOperandTypePair(parser, operand, type)) {
+                    return failure();
+                }
+                forwardArgs.push_back(operand);
+                forwardArgTypes.push_back(type);
+                return success();
+            };
+            if (parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Paren,
+                                               parseForwardArgAndType)) {
+                return failure();
+            }
+        }
+    }
+
+    // 7. Optional qreg section.
+    if (succeeded(parser.parseOptionalKeyword("quregs"))) {
+        OpAsmParser::UnresolvedOperand operand;
+        if (parser.parseLParen() || parser.parseOperand(operand) || parser.parseRParen()) {
+            return failure();
+        }
+        inQreg = operand;
+
+        auto parseIndexAndType = [&]() -> ParseResult {
+            OpAsmParser::UnresolvedOperand indexOperand;
+            Type indexType;
+            if (parseOperandTypePair(parser, indexOperand, indexType)) {
+                return failure();
+            }
+            arrQubitIndices.push_back(indexOperand);
+            arrQubitIndexTypes.push_back(indexType);
+            return success();
+        };
+        if (parser.parseKeyword("indices") ||
+            parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Paren, parseIndexAndType)) {
+            return failure();
+        }
+    }
+
+    // 8. Optional controls section (qubit controls or register controls).
+    if (succeeded(parser.parseOptionalKeyword("ctrls"))) {
+        if (inQreg) {
+            OpAsmParser::UnresolvedOperand ctrlIndices;
+            Type ctrlIndicesTy;
+            if (parser.parseLParen() || parseOperandTypePair(parser, ctrlIndices, ctrlIndicesTy) ||
+                parser.parseRParen()) {
+                return failure();
+            }
+            arrCtrlIndices = ctrlIndices;
+            arrCtrlIndicesType = ctrlIndicesTy;
+
+            OpAsmParser::UnresolvedOperand ctrlValues;
+            Type ctrlValuesTy;
+            if (parser.parseKeyword("ctrl_vals") || parser.parseLParen() ||
+                parseOperandTypePair(parser, ctrlValues, ctrlValuesTy) || parser.parseRParen()) {
+                return failure();
+            }
+            arrCtrlValues = ctrlValues;
+            arrCtrlValuesType = ctrlValuesTy;
+        }
+        else {
+            auto parseCtrlQubit = [&]() -> ParseResult {
+                OpAsmParser::UnresolvedOperand operand;
+                if (parser.parseOperand(operand)) {
+                    return failure();
+                }
+                inCtrlQubits.push_back(operand);
+                return success();
+            };
+            if (parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Paren, parseCtrlQubit) ||
+                parser.parseKeyword("ctrl_vals")) {
+                return failure();
+            }
+
+            auto parseCtrlValue = [&]() -> ParseResult {
+                OpAsmParser::UnresolvedOperand operand;
+                if (parser.parseOperand(operand)) {
+                    return failure();
+                }
+                inCtrlValues.push_back(operand);
+                return success();
+            };
+            if (parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Paren, parseCtrlValue)) {
+                return failure();
+            }
+        }
+    }
+
+    // 9. Optional inherent metadata blocks.
+    if (succeeded(parser.parseOptionalKeyword("static_data"))) {
+        DictionaryAttr staticData;
+        if (parser.parseEqual() || parser.parseAttribute(staticData)) {
+            return failure();
+        }
+        result.addAttribute("static_data", staticData);
+    }
+    if (succeeded(parser.parseOptionalKeyword("param_map"))) {
+        DictionaryAttr paramMap;
+        if (parser.parseEqual() || parseDenseI64ArrayDictionary(parser, builder, paramMap)) {
+            return failure();
+        }
+        result.addAttribute("param_map", paramMap);
+    }
+    if (succeeded(parser.parseOptionalKeyword("qubit_map"))) {
+        DictionaryAttr qubitMap;
+        if (parser.parseEqual() || parseDenseI64ArrayDictionary(parser, builder, qubitMap)) {
+            return failure();
+        }
+        result.addAttribute("qubit_map", qubitMap);
+    }
+
+    // 10. Resolve operands in segment order.
+    if (parser.resolveOperands(params, paramTypes, parser.getCurrentLocation(), result.operands)) {
+        return failure();
+    }
+    if (parser.resolveOperands(forwardArgs, forwardArgTypes, parser.getCurrentLocation(),
+                               result.operands)) {
+        return failure();
+    }
+    if (parser.resolveOperands(inQubits, QubitType::get(ctx), result.operands)) {
+        return failure();
+    }
+    if (parser.resolveOperands(inCtrlQubits, QubitType::get(ctx), result.operands)) {
+        return failure();
+    }
+    if (parser.resolveOperands(inCtrlValues, builder.getI1Type(), result.operands)) {
+        return failure();
+    }
+    if (inQreg && parser.resolveOperand(*inQreg, QuregType::get(ctx), result.operands)) {
+        return failure();
+    }
+    if (parser.resolveOperands(arrQubitIndices, arrQubitIndexTypes, parser.getCurrentLocation(),
+                               result.operands)) {
+        return failure();
+    }
+    if (arrCtrlIndices &&
+        parser.resolveOperand(*arrCtrlIndices, *arrCtrlIndicesType, result.operands)) {
+        return failure();
+    }
+    if (arrCtrlValues &&
+        parser.resolveOperand(*arrCtrlValues, *arrCtrlValuesType, result.operands)) {
+        return failure();
+    }
+
+    // 11. Add inferred results in segment order.
+    result.addTypes(SmallVector<Type>(inQubits.size(), QubitType::get(ctx)));
+    result.addTypes(SmallVector<Type>(inCtrlQubits.size(), QubitType::get(ctx)));
+    if (inQreg) {
+        result.addTypes(QuregType::get(ctx));
+    }
+
+    // 12. Add explicit segment sizes.
+    result.addAttribute(
+        "operandSegmentSizes",
+        builder.getDenseI32ArrayAttr(
+            {static_cast<int32_t>(params.size()), static_cast<int32_t>(forwardArgs.size()),
+             static_cast<int32_t>(inQubits.size()), static_cast<int32_t>(inCtrlQubits.size()),
+             static_cast<int32_t>(inCtrlValues.size()), inQreg ? 1 : 0,
+             static_cast<int32_t>(arrQubitIndices.size()), arrCtrlIndices ? 1 : 0,
+             arrCtrlValues ? 1 : 0}));
+    result.addAttribute(
+        "resultSegmentSizes",
+        builder.getDenseI32ArrayAttr({static_cast<int32_t>(inQubits.size()),
+                                      static_cast<int32_t>(inCtrlQubits.size()), inQreg ? 1 : 0}));
+
+    return success();
+}
+
 } // namespace catalyst::qref

--- a/mlir/lib/QRef/IR/QRefOps.cpp
+++ b/mlir/lib/QRef/IR/QRefOps.cpp
@@ -477,13 +477,13 @@ void OperatorOp::print(OpAsmPrinter &p)
     }
 
     // 4. Qubits
-    if (!getInQubits().empty()) {
-        p << " qubits(" << getInQubits() << ")";
+    if (!getQubits().empty()) {
+        p << " qubits(" << getQubits() << ")";
     }
 
     // 5. Attribute Dictionary
     SmallVector<StringRef> elidedAttrs = {"static_data", "param_map", "qubit_map",
-                                          "operandSegmentSizes", "resultSegmentSizes"};
+                                          "operandSegmentSizes"};
     p.printOptionalAttrDict(getOperation()->getAttrs(), elidedAttrs);
 
     p.increaseIndent();
@@ -502,9 +502,9 @@ void OperatorOp::print(OpAsmPrinter &p)
     }
 
     // 7. Quantum register
-    if (getInQreg()) {
+    if (getQreg()) {
         p.printNewline();
-        p << "quregs(" << getInQreg() << ") indices(";
+        p << "quregs(" << getQreg() << " : " << getQreg().getType() << ") indices(";
         llvm::interleaveComma(
             llvm::zip(getArrQubitIndices(), getArrQubitIndices().getTypes()), p,
             [&](auto pair) { p << std::get<0>(pair) << ": " << std::get<1>(pair); });
@@ -512,10 +512,10 @@ void OperatorOp::print(OpAsmPrinter &p)
     }
 
     // 8. Control qubits
-    if (!getInCtrlQubits().empty()) {
+    if (!getCtrlQubits().empty()) {
         p.printNewline();
-        p << "ctrls(" << getInCtrlQubits() << ") ";
-        p << "ctrl_vals(" << getInCtrlValues() << ")";
+        p << "ctrls(" << getCtrlQubits() << ") ";
+        p << "ctrl_vals(" << getCtrlValues() << ")";
     }
     else if (getArrCtrlIndices()) {
         p.printNewline();
@@ -620,12 +620,13 @@ ParseResult OperatorOp::parse(OpAsmParser &parser, OperationState &result)
         opProperties.setAdjoint(true);
     }
 
-    SmallVector<OpAsmParser::UnresolvedOperand> inQubits;
+    SmallVector<OpAsmParser::UnresolvedOperand> qubits;
     SmallVector<OpAsmParser::UnresolvedOperand> forwardArgs;
     SmallVector<Type> forwardArgTypes;
-    SmallVector<OpAsmParser::UnresolvedOperand> inCtrlQubits;
-    SmallVector<OpAsmParser::UnresolvedOperand> inCtrlValues;
-    std::optional<OpAsmParser::UnresolvedOperand> inQreg;
+    SmallVector<OpAsmParser::UnresolvedOperand> ctrlQubits;
+    SmallVector<OpAsmParser::UnresolvedOperand> ctrlValues;
+    std::optional<OpAsmParser::UnresolvedOperand> qreg;
+    std::optional<Type> qregType;
     SmallVector<OpAsmParser::UnresolvedOperand> arrQubitIndices;
     SmallVector<Type> arrQubitIndexTypes;
     std::optional<OpAsmParser::UnresolvedOperand> arrCtrlIndices;
@@ -640,7 +641,7 @@ ParseResult OperatorOp::parse(OpAsmParser &parser, OperationState &result)
             if (parser.parseOperand(operand)) {
                 return failure();
             }
-            inQubits.push_back(operand);
+            qubits.push_back(operand);
             return success();
         };
         if (parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Paren, parseQubitOperand)) {
@@ -684,10 +685,13 @@ ParseResult OperatorOp::parse(OpAsmParser &parser, OperationState &result)
     // 7. Optional qreg section.
     if (succeeded(parser.parseOptionalKeyword("quregs"))) {
         OpAsmParser::UnresolvedOperand operand;
-        if (parser.parseLParen() || parser.parseOperand(operand) || parser.parseRParen()) {
+        Type type;
+        if (parser.parseLParen() || parser.parseOperand(operand) || parser.parseColon() ||
+            parser.parseType(type) || parser.parseRParen()) {
             return failure();
         }
-        inQreg = operand;
+        qreg = operand;
+        qregType = type;
 
         auto parseIndexAndType = [&]() -> ParseResult {
             OpAsmParser::UnresolvedOperand indexOperand;
@@ -707,7 +711,7 @@ ParseResult OperatorOp::parse(OpAsmParser &parser, OperationState &result)
 
     // 8. Optional controls section (qubit controls or register controls).
     if (succeeded(parser.parseOptionalKeyword("ctrls"))) {
-        if (inQreg) {
+        if (qreg) {
             OpAsmParser::UnresolvedOperand ctrlIndices;
             Type ctrlIndicesTy;
             if (parser.parseLParen() || parseOperandTypePair(parser, ctrlIndices, ctrlIndicesTy) ||
@@ -732,7 +736,7 @@ ParseResult OperatorOp::parse(OpAsmParser &parser, OperationState &result)
                 if (parser.parseOperand(operand)) {
                     return failure();
                 }
-                inCtrlQubits.push_back(operand);
+                ctrlQubits.push_back(operand);
                 return success();
             };
             if (parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Paren, parseCtrlQubit) ||
@@ -745,7 +749,7 @@ ParseResult OperatorOp::parse(OpAsmParser &parser, OperationState &result)
                 if (parser.parseOperand(operand)) {
                     return failure();
                 }
-                inCtrlValues.push_back(operand);
+                ctrlValues.push_back(operand);
                 return success();
             };
             if (parser.parseCommaSeparatedList(OpAsmParser::Delimiter::Paren, parseCtrlValue)) {
@@ -785,16 +789,16 @@ ParseResult OperatorOp::parse(OpAsmParser &parser, OperationState &result)
                                result.operands)) {
         return failure();
     }
-    if (parser.resolveOperands(inQubits, QubitType::get(ctx), result.operands)) {
+    if (parser.resolveOperands(qubits, QubitType::get(ctx), result.operands)) {
         return failure();
     }
-    if (parser.resolveOperands(inCtrlQubits, QubitType::get(ctx), result.operands)) {
+    if (parser.resolveOperands(ctrlQubits, QubitType::get(ctx), result.operands)) {
         return failure();
     }
-    if (parser.resolveOperands(inCtrlValues, builder.getI1Type(), result.operands)) {
+    if (parser.resolveOperands(ctrlValues, builder.getI1Type(), result.operands)) {
         return failure();
     }
-    if (inQreg && parser.resolveOperand(*inQreg, QuregType::get(ctx), result.operands)) {
+    if (qreg && parser.resolveOperand(*qreg, *qregType, result.operands)) {
         return failure();
     }
     if (parser.resolveOperands(arrQubitIndices, arrQubitIndexTypes, parser.getCurrentLocation(),
@@ -810,26 +814,15 @@ ParseResult OperatorOp::parse(OpAsmParser &parser, OperationState &result)
         return failure();
     }
 
-    // 11. Add inferred results in segment order.
-    result.addTypes(SmallVector<Type>(inQubits.size(), QubitType::get(ctx)));
-    result.addTypes(SmallVector<Type>(inCtrlQubits.size(), QubitType::get(ctx)));
-    if (inQreg) {
-        result.addTypes(QuregType::get(ctx));
-    }
-
     // 12. Add explicit segment sizes.
     result.addAttribute(
         "operandSegmentSizes",
         builder.getDenseI32ArrayAttr(
             {static_cast<int32_t>(params.size()), static_cast<int32_t>(forwardArgs.size()),
-             static_cast<int32_t>(inQubits.size()), static_cast<int32_t>(inCtrlQubits.size()),
-             static_cast<int32_t>(inCtrlValues.size()), inQreg ? 1 : 0,
+             static_cast<int32_t>(qubits.size()), static_cast<int32_t>(ctrlQubits.size()),
+             static_cast<int32_t>(ctrlValues.size()), qreg ? 1 : 0,
              static_cast<int32_t>(arrQubitIndices.size()), arrCtrlIndices ? 1 : 0,
              arrCtrlValues ? 1 : 0}));
-    result.addAttribute(
-        "resultSegmentSizes",
-        builder.getDenseI32ArrayAttr({static_cast<int32_t>(inQubits.size()),
-                                      static_cast<int32_t>(inCtrlQubits.size()), inQreg ? 1 : 0}));
 
     return success();
 }

--- a/mlir/lib/QRef/IR/QRefOps.cpp
+++ b/mlir/lib/QRef/IR/QRefOps.cpp
@@ -226,29 +226,19 @@ LogicalResult CustomOp::verify()
 
 LogicalResult OperatorOp::verify()
 {
-    const bool hasQregInput = static_cast<bool>(getInQreg());
-    const bool hasQregOutput = static_cast<bool>(getOutQreg());
-    const bool hasQregMode = hasQregInput || hasQregOutput;
-
-    const bool hasQubitInput = !getInQubits().empty();
-    const bool hasQubitOutput = !getOutQubits().empty();
-    const bool hasQubitMode = hasQubitInput || hasQubitOutput;
+    const bool hasQregMode = static_cast<bool>(getQreg());
+    const bool hasQubitMode = !getQubits().empty();
 
     // Exactly one mode must be used: explicit qubits or qreg-based addressing.
     if (hasQregMode == hasQubitMode) {
         return emitOpError() << "must use either qubits or registers, but not both";
     }
 
-    if (hasQregInput != hasQregOutput) {
-        return emitOpError() << "in_qreg and out_qreg must either both be present or absent";
-    }
-
     if (!getForwardArgs().empty() && !getUID()) {
         return emitOpError() << "forward_args can only be present when UID is provided";
     }
 
-    const bool hasQubitControls =
-        !getInCtrlQubits().empty() || !getInCtrlValues().empty() || !getOutCtrlQubits().empty();
+    const bool hasQubitControls = !getCtrlQubits().empty() || !getCtrlValues().empty();
     const bool hasQregControls =
         static_cast<bool>(getArrCtrlIndices()) || static_cast<bool>(getArrCtrlValues());
 
@@ -299,7 +289,7 @@ LogicalResult OperatorOp::verify()
 
     auto qubitMap = getQubitMap();
     if (qubitMap) {
-        const size_t numTargets = hasQregMode ? getArrQubitIndices().size() : getInQubits().size();
+        const size_t numTargets = hasQregMode ? getArrQubitIndices().size() : getQubits().size();
         const char *boundsNoun = hasQregMode ? "index arrays" : "qubits";
         const char *coverageNoun =
             hasQregMode ? "index arrays in register mode" : "qubit values in qubit mode";

--- a/mlir/lib/QRef/IR/QRefOps.cpp
+++ b/mlir/lib/QRef/IR/QRefOps.cpp
@@ -243,9 +243,8 @@ LogicalResult OperatorOp::verify()
         static_cast<bool>(getArrCtrlIndices()) || static_cast<bool>(getArrCtrlValues());
 
     if (hasQubitControls && hasQregControls) {
-        return emitOpError()
-               << "cannot mix qubit controls (in_ctrl_qubits/in_ctrl_values/out_ctrl_qubits) "
-               << "with register controls (arr_ctrl_indices/arr_ctrl_values)";
+        return emitOpError() << "cannot mix qubit controls (ctrl_qubits/ctrl_values) "
+                             << "with register controls (arr_ctrl_indices/arr_ctrl_values)";
     }
 
     if (static_cast<bool>(getArrCtrlIndices()) != static_cast<bool>(getArrCtrlValues())) {

--- a/mlir/lib/QRef/IR/QRefOps.cpp
+++ b/mlir/lib/QRef/IR/QRefOps.cpp
@@ -386,26 +386,19 @@ LogicalResult HermitianOp::verify()
 //===----------------------------------------------------------------------===//
 
 void OperatorOp::build(OpBuilder &odsBuilder, OperationState &odsState, llvm::StringRef op_name,
-                       ValueRange params, ValueRange in_qubits, ValueRange in_ctrl_qubits,
-                       ValueRange in_ctrl_values, ValueRange forward_args, bool adjoint,
+                       ValueRange params, ValueRange qubits, ValueRange ctrl_qubits,
+                       ValueRange ctrl_values, ValueRange forward_args, bool adjoint,
                        std::optional<int64_t> UID, DictionaryAttr static_data,
                        DictionaryAttr param_map, DictionaryAttr qubit_map)
 {
-    SmallVector<Type> resultTypes;
-    TypeRange qubitTypes = TypeRange(in_qubits);
-    TypeRange ctrlQubitTypes = TypeRange(in_ctrl_qubits);
-    resultTypes.append(qubitTypes.begin(), qubitTypes.end());
-    resultTypes.append(ctrlQubitTypes.begin(), ctrlQubitTypes.end());
-
     build(odsBuilder, odsState,
-          /*resultTypes=*/resultTypes,
           /*op_name=*/op_name,
           /*params=*/params,
           /*forward_args=*/forward_args,
-          /*in_qubits=*/in_qubits,
-          /*in_ctrl_qubits=*/in_ctrl_qubits,
-          /*in_ctrl_values=*/in_ctrl_values,
-          /*in_qreg=*/Value(),
+          /*qubits=*/qubits,
+          /*ctrl_qubits=*/ctrl_qubits,
+          /*ctrl_values=*/ctrl_values,
+          /*qreg=*/Value(),
           /*arr_qubit_indices=*/ValueRange(),
           /*arr_ctrl_indices=*/Value(),
           /*arr_ctrl_values=*/Value(),
@@ -417,22 +410,19 @@ void OperatorOp::build(OpBuilder &odsBuilder, OperationState &odsState, llvm::St
 }
 
 void OperatorOp::build(OpBuilder &odsBuilder, OperationState &odsState, llvm::StringRef op_name,
-                       ValueRange params, Value in_qreg, ValueRange arr_qubit_indices,
+                       ValueRange params, Value qreg, ValueRange arr_qubit_indices,
                        Value arr_ctrl_indices, Value arr_ctrl_values, ValueRange forward_args,
                        bool adjoint, std::optional<int64_t> UID, DictionaryAttr static_data,
                        DictionaryAttr param_map, DictionaryAttr qubit_map)
 {
-    SmallVector<Type> resultTypes = {in_qreg.getType()};
-
     build(odsBuilder, odsState,
-          /*resultTypes=*/resultTypes,
           /*op_name=*/op_name,
           /*params=*/params,
           /*forward_args=*/forward_args,
-          /*in_qubits=*/ValueRange(),
-          /*in_ctrl_qubits=*/ValueRange(),
-          /*in_ctrl_values=*/ValueRange(),
-          /*in_qreg=*/in_qreg,
+          /*qubits=*/ValueRange(),
+          /*ctrl_qubits=*/ValueRange(),
+          /*ctrl_values=*/ValueRange(),
+          /*qreg=*/qreg,
           /*arr_qubit_indices=*/arr_qubit_indices,
           /*arr_ctrl_indices=*/arr_ctrl_indices,
           /*arr_ctrl_values=*/arr_ctrl_values,

--- a/mlir/test/QRef/VerifierTests.mlir
+++ b/mlir/test/QRef/VerifierTests.mlir
@@ -490,7 +490,7 @@ func.func @operator_invalid_ctrl_qubit_value_mismatch(%q : !qref.bit, %cq0 : !qr
 // -----
 
 func.func @operator_invalid_control_mode_mix(%cq : !qref.bit, %ctrlv : i1, %r : !qref.reg<4>, %idx : tensor<2xi64>, %cidx : tensor<2xi64>, %cval : tensor<2xi1>) {
-    // expected-error@+1 {{cannot mix qubit controls (in_ctrl_qubits/in_ctrl_values/out_ctrl_qubits) with register controls (arr_ctrl_indices/arr_ctrl_values)}}
+    // expected-error@+1 {{cannot mix qubit controls (ctrl_qubits/ctrl_values) with register controls (arr_ctrl_indices/arr_ctrl_values)}}
     "qref.operator"(%cq, %ctrlv, %r, %idx, %cidx, %cval) <{op_name = "bad_ctrl_mix", operandSegmentSizes = array<i32: 0, 0, 0, 1, 1, 1, 1, 1, 1>}> : (!qref.bit, i1, !qref.reg<4>, tensor<2xi64>, tensor<2xi64>, tensor<2xi1>) -> ()
     return
 }

--- a/mlir/test/QRef/VerifierTests.mlir
+++ b/mlir/test/QRef/VerifierTests.mlir
@@ -227,79 +227,79 @@ func.func @test_hermitian_bad_matrix_shape(%q0: !qref.bit, %matrix: tensor<20x20
 
 
 //////////////////////
-// quantum.operator //
+// qref.operator //
 //////////////////////
 
 
-func.func @operator_basic_qubits(%q0 : !quantum.bit, %q1 : !quantum.bit) {
-    %o0, %o1 = "quantum.operator"(%q0, %q1) <{op_name = "basic_qubits", operandSegmentSizes = array<i32: 0, 0, 2, 0, 0, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 2, 0, 0>}> : (!quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+func.func @operator_basic_qubits(%q0 : !qref.bit, %q1 : !qref.bit) {
+    "qref.operator"(%q0, %q1) <{op_name = "basic_qubits", operandSegmentSizes = array<i32: 0, 0, 2, 0, 0, 0, 0, 0, 0>}> : (!qref.bit, !qref.bit) -> ()
     return
 }
 
 // -----
 
-func.func @operator_custom_basic_qubits(%q0 : !quantum.bit, %q1 : !quantum.bit) {
-    %o0, %o1 = quantum.operator "custom_basic_qubits"() qubits(%q0, %q1)
+func.func @operator_custom_basic_qubits(%q0 : !qref.bit, %q1 : !qref.bit) {
+    qref.operator "custom_basic_qubits"() qubits(%q0, %q1)
     return
 }
 
 // -----
 
-func.func @operator_with_control_qubits(%q : !quantum.bit, %cq : !quantum.bit, %cv : i1) {
-    %oq, %ocq = "quantum.operator"(%q, %cq, %cv) <{op_name = "ctrl_qubits", operandSegmentSizes = array<i32: 0, 0, 1, 1, 1, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 1, 1, 0>}> : (!quantum.bit, !quantum.bit, i1) -> (!quantum.bit, !quantum.bit)
+func.func @operator_with_control_qubits(%q : !qref.bit, %cq : !qref.bit, %cv : i1) {
+    "qref.operator"(%q, %cq, %cv) <{op_name = "ctrl_qubits", operandSegmentSizes = array<i32: 0, 0, 1, 1, 1, 0, 0, 0, 0>}> : (!qref.bit, !qref.bit, i1) -> ()
     return
 }
 
 // -----
 
-func.func @operator_custom_with_control_qubits(%q : !quantum.bit, %cq : !quantum.bit, %cv : i1) {
-    %oq, %ocq = quantum.operator "custom_ctrl_qubits"() qubits(%q)
+func.func @operator_custom_with_control_qubits(%q : !qref.bit, %cq : !qref.bit, %cv : i1) {
+    qref.operator "custom_ctrl_qubits"() qubits(%q)
       ctrls(%cq) ctrl_vals(%cv)
     return
 }
 
 // -----
 
-func.func @operator_with_registers(%r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
-    %out = "quantum.operator"(%r, %idx0, %idx1) <{op_name = "with_registers", operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 2, 0, 0>, resultSegmentSizes = array<i32: 0, 0, 1>}> : (!quantum.reg, tensor<2xi64>, tensor<1xi64>) -> !quantum.reg
+func.func @operator_with_registers(%r : !qref.reg<6>, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
+    "qref.operator"(%r, %idx0, %idx1) <{op_name = "with_registers", operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 2, 0, 0>}> : (!qref.reg<6>, tensor<2xi64>, tensor<1xi64>) -> ()
     return
 }
 
 // -----
 
-func.func @operator_custom_with_registers(%r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
-    %out = quantum.operator "custom_with_registers"()
-      quregs(%r) indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
+func.func @operator_custom_with_registers(%r : !qref.reg<?>, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
+    qref.operator "custom_with_registers"()
+      quregs(%r : !qref.reg<?>) indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
     return
 }
 
 // -----
 
-func.func @operator_with_registers_and_controls(%r : !quantum.reg, %idx : tensor<2xi64>, %cidx : tensor<2xi64>, %cval : tensor<2xi1>) {
-    %out = "quantum.operator"(%r, %idx, %cidx, %cval) <{op_name = "reg_ctrls", operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 1, 1, 1>, resultSegmentSizes = array<i32: 0, 0, 1>}> : (!quantum.reg, tensor<2xi64>, tensor<2xi64>, tensor<2xi1>) -> !quantum.reg
+func.func @operator_with_registers_and_controls(%r : !qref.reg<4>, %idx : tensor<2xi64>, %cidx : tensor<2xi64>, %cval : tensor<2xi1>) {
+    "qref.operator"(%r, %idx, %cidx, %cval) <{op_name = "reg_ctrls", operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 1, 1, 1>}> : (!qref.reg<4>, tensor<2xi64>, tensor<2xi64>, tensor<2xi1>) -> ()
     return
 }
 
 // -----
 
-func.func @operator_custom_with_registers_and_controls(%r : !quantum.reg, %idx : tensor<2xi64>, %cidx : tensor<2xi64>, %cval : tensor<2xi1>) {
-    %out = quantum.operator "custom_reg_ctrls"()
-      quregs(%r) indices(%idx : tensor<2xi64>)
+func.func @operator_custom_with_registers_and_controls(%r : !qref.reg<?>, %idx : tensor<2xi64>, %cidx : tensor<2xi64>, %cval : tensor<2xi1>) {
+    qref.operator "custom_reg_ctrls"()
+      quregs(%r : !qref.reg<?>) indices(%idx : tensor<2xi64>)
       ctrls(%cidx : tensor<2xi64>) ctrl_vals(%cval : tensor<2xi1>)
     return
 }
 
 // -----
 
-func.func @operator_qubits_with_maps(%p0 : f64, %p1 : i64, %q0 : !quantum.bit, %q1 : !quantum.bit) {
-    %o0, %o1 = "quantum.operator"(%p0, %p1, %q0, %q1) <{op_name = "qubit_maps", param_map = {p0 = array<i64: 0>, p1 = array<i64: 1>}, qubit_map = {pair = array<i64: 0, 1>}, operandSegmentSizes = array<i32: 2, 0, 2, 0, 0, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 2, 0, 0>}> : (f64, i64, !quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+func.func @operator_qubits_with_maps(%p0 : f64, %p1 : i64, %q0 : !qref.bit, %q1 : !qref.bit) {
+    "qref.operator"(%p0, %p1, %q0, %q1) <{op_name = "qubit_maps", param_map = {p0 = array<i64: 0>, p1 = array<i64: 1>}, qubit_map = {pair = array<i64: 0, 1>}, operandSegmentSizes = array<i32: 2, 0, 2, 0, 0, 0, 0, 0, 0>}> : (f64, i64, !qref.bit, !qref.bit) -> ()
     return
 }
 
 // -----
 
-func.func @operator_custom_qubits_with_maps(%p0 : f64, %p1 : i64, %q0 : !quantum.bit, %q1 : !quantum.bit) {
-    %o0, %o1 = quantum.operator "custom_qubit_maps"(%p0 : f64, %p1 : i64) qubits(%q0, %q1)
+func.func @operator_custom_qubits_with_maps(%p0 : f64, %p1 : i64, %q0 : !qref.bit, %q1 : !qref.bit) {
+    qref.operator "custom_qubit_maps"(%p0 : f64, %p1 : i64) qubits(%q0, %q1)
       param_map = {p0 = [0], p1 = [1]}
       qubit_map = {pair = [0, 1]}
     return
@@ -307,16 +307,16 @@ func.func @operator_custom_qubits_with_maps(%p0 : f64, %p1 : i64, %q0 : !quantum
 
 // -----
 
-func.func @operator_registers_with_maps(%p0 : f64, %p1 : i64, %r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
-    %out = "quantum.operator"(%p0, %p1, %r, %idx0, %idx1) <{op_name = "reg_maps", param_map = {p0 = array<i64: 0>, p1 = array<i64: 1>}, qubit_map = {qi0 = array<i64: 0>, qi1 = array<i64: 1>}, operandSegmentSizes = array<i32: 2, 0, 0, 0, 0, 1, 2, 0, 0>, resultSegmentSizes = array<i32: 0, 0, 1>}> : (f64, i64, !quantum.reg, tensor<2xi64>, tensor<1xi64>) -> !quantum.reg
+func.func @operator_registers_with_maps(%p0 : f64, %p1 : i64, %r : !qref.reg<3>, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
+    "qref.operator"(%p0, %p1, %r, %idx0, %idx1) <{op_name = "reg_maps", param_map = {p0 = array<i64: 0>, p1 = array<i64: 1>}, qubit_map = {qi0 = array<i64: 0>, qi1 = array<i64: 1>}, operandSegmentSizes = array<i32: 2, 0, 0, 0, 0, 1, 2, 0, 0>}> : (f64, i64, !qref.reg<3>, tensor<2xi64>, tensor<1xi64>) -> ()
     return
 }
 
 // -----
 
-func.func @operator_custom_registers_with_maps(%p0 : f64, %p1 : i64, %r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
-    %out = quantum.operator "custom_reg_maps"(%p0 : f64, %p1 : i64)
-      quregs(%r) indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
+func.func @operator_custom_registers_with_maps(%p0 : f64, %p1 : i64, %r : !qref.reg<?>, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
+    qref.operator "custom_reg_maps"(%p0 : f64, %p1 : i64)
+      quregs(%r : !qref.reg<?>) indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
       param_map = {p0 = [0], p1 = [1]}
       qubit_map = {qi0 = [0], qi1 = [1]}
     return
@@ -324,8 +324,8 @@ func.func @operator_custom_registers_with_maps(%p0 : f64, %p1 : i64, %r : !quant
 
 // -----
 
-func.func @operator_register_multi_index_entry(%r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
-    %out = quantum.operator "custom_multi_index_entry"() quregs(%r)
+func.func @operator_register_multi_index_entry(%r : !qref.reg<3>, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
+    qref.operator "custom_multi_index_entry"() quregs(%r : !qref.reg<3>)
       indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
       qubit_map = {wires = [0, 1]}
     return
@@ -333,8 +333,8 @@ func.func @operator_register_multi_index_entry(%r : !quantum.reg, %idx0 : tensor
 
 // -----
 
-func.func @operator_custom_multi_param_entry(%p0 : f64, %p1 : f64, %q0 : !quantum.bit, %q1 : !quantum.bit) {
-    %o0, %o1 = quantum.operator "custom_multi_param_entry"(%p0 : f64, %p1 : f64) qubits(%q0, %q1)
+func.func @operator_custom_multi_param_entry(%p0 : f64, %p1 : f64, %q0 : !qref.bit, %q1 : !qref.bit) {
+    qref.operator "custom_multi_param_entry"(%p0 : f64, %p1 : f64) qubits(%q0, %q1)
       param_map = {angles = [0, 1]}
       qubit_map = {pair = [0, 1]}
     return
@@ -342,40 +342,40 @@ func.func @operator_custom_multi_param_entry(%p0 : f64, %p1 : f64, %q0 : !quantu
 
 // -----
 
-func.func @operator_basic_with_static_data(%p : f64, %q : !quantum.bit) {
-    %out = "quantum.operator"(%p, %q) <{op_name = "with_static_data", static_data = {pauli_string = "XYZ", conditioning = 1 : i64}, adjoint = unit, operandSegmentSizes = array<i32: 1, 0, 1, 0, 0, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 1, 0, 0>}> : (f64, !quantum.bit) -> !quantum.bit
+func.func @operator_basic_with_static_data(%p : f64, %q : !qref.bit) {
+    "qref.operator"(%p, %q) <{op_name = "with_static_data", static_data = {pauli_string = "XYZ", conditioning = 1 : i64}, adjoint = unit, operandSegmentSizes = array<i32: 1, 0, 1, 0, 0, 0, 0, 0, 0>}> : (f64, !qref.bit) -> ()
     return
 }
 
 // -----
 
-func.func @operator_custom_basic_with_static_data(%p : f64, %q : !quantum.bit) {
-    %out = quantum.operator "custom_with_static_data"(%p : f64) adj qubits(%q)
+func.func @operator_custom_basic_with_static_data(%p : f64, %q : !qref.bit) {
+    qref.operator "custom_with_static_data"(%p : f64) adj qubits(%q)
       static_data = {pauli_string = "XYZ", conditioning = 1 : i64}
     return
 }
 
 // -----
 
-func.func @operator_custom_with_uid_and_forward(%fwd : i64, %q0 : !quantum.bit, %q1 : !quantum.bit) {
-    %o0, %o1 = quantum.operator "custom_uid_forward"() qubits(%q0, %q1)
+func.func @operator_custom_with_uid_and_forward(%fwd : i64, %q0 : !qref.bit, %q1 : !qref.bit) {
+    qref.operator "custom_uid_forward"() qubits(%q0, %q1)
       UID(7) forward(%fwd : i64)
     return
 }
 
 // -----
 
-func.func @operator_invalid_param_map_coverage(%p0 : f64, %p1 : i64, %q0 : !quantum.bit, %q1 : !quantum.bit) {
+func.func @operator_invalid_param_map_coverage(%p0 : f64, %p1 : i64, %q0 : !qref.bit, %q1 : !qref.bit) {
     // expected-error@+1 {{param_map must cover all params when provided: expected 2, got 1}}
-    %o0, %o1 = "quantum.operator"(%p0, %p1, %q0, %q1) <{op_name = "bad_param_map", param_map = {p0 = array<i64: 0>}, qubit_map = {}, operandSegmentSizes = array<i32: 2, 0, 2, 0, 0, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 2, 0, 0>}> : (f64, i64, !quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+    "qref.operator"(%p0, %p1, %q0, %q1) <{op_name = "bad_param_map", param_map = {p0 = array<i64: 0>}, qubit_map = {}, operandSegmentSizes = array<i32: 2, 0, 2, 0, 0, 0, 0, 0, 0>}> : (f64, i64, !qref.bit, !qref.bit) -> ()
     return
 }
 
 // -----
 
-func.func @operator_custom_invalid_param_map_coverage(%p0 : f64, %p1 : i64, %q0 : !quantum.bit, %q1 : !quantum.bit) {
+func.func @operator_custom_invalid_param_map_coverage(%p0 : f64, %p1 : i64, %q0 : !qref.bit, %q1 : !qref.bit) {
     // expected-error@+1 {{param_map must cover all params when provided: expected 2, got 1}}
-    %o0, %o1 = quantum.operator "custom_bad_param_map"(%p0 : f64, %p1 : i64) qubits(%q0, %q1)
+    qref.operator "custom_bad_param_map"(%p0 : f64, %p1 : i64) qubits(%q0, %q1)
       param_map = {p0 = [0]}
       qubit_map = {}
     return
@@ -383,17 +383,17 @@ func.func @operator_custom_invalid_param_map_coverage(%p0 : f64, %p1 : i64, %q0 
 
 // -----
 
-func.func @operator_invalid_qubit_map_coverage(%r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
+func.func @operator_invalid_qubit_map_coverage(%r : !qref.reg<3>, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
     // expected-error@+1 {{qubit_map must cover all index arrays in register mode: expected 2, got 1}}
-    %out = "quantum.operator"(%r, %idx0, %idx1) <{op_name = "bad_qubit_map", param_map = {}, qubit_map = {qi0 = array<i64: 0>}, operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 2, 0, 0>, resultSegmentSizes = array<i32: 0, 0, 1>}> : (!quantum.reg, tensor<2xi64>, tensor<1xi64>) -> !quantum.reg
+    "qref.operator"(%r, %idx0, %idx1) <{op_name = "bad_qubit_map", param_map = {}, qubit_map = {qi0 = array<i64: 0>}, operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 2, 0, 0>}> : (!qref.reg<3>, tensor<2xi64>, tensor<1xi64>) -> ()
     return
 }
 
 // -----
 
-func.func @operator_custom_invalid_qubit_map_coverage(%r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
+func.func @operator_custom_invalid_qubit_map_coverage(%r : !qref.reg<?>, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
     // expected-error@+1 {{qubit_map must cover all index arrays in register mode: expected 2, got 1}}
-    %out = quantum.operator "custom_bad_qubit_map"() quregs(%r)
+    qref.operator "custom_bad_qubit_map"() quregs(%r : !qref.reg<?>)
       indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
       param_map = {}
       qubit_map = {qi0 = [0]}
@@ -402,17 +402,17 @@ func.func @operator_custom_invalid_qubit_map_coverage(%r : !quantum.reg, %idx0 :
 
 // -----
 
-func.func @operator_invalid_qubit_map_sum(%q0 : !quantum.bit, %q1 : !quantum.bit) {
+func.func @operator_invalid_qubit_map_sum(%q0 : !qref.bit, %q1 : !qref.bit) {
     // expected-error@+1 {{qubit_map must cover all qubit values in qubit mode: expected 2, got 1}}
-    %o0, %o1 = "quantum.operator"(%q0, %q1) <{op_name = "bad_qubit_map_sum", param_map = {}, qubit_map = {pair = array<i64: 0>}, operandSegmentSizes = array<i32: 0, 0, 2, 0, 0, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 2, 0, 0>}> : (!quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+    "qref.operator"(%q0, %q1) <{op_name = "bad_qubit_map_sum", param_map = {}, qubit_map = {pair = array<i64: 0>}, operandSegmentSizes = array<i32: 0, 0, 2, 0, 0, 0, 0, 0, 0>}> : (!qref.bit, !qref.bit) -> ()
     return
 }
 
 // -----
 
-func.func @operator_custom_invalid_qubit_map_sum(%q0 : !quantum.bit, %q1 : !quantum.bit) {
+func.func @operator_custom_invalid_qubit_map_sum(%q0 : !qref.bit, %q1 : !qref.bit) {
     // expected-error@+1 {{qubit_map must cover all qubit values in qubit mode: expected 2, got 1}}
-    %o0, %o1 = quantum.operator "custom_bad_qubit_map_sum"() qubits(%q0, %q1)
+    qref.operator "custom_bad_qubit_map_sum"() qubits(%q0, %q1)
       param_map = {}
       qubit_map = {pair = [0]}
     return
@@ -420,17 +420,17 @@ func.func @operator_custom_invalid_qubit_map_sum(%q0 : !quantum.bit, %q1 : !quan
 
 // -----
 
-func.func @operator_invalid_qubit_map_union(%q0 : !quantum.bit, %q1 : !quantum.bit) {
+func.func @operator_invalid_qubit_map_union(%q0 : !qref.bit, %q1 : !qref.bit) {
     // expected-error@+1 {{qubit_map must cover all qubit values in qubit mode: expected 2, got 1}}
-    %o0, %o1 = "quantum.operator"(%q0, %q1) <{op_name = "bad_qubit_map_union", param_map = {}, qubit_map = {a = array<i64: 0>, b = array<i64: 0>}, operandSegmentSizes = array<i32: 0, 0, 2, 0, 0, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 2, 0, 0>}> : (!quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+    "qref.operator"(%q0, %q1) <{op_name = "bad_qubit_map_union", param_map = {}, qubit_map = {a = array<i64: 0>, b = array<i64: 0>}, operandSegmentSizes = array<i32: 0, 0, 2, 0, 0, 0, 0, 0, 0>}> : (!qref.bit, !qref.bit) -> ()
     return
 }
 
 // -----
 
-func.func @operator_custom_invalid_qubit_map_union(%q0 : !quantum.bit, %q1 : !quantum.bit) {
+func.func @operator_custom_invalid_qubit_map_union(%q0 : !qref.bit, %q1 : !qref.bit) {
     // expected-error@+1 {{qubit_map must cover all qubit values in qubit mode: expected 2, got 1}}
-    %o0, %o1 = quantum.operator "custom_bad_qubit_map_union"() qubits(%q0, %q1)
+    qref.operator "custom_bad_qubit_map_union"() qubits(%q0, %q1)
       param_map = {}
       qubit_map = {a = [0], b = [0]}
     return
@@ -438,17 +438,17 @@ func.func @operator_custom_invalid_qubit_map_union(%q0 : !quantum.bit, %q1 : !qu
 
 // -----
 
-func.func @operator_invalid_register_qubit_map_oob(%r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
+func.func @operator_invalid_register_qubit_map_oob(%r : !qref.reg<3>, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
     // expected-error@+1 {{qubit_map index is out of bounds with respect to index arrays: 2 is not in [0, 2)}}
-    %out = "quantum.operator"(%r, %idx0, %idx1) <{op_name = "bad_register_map_oob", param_map = {}, qubit_map = {qi0 = array<i64: 0>, qi1 = array<i64: 2>}, operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 2, 0, 0>, resultSegmentSizes = array<i32: 0, 0, 1>}> : (!quantum.reg, tensor<2xi64>, tensor<1xi64>) -> !quantum.reg
+    "qref.operator"(%r, %idx0, %idx1) <{op_name = "bad_register_map_oob", param_map = {}, qubit_map = {qi0 = array<i64: 0>, qi1 = array<i64: 2>}, operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 2, 0, 0>}> : (!qref.reg<3>, tensor<2xi64>, tensor<1xi64>) -> ()
     return
 }
 
 // -----
 
-func.func @operator_custom_invalid_register_qubit_map_oob(%r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
+func.func @operator_custom_invalid_register_qubit_map_oob(%r : !qref.reg<?>, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
     // expected-error@+1 {{qubit_map index is out of bounds with respect to index arrays: 2 is not in [0, 2)}}
-    %out = quantum.operator "custom_bad_register_map_oob"() quregs(%r)
+    qref.operator "custom_bad_register_map_oob"() quregs(%r : !qref.reg<?>)
       indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
       param_map = {}
       qubit_map = {qi0 = [0], qi1 = [2]}
@@ -457,17 +457,17 @@ func.func @operator_custom_invalid_register_qubit_map_oob(%r : !quantum.reg, %id
 
 // -----
 
-func.func @operator_invalid_forward_args_without_uid(%fwd : i64, %q0 : !quantum.bit, %q1 : !quantum.bit) {
+func.func @operator_invalid_forward_args_without_uid(%fwd : i64, %q0 : !qref.bit, %q1 : !qref.bit) {
     // expected-error@+1 {{forward_args can only be present when UID is provided}}
-    %o0, %o1 = "quantum.operator"(%fwd, %q0, %q1) <{op_name = "bad_forward_no_uid", operandSegmentSizes = array<i32: 0, 1, 2, 0, 0, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 2, 0, 0>}> : (i64, !quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+    "qref.operator"(%fwd, %q0, %q1) <{op_name = "bad_forward_no_uid", operandSegmentSizes = array<i32: 0, 1, 2, 0, 0, 0, 0, 0, 0>}> : (i64, !qref.bit, !qref.bit) -> ()
     return
 }
 
 // -----
 
-func.func @operator_invalid_both_modes(%q : !quantum.bit, %r : !quantum.reg, %idx : tensor<2xi64>) {
+func.func @operator_invalid_both_modes(%q : !qref.bit, %r : !qref.reg<2>, %idx : tensor<2xi64>) {
     // expected-error@+1 {{must use either qubits or registers, but not both}}
-    %out_q, %out_r = "quantum.operator"(%q, %r, %idx) <{op_name = "bad_both", operandSegmentSizes = array<i32: 0, 0, 1, 0, 0, 1, 1, 0, 0>, resultSegmentSizes = array<i32: 1, 0, 1>}> : (!quantum.bit, !quantum.reg, tensor<2xi64>) -> (!quantum.bit, !quantum.reg)
+    "qref.operator"(%q, %r, %idx) <{op_name = "bad_both", operandSegmentSizes = array<i32: 0, 0, 1, 0, 0, 1, 1, 0, 0>}> : (!qref.bit, !qref.reg<2>, tensor<2xi64>) -> ()
     return
 }
 
@@ -475,71 +475,47 @@ func.func @operator_invalid_both_modes(%q : !quantum.bit, %r : !quantum.reg, %id
 
 func.func @operator_invalid_no_mode() {
     // expected-error@+1 {{must use either qubits or registers, but not both}}
-    "quantum.operator"() <{op_name = "bad_none", operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 0, 0, 0>}> : () -> ()
+    "qref.operator"() <{op_name = "bad_none", operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0>}> : () -> ()
     return
 }
 
 // -----
 
-func.func @operator_invalid_qubit_io_mismatch(%q0 : !quantum.bit, %q1 : !quantum.bit) {
-    // expected-error@+1 {{number of qubits in input (2) and output (1) must be the same}}
-    %out = "quantum.operator"(%q0, %q1) <{op_name = "bad_qio", operandSegmentSizes = array<i32: 0, 0, 2, 0, 0, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 1, 0, 0>}> : (!quantum.bit, !quantum.bit) -> !quantum.bit
-    return
-}
-
-// -----
-
-func.func @operator_invalid_qreg_io_mismatch(%r : !quantum.reg, %idx : tensor<2xi64>) {
-    // expected-error@+1 {{in_qreg and out_qreg must either both be present or absent}}
-    "quantum.operator"(%r, %idx) <{op_name = "bad_rio", operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 1, 0, 0>, resultSegmentSizes = array<i32: 0, 0, 0>}> : (!quantum.reg, tensor<2xi64>) -> ()
-    return
-}
-
-// -----
-
-func.func @operator_invalid_ctrl_qubit_io_mismatch(%q : !quantum.bit, %cq0 : !quantum.bit, %cq1 : !quantum.bit, %cv0 : i1, %cv1 : i1) {
-    // expected-error@+1 {{number of controlling qubits in input (2) and output (1) must be the same}}
-    %oq0, %oq1, %ocq = "quantum.operator"(%q, %cq0, %cq1, %cv0, %cv1) <{op_name = "bad_ctrl_qio", operandSegmentSizes = array<i32: 0, 0, 1, 2, 2, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 2, 1, 0>}> : (!quantum.bit, !quantum.bit, !quantum.bit, i1, i1) -> (!quantum.bit, !quantum.bit, !quantum.bit)
-    return
-}
-
-// -----
-
-func.func @operator_invalid_ctrl_qubit_value_mismatch(%q : !quantum.bit, %cq0 : !quantum.bit, %cq1 : !quantum.bit, %cv : i1) {
+func.func @operator_invalid_ctrl_qubit_value_mismatch(%q : !qref.bit, %cq0 : !qref.bit, %cq1 : !qref.bit, %cv : i1) {
     // expected-error@+1 {{number of controlling qubits in input (2) and controlling values (1) must be the same}}
-    %oq, %ocq0, %ocq1 = "quantum.operator"(%q, %cq0, %cq1, %cv) <{op_name = "bad_ctrl_qval", operandSegmentSizes = array<i32: 0, 0, 1, 2, 1, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 1, 2, 0>}> : (!quantum.bit, !quantum.bit, !quantum.bit, i1) -> (!quantum.bit, !quantum.bit, !quantum.bit)
+    "qref.operator"(%q, %cq0, %cq1, %cv) <{op_name = "bad_ctrl_qval", operandSegmentSizes = array<i32: 0, 0, 1, 2, 1, 0, 0, 0, 0>}> : (!qref.bit, !qref.bit, !qref.bit, i1) -> ()
     return
 }
 
 // -----
 
-func.func @operator_invalid_control_mode_mix(%cq : !quantum.bit, %ctrlv : i1, %r : !quantum.reg, %idx : tensor<2xi64>, %cidx : tensor<2xi64>, %cval : tensor<2xi1>) {
+func.func @operator_invalid_control_mode_mix(%cq : !qref.bit, %ctrlv : i1, %r : !qref.reg<4>, %idx : tensor<2xi64>, %cidx : tensor<2xi64>, %cval : tensor<2xi1>) {
     // expected-error@+1 {{cannot mix qubit controls (in_ctrl_qubits/in_ctrl_values/out_ctrl_qubits) with register controls (arr_ctrl_indices/arr_ctrl_values)}}
-    %out_cq, %out_r = "quantum.operator"(%cq, %ctrlv, %r, %idx, %cidx, %cval) <{op_name = "bad_ctrl_mix", operandSegmentSizes = array<i32: 0, 0, 0, 1, 1, 1, 1, 1, 1>, resultSegmentSizes = array<i32: 0, 1, 1>}> : (!quantum.bit, i1, !quantum.reg, tensor<2xi64>, tensor<2xi64>, tensor<2xi1>) -> (!quantum.bit, !quantum.reg)
+    "qref.operator"(%cq, %ctrlv, %r, %idx, %cidx, %cval) <{op_name = "bad_ctrl_mix", operandSegmentSizes = array<i32: 0, 0, 0, 1, 1, 1, 1, 1, 1>}> : (!qref.bit, i1, !qref.reg<4>, tensor<2xi64>, tensor<2xi64>, tensor<2xi1>) -> ()
     return
 }
 
 // -----
 
-func.func @operator_invalid_ctrl_pair_presence(%r : !quantum.reg, %idx : tensor<2xi64>, %cidx : tensor<2xi64>) {
+func.func @operator_invalid_ctrl_pair_presence(%r : !qref.reg<2>, %idx : tensor<2xi64>, %cidx : tensor<2xi64>) {
     // expected-error@+1 {{arr_ctrl_indices and arr_ctrl_values must either both be present or both absent}}
-    %out = "quantum.operator"(%r, %idx, %cidx) <{op_name = "bad_ctrl_pair", operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 1, 1, 0>, resultSegmentSizes = array<i32: 0, 0, 1>}> : (!quantum.reg, tensor<2xi64>, tensor<2xi64>) -> !quantum.reg
+    "qref.operator"(%r, %idx, %cidx) <{op_name = "bad_ctrl_pair", operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 1, 1, 0>}> : (!qref.reg<2>, tensor<2xi64>, tensor<2xi64>) -> ()
     return
 }
 
 // -----
 
-func.func @operator_invalid_ctrl_static_length(%r : !quantum.reg, %idx : tensor<2xi64>, %cidx : tensor<2xi64>, %cval : tensor<1xi1>) {
+func.func @operator_invalid_ctrl_static_length(%r : !qref.reg<2>, %idx : tensor<2xi64>, %cidx : tensor<2xi64>, %cval : tensor<1xi1>) {
     // expected-error@+1 {{number of input control qubits (2) and control values (1) must be the same}}
-    %out = "quantum.operator"(%r, %idx, %cidx, %cval) <{op_name = "bad_ctrl_len", operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 1, 1, 1>, resultSegmentSizes = array<i32: 0, 0, 1>}> : (!quantum.reg, tensor<2xi64>, tensor<2xi64>, tensor<1xi1>) -> !quantum.reg
+    "qref.operator"(%r, %idx, %cidx, %cval) <{op_name = "bad_ctrl_len", operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 1, 1, 1>}> : (!qref.reg<2>, tensor<2xi64>, tensor<2xi64>, tensor<1xi1>) -> ()
     return
 }
 
 // -----
 
-func.func @operator_custom_invalid_ctrl_static_length(%r : !quantum.reg, %idx : tensor<2xi64>, %cidx : tensor<2xi64>, %cval : tensor<1xi1>) {
+func.func @operator_custom_invalid_ctrl_static_length(%r : !qref.reg<?>, %idx : tensor<2xi64>, %cidx : tensor<2xi64>, %cval : tensor<1xi1>) {
     // expected-error@+1 {{number of input control qubits (2) and control values (1) must be the same}}
-    %out = quantum.operator "custom_bad_ctrl_len"() quregs(%r) indices(%idx : tensor<2xi64>)
+    qref.operator "custom_bad_ctrl_len"() quregs(%r : !qref.reg<?>) indices(%idx : tensor<2xi64>)
       ctrls(%cidx : tensor<2xi64>) ctrl_vals(%cval : tensor<1xi1>)
     return
 }

--- a/mlir/test/QRef/VerifierTests.mlir
+++ b/mlir/test/QRef/VerifierTests.mlir
@@ -222,3 +222,326 @@ func.func @test_hermitian_bad_matrix_shape(%q0: !qref.bit, %matrix: tensor<20x20
     %obs = qref.hermitian(%matrix : tensor<20x20xcomplex<f64>>) %q0 : !quantum.obs
     return
 }
+
+// -----
+
+
+//////////////////////
+// quantum.operator //
+//////////////////////
+
+
+func.func @operator_basic_qubits(%q0 : !quantum.bit, %q1 : !quantum.bit) {
+    %o0, %o1 = "quantum.operator"(%q0, %q1) <{op_name = "basic_qubits", operandSegmentSizes = array<i32: 0, 0, 2, 0, 0, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 2, 0, 0>}> : (!quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+    return
+}
+
+// -----
+
+func.func @operator_custom_basic_qubits(%q0 : !quantum.bit, %q1 : !quantum.bit) {
+    %o0, %o1 = quantum.operator "custom_basic_qubits"() qubits(%q0, %q1)
+    return
+}
+
+// -----
+
+func.func @operator_with_control_qubits(%q : !quantum.bit, %cq : !quantum.bit, %cv : i1) {
+    %oq, %ocq = "quantum.operator"(%q, %cq, %cv) <{op_name = "ctrl_qubits", operandSegmentSizes = array<i32: 0, 0, 1, 1, 1, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 1, 1, 0>}> : (!quantum.bit, !quantum.bit, i1) -> (!quantum.bit, !quantum.bit)
+    return
+}
+
+// -----
+
+func.func @operator_custom_with_control_qubits(%q : !quantum.bit, %cq : !quantum.bit, %cv : i1) {
+    %oq, %ocq = quantum.operator "custom_ctrl_qubits"() qubits(%q)
+      ctrls(%cq) ctrl_vals(%cv)
+    return
+}
+
+// -----
+
+func.func @operator_with_registers(%r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
+    %out = "quantum.operator"(%r, %idx0, %idx1) <{op_name = "with_registers", operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 2, 0, 0>, resultSegmentSizes = array<i32: 0, 0, 1>}> : (!quantum.reg, tensor<2xi64>, tensor<1xi64>) -> !quantum.reg
+    return
+}
+
+// -----
+
+func.func @operator_custom_with_registers(%r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
+    %out = quantum.operator "custom_with_registers"()
+      quregs(%r) indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
+    return
+}
+
+// -----
+
+func.func @operator_with_registers_and_controls(%r : !quantum.reg, %idx : tensor<2xi64>, %cidx : tensor<2xi64>, %cval : tensor<2xi1>) {
+    %out = "quantum.operator"(%r, %idx, %cidx, %cval) <{op_name = "reg_ctrls", operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 1, 1, 1>, resultSegmentSizes = array<i32: 0, 0, 1>}> : (!quantum.reg, tensor<2xi64>, tensor<2xi64>, tensor<2xi1>) -> !quantum.reg
+    return
+}
+
+// -----
+
+func.func @operator_custom_with_registers_and_controls(%r : !quantum.reg, %idx : tensor<2xi64>, %cidx : tensor<2xi64>, %cval : tensor<2xi1>) {
+    %out = quantum.operator "custom_reg_ctrls"()
+      quregs(%r) indices(%idx : tensor<2xi64>)
+      ctrls(%cidx : tensor<2xi64>) ctrl_vals(%cval : tensor<2xi1>)
+    return
+}
+
+// -----
+
+func.func @operator_qubits_with_maps(%p0 : f64, %p1 : i64, %q0 : !quantum.bit, %q1 : !quantum.bit) {
+    %o0, %o1 = "quantum.operator"(%p0, %p1, %q0, %q1) <{op_name = "qubit_maps", param_map = {p0 = array<i64: 0>, p1 = array<i64: 1>}, qubit_map = {pair = array<i64: 0, 1>}, operandSegmentSizes = array<i32: 2, 0, 2, 0, 0, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 2, 0, 0>}> : (f64, i64, !quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+    return
+}
+
+// -----
+
+func.func @operator_custom_qubits_with_maps(%p0 : f64, %p1 : i64, %q0 : !quantum.bit, %q1 : !quantum.bit) {
+    %o0, %o1 = quantum.operator "custom_qubit_maps"(%p0 : f64, %p1 : i64) qubits(%q0, %q1)
+      param_map = {p0 = [0], p1 = [1]}
+      qubit_map = {pair = [0, 1]}
+    return
+}
+
+// -----
+
+func.func @operator_registers_with_maps(%p0 : f64, %p1 : i64, %r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
+    %out = "quantum.operator"(%p0, %p1, %r, %idx0, %idx1) <{op_name = "reg_maps", param_map = {p0 = array<i64: 0>, p1 = array<i64: 1>}, qubit_map = {qi0 = array<i64: 0>, qi1 = array<i64: 1>}, operandSegmentSizes = array<i32: 2, 0, 0, 0, 0, 1, 2, 0, 0>, resultSegmentSizes = array<i32: 0, 0, 1>}> : (f64, i64, !quantum.reg, tensor<2xi64>, tensor<1xi64>) -> !quantum.reg
+    return
+}
+
+// -----
+
+func.func @operator_custom_registers_with_maps(%p0 : f64, %p1 : i64, %r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
+    %out = quantum.operator "custom_reg_maps"(%p0 : f64, %p1 : i64)
+      quregs(%r) indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
+      param_map = {p0 = [0], p1 = [1]}
+      qubit_map = {qi0 = [0], qi1 = [1]}
+    return
+}
+
+// -----
+
+func.func @operator_register_multi_index_entry(%r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
+    %out = quantum.operator "custom_multi_index_entry"() quregs(%r)
+      indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
+      qubit_map = {wires = [0, 1]}
+    return
+}
+
+// -----
+
+func.func @operator_custom_multi_param_entry(%p0 : f64, %p1 : f64, %q0 : !quantum.bit, %q1 : !quantum.bit) {
+    %o0, %o1 = quantum.operator "custom_multi_param_entry"(%p0 : f64, %p1 : f64) qubits(%q0, %q1)
+      param_map = {angles = [0, 1]}
+      qubit_map = {pair = [0, 1]}
+    return
+}
+
+// -----
+
+func.func @operator_basic_with_static_data(%p : f64, %q : !quantum.bit) {
+    %out = "quantum.operator"(%p, %q) <{op_name = "with_static_data", static_data = {pauli_string = "XYZ", conditioning = 1 : i64}, adjoint = unit, operandSegmentSizes = array<i32: 1, 0, 1, 0, 0, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 1, 0, 0>}> : (f64, !quantum.bit) -> !quantum.bit
+    return
+}
+
+// -----
+
+func.func @operator_custom_basic_with_static_data(%p : f64, %q : !quantum.bit) {
+    %out = quantum.operator "custom_with_static_data"(%p : f64) adj qubits(%q)
+      static_data = {pauli_string = "XYZ", conditioning = 1 : i64}
+    return
+}
+
+// -----
+
+func.func @operator_custom_with_uid_and_forward(%fwd : i64, %q0 : !quantum.bit, %q1 : !quantum.bit) {
+    %o0, %o1 = quantum.operator "custom_uid_forward"() qubits(%q0, %q1)
+      UID(7) forward(%fwd : i64)
+    return
+}
+
+// -----
+
+func.func @operator_invalid_param_map_coverage(%p0 : f64, %p1 : i64, %q0 : !quantum.bit, %q1 : !quantum.bit) {
+    // expected-error@+1 {{param_map must cover all params when provided: expected 2, got 1}}
+    %o0, %o1 = "quantum.operator"(%p0, %p1, %q0, %q1) <{op_name = "bad_param_map", param_map = {p0 = array<i64: 0>}, qubit_map = {}, operandSegmentSizes = array<i32: 2, 0, 2, 0, 0, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 2, 0, 0>}> : (f64, i64, !quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+    return
+}
+
+// -----
+
+func.func @operator_custom_invalid_param_map_coverage(%p0 : f64, %p1 : i64, %q0 : !quantum.bit, %q1 : !quantum.bit) {
+    // expected-error@+1 {{param_map must cover all params when provided: expected 2, got 1}}
+    %o0, %o1 = quantum.operator "custom_bad_param_map"(%p0 : f64, %p1 : i64) qubits(%q0, %q1)
+      param_map = {p0 = [0]}
+      qubit_map = {}
+    return
+}
+
+// -----
+
+func.func @operator_invalid_qubit_map_coverage(%r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
+    // expected-error@+1 {{qubit_map must cover all index arrays in register mode: expected 2, got 1}}
+    %out = "quantum.operator"(%r, %idx0, %idx1) <{op_name = "bad_qubit_map", param_map = {}, qubit_map = {qi0 = array<i64: 0>}, operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 2, 0, 0>, resultSegmentSizes = array<i32: 0, 0, 1>}> : (!quantum.reg, tensor<2xi64>, tensor<1xi64>) -> !quantum.reg
+    return
+}
+
+// -----
+
+func.func @operator_custom_invalid_qubit_map_coverage(%r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
+    // expected-error@+1 {{qubit_map must cover all index arrays in register mode: expected 2, got 1}}
+    %out = quantum.operator "custom_bad_qubit_map"() quregs(%r)
+      indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
+      param_map = {}
+      qubit_map = {qi0 = [0]}
+    return
+}
+
+// -----
+
+func.func @operator_invalid_qubit_map_sum(%q0 : !quantum.bit, %q1 : !quantum.bit) {
+    // expected-error@+1 {{qubit_map must cover all qubit values in qubit mode: expected 2, got 1}}
+    %o0, %o1 = "quantum.operator"(%q0, %q1) <{op_name = "bad_qubit_map_sum", param_map = {}, qubit_map = {pair = array<i64: 0>}, operandSegmentSizes = array<i32: 0, 0, 2, 0, 0, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 2, 0, 0>}> : (!quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+    return
+}
+
+// -----
+
+func.func @operator_custom_invalid_qubit_map_sum(%q0 : !quantum.bit, %q1 : !quantum.bit) {
+    // expected-error@+1 {{qubit_map must cover all qubit values in qubit mode: expected 2, got 1}}
+    %o0, %o1 = quantum.operator "custom_bad_qubit_map_sum"() qubits(%q0, %q1)
+      param_map = {}
+      qubit_map = {pair = [0]}
+    return
+}
+
+// -----
+
+func.func @operator_invalid_qubit_map_union(%q0 : !quantum.bit, %q1 : !quantum.bit) {
+    // expected-error@+1 {{qubit_map must cover all qubit values in qubit mode: expected 2, got 1}}
+    %o0, %o1 = "quantum.operator"(%q0, %q1) <{op_name = "bad_qubit_map_union", param_map = {}, qubit_map = {a = array<i64: 0>, b = array<i64: 0>}, operandSegmentSizes = array<i32: 0, 0, 2, 0, 0, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 2, 0, 0>}> : (!quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+    return
+}
+
+// -----
+
+func.func @operator_custom_invalid_qubit_map_union(%q0 : !quantum.bit, %q1 : !quantum.bit) {
+    // expected-error@+1 {{qubit_map must cover all qubit values in qubit mode: expected 2, got 1}}
+    %o0, %o1 = quantum.operator "custom_bad_qubit_map_union"() qubits(%q0, %q1)
+      param_map = {}
+      qubit_map = {a = [0], b = [0]}
+    return
+}
+
+// -----
+
+func.func @operator_invalid_register_qubit_map_oob(%r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
+    // expected-error@+1 {{qubit_map index is out of bounds with respect to index arrays: 2 is not in [0, 2)}}
+    %out = "quantum.operator"(%r, %idx0, %idx1) <{op_name = "bad_register_map_oob", param_map = {}, qubit_map = {qi0 = array<i64: 0>, qi1 = array<i64: 2>}, operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 2, 0, 0>, resultSegmentSizes = array<i32: 0, 0, 1>}> : (!quantum.reg, tensor<2xi64>, tensor<1xi64>) -> !quantum.reg
+    return
+}
+
+// -----
+
+func.func @operator_custom_invalid_register_qubit_map_oob(%r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
+    // expected-error@+1 {{qubit_map index is out of bounds with respect to index arrays: 2 is not in [0, 2)}}
+    %out = quantum.operator "custom_bad_register_map_oob"() quregs(%r)
+      indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
+      param_map = {}
+      qubit_map = {qi0 = [0], qi1 = [2]}
+    return
+}
+
+// -----
+
+func.func @operator_invalid_forward_args_without_uid(%fwd : i64, %q0 : !quantum.bit, %q1 : !quantum.bit) {
+    // expected-error@+1 {{forward_args can only be present when UID is provided}}
+    %o0, %o1 = "quantum.operator"(%fwd, %q0, %q1) <{op_name = "bad_forward_no_uid", operandSegmentSizes = array<i32: 0, 1, 2, 0, 0, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 2, 0, 0>}> : (i64, !quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+    return
+}
+
+// -----
+
+func.func @operator_invalid_both_modes(%q : !quantum.bit, %r : !quantum.reg, %idx : tensor<2xi64>) {
+    // expected-error@+1 {{must use either qubits or registers, but not both}}
+    %out_q, %out_r = "quantum.operator"(%q, %r, %idx) <{op_name = "bad_both", operandSegmentSizes = array<i32: 0, 0, 1, 0, 0, 1, 1, 0, 0>, resultSegmentSizes = array<i32: 1, 0, 1>}> : (!quantum.bit, !quantum.reg, tensor<2xi64>) -> (!quantum.bit, !quantum.reg)
+    return
+}
+
+// -----
+
+func.func @operator_invalid_no_mode() {
+    // expected-error@+1 {{must use either qubits or registers, but not both}}
+    "quantum.operator"() <{op_name = "bad_none", operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 0, 0, 0>}> : () -> ()
+    return
+}
+
+// -----
+
+func.func @operator_invalid_qubit_io_mismatch(%q0 : !quantum.bit, %q1 : !quantum.bit) {
+    // expected-error@+1 {{number of qubits in input (2) and output (1) must be the same}}
+    %out = "quantum.operator"(%q0, %q1) <{op_name = "bad_qio", operandSegmentSizes = array<i32: 0, 0, 2, 0, 0, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 1, 0, 0>}> : (!quantum.bit, !quantum.bit) -> !quantum.bit
+    return
+}
+
+// -----
+
+func.func @operator_invalid_qreg_io_mismatch(%r : !quantum.reg, %idx : tensor<2xi64>) {
+    // expected-error@+1 {{in_qreg and out_qreg must either both be present or absent}}
+    "quantum.operator"(%r, %idx) <{op_name = "bad_rio", operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 1, 0, 0>, resultSegmentSizes = array<i32: 0, 0, 0>}> : (!quantum.reg, tensor<2xi64>) -> ()
+    return
+}
+
+// -----
+
+func.func @operator_invalid_ctrl_qubit_io_mismatch(%q : !quantum.bit, %cq0 : !quantum.bit, %cq1 : !quantum.bit, %cv0 : i1, %cv1 : i1) {
+    // expected-error@+1 {{number of controlling qubits in input (2) and output (1) must be the same}}
+    %oq0, %oq1, %ocq = "quantum.operator"(%q, %cq0, %cq1, %cv0, %cv1) <{op_name = "bad_ctrl_qio", operandSegmentSizes = array<i32: 0, 0, 1, 2, 2, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 2, 1, 0>}> : (!quantum.bit, !quantum.bit, !quantum.bit, i1, i1) -> (!quantum.bit, !quantum.bit, !quantum.bit)
+    return
+}
+
+// -----
+
+func.func @operator_invalid_ctrl_qubit_value_mismatch(%q : !quantum.bit, %cq0 : !quantum.bit, %cq1 : !quantum.bit, %cv : i1) {
+    // expected-error@+1 {{number of controlling qubits in input (2) and controlling values (1) must be the same}}
+    %oq, %ocq0, %ocq1 = "quantum.operator"(%q, %cq0, %cq1, %cv) <{op_name = "bad_ctrl_qval", operandSegmentSizes = array<i32: 0, 0, 1, 2, 1, 0, 0, 0, 0>, resultSegmentSizes = array<i32: 1, 2, 0>}> : (!quantum.bit, !quantum.bit, !quantum.bit, i1) -> (!quantum.bit, !quantum.bit, !quantum.bit)
+    return
+}
+
+// -----
+
+func.func @operator_invalid_control_mode_mix(%cq : !quantum.bit, %ctrlv : i1, %r : !quantum.reg, %idx : tensor<2xi64>, %cidx : tensor<2xi64>, %cval : tensor<2xi1>) {
+    // expected-error@+1 {{cannot mix qubit controls (in_ctrl_qubits/in_ctrl_values/out_ctrl_qubits) with register controls (arr_ctrl_indices/arr_ctrl_values)}}
+    %out_cq, %out_r = "quantum.operator"(%cq, %ctrlv, %r, %idx, %cidx, %cval) <{op_name = "bad_ctrl_mix", operandSegmentSizes = array<i32: 0, 0, 0, 1, 1, 1, 1, 1, 1>, resultSegmentSizes = array<i32: 0, 1, 1>}> : (!quantum.bit, i1, !quantum.reg, tensor<2xi64>, tensor<2xi64>, tensor<2xi1>) -> (!quantum.bit, !quantum.reg)
+    return
+}
+
+// -----
+
+func.func @operator_invalid_ctrl_pair_presence(%r : !quantum.reg, %idx : tensor<2xi64>, %cidx : tensor<2xi64>) {
+    // expected-error@+1 {{arr_ctrl_indices and arr_ctrl_values must either both be present or both absent}}
+    %out = "quantum.operator"(%r, %idx, %cidx) <{op_name = "bad_ctrl_pair", operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 1, 1, 0>, resultSegmentSizes = array<i32: 0, 0, 1>}> : (!quantum.reg, tensor<2xi64>, tensor<2xi64>) -> !quantum.reg
+    return
+}
+
+// -----
+
+func.func @operator_invalid_ctrl_static_length(%r : !quantum.reg, %idx : tensor<2xi64>, %cidx : tensor<2xi64>, %cval : tensor<1xi1>) {
+    // expected-error@+1 {{number of input control qubits (2) and control values (1) must be the same}}
+    %out = "quantum.operator"(%r, %idx, %cidx, %cval) <{op_name = "bad_ctrl_len", operandSegmentSizes = array<i32: 0, 0, 0, 0, 0, 1, 1, 1, 1>, resultSegmentSizes = array<i32: 0, 0, 1>}> : (!quantum.reg, tensor<2xi64>, tensor<2xi64>, tensor<1xi1>) -> !quantum.reg
+    return
+}
+
+// -----
+
+func.func @operator_custom_invalid_ctrl_static_length(%r : !quantum.reg, %idx : tensor<2xi64>, %cidx : tensor<2xi64>, %cval : tensor<1xi1>) {
+    // expected-error@+1 {{number of input control qubits (2) and control values (1) must be the same}}
+    %out = quantum.operator "custom_bad_ctrl_len"() quregs(%r) indices(%idx : tensor<2xi64>)
+      ctrls(%cidx : tensor<2xi64>) ctrl_vals(%cval : tensor<1xi1>)
+    return
+}
+
+// -----

--- a/mlir/test/QRef/VerifierTests.mlir
+++ b/mlir/test/QRef/VerifierTests.mlir
@@ -377,7 +377,6 @@ func.func @operator_custom_invalid_param_map_coverage(%p0 : f64, %p1 : i64, %q0 
     // expected-error@+1 {{param_map must cover all params when provided: expected 2, got 1}}
     qref.operator "custom_bad_param_map"(%p0 : f64, %p1 : i64) qubits(%q0, %q1)
       param_map = {p0 = [0]}
-      qubit_map = {}
     return
 }
 
@@ -393,9 +392,8 @@ func.func @operator_invalid_qubit_map_coverage(%r : !qref.reg<3>, %idx0 : tensor
 
 func.func @operator_custom_invalid_qubit_map_coverage(%r : !qref.reg<?>, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
     // expected-error@+1 {{qubit_map must cover all index arrays in register mode: expected 2, got 1}}
-    qref.operator "custom_bad_qubit_map"() quregs(%r : !qref.reg<?>)
-      indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
-      param_map = {}
+    qref.operator "custom_bad_qubit_map"()
+      quregs(%r : !qref.reg<?>) indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
       qubit_map = {qi0 = [0]}
     return
 }
@@ -413,7 +411,6 @@ func.func @operator_invalid_qubit_map_sum(%q0 : !qref.bit, %q1 : !qref.bit) {
 func.func @operator_custom_invalid_qubit_map_sum(%q0 : !qref.bit, %q1 : !qref.bit) {
     // expected-error@+1 {{qubit_map must cover all qubit values in qubit mode: expected 2, got 1}}
     qref.operator "custom_bad_qubit_map_sum"() qubits(%q0, %q1)
-      param_map = {}
       qubit_map = {pair = [0]}
     return
 }
@@ -431,7 +428,6 @@ func.func @operator_invalid_qubit_map_union(%q0 : !qref.bit, %q1 : !qref.bit) {
 func.func @operator_custom_invalid_qubit_map_union(%q0 : !qref.bit, %q1 : !qref.bit) {
     // expected-error@+1 {{qubit_map must cover all qubit values in qubit mode: expected 2, got 1}}
     qref.operator "custom_bad_qubit_map_union"() qubits(%q0, %q1)
-      param_map = {}
       qubit_map = {a = [0], b = [0]}
     return
 }
@@ -448,9 +444,8 @@ func.func @operator_invalid_register_qubit_map_oob(%r : !qref.reg<3>, %idx0 : te
 
 func.func @operator_custom_invalid_register_qubit_map_oob(%r : !qref.reg<?>, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
     // expected-error@+1 {{qubit_map index is out of bounds with respect to index arrays: 2 is not in [0, 2)}}
-    qref.operator "custom_bad_register_map_oob"() quregs(%r : !qref.reg<?>)
-      indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
-      param_map = {}
+    qref.operator "custom_bad_register_map_oob"()
+      quregs(%r : !qref.reg<?>) indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
       qubit_map = {qi0 = [0], qi1 = [2]}
     return
 }

--- a/mlir/test/Quantum/VerifierTest.mlir
+++ b/mlir/test/Quantum/VerifierTest.mlir
@@ -633,8 +633,8 @@ func.func @operator_custom_registers_with_maps(%p0 : f64, %p1 : i64, %r : !quant
 // -----
 
 func.func @operator_register_multi_index_entry(%r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
-    %out = quantum.operator "custom_multi_index_entry"() quregs(%r)
-      indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
+    %out = quantum.operator "custom_multi_index_entry"()
+      quregs(%r) indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
       qubit_map = {wires = [0, 1]}
     return
 }
@@ -685,7 +685,6 @@ func.func @operator_custom_invalid_param_map_coverage(%p0 : f64, %p1 : i64, %q0 
     // expected-error@+1 {{param_map must cover all params when provided: expected 2, got 1}}
     %o0, %o1 = quantum.operator "custom_bad_param_map"(%p0 : f64, %p1 : i64) qubits(%q0, %q1)
       param_map = {p0 = [0]}
-      qubit_map = {}
     return
 }
 
@@ -701,9 +700,8 @@ func.func @operator_invalid_qubit_map_coverage(%r : !quantum.reg, %idx0 : tensor
 
 func.func @operator_custom_invalid_qubit_map_coverage(%r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
     // expected-error@+1 {{qubit_map must cover all index arrays in register mode: expected 2, got 1}}
-    %out = quantum.operator "custom_bad_qubit_map"() quregs(%r)
-      indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
-      param_map = {}
+    %out = quantum.operator "custom_bad_qubit_map"()
+      quregs(%r) indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
       qubit_map = {qi0 = [0]}
     return
 }
@@ -721,7 +719,6 @@ func.func @operator_invalid_qubit_map_sum(%q0 : !quantum.bit, %q1 : !quantum.bit
 func.func @operator_custom_invalid_qubit_map_sum(%q0 : !quantum.bit, %q1 : !quantum.bit) {
     // expected-error@+1 {{qubit_map must cover all qubit values in qubit mode: expected 2, got 1}}
     %o0, %o1 = quantum.operator "custom_bad_qubit_map_sum"() qubits(%q0, %q1)
-      param_map = {}
       qubit_map = {pair = [0]}
     return
 }
@@ -739,7 +736,6 @@ func.func @operator_invalid_qubit_map_union(%q0 : !quantum.bit, %q1 : !quantum.b
 func.func @operator_custom_invalid_qubit_map_union(%q0 : !quantum.bit, %q1 : !quantum.bit) {
     // expected-error@+1 {{qubit_map must cover all qubit values in qubit mode: expected 2, got 1}}
     %o0, %o1 = quantum.operator "custom_bad_qubit_map_union"() qubits(%q0, %q1)
-      param_map = {}
       qubit_map = {a = [0], b = [0]}
     return
 }
@@ -756,8 +752,8 @@ func.func @operator_invalid_register_qubit_map_oob(%r : !quantum.reg, %idx0 : te
 
 func.func @operator_custom_invalid_register_qubit_map_oob(%r : !quantum.reg, %idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>) {
     // expected-error@+1 {{qubit_map index is out of bounds with respect to index arrays: 2 is not in [0, 2)}}
-    %out = quantum.operator "custom_bad_register_map_oob"() quregs(%r)
-      indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
+    %out = quantum.operator "custom_bad_register_map_oob"()
+      quregs(%r) indices(%idx0 : tensor<2xi64>, %idx1 : tensor<1xi64>)
       param_map = {}
       qubit_map = {qi0 = [0], qi1 = [2]}
     return
@@ -847,7 +843,8 @@ func.func @operator_invalid_ctrl_static_length(%r : !quantum.reg, %idx : tensor<
 
 func.func @operator_custom_invalid_ctrl_static_length(%r : !quantum.reg, %idx : tensor<2xi64>, %cidx : tensor<2xi64>, %cval : tensor<1xi1>) {
     // expected-error@+1 {{number of input control qubits (2) and control values (1) must be the same}}
-    %out = quantum.operator "custom_bad_ctrl_len"() quregs(%r) indices(%idx : tensor<2xi64>)
+    %out = quantum.operator "custom_bad_ctrl_len"()
+      quregs(%r) indices(%idx : tensor<2xi64>)
       ctrls(%cidx : tensor<2xi64>) ctrl_vals(%cval : tensor<1xi1>)
     return
 }


### PR DESCRIPTION
Follow up on #2883, adds reference semantic version of `quantum.operator`.

Likely easier to review by looking at the commits that update the original quantum dialect changes (copied over 1-1).

[sc-120866]