### PR TITLE
Upper bound nanobind to 2.12.0

### DIFF
--- a/.github/workflows/build-wheel-linux-arm64.yaml
+++ b/.github/workflows/build-wheel-linux-arm64.yaml
@@ -177,7 +177,7 @@ jobs:
 
     - name: Install Dependencies (Python)
       run: |
-        python${{ matrix.python_version }} -m pip install numpy nanobind pybind11 PyYAML cmake ninja
+        python${{ matrix.python_version }} -m pip install numpy "nanobind<2.13" pybind11 PyYAML cmake ninja
         # Add cmake and ninja to the PATH env var
         PYTHON_BINS=$(find /opt/_internal/cpython-${{ matrix.python_version }}.*/bin -maxdepth 1 -type d | tr '\n' ':' | sed 's/:$//')
         echo $PYTHON_BINS >> $GITHUB_PATH
@@ -273,7 +273,7 @@ jobs:
 
     - name: Install Dependencies (Python)
       run: |
-        python${{ matrix.python_version }} -m pip install numpy nanobind pybind11 PyYAML cmake ninja
+        python${{ matrix.python_version }} -m pip install numpy "nanobind<2.13" pybind11 PyYAML cmake ninja
         # Add cmake and ninja to the PATH env var
         PYTHON_BINS=$(find /opt/_internal/cpython-${{ matrix.python_version }}.*/bin -maxdepth 1 -type d | tr '\n' ':' | sed 's/:$//')
         echo $PYTHON_BINS >> $GITHUB_PATH

--- a/.github/workflows/build-wheel-linux-x86_64.yaml
+++ b/.github/workflows/build-wheel-linux-x86_64.yaml
@@ -197,7 +197,7 @@ jobs:
 
     - name: Install Dependencies (Python)
       run: |
-        python${{ matrix.python_version }} -m pip install numpy nanobind pybind11 PyYAML cmake ninja
+        python${{ matrix.python_version }} -m pip install numpy "nanobind<2.13" pybind11 PyYAML cmake ninja
         # Add cmake and ninja to the PATH env var
         PYTHON_BINS=$(find /opt/_internal/cpython-${{ matrix.python_version }}.*/bin -maxdepth 1 -type d | tr '\n' ':' | sed 's/:$//')
         echo $PYTHON_BINS >> $GITHUB_PATH
@@ -295,7 +295,7 @@ jobs:
 
     - name: Install Dependencies (Python)
       run: |
-        python${{ matrix.python_version }} -m pip install numpy nanobind pybind11 PyYAML cmake ninja
+        python${{ matrix.python_version }} -m pip install numpy "nanobind<2.13" pybind11 PyYAML cmake ninja
         # Add cmake and ninja to the PATH env var
         PYTHON_BINS=$(find /opt/_internal/cpython-${{ matrix.python_version }}.*/bin -maxdepth 1 -type d | tr '\n' ':' | sed 's/:$//')
         echo $PYTHON_BINS >> $GITHUB_PATH

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -176,7 +176,7 @@ jobs:
 
     - name: Install Dependencies (Python)
       run: |
-        python${{ matrix.python_version }} -m pip install numpy nanobind pybind11 PyYAML cmake ninja
+        python${{ matrix.python_version }} -m pip install numpy "nanobind<2.13" pybind11 PyYAML cmake ninja
 
     - name: Build LLVM / MLIR
       if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -257,7 +257,7 @@ jobs:
     # LAPACKE reference implementation. TODO: Look into how to upgrade beyond this limit.
     - name: Install Dependencies (Python)
       run: |
-        python${{ matrix.python_version }} -m pip install numpy nanobind pybind11 PyYAML ninja delocate
+        python${{ matrix.python_version }} -m pip install numpy "nanobind<2.13" pybind11 PyYAML ninja delocate
         python${{ matrix.python_version }} -m pip install cmake'<4'
 
     - name: Get Cached LLVM Source

--- a/.github/workflows/check-catalyst.yaml
+++ b/.github/workflows/check-catalyst.yaml
@@ -55,7 +55,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -y -q install ninja-build make cmake clang
-          python3 -m pip install nanobind pybind11
+          python3 -m pip install "nanobind<2.13" pybind11
 
       - name: Get Cached LLVM Source
         id: cache-llvm-source
@@ -160,7 +160,7 @@ jobs:
         sudo apt-get install -y python3 python3-pip cmake ninja-build clang lld
 
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
-        python3 -m pip install numpy pybind11 nanobind PyYAML
+        python3 -m pip install numpy pybind11 "nanobind<2.13" PyYAML
 
     - name: Build LLVM
       if: steps.cache-llvm-build.outputs.cache-hit != 'true'
@@ -346,7 +346,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y python3 python3-pip cmake ninja-build ccache clang lld
         python3 --version | grep ${{ needs.constants.outputs.primary_python_version }}
-        python3 -m pip install numpy nanobind pybind11
+        python3 -m pip install numpy "nanobind<2.13" pybind11
 
     - name: Get Cached LLVM Source
       id: cache-llvm-source
@@ -698,7 +698,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -y -q install cmake ninja-build
-          python3 -m pip install nanobind pybind11
+          python3 -m pip install "nanobind<2.13" pybind11
 
       - name: Download Catalyst-Runtime Artifact
         uses: actions/download-artifact@v4
@@ -731,7 +731,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get -y -q install cmake ninja-build
-          python3 -m pip install nanobind pybind11
+          python3 -m pip install "nanobind<2.13" pybind11
 
       - name: Install lcov # Manually install lcov_1.15-1_all
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ pip>=22.3
 # this bug was fixed in 2.0.1 (https://github.com/numpy/numpy/pull/26995)
 numpy>2.0.0
 # llvm requires nanobind 2.9 or higher
-nanobind>=2.9
+# nanobind 2.13 has a bug in error handling
+nanobind>=2.9,<2.13
 pybind11>=2.12.0
 PyYAML
 


### PR DESCRIPTION
**Context:**
[Nanobind released a new package last night](https://pypi.org/project/nanobind/2.13.0/) and broke some code around python error handling. The `nanobind::python_error::what()` function seems to be returning null pointers in some situations.

**Description of the Change:**
Upper bound nanobind to the previously working verison (2.12.0).

**Benefits:**
CI works again.
