### PR TITLE
add support for OperatorOp with ResourceAnalysisPass

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -7,10 +7,12 @@
 
 * The new `pennylane.core.Operator2` can now be lowered to MLIR with program capture for operators
   without non-lowerable arguments. `Operator2` classes are now lowered to specialized operations
-  where applicable, unlocking compilation and execution for these cases.
+  where applicable, unlocking compilation and execution for these cases. `qp.specs` and the
+  `ResourceAnalysis` pass now support the `quantum::OperatorOp` and `qref::OperatorOp` instructions.
   [(#2979)](https://github.com/PennyLaneAI/catalyst/pull/2979)
   [(#2969)](https://github.com/PennyLaneAI/catalyst/pull/2969/)
   [(#2990)](https://github.com/PennyLaneAI/catalyst/pull/2990)
+  [(#2993)](https://github.com/PennyLaneAI/catalyst/pull/2993)
 
 * The `ResourceAnalysis` pass now reports each loop body and each subroutine as its own entry
   instead of folding their gate counts into the caller. Loops with constant bounds appear as `for_loop_<N>`

--- a/frontend/test/pytest/test_peephole_optimizations.py
+++ b/frontend/test/pytest/test_peephole_optimizations.py
@@ -331,7 +331,6 @@ def test_merge_ppr_ppm():
     assert ppm_specs_output["f_0"]["logical_qubits"] == 2
 
 
-@pytest.mark.skip  # FIXME: Remove in followup PR
 def test_ppr_to_ppm_auto_corrected():
 
     pipe = [("pipe", ["quantum-compilation-stage"])]
@@ -360,7 +359,6 @@ def test_ppr_to_ppm_auto_corrected():
     assert gate_types["PPR-pi/8-w1"] == 1
 
 
-@pytest.mark.skip  # FIXME: Remove in followup PR
 def test_ppr_to_ppm_inject_magic_state():
 
     pipe = [("pipe", ["quantum-compilation-stage"])]
@@ -388,7 +386,6 @@ def test_ppr_to_ppm_inject_magic_state():
     assert gate_types["PPM-w1"] == 2
 
 
-@pytest.mark.skip  # FIXME: Remove in followup PR
 def test_ppr_to_ppm_pauli_corrected():
 
     pipe = [("pipe", ["quantum-compilation-stage"])]

--- a/frontend/test/pytest/test_specs.py
+++ b/frontend/test/pytest/test_specs.py
@@ -975,19 +975,19 @@ class TestPassByPassSpecs:
 
         class DummyOp(qp.core.Operator2):
 
-            dynamic_argnames = ("phi", )
+            dynamic_argnames = ("phi",)
             wire_argnames = ("reg1", "reg2")
-            compilable_argnames = ("metadata", )
+            compilable_argnames = ("metadata",)
 
             def __init__(self, phi, reg1, reg2, metadata):
                 super().__init__(phi, reg1, reg2, metadata)
 
         @qp.qjit(capture=True, target="mlir")
         @qp.transforms.merge_rotations
-        @qp.qnode(qp.device('null.qubit', wires=10))
+        @qp.qnode(qp.device("null.qubit", wires=10))
         def c():
-            DummyOp(0.5, (0,1), (2,3,4), metadata="word")
-            DummyOp(0.5, (2,3, 4), (0, ), metadata="word")
+            DummyOp(0.5, (0, 1), (2, 3, 4), metadata="word")
+            DummyOp(0.5, (2, 3, 4), (0,), metadata="word")
             return qp.state()
 
         for level in [0, 1]:
@@ -995,7 +995,6 @@ class TestPassByPassSpecs:
 
             assert resources.gate_types == {"DummyOp": 2}
             assert resources.gate_sizes == {4: 1, 5: 1}
-    
 
 
 class TestSpecsWithPPR:

--- a/frontend/test/pytest/test_specs.py
+++ b/frontend/test/pytest/test_specs.py
@@ -969,6 +969,34 @@ class TestPassByPassSpecs:
 
         check_specs_same(actual, expected)
 
+    @pytest.mark.parametrize("with_pass", (True, False))
+    def test_operator2(self, with_pass):
+        """Test that specs works with operator2 classes."""
+
+        class DummyOp(qp.core.Operator2):
+
+            dynamic_argnames = ("phi", )
+            wire_argnames = ("reg1", "reg2")
+            compilable_argnames = ("metadata", )
+
+            def __init__(self, phi, reg1, reg2, metadata):
+                super().__init__(phi, reg1, reg2, metadata)
+
+        @qp.qjit(capture=True, target="mlir")
+        @qp.transforms.merge_rotations
+        @qp.qnode(qp.device('null.qubit', wires=10))
+        def c():
+            DummyOp(0.5, (0,1), (2,3,4), metadata="word")
+            DummyOp(0.5, (2,3, 4), (0, ), metadata="word")
+            return qp.state()
+
+        for level in [0, 1]:
+            resources = qp.specs(c, level=level)()
+
+            assert resources.gate_types == {"DummyOp": 2}
+            assert resources.gate_sizes == {4: 1, 5: 1}
+    
+
 
 class TestSpecsWithPPR:
     """Tests for using qp.specs with PPRs"""

--- a/frontend/test/pytest/test_specs.py
+++ b/frontend/test/pytest/test_specs.py
@@ -239,7 +239,6 @@ class TestDeviceLevelSpecs:
         assert complex_meas_specs["resources"].measurements == expected_measurements
 
 
-@pytest.mark.skip  # FIXME: Remove in followup PR
 class TestPassByPassSpecs:
     """Test qp.specs() pass-by-pass specs"""
 
@@ -992,7 +991,7 @@ class TestPassByPassSpecs:
             return qp.state()
 
         for level in [0, 1]:
-            resources = qp.specs(c, level=level)()
+            resources = qp.specs(c, level=level)().resources
 
             assert resources.gate_types == {"DummyOp": 2}
             assert resources.gate_sizes == {4: 1, 5: 1}

--- a/frontend/test/pytest/test_specs.py
+++ b/frontend/test/pytest/test_specs.py
@@ -969,11 +969,12 @@ class TestPassByPassSpecs:
 
         check_specs_same(actual, expected)
 
-    @pytest.mark.parametrize("with_pass", (True, False))
-    def test_operator2(self, with_pass):
+    def test_operator2(self):
         """Test that specs works with operator2 classes."""
 
+        # pylint: disable=useless-parent-delegation
         class DummyOp(qp.core.Operator2):
+            """Dummy Local Operator."""
 
             dynamic_argnames = ("phi",)
             wire_argnames = ("reg1", "reg2")

--- a/mlir/lib/Catalyst/Analysis/ResourceAnalysis.cpp
+++ b/mlir/lib/Catalyst/Analysis/ResourceAnalysis.cpp
@@ -77,6 +77,8 @@ static std::string getGateOpName(Operation *op, bool isAdjoint)
         llvm::TypeSwitch<Operation *, std::string>(op)
             .Case<quantum::CustomOp, qref::CustomOp>(
                 [](auto customOp) { return customOp.getGateName().str(); })
+            .Case<quantum::OperatorOp, qref::OperatorOp>(
+                [](auto operatorOp) { return operatorOp.getOpName().str(); })
             .Case<quantum::PauliRotOp, qref::PauliRotOp>([](auto) { return "PauliRot"; })
             .Case<quantum::GlobalPhaseOp, qref::GlobalPhaseOp>([](auto) { return "GlobalPhase"; })
             .Case<quantum::MultiRZOp, qref::MultiRZOp>([](auto) { return "MultiRZ"; })
@@ -482,7 +484,8 @@ void ResourceAnalysis::analyzeRegion(Region &region, ResourceResult &result, boo
 void ResourceAnalysis::collectOperation(Operation *op, ResourceResult &result, bool isAdjoint)
 {
     // Quantum gates
-    if (isa<quantum::CustomOp, qref::CustomOp, quantum::PauliRotOp, qref::PauliRotOp,
+    if (isa<quantum::CustomOp, qref::CustomOp, quantum::OperatorOp, qref::OperatorOp,
+            quantum::PauliRotOp, qref::PauliRotOp,
             quantum::GlobalPhaseOp, qref::GlobalPhaseOp, quantum::MultiRZOp, qref::MultiRZOp,
             quantum::PCPhaseOp, qref::PCPhaseOp, quantum::QubitUnitaryOp, qref::QubitUnitaryOp,
             quantum::SetStateOp, qref::SetStateOp, quantum::SetBasisStateOp, qref::SetBasisStateOp>(

--- a/mlir/lib/Catalyst/Analysis/ResourceAnalysis.cpp
+++ b/mlir/lib/Catalyst/Analysis/ResourceAnalysis.cpp
@@ -485,11 +485,10 @@ void ResourceAnalysis::collectOperation(Operation *op, ResourceResult &result, b
 {
     // Quantum gates
     if (isa<quantum::CustomOp, qref::CustomOp, quantum::OperatorOp, qref::OperatorOp,
-            quantum::PauliRotOp, qref::PauliRotOp,
-            quantum::GlobalPhaseOp, qref::GlobalPhaseOp, quantum::MultiRZOp, qref::MultiRZOp,
-            quantum::PCPhaseOp, qref::PCPhaseOp, quantum::QubitUnitaryOp, qref::QubitUnitaryOp,
-            quantum::SetStateOp, qref::SetStateOp, quantum::SetBasisStateOp, qref::SetBasisStateOp>(
-            op)) {
+            quantum::PauliRotOp, qref::PauliRotOp, quantum::GlobalPhaseOp, qref::GlobalPhaseOp,
+            quantum::MultiRZOp, qref::MultiRZOp, quantum::PCPhaseOp, qref::PCPhaseOp,
+            quantum::QubitUnitaryOp, qref::QubitUnitaryOp, quantum::SetStateOp, qref::SetStateOp,
+            quantum::SetBasisStateOp, qref::SetBasisStateOp>(op)) {
         std::string name = getGateOpName(op, isAdjoint);
         int nQubits = getGateQubitCount(op);
         int nParams = getGateParamCount(op);

--- a/mlir/test/Catalyst/ResourceAnalysisTest.mlir
+++ b/mlir/test/Catalyst/ResourceAnalysisTest.mlir
@@ -41,6 +41,47 @@ func.func @basic_gates() {
     return
 }
 
+// Operator2 gates
+
+// CHECK-LABEL: "operator2_gates"
+// CHECK:    "num_alloc_qubits": 10
+// CHECK:    "num_arg_qubits": 0
+// CHECK:    "num_qubits": 10
+// CHECK:    "operations"
+// CHECK-DAG: "DummyOp(4)": 1
+// CHECK-DAG: "DummyOp(5)": 1
+
+func.func @operator2_gates(){
+    %cst = stablehlo.constant dense<5.000000e-01> : tensor<f64>
+    %0 = quantum.alloc( 10) : !quantum.reg
+    %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
+    %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+    %3 = quantum.extract %0[ 2] : !quantum.reg -> !quantum.bit
+    %4 = quantum.extract %0[ 3] : !quantum.reg -> !quantum.bit
+    %5 = quantum.extract %0[ 4] : !quantum.reg -> !quantum.bit
+    %out_qubits:5 = quantum.operator "DummyOp"(%cst: tensor<f64>) qubits(%1, %2, %3, %4, %5)
+      static_data = {metadata = "word"}
+      param_map = {phi = [0]} qubit_map = {reg1 = [0, 1], reg2 = [2, 3, 4]}
+    %6 = quantum.insert %0[ 0], %out_qubits#0 : !quantum.reg, !quantum.bit
+    %7 = quantum.insert %6[ 1], %out_qubits#1 : !quantum.reg, !quantum.bit
+    %8 = quantum.insert %7[ 2], %out_qubits#2 : !quantum.reg, !quantum.bit
+    %9 = quantum.insert %8[ 3], %out_qubits#3 : !quantum.reg, !quantum.bit
+    %10 = quantum.insert %9[ 4], %out_qubits#4 : !quantum.reg, !quantum.bit
+    %11 = quantum.extract %10[ 2] : !quantum.reg -> !quantum.bit
+    %12 = quantum.extract %10[ 3] : !quantum.reg -> !quantum.bit
+    %13 = quantum.extract %10[ 4] : !quantum.reg -> !quantum.bit
+    %14 = quantum.extract %10[ 0] : !quantum.reg -> !quantum.bit
+    %out_qubits_0:4 = quantum.operator "DummyOp"(%cst: tensor<f64>) qubits(%11, %12, %13, %14)
+      static_data = {metadata = "word"}
+      param_map = {phi = [0]} qubit_map = {reg1 = [0, 1, 2], reg2 = [3]}
+    %15 = quantum.insert %10[ 2], %out_qubits_0#0 : !quantum.reg, !quantum.bit
+    %16 = quantum.insert %15[ 3], %out_qubits_0#1 : !quantum.reg, !quantum.bit
+    %17 = quantum.insert %16[ 4], %out_qubits_0#2 : !quantum.reg, !quantum.bit
+    %18 = quantum.insert %17[ 0], %out_qubits_0#3 : !quantum.reg, !quantum.bit
+    quantum.dealloc %18 : !quantum.reg
+    return
+}
+
 // -----
 
 // MBQC Operations


### PR DESCRIPTION
**Context:**

Adds support for qref::OperatorOp and quantum::OperatorOp to qp.specs and the ResourceAnalysisPass.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-123822]