### PR TITLE
Stateless `unknown_op_in_solution_raises` test

### DIFF
--- a/frontend/test/pytest/from_plxpr/test_decompose_transform.py
+++ b/frontend/test/pytest/from_plxpr/test_decompose_transform.py
@@ -1110,47 +1110,49 @@ class TestPlxPRDecomposition:
         wire count cannot be inferred.
         """
 
-        class _UnknownOp(qp.operation.Operation):
-            num_wires = 1
-            num_params = 0
-            name = "_UnknownOp"
+        with qp.decomposition.local_decomps():
 
-        def _unknown_resources():
-            return {qp.resource_rep(qp.PauliX): 1}
+            class _UnknownOp(qp.operation.Operation):
+                num_wires = 1
+                num_params = 0
+                name = "_UnknownOp"
 
-        @qp.register_resources(_unknown_resources)
-        def _unknown_decomp(wires):
-            qp.PauliX(wires)
+            def _unknown_resources():
+                return {qp.resource_rep(qp.PauliX): 1}
 
-        qp.add_decomps(_UnknownOp, _unknown_decomp)
+            @qp.register_resources(_unknown_resources)
+            def _unknown_decomp(wires):
+                qp.PauliX(wires)
 
-        def _rx_resources():
-            return {qp.resource_rep(_UnknownOp): 1}
+            qp.add_decomps(_UnknownOp, _unknown_decomp)
 
-        @qp.register_resources(_rx_resources)
-        def _rx_decomp(_, wires):
-            _UnknownOp(wires=wires)
+            def _rx_resources():
+                return {qp.resource_rep(_UnknownOp): 1}
 
-        qp.decomposition.enable_graph()
+            @qp.register_resources(_rx_resources)
+            def _rx_decomp(_, wires):
+                _UnknownOp(wires=wires)
 
-        @qp.qjit(capture=True)
-        @qp.decompose(
-            gate_set={"PauliX"},
-            fixed_decomps={qp.RX: _rx_decomp},
-        )
-        @qp.qnode(qp.device("null.qubit", wires=1))
-        def f(phi):
-            qp.RX(phi, 0)
-            return qp.state()
+            qp.decomposition.enable_graph()
 
-        try:
-            with pytest.raises(
-                ValueError,
-                match=r"Could not capture _UnknownOp without the number of wires\.",
-            ):
-                f(0.5)
-        finally:
-            qp.decomposition.disable_graph()
+            @qp.qjit(capture=True)
+            @qp.decompose(
+                gate_set={"PauliX"},
+                fixed_decomps={qp.RX: _rx_decomp},
+            )
+            @qp.qnode(qp.device("null.qubit", wires=1))
+            def f(phi):
+                qp.RX(phi, 0)
+                return qp.state()
+
+            try:
+                with pytest.raises(
+                    ValueError,
+                    match=r"Could not capture _UnknownOp without the number of wires\.",
+                ):
+                    f(0.5)
+            finally:
+                qp.decomposition.disable_graph()
 
     def test_symbolic_controlled_op_is_skipped(self):
         """Symbolic Controlled ops produced by ``qml.ctrl`` must be skipped when


### PR DESCRIPTION
**Context:**
The `TestPlxPRDecomposition::test_unknown_op_in_solution_raises` test in `frontend/test/pytest/from_plxpr/test_decompose_transform.py::` was failing flaky tests due to duplicate rules rather than invalid ops in the rule with repeated runs.

**Description of the Change:**
Ensures that the decompositions are added locally, keeping each run independent.

**Benefits:**
Stateless unit test.

**Possible Drawbacks:**

**Related GitHub Issues:**
