### PR TITLE
Prevent issues with duplicate function names in `measurements_from_samples`

### DIFF
--- a/frontend/catalyst/python_interface/transforms/quantum/measurements_from_samples.py
+++ b/frontend/catalyst/python_interface/transforms/quantum/measurements_from_samples.py
@@ -375,7 +375,7 @@ class MeasurementsFromSamplesPattern(RewritePattern):
         # relabel all the callees in the postprocessing FuncOp
         for op in postprocessing_func_op.body.walk():
             if isinstance(op, func.CallOp):
-                new_name = op.callee.string_value() + f"_{self.postprocessing_idx}"
+                new_name = op.callee.string_value() + f"_meas_from_samples_{self.postprocessing_idx}"
                 op.callee = builtin.SymbolRefAttr(new_name)
 
         parent_block = parent_func_op.parent
@@ -389,9 +389,9 @@ class MeasurementsFromSamplesPattern(RewritePattern):
                 # if the helper_op calls any functions in the module, also relabel those callees
                 for op in helper_op.body.walk():
                     if isinstance(op, func.CallOp):
-                        new_name = op.callee.string_value() + f"_{self.postprocessing_idx}"
+                        new_name = op.callee.string_value() + f"_meas_from_samples_{self.postprocessing_idx}"
                         op.callee = builtin.SymbolRefAttr(new_name)
-                new_name = helper_op.sym_name.data + f"_{self.postprocessing_idx}"
+                new_name = helper_op.sym_name.data + f"_meas_from_samples_{self.postprocessing_idx}"
                 helper_op.sym_name = builtin.StringAttr(new_name)
 
                 parent_block.insert_op_after(helper_op, prev_op)

--- a/frontend/catalyst/python_interface/transforms/quantum/measurements_from_samples.py
+++ b/frontend/catalyst/python_interface/transforms/quantum/measurements_from_samples.py
@@ -375,7 +375,9 @@ class MeasurementsFromSamplesPattern(RewritePattern):
         # relabel all the callees in the postprocessing FuncOp
         for op in postprocessing_func_op.body.walk():
             if isinstance(op, func.CallOp):
-                new_name = op.callee.string_value() + f"_meas_from_samples_{self.postprocessing_idx}"
+                new_name = (
+                    op.callee.string_value() + f"_meas_from_samples_{self.postprocessing_idx}"
+                )
                 op.callee = builtin.SymbolRefAttr(new_name)
 
         parent_block = parent_func_op.parent
@@ -389,7 +391,10 @@ class MeasurementsFromSamplesPattern(RewritePattern):
                 # if the helper_op calls any functions in the module, also relabel those callees
                 for op in helper_op.body.walk():
                     if isinstance(op, func.CallOp):
-                        new_name = op.callee.string_value() + f"_meas_from_samples_{self.postprocessing_idx}"
+                        new_name = (
+                            op.callee.string_value()
+                            + f"_meas_from_samples_{self.postprocessing_idx}"
+                        )
                         op.callee = builtin.SymbolRefAttr(new_name)
                 new_name = helper_op.sym_name.data + f"_meas_from_samples_{self.postprocessing_idx}"
                 helper_op.sym_name = builtin.StringAttr(new_name)


### PR DESCRIPTION
**Context:**
In certain contexts, the helper functions for `measurements_from_samples` end up being added in the MLIR where there is already a function with that name, causing an error. This came up in an algorithm in the benchmarks.

**Description of the Change:**
Instead of generic names like `_where_0`, `_where_1`, etc, we name the functions we are adding for post-processing for `measurements_from_samples` things like `_where_meas_from_samples_0`. 

Note that no test is added because its not entirely obvious to me what about the relevant benchmark is causing this to happen, and I haven't been able to replicate the problem on a small toy circuit for a test.

**Benefits:**
Now the pass won't clash with things other passes have done when it comes to adding helper functions.