### PR TITLE
Upgrade macos to macos-15

### DIFF
--- a/.github/workflows/build-nightly-release-candidate.yaml
+++ b/.github/workflows/build-nightly-release-candidate.yaml
@@ -83,7 +83,7 @@ jobs:
 
     steps:
     - name: Download wheels
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         merge-multiple: true
         path: dist

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -69,7 +69,7 @@ jobs:
         python_version: ${{ fromJson(format('["{0}"]', needs.constants.outputs.primary_python_version)) }}
 
     name: Build Dependencies (Python ${{ matrix.python_version }})
-    runs-on: macos-14
+    runs-on: macos-15
 
     if: needs.check_if_wheel_build_required.outputs.build-wheels == 'true'
 
@@ -238,7 +238,7 @@ jobs:
         python_version: ${{ fromJson(needs.constants.outputs.python_versions) }}
 
     name: Build Wheels (Python ${{ matrix.python_version }})
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
     - name: Checkout Catalyst repo
@@ -425,7 +425,7 @@ jobs:
 
     # To check all wheels for supported python3 versions
     name: Test Wheels (Python ${{ matrix.python_version }}) on Mac arm64
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
     - name: Checkout Catalyst repo

--- a/.github/workflows/build-wheel-macos-arm64.yaml
+++ b/.github/workflows/build-wheel-macos-arm64.yaml
@@ -38,7 +38,7 @@ on:
         type: string
 
 env:
-  MACOSX_DEPLOYMENT_TARGET: 14.0
+  MACOSX_DEPLOYMENT_TARGET: 15.0
 
   # If the `inputs.build_standalone_plugin` is set to a value (true/false), then that is used.
   # If the input is empty (meaning this workflow was not triggered by a workflow_call/workflow_dispatch), then check if event_name is schedule.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -194,7 +194,7 @@
 
 <h3>Internal changes ⚙️</h3>
 
-* Upgrade macOS runner to `macos-15`.
+* Upgrade macOS runner to `macos-15`; `macos-14` is no longer maintained.
   [(#2972)](https://github.com/PennyLaneAI/catalyst/pull/2972)
 
 * Update tests to not use global capture toggle where possible.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -194,6 +194,9 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* Upgrade macOS runner to `macos-15`.
+  [(#2972)](https://github.com/PennyLaneAI/catalyst/pull/2972)
+
 * Update tests to not use global capture toggle where possible.
   [(#2964)](https://github.com/PennyLaneAI/catalyst/pull/2964)
 


### PR DESCRIPTION
**Context:**
Macos-14 github runners will be deprecated on July 6th and will no longer be available after November 2nd 2026. See [statement](https://github.com/actions/runner-images/issues/13518)

**Description of the Change:**
Upgrade mac runners from macos-14 to macos-15

**Benefits:**
Mac runner stays up do date and available.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
