### PR TITLE
Fix `getAllParams` interface method on operator op

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -9,8 +9,9 @@
   without non-lowerable arguments. `Operator2` classes are now lowered to specialized operations
   where applicable, unlocking compilation and execution for these cases.
   [(#2979)](https://github.com/PennyLaneAI/catalyst/pull/2979)
-  [(#2969)](https://github.com/PennyLaneAI/catalyst/pull/2969/)
+  [(#2969)](https://github.com/PennyLaneAI/catalyst/pull/2969)
   [(#2990)](https://github.com/PennyLaneAI/catalyst/pull/2990)
+  [(#????)](https://github.com/PennyLaneAI/catalyst/pull/????)
 
 * The `ResourceAnalysis` pass now reports each loop body and each subroutine as its own entry
   instead of folding their gate counts into the caller. Loops with constant bounds appear as `for_loop_<N>`

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -11,7 +11,7 @@
   [(#2979)](https://github.com/PennyLaneAI/catalyst/pull/2979)
   [(#2969)](https://github.com/PennyLaneAI/catalyst/pull/2969)
   [(#2990)](https://github.com/PennyLaneAI/catalyst/pull/2990)
-  [(#????)](https://github.com/PennyLaneAI/catalyst/pull/????)
+  [(#2998)](https://github.com/PennyLaneAI/catalyst/pull/2998)
 
 * The `ResourceAnalysis` pass now reports each loop body and each subroutine as its own entry
   instead of folding their gate counts into the caller. Loops with constant bounds appear as `for_loop_<N>`

--- a/mlir/include/QRef/IR/QRefOps.td
+++ b/mlir/include/QRef/IR/QRefOps.td
@@ -439,8 +439,8 @@ def OperatorOp : UnitaryGate_Op<"operator", [ParametrizedGate, AttrSizedOperandS
     let extraClassDeclaration = extraBaseClassDeclaration # [{
         mlir::ValueRange getAllParams() {
             // the ODS operands must be next to each other
-            auto [start, lenParams] = getODSOperandIndexAndLength(/*params=*/1);
-            auto [_, lenForwardArgs] = getODSOperandIndexAndLength(/*forward_args=*/2);
+            auto [start, lenParams] = getODSOperandIndexAndLength(/*params=*/0);
+            auto [_, lenForwardArgs] = getODSOperandIndexAndLength(/*forward_args=*/1);
             return getOperands().slice(start, lenParams + lenForwardArgs);
         }
     }];

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -646,8 +646,8 @@ def OperatorOp : UnitaryGate_Op<"operator", [ParametrizedGate, NoMemoryEffect,
     let extraClassDeclaration = extraBaseClassDeclaration # [{
         mlir::ValueRange getAllParams() {
             // the ODS operands must be next to each other
-            auto [start, lenParams] = getODSOperandIndexAndLength(/*params=*/1);
-            auto [_, lenForwardArgs] = getODSOperandIndexAndLength(/*forward_args=*/2);
+            auto [start, lenParams] = getODSOperandIndexAndLength(/*params=*/0);
+            auto [_, lenForwardArgs] = getODSOperandIndexAndLength(/*forward_args=*/1);
             return getOperands().slice(start, lenParams + lenForwardArgs);
         }
     }];

--- a/mlir/unittests/QRef/InterfaceTest.cpp
+++ b/mlir/unittests/QRef/InterfaceTest.cpp
@@ -291,4 +291,59 @@ func.func @f(%q0: !qref.bit, %cv: i1, %param: f64) {
     ASSERT_TRUE(ctrlValueOperands.size() == 1 && ctrlValueOperands[0] == args[1]);
 }
 
+TEST(InterfaceTests, OperatorOpGetAllParamsEmpty)
+{
+    std::string moduleStr = R"mlir(
+func.func @f(%q0: !qref.bit, %q1: !qref.bit) {
+    qref.operator "custom_basic_qubits"() qubits(%q0, %q1)
+    return
+}
+  )mlir";
+
+    // Parsing boilerplate
+    DialectRegistry registry;
+    registry.insert<func::FuncDialect, catalyst::qref::QRefDialect>();
+    MLIRContext context(registry);
+    ParserConfig config(&context, /*verifyAfterParse=*/false);
+    OwningOpRef<ModuleOp> mod = parseSourceString<ModuleOp>(moduleStr, config);
+
+    // Parse ops
+    func::FuncOp f = *(*mod).getOps<func::FuncOp>().begin();
+    catalyst::qref::OperatorOp op = *f.getOps<catalyst::qref::OperatorOp>().begin();
+
+    // Run checks
+    ValueRange allParams = op.getAllParams();
+    ASSERT_TRUE(allParams.size() == 0);
+}
+
+TEST(InterfaceTests, OperatorOpGetAllParams)
+{
+    std::string moduleStr = R"mlir(
+func.func @f(%q0: !qref.bit, %q1: !qref.bit, %param0: f64, %param1: i64) {
+    qref.operator "custom_basic_qubits"(%param0: f64, %param1: i64) qubits(%q0, %q1)
+    return
+}
+  )mlir";
+
+    // Parsing boilerplate
+    DialectRegistry registry;
+    registry.insert<func::FuncDialect, catalyst::qref::QRefDialect>();
+    MLIRContext context(registry);
+    ParserConfig config(&context, /*verifyAfterParse=*/false);
+    OwningOpRef<ModuleOp> mod = parseSourceString<ModuleOp>(moduleStr, config);
+
+    // Parse ops
+    func::FuncOp f = *(*mod).getOps<func::FuncOp>().begin();
+    catalyst::qref::OperatorOp op = *f.getOps<catalyst::qref::OperatorOp>().begin();
+
+    Block &bb = f.getCallableRegion()->front();
+    auto args = bb.getArguments();
+
+    // Run checks
+    ValueRange allParams = op.getAllParams();
+    ASSERT_TRUE(allParams.size() == 2);
+    ASSERT_TRUE(allParams[0] == args[2]);
+    ASSERT_TRUE(allParams[1] == args[3]);
+}
+
 } // namespace


### PR DESCRIPTION
**Context:**
A while ago in #2969 , the string property for the gate name of `operator` op got changed to an attribute. 
This broke the implementation of `getAllParams()` interface method, since the method `getODSOperandIndexAndLength(unsigned index)` expects the index of ODS operands only, completely ignoring attributes. 

**Description of the Change:**
The addition of an attribute pushes every index down by one. We fix the index.
Also added an interface test for mlir capi access.

**Benefits:**
Correctness.

