### PR TITLE
[qref 4.6] Value-to-ref conversion for subroutines

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -212,6 +212,7 @@
   [(#2931)](https://github.com/PennyLaneAI/catalyst/pull/2931)
   [(#2937)](https://github.com/PennyLaneAI/catalyst/pull/2937)
   [(#2945)](https://github.com/PennyLaneAI/catalyst/pull/2945)
+  [(#2948)](https://github.com/PennyLaneAI/catalyst/pull/2948)
 
 * Removed the internal ``mlir_specs`` function which was the old backend for :func:`qp.specs`. The resource analysis pass replaces its use.
   [(#2841)](https://github.com/PennyLaneAI/catalyst/pull/2841)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -211,6 +211,7 @@
   [(#2930)](https://github.com/PennyLaneAI/catalyst/pull/2930)
   [(#2931)](https://github.com/PennyLaneAI/catalyst/pull/2931)
   [(#2937)](https://github.com/PennyLaneAI/catalyst/pull/2937)
+  [(#2945)](https://github.com/PennyLaneAI/catalyst/pull/2945)
 
 * Removed the internal ``mlir_specs`` function which was the old backend for :func:`qp.specs`. The resource analysis pass replaces its use.
   [(#2841)](https://github.com/PennyLaneAI/catalyst/pull/2841)

--- a/mlir/lib/QRef/Transforms/value_semantics_conversion.cpp
+++ b/mlir/lib/QRef/Transforms/value_semantics_conversion.cpp
@@ -13,6 +13,10 @@
 // limitations under the License.
 
 #define DEBUG_TYPE "value-semantics-conversion"
+#define REFERENCE_SEMANTICS_GATE_OPS                                                               \
+    qref::QuantumOperation, qref::MeasureOp, mbqc::RefMeasureInBasisOp, pbc::RefPPMeasurementOp
+#define REFERENCE_SEMANTICS_OBSERVABLE_OPS                                                         \
+    qref::ComputationalBasisOp, qref::NamedObsOp, qref::HermitianOp
 
 #include "value_semantics_conversion.h"
 
@@ -63,6 +67,23 @@ using namespace catalyst;
 // and variable names like "rQubit" stand for "qubits in reference semantics".
 
 namespace {
+
+LogicalResult ensureNoReferenceSemanticsOps(Operation *op)
+{
+    WalkResult walkResult = op->walk([](Operation *op) {
+        if (isa<REFERENCE_SEMANTICS_GATE_OPS, REFERENCE_SEMANTICS_OBSERVABLE_OPS>(op)) {
+            return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
+    });
+
+    if (walkResult.wasInterrupted()) {
+        return failure();
+    }
+    else {
+        return success();
+    }
+}
 
 // A struct to store the register and the index of rQubits from a qref.get operation.
 // This struct is intended to be the keys in `llvm::DenseMap`s.
@@ -686,7 +707,7 @@ void _getNecessaryRegionRValuesImpl(Region &r, SetVector<Value> &necessaryRegion
 
     r.walk([&](Operation *op) {
         if (!isa<qref::QRefDialect>(op->getDialect()) &&
-            !isa<func::CallOp, mbqc::RefMeasureInBasisOp, pbc::RefPPMeasurementOp>(op)) {
+            !isa<func::CallOp, REFERENCE_SEMANTICS_GATE_OPS>(op)) {
             return;
         }
         if (isa<qref::GetOp>(op)) {
@@ -1919,12 +1940,10 @@ struct ValueSemanticsConversionPass
 
         WalkResult getOpVerification = mod->walk([&](qref::GetOp getOp) {
             if (!llvm::all_of(getOp->getUsers(),
-                              llvm::IsaPred<qref::QuantumOperation, qref::MeasureOp,
-                                            qref::ComputationalBasisOp, qref::NamedObsOp,
-                                            qref::HermitianOp, mbqc::RefMeasureInBasisOp,
-                                            pbc::RefPPMeasurementOp, func::CallOp>)) {
-                getOp.emitOpError(
-                    "qref.get operations can only be used by qref dialect gate operations");
+                              llvm::IsaPred<REFERENCE_SEMANTICS_GATE_OPS,
+                                            REFERENCE_SEMANTICS_OBSERVABLE_OPS, func::CallOp>)) {
+                getOp.emitOpError("qref.get operations can only be used by qref dialect gate or "
+                                  "observable operations");
                 return WalkResult::interrupt();
             }
             return WalkResult::advance();
@@ -1969,6 +1988,11 @@ struct ValueSemanticsConversionPass
 
             SubroutineInfo info(subroutine);
             handleSubroutine(builder, subroutine, info.getNecessarySubroutineRValues());
+            if (failed(ensureNoReferenceSemanticsOps(subroutine))) {
+                subroutine.emitOpError(
+                    "Detected remaining reference semantics operations after conversion");
+                return signalPassFailure();
+            }
 
             auto uses = SymbolTable::getSymbolUses(subroutine, mod);
             if (uses) {
@@ -1987,6 +2011,11 @@ struct ValueSemanticsConversionPass
             QubitValueTracker tracker;
             handleRegion(builder, targetFunc.getBody(), tracker);
             eraseAllRemainingAnchorRValues(targetFunc);
+            if (failed(ensureNoReferenceSemanticsOps(targetFunc))) {
+                targetFunc.emitOpError(
+                    "Detected remaining reference semantics operations after conversion");
+                return signalPassFailure();
+            }
         }
     }
 };

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -844,7 +844,7 @@ std::optional<SmallVector<Operation *>> handleRegion(IRRewriter &builder, Region
     }
 }
 
-bool isQuantumSubroutine(func::FuncOp f)
+bool funcOpHasValueSemanticsOps(func::FuncOp f)
 {
     // quantum.node is not a subroutine
     if (f->hasAttrOfType<UnitAttr>("quantum.node")) {
@@ -869,7 +869,7 @@ bool isQuantumSubroutine(func::FuncOp f)
             auto funcOp = mlir::SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
                 callOp, callOp.getCalleeAttr());
             assert(funcOp && "calling a non-existent subroutine");
-            if (isQuantumSubroutine(funcOp)) {
+            if (funcOpHasValueSemanticsOps(funcOp)) {
                 return WalkResult::interrupt();
             }
         }
@@ -881,7 +881,6 @@ bool isQuantumSubroutine(func::FuncOp f)
 void handleSubroutine(IRRewriter &builder, func::FuncOp f,
                       const SmallVector<IntegerAttr> &qregSizesAtCallsite)
 {
-
     MLIRContext *ctx = f.getContext();
     OpBuilder::InsertionGuard guard(builder);
     Location loc = f->getLoc();
@@ -1003,7 +1002,7 @@ struct ReferenceSemanticsConversionPass
                 return signalPassFailure();
             }
 
-            if (!isQuantumSubroutine(subroutine)) {
+            if (!funcOpHasValueSemanticsOps(subroutine)) {
                 continue;
             }
 

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -1001,8 +1001,8 @@ struct ReferenceSemanticsConversionPass
                                 qregSizesAtCallsite.push_back(qrefQuregType.getSize());
                             }
                         }
+                        break;
                     }
-                    break;
                 }
             }
             QubitValueTracker tracker;

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <llvm/ADT/STLExtras.h>
 #define DEBUG_TYPE "reference-semantics-conversion"
+
+#include "reference_semantics_conversion.h"
 
 #include <optional>
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -35,8 +37,6 @@
 #include "Quantum/IR/QuantumInterfaces.h"
 #include "Quantum/IR/QuantumOps.h"
 #include "Quantum/IR/QuantumTypes.h"
-
-#include "reference_semantics_conversion.h"
 
 using namespace mlir;
 using namespace catalyst;

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -855,7 +855,6 @@ void handleSubroutine(IRRewriter &builder, func::FuncOp f,
 
     // Add new qref arguments
     QubitValueTracker regionTracker;
-    size_t originalNumArgs = f.getFunctionType().getNumInputs();
     SmallVector<unsigned> indicesToInsertArgs;
     SmallVector<Type> typesToInsertArgs;
     SmallVector<DictionaryAttr> attrsToInsertArgs;
@@ -871,17 +870,17 @@ void handleSubroutine(IRRewriter &builder, func::FuncOp f,
 
         if (isa<quantum::QubitType>(t)) {
             typesToInsertArgs.push_back(qref::QubitType::get(ctx));
-            newRargIndices.push_back(originalNumArgs + (numNewArgsAdded++));
+            newRargIndices.push_back(i + (numNewArgsAdded++));
             oldVargs.push_back(f.getBody().front().getArgument(i));
         }
         else if (isa<quantum::QuregType>(t)) {
             typesToInsertArgs.push_back(
                 qref::QuregType::get(ctx, qregSizesAtCallsite[qregSizeIdx++]));
-            newRargIndices.push_back(originalNumArgs + (numNewArgsAdded++));
+            newRargIndices.push_back(i + (numNewArgsAdded++));
             oldVargs.push_back(f.getBody().front().getArgument(i));
         }
 
-        indicesToInsertArgs.push_back(originalNumArgs);
+        indicesToInsertArgs.push_back(i);
         attrsToInsertArgs.push_back(DictionaryAttr::get(ctx));
         locsToInsertArgs.push_back(loc);
     }

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -15,6 +15,8 @@
 #define DEBUG_TYPE "reference-semantics-conversion"
 #define VALUE_SEMANTICS_GATE_OPS                                                                   \
     quantum::QuantumOperation, quantum::MeasureOp, pbc::PPMeasurementOp, mbqc::MeasureInBasisOp
+#define VALUE_SEMANTICS_OBSERVABLE_OPS                                                             \
+    quantum::ComputationalBasisOp, quantum::HermitianOp, quantum::NamedObsOp
 
 #include "reference_semantics_conversion.h"
 
@@ -54,7 +56,7 @@ namespace {
 LogicalResult ensureNoValueSemanticsOps(Operation *op)
 {
     WalkResult walkResult = op->walk([](Operation *op) {
-        if (isa<VALUE_SEMANTICS_GATE_OPS>(op)) {
+        if (isa<VALUE_SEMANTICS_GATE_OPS, VALUE_SEMANTICS_OBSERVABLE_OPS>(op)) {
             return WalkResult::interrupt();
         }
         return WalkResult::advance();

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 #define DEBUG_TYPE "reference-semantics-conversion"
+#define VALUE_SEMANTICS_GATE_OPS                                                                   \
+    quantum::QuantumOperation, quantum::MeasureOp, pbc::PPMeasurementOp, mbqc::MeasureInBasisOp
 
 #include "reference_semantics_conversion.h"
 
@@ -48,6 +50,23 @@ using namespace catalyst;
 // and variable names like "rQubit" stand for "qubits in reference semantics".
 
 namespace {
+
+LogicalResult ensureNoValueSemanticsOps(Operation *op)
+{
+    WalkResult walkResult = op->walk([](Operation *op) {
+        if (isa<VALUE_SEMANTICS_GATE_OPS>(op)) {
+            return WalkResult::interrupt();
+        }
+        return WalkResult::advance();
+    });
+
+    if (walkResult.wasInterrupted()) {
+        return failure();
+    }
+    else {
+        return success();
+    }
+}
 
 void eraseSCFYieldQuantumOperands(scf::YieldOp yieldOp)
 {
@@ -197,8 +216,7 @@ OpTy migrateOpToReferenceSemantics(IRRewriter &builder, Operation *vOp, QubitVal
 
     Operation *newOp = builder.create(state);
 
-    if (isa<quantum::QuantumOperation, quantum::MeasureOp, pbc::PPMeasurementOp,
-            mbqc::MeasureInBasisOp, func::CallOp>(vOp)) {
+    if (isa<VALUE_SEMANTICS_GATE_OPS, func::CallOp>(vOp)) {
         cascadeMapAhead(vOp, tracker);
     }
 
@@ -842,8 +860,7 @@ bool isQuantumSubroutine(func::FuncOp f)
     }
 
     WalkResult walkResult = f.walk([](Operation *op) {
-        if (isa<quantum::QuantumDialect>(op->getDialect()) ||
-            isa<pbc::PPMeasurementOp, mbqc::MeasureInBasisOp, mbqc::GraphStatePrepOp>(op)) {
+        if (isa<quantum::QuantumDialect>(op->getDialect()) || isa<VALUE_SEMANTICS_GATE_OPS>(op)) {
             return WalkResult::interrupt();
         }
         if (func::CallOp callOp = dyn_cast<func::CallOp>(op)) {
@@ -959,6 +976,11 @@ struct ReferenceSemanticsConversionPass
         for (auto targetFunc : targetFuncs) {
             QubitValueTracker tracker;
             handleRegion(builder, targetFunc.getBody(), tracker);
+            if (failed(ensureNoValueSemanticsOps(targetFunc))) {
+                targetFunc.emitOpError(
+                    "Detected remaining value semantics operations after conversion");
+                return signalPassFailure();
+            }
         }
 
         const CallGraph callGraph(mod);
@@ -1008,6 +1030,11 @@ struct ReferenceSemanticsConversionPass
             }
             QubitValueTracker tracker;
             handleSubroutine(builder, subroutine, qregSizesAtCallsite);
+            if (failed(ensureNoValueSemanticsOps(subroutine))) {
+                subroutine.emitOpError(
+                    "Detected remaining value semantics operations after conversion");
+                return signalPassFailure();
+            }
         }
     }
 };

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -19,10 +19,12 @@
 #include <optional>
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SCCIterator.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "mlir/Analysis/CallGraph.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
@@ -34,6 +36,7 @@
 #include "QRef/IR/QRefInterfaces.h"
 #include "QRef/IR/QRefOps.h"
 #include "QRef/IR/QRefTypes.h"
+#include "Quantum/IR/QuantumDialect.h"
 #include "Quantum/IR/QuantumInterfaces.h"
 #include "Quantum/IR/QuantumOps.h"
 #include "Quantum/IR/QuantumTypes.h"
@@ -195,7 +198,7 @@ OpTy migrateOpToReferenceSemantics(IRRewriter &builder, Operation *vOp, QubitVal
     Operation *newOp = builder.create(state);
 
     if (isa<quantum::QuantumOperation, quantum::MeasureOp, pbc::PPMeasurementOp,
-            mbqc::MeasureInBasisOp>(vOp)) {
+            mbqc::MeasureInBasisOp, func::CallOp>(vOp)) {
         cascadeMapAhead(vOp, tracker);
     }
 
@@ -376,6 +379,27 @@ void handlePPM(IRRewriter &builder, pbc::PPMeasurementOp vPPMOp, QubitValueTrack
 
     builder.replaceAllUsesWith(vPPMOp.getMres(), rPPMOp.getMres());
     erasureWorklist.push_back(vPPMOp);
+}
+
+void handleCall(IRRewriter &builder, func::CallOp callOp, QubitValueTracker &tracker,
+                SmallVector<Operation *> &erasureWorklist)
+{
+    OpBuilder::InsertionGuard guard(builder);
+
+    auto newCallOp = migrateOpToReferenceSemantics<func::CallOp>(builder, callOp, tracker);
+
+    SmallVector<Value> oldClassicalResults;
+    for (auto v : callOp.getResults()) {
+        if (!isa<quantum::QubitType, quantum::QuregType>(v.getType())) {
+            oldClassicalResults.push_back(v);
+        }
+    }
+
+    for (auto [oldResult, newResult] :
+         llvm::zip_equal(oldClassicalResults, newCallOp->getResults())) {
+        builder.replaceAllUsesWith(oldResult, newResult);
+    }
+    erasureWorklist.push_back(callOp);
 }
 
 void handleCompbasis(IRRewriter &builder, quantum::ComputationalBasisOp vCompbasisOp,
@@ -750,7 +774,7 @@ std::optional<SmallVector<Operation *>> handleRegion(IRRewriter &builder, Region
                 [&](auto o) { handleDeallocQubit(builder, o, tracker, erasureWorklist); })
             .Case<quantum::QuantumOperation>(
                 [&](auto o) { handleGate(builder, o, tracker, erasureWorklist); })
-            // .Case<func::CallOp>([&](auto o) { handleCall(builder, o, tracker); })
+            .Case<func::CallOp>([&](auto o) { handleCall(builder, o, tracker, erasureWorklist); })
             .Case<quantum::ComputationalBasisOp>(
                 [&](auto o) { handleCompbasis(builder, o, tracker); })
             .Case<quantum::NamedObsOp>([&](auto o) { handleNamedObs(builder, o, tracker); })
@@ -787,6 +811,110 @@ std::optional<SmallVector<Operation *>> handleRegion(IRRewriter &builder, Region
     }
 }
 
+bool isQuantumSubroutine(func::FuncOp f)
+{
+    // quantum.node is not a subroutine
+    if (f->hasAttrOfType<UnitAttr>("quantum.node")) {
+        return false;
+    }
+
+    // If has a quantum argument, definitely is a quantum subroutine
+    if (llvm::any_of(f.getArgumentTypes(), llvm::IsaPred<quantum::QubitType, quantum::QuregType>)) {
+        return true;
+    }
+
+    // If we don't know from the args, must look at the body
+    if (f.isDeclaration()) {
+        return false;
+    }
+
+    WalkResult walkResult = f.walk([](Operation *op) {
+        if (isa<quantum::QuantumDialect>(op->getDialect())) {
+            return WalkResult::interrupt();
+        }
+        if (func::CallOp callOp = dyn_cast<func::CallOp>(op)) {
+            auto funcOp = mlir::SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
+                callOp, callOp.getCalleeAttr());
+            assert(funcOp && "calling a non-existent subroutine");
+            if (isQuantumSubroutine(funcOp)) {
+                return WalkResult::interrupt();
+            }
+        }
+        return WalkResult::advance();
+    });
+    return walkResult.wasInterrupted();
+}
+
+void handleSubroutine(IRRewriter &builder, func::FuncOp f,
+                      const SmallVector<IntegerAttr> &qregSizesAtCallsite)
+{
+
+    MLIRContext *ctx = f.getContext();
+    OpBuilder::InsertionGuard guard(builder);
+    Location loc = f->getLoc();
+
+    // Add new qref arguments
+    QubitValueTracker regionTracker;
+    size_t originalNumArgs = f.getFunctionType().getNumInputs();
+    SmallVector<unsigned> indicesToInsertArgs;
+    SmallVector<Type> typesToInsertArgs;
+    SmallVector<DictionaryAttr> attrsToInsertArgs;
+    SmallVector<Location> locsToInsertArgs;
+    SmallVector<unsigned> newRargIndices;
+    SmallVector<Value> oldVargs;
+    size_t numNewArgsAdded = 0;
+    int qregSizeIdx = 0;
+    for (auto [i, t] : llvm::enumerate(f.getFunctionType().getInputs())) {
+        if (!isa<quantum::QubitType, quantum::QuregType>(t)) {
+            continue;
+        }
+
+        if (isa<quantum::QubitType>(t)) {
+            typesToInsertArgs.push_back(qref::QubitType::get(ctx));
+            newRargIndices.push_back(originalNumArgs + (numNewArgsAdded++));
+            oldVargs.push_back(f.getBody().front().getArgument(i));
+        }
+        else if (isa<quantum::QuregType>(t)) {
+            typesToInsertArgs.push_back(
+                qref::QuregType::get(ctx, qregSizesAtCallsite[qregSizeIdx++]));
+            newRargIndices.push_back(originalNumArgs + (numNewArgsAdded++));
+            oldVargs.push_back(f.getBody().front().getArgument(i));
+        }
+
+        indicesToInsertArgs.push_back(originalNumArgs);
+        attrsToInsertArgs.push_back(DictionaryAttr::get(ctx));
+        locsToInsertArgs.push_back(loc);
+    }
+    assert(succeeded(f.insertArguments(indicesToInsertArgs, typesToInsertArgs, attrsToInsertArgs,
+                                       locsToInsertArgs)));
+
+    // Add new qref args and handle
+    for (auto [i, vValue] : llvm::zip_equal(newRargIndices, oldVargs)) {
+        if (isa<quantum::QubitType>(vValue.getType())) {
+            regionTracker.setRQubit(vValue, f.getArgument(i));
+        }
+        else if (isa<quantum::QuregType>(vValue.getType())) {
+            regionTracker.setRQreg(vValue, f.getArgument(i));
+        }
+    }
+
+    auto retOp = cast<func::ReturnOp>(f.getBody().front().getTerminator());
+    BitVector retOpEraseIndices(retOp->getNumOperands());
+    for (auto [i, argType] : llvm::enumerate(retOp.getOperandTypes())) {
+        retOpEraseIndices[i] = isa<quantum::QuregType, quantum::QubitType>(argType);
+    }
+    assert(succeeded(f.eraseResults(retOpEraseIndices)));
+    retOp->eraseOperands(retOpEraseIndices);
+    handleRegion(builder, f.getBody(), regionTracker);
+
+    // Erase old quantum args
+    BitVector eraseArgsIndices(f.getNumArguments());
+    for (auto [i, argType] : llvm::enumerate(f.getArgumentTypes())) {
+        eraseArgsIndices[i] = isa<quantum::QuregType, quantum::QubitType>(argType);
+    }
+    assert(succeeded(f.eraseArguments(eraseArgsIndices)));
+}
+
 } // namespace
 
 namespace catalyst {
@@ -818,6 +946,55 @@ struct ReferenceSemanticsConversionPass
         for (auto targetFunc : targetFuncs) {
             QubitValueTracker tracker;
             handleRegion(builder, targetFunc.getBody(), tracker);
+        }
+
+        const CallGraph callGraph(mod);
+        SmallVector<func::FuncOp> subroutinesPostOrder;
+        for (auto scc = llvm::scc_begin(&callGraph); !scc.isAtEnd(); ++scc) {
+            if ((*scc->begin())->isExternal()) {
+                continue;
+            }
+
+            if (!isa<func::FuncOp>((*scc->begin())->getCallableRegion()->getParentOp())) {
+                continue;
+            }
+
+            func::FuncOp subroutine =
+                cast<func::FuncOp>((*scc->begin())->getCallableRegion()->getParentOp());
+            if (scc.hasCycle()) {
+                subroutine.emitOpError("Quantum subroutine call graphs must not have cycles");
+                return signalPassFailure();
+            }
+
+            if (!isQuantumSubroutine(subroutine)) {
+                continue;
+            }
+
+            subroutinesPostOrder.push_back(subroutine);
+        }
+
+        // We want to handle the calls before the subroutines, so we know the register sizes on the
+        // subroutine qreg arg type
+        // By default, scc iterates call graph in post order (callee before caller), so we reverse
+        // the visit order.
+        for (func::FuncOp subroutine : llvm::reverse(subroutinesPostOrder)) {
+            SmallVector<IntegerAttr> qregSizesAtCallsite;
+            auto uses = SymbolTable::getSymbolUses(subroutine, mod);
+            if (uses) {
+                for (auto use : *uses) {
+                    Operation *user = use.getUser();
+                    if (auto callOp = dyn_cast<func::CallOp>(user)) {
+                        for (Type t : callOp.getOperandTypes()) {
+                            if (auto qrefQuregType = dyn_cast<qref::QuregType>(t)) {
+                                qregSizesAtCallsite.push_back(qrefQuregType.getSize());
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+            QubitValueTracker tracker;
+            handleSubroutine(builder, subroutine, qregSizesAtCallsite);
         }
     }
 };

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -946,6 +946,26 @@ void handleSubroutine(IRRewriter &builder, func::FuncOp f,
     assert(succeeded(f.eraseArguments(eraseArgsIndices)));
 }
 
+SmallVector<IntegerAttr> collectQregSizesAtCallsite(func::FuncOp subroutine, Operation *mod)
+{
+    SmallVector<IntegerAttr> qregSizesAtCallsite;
+    auto uses = SymbolTable::getSymbolUses(subroutine, mod);
+    if (uses) {
+        for (auto use : *uses) {
+            Operation *user = use.getUser();
+            if (auto callOp = dyn_cast<func::CallOp>(user)) {
+                for (Type t : callOp.getOperandTypes()) {
+                    if (auto qrefQuregType = dyn_cast<qref::QuregType>(t)) {
+                        qregSizesAtCallsite.push_back(qrefQuregType.getSize());
+                    }
+                }
+                break;
+            }
+        }
+    }
+    return qregSizesAtCallsite;
+}
+
 } // namespace
 
 namespace catalyst {
@@ -1014,23 +1034,8 @@ struct ReferenceSemanticsConversionPass
         // By default, scc iterates call graph in post order (callee before caller), so we reverse
         // the visit order.
         for (func::FuncOp subroutine : llvm::reverse(subroutinesPostOrder)) {
-            SmallVector<IntegerAttr> qregSizesAtCallsite;
-            auto uses = SymbolTable::getSymbolUses(subroutine, mod);
-            if (uses) {
-                for (auto use : *uses) {
-                    Operation *user = use.getUser();
-                    if (auto callOp = dyn_cast<func::CallOp>(user)) {
-                        for (Type t : callOp.getOperandTypes()) {
-                            if (auto qrefQuregType = dyn_cast<qref::QuregType>(t)) {
-                                qregSizesAtCallsite.push_back(qrefQuregType.getSize());
-                            }
-                        }
-                        break;
-                    }
-                }
-            }
             QubitValueTracker tracker;
-            handleSubroutine(builder, subroutine, qregSizesAtCallsite);
+            handleSubroutine(builder, subroutine, collectQregSizesAtCallsite(subroutine, mod));
             if (failed(ensureNoValueSemanticsOps(subroutine))) {
                 subroutine.emitOpError(
                     "Detected remaining value semantics operations after conversion");

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -862,7 +862,8 @@ bool funcOpHasValueSemanticsOps(func::FuncOp f)
     }
 
     WalkResult walkResult = f.walk([](Operation *op) {
-        if (isa<quantum::QuantumDialect>(op->getDialect()) || isa<VALUE_SEMANTICS_GATE_OPS>(op)) {
+        if (isa<quantum::QuantumDialect>(op->getDialect()) ||
+            isa<VALUE_SEMANTICS_GATE_OPS, VALUE_SEMANTICS_OBSERVABLE_OPS>(op)) {
             return WalkResult::interrupt();
         }
         if (func::CallOp callOp = dyn_cast<func::CallOp>(op)) {

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -462,30 +462,14 @@ void handleIf(IRRewriter &builder, scf::IfOp ifOp, QubitValueTracker &tracker,
     builder.setInsertionPoint(ifOp);
     Location loc = ifOp->getLoc();
 
-    // Collect classical returns of the old if op
-    SmallVector<unsigned> classicalReturnIndices;
-    SmallVector<Type> classicalReturnTypes;
-    for (auto [i, t] : llvm::enumerate(ifOp.getResultTypes())) {
-        if (!isa<quantum::QubitType, quantum::QuregType>(t)) {
-            classicalReturnTypes.push_back(t);
-            classicalReturnIndices.push_back(i);
-        }
-    }
-    auto newIfOp = scf::IfOp::create(builder, loc, classicalReturnTypes, ifOp.getCondition(),
-                                     /*withElseRegion=*/true);
-
     // Handle Then region
     // Cannot just use `cascadeMapAhead` util to update the outside flow, since if op does not take
     // in operands. We get the references from the yield op on the thenRegion
-    builder.eraseBlock(newIfOp.thenBlock());
-    builder.inlineRegionBefore(ifOp.getThenRegion(), newIfOp.getThenRegion(),
-                               newIfOp.getThenRegion().end());
     QubitValueTracker thenRegionTracker = tracker;
-    SmallVector<Value> yieldOpArgSave(newIfOp.thenYield().getResults());
-    eraseSCFYieldQuantumOperands(
-        cast<scf::YieldOp>(newIfOp.getThenRegion().front().getTerminator()));
+    SmallVector<Value> yieldOpArgSave(ifOp.thenYield().getResults());
+    eraseSCFYieldQuantumOperands(cast<scf::YieldOp>(ifOp.getThenRegion().front().getTerminator()));
     SmallVector<Operation *> thenRegionErasureWorklist =
-        handleRegion(builder, newIfOp.getThenRegion(), thenRegionTracker, false).value();
+        handleRegion(builder, ifOp.getThenRegion(), thenRegionTracker, false).value();
     for (auto [vqo, vqr] : llvm::zip_equal(yieldOpArgSave, ifOp.getResults())) {
         if (isa<quantum::QubitType>(vqo.getType())) {
             tracker.setRQubit(vqr, thenRegionTracker.getRQubit(vqo));
@@ -497,21 +481,40 @@ void handleIf(IRRewriter &builder, scf::IfOp ifOp, QubitValueTracker &tracker,
     for (auto op : llvm::reverse(thenRegionErasureWorklist)) {
         op->erase();
     }
-    newIfOp.getThenRegion().front().eraseArguments([](BlockArgument arg) {
+    ifOp.getThenRegion().front().eraseArguments([](BlockArgument arg) {
         return isa<quantum::QubitType, quantum::QuregType>(arg.getType());
     });
 
     // Handle Else region
-    builder.eraseBlock(newIfOp.elseBlock());
-    builder.inlineRegionBefore(ifOp.getElseRegion(), newIfOp.getElseRegion(),
-                               newIfOp.getElseRegion().end());
     QubitValueTracker elseRegionTracker = tracker;
-    eraseSCFYieldQuantumOperands(
-        cast<scf::YieldOp>(newIfOp.getElseRegion().front().getTerminator()));
-    handleRegion(builder, newIfOp.getElseRegion(), elseRegionTracker);
-    newIfOp.getElseRegion().front().eraseArguments([](BlockArgument arg) {
+    eraseSCFYieldQuantumOperands(cast<scf::YieldOp>(ifOp.getElseRegion().front().getTerminator()));
+    handleRegion(builder, ifOp.getElseRegion(), elseRegionTracker);
+    ifOp.getElseRegion().front().eraseArguments([](BlockArgument arg) {
         return isa<quantum::QubitType, quantum::QuregType>(arg.getType());
     });
+
+    // The else block is empty if the only remaining op is the mandatory scf.yield terminator
+    bool hasElseRegion = &(ifOp.elseBlock()->front()) != ifOp.elseBlock()->getTerminator();
+
+    // Collect classical returns of the old if op
+    SmallVector<unsigned> classicalReturnIndices;
+    SmallVector<Type> classicalReturnTypes;
+    for (auto [i, t] : llvm::enumerate(ifOp.getResultTypes())) {
+        if (!isa<quantum::QubitType, quantum::QuregType>(t)) {
+            classicalReturnTypes.push_back(t);
+            classicalReturnIndices.push_back(i);
+        }
+    }
+    auto newIfOp = scf::IfOp::create(builder, loc, classicalReturnTypes, ifOp.getCondition(),
+                                     /*withElseRegion=*/hasElseRegion);
+    builder.eraseBlock(newIfOp.thenBlock());
+    builder.inlineRegionBefore(ifOp.getThenRegion(), newIfOp.getThenRegion(),
+                               newIfOp.getThenRegion().end());
+    if (hasElseRegion) {
+        builder.eraseBlock(newIfOp.elseBlock());
+        builder.inlineRegionBefore(ifOp.getElseRegion(), newIfOp.getElseRegion(),
+                                   newIfOp.getElseRegion().end());
+    }
 
     // Update connection with outside
     erasureWorklist.push_back(ifOp);

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -524,7 +524,6 @@ void handleIf(IRRewriter &builder, scf::IfOp ifOp, QubitValueTracker &tracker,
 void handleSwitch(IRRewriter &builder, scf::IndexSwitchOp switchOp, QubitValueTracker &tracker,
                   SmallVector<Operation *> &erasureWorklist)
 {
-
     OpBuilder::InsertionGuard guard(builder);
     builder.setInsertionPoint(switchOp);
     Location loc = switchOp->getLoc();

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -842,7 +842,8 @@ bool isQuantumSubroutine(func::FuncOp f)
     }
 
     WalkResult walkResult = f.walk([](Operation *op) {
-        if (isa<quantum::QuantumDialect>(op->getDialect())) {
+        if (isa<quantum::QuantumDialect>(op->getDialect()) ||
+            isa<pbc::PPMeasurementOp, mbqc::MeasureInBasisOp, mbqc::GraphStatePrepOp>(op)) {
             return WalkResult::interrupt();
         }
         if (func::CallOp callOp = dyn_cast<func::CallOp>(op)) {

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <llvm/ADT/STLExtras.h>
 #define DEBUG_TYPE "reference-semantics-conversion"
-
-#include "reference_semantics_conversion.h"
 
 #include <optional>
 
@@ -36,6 +35,8 @@
 #include "Quantum/IR/QuantumInterfaces.h"
 #include "Quantum/IR/QuantumOps.h"
 #include "Quantum/IR/QuantumTypes.h"
+
+#include "reference_semantics_conversion.h"
 
 using namespace mlir;
 using namespace catalyst;
@@ -454,6 +455,139 @@ void handleAdjoint(IRRewriter &builder, quantum::AdjointOp vAdjointOp, QubitValu
     });
 }
 
+void handleIf(IRRewriter &builder, scf::IfOp ifOp, QubitValueTracker &tracker,
+              SmallVector<Operation *> &erasureWorklist)
+{
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPoint(ifOp);
+    Location loc = ifOp->getLoc();
+
+    // Collect classical returns of the old if op
+    SmallVector<unsigned> classicalReturnIndices;
+    SmallVector<Type> classicalReturnTypes;
+    for (auto [i, t] : llvm::enumerate(ifOp.getResultTypes())) {
+        if (!isa<quantum::QubitType, quantum::QuregType>(t)) {
+            classicalReturnTypes.push_back(t);
+            classicalReturnIndices.push_back(i);
+        }
+    }
+    auto newIfOp = scf::IfOp::create(builder, loc, classicalReturnTypes, ifOp.getCondition(),
+                                     /*withElseRegion=*/true);
+
+    // Handle Then region
+    // Cannot just use `cascadeMapAhead` util to update the outside flow, since if op does not take
+    // in operands. We get the references from the yield op on the thenRegion
+    builder.eraseBlock(newIfOp.thenBlock());
+    builder.inlineRegionBefore(ifOp.getThenRegion(), newIfOp.getThenRegion(),
+                               newIfOp.getThenRegion().end());
+    QubitValueTracker thenRegionTracker = tracker;
+    SmallVector<Value> yieldOpArgSave(newIfOp.thenYield().getResults());
+    eraseSCFYieldQuantumOperands(
+        cast<scf::YieldOp>(newIfOp.getThenRegion().front().getTerminator()));
+    SmallVector<Operation *> thenRegionErasureWorklist =
+        handleRegion(builder, newIfOp.getThenRegion(), thenRegionTracker, false).value();
+    for (auto [vqo, vqr] : llvm::zip_equal(yieldOpArgSave, ifOp.getResults())) {
+        if (isa<quantum::QubitType>(vqo.getType())) {
+            tracker.setRQubit(vqr, thenRegionTracker.getRQubit(vqo));
+        }
+        else if (isa<quantum::QuregType>(vqo.getType())) {
+            tracker.setRQreg(vqr, thenRegionTracker.getRQreg(vqo));
+        }
+    }
+    for (auto op : llvm::reverse(thenRegionErasureWorklist)) {
+        op->erase();
+    }
+    newIfOp.getThenRegion().front().eraseArguments([](BlockArgument arg) {
+        return isa<quantum::QubitType, quantum::QuregType>(arg.getType());
+    });
+
+    // Handle Else region
+    builder.eraseBlock(newIfOp.elseBlock());
+    builder.inlineRegionBefore(ifOp.getElseRegion(), newIfOp.getElseRegion(),
+                               newIfOp.getElseRegion().end());
+    QubitValueTracker elseRegionTracker = tracker;
+    eraseSCFYieldQuantumOperands(
+        cast<scf::YieldOp>(newIfOp.getElseRegion().front().getTerminator()));
+    handleRegion(builder, newIfOp.getElseRegion(), elseRegionTracker);
+    newIfOp.getElseRegion().front().eraseArguments([](BlockArgument arg) {
+        return isa<quantum::QubitType, quantum::QuregType>(arg.getType());
+    });
+
+    // Update connection with outside
+    erasureWorklist.push_back(ifOp);
+    for (auto [oldResultIdx, newResult] :
+         llvm::zip_equal(classicalReturnIndices, newIfOp->getResults())) {
+        builder.replaceAllUsesWith(ifOp->getResult(oldResultIdx), newResult);
+    }
+}
+
+void handleSwitch(IRRewriter &builder, scf::IndexSwitchOp switchOp, QubitValueTracker &tracker,
+                  SmallVector<Operation *> &erasureWorklist)
+{
+
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPoint(switchOp);
+    Location loc = switchOp->getLoc();
+
+    // Collect classical returns of the old switch op
+    SmallVector<unsigned> classicalReturnIndices;
+    SmallVector<Type> classicalReturnTypes;
+    for (auto [i, t] : llvm::enumerate(switchOp.getResultTypes())) {
+        if (!isa<quantum::QubitType, quantum::QuregType>(t)) {
+            classicalReturnTypes.push_back(t);
+            classicalReturnIndices.push_back(i);
+        }
+    }
+    auto newSwitchOp =
+        scf::IndexSwitchOp::create(builder, loc, classicalReturnTypes, switchOp.getArg(),
+                                   switchOp.getCases(), switchOp.getNumCases());
+
+    // Handle the default region
+    // Cannot just use `cascadeMapAhead` util to update the outside flow, since switch op does not
+    // take in operands. We get the references from the yield op on the default region
+    builder.inlineRegionBefore(switchOp.getDefaultRegion(), newSwitchOp.getDefaultRegion(),
+                               newSwitchOp.getDefaultRegion().end());
+    QubitValueTracker defaultRegionTracker = tracker;
+    SmallVector<Value> yieldOpArgSave(newSwitchOp.getDefaultBlock().getTerminator()->getOperands());
+    eraseSCFYieldQuantumOperands(cast<scf::YieldOp>(newSwitchOp.getDefaultBlock().getTerminator()));
+    SmallVector<Operation *> defaultRegionErasureWorklist =
+        handleRegion(builder, newSwitchOp.getDefaultRegion(), defaultRegionTracker, false).value();
+    for (auto [vqo, vqr] : llvm::zip_equal(yieldOpArgSave, switchOp.getResults())) {
+        if (isa<quantum::QubitType>(vqo.getType())) {
+            tracker.setRQubit(vqr, defaultRegionTracker.getRQubit(vqo));
+        }
+        else if (isa<quantum::QuregType>(vqo.getType())) {
+            tracker.setRQreg(vqr, defaultRegionTracker.getRQreg(vqo));
+        }
+    }
+    for (auto op : llvm::reverse(defaultRegionErasureWorklist)) {
+        op->erase();
+    }
+    newSwitchOp.getDefaultBlock().eraseArguments([](BlockArgument arg) {
+        return isa<quantum::QubitType, quantum::QuregType>(arg.getType());
+    });
+
+    // Handle case regions
+    for (auto [oldCaseRegion, newCaseRegion] :
+         llvm::zip_equal(switchOp.getCaseRegions(), newSwitchOp.getCaseRegions())) {
+        // builder.eraseBlock(&(newCaseRegion.front()));
+        builder.inlineRegionBefore(oldCaseRegion, newCaseRegion, newCaseRegion.end());
+        QubitValueTracker caseRegionTracker = tracker;
+        eraseSCFYieldQuantumOperands(cast<scf::YieldOp>(newCaseRegion.front().getTerminator()));
+        handleRegion(builder, newCaseRegion, caseRegionTracker);
+        newCaseRegion.front().eraseArguments([](BlockArgument arg) {
+            return isa<quantum::QubitType, quantum::QuregType>(arg.getType());
+        });
+    }
+
+    // Update connection with outside
+    erasureWorklist.push_back(switchOp);
+    for (auto [oldResultIdx, newResult] :
+         llvm::zip_equal(classicalReturnIndices, newSwitchOp->getResults())) {
+        builder.replaceAllUsesWith(switchOp->getResult(oldResultIdx), newResult);
+    }
+}
+
 void handleFor(IRRewriter &builder, scf::ForOp forOp, QubitValueTracker &tracker,
                SmallVector<Operation *> &erasureWorklist)
 {
@@ -630,8 +764,9 @@ std::optional<SmallVector<Operation *>> handleRegion(IRRewriter &builder, Region
                 [&](auto o) { handlePPM(builder, o, tracker, erasureWorklist); })
             .Case<quantum::AdjointOp>(
                 [&](auto o) { handleAdjoint(builder, o, tracker, erasureWorklist); })
-            // .Case<scf::IfOp>([&](auto o) { handleIf(builder, o, tracker); })
-            // .Case<scf::IndexSwitchOp>([&](auto o) { handleSwitch(builder, o, tracker); })
+            .Case<scf::IfOp>([&](auto o) { handleIf(builder, o, tracker, erasureWorklist); })
+            .Case<scf::IndexSwitchOp>(
+                [&](auto o) { handleSwitch(builder, o, tracker, erasureWorklist); })
             .Case<scf::ForOp>([&](auto o) { handleFor(builder, o, tracker, erasureWorklist); })
             .Case<scf::WhileOp>([&](auto o) { handleWhile(builder, o, tracker, erasureWorklist); })
             .Case<mbqc::GraphStatePrepOp>(

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.h
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.h
@@ -71,8 +71,10 @@ void handleGraphStatePrep(IRRewriter &builder, mbqc::GraphStatePrepOp vGraphStat
                           QubitValueTracker &tracker, SmallVector<Operation *> &erasureWorklist);
 void handleAdjoint(IRRewriter &builder, quantum::AdjointOp vAdjointOp, QubitValueTracker &tracker,
                    SmallVector<Operation *> &erasureWorklist);
-// void handleIf(IRRewriter &builder, scf::IfOp ifOp, QubitValueTracker &tracker);
-// void handleSwitch(IRRewriter &builder, scf::IndexSwitchOp switchOp, QubitValueTracker &tracker);
+void handleIf(IRRewriter &builder, scf::IfOp ifOp, QubitValueTracker &tracker,
+              SmallVector<Operation *> &erasureWorklist);
+void handleSwitch(IRRewriter &builder, scf::IndexSwitchOp switchOp, QubitValueTracker &tracker,
+                  SmallVector<Operation *> &erasureWorklist);
 void handleFor(IRRewriter &builder, scf::ForOp forOp, QubitValueTracker &tracker,
                SmallVector<Operation *> &erasureWorklist);
 void handleWhile(IRRewriter &builder, scf::WhileOp whileOp, QubitValueTracker &tracker,

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.h
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.h
@@ -60,7 +60,8 @@ void handleMeasureInBasis(IRRewriter &builder, mbqc::MeasureInBasisOp vMeasureIn
                           QubitValueTracker &tracker, SmallVector<Operation *> &erasureWorklist);
 void handlePPM(IRRewriter &builder, pbc::PPMeasurementOp vPPMOp, QubitValueTracker &tracker,
                SmallVector<Operation *> &erasureWorklist);
-// void handleCall(IRRewriter &builder, func::CallOp callOp, QubitValueTracker &tracker);
+void handleCall(IRRewriter &builder, func::CallOp callOp, QubitValueTracker &tracker,
+                SmallVector<Operation *> &erasureWorklist);
 void handleCompbasis(IRRewriter &builder, quantum::ComputationalBasisOp vCompbasisOp,
                      QubitValueTracker &tracker);
 void handleNamedObs(IRRewriter &builder, quantum::NamedObsOp vNamedObsOp,
@@ -79,8 +80,8 @@ void handleFor(IRRewriter &builder, scf::ForOp forOp, QubitValueTracker &tracker
                SmallVector<Operation *> &erasureWorklist);
 void handleWhile(IRRewriter &builder, scf::WhileOp whileOp, QubitValueTracker &tracker,
                  SmallVector<Operation *> &erasureWorklist);
-// void handleSubroutine(IRRewriter &builder, func::FuncOp f,
-//                       const SetVector<Value> &rValuesUsedBySubroutine);
+void handleSubroutine(IRRewriter &builder, func::FuncOp subroutine,
+                      const SmallVector<IntegerAttr> &qregSizesAtCallsite);
 
 // Main driver
 std::optional<SmallVector<Operation *>> handleRegion(IRRewriter &builder, Region &r,

--- a/mlir/test/Quantum/SemanticsConversion/TestControlFlow.mlir
+++ b/mlir/test/Quantum/SemanticsConversion/TestControlFlow.mlir
@@ -455,3 +455,279 @@ func.func @test_while_loop_nested(%arg0: i1) attributes {quantum.node} {
     quantum.dealloc %3 : !quantum.reg
     return
 }
+
+
+// -----
+
+
+// CHECK-LABEL: test_if_non_root_no_else
+func.func @test_if_non_root_no_else(%arg0: i1) attributes {quantum.node} {
+
+    // CHECK: [[qreg:%.+]] = qref.alloc( 3) : !qref.reg<3>
+    // CHECK: [[q0:%.+]] = qref.get [[qreg]][ 0] : !qref.reg<3> -> !qref.bit
+    %0 = quantum.alloc( 3) : !quantum.reg
+    %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+
+    // CHECK: scf.if %arg0 {
+    // CHECK:   qref.custom "Hadamard"() [[q0]] : !qref.bit
+    // CHECK:   qref.custom "X"() [[q0]] : !qref.bit
+    // CHECK: } else {
+    // CHECK-NEXT: }
+    %2 = scf.if %arg0 -> (!quantum.bit) {
+        %out_qubits = quantum.custom "Hadamard"() %1 : !quantum.bit
+        %out_qubits_0 = quantum.custom "X"() %out_qubits : !quantum.bit
+        scf.yield %out_qubits_0 : !quantum.bit
+    } else {
+        scf.yield %1 : !quantum.bit
+    }
+
+    // CHECK-NOT: quantum.insert
+    %3 = quantum.insert %0[ 0], %2 : !quantum.reg, !quantum.bit
+
+    // CHECK: qref.dealloc [[qreg]] : !qref.reg<3>
+    quantum.dealloc %3 : !quantum.reg
+    return
+}
+
+
+// -----
+
+
+// CHECK-LABEL: test_if_non_root_with_else
+func.func @test_if_non_root_with_else(%arg0: i1) attributes {quantum.node} {
+    // CHECK: [[qreg:%.+]] = qref.alloc( 3) : !qref.reg<3>
+    // CHECK: [[q0:%.+]] = qref.get [[qreg]][ 0] : !qref.reg<3> -> !qref.bit
+    // CHECK: [[q1:%.+]] = qref.get [[qreg]][ 1] : !qref.reg<3> -> !qref.bit
+    %0 = quantum.alloc( 3) : !quantum.reg
+    %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+    %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+
+    // CHECK: scf.if %arg0 {
+    // CHECK:   qref.custom "CNOT"() [[q0]], [[q1]] : !qref.bit, !qref.bit
+    // CHECK: } else {
+    // CHECK:   qref.custom "Y"() [[q1]] : !qref.bit
+    // CHECK: }
+    %3:2 = scf.if %arg0 -> (!quantum.bit, !quantum.bit) {
+        %out_qubits:2 = quantum.custom "CNOT"() %1, %2 : !quantum.bit, !quantum.bit
+        scf.yield %out_qubits#0, %out_qubits#1 : !quantum.bit, !quantum.bit
+    } else {
+        %out_qubits = quantum.custom "Y"() %2 : !quantum.bit
+        scf.yield %1, %out_qubits : !quantum.bit, !quantum.bit
+    }
+
+    // CHECK-NOT: quantum.insert
+    %4 = quantum.insert %0[ 0], %3#0 : !quantum.reg, !quantum.bit
+    %5 = quantum.insert %4[ 1], %3#1 : !quantum.reg, !quantum.bit
+
+    // CHECK: qref.dealloc [[qreg]] : !qref.reg<3>
+    quantum.dealloc %5 : !quantum.reg
+    return
+}
+
+
+// -----
+
+
+// CHECK-LABEL: test_if_root_no_else
+func.func @test_if_root_no_else(%arg0: i1) attributes {quantum.node} {
+
+    // CHECK: [[qb:%.+]] = qref.alloc_qb : !qref.bit
+    %0 = quantum.alloc_qb : !quantum.bit
+
+    // CHECK: scf.if %arg0 {
+    // CHECK:   qref.custom "Hadamard"() [[qb]] : !qref.bit
+    // CHECK: } else {
+    // CHECK-NEXT: }
+    %1 = scf.if %arg0 -> (!quantum.bit) {
+        %out_qubits = quantum.custom "Hadamard"() %0 : !quantum.bit
+        scf.yield %out_qubits : !quantum.bit
+    } else {
+        scf.yield %0 : !quantum.bit
+    }
+
+    // CHECK: qref.dealloc_qb [[qb]] : !qref.bit
+    quantum.dealloc_qb %1 : !quantum.bit
+    return
+}
+
+
+// -----
+
+
+// CHECK-LABEL: test_if_root_with_else
+func.func @test_if_root_with_else(%arg0: i1, %arg1: f64) attributes {quantum.node} {
+
+    // CHECK: [[qb:%.+]] = qref.alloc_qb : !qref.bit
+    %0 = quantum.alloc_qb : !quantum.bit
+
+    // CHECK: scf.if %arg0 {
+    // CHECK:   qref.custom "Hadamard"() [[qb]] : !qref.bit
+    // CHECK: } else {
+    // CHECK:   qref.custom "RX"(%arg1) [[qb]] : !qref.bit
+    // CHECK: }
+    %1 = scf.if %arg0 -> (!quantum.bit) {
+        %out_qubits = quantum.custom "Hadamard"() %0 : !quantum.bit
+        scf.yield %out_qubits : !quantum.bit
+    } else {
+        %out_qubits = quantum.custom "RX"(%arg1) %0 : !quantum.bit
+        scf.yield %out_qubits : !quantum.bit
+    }
+
+    // CHECK: qref.dealloc_qb [[qb]] : !qref.bit
+    quantum.dealloc_qb %1 : !quantum.bit
+    return
+}
+
+
+// -----
+
+
+// CHECK-LABEL: test_if_with_existing_results
+func.func @test_if_with_existing_results(%arg0: i1, %arg1: f64) -> i1 attributes {quantum.node} {
+    // CHECK: [[qb:%.+]] = qref.alloc_qb : !qref.bit
+    %0 = quantum.alloc_qb : !quantum.bit
+
+    // CHECK: [[ifOut:%.+]] = scf.if %arg0 -> (i1) {
+    // CHECK:   qref.custom "Hadamard"() [[qb]] : !qref.bit
+    // CHECK:   [[mres_t:%.+]] = qref.measure [[qb]] : i1
+    // CHECK:   scf.yield [[mres_t]] : i1
+    // CHECK: } else {
+    // CHECK:   qref.custom "RX"(%arg1) [[qb]] : !qref.bit
+    // CHECK:   [[mres_f:%.+]] = qref.measure [[qb]] : i1
+    // CHECK:   scf.yield [[mres_f]] : i1
+    // CHECK: }
+    %1:2 = scf.if %arg0 -> (i1, !quantum.bit) {
+        %out_qubits = quantum.custom "Hadamard"() %0 : !quantum.bit
+        %mres, %out_qubit = quantum.measure %out_qubits : i1, !quantum.bit
+        scf.yield %mres, %out_qubit : i1, !quantum.bit
+    } else {
+        %out_qubits = quantum.custom "RX"(%arg1) %0 : !quantum.bit
+        %mres, %out_qubit = quantum.measure %out_qubits : i1, !quantum.bit
+        scf.yield %mres, %out_qubit : i1, !quantum.bit
+    }
+
+    // CHECK: qref.dealloc_qb [[qb]] : !qref.bit
+    // CHECK: return [[ifOut]] : i1
+    quantum.dealloc_qb %1#1 : !quantum.bit
+    return %1#0 : i1
+}
+
+
+// -----
+
+
+// CHECK-LABEL: test_if_nested_for
+func.func @test_if_nested_for(%arg0: i1) attributes {quantum.node} {
+    %c37 = arith.constant 37 : index
+    %c1 = arith.constant 1 : index
+    %c0 = arith.constant 0 : index
+
+    // CHECK: [[qreg:%.+]] = qref.alloc( 3) : !qref.reg<3>
+    %0 = quantum.alloc( 3) : !quantum.reg
+
+    // CHECK: scf.if %arg0 {
+    %1 = scf.if %arg0 -> (!quantum.reg) {
+
+        // CHECK: scf.for %arg1 = {{%.+}} to {{%.+}} step {{%.+}} {
+        %2 = scf.for %arg1 = %c0 to %c37 step %c1 iter_args(%arg2 = %0) -> (!quantum.reg) {
+            // CHECK: [[i:%.+]] = index.casts %arg1 : index to i64
+            // CHECK: [[q0:%.+]] = qref.get [[qreg]][ 0] : !qref.reg<3> -> !qref.bit
+            // CHECK: [[q1:%.+]] = qref.get [[qreg]][ 1] : !qref.reg<3> -> !qref.bit
+            // CHECK: [[qi:%.+]] = qref.get [[qreg]][[[i]]] : !qref.reg<3>, i64 -> !qref.bit
+            // CHECK: qref.custom "Toffoli"() [[q0]], [[q1]], [[qi]] : !qref.bit, !qref.bit, !qref.bit
+            %7 = index.casts %arg1 : index to i64
+            %8 = quantum.extract %arg2[ 0] : !quantum.reg -> !quantum.bit
+            %9 = quantum.extract %arg2[ 1] : !quantum.reg -> !quantum.bit
+            %10 = quantum.extract %arg2[%7] : !quantum.reg -> !quantum.bit
+            %out_qubits_0:3 = quantum.custom "Toffoli"() %8, %9, %10 : !quantum.bit, !quantum.bit, !quantum.bit
+
+            // CHECK-NOT: quantum.insert
+            %11 = quantum.insert %arg2[ 0], %out_qubits_0#0 : !quantum.reg, !quantum.bit
+            %12 = quantum.insert %11[ 1], %out_qubits_0#1 : !quantum.reg, !quantum.bit
+            %13 = quantum.insert %12[%7], %out_qubits_0#2 : !quantum.reg, !quantum.bit
+
+            // CHECK-NOT: scf.yield
+            scf.yield %13 : !quantum.reg
+        }
+
+        // CHECK: [[q0:%.+]] = qref.get [[qreg]][ 0] : !qref.reg<3> -> !qref.bit
+        // CHECK: [[q1:%.+]] = qref.get [[qreg]][ 1] : !qref.reg<3> -> !qref.bit
+        // CHECK: qref.custom "CNOT"() [[q0]], [[q1]] : !qref.bit, !qref.bit
+        %3 = quantum.extract %2[ 0] : !quantum.reg -> !quantum.bit
+        %4 = quantum.extract %2[ 1] : !quantum.reg -> !quantum.bit
+        %out_qubits:2 = quantum.custom "CNOT"() %3, %4 : !quantum.bit, !quantum.bit
+
+        // CHECK-NOT: quantum.insert
+        %5 = quantum.insert %2[ 0], %out_qubits#0 : !quantum.reg, !quantum.bit
+        %6 = quantum.insert %5[ 1], %out_qubits#1 : !quantum.reg, !quantum.bit
+
+        // CHECK-NOT: scf.yield
+        scf.yield %6 : !quantum.reg
+
+    // CHECK: } else {
+    // CHECK-NEXT: }
+    } else {
+        scf.yield %0 : !quantum.reg
+    }
+
+    // CHECK: qref.dealloc [[qreg]] : !qref.reg<3>
+    quantum.dealloc %1 : !quantum.reg
+    return
+}
+
+
+// -----
+
+
+// CHECK-LABEL: test_switch
+func.func @test_switch(%arg0: index, %arg1: f64) -> f64 attributes {quantum.node} {
+    // CHECK: [[qb:%.+]] = qref.alloc_qb : !qref.bit
+    // CHECK: [[qreg:%.+]] = qref.alloc( 3) : !qref.reg<3>
+    // CHECK: [[q0:%.+]] = qref.get [[qreg]][ 0] : !qref.reg<3> -> !qref.bit
+    // CHECK: [[q1:%.+]] = qref.get [[qreg]][ 1] : !qref.reg<3> -> !qref.bit
+    %0 = quantum.alloc_qb : !quantum.bit
+    %1 = quantum.alloc( 3) : !quantum.reg
+    %2 = quantum.extract %1[ 0] : !quantum.reg -> !quantum.bit
+    %3 = quantum.extract %1[ 1] : !quantum.reg -> !quantum.bit
+
+    // CHECK: [[switchOut:%.+]] = scf.index_switch %arg0 -> f64
+    %4:4 = scf.index_switch %arg0 -> !quantum.bit, !quantum.bit, !quantum.bit, f64
+    // CHECK: case 10 {
+    // CHECK:   qref.custom "Hadamard"() [[qb]] : !qref.bit
+    // CHECK:   qref.custom "Toffoli"() [[qb]], [[q0]], [[q1]] : !qref.bit, !qref.bit, !qref.bit
+    // CHECK:   scf.yield %arg1 : f64
+    // CHECK: }
+    case 10 {
+        %out_qubits = quantum.custom "Hadamard"() %0 : !quantum.bit
+        %out_qubits_0:3 = quantum.custom "Toffoli"() %out_qubits, %2, %3 : !quantum.bit, !quantum.bit, !quantum.bit
+        scf.yield %out_qubits_0#0, %out_qubits_0#1, %out_qubits_0#2, %arg1 : !quantum.bit, !quantum.bit, !quantum.bit, f64
+    }
+    // CHECK: case 20 {
+    // CHECK:   qref.custom "RX"(%arg1) [[qb]] : !qref.bit
+    // CHECK:   qref.custom "CNOT"() [[qb]], [[q1]] : !qref.bit, !qref.bit
+    // CHECK:   scf.yield %arg1 : f64
+    // CHECK: }
+    case 20 {
+        %out_qubits = quantum.custom "RX"(%arg1) %0 : !quantum.bit
+        %out_qubits_0:2 = quantum.custom "CNOT"() %out_qubits, %3 : !quantum.bit, !quantum.bit
+        scf.yield %out_qubits_0#0, %2, %out_qubits_0#1, %arg1 : !quantum.bit, !quantum.bit, !quantum.bit, f64
+    }
+
+    // CHECK: default {
+    // CHECK:   scf.yield %arg1 : f64
+    // CHECK: }
+    default {
+        scf.yield %0, %2, %3, %arg1 : !quantum.bit, !quantum.bit, !quantum.bit, f64
+    }
+
+    // CHECK-NOT: quantum.insert
+    %5 = quantum.insert %1[ 0], %4#1 : !quantum.reg, !quantum.bit
+    %6 = quantum.insert %5[ 1], %4#2 : !quantum.reg, !quantum.bit
+
+    // CHECK: qref.dealloc_qb [[qb]] : !qref.bit
+    // CHECK: qref.dealloc [[qreg]] : !qref.reg<3>
+    // CHECK: return [[switchOut]] : f64
+    quantum.dealloc_qb %4#0 : !quantum.bit
+    quantum.dealloc %6 : !quantum.reg
+    return %4#3 : f64
+}

--- a/mlir/test/Quantum/SemanticsConversion/TestControlFlow.mlir
+++ b/mlir/test/Quantum/SemanticsConversion/TestControlFlow.mlir
@@ -520,8 +520,8 @@ func.func @test_if_non_root_with_else(%arg0: i1) attributes {quantum.node} {
         %out_qubits:2 = quantum.custom "CNOT"() %1, %2 : !quantum.bit, !quantum.bit
         scf.yield %out_qubits#0, %out_qubits#1 : !quantum.bit, !quantum.bit
     } else {
-        %out_qubits = quantum.custom "Y"() %2 : !quantum.bit
-        scf.yield %1, %out_qubits : !quantum.bit, !quantum.bit
+        %out_qubit = quantum.custom "Y"() %2 : !quantum.bit
+        scf.yield %1, %out_qubit : !quantum.bit, !quantum.bit
     }
 
     // CHECK-NOT: quantum.insert

--- a/mlir/test/Quantum/SemanticsConversion/TestControlFlow.mlir
+++ b/mlir/test/Quantum/SemanticsConversion/TestControlFlow.mlir
@@ -289,6 +289,11 @@ func.func public @test_for_loop_with_dynamic_allocation() attributes {quantum.no
 // -----
 
 
+//
+// while loop
+//
+
+
 // CHECK-LABEL: test_basic_while_loop
 func.func @test_basic_while_loop(%arg0: f64) attributes {quantum.node} {
 
@@ -458,6 +463,11 @@ func.func @test_while_loop_nested(%arg0: i1) attributes {quantum.node} {
 
 
 // -----
+
+
+//
+// if
+//
 
 
 // CHECK-LABEL: test_if_non_root_no_else
@@ -677,6 +687,11 @@ func.func @test_if_nested_for(%arg0: i1) attributes {quantum.node} {
 
 
 // -----
+
+
+//
+// switch
+//
 
 
 // CHECK-LABEL: test_switch

--- a/mlir/test/Quantum/SemanticsConversion/TestControlFlow.mlir
+++ b/mlir/test/Quantum/SemanticsConversion/TestControlFlow.mlir
@@ -481,8 +481,7 @@ func.func @test_if_non_root_no_else(%arg0: i1) attributes {quantum.node} {
     // CHECK: scf.if %arg0 {
     // CHECK:   qref.custom "Hadamard"() [[q0]] : !qref.bit
     // CHECK:   qref.custom "X"() [[q0]] : !qref.bit
-    // CHECK: } else {
-    // CHECK-NEXT: }
+    // CHECK-NOT: else
     %2 = scf.if %arg0 -> (!quantum.bit) {
         %out_qubits = quantum.custom "Hadamard"() %1 : !quantum.bit
         %out_qubits_0 = quantum.custom "X"() %out_qubits : !quantum.bit
@@ -546,8 +545,7 @@ func.func @test_if_root_no_else(%arg0: i1) attributes {quantum.node} {
 
     // CHECK: scf.if %arg0 {
     // CHECK:   qref.custom "Hadamard"() [[qb]] : !qref.bit
-    // CHECK: } else {
-    // CHECK-NEXT: }
+    // CHECK-NOT: else
     %1 = scf.if %arg0 -> (!quantum.bit) {
         %out_qubits = quantum.custom "Hadamard"() %0 : !quantum.bit
         scf.yield %out_qubits : !quantum.bit
@@ -674,8 +672,7 @@ func.func @test_if_nested_for(%arg0: i1) attributes {quantum.node} {
         // CHECK-NOT: scf.yield
         scf.yield %6 : !quantum.reg
 
-    // CHECK: } else {
-    // CHECK-NEXT: }
+    // CHECK-NOT: else
     } else {
         scf.yield %0 : !quantum.reg
     }

--- a/mlir/test/Quantum/SemanticsConversion/TestSubroutines.mlir
+++ b/mlir/test/Quantum/SemanticsConversion/TestSubroutines.mlir
@@ -1,0 +1,442 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test conversion to reference semantics quantum dialect where control flow is present.
+
+// RUN: quantum-opt --convert-to-reference-semantics --split-input-file --verify-diagnostics %s | FileCheck %s
+
+
+// CHECK: func.func @test_qreg_arg(%arg0: f64, %arg1: i64, %arg2: !qref.reg<2>) {
+// CHECK:     [[q:%.+]] = qref.get %arg2[%arg1] : !qref.reg<2>, i64 -> !qref.bit
+// CHECK:     qref.custom "RX"(%arg0) [[q]] : !qref.bit
+// CHECK:     return
+// CHECK: }
+
+func.func @test_qreg_arg(%arg0: f64, %arg1: i64, %arg2: !quantum.reg) -> !quantum.reg {
+    %0 = quantum.extract %arg2[%arg1] : !quantum.reg -> !quantum.bit
+    %out_qubits = quantum.custom "RX"(%arg0) %0 : !quantum.bit
+    %1 = quantum.insert %arg2[%arg1], %out_qubits : !quantum.reg, !quantum.bit
+    return %1 : !quantum.reg
+}
+
+// CHECK: func.func @main(%arg0: f64, %arg1: i64) attributes {quantum.node} {
+// CHECK:     [[reg1:%.+]] = qref.alloc( 2) : !qref.reg<2>
+// CHECK:     [[reg2:%.+]] = qref.alloc( 2) : !qref.reg<2>
+// CHECK:     call @test_qreg_arg(%arg0, %arg1, [[reg1]]) : (f64, i64, !qref.reg<2>) -> ()
+// CHECK:     call @test_qreg_arg(%arg0, %arg1, [[reg2]]) : (f64, i64, !qref.reg<2>) -> ()
+// CHECK:     qref.dealloc [[reg1]] : !qref.reg<2>
+// CHECK:     qref.dealloc [[reg2]] : !qref.reg<2>
+// CHECK:     return
+// CHECK: }
+
+func.func @main(%arg0: f64, %arg1: i64) attributes {quantum.node} {
+    %0 = quantum.alloc( 2) : !quantum.reg
+    %1 = quantum.alloc( 2) : !quantum.reg
+    %2 = call @test_qreg_arg(%arg0, %arg1, %0) : (f64, i64, !quantum.reg) -> !quantum.reg
+    %3 = call @test_qreg_arg(%arg0, %arg1, %1) : (f64, i64, !quantum.reg) -> !quantum.reg
+    quantum.dealloc %2 : !quantum.reg
+    quantum.dealloc %3 : !quantum.reg
+    return
+}
+
+
+// -----
+
+
+// CHECK: func.func @test_multi_qreg_arg(%arg0: !qref.reg<2>, %arg1: i64, %arg2: !qref.reg<?>) {
+// CHECK:     [[q0:%.+]] = qref.get %arg0[%arg1] : !qref.reg<2>, i64 -> !qref.bit
+// CHECK:     [[q2:%.+]] = qref.get %arg2[%arg1] : !qref.reg<?>, i64 -> !qref.bit
+// CHECK:     qref.custom "gate"() [[q0]], [[q2]] : !qref.bit, !qref.bit
+// CHECK:     return
+// CHECK: }
+
+func.func @test_multi_qreg_arg(%arg0: !quantum.reg, %arg1: i64, %arg2: !quantum.reg) -> (!quantum.reg, !quantum.reg) {
+    %0 = quantum.extract %arg0[%arg1] : !quantum.reg -> !quantum.bit
+    %1 = quantum.extract %arg2[%arg1] : !quantum.reg -> !quantum.bit
+    %out_qubits:2 = quantum.custom "gate"() %0, %1 : !quantum.bit, !quantum.bit
+    %2 = quantum.insert %arg0[%arg1], %out_qubits#0 : !quantum.reg, !quantum.bit
+    %3 = quantum.insert %arg2[%arg1], %out_qubits#1 : !quantum.reg, !quantum.bit
+    return %2, %3 : !quantum.reg, !quantum.reg
+}
+
+// CHECK: func.func @main(%arg0: i64) attributes {quantum.node} {
+// CHECK:     [[reg2:%.+]] = qref.alloc( 2) : !qref.reg<2>
+// CHECK:     [[reg_dyn:%.+]] = qref.alloc(%arg0) : !qref.reg<?>
+// CHECK:     call @test_multi_qreg_arg([[reg2]], %arg0, [[reg_dyn]]) : (!qref.reg<2>, i64, !qref.reg<?>) -> ()
+// CHECK:     qref.dealloc [[reg2]] : !qref.reg<2>
+// CHECK:     qref.dealloc [[reg_dyn]] : !qref.reg<?>
+// CHECK:     return
+// CHECK: }
+
+func.func @main(%arg0: i64) attributes {quantum.node} {
+    %0 = quantum.alloc( 2) : !quantum.reg
+    %1 = quantum.alloc(%arg0) : !quantum.reg
+    %2:2 = call @test_multi_qreg_arg(%0, %arg0, %1) : (!quantum.reg, i64, !quantum.reg) -> (!quantum.reg, !quantum.reg)
+    quantum.dealloc %2#0 : !quantum.reg
+    quantum.dealloc %2#1 : !quantum.reg
+    return
+}
+
+
+// -----
+
+
+// CHECK: func.func @test_qubit_args(%arg0: f64, %arg1: !qref.bit, %arg2: !qref.bit, %arg3: !qref.bit) {
+// CHECK:     qref.custom "CNOT"() %arg1, %arg2 : !qref.bit, !qref.bit
+// CHECK:     qref.custom "RX"(%arg0) %arg3 : !qref.bit
+// CHECK:     qref.custom "Toffoli"() %arg1, %arg2, %arg3 : !qref.bit, !qref.bit, !qref.bit
+// CHECK:     return
+// CHECK: }
+
+func.func @test_qubit_args(%arg0: f64, %arg1: !quantum.bit, %arg2: !quantum.bit, %arg3: !quantum.bit) -> (!quantum.bit, !quantum.bit, !quantum.bit) {
+    %out_qubits:2 = quantum.custom "CNOT"() %arg1, %arg2 : !quantum.bit, !quantum.bit
+    %out_qubits_0 = quantum.custom "RX"(%arg0) %arg3 : !quantum.bit
+    %out_qubits_1:3 = quantum.custom "Toffoli"() %out_qubits#0, %out_qubits#1, %out_qubits_0 : !quantum.bit, !quantum.bit, !quantum.bit
+    return %out_qubits_1#0, %out_qubits_1#1, %out_qubits_1#2 : !quantum.bit, !quantum.bit, !quantum.bit
+}
+
+func.func @main(%arg0: i64, %arg1: f64) -> (!quantum.obs, !quantum.obs) attributes {quantum.node} {
+    // CHECK: [[reg2:%.+]] = qref.alloc( 2) : !qref.reg<2>
+    // CHECK: [[reg_dyn:%.+]] = qref.alloc(%arg0) : !qref.reg<?>
+    %0 = quantum.alloc( 2) : !quantum.reg
+    %1 = quantum.alloc(%arg0) : !quantum.reg
+
+    // CHECK: [[q20:%.+]] = qref.get [[reg2]][ 0] : !qref.reg<2> -> !qref.bit
+    // CHECK: [[q21:%.+]] = qref.get [[reg2]][ 1] : !qref.reg<2> -> !qref.bit
+    // CHECK: [[q_dyn_1:%.+]] = qref.get [[reg_dyn]][ 1] : !qref.reg<?> -> !qref.bit
+    // CHECK: call @test_qubit_args(%arg1, [[q20]], [[q21]], [[q_dyn_1]]) : (f64, !qref.bit, !qref.bit, !qref.bit) -> ()
+    %2 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+    %3 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+    %4 = quantum.extract %1[ 1] : !quantum.reg -> !quantum.bit
+    %5:3 = call @test_qubit_args(%arg1, %2, %3, %4) : (f64, !quantum.bit, !quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit, !quantum.bit)
+    %6 = quantum.insert %0[ 0], %5#0 : !quantum.reg, !quantum.bit
+    %7 = quantum.insert %6[ 1], %5#1 : !quantum.reg, !quantum.bit
+    %8 = quantum.insert %1[ 1], %5#2 : !quantum.reg, !quantum.bit
+
+    // CHECK: [[q20:%.+]] = qref.get [[reg2]][ 0] : !qref.reg<2> -> !qref.bit
+    // CHECK: [[q21:%.+]] = qref.get [[reg2]][ 1] : !qref.reg<2> -> !qref.bit
+    // CHECK: [[q_dyn_1:%.+]] = qref.get [[reg_dyn]][ 1] : !qref.reg<?> -> !qref.bit
+    // CHECK: call @test_qubit_args(%arg1, [[q20]], [[q21]], [[q_dyn_1]]) : (f64, !qref.bit, !qref.bit, !qref.bit) -> ()
+    %9 = quantum.extract %7[ 0] : !quantum.reg -> !quantum.bit
+    %10 = quantum.extract %7[ 1] : !quantum.reg -> !quantum.bit
+    %11 = quantum.extract %8[ 1] : !quantum.reg -> !quantum.bit
+    %12:3 = call @test_qubit_args(%arg1, %9, %10, %11) : (f64, !quantum.bit, !quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit, !quantum.bit)
+    %13 = quantum.insert %7[ 0], %12#0 : !quantum.reg, !quantum.bit
+    %14 = quantum.insert %13[ 1], %12#1 : !quantum.reg, !quantum.bit
+    %15 = quantum.insert %8[ 1], %12#2 : !quantum.reg, !quantum.bit
+
+    // CHECK: [[q20:%.+]] = qref.get [[reg2]][ 0] : !qref.reg<2> -> !qref.bit
+    // CHECK: [[obs0:%.+]] = qref.compbasis qubits [[q20]] : !quantum.obs
+    // CHECK: [[obs1:%.+]] = qref.compbasis(qreg [[reg_dyn]] : !qref.reg<?>) : !quantum.obs
+    %16 = quantum.extract %14[ 0] : !quantum.reg -> !quantum.bit
+    %17 = quantum.compbasis qubits %16 : !quantum.obs
+    %18 = quantum.insert %14[ 0], %16 : !quantum.reg, !quantum.bit
+    %19 = quantum.compbasis qreg %15 : !quantum.obs
+
+    // CHECK: qref.dealloc [[reg2]] : !qref.reg<2>
+    // CHECK: qref.dealloc [[reg_dyn]] : !qref.reg<?>
+    quantum.dealloc %18 : !quantum.reg
+    quantum.dealloc %15 : !quantum.reg
+
+    // return [[obs0]], [[obs1]] : !quantum.obs, !quantum.obs
+    return %17, %19 : !quantum.obs, !quantum.obs
+}
+
+
+// -----
+
+
+// CHECK: func.func @test_single_qubit_alloc(%arg0: f64, %arg1: !qref.bit) {
+// CHECK:     qref.custom "RX"(%arg0) %arg1 : !qref.bit
+// CHECK:     return
+// CHECK: }
+
+func.func @test_single_qubit_alloc(%arg0: f64, %arg1: !quantum.bit) -> !quantum.bit {
+    %out_qubits = quantum.custom "RX"(%arg0) %arg1 : !quantum.bit
+    return %out_qubits : !quantum.bit
+}
+
+// CHECK: func.func @main(%arg0: f64) attributes {quantum.node} {
+// CHECK:     [[q0:%.+]] = qref.alloc_qb : !qref.bit
+// CHECK:     call @test_single_qubit_alloc(%arg0, [[q0]]) : (f64, !qref.bit) -> ()
+// CHECK:     call @test_single_qubit_alloc(%arg0, [[q0]]) : (f64, !qref.bit) -> ()
+// CHECK:     qref.dealloc_qb [[q0]] : !qref.bit
+// CHECK:     return
+// CHECK: }
+
+func.func @main(%arg0: f64) attributes {quantum.node} {
+    %0 = quantum.alloc_qb : !quantum.bit
+    %2 = call @test_single_qubit_alloc(%arg0, %0) : (f64, !quantum.bit) -> !quantum.bit
+    %3 = call @test_single_qubit_alloc(%arg0, %2) : (f64, !quantum.bit) -> !quantum.bit
+    quantum.dealloc_qb %3 : !quantum.bit
+    return
+}
+
+
+// -----
+
+
+// CHECK: func.func @test_mixed_args(%arg0: i64, %arg1: !qref.bit, %arg2: !qref.reg<3>, %arg3: !qref.bit) -> (i1, i1, i1) {
+func.func @test_mixed_args(%arg0: i64, %arg1: !quantum.bit, %arg2: !quantum.reg, %arg3: !quantum.bit) -> (i1, i1, i1, !quantum.bit, !quantum.reg, !quantum.bit) {
+    // CHECK: [[q_from_reg:%.+]] = qref.get %arg2[%arg0] : !qref.reg<3>, i64 -> !qref.bit
+    // CHECK: qref.custom "gate"() %arg1, [[q_from_reg]], %arg3 : !qref.bit, !qref.bit, !qref.bit
+    %0 = quantum.extract %arg2[%arg0] : !quantum.reg -> !quantum.bit
+    %out_qubits:3 = quantum.custom "gate"() %arg1, %0, %arg3 : !quantum.bit, !quantum.bit, !quantum.bit
+    %1 = quantum.insert %arg2[%arg0], %out_qubits#1 : !quantum.reg, !quantum.bit
+
+    // CHECK: [[mres1:%.+]] = qref.measure %arg1 : i1
+    %mres, %out_qubit = quantum.measure %out_qubits#0 : i1, !quantum.bit
+
+    // CHECK: [[q_from_reg:%.+]] = qref.get %arg2[%arg0] : !qref.reg<3>, i64 -> !qref.bit
+    // CHECK: [[mres2:%.+]] = qref.measure [[q_from_reg]] : i1
+    %2 = quantum.extract %1[%arg0] : !quantum.reg -> !quantum.bit
+    %mres_0, %out_qubit_1 = quantum.measure %2 : i1, !quantum.bit
+    %3 = quantum.insert %1[%arg0], %out_qubit_1 : !quantum.reg, !quantum.bit
+
+    // CHECK: [[mres3:%.+]] = qref.measure %arg3 : i1
+    %mres_2, %out_qubit_3 = quantum.measure %out_qubits#2 : i1, !quantum.bit
+
+    // CHECK: return [[mres1]], [[mres2]], [[mres3]] : i1, i1, i1
+    return %mres, %mres_0, %mres_2, %out_qubit, %3, %out_qubit_3 : i1, i1, i1, !quantum.bit, !quantum.reg, !quantum.bit
+}
+
+
+func.func @main(%arg0: i64) -> (i1, i1, i1, i1, i1, i1) attributes {quantum.node} {
+    // CHECK: [[q:%.+]] = qref.alloc_qb : !qref.bit
+    // CHECK: [[reg2:%.+]] = qref.alloc( 2) : !qref.reg<2>
+    // CHECK: [[reg3:%.+]] = qref.alloc( 3) : !qref.reg<3>
+    %0 = quantum.alloc_qb : !quantum.bit
+    %2 = quantum.alloc( 2) : !quantum.reg
+    %3 = quantum.alloc( 3) : !quantum.reg
+
+    // CHECK: [[q20:%.+]] = qref.get [[reg2]][ 0] : !qref.reg<2> -> !qref.bit
+    // CHECK: [[first_call:%.+]]:3 = call @test_mixed_args(%arg0, [[q20]], [[reg3]], [[q]]) : (i64, !qref.bit, !qref.reg<3>, !qref.bit) -> (i1, i1, i1)
+    %4 = quantum.extract %2[ 0] : !quantum.reg -> !quantum.bit
+    %5:6 = call @test_mixed_args(%arg0, %4, %3, %0) : (i64, !quantum.bit, !quantum.reg, !quantum.bit) -> (i1, i1, i1, !quantum.bit, !quantum.reg, !quantum.bit)
+    %6 = quantum.insert %2[ 0], %5#3 : !quantum.reg, !quantum.bit
+
+    // CHECK: [[q20:%.+]] = qref.get [[reg2]][ 0] : !qref.reg<2> -> !qref.bit
+    // CHECK: [[second_call:%.+]]:3 = call @test_mixed_args(%arg0, [[q20]], [[reg3]], [[q]]) : (i64, !qref.bit, !qref.reg<3>, !qref.bit) -> (i1, i1, i1)
+    %7 = quantum.extract %6[ 0] : !quantum.reg -> !quantum.bit
+    %8:6 = call @test_mixed_args(%arg0, %7, %5#4, %5#5) : (i64, !quantum.bit, !quantum.reg, !quantum.bit) -> (i1, i1, i1, !quantum.bit, !quantum.reg, !quantum.bit)
+    %9 = quantum.insert %6[ 0], %8#3 : !quantum.reg, !quantum.bit
+
+    // CHECK: qref.dealloc_qb [[q]] : !qref.bit
+    // CHECK: qref.dealloc [[reg2]] : !qref.reg<2>
+    // CHECK: qref.dealloc [[reg3]] : !qref.reg<3>
+    quantum.dealloc_qb %8#5 : !quantum.bit
+    quantum.dealloc %9 : !quantum.reg
+    quantum.dealloc %8#4 : !quantum.reg
+
+    // CHECK: return [[first_call]]#0, [[first_call]]#1, [[first_call]]#2, [[second_call]]#0, [[second_call]]#1, [[second_call]]#2 : i1, i1, i1, i1, i1, i1
+    return %5#0, %5#1, %5#2, %8#0, %8#1, %8#2 : i1, i1, i1, i1, i1, i1
+}
+
+
+// -----
+
+
+// CHECK: func.func @test_loop_callsite(%arg0: !qref.bit, %arg1: !qref.bit) {
+// CHECK:     qref.custom "CNOT"() %arg0, %arg1 : !qref.bit, !qref.bit
+// CHECK:     return
+// CHECK: }
+
+func.func @test_loop_callsite(%arg0: !quantum.bit, %arg1: !quantum.bit) -> (!quantum.bit, !quantum.bit) {
+    %out_qubits:2 = quantum.custom "CNOT"() %arg0, %arg1 : !quantum.bit, !quantum.bit
+    return %out_qubits#0, %out_qubits#1 : !quantum.bit, !quantum.bit
+}
+
+func.func @main() attributes {quantum.node} {
+    // CHECK: [[q:%.+]] = qref.alloc_qb : !qref.bit
+    // CHECK: [[reg0:%.+]] = qref.alloc( 2) : !qref.reg<2>
+    // CHECK: [[reg1:%.+]] = qref.alloc( 2) : !qref.reg<2>
+    %0 = quantum.alloc_qb : !quantum.bit
+    %2 = quantum.alloc( 2) : !quantum.reg
+    %3 = quantum.alloc( 2) : !quantum.reg
+
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c37 = arith.constant 37 : index
+
+    // CHECK: [[q0:%.+]] = qref.get [[reg0]][ 0] : !qref.reg<2> -> !qref.bit
+    // CHECK: [[q1:%.+]] = qref.get [[reg1]][ 0] : !qref.reg<2> -> !qref.bit
+    %4 = quantum.extract %2[ 0] : !quantum.reg -> !quantum.bit
+    %5 = quantum.extract %3[ 0] : !quantum.reg -> !quantum.bit
+
+    // CHECK: scf.for %arg0 = {{%.+}} to {{%.+}} step {{%.+}} {
+    // CHECK:     func.call @test_loop_callsite([[q]], [[q0]]) : (!qref.bit, !qref.bit) -> ()
+    // CHECK:     func.call @test_loop_callsite([[q]], [[q1]]) : (!qref.bit, !qref.bit) -> ()
+    // CHECK: }
+    %6:3 = scf.for %arg0 = %c0 to %c37 step %c1 iter_args(%arg1 = %0, %arg2 = %4, %arg3 = %5) -> (!quantum.bit, !quantum.bit, !quantum.bit) {
+        %9:2 = func.call @test_loop_callsite(%arg1, %arg2) : (!quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+        %10:2 = func.call @test_loop_callsite(%9#0, %arg3) : (!quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+        scf.yield %10#0, %9#1, %10#1 : !quantum.bit, !quantum.bit, !quantum.bit
+    }
+    %7 = quantum.insert %2[ 0], %6#1 : !quantum.reg, !quantum.bit
+    %8 = quantum.insert %3[ 0], %6#2 : !quantum.reg, !quantum.bit
+
+    // CHECK: qref.dealloc_qb [[q]] : !qref.bit
+    // CHECK: qref.dealloc [[reg0]] : !qref.reg<2>
+    // CHECK: qref.dealloc [[reg1]] : !qref.reg<2>
+    quantum.dealloc_qb %6#0 : !quantum.bit
+    quantum.dealloc %7 : !quantum.reg
+    quantum.dealloc %8 : !quantum.reg
+    return
+}
+
+
+// -----
+
+
+// CHECK: func.func @test_cond_callsite(%arg0: !qref.bit, %arg1: !qref.bit) {
+// CHECK:     qref.custom "CNOT"() %arg0, %arg1 : !qref.bit, !qref.bit
+// CHECK:     return
+// CHECK: }
+
+func.func @test_cond_callsite(%arg0: !quantum.bit, %arg1: !quantum.bit) -> (!quantum.bit, !quantum.bit) {
+    %out_qubits:2 = quantum.custom "CNOT"() %arg0, %arg1 : !quantum.bit, !quantum.bit
+    return %out_qubits#0, %out_qubits#1 : !quantum.bit, !quantum.bit
+}
+
+func.func @main(%arg0: i1) attributes {quantum.node} {
+    // CHECK: [[q:%.+]] = qref.alloc_qb : !qref.bit
+    // CHECK: [[reg0:%.+]] = qref.alloc( 2) : !qref.reg<2>
+    // CHECK: [[reg1:%.+]] = qref.alloc( 2) : !qref.reg<2>
+    %0 = quantum.alloc_qb : !quantum.bit
+    %2 = quantum.alloc( 2) : !quantum.reg
+    %3 = quantum.alloc( 2) : !quantum.reg
+
+    // CHECK: [[q0:%.+]] = qref.get [[reg0]][ 0] : !qref.reg<2> -> !qref.bit
+    // CHECK: [[q1:%.+]] = qref.get [[reg1]][ 0] : !qref.reg<2> -> !qref.bit
+    %4 = quantum.extract %2[ 0] : !quantum.reg -> !quantum.bit
+    %5 = quantum.extract %3[ 0] : !quantum.reg -> !quantum.bit
+
+    // CHECK: scf.if %arg0 {
+    // CHECK:   func.call @test_cond_callsite([[q]], [[q0]]) : (!qref.bit, !qref.bit) -> ()
+    // CHECK:   func.call @test_cond_callsite([[q]], [[q1]]) : (!qref.bit, !qref.bit) -> ()
+    // CHECK: } else {
+    // CHECK: }
+    %6:3 = scf.if %arg0 -> (!quantum.bit, !quantum.bit, !quantum.bit) {
+        %9:2 = func.call @test_cond_callsite(%0, %4) : (!quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+        %10:2 = func.call @test_cond_callsite(%9#0, %5) : (!quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+        scf.yield %10#0, %9#1, %10#1 : !quantum.bit, !quantum.bit, !quantum.bit
+    } else {
+        scf.yield %0, %4, %5 : !quantum.bit, !quantum.bit, !quantum.bit
+    }
+    %7 = quantum.insert %2[ 0], %6#1 : !quantum.reg, !quantum.bit
+    %8 = quantum.insert %3[ 0], %6#2 : !quantum.reg, !quantum.bit
+
+    // CHECK: qref.dealloc_qb [[q]] : !qref.bit
+    // CHECK: qref.dealloc [[reg0]] : !qref.reg<2>
+    // CHECK: qref.dealloc [[reg1]] : !qref.reg<2>
+    quantum.dealloc_qb %6#0 : !quantum.bit
+    quantum.dealloc %7 : !quantum.reg
+    quantum.dealloc %8 : !quantum.reg
+    return
+}
+
+
+// -----
+
+// CHECK: func.func @test_callsite_in_nested_region(%arg0: !qref.bit, %arg1: !qref.bit) {
+// CHECK:     qref.custom "CNOT"() %arg0, %arg1 : !qref.bit, !qref.bit
+// CHECK:     return
+// CHECK: }
+func.func @test_callsite_in_nested_region(%arg0: !quantum.bit, %arg1: !quantum.bit) -> (!quantum.bit, !quantum.bit) {
+    %out_qubits:2 = quantum.custom "CNOT"() %arg0, %arg1 : !quantum.bit, !quantum.bit
+    return %out_qubits#0, %out_qubits#1 : !quantum.bit, !quantum.bit
+}
+
+func.func @main(%arg0: i1) attributes {quantum.node} {
+    // CHECK: [[q:%.+]] = qref.alloc_qb : !qref.bit
+    // CHECK: [[reg0:%.+]] = qref.alloc( 2) : !qref.reg<2>
+    // CHECK: [[reg1:%.+]] = qref.alloc( 2) : !qref.reg<2>
+    %0 = quantum.alloc_qb : !quantum.bit
+    %2 = quantum.alloc( 2) : !quantum.reg
+    %3 = quantum.alloc( 2) : !quantum.reg
+
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c37 = arith.constant 37 : index
+
+    // CHECK: [[q0:%.+]] = qref.get [[reg0]][ 0] : !qref.reg<2> -> !qref.bit
+    // CHECK: [[q1:%.+]] = qref.get [[reg1]][ 0] : !qref.reg<2> -> !qref.bit
+    %4 = quantum.extract %2[ 0] : !quantum.reg -> !quantum.bit
+    %5 = quantum.extract %3[ 0] : !quantum.reg -> !quantum.bit
+
+    // CHECK: scf.if %arg0 {
+    // CHECK:   scf.for %arg1 = {{%.+}} to {{%.+}} step {{%.+}} {
+    // CHECK:     func.call @test_callsite_in_nested_region([[q]], [[q0]]) : (!qref.bit, !qref.bit) -> ()
+    // CHECK:     func.call @test_callsite_in_nested_region([[q]], [[q1]]) : (!qref.bit, !qref.bit) -> ()
+    // CHECK:   }
+    // CHECK: } else {
+    // CHECK: }
+    %6:3 = scf.if %arg0 -> (!quantum.bit, !quantum.bit, !quantum.bit) {
+        %9:3 = scf.for %arg1 = %c0 to %c37 step %c1 iter_args(%arg2 = %0, %arg3 = %4, %arg4 = %5) -> (!quantum.bit, !quantum.bit, !quantum.bit) {
+        %10:2 = func.call @test_callsite_in_nested_region(%arg2, %arg3) : (!quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+        %11:2 = func.call @test_callsite_in_nested_region(%10#0, %arg4) : (!quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
+        scf.yield %11#0, %10#1, %11#1 : !quantum.bit, !quantum.bit, !quantum.bit
+        }
+        scf.yield %9#0, %9#1, %9#2 : !quantum.bit, !quantum.bit, !quantum.bit
+    } else {
+        scf.yield %0, %4, %5 : !quantum.bit, !quantum.bit, !quantum.bit
+    }
+    %7 = quantum.insert %2[ 0], %6#1 : !quantum.reg, !quantum.bit
+    %8 = quantum.insert %3[ 0], %6#2 : !quantum.reg, !quantum.bit
+
+    // CHECK: qref.dealloc_qb [[q]] : !qref.bit
+    // CHECK: qref.dealloc [[reg0]] : !qref.reg<2>
+    // CHECK: qref.dealloc [[reg1]] : !qref.reg<2>
+    quantum.dealloc_qb %6#0 : !quantum.bit
+    quantum.dealloc %7 : !quantum.reg
+    quantum.dealloc %8 : !quantum.reg
+    return
+}
+
+
+// -----
+
+// CHECK: func.func @callee(%arg0: !qref.bit) {
+// CHECK:     qref.custom "PauliX"() %arg0 : !qref.bit
+// CHECK:     return
+// CHECK: }
+// CHECK: func.func @caller(%arg0: !qref.bit) {
+// CHECK:     call @callee(%arg0) : (!qref.bit) -> ()
+// CHECK:     return
+// CHECK: }
+
+func.func @callee(%arg0: !quantum.bit) -> !quantum.bit {
+    %out_qubits = quantum.custom "PauliX"() %arg0 : !quantum.bit
+    return %out_qubits : !quantum.bit
+}
+func.func @caller(%arg0: !quantum.bit) -> !quantum.bit {
+    %0 = call @callee(%arg0) : (!quantum.bit) -> !quantum.bit
+    return %0 : !quantum.bit
+}
+
+// CHECK: func.func @main() attributes {quantum.node} {
+// CHECK:     [[reg:%.+]] = qref.alloc( 1) : !qref.reg<1>
+// CHECK:     [[q:%.+]] = qref.get [[reg]][ 0] : !qref.reg<1> -> !qref.bit
+// CHECK:     call @caller([[q]]) : (!qref.bit) -> ()
+// CHECK:     qref.dealloc [[reg]] : !qref.reg<1>
+// CHECK:     return
+// CHECK: }
+func.func @main() attributes {quantum.node} {
+    %0 = quantum.alloc( 1) : !quantum.reg
+    %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+    %2 = call @caller(%1) : (!quantum.bit) -> !quantum.bit
+    %3 = quantum.insert %0[ 0], %2 : !quantum.reg, !quantum.bit
+    quantum.dealloc %3 : !quantum.reg
+    return
+}

--- a/mlir/test/Quantum/SemanticsConversion/TestSubroutines.mlir
+++ b/mlir/test/Quantum/SemanticsConversion/TestSubroutines.mlir
@@ -325,8 +325,7 @@ func.func @main(%arg0: i1) attributes {quantum.node} {
     // CHECK: scf.if %arg0 {
     // CHECK:   func.call @test_cond_callsite([[q]], [[q0]]) : (!qref.bit, !qref.bit) -> ()
     // CHECK:   func.call @test_cond_callsite([[q]], [[q1]]) : (!qref.bit, !qref.bit) -> ()
-    // CHECK: } else {
-    // CHECK: }
+    // CHECK-NOT: else
     %6:3 = scf.if %arg0 -> (!quantum.bit, !quantum.bit, !quantum.bit) {
         %9:2 = func.call @test_cond_callsite(%0, %4) : (!quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
         %10:2 = func.call @test_cond_callsite(%9#0, %5) : (!quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)
@@ -380,8 +379,7 @@ func.func @main(%arg0: i1) attributes {quantum.node} {
     // CHECK:     func.call @test_callsite_in_nested_region([[q]], [[q0]]) : (!qref.bit, !qref.bit) -> ()
     // CHECK:     func.call @test_callsite_in_nested_region([[q]], [[q1]]) : (!qref.bit, !qref.bit) -> ()
     // CHECK:   }
-    // CHECK: } else {
-    // CHECK: }
+    // CHECK-NOT: else
     %6:3 = scf.if %arg0 -> (!quantum.bit, !quantum.bit, !quantum.bit) {
         %9:3 = scf.for %arg1 = %c0 to %c37 step %c1 iter_args(%arg2 = %0, %arg3 = %4, %arg4 = %5) -> (!quantum.bit, !quantum.bit, !quantum.bit) {
         %10:2 = func.call @test_callsite_in_nested_region(%arg2, %arg3) : (!quantum.bit, !quantum.bit) -> (!quantum.bit, !quantum.bit)


### PR DESCRIPTION
Context:
Add calls and subroutines to `--convert-to-reference-semantics`.

[sc-105534]