### PR TITLE
Represent Operators' static data as a dict in graph-decomposition

### DIFF
--- a/mlir/include/Quantum/Transforms/DecompStaticData.h
+++ b/mlir/include/Quantum/Transforms/DecompStaticData.h
@@ -1,0 +1,106 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file DecompStaticData.h
+ *
+ * @brief helpers for operators specialized by static data.
+ */
+#pragma once
+
+#include <algorithm>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Operation.h"
+
+#include "Quantum/IR/QuantumOps.h"
+
+namespace catalyst {
+namespace quantum {
+
+/// Stringify a single static-data attribute value. String values are used verbatim;
+/// anything else falls back to its generic printed form so the representation stays
+/// stable and comparable.
+inline std::string stringifyStaticDataValue(mlir::Attribute value)
+{
+    if (auto strAttr = mlir::dyn_cast<mlir::StringAttr>(value)) {
+        return strAttr.getValue().str();
+    }
+    std::string out;
+    llvm::raw_string_ostream os(out);
+    value.print(os);
+    return os.str();
+}
+
+/// Convert a `static_data` dictionary in Operators into the `staticNamedArgs` map
+/// used by the graph solver.
+inline std::unordered_map<std::string, std::string> staticDataToMap(mlir::DictionaryAttr staticData)
+{
+    std::unordered_map<std::string, std::string> result;
+    if (!staticData) {
+        return result;
+    }
+    for (mlir::NamedAttribute entry : staticData) {
+        result[entry.getName().str()] = stringifyStaticDataValue(entry.getValue());
+    }
+    return result;
+}
+
+/// Return the static data specializing a concrete op as a DictionaryAttr.
+inline mlir::DictionaryAttr staticDataOf(mlir::Operation *op)
+{
+    if (auto operatorOp = mlir::dyn_cast<OperatorOp>(op)) {
+        return operatorOp.getStaticDataAttr();
+    }
+    if (auto pauliRot = mlir::dyn_cast<PauliRotOp>(op)) {
+        mlir::MLIRContext *ctx = op->getContext();
+        return mlir::DictionaryAttr::get(
+            ctx, {mlir::NamedAttribute(mlir::StringAttr::get(ctx, "pauli_word"),
+                                       mlir::StringAttr::get(ctx, pauliRot.getPauliWord()))});
+    }
+    return mlir::DictionaryAttr();
+}
+
+/// Build a decomposition-registry key from a base operator name and its static data.
+inline std::string makeDecompRegistryKey(llvm::StringRef baseName, mlir::DictionaryAttr staticData)
+{
+    if (!staticData || staticData.empty()) {
+        return baseName.str();
+    }
+
+    std::vector<std::pair<std::string, std::string>> entries;
+    entries.reserve(staticData.size());
+    for (mlir::NamedAttribute entry : staticData) {
+        entries.emplace_back(entry.getName().str(), stringifyStaticDataValue(entry.getValue()));
+    }
+    std::sort(entries.begin(), entries.end());
+
+    std::string key = baseName.str() + "#";
+    for (std::size_t i = 0; i < entries.size(); ++i) {
+        if (i != 0) {
+            key += ";";
+        }
+        key += entries[i].first + "=" + entries[i].second;
+    }
+    return key;
+}
+
+} // namespace quantum
+} // namespace catalyst

--- a/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/DecomposeLoweringPatterns.cpp
@@ -37,6 +37,7 @@
 #include "Quantum/IR/QuantumInterfaces.h"
 #include "Quantum/IR/QuantumOps.h"
 #include "Quantum/IR/QuantumTypes.h"
+#include "Quantum/Transforms/DecompStaticData.h"
 
 #include "DecomposeLoweringImpl.hpp"
 
