### PR TITLE
Add tests to ensure expval, var and probs measurements supported in QEC pipeline

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -306,6 +306,10 @@
   - For loops (`scf.for`)
     [(#2881)](https://github.com/PennyLaneAI/catalyst/pull/2881)
 
+* The experimental QEC pipeline now supports programs that sample wires, where before it only
+  supported sampling mid-circuit measurements.
+  [(#2941)](https://github.com/PennyLaneAI/catalyst/pull/2941)
+
 <h3>Documentation 📝</h3>
 
 * A broken link was removed in the [Compiler Core](https://docs.pennylane.ai/projects/catalyst/en/stable/modules/mlir.html) documentation page. The link referred to where precompiled decomposition rules were implemented, which has since been refactored.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -321,6 +321,10 @@
   supported sampling mid-circuit measurements.
   [(#2941)](https://github.com/PennyLaneAI/catalyst/pull/2941)
 
+  The QEC pipeline also now supports `qp.expval`, `qp.var` and `qp.probs` measurement processes when
+  used in conjunction with the `measurements-from-samples` pass.
+  [(#2958)](https://github.com/PennyLaneAI/catalyst/pull/2958)
+
 <h3>Documentation 📝</h3>
 
 * A broken link was removed in the [Compiler Core](https://docs.pennylane.ai/projects/catalyst/en/stable/modules/mlir.html) documentation page. The link referred to where precompiled decomposition rules were implemented, which has since been refactored.

--- a/frontend/catalyst/python_interface/transforms/qecl/convert_quantum_to_qecl.py
+++ b/frontend/catalyst/python_interface/transforms/qecl/convert_quantum_to_qecl.py
@@ -515,6 +515,100 @@ class MeasureOpConversion(RewritePattern):
         rewriter.replace_op(op, ops_to_insert, new_results=new_results)
 
 
+# MARK: Compbasis Op Pattern
+
+
+class ComputationalBasisOpConversion(RewritePattern):
+    """Converts `quantum.compbasis` ops to sets of `qecl.measure` and `quantum.mcmobs` ops.
+
+    As with the `quantum.measure` conversion pattern, this conversion also assumes that k = 1, and
+    as such always applies the logical measurement operation to the codeblock at index 0.
+
+    Example
+    -------
+
+    Input:
+
+        %b0 = ... : !qecl.codeblock<1>
+        %q0 = builtin.unrealized_conversion_cast %b0 : !qecl.codeblock<1> to !quantum.bit
+        %b1 = ... : !qecl.codeblock<1>
+        %q1 = builtin.unrealized_conversion_cast %b1 : !qecl.codeblock<1> to !quantum.bit
+        %obs = quantum.compbasis qubits %q0, %q1 : !quantum.obs
+        %samples = quantum.sample %obs : tensor<100x2xf64>
+
+    Output (after applying `reconcile-unrealized-casts`):
+
+        %b0 = ... : !qecl.codeblock<1>
+        %b1 = ... : !qecl.codeblock<1>
+        %mres0, %b01 = qecl.measure %b0[0] : i1, !qecl.codeblock<1>
+        %mres1, %b11 = qecl.measure %b1[0] : i1, !qecl.codeblock<1>
+        %obs = quantum.mcmobs %mres0, %mres1 : !quantum.obs
+        %samples = quantum.sample %obs : tensor<100x2xf64>
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: quantum.ComputationalBasisOp, rewriter: PatternRewriter):
+        """Rewrite pattern for `quantum.compbasis` ops."""
+
+        if op.qreg is not None:
+            self._convert_qreg_compbasis_to_mcm_obs(op, rewriter)
+        else:
+            self._convert_qubit_compbasis_to_mcm_obs(op, rewriter)
+
+    @classmethod
+    def _convert_qubit_compbasis_to_mcm_obs(
+        cls, op: quantum.ComputationalBasisOp, rewriter: PatternRewriter
+    ):
+        """Helper function to match_and_rewrite() that handles the conversion of a
+        `quantum.compbasis` op acting on qubits.
+        """
+        meas_results: list[OpResult] = []
+
+        for qubit in op.qubits:
+            qubit_owner_op = qubit.owner
+            if not _is_type_convertible(
+                qubit_owner_op, qecl.LogicalCodeblockType
+            ):  # pragma: no cover
+                _raise_failed_to_convert_op_compile_error(op)
+
+            conv_cast_op = builtin.UnrealizedConversionCastOp.get(
+                (qubit_owner_op.results[0],), (qubit_owner_op.operands[0].type,)
+            )
+            measure_op = qecl.MeasureOp(in_codeblock=conv_cast_op.results[0], idx=0)
+            cast_to_qubit_op = _cast_to_qubit(measure_op.out_codeblock)
+
+            rewriter.insert_op(conv_cast_op, insertion_point=InsertPoint.before(op))
+            rewriter.insert_op(measure_op, insertion_point=InsertPoint.after(conv_cast_op))
+            rewriter.insert_op(cast_to_qubit_op, insertion_point=InsertPoint.after(measure_op))
+
+            rewriter.replace_uses_with_if(
+                qubit_owner_op.results[0],
+                cast_to_qubit_op.results[0],
+                lambda use, _op=conv_cast_op: use.operation is not _op,
+            )
+
+            meas_results.append(measure_op.mres)
+
+        mcmobs_op = quantum.MCMObsOp(
+            operands=(meas_results,), result_types=(quantum.ObservableType(),)
+        )
+
+        rewriter.replace_op(op, mcmobs_op)
+
+    @classmethod
+    def _convert_qreg_compbasis_to_mcm_obs(
+        cls, op: quantum.ComputationalBasisOp, rewriter: PatternRewriter
+    ):
+        """Helper function to match_and_rewrite() that handles the conversion of a
+        `quantum.compbasis` op acting on the global quantum register.
+        """
+        raise CompileError(
+            "Implicitly sampling all wires on the device is not supported in the QEC pipeline. "
+            "Instead, please provide an explicit list of wires to sample, e.g. "
+            "`qp.sample(wires=[0, 1, 2])`."
+        )
+
+
 # MARK: SCF Yield Pattern
 
 
@@ -796,100 +890,6 @@ class ScfForConversion(ScfConversionPattern):
         return yield_op
 
 
-# MARK: Compbasis Op Pattern
-
-
-class ComputationalBasisOpConversion(RewritePattern):
-    """Converts `quantum.compbasis` ops to sets of `qecl.measure` and `quantum.mcmobs` ops.
-
-    As with the `quantum.measure` conversion pattern, this conversion also assumes that k = 1, and
-    as such always applies the logical measurement operation to the codeblock at index 0.
-
-    Example
-    -------
-
-    Input:
-
-        %b0 = ... : !qecl.codeblock<1>
-        %q0 = builtin.unrealized_conversion_cast %b0 : !qecl.codeblock<1> to !quantum.bit
-        %b1 = ... : !qecl.codeblock<1>
-        %q1 = builtin.unrealized_conversion_cast %b1 : !qecl.codeblock<1> to !quantum.bit
-        %obs = quantum.compbasis qubits %q0, %q1 : !quantum.obs
-        %samples = quantum.sample %obs : tensor<100x2xf64>
-
-    Output (after applying `reconcile-unrealized-casts`):
-
-        %b0 = ... : !qecl.codeblock<1>
-        %b1 = ... : !qecl.codeblock<1>
-        %mres0, %b01 = qecl.measure %b0[0] : i1, !qecl.codeblock<1>
-        %mres1, %b11 = qecl.measure %b1[0] : i1, !qecl.codeblock<1>
-        %obs = quantum.mcmobs %mres0, %mres1 : !quantum.obs
-        %samples = quantum.sample %obs : tensor<100x2xf64>
-    """
-
-    @op_type_rewrite_pattern
-    def match_and_rewrite(self, op: quantum.ComputationalBasisOp, rewriter: PatternRewriter):
-        """Rewrite pattern for `quantum.compbasis` ops."""
-
-        if op.qreg is not None:
-            self._convert_qreg_compbasis_to_mcm_obs(op, rewriter)
-        else:
-            self._convert_qubit_compbasis_to_mcm_obs(op, rewriter)
-
-    @classmethod
-    def _convert_qubit_compbasis_to_mcm_obs(
-        cls, op: quantum.ComputationalBasisOp, rewriter: PatternRewriter
-    ):
-        """Helper function to match_and_rewrite() that handles the conversion of a
-        `quantum.compbasis` op acting on qubits.
-        """
-        meas_results: list[OpResult] = []
-
-        for qubit in op.qubits:
-            qubit_owner_op = qubit.owner
-            if not _is_type_convertible(
-                qubit_owner_op, qecl.LogicalCodeblockType
-            ):  # pragma: no cover
-                _raise_failed_to_convert_op_compile_error(op)
-
-            conv_cast_op = builtin.UnrealizedConversionCastOp.get(
-                (qubit_owner_op.results[0],), (qubit_owner_op.operands[0].type,)
-            )
-            measure_op = qecl.MeasureOp(in_codeblock=conv_cast_op.results[0], idx=0)
-            cast_to_qubit_op = _cast_to_qubit(measure_op.out_codeblock)
-
-            rewriter.insert_op(conv_cast_op, insertion_point=InsertPoint.before(op))
-            rewriter.insert_op(measure_op, insertion_point=InsertPoint.after(conv_cast_op))
-            rewriter.insert_op(cast_to_qubit_op, insertion_point=InsertPoint.after(measure_op))
-
-            rewriter.replace_uses_with_if(
-                qubit_owner_op.results[0],
-                cast_to_qubit_op.results[0],
-                lambda use, _op=conv_cast_op: use.operation is not _op,
-            )
-
-            meas_results.append(measure_op.mres)
-
-        mcmobs_op = quantum.MCMObsOp(
-            operands=(meas_results,), result_types=(quantum.ObservableType(),)
-        )
-
-        rewriter.replace_op(op, mcmobs_op)
-
-    @classmethod
-    def _convert_qreg_compbasis_to_mcm_obs(
-        cls, op: quantum.ComputationalBasisOp, rewriter: PatternRewriter
-    ):
-        """Helper function to match_and_rewrite() that handles the conversion of a
-        `quantum.compbasis` op acting on the global quantum register.
-        """
-        raise CompileError(
-            "Implicitly sampling all wires on the device is not supported in the QEC pipeline. "
-            "Instead, please provide an explicit list of wires to sample, e.g. "
-            "`qp.sample(wires=[0, 1, 2])`."
-        )
-
-
 # MARK: Helpers
 
 
@@ -1009,10 +1009,10 @@ class ConvertQuantumToQecLogicalPass(ModulePass):
                     DeallocOpConversion(),
                     CustomOpConversion(t_subroutine=t_subroutine),
                     MeasureOpConversion(),
+                    ComputationalBasisOpConversion(),
                     ScfYieldConversion(),
                     ScfIfConversion(),
                     ScfForConversion(),
-                    ComputationalBasisOpConversion(),
                 ]
             )
         ).rewrite_module(op)

--- a/frontend/catalyst/python_interface/transforms/qecl/convert_quantum_to_qecl.py
+++ b/frontend/catalyst/python_interface/transforms/qecl/convert_quantum_to_qecl.py
@@ -75,6 +75,8 @@ The convert-quantum-to-qecl pass does not support the following cases:
   * Programs with non-Clifford gates; specifically any gates other than I, X, Y, Z, Hadamard, S or
     CNOT.
   * Programs with control-flow operations other than `scf.for` and `scf.if`.
+  * Programs that implicitly sample all wires on the device, e.g. `return qp.sample()`. However,
+    sampling an explicit list of wires is supported, e.g. `return qp.sample(wires=[0, 1, 2])`.
 """
 
 import math
@@ -794,10 +796,35 @@ class ScfForConversion(ScfConversionPattern):
         return yield_op
 
 
+# MARK: Compbasis Op Pattern
+
+
 class ComputationalBasisOpConversion(RewritePattern):
     """Converts `quantum.compbasis` ops to sets of `qecl.measure` and `quantum.mcmobs` ops.
 
-    TODO (more explanation; do we assume k = 1?)
+    As with the `quantum.measure` conversion pattern, this conversion also assumes that k = 1, and
+    as such always applies the logical measurement operation to the codeblock at index 0.
+
+    Example
+    -------
+
+    Input:
+
+        %b0 = ... : !qecl.codeblock<1>
+        %q0 = builtin.unrealized_conversion_cast %b0 : !qecl.codeblock<1> to !quantum.bit
+        %b1 = ... : !qecl.codeblock<1>
+        %q1 = builtin.unrealized_conversion_cast %b1 : !qecl.codeblock<1> to !quantum.bit
+        %obs = quantum.compbasis qubits %q0, %q1 : !quantum.obs
+        %samples = quantum.sample %obs : tensor<100x2xf64>
+
+    Output (after applying `reconcile-unrealized-casts`):
+
+        %b0 = ... : !qecl.codeblock<1>
+        %b1 = ... : !qecl.codeblock<1>
+        %mres0, %b01 = qecl.measure %b0[0] : i1, !qecl.codeblock<1>
+        %mres1, %b11 = qecl.measure %b1[0] : i1, !qecl.codeblock<1>
+        %obs = quantum.mcmobs %mres0, %mres1 : !quantum.obs
+        %samples = quantum.sample %obs : tensor<100x2xf64>
     """
 
     @op_type_rewrite_pattern
@@ -813,7 +840,9 @@ class ComputationalBasisOpConversion(RewritePattern):
     def _convert_qubit_compbasis_to_mcm_obs(
         cls, op: quantum.ComputationalBasisOp, rewriter: PatternRewriter
     ):
-        """TODO"""
+        """Helper function to match_and_rewrite() that handles the conversion of a
+        `quantum.compbasis` op acting on qubits.
+        """
         meas_results: list[OpResult] = []
 
         for qubit in op.qubits:
@@ -851,8 +880,14 @@ class ComputationalBasisOpConversion(RewritePattern):
     def _convert_qreg_compbasis_to_mcm_obs(
         cls, op: quantum.ComputationalBasisOp, rewriter: PatternRewriter
     ):
-        """TODO"""
-        raise NotImplementedError("support for `quantum.compbasis qreg` is not yet implemented")
+        """Helper function to match_and_rewrite() that handles the conversion of a
+        `quantum.compbasis` op acting on the global quantum register.
+        """
+        raise CompileError(
+            "Implicitly sampling all wires on the device is not supported in the QEC pipeline. "
+            "Instead, please provide an explicit list of wires to sample, e.g. "
+            "`qp.sample(wires=[0, 1, 2])`."
+        )
 
 
 # MARK: Helpers

--- a/frontend/catalyst/python_interface/transforms/qecl/convert_quantum_to_qecl.py
+++ b/frontend/catalyst/python_interface/transforms/qecl/convert_quantum_to_qecl.py
@@ -794,6 +794,67 @@ class ScfForConversion(ScfConversionPattern):
         return yield_op
 
 
+class ComputationalBasisOpConversion(RewritePattern):
+    """Converts `quantum.compbasis` ops to sets of `qecl.measure` and `quantum.mcmobs` ops.
+
+    TODO (more explanation; do we assume k = 1?)
+    """
+
+    @op_type_rewrite_pattern
+    def match_and_rewrite(self, op: quantum.ComputationalBasisOp, rewriter: PatternRewriter):
+        """Rewrite pattern for `quantum.compbasis` ops."""
+
+        if op.qreg is not None:
+            self._convert_qreg_compbasis_to_mcm_obs(op, rewriter)
+        else:
+            self._convert_qubit_compbasis_to_mcm_obs(op, rewriter)
+
+    @classmethod
+    def _convert_qubit_compbasis_to_mcm_obs(
+        cls, op: quantum.ComputationalBasisOp, rewriter: PatternRewriter
+    ):
+        """TODO"""
+        meas_results: list[OpResult] = []
+
+        for qubit in op.qubits:
+            qubit_owner_op = qubit.owner
+            if not _is_type_convertible(
+                qubit_owner_op, qecl.LogicalCodeblockType
+            ):  # pragma: no cover
+                _raise_failed_to_convert_op_compile_error(op)
+
+            conv_cast_op = builtin.UnrealizedConversionCastOp.get(
+                (qubit_owner_op.results[0],), (qubit_owner_op.operands[0].type,)
+            )
+            measure_op = qecl.MeasureOp(in_codeblock=conv_cast_op.results[0], idx=0)
+            cast_to_qubit_op = _cast_to_qubit(measure_op.out_codeblock)
+
+            rewriter.insert_op(conv_cast_op, insertion_point=InsertPoint.before(op))
+            rewriter.insert_op(measure_op, insertion_point=InsertPoint.after(conv_cast_op))
+            rewriter.insert_op(cast_to_qubit_op, insertion_point=InsertPoint.after(measure_op))
+
+            rewriter.replace_uses_with_if(
+                qubit_owner_op.results[0],
+                cast_to_qubit_op.results[0],
+                lambda use: use.operation is not conv_cast_op,
+            )
+
+            meas_results.append(measure_op.mres)
+
+        mcmobs_op = quantum.MCMObsOp(
+            operands=(meas_results,), result_types=(quantum.ObservableType(),)
+        )
+
+        rewriter.replace_op(op, mcmobs_op)
+
+    @classmethod
+    def _convert_qreg_compbasis_to_mcm_obs(
+        cls, op: quantum.ComputationalBasisOp, rewriter: PatternRewriter
+    ):
+        """TODO"""
+        raise NotImplementedError("support for `quantum.compbasis qreg` is not yet implemented")
+
+
 # MARK: Helpers
 
 
@@ -916,6 +977,7 @@ class ConvertQuantumToQecLogicalPass(ModulePass):
                     ScfYieldConversion(),
                     ScfIfConversion(),
                     ScfForConversion(),
+                    ComputationalBasisOpConversion(),
                 ]
             )
         ).rewrite_module(op)

--- a/frontend/catalyst/python_interface/transforms/qecl/convert_quantum_to_qecl.py
+++ b/frontend/catalyst/python_interface/transforms/qecl/convert_quantum_to_qecl.py
@@ -836,7 +836,7 @@ class ComputationalBasisOpConversion(RewritePattern):
             rewriter.replace_uses_with_if(
                 qubit_owner_op.results[0],
                 cast_to_qubit_op.results[0],
-                lambda use: use.operation is not conv_cast_op,
+                lambda use, _op=conv_cast_op: use.operation is not _op,
             )
 
             meas_results.append(measure_op.mres)

--- a/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
+++ b/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
@@ -1425,9 +1425,7 @@ class TestMeasurementProcesses:
 
         run_filecheck_qjit(circuit)
 
-    @pytest.mark.xfail(
-        reason="Sampling quantum register not implemented", raises=CompileError
-    )
+    @pytest.mark.xfail(reason="Sampling quantum register not implemented", raises=CompileError)
     def test_sample_register_integration(self, run_filecheck_qjit):
         """Test the convert-quantum-to-qecl pass on a program whose terminal measurement is a sample
         on the quantum register.

--- a/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
+++ b/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
@@ -1469,14 +1469,13 @@ class TestQuantumToQecLogicalPassIntegration:
             # CHECK: qecl.qec
             # CHECK: apply_T
             # CHECK: qecl.measure {{%.+}}[0]
-            # CHECK: qecl.insert_block
             # CHECK: quantum.mcmobs
+            # CHECK: qecl.insert_block
             # CHECK: quantum.sample
             # CHECK: qecl.dealloc
             qp.H(0)
             qp.T(0)
-            m0 = qp.measure(0)
-            return qp.sample([m0])
+            return qp.sample(wires=[0])
 
         run_filecheck_qjit(circuit)
 
@@ -1507,16 +1506,13 @@ class TestQuantumToQecLogicalPassIntegration:
             # CHECK: qecl.measure
             # CHECK: qecl.measure
             # CHECK: qecl.measure
-            # CHECK: qecl.insert_block
             # CHECK: quantum.mcmobs
+            # CHECK: qecl.insert_block
             # CHECK: quantum.sample
             # CHECK: qecl.dealloc
             qp.H(0)
             qp.CNOT([0, 1])
             qp.CNOT([1, 2])
-            m0 = qp.measure(0)
-            m1 = qp.measure(1)
-            m2 = qp.measure(2)
-            return qp.sample([m0, m1, m2])
+            return qp.sample(wires=[0, 1, 2])
 
         run_filecheck_qjit(circuit)

--- a/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
+++ b/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
@@ -1405,6 +1405,7 @@ class TestMeasurementProcesses:
         @convert_quantum_to_qecl_pass(k=1)
         @qp.qnode(dev, shots=100, mcm_method="one-shot")
         def circuit():
+            # pylint: disable=line-too-long
             # CHECK-LABEL: func.func public @circuit{{.+}} quantum.node
             # CHECK-NOT: builtin.unrealized_conversion_cast
             # CHECK-NOT: quantum.compbasis

--- a/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
+++ b/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
@@ -1738,7 +1738,7 @@ class TestMeasurementProcesses:
         inserting the appropriate post-processing functions to recover the expectation value
         measurement from the samples.
         """
-        dev = qp.device("null.qubit", wires=1)
+        dev = qp.device("null.qubit", wires=2)
 
         @qp.qjit(capture=True, target="mlir")
         @convert_quantum_to_qecl_pass(k=1)

--- a/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
+++ b/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
@@ -1334,6 +1334,9 @@ class TestControlFlow:
         run_filecheck(program, quantum_to_qecl_pipeline_k_1)
 
 
+# MARK: Measurement Processes
+
+
 class TestMeasurementProcesses:
     """Unit/integration tests for input quantum-dialect programs with various terminal measurement
     processes.

--- a/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
+++ b/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
@@ -1426,7 +1426,7 @@ class TestMeasurementProcesses:
         run_filecheck_qjit(circuit)
 
     @pytest.mark.xfail(
-        reason="Sampling quantum register not implemented", raises=NotImplementedError
+        reason="Sampling quantum register not implemented", raises=CompileError
     )
     def test_sample_register_integration(self, run_filecheck_qjit):
         """Test the convert-quantum-to-qecl pass on a program whose terminal measurement is a sample

--- a/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
+++ b/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
@@ -760,6 +760,65 @@ class TestMeasurePattern:
         run_filecheck(program, quantum_to_qecl_pipeline_k_1)
 
 
+# MARK: TestCompBasisPattern
+
+
+class TestCompBasisPattern:
+    """Unit tests for the `compbasis` op conversion pattern of the convert-quantum-to-qecl pass."""
+
+    def test_compbasis_qubits_1_k_1(self, run_filecheck, quantum_to_qecl_pipeline_k_1):
+        """Test that computational-basis observable ops (`quantum.compbasis`) acting on qubits are
+        converted to `qecl.measure` and `quantum.mcmobs` where the number of qubits is 1, and for
+        k = 1.
+        """
+        program = """
+        func.func @test_program() {
+            // CHECK: [[cb0:%.+]] = "test.op"() : () -> !qecl.codeblock<1>
+            // CHECK-NOT: builtin.unrealized_conversion_cast
+            %0 = "test.op"() : () -> !qecl.codeblock<1>
+            %1 = builtin.unrealized_conversion_cast %0 : !qecl.codeblock<1> to !quantum.bit
+
+            // CHECK: [[mres:%.+]], [[cb1:%.+]] = qecl.measure [[cb0]][0] : i1, !qecl.codeblock<1>
+            // CHECK: [[obs:%.+]] = quantum.mcmobs %1 : !quantum.obs
+            %obs = quantum.compbasis qubits %1 : !quantum.obs
+
+            // CHECK: quantum.sample [[obs]] : tensor<100x1xf64>
+            %samples = quantum.sample %obs : tensor<100x1xf64>
+            return
+        }
+        """
+        run_filecheck(program, quantum_to_qecl_pipeline_k_1)
+
+    def test_compbasis_qubits_2_k_1(self, run_filecheck, quantum_to_qecl_pipeline_k_1):
+        """Test that computational-basis observable ops (`quantum.compbasis`) acting on qubits are
+        converted to `qecl.measure` and `quantum.mcmobs` where the number of qubits is 2, and for
+        k = 1.
+        """
+        program = """
+        func.func @test_program() {
+            // CHECK: [[cb0:%.+]] = "test.op"() : () -> !qecl.codeblock<1>
+            // CHECK-NOT: builtin.unrealized_conversion_cast
+            %0 = "test.op"() : () -> !qecl.codeblock<1>
+            %1 = builtin.unrealized_conversion_cast %0 : !qecl.codeblock<1> to !quantum.bit
+
+            // CHECK: [[cb1:%.+]] = "test.op"() : () -> !qecl.codeblock<1>
+            // CHECK-NOT: builtin.unrealized_conversion_cast
+            %2 = "test.op"() : () -> !qecl.codeblock<1>
+            %3 = builtin.unrealized_conversion_cast %2 : !qecl.codeblock<1> to !quantum.bit
+
+            // CHECK-DAG: [[mres2:%.+]], [[cb2:%.+]] = qecl.measure [[cb0]][0] : i1, !qecl.codeblock<1>
+            // CHECK-DAG: [[mres3:%.+]], [[cb3:%.+]] = qecl.measure [[cb1]][0] : i1, !qecl.codeblock<1>
+            //     CHECK: [[obs:%.+]] = quantum.mcmobs [[mres2]], [[mres3]] : !quantum.obs
+            %obs = quantum.compbasis qubits %1, %3 : !quantum.obs
+
+            // CHECK: quantum.sample [[obs]] : tensor<100x1xf64>
+            %samples = quantum.sample %obs : tensor<100x1xf64>
+            return
+        }
+        """
+        run_filecheck(program, quantum_to_qecl_pipeline_k_1)
+
+
 # MARK: TestInvalidInputIR
 
 
@@ -1273,6 +1332,115 @@ class TestControlFlow:
         }
         """
         run_filecheck(program, quantum_to_qecl_pipeline_k_1)
+
+
+class TestMeasurementProcesses:
+    """Unit/integration tests for input quantum-dialect programs with various terminal measurement
+    processes.
+
+    In all the tests below, we use the dynamic-one-shot MCM method, which creates a kernel function
+    in the IR that computes the result for a single shot, with a post-processing function to pack
+    these results into a tensor that contains the results of all shots. When the observable to the
+    sampling op is an MCM observable, the MCM results are used directly (after casting to the
+    appropriate type) and the `quantum.sample` op is removed.
+    """
+
+    def test_sample_mcms_integration(self, run_filecheck_qjit):
+        """Test the convert-quantum-to-qecl pass on a program whose terminal measurement is a sample
+        on a single MCM.
+        """
+        dev = qp.device("null.qubit", wires=1)
+
+        @qp.qjit(capture=True, target="mlir")
+        @convert_quantum_to_qecl_pass(k=1)
+        @qp.qnode(dev, shots=100, mcm_method="one-shot")
+        def circuit():
+            # CHECK-LABEL: func.func public @circuit{{.+}} quantum.node
+            # CHECK-NOT: builtin.unrealized_conversion_cast
+            # CHECK-NOT: quantum.measure
+            # CHECK-NOT: quantum.mcmobs
+            # CHECK-NOT: quantum.sample
+            # CHECK: qecl.measure
+            # CHECK: [[mres_i64:%.+]] = arith.extui {{%.+}} : i1 to i64
+            # CHECK: [[mres_f64:%.+]] = arith.sitofp [[mres_i64]] : i64 to f64
+            # CHECK: [[mres_1x1xf64:%.+]] = tensor.from_elements [[mres_f64]] : tensor<1x1xf64>
+            # CHECK: return [[mres_1x1xf64]] : tensor<1x1xf64>
+            m0 = qp.measure(0)
+            return qp.sample([m0])
+
+        run_filecheck_qjit(circuit)
+
+    def test_sample_qubit_1_integration(self, run_filecheck_qjit):
+        """Test the convert-quantum-to-qecl pass on a program whose terminal measurement is a sample
+        on a single qubit.
+        """
+        dev = qp.device("null.qubit", wires=1)
+
+        @qp.qjit(capture=True, target="mlir")
+        @convert_quantum_to_qecl_pass(k=1)
+        @qp.qnode(dev, shots=100, mcm_method="one-shot")
+        def circuit():
+            # CHECK-LABEL: func.func public @circuit{{.+}} quantum.node
+            # CHECK-NOT: builtin.unrealized_conversion_cast
+            # CHECK-NOT: quantum.compbasis
+            # CHECK-NOT: quantum.sample
+            # CHECK: [[mres:%.+]], [[cb0:%.+]] = qecl.measure
+            # CHECK: [[hreg:%.+]] = qecl.insert_block {{.*}}, [[cb0]]
+            # CHECK: qecl.dealloc [[hreg]]
+            # CHECK: [[mres_i64:%.+]] = arith.extui [[mres]] : i1 to i64
+            # CHECK: [[mres_f64:%.+]] = arith.sitofp [[mres_i64]] : i64 to f64
+            # CHECK: [[mres_1x1xf64:%.+]] = tensor.from_elements [[mres_f64]] : tensor<1x1xf64>
+            # CHECK: return [[mres_1x1xf64]] : tensor<1x1xf64>
+            return qp.sample(wires=[0])
+
+        run_filecheck_qjit(circuit)
+
+    def test_sample_qubit_2_integration(self, run_filecheck_qjit):
+        """Test the convert-quantum-to-qecl pass on a program whose terminal measurement is a sample
+        on two qubits.
+        """
+        dev = qp.device("null.qubit", wires=2)
+
+        @qp.qjit(capture=True, target="mlir")
+        @convert_quantum_to_qecl_pass(k=1)
+        @qp.qnode(dev, shots=100, mcm_method="one-shot")
+        def circuit():
+            # CHECK-LABEL: func.func public @circuit{{.+}} quantum.node
+            # CHECK-NOT: builtin.unrealized_conversion_cast
+            # CHECK-NOT: quantum.compbasis
+            # CHECK-NOT: quantum.sample
+            # CHECK: [[mres0:%.+]], [[cb0:%.+]] = qecl.measure
+            # CHECK: [[mres1:%.+]], [[cb1:%.+]] = qecl.measure
+            # CHECK: [[hreg0:%.+]] = qecl.insert_block {{.*}}, [[cb0]]
+            # CHECK: [[hreg1:%.+]] = qecl.insert_block {{.*}}, [[cb1]]
+            # CHECK: qecl.dealloc [[hreg1]]
+            # CHECK: [[mres0_i64:%.+]] = arith.extui [[mres0]] : i1 to i64
+            # CHECK: [[mres0_f64:%.+]] = arith.sitofp [[mres0_i64]] : i64 to f64
+            # CHECK: [[mres1_i64:%.+]] = arith.extui [[mres1]] : i1 to i64
+            # CHECK: [[mres1_f64:%.+]] = arith.sitofp [[mres1_i64]] : i64 to f64
+            # CHECK: [[mres_1x2xf64:%.+]] = tensor.from_elements [[mres0_f64]], [[mres1_f64]] : tensor<1x2xf64>
+            # CHECK: return [[mres_1x2xf64]] : tensor<1x2xf64>
+            return qp.sample(wires=[0, 1])
+
+        run_filecheck_qjit(circuit)
+
+    @pytest.mark.xfail(
+        reason="Sampling quantum register not implemented", raises=NotImplementedError
+    )
+    def test_sample_register_integration(self, run_filecheck_qjit):
+        """Test the convert-quantum-to-qecl pass on a program whose terminal measurement is a sample
+        on the quantum register.
+        """
+        dev = qp.device("null.qubit", wires=2)
+
+        @qp.qjit(capture=True, target="mlir")
+        @convert_quantum_to_qecl_pass(k=1)
+        @qp.qnode(dev, shots=100, mcm_method="one-shot")
+        def circuit():
+            # CHECK-NOT: builtin.unrealized_conversion_cast
+            return qp.sample()
+
+        run_filecheck_qjit(circuit)
 
 
 # MARK: Integration Tests

--- a/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
+++ b/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
@@ -19,6 +19,7 @@
 import pennylane as qp
 import pytest
 
+from catalyst.python_interface.transforms import measurements_from_samples_pass
 from catalyst.python_interface.transforms.qecl import (
     ConvertQuantumToQecLogicalPass,
     convert_quantum_to_qecl_pass,
@@ -1468,8 +1469,8 @@ class TestMeasurementProcesses:
     """
 
     def test_sample_mcms_integration(self, run_filecheck_qjit):
-        """Test the convert-quantum-to-qecl pass on a program whose terminal measurement is a sample
-        on a single MCM.
+        """Test the convert-quantum-to-qecl pass on a program with a samples terminal measurement on
+        a single MCM.
         """
         dev = qp.device("null.qubit", wires=1)
 
@@ -1493,8 +1494,8 @@ class TestMeasurementProcesses:
         run_filecheck_qjit(circuit)
 
     def test_sample_qubit_1_integration(self, run_filecheck_qjit):
-        """Test the convert-quantum-to-qecl pass on a program whose terminal measurement is a sample
-        on a single qubit.
+        """Test the convert-quantum-to-qecl pass on a program with a samples terminal measurement on
+        a single qubit.
         """
         dev = qp.device("null.qubit", wires=1)
 
@@ -1518,8 +1519,8 @@ class TestMeasurementProcesses:
         run_filecheck_qjit(circuit)
 
     def test_sample_qubit_2_integration(self, run_filecheck_qjit):
-        """Test the convert-quantum-to-qecl pass on a program whose terminal measurement is a sample
-        on two qubits.
+        """Test the convert-quantum-to-qecl pass on a program with a samples terminal measurement on
+        two qubits.
         """
         dev = qp.device("null.qubit", wires=2)
 
@@ -1549,8 +1550,8 @@ class TestMeasurementProcesses:
 
     @pytest.mark.xfail(reason="Sampling quantum register not implemented", raises=CompileError)
     def test_sample_register_integration(self, run_filecheck_qjit):
-        """Test the convert-quantum-to-qecl pass on a program whose terminal measurement is a sample
-        on the quantum register.
+        """Test the convert-quantum-to-qecl pass on a program with a samples terminal measurement on
+        the quantum register.
         """
         dev = qp.device("null.qubit", wires=2)
 
@@ -1560,6 +1561,168 @@ class TestMeasurementProcesses:
         def circuit():
             # CHECK-NOT: builtin.unrealized_conversion_cast
             return qp.sample()
+
+        run_filecheck_qjit(circuit)
+
+    def test_expval_pauli_z_integration(self, run_filecheck_qjit):
+        """Test the convert-quantum-to-qecl pass on a program with an expectation-value terminal
+        measurement of a Pauli Z observable.
+
+        The measurements-from-samples pass is applied first since the convert-quantum-to-qecl pass
+        can only handle conversion of sampling measurements, with measurements-from-samples
+        inserting the appropriate post-processing functions to recover the expectation value
+        measurement from the samples.
+        """
+        dev = qp.device("null.qubit", wires=1)
+
+        @qp.qjit(capture=True, target="mlir")
+        @convert_quantum_to_qecl_pass(k=1)
+        @measurements_from_samples_pass
+        @qp.qnode(dev, shots=100, mcm_method="one-shot")
+        def circuit():
+            # CHECK-NOT: builtin.unrealized_conversion_cast
+
+            # CHECK-LABEL: func.func public @circuit{{.+}} quantum.node
+            # CHECK-NOT: qecl.hadamard
+            # CHECK: [[mres:%.+]], {{%.+}} = qecl.measure
+            # CHECK: [[mres_i64:%.+]] = arith.extui [[mres]] : i1 to i64
+            # CHECK: [[mres_f64:%.+]] = arith.sitofp [[mres_i64]] : i64 to f64
+            # CHECK: [[mres_1x1xf64:%.+]] = tensor.from_elements [[mres_f64]] : tensor<1x1xf64>
+            # CHECK: return [[mres_1x1xf64]] : tensor<1x1xf64>
+
+            # CHECK-LABEL: func.func public @circuit() -> tensor<f64>
+            # CHECK: [[samples:%.+]] = func.call @circuit.from_samples() : () -> tensor<100x1xf64>
+            # CHECK: [[expval:%.+]] = func.call @expval_from_samples{{.*}}([[samples]])
+            # CHECK: func.return [[expval]] : tensor<f64>
+            return qp.expval(qp.PauliZ(0))
+
+        run_filecheck_qjit(circuit)
+
+    def test_expval_pauli_x_integration(self, run_filecheck_qjit):
+        """Test the convert-quantum-to-qecl pass on a program with an expectation-value terminal
+        measurement of a Pauli X observable.
+
+        The measurements-from-samples pass is applied first since the convert-quantum-to-qecl pass
+        can only handle conversion of sampling measurements, with measurements-from-samples
+        inserting the appropriate post-processing functions to recover the expectation value
+        measurement from the samples.
+
+        The output IR should be the same as for the Pauli-Z observable, except that the
+        measurements-from-samples pass inserts the diagonalizing Hadamard gate before measuring the
+        target qubit (codeblock).
+        """
+        dev = qp.device("null.qubit", wires=1)
+
+        @qp.qjit(capture=True, target="mlir")
+        @convert_quantum_to_qecl_pass(k=1)
+        @measurements_from_samples_pass
+        @qp.qnode(dev, shots=100, mcm_method="one-shot")
+        def circuit():
+            # CHECK-NOT: builtin.unrealized_conversion_cast
+
+            # CHECK-LABEL: func.func public @circuit{{.+}} quantum.node
+            # CHECK: qecl.hadamard
+            # CHECK: [[mres:%.+]], {{%.+}} = qecl.measure
+            # CHECK: [[mres_i64:%.+]] = arith.extui [[mres]] : i1 to i64
+            # CHECK: [[mres_f64:%.+]] = arith.sitofp [[mres_i64]] : i64 to f64
+            # CHECK: [[mres_1x1xf64:%.+]] = tensor.from_elements [[mres_f64]] : tensor<1x1xf64>
+            # CHECK: return [[mres_1x1xf64]] : tensor<1x1xf64>
+
+            # CHECK-LABEL: func.func public @circuit() -> tensor<f64>
+            # CHECK: [[samples:%.+]] = func.call @circuit.from_samples() : () -> tensor<100x1xf64>
+            # CHECK: [[expval:%.+]] = func.call @expval_from_samples{{.*}}([[samples]])
+            # CHECK: func.return [[expval]] : tensor<f64>
+            return qp.expval(qp.PauliX(0))
+
+        run_filecheck_qjit(circuit)
+
+    def test_var_pauli_z_integration(self, run_filecheck_qjit):
+        """Test the convert-quantum-to-qecl pass on a program with an variance terminal measurement
+        of a Pauli Z observable.
+
+        The measurements-from-samples pass is applied first since the convert-quantum-to-qecl pass
+        can only handle conversion of sampling measurements, with measurements-from-samples
+        inserting the appropriate post-processing functions to recover the expectation value
+        measurement from the samples.
+        """
+        dev = qp.device("null.qubit", wires=1)
+
+        @qp.qjit(capture=True, target="mlir")
+        @convert_quantum_to_qecl_pass(k=1)
+        @measurements_from_samples_pass
+        @qp.qnode(dev, shots=100, mcm_method="one-shot")
+        def circuit():
+            # CHECK-NOT: builtin.unrealized_conversion_cast
+
+            # CHECK-LABEL: func.func public @circuit{{.+}} quantum.node
+            # CHECK-NOT: qecl.hadamard
+            # CHECK: [[mres:%.+]], {{%.+}} = qecl.measure
+            # CHECK: [[mres_i64:%.+]] = arith.extui [[mres]] : i1 to i64
+            # CHECK: [[mres_f64:%.+]] = arith.sitofp [[mres_i64]] : i64 to f64
+            # CHECK: [[mres_1x1xf64:%.+]] = tensor.from_elements [[mres_f64]] : tensor<1x1xf64>
+            # CHECK: return [[mres_1x1xf64]] : tensor<1x1xf64>
+
+            # CHECK-LABEL: func.func public @circuit() -> tensor<f64>
+            # CHECK: [[samples:%.+]] = func.call @circuit.from_samples() : () -> tensor<100x1xf64>
+            # CHECK: [[var:%.+]] = func.call @var_from_samples{{.*}}([[samples]])
+            # CHECK: func.return [[var]] : tensor<f64>
+            return qp.var(qp.PauliZ(0))
+
+        run_filecheck_qjit(circuit)
+
+    def test_probs_qubit_1_integration(self, run_filecheck_qjit):
+        """Test the convert-quantum-to-qecl pass on a program with a probabilities terminal
+        measurement on a single qubit.
+
+        The measurements-from-samples pass is applied first since the convert-quantum-to-qecl pass
+        can only handle conversion of sampling measurements, with measurements-from-samples
+        inserting the appropriate post-processing functions to recover the expectation value
+        measurement from the samples.
+        """
+        dev = qp.device("null.qubit", wires=1)
+
+        @qp.qjit(capture=True, target="mlir")
+        @convert_quantum_to_qecl_pass(k=1)
+        @measurements_from_samples_pass
+        @qp.qnode(dev, shots=100, mcm_method="one-shot")
+        def circuit():
+            # CHECK-NOT: builtin.unrealized_conversion_cast
+
+            # CHECK-LABEL: func.func public @circuit{{.+}} quantum.node
+            # CHECK-NOT: qecl.hadamard
+            # CHECK: [[mres:%.+]], {{%.+}} = qecl.measure
+            # CHECK: [[mres_i64:%.+]] = arith.extui [[mres]] : i1 to i64
+            # CHECK: [[mres_f64:%.+]] = arith.sitofp [[mres_i64]] : i64 to f64
+            # CHECK: [[mres_1x1xf64:%.+]] = tensor.from_elements [[mres_f64]] : tensor<1x1xf64>
+            # CHECK: return [[mres_1x1xf64]] : tensor<1x1xf64>
+
+            # CHECK-LABEL: func.func public @circuit() -> tensor<2xf64>
+            # CHECK: [[samples:%.+]] = func.call @circuit.from_samples() : () -> tensor<100x1xf64>
+            # CHECK: [[probs:%.+]] = func.call @probs_from_samples{{.*}}([[samples]])
+            # CHECK: func.return [[probs]] : tensor<2xf64>
+            return qp.probs(wires=0)
+
+        run_filecheck_qjit(circuit)
+
+    @pytest.mark.xfail(reason="Sampling quantum register not implemented", raises=CompileError)
+    def test_probs_register_integration(self, run_filecheck_qjit):
+        """Test the convert-quantum-to-qecl pass on a program with a probabilities terminal
+        measurement on two qubits.
+
+        The measurements-from-samples pass is applied first since the convert-quantum-to-qecl pass
+        can only handle conversion of sampling measurements, with measurements-from-samples
+        inserting the appropriate post-processing functions to recover the expectation value
+        measurement from the samples.
+        """
+        dev = qp.device("null.qubit", wires=1)
+
+        @qp.qjit(capture=True, target="mlir")
+        @convert_quantum_to_qecl_pass(k=1)
+        @measurements_from_samples_pass
+        @qp.qnode(dev, shots=100, mcm_method="one-shot")
+        def circuit():
+            # CHECK-NOT: builtin.unrealized_conversion_cast
+            return qp.probs()
 
         run_filecheck_qjit(circuit)
 

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecl_to_qecp.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecl_to_qecp.py
@@ -1319,8 +1319,7 @@ class TestControlFlow:
 
             qp.cond(x > 0, true_branch, false_branch)()
 
-            m0 = qp.measure(0)
-            return qp.sample([m0])
+            return qp.sample(wires=[0])
 
         run_filecheck_qjit(circuit)
 
@@ -1354,8 +1353,7 @@ class TestControlFlow:
                 qp.PauliX(0)
 
             loop_pauli_x()
-            m0 = qp.measure(0)
-            return qp.sample([m0])
+            return qp.sample(wires=[0])
 
         run_filecheck_qjit(circuit)
 
@@ -1397,8 +1395,7 @@ class TestControlFlow:
             # apply the while loop
             loop_rx(value)
 
-            m0 = qp.measure(0)
-            return qp.sample([m0])
+            return qp.sample(wires=[0])
 
         run_filecheck_qjit(circuit)
 

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecl_to_qecp.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecl_to_qecp.py
@@ -1235,17 +1235,14 @@ class TestQECPLoweringIntegration:
             # CHECK: func.call @measure_transversal_Steane
             # CHECK: func.call @measure_transversal_Steane
             # CHECK: func.call @measure_transversal_Steane
-            # CHECK: qecp.insert_block
             # CHECK: quantum.mcmobs
+            # CHECK: qecp.insert_block
             # CHECK: quantum.sample
             # CHECK: qecp.dealloc
             qp.H(0)
             qp.CNOT([0, 1])
             qp.CNOT([1, 2])
-            m0 = qp.measure(0)
-            m1 = qp.measure(1)
-            m2 = qp.measure(2)
-            return qp.sample([m0, m1, m2])
+            return qp.sample(wires=[0, 1, 2])
 
         run_filecheck_qjit(circuit)
 
@@ -1273,7 +1270,6 @@ class TestQECPLoweringIntegration:
             # CHECK: func.call @noise_subroutine_code
             # CHECK: func.call @qec_cycle_Steane
             # CHECK: func.call @measure_transversal_Steane
-            m0 = qp.measure(0)
-            return qp.sample([m0])
+            return qp.sample(wires=[0])
 
         run_filecheck_qjit(circuit)

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
@@ -14,8 +14,6 @@
 
 """Tests for the convert-qecp-to-quantum xDSL dialect-conversion pass."""
 
-from functools import partial
-
 import numpy as np
 import pennylane as qp
 import pytest

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
@@ -823,8 +823,7 @@ class TestControlFlow:
 
             qp.cond(x > 0, true_branch, false_branch)()
 
-            m0 = qp.measure(0)
-            return qp.sample([m0])
+            return qp.sample(wires=[0])
 
         run_filecheck_qjit(circuit)
 
@@ -878,9 +877,7 @@ class TestControlFlow:
 
             qp.cond(x > 0, true_branch, false_branch)()
 
-            m0 = qp.measure(0)
-            m1 = qp.measure(1)
-            return qp.sample([m0, m1])
+            return qp.sample(wires=[0, 1])
 
         run_filecheck_qjit(circuit)
 
@@ -916,8 +913,7 @@ class TestControlFlow:
                 qp.PauliX(0)
 
             loop_pauli_x()
-            m0 = qp.measure(0)
-            return qp.sample([m0])
+            return qp.sample(wires=[0])
 
         run_filecheck_qjit(circuit)
 
@@ -961,8 +957,7 @@ class TestControlFlow:
             # apply the while loop
             loop_rx(value)
 
-            m0 = qp.measure(0)
-            return qp.sample([m0])
+            return qp.sample(wires=[0])
 
         run_filecheck_qjit(circuit)
 
@@ -988,9 +983,7 @@ class TestControlFlow:
             for i in range(N_WIRES):
                 qp.H(i)
 
-            m0 = qp.measure(0)
-            m1 = qp.measure(1)
-            return qp.sample([m0, m1])
+            return qp.sample(wires=[0, 1])
 
         run_filecheck_qjit(circuit)
 
@@ -1165,6 +1158,26 @@ class TestQECPassIntegration:
         assert np.all(samples[:, 0] == 0)
         assert np.all(samples[:, 1] == 1)
 
+    def test_sample_on_wires(self):
+        """Test that sampling on MCMs returns correct results."""
+        dev = qp.device("lightning.qubit", wires=2)
+
+        @qp.qjit(capture=True, pipelines=qec_pipeline(), seed=42)
+        @convert_qecp_to_quantum_pass
+        @convert_qecl_to_qecp_pass(qec_code="Steane", number_errors=1)
+        @inject_noise_to_qecl_pass
+        @convert_quantum_to_qecl_pass(k=1)
+        @qp.set_shots(10)
+        @qp.qnode(dev, mcm_method="one-shot")
+        def circ():
+            qp.Z(0)
+            qp.X(1)
+            return qp.sample(wires=[0, 1])
+
+        samples = circ()
+        assert np.all(samples[:, 0] == 0)
+        assert np.all(samples[:, 1] == 1)
+
     def test_expval(self):
         """Test that expectation-value terminal measurements return correct results."""
         dev = qp.device("lightning.qubit", wires=2)
@@ -1295,9 +1308,8 @@ class TestQECPassIntegration:
                 qp.cond(i % 2 == 0, qp.X, qp.Z)(0)
 
             loop()
-            m0 = qp.measure(0)
 
-            return qp.sample([m0])
+            return qp.sample(wires=[0])
 
         circ()
 
@@ -1336,8 +1348,7 @@ class TestQECPassIntegration:
                 qp.adjoint(qp.T(0))
             for op in diagonalizing_gates:
                 op(0)
-            m0 = qp.measure(0)
-            return qp.sample(m0)
+            return qp.sample(wires=[0])
 
         run_filecheck_qjit(circ)
         samples = circ()

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
@@ -14,6 +14,8 @@
 
 """Tests for the convert-qecp-to-quantum xDSL dialect-conversion pass."""
 
+from functools import partial
+
 import numpy as np
 import pennylane as qp
 import pytest
@@ -21,6 +23,7 @@ import pytest
 from catalyst.ftqc import qec_pipeline
 from catalyst.python_interface.dialects import qecp
 from catalyst.python_interface.dialects.quantum.attributes import QubitType
+from catalyst.python_interface.transforms import measurements_from_samples_pass
 from catalyst.python_interface.transforms.qecl import (
     convert_quantum_to_qecl_pass,
     inject_noise_to_qecl_pass,
@@ -946,6 +949,76 @@ class TestQECPassIntegration:
         samples = circ()
         assert np.all(samples[:, 0] == 0)
         assert np.all(samples[:, 1] == 1)
+
+    def test_expval(self):
+        """Test that expectation-value terminal measurements return correct results."""
+        dev = qp.device("lightning.qubit", wires=2)
+
+        @qp.qjit(capture=True, pipelines=qec_pipeline())
+        @convert_qecp_to_quantum_pass
+        @convert_qecl_to_qecp_pass(qec_code="Steane", number_errors=1)
+        @inject_noise_to_qecl_pass
+        @convert_quantum_to_qecl_pass(k=1)
+        @measurements_from_samples_pass
+        @qp.set_shots(10)
+        @qp.qnode(dev, mcm_method="one-shot")
+        def circ():
+            qp.X(1)
+            return qp.expval(qp.Z(0)), qp.expval(qp.Z(1))
+
+        expval0, expval1 = circ()
+        assert np.allclose(expval0, np.array(1.0))
+        assert np.allclose(expval1, np.array(-1.0))
+
+    def test_var(self):
+        """Test that variance terminal measurements return correct results."""
+        dev = qp.device("lightning.qubit", wires=2)
+
+        @qp.qjit(capture=True, pipelines=qec_pipeline())
+        @convert_qecp_to_quantum_pass
+        @convert_qecl_to_qecp_pass(qec_code="Steane", number_errors=1)
+        @inject_noise_to_qecl_pass
+        @convert_quantum_to_qecl_pass(k=1)
+        @measurements_from_samples_pass
+        @qp.set_shots(10)
+        @qp.qnode(dev, mcm_method="one-shot")
+        def circ():
+            qp.X(1)
+            return qp.var(qp.Z(0)), qp.var(qp.Z(1))
+
+        expval0, expval1 = circ()
+        assert np.allclose(expval0, np.array(0.0))
+        assert np.allclose(expval1, np.array(0.0))
+
+    @pytest.mark.parametrize(
+        "ops, wires, expected_probs",
+        [
+            ([], [], np.array([1.0, 0.0, 0.0, 0.0])),
+            ([qp.X], [1], np.array([0.0, 1.0, 0.0, 0.0])),
+            ([qp.X], [0], np.array([0.0, 0.0, 1.0, 0.0])),
+            ([qp.X, qp.X], [0, 1], np.array([0.0, 0.0, 0.0, 1.0])),
+        ],
+    )
+    def test_probs(self, ops, wires, expected_probs):
+        """Test that probability terminal measurements return correct results."""
+        dev = qp.device("lightning.qubit", wires=2)
+
+        @qp.qjit(capture=True, pipelines=qec_pipeline())
+        @convert_qecp_to_quantum_pass
+        @convert_qecl_to_qecp_pass(qec_code="Steane", number_errors=1)
+        @inject_noise_to_qecl_pass
+        @convert_quantum_to_qecl_pass(k=1)
+        @measurements_from_samples_pass
+        @qp.set_shots(10)
+        @qp.qnode(dev, mcm_method="one-shot")
+        def circ():
+            for op, w in zip(ops, wires):
+                op(wires=w)
+
+            return qp.probs(wires=[0, 1])
+
+        probs = circ()
+        assert np.allclose(probs, expected_probs)
 
     # pylint: disable=too-many-positional-arguments, too-many-arguments
     @pytest.mark.parametrize(

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
@@ -675,10 +675,7 @@ class TestQECPassIntegration:
             qp.Hadamard(0)
             qp.CNOT([0, 1])
             qp.CNOT([1, 2])
-            m0 = qp.measure(0)
-            m1 = qp.measure(1)
-            m2 = qp.measure(2)
-            return qp.sample([m0, m1, m2])
+            return qp.sample(wires=[0, 1, 2])
 
         run_filecheck_qjit(ghz)
         samples = np.atleast_2d(np.asarray(ghz()))
@@ -702,10 +699,7 @@ class TestQECPassIntegration:
             qp.Hadamard(0)
             qp.CNOT([0, 1])
             qp.CNOT([1, 2])
-            m0 = qp.measure(0)
-            m1 = qp.measure(1)
-            m2 = qp.measure(2)
-            return qp.sample([m0, m1, m2])
+            return qp.sample(wires=[0, 1, 2])
 
         ghz()
 
@@ -751,8 +745,7 @@ class TestQECPassIntegration:
             for gate in gates:
                 gate(0)
             qp.H(0)
-            m0 = qp.measure(0)
-            return qp.sample(m0)
+            return qp.sample(wires=[0])
 
         @qp.qjit(capture=True, pipelines=qec_pipeline(), seed=456)
         @qec_conversion_and_noise_passes
@@ -764,8 +757,7 @@ class TestQECPassIntegration:
             qp.Z(0)
             qp.S(0)
             qp.H(0)
-            m0 = qp.measure(0)
-            return qp.sample(m0)
+            return qp.sample(wires=[0])
 
         @qp.qjit(capture=True, pipelines=qec_pipeline(), seed=789)
         @qec_conversion_and_noise_passes
@@ -774,8 +766,7 @@ class TestQECPassIntegration:
         def z_circ():
             for gate in gates:
                 gate(0)
-            m0 = qp.measure(0)
-            return qp.sample(m0)
+            return qp.sample(wires=[0])
 
         all_samples = x_circ(), y_circ(), z_circ()
 
@@ -783,6 +774,28 @@ class TestQECPassIntegration:
             eigvals = [-1 if s else 1 for s in samples]
             # the tolerance is a bit high, but it keeps number of shots down
             assert np.isclose(np.mean(eigvals), res, atol=0.1)
+
+    def test_sample_on_mcm(self):
+        """Test that sampling on MCMs returns correct results."""
+        dev = qp.device("lightning.qubit", wires=2)
+
+        @qp.qjit(capture=True, pipelines=qec_pipeline(), seed=42)
+        @convert_qecp_to_quantum_pass
+        @convert_qecl_to_qecp_pass(qec_code="Steane", number_errors=1)
+        @inject_noise_to_qecl_pass
+        @convert_quantum_to_qecl_pass(k=1)
+        @qp.set_shots(10)
+        @qp.qnode(dev, mcm_method="one-shot")
+        def circ():
+            qp.Z(0)
+            qp.X(1)
+            m0 = qp.measure(0)
+            m1 = qp.measure(1)
+            return qp.sample([m0, m1])
+
+        samples = circ()
+        assert np.all(samples[:, 0] == 0)
+        assert np.all(samples[:, 1] == 1)
 
     # pylint: disable=too-many-positional-arguments, too-many-arguments
     @pytest.mark.parametrize(
@@ -821,8 +834,7 @@ class TestQECPassIntegration:
                 qp.T(0)
             for op in diagonalizing_gates:
                 op(0)
-            m0 = qp.measure(0)
-            return qp.sample(m0)
+            return qp.sample(wires=[0])
 
         run_filecheck_qjit(circ)
         samples = circ()


### PR DESCRIPTION
**Context:** Part of the effort to expand support in the QEC pipeline for more general input programs, this PR follows #2941, which added support for programs that return samples on wires, and ensures we also support other measurement processes, including `qp.expval`, `qp.var` and `qp.probs` (we do not currently aim to support `qp.counts`).

**Description of the Change:** With the QEC pipeline already supporting samples on wires, and when used in conjunction with the `measurements-from-samples` pass, the QEC pipeline should get support for the other terminal measurement processes listed above for free. This PR adds tests (both lit tests for the `convert-quantum-to-qecl` pass and end-to-end tests with noise injected and executed on Lightning) to ensure that programs with these measurement processes are handled correctly.

[sc-120295]