### PR TITLE
Add `adjoint` and `n_ctrls` args to Operator2 primitive

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.238
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.46.0.dev38
+pennylane=0.46.0.dev46
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -10,6 +10,7 @@
   where applicable, unlocking compilation and execution for these cases.
   [(#2979)](https://github.com/PennyLaneAI/catalyst/pull/2979)
   [(#2969)](https://github.com/PennyLaneAI/catalyst/pull/2969/)
+  [(#2990)](https://github.com/PennyLaneAI/catalyst/pull/2990)
 
 * The `ResourceAnalysis` pass now reports each loop body and each subroutine as its own entry
   instead of folding their gate counts into the caller. Loops with constant bounds appear as `for_loop_<N>`

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -34,4 +34,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.46.0-dev10
 pennylane-lightning==0.46.0-dev10
-pennylane==0.46.0.dev38
+pennylane==0.46.0.dev46

--- a/frontend/catalyst/from_plxpr/qfunc_interpreter.py
+++ b/frontend/catalyst/from_plxpr/qfunc_interpreter.py
@@ -292,6 +292,7 @@ class PLxPRToQuantumJaxprInterpreter(PlxprInterpreter):
         return self.eval(jaxpr.jaxpr, jaxpr.consts, *args)
 
 
+# pylint: disable=too-many-arguments
 @PLxPRToQuantumJaxprInterpreter.register_primitive(operator_p)
 def _handle_operator(self, *args, op_cls, hybrid_lens, hybrid_trees, adjoint, n_ctrls, **kwargs):
 

--- a/frontend/catalyst/from_plxpr/qfunc_interpreter.py
+++ b/frontend/catalyst/from_plxpr/qfunc_interpreter.py
@@ -210,16 +210,24 @@ class PLxPRToQuantumJaxprInterpreter(PlxprInterpreter):
         """Check some constraints regarding dynamic allocation."""
         if self.has_dynamic_allocation:
             if len(measurement.wires) == 0 and not isinstance(measurement, qp.measurements.StateMP):
-                raise CompileError(textwrap.dedent("""
+                raise CompileError(
+                    textwrap.dedent(
+                        """
                         Terminal measurements must take in an explicit list of wires when
                         dynamically allocated wires are present in the program.
-                        """))
+                        """
+                    )
+                )
 
             if any(is_abstract_qubit(w) for w in measurement.wires):
-                raise CompileError(textwrap.dedent("""
+                raise CompileError(
+                    textwrap.dedent(
+                        """
                         Terminal measurements cannot take in dynamically allocated wires
                         since they must be temporary.
-                        """))
+                        """
+                    )
+                )
 
     # pylint: disable=too-many-branches
     def interpret_measurement(self, measurement):
@@ -293,7 +301,7 @@ class PLxPRToQuantumJaxprInterpreter(PlxprInterpreter):
 
 
 @PLxPRToQuantumJaxprInterpreter.register_primitive(operator_p)
-def _handle_operator(self, *args, op_cls, hybrid_lens, hybrid_trees, **kwargs):
+def _handle_operator(self, *args, op_cls, hybrid_lens, hybrid_trees, adjoint, n_ctrls, **kwargs):
 
     if hybrid_lens or hybrid_trees or op_cls.static_argnames:
         # only support compilable_argnames for the moment
@@ -310,6 +318,8 @@ def _handle_operator(self, *args, op_cls, hybrid_lens, hybrid_trees, **kwargs):
         op_cls=op_cls,
         hybrid_lens=hybrid_lens,
         hybrid_trees=hybrid_trees,
+        adjoint=adjoint,
+        n_ctrls=n_ctrls,
         **kwargs,
     )
     return []

--- a/frontend/catalyst/from_plxpr/qfunc_interpreter.py
+++ b/frontend/catalyst/from_plxpr/qfunc_interpreter.py
@@ -210,24 +210,16 @@ class PLxPRToQuantumJaxprInterpreter(PlxprInterpreter):
         """Check some constraints regarding dynamic allocation."""
         if self.has_dynamic_allocation:
             if len(measurement.wires) == 0 and not isinstance(measurement, qp.measurements.StateMP):
-                raise CompileError(
-                    textwrap.dedent(
-                        """
+                raise CompileError(textwrap.dedent("""
                         Terminal measurements must take in an explicit list of wires when
                         dynamically allocated wires are present in the program.
-                        """
-                    )
-                )
+                        """))
 
             if any(is_abstract_qubit(w) for w in measurement.wires):
-                raise CompileError(
-                    textwrap.dedent(
-                        """
+                raise CompileError(textwrap.dedent("""
                         Terminal measurements cannot take in dynamically allocated wires
                         since they must be temporary.
-                        """
-                    )
-                )
+                        """))
 
     # pylint: disable=too-many-branches
     def interpret_measurement(self, measurement):

--- a/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
+++ b/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
@@ -112,6 +112,8 @@ def _qref_operator_p_lowering(
     # will be used in future improvements
     hybrid_lens = kwargs.pop("hybrid_lens")  # pylint: disable=unused-variable
     hybrid_trees = kwargs.pop("hybrid_trees")  # pylint: disable=unused-variable
+    adjoint = kwargs.pop("adjoint")  # pylint: disable=unused-variable
+    n_ctrls = kwargs.pop("n_ctrls")  # pylint: disable=unused-variable
     wire_lens = kwargs.pop("wire_lens")
     params = args[: len(op_cls.dynamic_argnames)]
     qubits = args[len(op_cls.dynamic_argnames) :]


### PR DESCRIPTION
Fixing LLL failures due to disparity between operator primitive in pennylane and the implementation in catalyst.