@@ -266,7 +267,8 @@ struct DLPauliRotOpPattern : public OpRewritePattern<PauliRotOp> {
 
     LogicalResult matchAndRewrite(PauliRotOp op, PatternRewriter &rewriter) const override
     {
-        std::string gateName = "paulirot" + op.getPauliWord();
+        // The registry key is the base op name specialized by its static data (e.g., pauli word)
+        std::string gateName = makeDecompRegistryKey("paulirot", staticDataOf(op.getOperation()));
 
         // Only decompose the op if it is not in the target gate set
         if (targetGateSet.contains("paulirot")) {

--- a/mlir/lib/Quantum/Transforms/decompose_lowering.cpp
+++ b/mlir/lib/Quantum/Transforms/decompose_lowering.cpp
@@ -43,6 +43,7 @@
 
 #include "Quantum/IR/QuantumDialect.h"
 #include "Quantum/IR/QuantumOps.h"
+#include "Quantum/Transforms/DecompStaticData.h"
 #include "Quantum/Transforms/Patterns.h"
 
 #define DEBUG_TYPE "decompose-lowering"
@@ -83,6 +84,14 @@ uint64_t getNumWires(func::FuncOp func)
         return num_wires_attr.getValue().getZExtValue();
     }
     return 0;
+}
+
+// Read a decomposition rule's `static_data` attribute.
+// This is currently used for PauliRot (`{pauli_word = "ZXY"}`),
+// but can be also utilized for quantum.operator in the IR.
+DictionaryAttr getStaticData(func::FuncOp func)
+{
+    return func->getAttrOfType<DictionaryAttr>("static_data");
 }
 
 } // namespace DecompUtils
@@ -130,7 +139,8 @@ struct DecomposeLoweringPass : impl::DecomposeLoweringPassBase<DecomposeLowering
                     decompositionRegistry[newTargetOpStr] = func;
                 }
                 else {
-                    decompositionRegistry[targetOp] = func;
+                    decompositionRegistry[makeDecompRegistryKey(
+                        targetOp, DecompUtils::getStaticData(func))] = func;
                 }
             }
             // No need to walk into the function body

--- a/mlir/lib/Quantum/Transforms/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/graph_decomposition.cpp
@@ -54,6 +54,7 @@
 #include "Quantum/IR/QuantumDialect.h"
 #include "Quantum/IR/QuantumInterfaces.h"
 #include "Quantum/IR/QuantumOps.h"
+#include "Quantum/Transforms/DecompStaticData.h"
 #include "Quantum/Transforms/Passes.h"
 #include "Quantum/Transforms/QPDLoader.h"
 
@@ -358,7 +359,12 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
 
             mlir::func::FuncOp funcOp = outOp.get();
             outOp->setName((outOp->getName() + "_" + pauliWord).str()); // unique name per pauliword
-            funcOp->setAttr("target_gate", mlir::StringAttr::get(context, "paulirot" + pauliWord));
+            funcOp->setAttr("target_gate", mlir::StringAttr::get(context, "paulirot"));
+            funcOp->setAttr(
+                "static_data",
+                mlir::DictionaryAttr::get(
+                    context, {mlir::NamedAttribute(mlir::StringAttr::get(context, "pauli_word"),
+                                                   mlir::StringAttr::get(context, pauliWord))}));
 
             auto analysis = ResourceAnalysis(funcOp);
             if (const ResourceResult *flat = analysis.getFlattenedResource(funcOp.getName())) {
@@ -378,18 +384,19 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
             node.numWires = op.getNonCtrlQubitOperands().size();
             node.adjoint = op.getAdjointFlag();
 
+            // Static arguments (e.g. paulirot's pauli word, or a quantum.operator's static_data)
+            node.staticNamedArgs = staticDataToMap(staticDataOf(op.getOperation()));
+
             if (auto customOp = llvm::dyn_cast<quantum::CustomOp>(op.getOperation())) {
                 node.name = customOp.getGateName().str();
             }
-            // Name handling for non-custom ops
+            else if (auto operatorOp = llvm::dyn_cast<quantum::OperatorOp>(op.getOperation())) {
+                node.name = operatorOp.getOpName().str();
+            }
             else {
                 std::string name = op->getName().stripDialect().str();
                 if (name == "gphase") {
                     name = "GlobalPhase";
-                }
-                else if (name == "paulirot") {
-                    node.staticNamedArgs["pauli_word"] =
-                        cast<quantum::PauliRotOp>(op.getOperation()).getPauliWord();
                 }
                 node.name = name;
             }
@@ -450,13 +457,22 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
             // numParams at the wildcard default so old bytecode keeps working.
         }
 
-        if (llvm::StringRef nameRef(node.name);
-            nameRef.consume_front("paulirot") && !nameRef.empty()) {
-            node.staticNamedArgs["pauli_word"] = nameRef.str();
-            node.name = "paulirot";
-        }
-
         return node;
