### PR TITLE
Put an upper bound to the `scipy-openblas32` dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ requirements = [
     f"jax=={jax_version}",
     f"jaxlib=={jax_version}",
     "numpy>2.0.0",
-    "scipy-openblas32>=0.3.26,!=0.3.33",  # symbol and library name
+    "scipy-openblas32>=0.3.26,<0.3.33",  # symbol and library name
     "diastatic-malt==2.15.3",
     "xdsl==0.63.0",
     "xdsl-jax==0.5.2",


### PR DESCRIPTION
**Context:**
[`scipy-openblas32` released a new verison](https://pypi.org/project/scipy-openblas32/0.3.33.112.0/) about an hour ago, which caused some failures in jax linalg tests.

While the root cause of the failures is not immediately clear, for now we put an upper bound to the version of the package.
