### PR TITLE
Install upper-bounded openblas package in SSS workflow

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -132,6 +132,11 @@ jobs:
         sudo apt-get install -y graphviz
         pip install pennylane-catalyst
 
+        # A test on stable (v0.15.0) fails due to an upstream openblas update
+        # We set an upper bound for the upstream package, so SSS can pass again
+        # TODO: remove once v0.16.0 has been released.
+        pip install "scipy-openblas32<0.3.33"
+
     - name: Add Frontend Dependencies to PATH
       if: ${{ inputs.catalyst == 'latest' }}
       run: |


### PR DESCRIPTION
**Context:**
[`scipy-openblas32` released a new verison](https://pypi.org/project/scipy-openblas32/0.3.33.112.0/) yesterday, which caused some failures in jax linalg tests.

We added a upper ceiling to the blas package version to `setup.py` #2950 , but that would only fix catalyst packages built from source (i.e. LLL workload). Packages installed from pypi (i.e. SSS workload) would still be under the old `setup.py`, and hence would still fail the tests.

This specific failure isn't actually a failure. The results are still correct; we are just checking qjit results against jax results, both are correct but both are different.

**Description of the Change:**
In SSS workflow, manually install the correct blas package version.

**Benefits:**
SSS passes again.
More specifically, other failures in SSS would not be shrouded by this "fake" failure.

**Possible Drawbacks:**
Need to remember to disable the hack after the next release.