+    }
+
+    /**
+     * @brief Overlay a rule function's structured operator identity onto its output node.
+     */
+    void applyStructuredOperatorIdentity(mlir::func::FuncOp func, OperatorNode &output)
+    {
+        if (auto opNameAttr = func->getAttrOfType<StringAttr>("op_name")) {
+            output.name = opNameAttr.getValue().str();
+        }
+        if (auto staticData = func->getAttrOfType<DictionaryAttr>("static_data")) {
+            for (const auto &[key, value] : staticDataToMap(staticData)) {
+                output.staticNamedArgs[key] = value;
+            }
+        }
     }
 
     /**
@@ -498,6 +514,7 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
             RuleNode ruleNode;
             ruleNode.name = ruleName.str();
             ruleNode.output = parseOperator(targetGateAttr.getValue());
+            applyStructuredOperatorIdentity(func, ruleNode.output);
 
             for (const auto &namedAttr : operations) {
                 if (auto intAttr = mlir::dyn_cast<IntegerAttr>(namedAttr.getValue())) {

--- a/mlir/lib/Quantum/Transforms/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/graph_decomposition.cpp
@@ -363,7 +363,8 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
                     name = "GlobalPhase";
                 }
                 else if (name == "paulirot") {
-                    name = "paulirot" + cast<quantum::PauliRotOp>(op.getOperation()).getPauliWord();
+                    node.staticNamedArgs["pauli_word"] =
+                        cast<quantum::PauliRotOp>(op.getOperation()).getPauliWord();
                 }
                 node.name = name;
             }
@@ -422,6 +423,12 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
             }
             // If pStr is empty we were given the legacy "(w)" format; leave
             // numParams at the wildcard default so old bytecode keeps working.
+        }
+
+        if (llvm::StringRef nameRef(node.name);
+            nameRef.consume_front("paulirot") && !nameRef.empty()) {
+            node.staticNamedArgs["pauli_word"] = nameRef.str();
+            node.name = "paulirot";
         }
 
         return node;

--- a/mlir/test/Quantum/DecomposeLoweringTest.mlir
+++ b/mlir/test/Quantum/DecomposeLoweringTest.mlir
@@ -669,7 +669,7 @@ module @test_paulirot {
     }
 
     // CHECK: my_paulirot_decomp
-    func.func private @my_paulirot_decomp(%inreg : !quantum.reg, %angle_tensor : tensor<f64>, %q_tensor : tensor<3xi64>) -> !quantum.reg attributes {target_gate = "paulirotZXY"} {
+    func.func private @my_paulirot_decomp(%inreg : !quantum.reg, %angle_tensor : tensor<f64>, %q_tensor : tensor<3xi64>) -> !quantum.reg attributes {target_gate = "paulirot", static_data = {pauli_word = "ZXY"}} {
         %pi_by_2 = arith.constant 1.57 : f64
         %m_pi_by_2 = arith.constant -1.57 : f64
         %angle = tensor.extract %angle_tensor[] : tensor<f64>


### PR DESCRIPTION
**Context:**

Operators specialized by compile-time static data (e.g.. `pauli_word` or `quantum.operator` static data dict) are currently handled by mingling that data as metadata into `operator` and `target_gate` names (`"paulirotYXZ"`) and is utilized in the decomposition graph. The graph already supports static data [here](https://github.com/PennyLaneAI/catalyst/blob/c30fe9a9ed35f83e9f83d65cdbf5f2bb2b928215/mlir/lib/Quantum/Transforms/DecompGraphSolver/DGTypes.hpp#L60). This PR **prototypes** a single canonical repr. of `static_data` for decomposition rules and the graph-decomposition pass pipeline. 

**Benefits:**
- Frontend and rule capture/lowering are unchanged. no updates needed there   
- The graph-solver, registry system for decomp rules, and the matcher logic in graph-decomposition are all synced on the name of ops with static_data (`PauliRot` :heavy_check_mark: ) 
- No more name mangling in the graph-decomp system and parsing substrings of rules names anymore.
 
**Possible Drawbacks:**
- `MultiRZ` still is a special case. I think this is a right call for now but we can revisit it later. Note that `MultiRZ` key is `num_wires`, so it's not really a static data, so it keeps its own branch in the pass.
- Integration with `quantum.operator` will be done in a separate PR (@kipawaa's workng on it)

**Related GitHub Issues:**