### PR TITLE
fix: upperbound pytest version in SSS workflow

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -68,6 +68,17 @@ jobs:
         pip install amazon-braket-pennylane-plugin
         echo "AWS_DEFAULT_REGION=us-east-1" >> $GITHUB_ENV
 
+    - name: Upperbound 'pytest' when testing with stable Catalyst
+      if: ${{ inputs.catalyst == 'stable' }}
+      runs: |
+        # Stable Catalyst (v0.15.0) contains a test
+        # that fails to collect with pytest 9.1.
+        #
+        # This is a work-around to get SSS green again.
+        #
+        # TODO: Remove once v0.16.0 has been released.
+        python3 -m pip install "pytest<9.1"
+
     - name: Get Catalyst Build Dependencies (latest)
       uses: actions/cache/restore@v4
       if: ${{ inputs.catalyst == 'latest' }}

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -70,7 +70,7 @@ jobs:
 
     - name: Upperbound 'pytest' when testing with stable Catalyst
       if: ${{ inputs.catalyst == 'stable' }}
-      runs: |
+      run: |
         # Stable Catalyst (v0.15.0) contains a test
         # that fails to collect with pytest 9.1.
         #


### PR DESCRIPTION
⚠️ Tested here: https://github.com/PennyLaneAI/catalyst/actions/runs/27568402842

**Context:**

SSS and LLL are [failing](https://github.com/PennyLaneAI/catalyst/actions/runs/27546209905/job/81420182124) with the same error. :arrow_heading_down:

Both of them are failing as pytest 9.1 (release 2 days ago) doesn't like the extra comma here in `test_mbqc_dialect.py`
```python
@pytest.mark.parametrize("plane,", ["XY", "YZ", "ZX"])
```

Turns out, this was fixed earlier: https://github.com/PennyLaneAI/catalyst/pull/2946, which solves LLL.

**Description of the Change:**

This PR temporarily adjusts the workflow to upper bound `pytest` if Catalyst stable is being tested.

**Benefits:** SSS is unblocked.

**Possible Drawbacks:** Need to remember to remove this. Shortcut story made to track: [sc-122432]

[sc-122424]
