### PR TITLE
Fix resource analysis pass to include functions in nested modules

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -141,7 +141,7 @@
 * Fixed a bug where the `ResourceAnalysis` pass only analyzed functions directly contained in
   the top-level module. Functions inside nested modules, such as kernels called through
   `catalyst.launch_kernel`, are now included in the output.
-  [(#XXXX)](https://github.com/PennyLaneAI/catalyst/pull/XXXX)
+  [(#2961)](https://github.com/PennyLaneAI/catalyst/pull/2961)
 
 * Fixed a bug in `DecompRuleInterpreter.cleanup` by replacing fragile string-based operator
   checks with strict type-based checking.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -138,6 +138,11 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a bug where the `ResourceAnalysis` pass only analyzed functions directly contained in
+  the top-level module. Functions inside nested modules, such as kernels called through
+  `catalyst.launch_kernel`, are now included in the output.
+  [(#XXXX)](https://github.com/PennyLaneAI/catalyst/pull/XXXX)
+
 * Fixed a bug in `DecompRuleInterpreter.cleanup` by replacing fragile string-based operator
   checks with strict type-based checking.
   [(#2873)](https://github.com/PennyLaneAI/catalyst/pull/2873)

--- a/mlir/lib/Catalyst/Analysis/ResourceAnalysis.cpp
+++ b/mlir/lib/Catalyst/Analysis/ResourceAnalysis.cpp
@@ -232,11 +232,11 @@ ResourceAnalysis::ResourceAnalysis(ModuleOp moduleOp)
     LLVM_DEBUG(dbgs() << "ResourceAnalysis: analyzing operation " << moduleOp->getName() << "\n");
 
     SmallVector<func::FuncOp> definedFuncOps;
-    for (func::FuncOp funcOp : moduleOp.getOps<func::FuncOp>()) {
+    moduleOp.walk([&](func::FuncOp funcOp) {
         if (!funcOp.isDeclaration()) {
             definedFuncOps.push_back(funcOp);
         }
-    }
+    });
 
     // Reserve every user function's name in `funcResults`. This
     // ensures `makeUniqueSyntheticName` will skip past names like

--- a/mlir/test/Catalyst/ResourceAnalysisTest.mlir
+++ b/mlir/test/Catalyst/ResourceAnalysisTest.mlir
@@ -904,3 +904,32 @@ func.func @qref(%arg0: !qref.bit, %arg1: !qref.reg<2>) {
     qref.dealloc %0 : !qref.reg<2>
     return
 }
+
+// -----
+
+// Resource analysis should include functions inside nested modules.
+
+// CHECK-LABEL: "circuit"
+// CHECK: "num_alloc_qubits": 1
+// CHECK: "operations"
+// CHECK-DAG: "Hadamard(1)": 1
+
+// CHECK-LABEL: "jit_circuit"
+// CHECK: "catalyst.launch_kernel": 1
+module @nested_resource_module {
+  func.func public @jit_circuit() attributes {llvm.emit_c_interface} {
+    catalyst.launch_kernel @module_circuit::@circuit() : () -> ()
+    return
+  }
+
+  module @module_circuit {
+    func.func public @circuit() attributes {quantum.node} {
+      %0 = quantum.alloc( 1) : !quantum.reg
+      %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+      %2 = quantum.custom "Hadamard"() %1 : !quantum.bit
+      %3 = quantum.insert %0[ 0], %2 : !quantum.reg, !quantum.bit
+      quantum.dealloc %3 : !quantum.reg
+      return
+    }
+  }
+}


### PR DESCRIPTION
Currently, `ResourceAnalysis` only looked at top-level func.func definitions, so nested kernels behind catalyst.launch_kernel were missing from the JSON output. It now walks nested modules recursively, so those functions are included in resource analysis results.