### PR TITLE
Remove extraneous comma in mbqc test parametrize

### DIFF
--- a/frontend/test/pytest/python_interface/dialects/test_mbqc_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_mbqc_dialect.py
@@ -149,7 +149,7 @@ def test_assembly_format(run_filecheck, pretty_print):
 class TestMeasureInBasisOp:
     """Unit tests for the mbqc.measure_in_basis op."""
 
-    @pytest.mark.parametrize("plane,", ["XY", "YZ", "ZX"])
+    @pytest.mark.parametrize("plane", ["XY", "YZ", "ZX"])
     @pytest.mark.parametrize("postselect", ["", "postselect 0", "postselect 1"])
     def test_measure_in_basis_properties(self, plane, postselect):
         """Test the parsing of the mbqc.measure_in_basis op's properties."""


### PR DESCRIPTION
There was an extraneous trailing comma in one of the mbqc pytest parameterizations, which ostensibly resulted in this error:

https://github.com/PennyLaneAI/catalyst/actions/runs/27482941747/job/81233770136

This PR removes the comma.