### PR TITLE
fix:Mismatch in Catalyst pipeline names

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -391,10 +391,11 @@ Yushao Chen,
 Lillian Frederiksen,
 Sengthai Heng,
 David Ittah,
+JiaRung Jian,
 Christina Lee,
 Mehrdad Malekmohammadi,
 River McCubbin,
 Shuli Shu,
 Paul Haochen Wang,
-Jake Zaia,
-JiaRung Jian.
+Jake Zaia.
+

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -372,6 +372,10 @@
   used in conjunction with the `measurements-from-samples` pass.
   [(#2958)](https://github.com/PennyLaneAI/catalyst/pull/2958)
 
+* Rename the pipeline names in the default pipeline specification (e.g. `quantum-compilation-pipeline`) to match the
+  `-stage` naming convention used when invoking them from the command line (e.g. `quantum-compilation-stage`).
+  [#3002](https://github.com/PennyLaneAI/catalyst/pull/3002)
+
 <h3>Documentation 📝</h3>
 
 * A broken link was removed in the [Compiler Core](https://docs.pennylane.ai/projects/catalyst/en/stable/modules/mlir.html) documentation page. The link referred to where precompiled decomposition rules were implemented, which has since been refactored.
@@ -392,4 +396,5 @@ Mehrdad Malekmohammadi,
 River McCubbin,
 Shuli Shu,
 Paul Haochen Wang,
-Jake Zaia.
+Jake Zaia,
+JiaRung Jian.

--- a/mlir/include/Driver/DefaultPipelines/DefaultPipelines.h
+++ b/mlir/include/Driver/DefaultPipelines/DefaultPipelines.h
@@ -32,7 +32,7 @@ using PipelineList = std::vector<PipelineInfo>;
 
 // clang-format off
 const PipelineList pipelineList{
-    {"quantum-compilation-pipeline",
+    {"quantum-compilation-stage",
      {"canonicalize",
       "verify-no-quantum-use-after-free",
       "convert-to-value-semantics",
@@ -58,7 +58,7 @@ const PipelineList pipelineList{
       "lower-pbc-init-ops",
       "disable-assertion",
       "symbol-dce"}},  // to remove user decomposition rules after all graph-decomposition passes
-    {"hlo-lowering-pipeline",
+    {"hlo-lowering-stage",
      {"canonicalize",
       "func.func(chlo-legalize-to-stablehlo)",
       "func.func(stablehlo-legalize-control-flow)",
@@ -76,10 +76,10 @@ const PipelineList pipelineList{
       "detensorize-function-boundary",
       "canonicalize",
       "symbol-dce"}},
-    {"gradient-lowering-pipeline",
+    {"gradient-lowering-stage",
      {"annotate-invalid-gradient-functions",
       "lower-gradients"}},
-    {"bufferization-pipeline",
+    {"bufferization-stage",
      {// tensor.pad
       "convert-tensor-to-linalg",
       // Must be run before --one-shot-bufferize.
@@ -116,7 +116,7 @@ const PipelineList pipelineList{
        * "cse",
        */
       "cp-global-memref"}},
-    {"llvm-dialect-lowering-pipeline",
+    {"llvm-dialect-lowering-stage",
      {"qnode-to-async-lowering",
       "async-func-to-async-runtime",
       "async-to-async-runtime",


### PR DESCRIPTION
**Context:**
fix: Mismatch in Catalyst pipeline names

**Description of the Change:**
Change the stage names from `***-pipeline` to `***-stage` in `DefaultPipelines.h`, including:
    quantum-compilation-stage, 
    hlo-lowering-stage, 
    gradient-lowering-stage, 
    bufferization-stage, 
    llvm-dialect-lowering-stage。

**Benefits:**
Housecleaning

**Related GitHub Issues:**
Closes #2960

[sc-122704]