### PR TITLE
Improve benchmark trigger mechanism

### DIFF
--- a/.github/workflows/trigger_benchmarks.yml
+++ b/.github/workflows/trigger_benchmarks.yml
@@ -5,7 +5,7 @@ on:
       - created
 
 env:
-  BENCHMARK_TRIGGER_COMMAND: /benchmark
+  BENCHMARK_TRIGGER_COMMAND: "!benchmark"
 
 permissions:
   contents: read
@@ -23,11 +23,12 @@ jobs:
         id: comment_body
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
+          BENCHMARK_TRIGGER_COMMAND: ${{ env.BENCHMARK_TRIGGER_COMMAND }}
         run: |
-          if [ "$COMMENT_BODY" = "$BENCHMARK_TRIGGER_COMMAND" ]; then
-            echo "triggers_benchmark=true" >> "$GITHUB_OUTPUT"
+          if [[ "$COMMENT_BODY" =~ ^[[:space:]]*"$BENCHMARK_TRIGGER_COMMAND" ]]; then
+            echo "triggers_benchmark=true" >> $GITHUB_OUTPUT
           else
-            echo "triggers_benchmark=false" >> "$GITHUB_OUTPUT"
+            echo "triggers_benchmark=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Set Repository Info
@@ -63,21 +64,22 @@ jobs:
             console.log(`User '${user}' has admin/maintain/write access => ${permission}`);
 
             return permission;
-      
+
       - name: Trigger Benchmark Webhook
         if: steps.comment_body.outputs.triggers_benchmark == 'true' && steps.comment_user.outputs.result == 'true'
         uses: peter-evans/repository-dispatch@v3
         env:
           # The repo that is triggering the source webhook
           WEBHOOK_METADATA_SOURCE_REPO: ${{ steps.repo_info.outputs.REPO_OWNER }}/${{ steps.repo_info.outputs.REPO_NAME }}
-          
+
           # The URL of the actual actions run that triggered the webhook
           WEBHOOK_METADATA_ACTIONS_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          
+
           # The username of the person who commented the trigger command on the pull request
           WEBHOOK_METADATA_GITHUB_ACTOR: ${{ github.event.comment.user.login }}
-          WEBHOOK_METADATA_COMMENT_LINK: ${{ github.event.comment.html_url }}
-          
+          WEBHOOK_METADATA_COMMENT_LINK_API: ${{ github.event.comment.url }}
+          WEBHOOK_METADATA_COMMENT_LINK_HTML: ${{ github.event.comment.html_url }}
+
           # Information regarding the pull request
           WEBHOOK_METADATA_PULL_REQUEST_NUMBER: ${{ github.event.issue.number }}
           WEBHOOK_METADATA_PULL_REQUEST_URL: ${{ github.event.issue.html_url }}
@@ -92,9 +94,10 @@ jobs:
               "github_actor": "${{ env.WEBHOOK_METADATA_GITHUB_ACTOR }}",
               "pull_request_number": ${{ env.WEBHOOK_METADATA_PULL_REQUEST_NUMBER }},
               "pull_request_url": "${{ env.WEBHOOK_METADATA_PULL_REQUEST_URL }}",
-              "comment_link": "${{ env.WEBHOOK_METADATA_COMMENT_LINK }}"
+              "comment_link_api": "${{ env.WEBHOOK_METADATA_COMMENT_LINK_API }}",
+              "comment_link_html": "${{ env.WEBHOOK_METADATA_COMMENT_LINK_HTML }}"
             }
-          
+
       - name: React to original comment indicating webhook sent
         if: steps.comment_body.outputs.triggers_benchmark == 'true' && steps.comment_user.outputs.result == 'true'
         uses: actions/github-script@v7
@@ -109,5 +112,3 @@ jobs:
               comment_id: context.payload.comment.id,
               content: '+1'
             });
-
-

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -192,6 +192,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* The `/benchmark` GitHub comment trigger can now accept additional arguments and has been renamed to `!benchmark`.
+  [(#2947)](https://github.com/PennyLaneAI/catalyst/pull/2947)
+
 * The frontend now generates MLIR in reference semantics when capture is enabled.
   [(#2663)](https://github.com/PennyLaneAI/catalyst/pull/2663)
   [(#2664)](https://github.com/PennyLaneAI/catalyst/pull/2664)


### PR DESCRIPTION
**Context:**
[sc-103160] plans to introduce support for extra arguments to the `/benchmark` trigger. To support this, we will have to change the `/benchmark` triggers in PennyLane, Lightning, and Catalyst to match on the beginning of the comment rather than the full comment.

**Description of the Change:**
Changes the check on the trigger condition for `/benchmark`, renames `/benchmark` to `!benchmark`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-122206]
https://github.com/PennyLaneAI/pennylane/pull/9676
https://github.com/PennyLaneAI/pennylane-lightning/pull/1392