### PR TITLE
Rework the `catalyst` CLI installation mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ test_rules.mlirbc
 
 # Packaging directories
 dist
-frontend/bin
+frontend/catalyst/bin
 frontend/catalyst/lib
 frontend/catalyst/_revision.py
 frontend/mlir_quantum

--- a/Makefile
+++ b/Makefile
@@ -239,8 +239,8 @@ wheel:
 	for file in gradient qref quantum _ods_common catalyst mbqc mitigation pbc _transform; do \
 		cp $(COPY_FLAGS) $(DIALECTS_BUILD_DIR)/python_packages/quantum/mlir_quantum/dialects/*$${file}* $(MK_DIR)/frontend/mlir_quantum/dialects ; \
 	done
-	mkdir -p $(MK_DIR)/frontend/bin
-	cp $(COPY_FLAGS) $(DIALECTS_BUILD_DIR)/bin/catalyst $(MK_DIR)/frontend/bin/
+	mkdir -p $(MK_DIR)/frontend/catalyst/bin
+	cp $(COPY_FLAGS) $(DIALECTS_BUILD_DIR)/bin/catalyst $(MK_DIR)/frontend/catalyst/bin/
 	find $(MK_DIR)/frontend -type d -name __pycache__ -exec rm -rf {} +
 
 
@@ -292,7 +292,7 @@ clean:
 	find frontend/catalyst -name "*.so" -not -path "*/third_party/*" -exec rm -v {} +
 	git restore frontend/catalyst/_configuration.py
 	rm -rf $(MK_DIR)/frontend/catalyst/_revision.py
-	rm -rf $(MK_DIR)/frontend/catalyst/include $(MK_DIR)/frontend/catalyst/lib $(MK_DIR)/frontend/bin
+	rm -rf $(MK_DIR)/frontend/catalyst/include $(MK_DIR)/frontend/catalyst/lib $(MK_DIR)/frontend/catalyst/bin
 	rm -rf $(MK_DIR)/frontend/catalyst/resources
 	rm -rf $(MK_DIR)/frontend/test/lit/GraphDecomposition/test_rules.mlirbc
 	rm -rf $(MK_DIR)/frontend/mlir_quantum

--- a/frontend/catalyst/compiler.py
+++ b/frontend/catalyst/compiler.py
@@ -275,8 +275,11 @@ class LinkerDriver:
 def _get_catalyst_cli_cmd(*args, stdin=None):
     """Just get the command, do not run it"""
     cli_path = get_cli_path()
-    if not path.isfile(cli_path):
-        raise FileNotFoundError("catalyst executable was not found.")  # pragma: nocover
+    if not path.isfile(cli_path):  # pragma: nocover
+        raise FileNotFoundError(
+            f"Could not locate the `catalyst` executable at {cli_path}. "
+            "Please verify your installation or report the issue on GitHub."
+        )
 
     cmd = [cli_path]
     for arg in args:

--- a/frontend/catalyst/utils/cli_shim.py
+++ b/frontend/catalyst/utils/cli_shim.py
@@ -1,0 +1,33 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Thin launcher exposed as the ``catalyst`` console script.
+
+Console scripts are automatically installed by Python package managers such that they are
+available on PATH, however the exact location is system-dependent. Using a shim allows us
+to place the real Catalyst executable into a known location within the package/wheel,
+making it easier for us to find, and distribute shared library dependencies for
+(predictable RPATH).
+"""
+
+import os
+import sys
+
+from catalyst.utils.runtime_environment import get_cli_path
+
+
+def main():
+    """Run the Catalyst CLI."""
+    binary = get_cli_path()
+    os.execv(binary, [binary, *sys.argv[1:]])

--- a/frontend/catalyst/utils/cli_shim.py
+++ b/frontend/catalyst/utils/cli_shim.py
@@ -30,4 +30,9 @@ from catalyst.utils.runtime_environment import get_cli_path
 def main():
     """Run the Catalyst CLI."""
     binary = get_cli_path()
+    if not os.path.isfile(binary):  # pragma: nocover
+        raise FileNotFoundError(
+            f"Could not locate the `catalyst` executable at {binary}. "
+            "Please verify your installation or report the issue on GitHub."
+        )
     os.execv(binary, [binary, *sys.argv[1:]])

--- a/frontend/catalyst/utils/runtime_environment.py
+++ b/frontend/catalyst/utils/runtime_environment.py
@@ -72,25 +72,27 @@ def get_libpython_path() -> str:  # pragma: no cover
 
 def get_lib_path(project, env_var):
     """Get the path to Catalyst's shared libraries."""
-    if INSTALLED:
-        return os.path.join(package_root, "lib")  # pragma: no cover
+    if INSTALLED:  # pragma: no cover
+        return os.path.join(package_root, "lib")
+
     return os.getenv(env_var, DEFAULT_LIB_PATHS.get(project, ""))
 
 
 def get_include_path():
     """Return the path to Catalyst's include directory."""
-    if INSTALLED:
-        return os.path.join(package_root, "include")  # pragma: no cover
+    if INSTALLED:  # pragma: no cover
+        return os.path.join(package_root, "include")
+
     return os.getenv("CATALYST_INCLUDE_DIRS", DEFAULT_INCLUDE_PATHS.get("mlir", ""))
 
 
-def get_cli_path() -> str:  # pragma: nocover
+def get_cli_path() -> str:
     """Method to obtain the Catalyst CLI path whether installed or locally built."""
     catalyst_cli = "catalyst"
 
-    if not INSTALLED:
-        return os.path.join(
-            os.getenv("CATALYST_BIN_DIR", DEFAULT_BIN_PATHS.get("cli", "")), catalyst_cli
-        )
+    if INSTALLED:  # pragma: nocover
+        return os.path.join(package_root, "bin", catalyst_cli)
 
-    return os.path.join(package_root, "bin", catalyst_cli)
+    return os.path.join(
+        os.getenv("CATALYST_BIN_DIR", DEFAULT_BIN_PATHS.get("cli", "")), catalyst_cli
+    )

--- a/frontend/catalyst/utils/runtime_environment.py
+++ b/frontend/catalyst/utils/runtime_environment.py
@@ -16,7 +16,6 @@
 
 import os
 import os.path
-import sys
 import sysconfig
 
 from catalyst._configuration import INSTALLED
@@ -86,7 +85,7 @@ def get_include_path():
 
 
 def get_cli_path() -> str:  # pragma: nocover
-    """Method to obtain the Catalyst CLI path packaged via the data_files mechanism."""
+    """Method to obtain the Catalyst CLI path whether installed or locally built."""
     catalyst_cli = "catalyst"
 
     if not INSTALLED:
@@ -94,28 +93,4 @@ def get_cli_path() -> str:  # pragma: nocover
             os.getenv("CATALYST_BIN_DIR", DEFAULT_BIN_PATHS.get("cli", "")), catalyst_cli
         )
 
-    # Default path
-    path = os.path.join(sysconfig.get_path("scripts"), catalyst_cli)
-    if os.path.isfile(path):
-        return path
-
-    # User path
-    user_scheme = sysconfig.get_preferred_scheme("user")
-    path = os.path.join(sysconfig.get_path("scripts", scheme=user_scheme), catalyst_cli)
-    if os.path.isfile(path):
-        return path
-
-    # Fallback to python location
-    path = os.path.join(os.path.dirname(sys.executable), catalyst_cli)
-    if os.path.isfile(path):
-        return path
-
-    # Check the old bin directory location, which in rare scenarios may still be used
-    # (e.g. the configuration after `make wheel` has been run).
-    path = os.path.join(package_root, "..", "bin", catalyst_cli)
-    if os.path.isfile(path):
-        return path
-
-    raise RuntimeError(
-        "Could not locate the Catalyst executable, please report this issue on GitHub."
-    )
+    return os.path.join(package_root, "bin", catalyst_cli)

--- a/frontend/catalyst/utils/runtime_environment.py
+++ b/frontend/catalyst/utils/runtime_environment.py
@@ -14,15 +14,29 @@
 
 """Utility code for keeping paths."""
 
+import importlib.util
 import os
 import os.path
 import sysconfig
 
-from catalyst._configuration import INSTALLED
-from catalyst._revision import __revision__
-from catalyst._version import __version__
-
 package_root = os.path.join(os.path.dirname(__file__), "..")
+
+
+def _load_config(filename, attr):
+    """Read Catalyst config flags without importing Catalyst via the usual machinery.
+
+    This enables us to use this utility module from outside the Catalyst package as well.
+    """
+    path = os.path.join(package_root, filename)
+    spec = importlib.util.spec_from_file_location("", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return getattr(mod, attr)
+
+
+INSTALLED = _load_config("_configuration.py", "INSTALLED")
+__revision__ = _load_config("_revision.py", "__revision__")
+__version__ = _load_config("_version.py", "__version__")
 
 # Default paths to dep libraries
 DEFAULT_LIB_PATHS = {

--- a/frontend/catalyst_cli_shim.py
+++ b/frontend/catalyst_cli_shim.py
@@ -37,7 +37,9 @@ def _get_cli_path() -> str:
     spec = importlib.util.find_spec("catalyst")
     if spec is None or spec.origin is None:
         raise ImportError(
-            "Could not locate the 'catalyst' package, please make sure it is installed."
+            "Could not locate the 'catalyst' package, please make sure it is installed. "
+            "Refer to https://docs.pennylane.ai/projects/catalyst/en/stable/dev/installation.html "
+            "for additional instructions."
         )
     catalyst_path = os.path.dirname(spec.origin)
 

--- a/frontend/catalyst_cli_shim.py
+++ b/frontend/catalyst_cli_shim.py
@@ -17,19 +17,40 @@
 Console scripts are automatically installed by Python package managers such that they are
 available on PATH, however the exact location is system-dependent. Using a shim allows us
 to place the real Catalyst executable into a known location within the package/wheel,
-making it easier for us to find, and distribute shared library dependencies for
-(predictable RPATH).
+making it easier for us to find and handle dynamically linked dependencies.
+
+This module deliberately lives outside the ``catalyst`` package and loads Catalyst
+functionality only via importlib, in order to avoid the expensive overhead of importing
+all of Catalyst and all its dependencies.
 """
 
+import importlib.util
 import os
 import sys
 
-from catalyst.utils.runtime_environment import get_cli_path
+
+def _get_cli_path() -> str:
+    """Resolve the Catalyst CLI path without importing Catalyst via the usual machinery.
+
+    Relies on the runtime_environment module not importing Catalyst directly either.
+    """
+    spec = importlib.util.find_spec("catalyst")
+    if spec is None or spec.origin is None:
+        raise ImportError(
+            "Could not locate the 'catalyst' package, please make sure it is installed."
+        )
+    catalyst_path = os.path.dirname(spec.origin)
+
+    runtime_env_path = os.path.join(catalyst_path, "utils", "runtime_environment.py")
+    spec = importlib.util.spec_from_file_location("", runtime_env_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.get_cli_path()
 
 
 def main():
     """Run the Catalyst CLI."""
-    binary = get_cli_path()
+    binary = _get_cli_path()
     if not os.path.isfile(binary):  # pragma: nocover
         raise FileNotFoundError(
             f"Could not locate the `catalyst` executable at {binary}. "

--- a/setup.py
+++ b/setup.py
@@ -167,6 +167,9 @@ entry_points = {
     "pennylane.drawer": [
         "draw_graph = catalyst:draw_graph",
     ],
+    "console_scripts": [
+        "catalyst = catalyst.utils.cli_shim:main",
+    ],
 }
 
 classifiers = [
@@ -391,15 +394,6 @@ options = {"bdist_wheel": {"py_limited_api": "cp312"}} if sys.hexversion >= 0x03
 # - `ops`: Path to the compiler operations module.
 # - `qjit`: Path to the JIT compiler decorator provided by the compiler.
 
-# Install the `catalyst` binary into the user's Python environment so it is accessible on the PATH.
-# Does not work with editable installs. Requires the Catalyst mlir module to be built.
-if os.path.exists("frontend/bin/catalyst"):
-    catalyst_cli = ["frontend/bin/catalyst"]
-elif os.path.exists("mlir/build/bin/catalyst"):
-    catalyst_cli = ["mlir/build/bin/catalyst"]
-else:
-    catalyst_cli = []
-
 setup(
     classifiers=classifiers,
     name="pennylane_catalyst",
@@ -418,9 +412,6 @@ setup(
     ),
     package_dir={"": "frontend"},
     include_package_data=True,
-    data_files=[
-        ("bin", catalyst_cli),
-    ],
     ext_modules=ext_modules,
     cmdclass=cmdclass,
     **description,

--- a/setup.py
+++ b/setup.py
@@ -168,7 +168,7 @@ entry_points = {
         "draw_graph = catalyst:draw_graph",
     ],
     "console_scripts": [
-        "catalyst = catalyst.utils.cli_shim:main",
+        "catalyst = catalyst_cli_shim:main",
     ],
 }
 
@@ -411,6 +411,7 @@ setup(
         ],
     ),
     package_dir={"": "frontend"},
+    py_modules=["catalyst_cli_shim"],
     include_package_data=True,
     ext_modules=ext_modules,
     cmdclass=cmdclass,


### PR DESCRIPTION
In order to better support dynamically linked or loaded libraries from the Catalyst executable (the CLI tool), we need to guarantee a predictable location. Currently, the binary is installed via the `data_files` mechanism which is not the most predictable (see current `get_cli_path` impl), and separates the CLI binary from other package libraries (typically under `site-packages/catalyst/lib`).

For dynamic linking of shared libs, we'd need the .so to be located on a fixed path relative to the executable, since this path needs to be set at build time (i.e. `RPATH`). For dynamically loaded libraries (dlopen), the fixed relative path removes the need for heuristics to compute the real path of a shared lib.

The new system leverages the [console_scripts entry point](https://packaging.python.org/en/latest/specifications/entry-points/) mechanism to install a tiny shim in a location automatically available on PATH for most Python installs. 
This is common practice among CLI tools distributed as a Python package (e.g. cmake) and comes with a few advantages:
- `catalyst` is available as a command for both wheel installations and editable installs (the current mechanism only works for wheel installs)
- predictable/fixed path of the CLI within the Catalyst package
- simpler `get_cli_path` implementation (fewer heuristics)
 
[sc-122013]


**Note on performance:**

The overhead of running the CLI through the shim in the first version was about 100x. While only a couple of seconds total (on an empty file / pipeline), when used interactively this is clearly noticeable and off-putting. The new structure avoids importing Catalyst except the necessary pieces to locate the binary. The final result is about 10x slower than when invoked directly, but this is fast enough to not be a burden (~0.3s).