### PR TITLE
Rename mac wheels away from `universal2` when uploading the nightly

### DIFF
--- a/.github/workflows/build-nightly-release-candidate.yaml
+++ b/.github/workflows/build-nightly-release-candidate.yaml
@@ -25,7 +25,7 @@ jobs:
         RC_BRANCH="v${MAJ}.$((MIN-1)).${PAT}-rc"
         if git ls-remote --exit-code origin "refs/heads/$RC_BRANCH"; then
           echo "branch_exists=true" >> $GITHUB_OUTPUT
-          echo "rc_branch=$RC_BRANCH" >> $GITHUB_OUTPUT 
+          echo "rc_branch=$RC_BRANCH" >> $GITHUB_OUTPUT
           echo "Found rc branch: $RC_BRANCH"
         else
           echo "branch_exists=false" >> $GITHUB_OUTPUT
@@ -95,8 +95,8 @@ jobs:
     - name: Prepare wheels
       run: |
         rename "s/linux/manylinux_2_28/" dist/pennylane_catalyst-*
-        rename "s/macosx_14_0_universal2/macosx_13_0_arm64/" dist/pennylane_catalyst-*
-        rename "s/macosx_14/macosx_13/" dist/pennylane_catalyst-*
+        rename "s/macosx_15_0_universal2/macosx_14_0_universal2/macosx_13_0_arm64/" dist/pennylane_catalyst-*
+        rename "s/macosx_15/macosx_14/macosx_13/" dist/pennylane_catalyst-*
 
     - name: Upload wheels
       uses: pypa/gh-action-pypi-publish@release/v1
@@ -114,7 +114,7 @@ jobs:
     steps:
     - name: Trigger PennyLane release workflow
       env:
-        GITHUB_TOKEN: "${{ secrets.PENNYLANE_TRIGGER_RC_WORKFLOW }}"    
+        GITHUB_TOKEN: "${{ secrets.PENNYLANE_TRIGGER_RC_WORKFLOW }}"
       run: |
         gh workflow run upload-nightly-rc-release.yml \
-          --repo PennyLaneAI/pennylane 
+          --repo PennyLaneAI/pennylane

--- a/.github/workflows/build-nightly-release-candidate.yaml
+++ b/.github/workflows/build-nightly-release-candidate.yaml
@@ -95,8 +95,8 @@ jobs:
     - name: Prepare wheels
       run: |
         rename "s/linux/manylinux_2_28/" dist/pennylane_catalyst-*
-        rename "s/macosx_15_0_universal2/macosx_14_0_universal2/macosx_13_0_arm64/" dist/pennylane_catalyst-*
-        rename "s/macosx_15/macosx_14/macosx_13/" dist/pennylane_catalyst-*
+        rename "s/macosx_15_0_universal2/macosx_13_0_arm64/" dist/pennylane_catalyst-*
+        rename "s/macosx_15/macosx_13/" dist/pennylane_catalyst-*
 
     - name: Upload wheels
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -77,8 +77,8 @@ jobs:
     - name: Prepare wheels
       run: |
         rename "s/linux/manylinux_2_28/" dist/pennylane_catalyst-*
-        rename "s/macosx_15_0_universal2/macosx_14_0_universal2/macosx_13_0_arm64/" dist/pennylane_catalyst-*
-        rename "s/macosx_15/macosx_14/macosx_13/" dist/pennylane_catalyst-*
+        rename "s/macosx_15_0_universal2/macosx_13_0_arm64/" dist/pennylane_catalyst-*
+        rename "s/macosx_15/macosx_13/" dist/pennylane_catalyst-*
 
     - name: Upload wheels
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build-nightly-release.yaml
+++ b/.github/workflows/build-nightly-release.yaml
@@ -77,8 +77,8 @@ jobs:
     - name: Prepare wheels
       run: |
         rename "s/linux/manylinux_2_28/" dist/pennylane_catalyst-*
-        rename "s/macosx_14_0_universal2/macosx_13_0_arm64/" dist/pennylane_catalyst-*
-        rename "s/macosx_14/macosx_13/" dist/pennylane_catalyst-*
+        rename "s/macosx_15_0_universal2/macosx_14_0_universal2/macosx_13_0_arm64/" dist/pennylane_catalyst-*
+        rename "s/macosx_15/macosx_14/macosx_13/" dist/pennylane_catalyst-*
 
     - name: Upload wheels
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -206,9 +206,6 @@
 
 <h3>Internal changes ⚙️</h3>
 
-* Upgrade macOS runner to `macos-15`; `macos-14` is no longer maintained.
-  [(#2972)](https://github.com/PennyLaneAI/catalyst/pull/2972)
-
 * Update tests to not use global capture toggle where possible.
   [(#2964)](https://github.com/PennyLaneAI/catalyst/pull/2964)
 


### PR DESCRIPTION
**Context:**
After building mac wheels, we need to rename from universal2 to just arm64
When updating the wheels building runner to macos 15, we didn't update the default name to search for when renaming.
