### PR TITLE
Add support for choosing decomposition rules in `decompose-lowering`

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -5,6 +5,13 @@
 
 <h3>Improvements 🛠</h3>
 
+* The `decompose-lowering` pass now supports applying a selection of the available decomposition rules via the `target_rules` parameter.
+  The pass also no longer applies the `inline`, `cse` and `canonicalize` passes to avoid unnecessary IR mutations.
+  Instead, decomposition rules are deterministically inlined by a custom function (`inline` is non-deterministic, using an estimated benefit and threshold as criteria for inlining).
+  Decomposition rules are no longer removed after the `decompose-lowering` pass, which allows them to be used by subsequent passes, namely `graph-decomposition`.
+  Instead, rules are removed by the `symbol-dce` pass at the end of the `QuantumCompilationStage`.
+  [(#2973)](https://github.com/PennyLaneAI/catalyst/pull/2973)
+
 * The `ResourceAnalysis` pass now reports each loop body and each subroutine as its own entry
   instead of folding their gate counts into the caller. Loops with constant bounds appear as `for_loop_<N>`
   with their trip count. Loops with dynamic bounds appear as `dyn_for_loop_<N>` with a stable

--- a/mlir/include/Quantum/Transforms/Passes.td
+++ b/mlir/include/Quantum/Transforms/Passes.td
@@ -189,6 +189,14 @@ def GraphDecompositionPass : Pass<"graph-decomposition", "mlir::ModuleOp"> {
 
 def DecomposeLoweringPass : Pass<"decompose-lowering"> {
     let summary = "Replace quantum operations with compiled decomposition rules.";
+
+    let options = [
+        ListOption<
+            /*C++ name*/"targetRulesOption",
+            /*CLI name*/"target-rules",
+            /*Type*/"std::string",
+            /*Description*/"The set of decomposition rules to apply. If empty, applies all rules.">
+    ];
 }
 
 def DisentangleCNOTPass : Pass<"disentangle-cnot"> {

--- a/mlir/lib/Quantum/Transforms/DecomposeLoweringImpl.hpp
+++ b/mlir/lib/Quantum/Transforms/DecomposeLoweringImpl.hpp
@@ -13,15 +13,26 @@
 // limitations under the License.
 
 #include <algorithm> // std::move_backward
+#include <cassert>
+#include <cstddef>
+#include <iterator>
+#include <utility>
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Location.h"
+#include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Value.h"
 #include "mlir/IR/ValueRange.h"
+#include "mlir/Support/LLVM.h"
 
 #include "Quantum/IR/QuantumOps.h"
 #include "Quantum/IR/QuantumTypes.h"
@@ -34,8 +45,8 @@ namespace catalyst {
 namespace quantum {
 
 // The goal of this class is to analyze the signature of a custom operation to get the enough
-// information to prepare the call operands and results for replacing the op to calling the
-// decomposition function.
+// information to prepare the operands and results for replacing the op with the decomposition
+// function.
 class BaseSignatureAnalyzer {
   protected:
     bool isValid = true;
@@ -177,7 +188,7 @@ class BaseSignatureAnalyzer {
         return latestQreg;
     }
 
-    // Prepare the operands for calling the decomposition function
+    // Prepare the operands for the decomposition function
     // There are two cases:
     // 1. The first input is a qreg, which means the decomposition function is a qreg mode function
     // 2. Otherwise, the decomposition function is a qubit mode function
@@ -187,10 +198,10 @@ class BaseSignatureAnalyzer {
     //    - func(qreg, param*, inWires*, inCtrlWires*?, inCtrlValues*?) -> qreg
     // 2. qubit mode:
     //    - func(param*, inQubits*, inCtrlQubits*?, inCtrlValues*?) -> outQubits*
-    llvm::SmallVector<Value> prepareCallOperands(func::FuncOp decompFunc, PatternRewriter &rewriter,
-                                                 Location loc)
+    llvm::SmallVector<Value> prepareOperands(func::FuncOp rule, PatternRewriter &rewriter,
+                                             Location loc)
     {
-        auto funcType = decompFunc.getFunctionType();
+        auto funcType = rule.getFunctionType();
         auto funcInputs = funcType.getInputs();
 
         SmallVector<Type> funcInputsNoQreg;
@@ -202,10 +213,10 @@ class BaseSignatureAnalyzer {
 
         SmallVector<Value> operands(funcInputs.size());
 
-        auto qregIt = llvm::find_if(decompFunc.getFunctionType().getInputs(),
+        auto qregIt = llvm::find_if(rule.getFunctionType().getInputs(),
                                     [](mlir::Type t) { return isa<quantum::QuregType>(t); });
-        int qregIdx = std::distance(decompFunc.getFunctionType().getInputs().begin(), qregIt);
-        bool hasQreg = (qregIt != decompFunc.getFunctionType().getInputs().end());
+        int qregIdx = std::distance(rule.getFunctionType().getInputs().begin(), qregIt);
+        bool hasQreg = (qregIt != rule.getFunctionType().getInputs().end());
 
         int operandIdx = 0;
         if (!signature.params.empty()) {
@@ -264,22 +275,18 @@ class BaseSignatureAnalyzer {
         return operands;
     }
 
-    // Prepare the results for the call operation
-    SmallVector<Value> prepareCallResultForQreg(func::CallOp callOp, PatternRewriter &rewriter)
+    // Prepare the results produced by a qreg-mode decomposition rule
+    SmallVector<Value> prepareResultsForQreg(Value qreg, Location loc, PatternRewriter &rewriter)
     {
-        assert(callOp.getNumResults() == 1 && "only one qreg result for qreg mode is allowed");
-
-        auto qreg = callOp.getResult(0);
         assert(isa<quantum::QuregType>(qreg.getType()) && "only allow to have qreg result");
 
         SmallVector<Value> newResults;
-        rewriter.setInsertionPointAfter(callOp);
 
         for (const auto &indices : {signature.outQubitIndices, signature.outCtrlQubitIndices}) {
             for (const auto &index : indices) {
                 auto extractOp = quantum::ExtractOp::create(
-                    rewriter, callOp.getLoc(), rewriter.getType<quantum::QubitType>(), qreg,
-                    index.getValue(), index.getAttr());
+                    rewriter, loc, rewriter.getType<quantum::QubitType>(), qreg, index.getValue(),
+                    index.getAttr());
                 newResults.emplace_back(extractOp.getResult());
             }
         }
@@ -325,7 +332,7 @@ class BaseSignatureAnalyzer {
         return {startIdx, paramTypeEnd};
     }
 
-    // generate params for calling the decomposition function based on function type requirements
+    // generate params for the decomposition function based on function type requirements
     SmallVector<Value> generateParams(ValueRange signatureParams, ArrayRef<Type> funcParamTypes,
                                       PatternRewriter &rewriter, Location loc)
     {

--- a/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
@@ -57,6 +57,7 @@ namespace quantum {
 static SmallVector<Value> inlineRuleBody(PatternRewriter &rewriter, func::FuncOp rule,
                                          ValueRange operands)
 {
+    assert(rule.getBlocks().size() == 1)
     Block &body = rule.front();
     auto returnOp = cast<func::ReturnOp>(body.getTerminator());
 

--- a/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
@@ -40,16 +40,16 @@
 
 #include "DecomposeLoweringImpl.hpp"
 
+#define DEBUG_TYPE "decompose-lowering"
+
 using namespace mlir;
 using namespace catalyst::quantum;
-
-#define DEBUG_TYPE "decompose-lowering"
 
 namespace catalyst {
 namespace quantum {
 
-SmallVector<Value> inlineDecompositionRule(func::FuncOp rule, ValueRange operands,
-                                           PatternRewriter &rewriter)
+SmallVector<Value> getDecompRuleResults(func::FuncOp rule, ValueRange operands,
+                                        PatternRewriter &rewriter)
 {
     Block &body = rule.front();
     auto returnOp = cast<func::ReturnOp>(body.getTerminator());
@@ -103,6 +103,8 @@ struct DLCustomOpPattern : public OpRewritePattern<CustomOp> {
             return failure();
         }
 
+        // do not nest decomposition rules, they're applied greedily and this can lead to
+        // cycles/identity rules
         if (isInDecompRule(op)) {
             return failure();
         }
@@ -144,17 +146,17 @@ struct DLCustomOpPattern : public OpRewritePattern<CustomOp> {
         assert(analyzer && "Analyzer should be valid");
 
         auto operands = analyzer.prepareOperands(rule, rewriter, op.getLoc());
-        SmallVector<Value> inlinedFunction = inlineDecompositionRule(rule, operands, rewriter);
+        SmallVector<Value> inlinedFunctionResults = getDecompRuleResults(rule, operands, rewriter);
 
         // Replace the op with the inlined function and adjust the insert ops for the qreg mode
-        if (inlinedFunction.size() == 1 &&
-            isa<quantum::QuregType>(inlinedFunction.front().getType())) {
-            auto results =
-                analyzer.prepareResultsForQreg(inlinedFunction.front(), op.getLoc(), rewriter);
+        if (inlinedFunctionResults.size() == 1 &&
+            isa<quantum::QuregType>(inlinedFunctionResults.front().getType())) {
+            auto results = analyzer.prepareResultsForQreg(inlinedFunctionResults.front(),
+                                                          op.getLoc(), rewriter);
             rewriter.replaceOp(op, results);
         }
         else {
-            rewriter.replaceOp(op, inlinedFunction);
+            rewriter.replaceOp(op, inlinedFunctionResults);
         }
 
         return success();
@@ -183,6 +185,8 @@ struct DLMultiRZOpPattern : public OpRewritePattern<MultiRZOp> {
             return failure();
         }
 
+        // do not nest decomposition rules, they're applied greedily and this can lead to
+        // cycles/identity rules
         if (isInDecompRule(op)) {
             return failure();
         }
@@ -223,18 +227,18 @@ struct DLMultiRZOpPattern : public OpRewritePattern<MultiRZOp> {
         assert(analyzer && "Analyzer should be valid");
 
         auto operands = analyzer.prepareOperands(decompFunc, rewriter, op.getLoc());
-        SmallVector<Value> inlinedFunction =
-            inlineDecompositionRule(decompFunc, operands, rewriter);
+        SmallVector<Value> inlinedFunctionResults =
+            getDecompRuleResults(decompFunc, operands, rewriter);
 
         // Replace the op with the inlined function and adjust the insert ops for the qreg mode
-        if (inlinedFunction.size() == 1 &&
-            isa<quantum::QuregType>(inlinedFunction.front().getType())) {
-            auto results =
-                analyzer.prepareResultsForQreg(inlinedFunction.front(), op.getLoc(), rewriter);
+        if (inlinedFunctionResults.size() == 1 &&
+            isa<quantum::QuregType>(inlinedFunctionResults.front().getType())) {
+            auto results = analyzer.prepareResultsForQreg(inlinedFunctionResults.front(),
+                                                          op.getLoc(), rewriter);
             rewriter.replaceOp(op, results);
         }
         else {
-            rewriter.replaceOp(op, inlinedFunction);
+            rewriter.replaceOp(op, inlinedFunctionResults);
         }
 
         return success();
@@ -263,6 +267,8 @@ struct DLPauliRotOpPattern : public OpRewritePattern<PauliRotOp> {
             return failure();
         }
 
+        // do not nest decomposition rules, they're applied greedily and this can lead to
+        // cycles/identity rules
         if (isInDecompRule(op)) {
             return failure();
         }
@@ -289,18 +295,18 @@ struct DLPauliRotOpPattern : public OpRewritePattern<PauliRotOp> {
         assert(analyzer && "Analyzer should be valid");
 
         auto operands = analyzer.prepareOperands(decompFunc, rewriter, op.getLoc());
-        SmallVector<Value> inlinedFunction =
-            inlineDecompositionRule(decompFunc, operands, rewriter);
+        SmallVector<Value> inlinedFunctionResults =
+            getDecompRuleResults(decompFunc, operands, rewriter);
 
         // Replace the op with the inlined results and adjust the insert ops for the qreg mode
-        if (inlinedFunction.size() == 1 &&
-            isa<quantum::QuregType>(inlinedFunction.front().getType())) {
-            auto results =
-                analyzer.prepareResultsForQreg(inlinedFunction.front(), op.getLoc(), rewriter);
+        if (inlinedFunctionResults.size() == 1 &&
+            isa<quantum::QuregType>(inlinedFunctionResults.front().getType())) {
+            auto results = analyzer.prepareResultsForQreg(inlinedFunctionResults.front(),
+                                                          op.getLoc(), rewriter);
             rewriter.replaceOp(op, results);
         }
         else {
-            rewriter.replaceOp(op, inlinedFunction);
+            rewriter.replaceOp(op, inlinedFunctionResults);
         }
 
         return success();

--- a/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
@@ -54,7 +54,7 @@ namespace quantum {
  * replace the parameters of `rule` and returning the results. `rewriter`'s insertion point will be
  * moved to the end of the inlined function body.
  */
-SmallVector<Value> inlineRuleBody(PatternRewriter &rewriter, func::FuncOp rule, ValueRange operands)
+static SmallVector<Value> inlineRuleBody(PatternRewriter &rewriter, func::FuncOp rule, ValueRange operands)
 {
     Block &body = rule.front();
     auto returnOp = cast<func::ReturnOp>(body.getTerminator());
@@ -73,7 +73,7 @@ SmallVector<Value> inlineRuleBody(PatternRewriter &rewriter, func::FuncOp rule, 
     return results;
 }
 
-bool isInDecompRule(Operation *op)
+static bool isInDecompRule(Operation *op)
 {
     while (auto parentOp = op->getParentOp()) {
         if (auto funcOp = dyn_cast<func::FuncOp>(parentOp)) {

--- a/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
@@ -48,8 +48,13 @@ using namespace catalyst::quantum;
 namespace catalyst {
 namespace quantum {
 
-SmallVector<Value> getDecompRuleResults(func::FuncOp rule, ValueRange operands,
-                                        PatternRewriter &rewriter)
+/**
+ * @brief
+ * Inline the body of `rule` at `rewriter`'s current insertion point, using `operands` to
+ * replace the parameters of `rule` and returning the results. `rewriter`'s insertion point will be
+ * moved to the end of the inlined function body.
+ */
+SmallVector<Value> inlineRuleBody(PatternRewriter &rewriter, func::FuncOp rule, ValueRange operands)
 {
     Block &body = rule.front();
     auto returnOp = cast<func::ReturnOp>(body.getTerminator());
@@ -146,7 +151,7 @@ struct DLCustomOpPattern : public OpRewritePattern<CustomOp> {
         assert(analyzer && "Analyzer should be valid");
 
         auto operands = analyzer.prepareOperands(rule, rewriter, op.getLoc());
-        SmallVector<Value> inlinedFunctionResults = getDecompRuleResults(rule, operands, rewriter);
+        SmallVector<Value> inlinedFunctionResults = inlineRuleBody(rewriter, rule, operands);
 
         // Replace the op with the inlined function and adjust the insert ops for the qreg mode
         if (inlinedFunctionResults.size() == 1 &&
@@ -227,8 +232,7 @@ struct DLMultiRZOpPattern : public OpRewritePattern<MultiRZOp> {
         assert(analyzer && "Analyzer should be valid");
 
         auto operands = analyzer.prepareOperands(decompFunc, rewriter, op.getLoc());
-        SmallVector<Value> inlinedFunctionResults =
-            getDecompRuleResults(decompFunc, operands, rewriter);
+        SmallVector<Value> inlinedFunctionResults = inlineRuleBody(rewriter, decompFunc, operands);
 
         // Replace the op with the inlined function and adjust the insert ops for the qreg mode
         if (inlinedFunctionResults.size() == 1 &&
@@ -295,8 +299,7 @@ struct DLPauliRotOpPattern : public OpRewritePattern<PauliRotOp> {
         assert(analyzer && "Analyzer should be valid");
 
         auto operands = analyzer.prepareOperands(decompFunc, rewriter, op.getLoc());
-        SmallVector<Value> inlinedFunctionResults =
-            getDecompRuleResults(decompFunc, operands, rewriter);
+        SmallVector<Value> inlinedFunctionResults = inlineRuleBody(rewriter, decompFunc, operands);
 
         // Replace the op with the inlined results and adjust the insert ops for the qreg mode
         if (inlinedFunctionResults.size() == 1 &&

--- a/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
@@ -54,7 +54,8 @@ namespace quantum {
  * replace the parameters of `rule` and returning the results. `rewriter`'s insertion point will be
  * moved to the end of the inlined function body.
  */
-static SmallVector<Value> inlineRuleBody(PatternRewriter &rewriter, func::FuncOp rule, ValueRange operands)
+static SmallVector<Value> inlineRuleBody(PatternRewriter &rewriter, func::FuncOp rule,
+                                         ValueRange operands)
 {
     Block &body = rule.front();
     auto returnOp = cast<func::ReturnOp>(body.getTerminator());

--- a/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
@@ -12,13 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#define DEBUG_TYPE "decompose-lowering"
+#include <cassert>
+#include <cstddef>
+#include <string>
 
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/Support/AllocatorBase.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Block.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/IRMapping.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Value.h"
+#include "mlir/IR/ValueRange.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
 
 #include "Quantum/IR/QuantumInterfaces.h"
 #include "Quantum/IR/QuantumOps.h"
@@ -29,8 +43,43 @@
 using namespace mlir;
 using namespace catalyst::quantum;
 
+#define DEBUG_TYPE "decompose-lowering"
+
 namespace catalyst {
 namespace quantum {
+
+SmallVector<Value> inlineDecompositionRule(func::FuncOp rule, ValueRange operands,
+                                           PatternRewriter &rewriter)
+{
+    Block &body = rule.front();
+    auto returnOp = cast<func::ReturnOp>(body.getTerminator());
+
+    IRMapping mapping;
+    mapping.map(body.getArguments(), operands);
+
+    for (Operation &op : body.without_terminator()) {
+        rewriter.clone(op, mapping);
+    }
+
+    SmallVector<Value> results;
+    for (Value operand : returnOp.getOperands()) {
+        results.push_back(mapping.lookupOrDefault(operand));
+    }
+    return results;
+}
+
+bool isInDecompRule(Operation *op)
+{
+    while (auto parentOp = op->getParentOp()) {
+        if (auto funcOp = dyn_cast<func::FuncOp>(parentOp)) {
+            if (funcOp->hasAttr("target_gate")) {
+                return true;
+            }
+        }
+        op = parentOp;
+    }
+    return false;
+}
 
 struct DLCustomOpPattern : public OpRewritePattern<CustomOp> {
   private:
@@ -54,18 +103,22 @@ struct DLCustomOpPattern : public OpRewritePattern<CustomOp> {
             return failure();
         }
 
-        // Find the corresponding decomposition function for the op
+        if (isInDecompRule(op)) {
+            return failure();
+        }
+
+        // Find the corresponding decomposition rule for the op
         auto it = decompositionRegistry.find(gateName);
         if (it == decompositionRegistry.end()) {
             return failure();
         }
-        func::FuncOp decompFunc = it->second;
+        func::FuncOp rule = it->second;
 
         // For null decomp rules, the signature will not have any quantum values
         // This is a deviation from the standard decomp func signature, so we deal with it
         // separately
-        if (!llvm::any_of(llvm::concat<const Type>(decompFunc.getFunctionType().getInputs(),
-                                                   decompFunc.getFunctionType().getResults()),
+        if (!llvm::any_of(llvm::concat<const Type>(rule.getFunctionType().getInputs(),
+                                                   rule.getFunctionType().getResults()),
                           [](const mlir::Type t) {
                               return isa<quantum::QuregType, quantum::QubitType>(t);
                           })) {
@@ -76,32 +129,32 @@ struct DLCustomOpPattern : public OpRewritePattern<CustomOp> {
             return success();
         }
 
-        // Here is the assumption that the decomposition function must have at least one input and
+        // Here is the assumption that the decomposition rule must have at least one input and
         // one result
-        assert(decompFunc.getFunctionType().getNumInputs() > 0 &&
+        assert(rule.getFunctionType().getNumInputs() > 0 &&
                "Decomposition function must have at least one input");
-        assert(decompFunc.getFunctionType().getNumResults() >= 1 &&
+        assert(rule.getFunctionType().getNumResults() >= 1 &&
                "Decomposition function must have at least one result");
 
         rewriter.setInsertionPointAfter(op);
 
-        auto enableQreg = llvm::any_of(decompFunc.getFunctionType().getInputs(),
+        auto enableQreg = llvm::any_of(rule.getFunctionType().getInputs(),
                                        [](mlir::Type t) { return isa<quantum::QuregType>(t); });
         auto analyzer = CustomOpSignatureAnalyzer(op, enableQreg);
         assert(analyzer && "Analyzer should be valid");
 
-        auto callOperands = analyzer.prepareCallOperands(decompFunc, rewriter, op.getLoc());
-        auto callOp =
-            func::CallOp::create(rewriter, op.getLoc(), decompFunc.getFunctionType().getResults(),
-                                 decompFunc.getSymName(), callOperands);
+        auto operands = analyzer.prepareOperands(rule, rewriter, op.getLoc());
+        SmallVector<Value> inlinedFunction = inlineDecompositionRule(rule, operands, rewriter);
 
-        // Replace the op with the call op and adjust the insert ops for the qreg mode
-        if (callOp.getNumResults() == 1 && isa<quantum::QuregType>(callOp.getResult(0).getType())) {
-            auto results = analyzer.prepareCallResultForQreg(callOp, rewriter);
+        // Replace the op with the inlined function and adjust the insert ops for the qreg mode
+        if (inlinedFunction.size() == 1 &&
+            isa<quantum::QuregType>(inlinedFunction.front().getType())) {
+            auto results =
+                analyzer.prepareResultsForQreg(inlinedFunction.front(), op.getLoc(), rewriter);
             rewriter.replaceOp(op, results);
         }
         else {
-            rewriter.replaceOp(op, callOp->getResults());
+            rewriter.replaceOp(op, inlinedFunction);
         }
 
         return success();
@@ -127,6 +180,10 @@ struct DLMultiRZOpPattern : public OpRewritePattern<MultiRZOp> {
 
         // Only decompose the op if it is not in the target gate set
         if (targetGateSet.contains(gateName)) {
+            return failure();
+        }
+
+        if (isInDecompRule(op)) {
             return failure();
         }
 
@@ -165,18 +222,19 @@ struct DLMultiRZOpPattern : public OpRewritePattern<MultiRZOp> {
         auto analyzer = MultiRZOpSignatureAnalyzer(op, enableQreg);
         assert(analyzer && "Analyzer should be valid");
 
-        auto callOperands = analyzer.prepareCallOperands(decompFunc, rewriter, op.getLoc());
-        auto callOp =
-            func::CallOp::create(rewriter, op.getLoc(), decompFunc.getFunctionType().getResults(),
-                                 decompFunc.getSymName(), callOperands);
+        auto operands = analyzer.prepareOperands(decompFunc, rewriter, op.getLoc());
+        SmallVector<Value> inlinedFunction =
+            inlineDecompositionRule(decompFunc, operands, rewriter);
 
-        // Replace the op with the call op and adjust the insert ops for the qreg mode
-        if (callOp.getNumResults() == 1 && isa<quantum::QuregType>(callOp.getResult(0).getType())) {
-            auto results = analyzer.prepareCallResultForQreg(callOp, rewriter);
+        // Replace the op with the inlined function and adjust the insert ops for the qreg mode
+        if (inlinedFunction.size() == 1 &&
+            isa<quantum::QuregType>(inlinedFunction.front().getType())) {
+            auto results =
+                analyzer.prepareResultsForQreg(inlinedFunction.front(), op.getLoc(), rewriter);
             rewriter.replaceOp(op, results);
         }
         else {
-            rewriter.replaceOp(op, callOp->getResults());
+            rewriter.replaceOp(op, inlinedFunction);
         }
 
         return success();
@@ -205,6 +263,10 @@ struct DLPauliRotOpPattern : public OpRewritePattern<PauliRotOp> {
             return failure();
         }
 
+        if (isInDecompRule(op)) {
+            return failure();
+        }
+
         // Find the corresponding decomposition function for the op
         auto it = decompositionRegistry.find(gateName);
         if (it == decompositionRegistry.end()) {
@@ -226,18 +288,19 @@ struct DLPauliRotOpPattern : public OpRewritePattern<PauliRotOp> {
         auto analyzer = PauliRotOpSignatureAnalyzer(op, enableQreg);
         assert(analyzer && "Analyzer should be valid");
 
-        auto callOperands = analyzer.prepareCallOperands(decompFunc, rewriter, op.getLoc());
-        auto callOp =
-            func::CallOp::create(rewriter, op.getLoc(), decompFunc.getFunctionType().getResults(),
-                                 decompFunc.getSymName(), callOperands);
+        auto operands = analyzer.prepareOperands(decompFunc, rewriter, op.getLoc());
+        SmallVector<Value> inlinedFunction =
+            inlineDecompositionRule(decompFunc, operands, rewriter);
 
-        // Replace the op with the call op and adjust the insert ops for the qreg mode
-        if (callOp.getNumResults() == 1 && isa<quantum::QuregType>(callOp.getResult(0).getType())) {
-            auto results = analyzer.prepareCallResultForQreg(callOp, rewriter);
+        // Replace the op with the inlined results and adjust the insert ops for the qreg mode
+        if (inlinedFunction.size() == 1 &&
+            isa<quantum::QuregType>(inlinedFunction.front().getType())) {
+            auto results =
+                analyzer.prepareResultsForQreg(inlinedFunction.front(), op.getLoc(), rewriter);
             rewriter.replaceOp(op, results);
         }
         else {
-            rewriter.replaceOp(op, callOp->getResults());
+            rewriter.replaceOp(op, inlinedFunction);
         }
 
         return success();

--- a/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
@@ -57,7 +57,7 @@ namespace quantum {
 static SmallVector<Value> inlineRuleBody(PatternRewriter &rewriter, func::FuncOp rule,
                                          ValueRange operands)
 {
-    assert(rule.getBlocks().size() == 1)
+    assert(rule.getBlocks().size() == 1);
     Block &body = rule.front();
     auto returnOp = cast<func::ReturnOp>(body.getTerminator());
 

--- a/mlir/lib/Quantum/Transforms/decompose_lowering.cpp
+++ b/mlir/lib/Quantum/Transforms/decompose_lowering.cpp
@@ -12,25 +12,32 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <string>
+#include <utility>
 
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/AllocatorBase.h"
+#include "llvm/Support/DebugLog.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Value.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/LLVM.h"
 #include "mlir/Support/WalkResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Inliner.h"
 #include "mlir/Transforms/Passes.h"
 #include "stablehlo/dialect/StablehloOps.h" // When we read the decomposition rules module from file, StablehloDialect may not be registered from start.
 
@@ -162,33 +169,6 @@ struct DecomposeLoweringPass : impl::DecomposeLoweringPassBase<DecomposeLowering
                                             f.front().getTerminator()->getOperandTypes()));
     }
 
-    // Remove unused decomposition functions:
-    // Since the decomposition functions are marked as public from the frontend,
-    // there is no way to remove them with any DCE pass automatically.
-    // So we need to manually remove them from the module
-    void removeDecompositionFunctions(ModuleOp module,
-                                      llvm::StringMap<func::FuncOp> &decompositionRegistry)
-    {
-        llvm::DenseSet<func::FuncOp> usedDecompositionFunctions;
-
-        module.walk([&](func::CallOp callOp) {
-            if (auto targetFunc = module.lookupSymbol<func::FuncOp>(callOp.getCallee())) {
-                if (DecompUtils::isDecompositionFunction(targetFunc)) {
-                    usedDecompositionFunctions.insert(targetFunc);
-                }
-            }
-        });
-
-        // remove unused decomposition functions
-        module.walk([&](func::FuncOp func) {
-            if (DecompUtils::isDecompositionFunction(func) &&
-                !usedDecompositionFunctions.contains(func)) {
-                func.erase();
-            }
-            return WalkResult::skip();
-        });
-    }
-
   public:
     void runOnOperation() final
     {
@@ -204,44 +184,18 @@ struct DecomposeLoweringPass : impl::DecomposeLoweringPassBase<DecomposeLowering
             return;
         }
 
-        // Step 1.1: Find the target gate set
+        // Step 2: Find the target gate set
         findTargetGateSet(module, targetGateSet);
 
-        // Step 2: Canonicalize the module
-        RewritePatternSet patternsCanonicalization(&getContext());
-        catalyst::quantum::CustomOp::getCanonicalizationPatterns(patternsCanonicalization,
-                                                                 &getContext());
-        if (failed(applyPatternsGreedily(module, std::move(patternsCanonicalization)))) {
-            return signalPassFailure();
-        }
-
-        // Step 3: Apply the decomposition patterns
+        // Step 3: Apply the decomposition patterns, canonicalizing the insert/extract pairs
         RewritePatternSet decompositionPatterns(&getContext());
         populateDecomposeLoweringPatterns(decompositionPatterns, decompositionRegistry,
                                           targetGateSet);
-        if (failed(applyPatternsGreedily(module, std::move(decompositionPatterns)))) {
-            return signalPassFailure();
-        }
-
-        // Step 4: Inline and canonicalize/CSE the module again
-        PassManager pm(&getContext());
-        pm.addPass(createInlinerPass());
-        pm.addPass(createCanonicalizerPass());
-        pm.addPass(createCSEPass());
-        if (failed(pm.run(module))) {
-            return signalPassFailure();
-        }
-
-        // Step 5. Remove redundant decomposition functions
-        removeDecompositionFunctions(module, decompositionRegistry);
-
-        // Step 6. Canonicalize the extract/insert pair
-        RewritePatternSet patternsInsertExtract(&getContext());
-        catalyst::quantum::InsertOp::getCanonicalizationPatterns(patternsInsertExtract,
+        catalyst::quantum::InsertOp::getCanonicalizationPatterns(decompositionPatterns,
                                                                  &getContext());
-        catalyst::quantum::ExtractOp::getCanonicalizationPatterns(patternsInsertExtract,
+        catalyst::quantum::ExtractOp::getCanonicalizationPatterns(decompositionPatterns,
                                                                   &getContext());
-        if (failed(applyPatternsGreedily(module, std::move(patternsInsertExtract)))) {
+        if (failed(applyPatternsGreedily(module, std::move(decompositionPatterns)))) {
             return signalPassFailure();
         }
     }

--- a/mlir/lib/Quantum/Transforms/decompose_lowering.cpp
+++ b/mlir/lib/Quantum/Transforms/decompose_lowering.cpp
@@ -15,6 +15,7 @@
 #include <string>
 
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/AllocatorBase.h"
@@ -36,8 +37,6 @@
 #include "Quantum/IR/QuantumDialect.h"
 #include "Quantum/IR/QuantumOps.h"
 #include "Quantum/Transforms/Patterns.h"
-
-#include <llvm/ADT/SmallSet.h>
 
 using namespace mlir;
 using namespace catalyst::quantum;

--- a/mlir/lib/Quantum/Transforms/decompose_lowering.cpp
+++ b/mlir/lib/Quantum/Transforms/decompose_lowering.cpp
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <llvm/ADT/SmallSet.h>
-#define DEBUG_TYPE "decompose-lowering"
-
 #include <string>
 
 #include "llvm/ADT/DenseSet.h"
@@ -40,11 +37,16 @@
 #include "Quantum/IR/QuantumOps.h"
 #include "Quantum/Transforms/Patterns.h"
 
+#include <llvm/ADT/SmallSet.h>
+
 using namespace mlir;
 using namespace catalyst::quantum;
 
+#define DEBUG_TYPE "decompose-lowering"
+
 namespace catalyst {
 namespace quantum {
+
 #define GEN_PASS_DEF_DECOMPOSELOWERINGPASS
 #define GEN_PASS_DECL_DECOMPOSELOWERINGPASS
 #include "Quantum/Transforms/Passes.h.inc"

--- a/mlir/lib/Quantum/Transforms/decompose_lowering.cpp
+++ b/mlir/lib/Quantum/Transforms/decompose_lowering.cpp
@@ -45,10 +45,10 @@
 #include "Quantum/IR/QuantumOps.h"
 #include "Quantum/Transforms/Patterns.h"
 
+#define DEBUG_TYPE "decompose-lowering"
+
 using namespace mlir;
 using namespace catalyst::quantum;
-
-#define DEBUG_TYPE "decompose-lowering"
 
 namespace catalyst {
 namespace quantum {

--- a/mlir/lib/Quantum/Transforms/decompose_lowering.cpp
+++ b/mlir/lib/Quantum/Transforms/decompose_lowering.cpp
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <llvm/ADT/SmallSet.h>
 #define DEBUG_TYPE "decompose-lowering"
 
-// When we read the decomposition rules module from file,
-// StablehloDialect may not be registered from start.
+#include <string>
+
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSet.h"
@@ -24,14 +25,18 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/UB/IR/UBOps.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/WalkResult.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
-#include "stablehlo/dialect/StablehloOps.h"
+#include "stablehlo/dialect/StablehloOps.h" // When we read the decomposition rules module from file, StablehloDialect may not be registered from start.
 
+#include "Quantum/IR/QuantumDialect.h"
 #include "Quantum/IR/QuantumOps.h"
 #include "Quantum/Transforms/Patterns.h"
 
@@ -96,9 +101,15 @@ struct DecomposeLoweringPass : impl::DecomposeLoweringPassBase<DecomposeLowering
     // Function to discover and register decomposition functions from a module
     // It's bookkeeping the targetOp and the decomposition function that can decompose the targetOp
     void discoverAndRegisterDecompositions(ModuleOp module,
-                                           llvm::StringMap<func::FuncOp> &decompositionRegistry)
+                                           llvm::StringMap<func::FuncOp> &decompositionRegistry,
+                                           llvm::StringSet<> targetRules)
     {
         module.walk([&](func::FuncOp func) {
+            // if targetRules is provided, only add requested rules
+            if (!targetRules.empty() && !targetRules.contains(func.getName())) {
+                return WalkResult::skip();
+            }
+
             if (StringRef targetOp = DecompUtils::getTargetGateName(func); !targetOp.empty()) {
                 removeUnusedFuncArgs(func);
                 if (targetOp == "MultiRZ") {
@@ -183,7 +194,11 @@ struct DecomposeLoweringPass : impl::DecomposeLoweringPassBase<DecomposeLowering
         ModuleOp module = cast<ModuleOp>(getOperation());
 
         // Step 1: Discover and register all decomposition functions in the module
-        discoverAndRegisterDecompositions(module, decompositionRegistry);
+        llvm::StringSet<> targetRules;
+        for (auto rule : targetRulesOption) {
+            targetRules.insert(rule);
+        }
+        discoverAndRegisterDecompositions(module, decompositionRegistry, targetRules);
         if (decompositionRegistry.empty()) {
             return;
         }

--- a/mlir/lib/Quantum/Transforms/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/graph_decomposition.cpp
@@ -136,8 +136,11 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
 
         ///////////////////////////
         // Step 5: Re-introduce (all) user rules for future decompositions
+        SymbolTable symbolTable(module);
         for (auto &rule : allUserRules) {
-            module.getBody()->push_back(rule.release());
+            if (!symbolTable.lookup<func::FuncOp>(rule->getName())) {
+                module.getBody()->push_back(rule.release());
+            }
         }
     }
 

--- a/mlir/lib/Quantum/Transforms/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/graph_decomposition.cpp
@@ -12,27 +12,47 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#define DEBUG_TYPE "graph-decomposition"
+#include <cstdint>
+#include <numeric>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
 
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/DebugLog.h"
+#include "llvm/Support/raw_ostream.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/AsmState.h"
+#include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/Location.h"
 #include "mlir/IR/OwningOpRef.h"
+#include "mlir/IR/SymbolTable.h"
 #include "mlir/Parser/Parser.h"
 #include "mlir/Pass/PassManager.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Support/WalkResult.h"
 #include "stablehlo/dialect/StablehloOps.h"
 
 #include "Catalyst/Analysis/ResourceAnalysis.h"
+#include "Catalyst/Analysis/ResourceResult.h"
 #include "Catalyst/Transforms/Passes.h"
 #include "QRef/Transforms/Passes.h"
 #include "Quantum/IR/QuantumDialect.h"
+#include "Quantum/IR/QuantumInterfaces.h"
 #include "Quantum/IR/QuantumOps.h"
 #include "Quantum/Transforms/Passes.h"
 #include "Quantum/Transforms/QPDLoader.h"
@@ -40,6 +60,8 @@
 #include "DGBuilder.hpp"
 #include "DGSolver.hpp"
 #include "DGTypes.hpp"
+
+#define DEBUG_TYPE "graph-decomposition"
 
 using namespace mlir;
 using namespace catalyst::quantum;
@@ -135,7 +157,7 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
         }
 
         ///////////////////////////
-        // Step 5: Re-introduce (all) user rules for future decompositions
+        // Step 5: Re-introduce any missing user rules for future decompositions
         SymbolTable symbolTable(module);
         for (auto &rule : allUserRules) {
             if (!symbolTable.lookup<func::FuncOp>(rule->getName())) {

--- a/mlir/test/Quantum/DecomposeLoweringTargetRulesTest.mlir
+++ b/mlir/test/Quantum/DecomposeLoweringTargetRulesTest.mlir
@@ -1,0 +1,50 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RUN: quantum-opt --pass-pipeline='builtin.module(decompose-lowering{target-rules=my_X_decomp,my_Z_decomp})' --split-input-file -verify-diagnostics %s | FileCheck %s
+
+// Test that decompose-lowering only applies the rules requested by the `target-rules` option when present
+
+module @test_module {
+    // CHECK: func.func private @my_X_decomp
+    func.func private @my_X_decomp(%q: !quantum.bit) -> !quantum.bit attributes {target_gate="X"} {
+        %angle = arith.constant 1.57 : f64
+        %out = quantum.custom "RX"(%angle) %q : !quantum.bit
+        return %out : !quantum.bit
+    }
+
+    func.func private @my_Y_decomp(%q: !quantum.bit) -> !quantum.bit attributes {target_gate="Y"} {
+        %angle = arith.constant 1.57 : f64
+        %out = quantum.custom "RY"(%angle) %q : !quantum.bit
+        return %out : !quantum.bit
+    }
+
+    // CHECK: func.func private @my_Z_decomp
+    func.func private @my_Z_decomp(%q: !quantum.bit) -> !quantum.bit attributes {target_gate="Z"} {
+        %angle = arith.constant 1.57 : f64
+        %out = quantum.custom "RZ"(%angle) %q : !quantum.bit
+        return %out : !quantum.bit
+    }
+
+    // CHECK: [[q_alloc:%.+]] = quantum.alloc_qb
+    // CHECK: [[x_out:%.+]] = func.call @my_X_decomp([[q_alloc]])
+    // CHECK: [[y_out:%.+]] = quantum.custom "Y"() [[x_out]]
+    // CHECK: [[z_out:%.+]] = func.call @my_Z_decomp([[y_out]])
+    // CHECK: quantum.dealloc_qb [[z_out]]
+    %0 = quantum.alloc_qb : !quantum.bit
+    %1 = quantum.custom "X"() %0 : !quantum.bit
+    %2 = quantum.custom "Y"() %1 : !quantum.bit
+    %3 = quantum.custom "Z"() %2 : !quantum.bit
+    quantum.dealloc_qb %3 : !quantum.bit
+}

--- a/mlir/test/Quantum/DecomposeLoweringTargetRulesTest.mlir
+++ b/mlir/test/Quantum/DecomposeLoweringTargetRulesTest.mlir
@@ -24,6 +24,7 @@ module @test_module {
         return %out : !quantum.bit
     }
 
+    // CHECK: func.func private @my_Y_decomp
     func.func private @my_Y_decomp(%q: !quantum.bit) -> !quantum.bit attributes {target_gate="Y"} {
         %angle = arith.constant 1.57 : f64
         %out = quantum.custom "RY"(%angle) %q : !quantum.bit
@@ -37,10 +38,10 @@ module @test_module {
         return %out : !quantum.bit
     }
 
-    // CHECK: [[q_alloc:%.+]] = quantum.alloc_qb
-    // CHECK: [[x_out:%.+]] = func.call @my_X_decomp([[q_alloc]])
+    // CHECK: [[q:%.+]] = quantum.alloc_qb
+    // CHECK: [[x_out:%.+]] = quantum.custom "RX"(%{{.+}}) [[q]]
     // CHECK: [[y_out:%.+]] = quantum.custom "Y"() [[x_out]]
-    // CHECK: [[z_out:%.+]] = func.call @my_Z_decomp([[y_out]])
+    // CHECK: [[z_out:%.+]] = quantum.custom "RZ"(%{{.+}}) [[y_out]]
     // CHECK: quantum.dealloc_qb [[z_out]]
     %0 = quantum.alloc_qb : !quantum.bit
     %1 = quantum.custom "X"() %0 : !quantum.bit

--- a/mlir/test/Quantum/DecomposeLoweringTest.mlir
+++ b/mlir/test/Quantum/DecomposeLoweringTest.mlir
@@ -41,8 +41,8 @@ module @two_hadamards {
     return %4 : tensor<4xf64>
   }
 
-  // Decomposition function should be applied and removed from the module
-  // CHECK-NOT: func.func private @Hadamard_to_RY_decomp
+  // Decomposition function should be retained for future passes
+  // CHECK: func.func private @Hadamard_to_RY_decomp
   func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
     %cst = arith.constant 3.1415926535897931 : f64
     %cst_0 = arith.constant 1.5707963267948966 : f64
@@ -55,6 +55,8 @@ module @two_hadamards {
 // -----
 
 // Test single Hadamard decomposition
+
+// CHECK-LABEL: module @single_hadamard
 module @single_hadamard {
   func.func @test_single_hadamard() -> !quantum.bit {
       // CHECK: [[CST_PI2:%.+]] = arith.constant 1.5707963267948966 : f64
@@ -73,8 +75,8 @@ module @single_hadamard {
       return %2 : !quantum.bit
   }
 
-  // Decomposition function should be applied and removed from the module
-  // CHECK-NOT: func.func private @Hadamard_to_RY_decomp
+  // Decomposition function should be retained for future passes
+  // CHECK: func.func private @Hadamard_to_RY_decomp
   func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
       %cst = arith.constant 3.1415926535897931 : f64
       %cst_0 = arith.constant 1.5707963267948966 : f64
@@ -85,6 +87,8 @@ module @single_hadamard {
 }
 
 // -----
+
+// CHECK-LABEL: module @recursive
 module @recursive {
   func.func public @test_recursive() -> tensor<4xf64> attributes {quantum.node} {
     %0 = quantum.alloc( 2) : !quantum.reg
@@ -112,15 +116,15 @@ module @recursive {
     return %4 : tensor<4xf64>
   }
 
-  // Decomposition function should be applied and removed from the module
-  // CHECK-NOT: func.func private @Hadamard_to_RY_decomp
+  // Decomposition function should be retained for future passes
+  // CHECK: func.func private @Hadamard_to_RY_decomp
   func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
     %out_qubits_0 = quantum.custom "RZRY"() %arg0 : !quantum.bit
     return %out_qubits_0 : !quantum.bit
   }
 
-  // Decomposition function should be applied and removed from the module
-  // CHECK-NOT: func.func private @RZRY_decomp
+  // Decomposition function should be retained for future passes
+  // CHECK: func.func private @RZRY_decomp
   func.func private @RZRY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "RZRY", llvm.linkage = #llvm.linkage<internal>} {
     %cst = arith.constant 3.1415926535897931 : f64
     %cst_0 = arith.constant 1.5707963267948966 : f64
@@ -131,6 +135,8 @@ module @recursive {
 }
 
 // -----
+
+// CHECK-LABEL: module @recursive
 module @recursive {
   func.func public @test_recursive() -> tensor<4xf64> attributes {quantum.node} {
     %0 = quantum.alloc( 2) : !quantum.reg
@@ -158,15 +164,15 @@ module @recursive {
     return %4 : tensor<4xf64>
   }
 
-  // Decomposition function should be applied and removed from the module
-  // CHECK-NOT: func.func private @Hadamard_to_RY_decomp
+  // Decomposition function should be retained for future passes
+  // CHECK: func.func private @Hadamard_to_RY_decomp
   func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
     %out_qubits_0 = quantum.custom "RZRY"() %arg0 : !quantum.bit
     return %out_qubits_0 : !quantum.bit
   }
 
-  // Decomposition function should be applied and removed from the module
-  // CHECK-NOT: func.func private @RZRY_decomp
+  // Decomposition function should be retained for future passes
+  // CHECK: func.func private @RZRY_decomp
   func.func private @RZRY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "RZRY", llvm.linkage = #llvm.linkage<internal>} {
     %cst = arith.constant 3.1415926535897931 : f64
     %cst_0 = arith.constant 1.5707963267948966 : f64
@@ -179,6 +185,8 @@ module @recursive {
 // -----
 
 // Test parametric gates and wires
+
+// CHECK-LABEL: module @param_rxry
 module @param_rxry {
   func.func public @test_param_rxry(%arg0: tensor<f64>, %arg1: tensor<i64>) -> tensor<2xf64> attributes {quantum.node} {
     %c0_i64 = arith.constant 0 : i64
@@ -209,7 +217,7 @@ module @param_rxry {
   }
 
   // Decomposition function expects tensor<f64> while operation provides f64
-  // CHECK-NOT: func.func private @ParametrizedRX_decomp
+  // CHECK: func.func private @ParametrizedRXRY_decomp
   func.func private @ParametrizedRXRY_decomp(%arg0: tensor<f64>, %arg1: !quantum.bit) -> !quantum.bit
       attributes {target_gate = "ParametrizedRXRY", llvm.linkage = #llvm.linkage<internal>} {
     %extracted = tensor.extract %arg0[] : tensor<f64>
@@ -219,92 +227,60 @@ module @param_rxry {
     return %out_qubits_1 : !quantum.bit
   }
 }
-// -----
 
-// Test parametric gates and wires
-module @param_rxry_2 {
-  func.func public @test_param_rxry_2(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: tensor<i64>) -> tensor<2xf64> attributes {quantum.node} {
-    %c0_i64 = arith.constant 0 : i64
-
-    // CHECK: [[REG:%.+]] = quantum.alloc( 1) : !quantum.reg
-    %0 = quantum.alloc( 1) : !quantum.reg
-
-    // CHECK: [[WIRE:%.+]] = tensor.extract %arg2[] : tensor<i64>
-    %extracted = tensor.extract %arg2[] : tensor<i64>
-
-    // CHECK: [[QUBIT:%.+]] = quantum.extract [[REG]][[[WIRE]]] : !quantum.reg -> !quantum.bit
-    %1 = quantum.extract %0[%extracted] : !quantum.reg -> !quantum.bit
-
-    // CHECK: [[PARAM_0:%.+]] = tensor.extract %arg0[] : tensor<f64>
-    %param_0 = tensor.extract %arg0[] : tensor<f64>
-
-    // CHECK: [[PARAM_1:%.+]] = tensor.extract %arg1[] : tensor<f64>
-    %param_1 = tensor.extract %arg1[] : tensor<f64>
-
-    // CHECK: [[QUBIT1:%.+]] = quantum.custom "RX"([[PARAM_0]]) [[QUBIT]] : !quantum.bit
-    // CHECK: [[QUBIT2:%.+]] = quantum.custom "RY"([[PARAM_1]]) [[QUBIT1]] : !quantum.bit
-    // CHECK-NOT: quantum.custom "ParametrizedRXRY"
-    %out_qubits = quantum.custom "ParametrizedRXRY"(%param_0, %param_1) %1 : !quantum.bit
-
-    // CHECK: [[UPDATED_REG:%.+]] = quantum.insert [[REG]][ 0], [[QUBIT2]] : !quantum.reg, !quantum.bit
-    %2 = quantum.insert %0[ 0], %out_qubits : !quantum.reg, !quantum.bit
-    %3 = quantum.compbasis qreg %2 : !quantum.obs
-    %4 = quantum.probs %3 : tensor<2xf64>
-    quantum.dealloc %2 : !quantum.reg
-    return %4 : tensor<2xf64>
-  }
-
-  // Decomposition function expects tensor<f64> while operation provides f64
-  // CHECK-NOT: func.func private @ParametrizedRX_decomp
-  func.func private @ParametrizedRXRY_decomp(%arg0: tensor<f64>, %arg1: tensor<f64>, %arg2: !quantum.bit) -> !quantum.bit
-      attributes {target_gate = "ParametrizedRXRY", llvm.linkage = #llvm.linkage<internal>} {
-    %extracted_param_0 = tensor.extract %arg0[] : tensor<f64>
-    %out_qubits = quantum.custom "RX"(%extracted_param_0) %arg2 : !quantum.bit
-    %extracted_param_1 = tensor.extract %arg1[] : tensor<f64>
-    %out_qubits_1 = quantum.custom "RY"(%extracted_param_1) %out_qubits : !quantum.bit
-    return %out_qubits_1 : !quantum.bit
-  }
-}
 // -----
 
 // Test recursive and qreg-based gate decomposition
+
+// CHECK-LABEL: module @qreg_base_circuit
 module @qreg_base_circuit {
   func.func public @test_qreg_base_circuit() -> tensor<2xf64> attributes {quantum.node} {
-      // CHECK: [[CST:%.+]] = arith.constant 1.000000e+00 : f64
+      // CHECK-DAG: [[cmp_0:%.+]] = stablehlo.constant dense<0.000000e+00> : tensor<f64>
+      // CHECK-DAG: [[test_angle:%.+]] = arith.constant 1.000000e+00 : f64
+      // CHECK-DAG: [[index_tensor:%.+]] = arith.constant dense<0> : tensor<1xi64>
+      // CHECK-DAG: [[cmp_1:%.+]] = arith.constant dense<1.000000e+00> : tensor<f64>
+      // CHECK: [[reg0:%.+]] = quantum.alloc( 1) : !quantum.reg
       %cst = arith.constant 1.000000e+00 : f64
-
-      // CHECK: [[CST_0:%.+]] = stablehlo.constant dense<0.000000e+00> : tensor<f64>
-      // CHECK: [[CST_1:%.+]] = arith.constant dense<0> : tensor<1xi64>
-      // CHECK: [[CST_2:%.+]] = arith.constant dense<1.000000e+00> : tensor<f64>
-      // CHECK: [[REG:%.+]] = quantum.alloc( 1) : !quantum.reg
       %0 = quantum.alloc( 1) : !quantum.reg
 
-      // CHECK: [[EXTRACT_QUBIT:%.+]] = quantum.extract [[REG]][ 0] : !quantum.reg -> !quantum.bit
-      // CHECK: [[MRES:%.+]], [[OUT_QUBIT:%.+]] = quantum.measure [[EXTRACT_QUBIT]] : i1, !quantum.bit
-      // CHECK: [[REG1:%.+]] = quantum.insert [[REG]][ 0], [[OUT_QUBIT]] : !quantum.reg, !quantum.bit
-      // CHECK: [[COMPARE:%.+]] = stablehlo.compare  NE, [[CST_2]], [[CST_0]],  FLOAT : (tensor<f64>, tensor<f64>) -> tensor<i1>
-      // CHECK: [[EXTRACTED:%.+]] = tensor.extract [[COMPARE]][] : tensor<i1>
-      // CHECK: [[CONDITIONAL:%.+]] = scf.if [[EXTRACTED]] -> (!quantum.reg) {
-      // CHECK:   [[SLICE1:%.+]] = stablehlo.slice [[CST_1]] [0:1] : (tensor<1xi64>) -> tensor<1xi64>
-      // CHECK:   [[RESHAPE1:%.+]] = stablehlo.reshape [[SLICE1]] : (tensor<1xi64>) -> tensor<i64>
-      // CHECK:   [[EXTRACTED_3:%.+]] = tensor.extract [[RESHAPE1]][] : tensor<i64>
-      // CHECK:   [[FROM_ELEMENTS:%.+]] = tensor.from_elements [[EXTRACTED_3]] : tensor<1xi64>
-      // CHECK:   [[SLICE2:%.+]] = stablehlo.slice [[FROM_ELEMENTS]] [0:1] : (tensor<1xi64>) -> tensor<1xi64>
-      // CHECK:   [[RESHAPE2:%.+]] = stablehlo.reshape [[SLICE2]] : (tensor<1xi64>) -> tensor<i64>
-      // CHECK:   [[EXTRACTED_4:%.+]] = tensor.extract [[RESHAPE2]][] : tensor<i64>
-      // CHECK:   [[EXTRACT1:%.+]] = quantum.extract [[REG1]][[[EXTRACTED_4]]] : !quantum.reg -> !quantum.bit
-      // CHECK:   [[RZ1:%.+]] = quantum.custom "RZ"([[CST]]) [[EXTRACT1]] : !quantum.bit
-      // CHECK:   [[INSERT1:%.+]] = quantum.insert [[REG1]][[[EXTRACTED_4]]], [[RZ1]] : !quantum.reg, !quantum.bit
-      // CHECK:   [[EXTRACT2:%.+]] = quantum.extract [[INSERT1]][[[EXTRACTED_3]]] : !quantum.reg -> !quantum.bit
-      // CHECK:   [[INSERT2:%.+]] = quantum.insert [[REG1]][[[EXTRACTED_3]]], [[EXTRACT2]] : !quantum.reg, !quantum.bit
-      // CHECK:   [[EXTRACT3:%.+]] = quantum.extract [[INSERT2]][[[EXTRACTED_4]]] : !quantum.reg -> !quantum.bit
-      // CHECK:   [[RZ2:%.+]] = quantum.custom "RZ"([[CST]]) [[EXTRACT3]] : !quantum.bit
-      // CHECK:   [[INSERT3:%.+]] = quantum.insert [[INSERT2]][[[EXTRACTED_4]]], [[RZ2]] : !quantum.reg, !quantum.bit
-      // CHECK:   [[EXTRACT4:%.+]] = quantum.extract [[INSERT3]][[[EXTRACTED_3]]] : !quantum.reg -> !quantum.bit
-      // CHECK:   [[INSERT4:%.+]] = quantum.insert [[INSERT2]][[[EXTRACTED_3]]], [[EXTRACT4]] : !quantum.reg, !quantum.bit
-      // CHECK:   scf.yield [[INSERT4]] : !quantum.reg
+
+      // CHECK: [[q0:%.+]] = quantum.extract [[reg0]][ 0] : !quantum.reg -> !quantum.bit
+      // CHECK: [[meas:%.+]], [[q1:%.+]] = quantum.measure [[q0]] : i1, !quantum.bit
+      // CHECK: [[reg1:%.+]] = quantum.insert [[reg0]][ 0], [[q1]] : !quantum.reg, !quantum.bit
+      // CHECK: [[cmp:%.+]] = stablehlo.compare  NE, [[cmp_1]], [[cmp_0]],  FLOAT : (tensor<f64>, tensor<f64>) -> tensor<i1>
+      // CHECK: [[cond:%.+]] = tensor.extract [[cmp]][] : tensor<i1>
+      // CHECK: [[condresult:%.+]] = scf.if [[cond]] -> (!quantum.reg) {
+      // CHECK:   [[slice0:%.+]] = stablehlo.slice [[index_tensor]] [0:1] : (tensor<1xi64>) -> tensor<1xi64>
+      // CHECK:   [[reshape0:%.+]] = stablehlo.reshape [[slice0]] : (tensor<1xi64>) -> tensor<i64>
+      // CHECK:   [[index0:%.+]] = tensor.extract [[reshape0]][] : tensor<i64>
+      // CHECK:   [[fromelements0:%.+]] = tensor.from_elements [[index0]] : tensor<1xi64>
+      // CHECK:   [[slice1:%.+]] = stablehlo.slice [[fromelements0]] [0:1] : (tensor<1xi64>) -> tensor<1xi64>
+      // CHECK:   [[reshape1:%.+]] = stablehlo.reshape [[slice1]] : (tensor<1xi64>) -> tensor<i64>
+      // CHECK:   [[index1:%.+]] = tensor.extract [[reshape1]][] : tensor<i64>
+      // CHECK:   [[q2:%.+]] = quantum.extract [[reg1]][[[index1]]] : !quantum.reg -> !quantum.bit
+      // CHECK:   [[q3:%.+]] = quantum.custom "RZ"([[test_angle]]) [[q2]] : !quantum.bit
+      // CHECK:   [[index2:%.+]] = tensor.extract [[reshape1]][]
+      // CHECK:   [[reg2:%.+]] = quantum.insert [[reg1]][[[index2]]], [[q3]] : !quantum.reg, !quantum.bit
+      // CHECK:   [[q4:%.+]] = quantum.extract [[reg2]][[[index0]]] : !quantum.reg -> !quantum.bit
+      // CHECK:   [[slice3:%.+]] = stablehlo.slice [[index_tensor]] [0:1] : (tensor<1xi64>) -> tensor<1xi64>
+      // CHECK:   [[reshape3:%.+]] = stablehlo.reshape [[slice3]] : (tensor<1xi64>) -> tensor<i64>
+      // CHECK:   [[extract6:%.+]] = tensor.extract [[reshape0]][]
+      // CHECK:   [[reg3:%.+]] = quantum.insert [[reg1]][[[extract6]]], [[q4]] : !quantum.reg, !quantum.bit
+      // CHECK:   [[index3:%.+]] = tensor.extract [[reshape3]][]
+      // CHECK:   [[fromelements1:%.+]] = tensor.from_elements [[index3]]
+      // CHECK:   [[slice4:%.+]] = stablehlo.slice [[fromelements1]] [0:1]
+      // CHECK:   [[reshape4:%.+]] = stablehlo.reshape [[slice4]]
+      // CHECK:   [[index4:%.+]] = tensor.extract [[reshape4]][]
+      // CHECK:   [[q5:%.+]] = quantum.extract [[reg3]][[[index4]]] : !quantum.reg -> !quantum.bit
+      // CHECK:   [[q6:%.+]] = quantum.custom "RZ"([[test_angle]]) [[q5]] : !quantum.bit
+      // CHECK:   [[index5:%.+]] = tensor.extract [[reshape4]][]
+      // CHECK:   [[reg4:%.+]] = quantum.insert [[reg3]][[[index5]]], [[q6]] : !quantum.reg, !quantum.bit
+      // CHECK:   [[q7:%.+]] = quantum.extract [[reg4]][[[index3]]] : !quantum.reg -> !quantum.bit
+      // CHECK:   [[index6:%.+]] = tensor.extract [[reshape3]][]
+      // CHECK:   [[out:%.+]] = quantum.insert [[reg3]][[[index6]]], [[q7]] : !quantum.reg, !quantum.bit
+      // CHECK:   scf.yield [[out]] : !quantum.reg
       // CHECK: } else {
-      // CHECK:   scf.yield [[REG1]] : !quantum.reg
+      // CHECK:   scf.yield [[reg1]] : !quantum.reg
       // CHECK: }
       // CHECK-NOT: quantum.custom "Test"
       %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
@@ -318,8 +294,8 @@ module @qreg_base_circuit {
       return %4 : tensor<2xf64>
     }
 
-    // Decomposition function should be applied and removed from the module
-    // CHECK-NOT: func.func private @Test_rule_1
+    // Decomposition function should be retained for future passes
+    // CHECK: func.func private @Test_rule_1
     func.func private @Test_rule_1(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg
         attributes {target_gate = "Test", llvm.linkage = #llvm.linkage<internal>} {
       %cst = stablehlo.constant dense<0.000000e+00> : tensor<f64>
@@ -352,8 +328,8 @@ module @qreg_base_circuit {
       return %1 : !quantum.reg
     }
 
-    // Decomposition function should be applied and removed from the module
-    // CHECK-NOT: func.func private @RzDecomp_rule_1
+    // Decomposition function should be retained for future passes
+    // CHECK: func.func private @RzDecomp_rule_1
     func.func private @RzDecomp_rule_1(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg
         attributes {target_gate = "RzDecomp", llvm.linkage = #llvm.linkage<internal>} {
       %0 = stablehlo.slice %arg2 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
@@ -370,12 +346,12 @@ module @qreg_base_circuit {
 
 // -----
 
+// CHECK-LABEL: module @multi_wire_cnot_decomposition
 module @multi_wire_cnot_decomposition {
   func.func public @test_cnot_decomposition() -> tensor<4xf64> attributes {quantum.node} {
     %0 = quantum.alloc( 2) : !quantum.reg
     %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
     %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
-
     // CHECK: [[CST_PI:%.+]] = arith.constant 3.1415926535897931 : f64
     // CHECK: [[CST_PI2:%.+]] = arith.constant 1.5707963267948966 : f64
     // CHECK: [[WIRE_TENSOR:%.+]] = arith.constant dense<[0, 1]> : tensor<2xi64>
@@ -388,13 +364,22 @@ module @multi_wire_cnot_decomposition {
     // CHECK: [[QUBIT1:%.+]] = quantum.extract [[REG]][[[EXTRACTED]]] : !quantum.reg -> !quantum.bit
     // CHECK: [[RZ1:%.+]] = quantum.custom "RZ"([[CST_PI]]) [[QUBIT1]] : !quantum.bit
     // CHECK: [[RY1:%.+]] = quantum.custom "RY"([[CST_PI2]]) [[RZ1]] : !quantum.bit
+    // CHECK: [[index:%.+]] = tensor.extract [[RESHAPE2]][]
+    // CHECK: [[INSERT_TARGET:%.+]] = quantum.insert [[REG]][[[index]]], [[RY1]] : !quantum.reg, !quantum.bit
     // CHECK: [[EXTRACTED2:%.+]] = tensor.extract [[RESHAPE1]][] : tensor<i64>
-    // CHECK: [[QUBIT0:%.+]] = quantum.extract [[REG]][[[EXTRACTED2]]] : !quantum.reg -> !quantum.bit
-    // CHECK: [[CZ_RESULT:%.+]]:2 = quantum.custom "CZ"() [[QUBIT0]], [[RY1]] : !quantum.bit, !quantum.bit
-    // CHECK: [[INSERT2:%.+]] = quantum.insert [[REG]][[[EXTRACTED2]]], [[CZ_RESULT]]#0 : !quantum.reg, !quantum.bit
-    // CHECK: [[RZ2:%.+]] = quantum.custom "RZ"([[CST_PI]]) [[CZ_RESULT]]#1 : !quantum.bit
+    // CHECK: [[QUBIT0:%.+]] = quantum.extract [[INSERT_TARGET]][[[EXTRACTED2]]] : !quantum.reg -> !quantum.bit
+    // CHECK: [[index2:%.+]] = tensor.extract [[RESHAPE2]][]
+    // CHECK: [[QUBIT1_UPDATED:%.+]] = quantum.extract [[INSERT_TARGET]][[[index2]]] : !quantum.reg -> !quantum.bit
+    // CHECK: [[CZ_RESULT:%.+]]:2 = quantum.custom "CZ"() [[QUBIT0]], [[QUBIT1_UPDATED]] : !quantum.bit, !quantum.bit
+    // CHECK: [[index3:%.+]] = tensor.extract [[RESHAPE1]][]
+    // CHECK: [[INSERT2:%.+]] = quantum.insert [[INSERT_TARGET]][[[index3]]], [[CZ_RESULT]]#0 : !quantum.reg, !quantum.bit
+    // CHECK: [[index4:%.+]] = tensor.extract [[RESHAPE2]][]
+    // CHECK: [[INSERT_CZ1:%.+]] = quantum.insert [[INSERT2]][[[index4]]], [[CZ_RESULT]]#1 : !quantum.reg, !quantum.bit
+    // CHECK: [[TARGET_AFTER_CZ:%.+]] = quantum.extract [[INSERT_CZ1]][{{%.+}}] : !quantum.reg -> !quantum.bit
+    // CHECK: [[RZ2:%.+]] = quantum.custom "RZ"([[CST_PI]]) [[TARGET_AFTER_CZ]] : !quantum.bit
     // CHECK: [[RY2:%.+]] = quantum.custom "RY"([[CST_PI2]]) [[RZ2]] : !quantum.bit
-    // CHECK: [[INSERT3:%.+]] = quantum.insert [[INSERT2]][[[EXTRACTED]]], [[RY2]] : !quantum.reg, !quantum.bit
+    // CHECK: [[index5:%.+]] = tensor.extract [[RESHAPE2]][]
+    // CHECK: [[INSERT3:%.+]] = quantum.insert [[INSERT_CZ1]][[[index5]]], [[RY2]] : !quantum.reg, !quantum.bit
     // CHECK: [[FINAL_QUBIT0:%.+]] = quantum.extract [[INSERT3]][ 0] : !quantum.reg -> !quantum.bit
     // CHECK: [[FINAL_QUBIT1:%.+]] = quantum.extract [[INSERT3]][ 1] : !quantum.reg -> !quantum.bit
     // CHECK-NOT: quantum.custom "CNOT"
@@ -410,8 +395,8 @@ module @multi_wire_cnot_decomposition {
     return %8 : tensor<4xf64>
   }
 
-  // Decomposition function should be applied and removed from the module
-  // CHECK-NOT: func.func private @CNOT_rule_cz_rz_ry
+  // Decomposition function should be retained for future passes
+  // CHECK: func.func private @CNOT_rule_cz_rz_ry
   func.func private @CNOT_rule_cz_rz_ry(%arg0: !quantum.reg, %arg1: tensor<2xi64>) -> !quantum.reg attributes {target_gate = "CNOT", llvm.linkage = #llvm.linkage<internal>} {
     // CNOT decomposition: CNOT = (I ⊗ H) * CZ * (I ⊗ H)
     %cst = arith.constant 1.5707963267948966 : f64
@@ -456,6 +441,7 @@ module @multi_wire_cnot_decomposition {
 
 // -----
 
+// CHECK-LABEL: module @cnot_alternative_decomposition
 module @cnot_alternative_decomposition {
   func.func public @test_cnot_alternative_decomposition() -> tensor<4xf64> attributes {quantum.node} {
     %0 = quantum.alloc( 2) : !quantum.reg
@@ -485,8 +471,8 @@ module @cnot_alternative_decomposition {
     return %8 : tensor<4xf64>
   }
 
-  // Decomposition function should be applied and removed from the module
-  // CHECK-NOT: func.func private @CNOT_rule_h_cnot_h
+  // Decomposition function should be retained for future passes
+  // CHECK: func.func private @CNOT_rule_h_cnot_h
   func.func private @CNOT_rule_h_cnot_h(%arg0: !quantum.bit, %arg1: !quantum.bit) -> (!quantum.bit, !quantum.bit) attributes {target_gate = "CNOT", llvm.linkage = #llvm.linkage<internal>} {
     // CNOT decomposition: CNOT = (I ⊗ H) * CZ * (I ⊗ H)
     %cst = arith.constant 1.5707963267948966 : f64
@@ -509,6 +495,7 @@ module @cnot_alternative_decomposition {
 
 // -----
 
+// CHECK-LABEL: module @mcm_example
 module @mcm_example {
   func.func public @test_mcm_hadamard() -> tensor<2xf64> attributes {quantum.node} {
     %0 = quantum.alloc( 1) : !quantum.reg
@@ -516,9 +503,9 @@ module @mcm_example {
     %mres, %out_qubit = quantum.measure %1 : i1, !quantum.bit
     %2 = quantum.insert %0[ 0], %out_qubit : !quantum.reg, !quantum.bit
 
-    // CHECK: [[RZ_QUBIT:%.+]] = quantum.custom "RZ"([[CST_0:%.+]])
-    // CHECK: [[RY_QUBIT:%.+]] = quantum.custom "RY"([[CST_1:%.+]]) [[RZ_QUBIT]] : !quantum.bit
-    // CHECK: [[REG_1:%.+]] = quantum.insert [[REG:%.+]][[[EXTRACTED:%.+]]], [[RY_QUBIT]] : !quantum.reg, !quantum.bit
+    // CHECK: quantum.custom "RZ"
+    // CHECK: quantum.custom "RY"
+
     // CHECK-NOT: quantum.custom "Hadamard"
     %3 = quantum.extract %2[ 0] : !quantum.reg -> !quantum.bit
     %out_qubits = quantum.custom "Hadamard"() %3 : !quantum.bit
@@ -530,8 +517,8 @@ module @mcm_example {
     return %6 : tensor<2xf64>
   }
 
-  // Decomposition function should be applied and removed from the module
-  // CHECK-NOT: func.func public @rz_ry
+  // Decomposition function should be retained for future passes
+  // CHECK: func.func public @rz_ry
   func.func public @rz_ry(%arg0: !quantum.reg, %arg1: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Hadamard"} {
     %cst = arith.constant 3.1415926535897931 : f64
     %cst_0 = arith.constant 1.5707963267948966 : f64
@@ -555,15 +542,16 @@ module @mcm_example {
 
 // -----
 
+// CHECK-LABEL: module @circuit_with_multirz
 module @circuit_with_multirz {
   func.func public @test_with_multirz() -> tensor<4xf64> attributes {quantum.node} {
     %0 = quantum.alloc( 2) : !quantum.reg
     %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
     // CHECK: func.func public @test_with_multirz() -> tensor<4xf64>
-    // CHECK: [[CST_RZ:%.+]] = arith.constant 5.000000e-01 : f64
-    // CHECK: [[CST_PI2:%.+]] = arith.constant 1.5707963267948966 : f64
-    // CHECK: [[CST_PI:%.+]] = arith.constant 3.1415926535897931 : f64
-    // CHECK: [[REG:%.+]] = quantum.alloc( 2) : !quantum.reg
+    // CHECK-DAG: [[CST_PI2:%.+]] = arith.constant 1.5707963267948966 : f64
+    // CHECK-DAG: [[CST_PI:%.+]] = arith.constant 3.1415926535897931 : f64
+    // CHECK-DAG: [[CST_RZ:%.+]] = arith.constant 5.000000e-01 : f64
+    // CHECK-DAG: [[REG:%.+]] = quantum.alloc( 2) : !quantum.reg
 
     // CHECK: [[QUBIT1:%.+]] = quantum.custom "RZ"([[CST_RZ]]) {{%.+}} : !quantum.bit
     // CHECK-NOT: quantum.multirz
@@ -584,7 +572,7 @@ module @circuit_with_multirz {
     return %4 : tensor<4xf64>
   }
 
-  // CHECK-NOT: func.func private @Hadamard_to_RY_decomp
+  // CHECK: func.func private @Hadamard_to_RY_decomp
   func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
     %cst = arith.constant 3.1415926535897931 : f64
     %cst_0 = arith.constant 1.5707963267948966 : f64
@@ -593,8 +581,8 @@ module @circuit_with_multirz {
     return %out_qubits_1 : !quantum.bit
   }
 
-  // CHECK-NOT: func.func private @_multi_rz_decomposition_wires_1
-  func.func public @_multi_rz_decomposition_wires_1(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "MultiRZ"} {
+  // CHECK: func.func private @_multi_rz_decomposition_wires_1
+  func.func private @_multi_rz_decomposition_wires_1(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "MultiRZ"} {
     %0 = stablehlo.slice %arg2 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
     %1 = stablehlo.reshape %0 : (tensor<1xi64>) -> tensor<i64>
     %extracted = tensor.extract %1[] : tensor<i64>
@@ -610,6 +598,7 @@ module @circuit_with_multirz {
 
 // -----
 
+// CHECK-LABEL: module @qreg_at_not_first_arg
 module @qreg_at_not_first_arg {
   func.func public @test_qreg_at_not_first_arg() attributes {quantum.node} {
     // CHECK: [[wire_tensor:%.+]] = arith.constant dense<[0, 1]> : tensor<2xi64>
@@ -635,7 +624,7 @@ module @qreg_at_not_first_arg {
     return
   }
 
-  // CHECK-NOT: func.func private @my_cnot
+  // CHECK: func.func private @my_cnot
   func.func private @my_cnot(%arg0: tensor<2xi64>, %arg1: !quantum.reg) -> !quantum.reg attributes {target_gate = "CNOT"} {
     %0 = stablehlo.slice %arg0 [0:1] : (tensor<2xi64>) -> tensor<1xi64>
     %1 = stablehlo.reshape %0 : (tensor<1xi64>) -> tensor<i64>
@@ -654,6 +643,7 @@ module @qreg_at_not_first_arg {
 
 // -----
 
+// CHECK-LABEL: module @test_paulirot
 module @test_paulirot {
     func.func @test() attributes {quantum.node} {
         %pi = arith.constant 3.1 : f64
@@ -678,7 +668,7 @@ module @test_paulirot {
         return
     }
 
-    // CHECK-NOT: my_paulirot_decomp
+    // CHECK: my_paulirot_decomp
     func.func private @my_paulirot_decomp(%inreg : !quantum.reg, %angle_tensor : tensor<f64>, %q_tensor : tensor<3xi64>) -> !quantum.reg attributes {target_gate = "paulirotZXY"} {
         %pi_by_2 = arith.constant 1.57 : f64
         %m_pi_by_2 = arith.constant -1.57 : f64
@@ -717,6 +707,7 @@ module @test_paulirot {
 
 // -----
 
+// CHECK-LABEL: module @null_decomp_rule
 module @null_decomp_rule{
   func.func public @test_null_decomp_rule() attributes {quantum.node} {
     // CHECK: [[reg:%.+]] = quantum.alloc( 1)
@@ -733,7 +724,7 @@ module @null_decomp_rule{
     return
   }
 
-  // CHECK-NOT: func.func private @null_decomp
+  // CHECK: func.func private @null_decomp
   func.func private @null_decomp() attributes {target_gate = "PauliX"} {
     return
   }
@@ -741,6 +732,7 @@ module @null_decomp_rule{
 
 // -----
 
+// CHECK-LABEL: module @different_qreg_values
 module @different_qreg_values{
   func.func public @circuit() attributes {quantum.node} {
     // CHECK: [[wire_tensor:%.+]] = arith.constant dense<[2, 1]> : tensor<2xi64>
@@ -776,7 +768,7 @@ module @different_qreg_values{
     return
   }
 
-  // CHECK-NOT: func.func private @my_cnot
+  // CHECK: func.func private @my_cnot
   func.func private @my_cnot(%arg0: tensor<2xi64>, %arg1: !quantum.reg) -> !quantum.reg attributes {target_gate = "CNOT"} {
     %0 = stablehlo.slice %arg0 [0:1] : (tensor<2xi64>) -> tensor<1xi64>
     %1 = stablehlo.reshape %0 : (tensor<1xi64>) -> tensor<i64>


### PR DESCRIPTION
**Context:**
`decompose-lowering` always applies all (applicable) decomposition rules in the IR, and removes all decomposition rules on cleanup.

**Description of the Change:**
Introduces a `target-rules` option to apply only a subset of the rules available in the IR. Rules are now applied by aligning the `target_op`'s operands with the decomposition functions body and cloning the function body inline, to avoid the inconsistencies/heuristics of the built-in inliner. Rules are no longer removed after the `decompose-lowering` pass to allow use throughout the pipeline in `graph-decomposition` passes. Decomposition functions will be removed by the `symbol-dce` pass at the end of the default pipeline.

**Benefits:**
Provides a more versatile `decompose-lowering` pass, and will support a more efficient `graph-decomposition` pass.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-122013]