### PR TITLE
Fix extract_block bug in convert-qecp-to-quantum pass

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -2,15 +2,6 @@
 
 <h3>New features since last release</h3>
 
-* A new, experimental compiler pass `convert-qecp-to-quantum` has been added to lower operations
-  from the QEC Physical (`qecp`) dialect into the Quantum (`quantum`) dialect.
-  [(#2822)](https://github.com/PennyLaneAI/catalyst/pull/2822)
-  [(#2809)](https://github.com/PennyLaneAI/catalyst/pull/2809)
-  [(#2824)](https://github.com/PennyLaneAI/catalyst/pull/2824)
-  [(#2835)](https://github.com/PennyLaneAI/catalyst/pull/2835)
-  [(#2839)](https://github.com/PennyLaneAI/catalyst/pull/2839)
-  [(#2849)](https://github.com/PennyLaneAI/catalyst/pull/2849)
-
 
 <h3>Improvements 🛠</h3>
 
@@ -227,6 +218,16 @@
 * Fix build failures when using clang with GCC ≤ 13 libstdc++ by replacing
   `std::views::filter`/`std::views::transform` with `std::copy_if`/`std::transform`
   [(#2801)](https://github.com/PennyLaneAI/catalyst/pull/2801)
+
+* A new, experimental compiler pass `convert-qecp-to-quantum` has been added to lower operations
+  from the QEC Physical (`qecp`) dialect into the Quantum (`quantum`) dialect.
+  [(#2822)](https://github.com/PennyLaneAI/catalyst/pull/2822)
+  [(#2809)](https://github.com/PennyLaneAI/catalyst/pull/2809)
+  [(#2824)](https://github.com/PennyLaneAI/catalyst/pull/2824)
+  [(#2835)](https://github.com/PennyLaneAI/catalyst/pull/2835)
+  [(#2839)](https://github.com/PennyLaneAI/catalyst/pull/2839)
+  [(#2849)](https://github.com/PennyLaneAI/catalyst/pull/2849)
+  [(#2955)](https://github.com/PennyLaneAI/catalyst/pull/2955)
 
 * The experimental compiler pass `convert-qecl-to-qecp` has been extended to lower
   transversal gate operations from the QEC Logical (`qecl`) dialect into the QEC

--- a/frontend/catalyst/python_interface/transforms/qecp/convert_qecp_to_quantum.py
+++ b/frontend/catalyst/python_interface/transforms/qecp/convert_qecp_to_quantum.py
@@ -346,30 +346,51 @@ class ConvertQecPhysicalToQuantumPass(ModulePass):
 
                 for quantum_op in op_.walk():
                     rewriter = PatternRewriter(quantum_op)
+
                     match quantum_op:
                         case qecp.AllocOp():
                             qecp_alloc_op = quantum_op
                             qecp_ops_to_remove.append(quantum_op)
+
                         case func.CallOp() if "encode_zero_" in quantum_op.callee.string_value():
                             regs.append(quantum_op.results[0])
+
                         case qecp.ExtractCodeblockOp():
                             assert (quantum_op.idx is not None) ^ (quantum_op.idx_attr is not None)
                             qecp_ops_to_remove.append(quantum_op)
                             if quantum_op.idx is not None:
                                 idx = resolve_constant_params(quantum_op.idx)
                             else:
+                                assert quantum_op.idx_attr is not None
                                 idx = quantum_op.idx_attr.value.data
-                            quantum_op.codeblock.replace_all_uses_with(regs[idx])
+
+                            if idx not in dealloced_regs:
+                                # This is the first time we extract_block on this index, so replace
+                                # all the uses of the extracted codeblock with the corresponding
+                                # register returned after the encoding step.
+                                quantum_op.codeblock.replace_all_uses_with(regs[idx])
+                            else:
+                                # This handles the case where an extract_block follows an
+                                # insert_block on the same index. In this case, undo the
+                                # deallocation (by removing it from the 'dealloced_regs' dictionary)
+                                # and replace all uses of the extracted codeblock with the register
+                                # that was given as input to the (now undone) quantum.dealloc op.
+                                dealloc_op = dealloced_regs.pop(idx)
+                                quantum_op.codeblock.replace_all_uses_with(dealloc_op.operands[0])
+
                         case qecp.InsertCodeblockOp():
                             qecp_ops_to_remove.append(quantum_op)
                             if quantum_op.idx is not None:
                                 idx = resolve_constant_params(quantum_op.idx)
                             elif quantum_op.idx_attr is not None:
                                 idx = quantum_op.idx_attr.value.data
+
                             dealloced_regs[idx] = quantum.DeallocOp(quantum_op.codeblock)
                             quantum_op.results[0].replace_all_uses_with(qecp_alloc_op.results[0])
+
                         case qecp.DeallocOp():
                             rewriter.erase_op(quantum_op)
+
                         case quantum.DeviceReleaseOp():
                             # Dealloc qregs before device release
                             for _, dealloced_reg in dealloced_regs.items():

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
@@ -573,8 +573,158 @@ class TestSubroutineConversion:
 class TestHyperRegisterLowering:
     """Unit test for hyperreg related type and operations lowering."""
 
-    def test_hyperregister_lowering(self, run_filecheck):
-        """Test for hyperreg related type and operations lowering."""
+    def test_encode_loop_unrolling_1cb(self, run_filecheck):
+        """Test the step in the hyper-register lowering that unrolls the loop that encodes each
+        codeblock in the hyper-register. This test is for the case where the hyper-register contains
+        a single physical codeblock.
+        """
+        program = """
+        builtin.module {
+        // CHECK-LABEL: @test_program()
+        func.func public @test_program() -> () attributes {quantum.node} {
+            // CHECK: [[reg0:%.+]] = quantum.alloc(7) : !quantum.reg
+            // CHECK: [[reg1:%.+]] = func.call @encode_zero_TestCode([[reg0]]) : (!quantum.reg) -> !quantum.reg
+            // CHECK: "test.op"([[reg1]]) : (!quantum.reg) -> ()
+
+            %0 = qecp.alloc() : !qecp.hyperreg<1 x 1 x 7>
+            %1 = arith.constant 0 : index
+            %2 = arith.constant 1 : index
+            %3 = arith.constant 1 : index
+            %4 = scf.for %5 = %1 to %2 step %3 iter_args(%6 = %0) -> (!qecp.hyperreg<1 x 1 x 7>) {
+                %7 = qecp.extract_block %6[%5] : !qecp.hyperreg<1 x 1 x 7> -> !qecp.codeblock<1 x 7>
+                %8 = func.call @encode_zero_TestCode(%7) : (!qecp.codeblock<1 x 7>) -> !qecp.codeblock<1 x 7>
+                %9 = qecp.insert_block %6[%5], %8 : !qecp.hyperreg<1 x 1 x 7>, !qecp.codeblock<1 x 7>
+                scf.yield %9 : !qecp.hyperreg<1 x 1 x 7>
+            }
+            %10 = qecp.extract_block %4[0] : !qecp.hyperreg<1 x 1 x 7> -> !qecp.codeblock<1 x 7>
+            "test.op"(%10) : (!qecp.codeblock<1 x 7>) -> ()  // To prevent DCE
+        }
+        }
+        """
+        run_filecheck(program, (ConvertQecPhysicalToQuantumPass(),))
+
+    def test_encode_loop_unrolling_2cb(self, run_filecheck):
+        """Test the step in the hyper-register lowering that unrolls the loop that encodes each
+        codeblock in the hyper-register. This test is for the case where the hyper-register contains
+        two physical codeblocks.
+        """
+        program = """
+        builtin.module {
+        // CHECK-LABEL: @test_program()
+        func.func public @test_program() -> () attributes {quantum.node} {
+            // CHECK: [[reg00:%.+]] = quantum.alloc(7) : !quantum.reg
+            // CHECK: [[reg01:%.+]] = func.call @encode_zero_TestCode([[reg00]]) : (!quantum.reg) -> !quantum.reg
+            // CHECK: [[reg10:%.+]] = quantum.alloc(7) : !quantum.reg
+            // CHECK: [[reg11:%.+]] = func.call @encode_zero_TestCode([[reg10]]) : (!quantum.reg) -> !quantum.reg
+            // CHECK: "test.op"([[reg01]]) : (!quantum.reg) -> ()
+            // CHECK: "test.op"([[reg11]]) : (!quantum.reg) -> ()
+
+            %0 = qecp.alloc() : !qecp.hyperreg<2 x 1 x 7>
+            %1 = arith.constant 0 : index
+            %2 = arith.constant 2 : index
+            %3 = arith.constant 1 : index
+            %4 = scf.for %5 = %1 to %2 step %3 iter_args(%6 = %0) -> (!qecp.hyperreg<2 x 1 x 7>) {
+                %7 = qecp.extract_block %6[%5] : !qecp.hyperreg<2 x 1 x 7> -> !qecp.codeblock<1 x 7>
+                %8 = func.call @encode_zero_TestCode(%7) : (!qecp.codeblock<1 x 7>) -> !qecp.codeblock<1 x 7>
+                %9 = qecp.insert_block %6[%5], %8 : !qecp.hyperreg<2 x 1 x 7>, !qecp.codeblock<1 x 7>
+                scf.yield %9 : !qecp.hyperreg<2 x 1 x 7>
+            }
+            %10 = qecp.extract_block %4[0] : !qecp.hyperreg<2 x 1 x 7> -> !qecp.codeblock<1 x 7>
+            "test.op"(%10) : (!qecp.codeblock<1 x 7>) -> ()  // To prevent DCE
+            %11 = qecp.extract_block %4[1] : !qecp.hyperreg<2 x 1 x 7> -> !qecp.codeblock<1 x 7>
+            "test.op"(%11) : (!qecp.codeblock<1 x 7>) -> ()  // To prevent DCE
+        }
+        }
+        """
+        run_filecheck(program, (ConvertQecPhysicalToQuantumPass(),))
+
+    def test_alloc_extract_insert_dealloc_chain_1cb(self, run_filecheck):
+        """Test the hyper-register lowering pattern where the input program has a typical chain of
+        alloc, extract_block, operations on the physical codeblock, insert_block and dealloc ops.
+        Note that the 'quantum.device_release' op at the end of the program is necessary, since this
+        is what triggers the insertion of the 'quantum.dealloc' ops into the program.
+        """
+        program = """
+        builtin.module {
+        // CHECK-LABEL: @test_program()
+        func.func public @test_program() -> () attributes {quantum.node} {
+            //      CHECK: [[reg0:%.+]] = quantum.alloc(7) : !quantum.reg
+            //      CHECK: [[reg1:%.+]] = func.call @encode_zero_TestCode([[reg0]]) : (!quantum.reg) -> !quantum.reg
+            //      CHECK: [[reg2:%.+]] = func.call @gate_op([[reg1]]) : (!quantum.reg) -> !quantum.reg
+            //      CHECK: quantum.dealloc [[reg2]] : !quantum.reg
+            // CHECK-NEXT: quantum.device_release
+
+            %0 = qecp.alloc() : !qecp.hyperreg<1 x 1 x 7>
+            %1 = arith.constant 0 : index
+            %2 = arith.constant 1 : index
+            %3 = arith.constant 1 : index
+            %4 = scf.for %5 = %1 to %2 step %3 iter_args(%6 = %0) -> (!qecp.hyperreg<1 x 1 x 7>) {
+                %7 = qecp.extract_block %6[%5] : !qecp.hyperreg<1 x 1 x 7> -> !qecp.codeblock<1 x 7>
+                %8 = func.call @encode_zero_TestCode(%7) : (!qecp.codeblock<1 x 7>) -> !qecp.codeblock<1 x 7>
+                %9 = qecp.insert_block %6[%5], %8 : !qecp.hyperreg<1 x 1 x 7>, !qecp.codeblock<1 x 7>
+                scf.yield %9 : !qecp.hyperreg<1 x 1 x 7>
+            }
+            %10 = qecp.extract_block %4[0] : !qecp.hyperreg<1 x 1 x 7> -> !qecp.codeblock<1 x 7>
+            %11 = func.call @gate_op(%10) : (!qecp.codeblock<1 x 7>) -> !qecp.codeblock<1 x 7>
+            %12 = qecp.insert_block %4[0], %11 : !qecp.hyperreg<1 x 1 x 7>, !qecp.codeblock<1 x 7>
+            qecp.dealloc %12 : !qecp.hyperreg<1 x 1 x 7>
+            quantum.device_release
+            func.return
+        }
+        }
+        """
+        run_filecheck(program, (ConvertQecPhysicalToQuantumPass(),))
+
+    def test_extract_after_insert_2cb(self, run_filecheck):
+        """Test the hyper-register lowering pattern where the input program has a
+        'qecp.extract_block' op after a 'qecp.insert_block' op on the same index. This pattern is
+        less common in simple programs, but does appear in some cases, e.g. after a control-flow
+        region acting on multiple qubits.
+        """
+        program = """
+        builtin.module {
+        // CHECK-LABEL: @test_program()
+        func.func public @test_program() -> () attributes {quantum.node} {
+            //      CHECK: [[reg00:%.+]] = quantum.alloc(7) : !quantum.reg
+            //      CHECK: [[reg01:%.+]] = func.call @encode_zero_TestCode([[reg00]]) : (!quantum.reg) -> !quantum.reg
+            //      CHECK: [[reg10:%.+]] = quantum.alloc(7) : !quantum.reg
+            //      CHECK: [[reg11:%.+]] = func.call @encode_zero_TestCode([[reg10]]) : (!quantum.reg) -> !quantum.reg
+            //      CHECK: [[reg02:%.+]] = func.call @gate_op1([[reg01]]) : (!quantum.reg) -> !quantum.reg
+            //      CHECK: [[reg12:%.+]] = func.call @gate_op2([[reg11]]) : (!quantum.reg) -> !quantum.reg
+            //      CHECK: [[reg03:%.+]] = func.call @gate_op3([[reg02]]) : (!quantum.reg) -> !quantum.reg
+            //  CHECK-DAG: quantum.dealloc [[reg03]] : !quantum.reg
+            //  CHECK-DAG: quantum.dealloc [[reg12]] : !quantum.reg
+            // CHECK-NEXT: quantum.device_release
+
+            %0 = qecp.alloc() : !qecp.hyperreg<2 x 1 x 7>
+            %1 = arith.constant 0 : index
+            %2 = arith.constant 2 : index
+            %3 = arith.constant 1 : index
+            %4 = scf.for %5 = %1 to %2 step %3 iter_args(%6 = %0) -> (!qecp.hyperreg<2 x 1 x 7>) {
+                %7 = qecp.extract_block %6[%5] : !qecp.hyperreg<2 x 1 x 7> -> !qecp.codeblock<1 x 7>
+                %8 = func.call @encode_zero_TestCode(%7) : (!qecp.codeblock<1 x 7>) -> !qecp.codeblock<1 x 7>
+                %9 = qecp.insert_block %6[%5], %8 : !qecp.hyperreg<2 x 1 x 7>, !qecp.codeblock<1 x 7>
+                scf.yield %9 : !qecp.hyperreg<2 x 1 x 7>
+            }
+            %10 = qecp.extract_block %4[0] : !qecp.hyperreg<2 x 1 x 7> -> !qecp.codeblock<1 x 7>
+            %11 = qecp.extract_block %4[1] : !qecp.hyperreg<2 x 1 x 7> -> !qecp.codeblock<1 x 7>
+            %12 = func.call @gate_op1(%10) : (!qecp.codeblock<1 x 7>) -> !qecp.codeblock<1 x 7>
+            %13 = func.call @gate_op2(%11) : (!qecp.codeblock<1 x 7>) -> !qecp.codeblock<1 x 7>
+            %14 = qecp.insert_block %4[0], %12 : !qecp.hyperreg<2 x 1 x 7>, !qecp.codeblock<1 x 7>
+            %15 = qecp.insert_block %14[1], %13 : !qecp.hyperreg<2 x 1 x 7>, !qecp.codeblock<1 x 7>
+            %16 = qecp.extract_block %15[0] : !qecp.hyperreg<2 x 1 x 7> -> !qecp.codeblock<1 x 7>
+            %17 = func.call @gate_op3(%16) : (!qecp.codeblock<1 x 7>) -> !qecp.codeblock<1 x 7>
+            %18 = qecp.insert_block %15[0], %17 : !qecp.hyperreg<2 x 1 x 7>, !qecp.codeblock<1 x 7>
+            qecp.dealloc %18 : !qecp.hyperreg<2 x 1 x 7>
+            quantum.device_release
+            func.return
+        }
+        }
+        """
+        run_filecheck(program, (ConvertQecPhysicalToQuantumPass(),))
+
+    def test_hyperreg_lowering_integration(self, run_filecheck):
+        """Integration test for hyperreg related type and operations lowering."""
         program = """
             builtin.module {
             // CHECK-LABEL: @circuit()

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
@@ -34,7 +34,7 @@ from catalyst.python_interface.transforms.qecp.convert_qecp_to_quantum import (
     QecPhysicalQubitTypeConversion,
 )
 
-# pylint: disable=line-too-long
+# pylint: disable=line-too-long,too-many-lines
 
 pytestmark = pytest.mark.xdsl
 


### PR DESCRIPTION
This PR fixes a bug in the `convert-qecp-to-quantum` pass that occurs when a `qecp.extract_block` op appears after a `qecp.insert_block` op on the same index. This resulted in the incorrect use of SSA values downstream of the `qecp.insert_block` op. While this pattern of `extract` ops following `insert` ops on the same index isn't common, it _is_ a case we have to handle, since it appears in some initial program representations generated by Catalyst (in value semantics), e.g. after certain control-flow regions acting on multiple qubits (see [this comment](https://github.com/PennyLaneAI/catalyst/pull/2927/changes#r3421823993) for context).

[sc-122596]
