### PR TITLE
Support decomposition of Controlled ops to GraphSolver

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -12,9 +12,14 @@
 
 <h3>Improvements 🛠</h3>
 
-* Add adjoint support to the decomposition graph solver, enabling `Adjoint(Op)` to be decomposed either
-  via registered adjoint rules or by adjointing the base operator's decomposition rule,
-  with the solver choosing the cheapest.
+* Add controlled support to the decomposition graph solver, enabling `C(Op)`
+  to be decomposed either via registered controlled rules or by controlling
+  the base operator's decomposition rule, with the solver choosing the cheapest.
+  [(#3003)](https://github.com/PennyLaneAI/catalyst/pull/3003)
+
+* Add adjoint support to the decomposition graph solver, enabling `Adjoint(Op)` to be
+  decomposed either via registered adjoint rules or by adjointing the base operator's
+  decomposition rule, with the solver choosing the cheapest.
   [(#3001)](https://github.com/PennyLaneAI/catalyst/pull/3001)
 
 * The `ResourceAnalysis` pass has received a new compiler hint to more accurately estimate quantum

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGBuilder.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGBuilder.cpp
@@ -112,6 +112,7 @@ struct DecompositionGraph::Impl {
     {
         materializeRules();
         generateAdjointRules();
+        generateControlledRules();
     }
 
     void materializeRules()
@@ -235,6 +236,94 @@ struct DecompositionGraph::Impl {
                 generated.push_back(std::move(adjRule));
             }
         }
+        for (auto &rule : generated) {
+            rules.push_back(std::move(rule));
+        }
+    }
+
+    /**
+     * @brief Operators whose controlled form must be produced by a dedicated rule
+     * rather than by controlling their decomposition, so control-each-gate is
+     * suppressed for them.
+     *
+     * TODO: revisit this
+     */
+    static bool isCtrlRuleRequired(const std::string &opName) { return opName == "GlobalPhase"; }
+
+    /**
+     * @brief Generate Controlled decomposition rules.
+     *
+     * For a needed controlled operator `Controlled(Op)` with k control wires this synthesizes,
+     * from every base decomposition `Op`, a rule `Controlled(Op)`with the same k control wires,
+     * so a controlled operator can be decomposed by controlling the decomposition of its base.
+     * These coexist with any explicitly registered controlled rules. The solver then compares
+     * their costs and picks the cheapest rules.
+     *
+     * Rules are synthesized lazily: only controlled operators that actually appear in the problem
+     * seed the process, and controlling a decomposition introduces new `Controlled(Op)` operators
+     * that require their own synthesized rules, so it runs to a fixpoint.
+     *
+     * Only non-empty, uncontrolled base rules are used as a base, and control-each-gate is
+     * suppressed for operators in `isCtrlRuleRequired`. Those operators require dedicated
+     * decomposition rules.
+     */
+    void generateControlledRules()
+    {
+        std::unordered_map<OperatorNode, std::vector<RuleNode>, OperatorNodeHash> baseByOutput;
+        for (const auto &rule : rules) {
+            if (rule.output.numControlWires == 0 && !rule.isEmpty()) {
+                baseByOutput[rule.output].push_back(rule);
+            }
+        }
+        if (baseByOutput.empty()) {
+            return;
+        }
+
+        std::unordered_set<OperatorNode, OperatorNodeHash> seen;
+        std::vector<OperatorNode> worklist;
+        auto enqueue = [&](const OperatorNode &op) {
+            if (op.numControlWires > 0 && seen.insert(op).second) {
+                worklist.push_back(op);
+            }
+        };
+        for (const auto &op : operators) {
+            enqueue(op);
+        }
+        for (const auto &rule : rules) {
+            enqueue(rule.output);
+            for (const auto &term : rule.inputs) {
+                enqueue(term.op);
+            }
+        }
+
+        // Synthesize controlled rules to a fixpoint,
+        // discovering new controlled inputs as we go.
+        std::vector<RuleNode> generated;
+        while (!worklist.empty()) {
+            const OperatorNode ctrlOp = worklist.back();
+            worklist.pop_back();
+
+            if (isCtrlRuleRequired(ctrlOp.name)) {
+                continue;
+            }
+
+            OperatorNode baseOp = ctrlOp;
+            const std::size_t numControlWires = baseOp.numControlWires;
+            baseOp.numControlWires = 0;
+
+            const auto it = baseByOutput.find(baseOp);
+            if (it == baseByOutput.end()) {
+                continue;
+            }
+            for (const auto &baseRule : it->second) {
+                RuleNode ctrlRule = makeControlledRule(baseRule, numControlWires);
+                for (const auto &term : ctrlRule.inputs) {
+                    enqueue(term.op);
+                }
+                generated.push_back(std::move(ctrlRule));
+            }
+        }
+
         for (auto &rule : generated) {
             rules.push_back(std::move(rule));
         }

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGBuilder.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGBuilder.cpp
@@ -245,10 +245,23 @@ struct DecompositionGraph::Impl {
      * @brief Operators whose controlled form must be produced by a dedicated rule
      * rather than by controlling their decomposition, so control-each-gate is
      * suppressed for them.
-     *
-     * TODO: revisit this
      */
     static bool isCtrlRuleRequired(const std::string &opName) { return opName == "GlobalPhase"; }
+
+    /**
+     * @brief Index non-empty, uncontrolled decompositions by their output operator.
+     */
+    std::unordered_map<OperatorNode, std::vector<RuleNode>, OperatorNodeHash>
+    indexUncontrolledBaseRules() const
+    {
+        std::unordered_map<OperatorNode, std::vector<RuleNode>, OperatorNodeHash> baseByOutput;
+        for (const auto &rule : rules) {
+            if (rule.output.numControlWires == 0 && !rule.isEmpty()) {
+                baseByOutput[rule.output].push_back(rule);
+            }
+        }
+        return baseByOutput;
+    }
 
     /**
      * @brief Generate Controlled decomposition rules.
@@ -269,16 +282,13 @@ struct DecompositionGraph::Impl {
      */
     void generateControlledRules()
     {
-        std::unordered_map<OperatorNode, std::vector<RuleNode>, OperatorNodeHash> baseByOutput;
-        for (const auto &rule : rules) {
-            if (rule.output.numControlWires == 0 && !rule.isEmpty()) {
-                baseByOutput[rule.output].push_back(rule);
-            }
-        }
+        const auto baseByOutput = indexUncontrolledBaseRules();
         if (baseByOutput.empty()) {
             return;
         }
 
+        // Breadth-first over controlled operators
+        // the controlled inputs each synthesized rule introduces, until no new ones appear:
         std::unordered_set<OperatorNode, OperatorNodeHash> seen;
         std::vector<OperatorNode> worklist;
         auto enqueue = [&](const OperatorNode &op) {
@@ -296,8 +306,6 @@ struct DecompositionGraph::Impl {
             }
         }
 
-        // Synthesize controlled rules to a fixpoint,
-        // discovering new controlled inputs as we go.
         std::vector<RuleNode> generated;
         while (!worklist.empty()) {
             const OperatorNode ctrlOp = worklist.back();
@@ -307,16 +315,12 @@ struct DecompositionGraph::Impl {
                 continue;
             }
 
-            OperatorNode baseOp = ctrlOp;
-            const std::size_t numControlWires = baseOp.numControlWires;
-            baseOp.numControlWires = 0;
-
-            const auto it = baseByOutput.find(baseOp);
+            const auto it = baseByOutput.find(withoutControls(ctrlOp));
             if (it == baseByOutput.end()) {
                 continue;
             }
             for (const auto &baseRule : it->second) {
-                RuleNode ctrlRule = makeControlledRule(baseRule, numControlWires);
+                RuleNode ctrlRule = makeControlledRule(baseRule, ctrlOp.numControlWires);
                 for (const auto &term : ctrlRule.inputs) {
                     enqueue(term.op);
                 }

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGBuilder.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGBuilder.cpp
@@ -210,13 +210,22 @@ struct DecompositionGraph::Impl {
                 worklist.push_back(op);
             }
         };
-        for (const auto &op : operators) {
+        // Seed each op and, for controlled-adjoint ops, its uncontrolled adjoint form. The latter
+        // lets a nested `C(Adjoint(Op))` compose across the two generators: this pass synthesizes
+        // the `Adjoint(Op)` rule, and `generateControlledRules` (run next) then controls it.
+        auto seed = [&](const OperatorNode &op) {
             enqueue(op);
+            if (op.numControlWires > 0) {
+                enqueue(withoutControls(op));
+            }
+        };
+        for (const auto &op : operators) {
+            seed(op);
         }
         for (const auto &rule : rules) {
-            enqueue(rule.output);
+            seed(rule.output);
             for (const auto &term : rule.inputs) {
-                enqueue(term.op);
+                seed(term.op);
             }
         }
 

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGTypes.hpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGTypes.hpp
@@ -128,9 +128,15 @@ struct RuleTerm {
  * - Fixed: A fixed rule that cannot be changed or overridden by the solver.
  * - Alternative: An alternative rule that can be used in place of the default rule.
  * - AdjointGenerated: A rule synthesized by adjointing a base decomposition rule.
- * - ControlGenerated: A rule synthesized by controlling a base decomposition rule. 
+ * - ControlGenerated: A rule synthesized by controlling a base decomposition rule.
  */
-enum class RuleOrigin : uint8_t { Default = 0, Fixed = 1, Alternative = 2, AdjointGenerated = 3, ControlGenerated = 4 };
+enum class RuleOrigin : uint8_t {
+    Default = 0,
+    Fixed = 1,
+    Alternative = 2,
+    AdjointGenerated = 3,
+    ControlGenerated = 4
+};
 
 /**
  * @brief This represents the decomposition rules in the graph decomposition problem.

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGTypes.hpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGTypes.hpp
@@ -141,7 +141,7 @@ enum class RuleOrigin : uint8_t { Default = 0, Fixed = 1, Alternative = 2, Adjoi
  * decomposition rules to break down complex operators into simpler ones that are part of
  * the target gateset.
  *
- * TODO:
+ * @todo
  * - We can add a field for work_wires_required if we want to consider the number of ancillary
  * wires needed for the decomposition, which can be an important factor in resource
  * optimization.
@@ -231,6 +231,15 @@ inline RuleNode makeAdjointRule(const RuleNode &base)
         adj.inputs.push_back({makeAdjoint(term.op), term.multiplicity});
     }
     return adj;
+}
+
+/**
+ * @brief This returns a copy of the given operator with all controls removed.
+ */
+inline OperatorNode withoutControls(OperatorNode op)
+{
+    op.numControlWires = 0;
+    return op;
 }
 
 /**

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGTypes.hpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGTypes.hpp
@@ -55,6 +55,7 @@ namespace DecompGraph::Core {
 struct OperatorNode {
     std::string id;
     bool adjoint{false};
+    std::size_t numControlWires{0};
 
     // optional params, primarily for debug use
     std::string name{""};
@@ -127,8 +128,9 @@ struct RuleTerm {
  * - Fixed: A fixed rule that cannot be changed or overridden by the solver.
  * - Alternative: An alternative rule that can be used in place of the default rule.
  * - AdjointGenerated: A rule synthesized by adjointing a base decomposition rule.
+ * - ControlGenerated: A rule synthesized by controlling a base decomposition rule. 
  */
-enum class RuleOrigin : uint8_t { Default = 0, Fixed = 1, Alternative = 2, AdjointGenerated = 3 };
+enum class RuleOrigin : uint8_t { Default = 0, Fixed = 1, Alternative = 2, AdjointGenerated = 3, ControlGenerated = 4 };
 
 /**
  * @brief This represents the decomposition rules in the graph decomposition problem.
@@ -198,6 +200,16 @@ inline OperatorNode makeAdjoint(OperatorNode op)
         op.id = std::string(kPrefix) + op.id + ")";
         op.adjoint = true;
     }
+}
+
+/**
+ * @brief This returns a copy of the given operator wrapped in `numControlWires`
+ * additional controls (Controlled(op)). Control wires accumulate, so applying it
+ * repeatedly yields a multi-controlled operator.
+ */
+inline OperatorNode makeControlled(OperatorNode op, std::size_t numControlWires = 1)
+{
+    op.numControlWires += numControlWires;
     return op;
 }
 
@@ -219,6 +231,34 @@ inline RuleNode makeAdjointRule(const RuleNode &base)
         adj.inputs.push_back({makeAdjoint(term.op), term.multiplicity});
     }
     return adj;
+}
+
+/**
+ * @brief Constructs the Controlled decomposition rule from a base rule.
+ *
+ * Given a rule `output -> {inputs}`, produces `Controlled(output) -> {Controlled(input), ...}`
+ * where every operator gains `numControlWires` control wires: controlling a decomposition means
+ * applying the same controls to each gate it produces.
+ *
+ * The `numControlWires` count is encoded in the rule name so distinct control counts over
+ * the same base rule stay unique. The result is tagged with `RuleOrigin::ControlGenerated`
+ * so later stages can lower it by controlling each gate.
+ *
+ * @note: PennyLane counts `PauliX` flips for zero `control_values`.
+ * Those flips and `control_values` are not supported yet; the cost reflects only the
+ * cost of controlling each produced gate.
+ */
+inline RuleNode makeControlledRule(const RuleNode &base, std::size_t numControlWires)
+{
+    RuleNode ctrl;
+    ctrl.name = base.name + "_controlled_" + std::to_string(numControlWires);
+    ctrl.output = makeControlled(base.output, numControlWires);
+    ctrl.origin = RuleOrigin::ControlGenerated;
+    ctrl.inputs.reserve(base.inputs.size());
+    for (const auto &term : base.inputs) {
+        ctrl.inputs.push_back({makeControlled(term.op, numControlWires), term.multiplicity});
+    }
+    return ctrl;
 }
 
 /**

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGTypes.hpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGTypes.hpp
@@ -175,41 +175,107 @@ using FixedDecomps = std::unordered_map<OperatorNode, RuleNode, OperatorNodeHash
  */
 using AltDecomps = std::unordered_map<OperatorNode, std::vector<RuleNode>, OperatorNodeHash>;
 
+namespace modifiers {
+
 /**
- * @brief This returns a copy of the given operator with the adjoint modifier toggled.
+ * @brief The modifiers parsed out of an operator id.
  *
- * Identity is the opaque `id` string (equality/hashing are id-only),
- * so the modifier must be folded into the id: we wrap it in `Adjoint(...)`
- * (or strip that wrapper to cancel adjoint).
- * Applying twice cancels: `makeAdjoint(makeAdjoint(op)) == op`.
+ * Modifiers are serialized in one canonical form, control-outermost then adjoint:
+ * `[C(<k>, ][Adjoint(]<core>[)][)]`. Because adjoint and control commute, serializing them in a
+ * fixed order means any order of application yields the same id (e.g. `C(Adjoint(op))` and
+ * `Adjoint(C(op))` are the same node), and control wires accumulate instead of nesting.
+ */
+struct Modifiers {
+    std::size_t numControlWires{0};
+    bool adjoint{false};
+    std::string core; // the base id with all modifiers stripped
+};
+
+inline Modifiers parseModifiers(const std::string &id)
+{
+    Modifiers m;
+    std::string s = id;
+
+    // Strip the outermost "C(<k>, ...)" control wrapper (op ids never start with "C(", so this is
+    // unambiguous). The control count is parsed by hand because the build has exceptions disabled.
+    if (s.rfind("C(", 0) == 0 && !s.empty() && s.back() == ')') {
+        std::size_t sep = s.find(", ", 2);
+        if (sep != std::string::npos) {
+            std::string kStr = s.substr(2, sep - 2);
+            std::size_t k = 0;
+            bool ok = !kStr.empty();
+            for (char c : kStr) {
+                if (c < '0' || c > '9') {
+                    ok = false;
+                    break;
+                }
+                k = k * 10 + static_cast<std::size_t>(c - '0');
+            }
+            if (ok) {
+                m.numControlWires = k;
+                s = s.substr(sep + 2, s.size() - (sep + 2) - 1);
+            }
+        }
+    }
+
+    // Strip the "Adjoint( ... )" wrapper.
+    static constexpr char kAdj[] = "Adjoint(";
+    constexpr std::size_t kAdjLen = sizeof(kAdj) - 1;
+    if (s.size() > kAdjLen && s.compare(0, kAdjLen, kAdj) == 0 && s.back() == ')') {
+        m.adjoint = true;
+        s = s.substr(kAdjLen, s.size() - kAdjLen - 1);
+    }
+
+    m.core = s;
+    return m;
+}
+
+inline std::string buildId(const Modifiers &m)
+{
+    std::string s = m.core;
+    if (m.adjoint) {
+        s = "Adjoint(" + s + ")";
+    }
+    if (m.numControlWires > 0) {
+        s = "C(" + std::to_string(m.numControlWires) + ", " + s + ")";
+    }
+    return s;
+}
+
+} // namespace modifiers
+
+/**
+ * @brief This returns a copy of the operator with the adjoint modifier toggled.
+ *
+ * Identity is the opaque `id` string (equality/hashing are id-only), so the modifier is folded into
+ * the id, re-serialized in canonical control-outermost form. The `adjoint` bool and
+ * `numControlWires` count are kept in lockstep with the id. Applying twice cancels:
+ * `makeAdjoint(makeAdjoint(op)) == op`.
  */
 inline OperatorNode makeAdjoint(OperatorNode op)
 {
-    static constexpr char kPrefix[] = "Adjoint(";
-    constexpr std::size_t kPrefixLen = sizeof(kPrefix) - 1;
-
-    if (op.adjoint) {
-        // Cancel: strip the outermost "Adjoint( ... )" wrapper from the id.
-        if (op.id.size() > kPrefixLen && op.id.compare(0, kPrefixLen, kPrefix) == 0 &&
-            op.id.back() == ')') {
-            op.id = op.id.substr(kPrefixLen, op.id.size() - kPrefixLen - 1);
-        }
-        op.adjoint = false;
-    }
-    else {
-        op.id = std::string(kPrefix) + op.id + ")";
-        op.adjoint = true;
-    }
+    modifiers::Modifiers m = modifiers::parseModifiers(op.id);
+    m.adjoint = !m.adjoint;
+    op.id = modifiers::buildId(m);
+    op.adjoint = m.adjoint;
+    op.numControlWires = m.numControlWires;
+    return op;
 }
 
 /**
- * @brief This returns a copy of the given operator wrapped in `numControlWires`
- * additional controls (Controlled(op)). Control wires accumulate, so applying it
- * repeatedly yields a multi-controlled operator.
+ * @brief This returns a copy of the operator with `numControlWires` additional control wires.
+ *
+ * Controls accumulate (`C(1, C(1, op)) == C(2, op)`) and the id is re-serialized in canonical
+ * control-outermost form, so control commutes with adjoint (`C(Adjoint(op)) == Adjoint(C(op))`).
+ * The `numControlWires` count and `adjoint` bool are kept in lockstep with the id.
  */
 inline OperatorNode makeControlled(OperatorNode op, std::size_t numControlWires = 1)
 {
-    op.numControlWires += numControlWires;
+    modifiers::Modifiers m = modifiers::parseModifiers(op.id);
+    m.numControlWires += numControlWires;
+    op.id = modifiers::buildId(m);
+    op.numControlWires = m.numControlWires;
+    op.adjoint = m.adjoint;
     return op;
 }
 
@@ -238,7 +304,11 @@ inline RuleNode makeAdjointRule(const RuleNode &base)
  */
 inline OperatorNode withoutControls(OperatorNode op)
 {
+    modifiers::Modifiers m = modifiers::parseModifiers(op.id);
+    m.numControlWires = 0;
+    op.id = modifiers::buildId(m);
     op.numControlWires = 0;
+    op.adjoint = m.adjoint;
     return op;
 }
 

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGUtils.hpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGUtils.hpp
@@ -46,6 +46,9 @@ static inline auto print_op(const OperatorNode &op) -> std::string
     if (op.adjoint) {
         oss << "[adj]";
     }
+    if (op.numControlWires > 0) {
+        oss << "[c:" << op.numControlWires << "]";
+    }
     if (!op.staticNamedArgs.empty()) {
         std::vector<std::string> keys;
         keys.reserve(op.staticNamedArgs.size());

--- a/mlir/unittests/DecompGraphSolver/Test_DecompGraphSolverSymbolicOps.cpp
+++ b/mlir/unittests/DecompGraphSolver/Test_DecompGraphSolverSymbolicOps.cpp
@@ -227,12 +227,33 @@ TEST_CASE("Test Adjoint: adjoint pushed through a decomposition", "[DecompGraph:
     REQUIRE(chosen.basisCounts.at(b) == 1);
 }
 
+TEST_CASE("Test makeControlled/makeAdjoint canonical ids", "[DecompGraph::Core]")
+{
+    const OperatorNode rx{"RX[f64][1]{}"};
+
+    // Control folds into the id, accumulates, and is serialized control-outermost.
+    REQUIRE(makeControlled(rx).id == "C(1, RX[f64][1]{})");
+    REQUIRE(makeControlled(rx).numControlWires == 1);
+    REQUIRE(makeControlled(rx, 2).id == "C(2, RX[f64][1]{})");
+    REQUIRE(makeControlled(makeControlled(rx)) == makeControlled(rx, 2)); // accumulate, not nest
+
+    // Adjoint and control commute: both application orders yield the same canonical node.
+    REQUIRE(makeControlled(makeAdjoint(rx)) == makeAdjoint(makeControlled(rx)));
+    REQUIRE(makeControlled(makeAdjoint(rx)).id == "C(1, Adjoint(RX[f64][1]{}))");
+    REQUIRE(makeControlled(makeAdjoint(rx)).adjoint);
+    REQUIRE(makeControlled(makeAdjoint(rx)).numControlWires == 1);
+
+    // withoutControls strips only the controls, keeping adjoint; double adjoint still cancels.
+    REQUIRE(withoutControls(makeControlled(makeAdjoint(rx))) == makeAdjoint(rx));
+    REQUIRE(makeAdjoint(makeAdjoint(makeControlled(rx))) == makeControlled(rx));
+}
+
 TEST_CASE("Test DecompositionGraph synthesizes controlled rules from base rules",
           "[DecompGraph::Solver]")
 {
-    const OperatorNode rot{"Rot", 1, 3, false};
-    const OperatorNode rz{"RZ", 1, 1, false};
-    const OperatorNode ry{"RY", 1, 1, false};
+    const OperatorNode rot{"Rot[f64,f64,f64][1]{}"};
+    const OperatorNode rz{"RZ[f64][1]{}"};
+    const OperatorNode ry{"RY[f64][1]{}"};
 
     const WeightedGateset gateset{{{makeControlled(rz), 1.0}, {makeControlled(ry), 1.0}}};
     const std::vector<RuleNode> rules{{"rot_decomp", rot, {{rz, 2}, {ry, 1}}}};
@@ -254,10 +275,10 @@ TEST_CASE("Test DecompositionGraph synthesizes controlled rules from base rules"
 
 TEST_CASE("Test Controlled: solver picks the cheaper", "[DecompGraph::Solver]")
 {
-    const OperatorNode rot{"Rot", 1, 3, false};
-    const OperatorNode rz{"RZ", 1, 1, false};
-    const OperatorNode ry{"RY", 1, 1, false};
-    const OperatorNode e{"E", 1, 0, false};
+    const OperatorNode rot{"Rot[f64,f64,f64][1]{}"};
+    const OperatorNode rz{"RZ[f64][1]{}"};
+    const OperatorNode ry{"RY[f64][1]{}"};
+    const OperatorNode e{"E[][1]{}"};
 
     const std::vector<RuleNode> baseRules{{"rot_decomp", rot, {{rz, 2}, {ry, 1}}}};
 
@@ -299,11 +320,38 @@ TEST_CASE("Test Controlled: solver picks the cheaper", "[DecompGraph::Solver]")
     }
 }
 
+TEST_CASE("Test Controlled: multi-control synthesis", "[DecompGraph::Solver]")
+{
+    const OperatorNode rot{"Rot[f64,f64,f64][1]{}"};
+    const OperatorNode rz{"RZ[f64][1]{}"};
+    const OperatorNode ry{"RY[f64][1]{}"};
+
+    // C(2, Rot): two control wires applied to every produced gate.
+    const OperatorNode ccRot = makeControlled(rot, 2);
+    const WeightedGateset gateset{{{makeControlled(rz, 2), 1.0}, {makeControlled(ry, 2), 1.0}}};
+    const std::vector<RuleNode> rules{{"rot_decomp", rot, {{rz, 2}, {ry, 1}}}};
+
+    const DecompositionGraph graph({ccRot}, gateset, rules);
+
+    const auto &ctrlRules = graph.getAllRulesFor(ccRot);
+    REQUIRE(ctrlRules.size() == 1);
+    REQUIRE(ctrlRules[0].name == "rot_decomp_controlled_2");
+    REQUIRE(ctrlRules[0].inputs[0].op == makeControlled(rz, 2));
+
+    DecompositionSolver solver(graph);
+    const auto result = solver.solve();
+    const auto &chosen = result.at(ccRot);
+    REQUIRE(chosen.origin == RuleOrigin::ControlGenerated);
+    REQUIRE(chosen.totalCost == 3.0);
+    REQUIRE(chosen.basisCounts.at(makeControlled(rz, 2)) == 2);
+    REQUIRE(chosen.basisCounts.at(makeControlled(ry, 2)) == 1);
+}
+
 TEST_CASE("Test Controlled: control pushed through a decomposition", "[DecompGraph::Solver]")
 {
-    const OperatorNode myOp{"MyOp", 2, 0, false};
-    const OperatorNode a{"A", 1, 0, false};
-    const OperatorNode b{"B", 1, 0, false};
+    const OperatorNode myOp{"MyOp[][2]{}"};
+    const OperatorNode a{"A[][1]{}"};
+    const OperatorNode b{"B[][1]{}"};
 
     const WeightedGateset gateset{{{makeControlled(a), 1.0}, {makeControlled(b), 1.0}}};
     const std::vector<RuleNode> rules{{"myop_decomp", myOp, {{a, 1}, {b, 1}}}};
@@ -325,8 +373,10 @@ TEST_CASE("Test Controlled: control pushed through a decomposition", "[DecompGra
 TEST_CASE("Test Controlled: suppressed Ctrl rule for special-cased operators",
           "[DecompGraph::Solver]")
 {
-    const OperatorNode globalPhase{"GlobalPhase", -1, -1, false};
-    const OperatorNode rz{"RZ", 1, 1, false};
+    // `name` must be set so `isCtrlRuleRequired` can special-case GlobalPhase; program ops get it
+    // from `getOperatorName()`. Field order: {id, adjoint, numControlWires, name}.
+    const OperatorNode globalPhase{"GlobalPhase[f64][0]{}", false, 0, "GlobalPhase"};
+    const OperatorNode rz{"RZ[f64][1]{}"};
 
     const WeightedGateset gateset{{{makeControlled(rz), 1.0}}};
     const std::vector<RuleNode> rules{
@@ -336,8 +386,63 @@ TEST_CASE("Test Controlled: suppressed Ctrl rule for special-cased operators",
 
     const DecompositionGraph graph({makeControlled(globalPhase)}, gateset, rules);
 
+    // Control-each-gate is suppressed for GlobalPhase, so only the dedicated rule survives.
     const auto &ctrlRules = graph.getAllRulesFor(makeControlled(globalPhase));
     REQUIRE(ctrlRules.size() == 1);
     REQUIRE(ctrlRules[0].name == "cgp_direct");
     REQUIRE(ctrlRules[0].origin == RuleOrigin::Default);
+}
+
+TEST_CASE("Test Controlled+Adjoint: dedicated nested rule (Pathway 1)", "[DecompGraph::Solver]")
+{
+    const OperatorNode rx{"RX[f64][1]{}"};
+    const OperatorNode crx{"CRX[f64][2]{}"};
+    const OperatorNode cAdjRx = makeControlled(makeAdjoint(rx)); // C(Adjoint(RX))
+
+    // A dedicated rule registered against the nested operator decomposes it directly.
+    const WeightedGateset gateset{{{crx, 1.0}}};
+    const std::vector<RuleNode> rules{{"c_adj_rx", cAdjRx, {{crx, 1}}}};
+
+    const DecompositionGraph graph({cAdjRx}, gateset, rules);
+    DecompositionSolver solver(graph);
+    const auto result = solver.solve();
+
+    const auto &chosen = result.at(cAdjRx);
+    REQUIRE(chosen.ruleName == "c_adj_rx");
+    REQUIRE(chosen.origin == RuleOrigin::Default);
+    REQUIRE(chosen.totalCost == 1.0);
+    REQUIRE(chosen.basisCounts.at(crx) == 1);
+}
+
+TEST_CASE("Test Controlled+Adjoint: synthesized nested decomposition (Pathway 2)",
+          "[DecompGraph::Solver]")
+{
+    const OperatorNode myOp{"MyOp[][2]{}"};
+    const OperatorNode a{"A[][1]{}"};
+    const OperatorNode b{"B[][1]{}"};
+
+    const WeightedGateset gateset{{{makeControlled(a), 1.0}, {makeControlled(b), 1.0}}};
+    const std::vector<RuleNode> rules{
+        {"myop_decomp", myOp, {{a, 1}, {b, 1}}},
+        // self-adjoint rules so the adjointed produced gates bottom out at C(A) / C(B).
+        {"self_adjoint_A", makeAdjoint(a), {{a, 1}}},
+        {"self_adjoint_B", makeAdjoint(b), {{b, 1}}},
+    };
+
+    // Root C(Adjoint(MyOp)): no dedicated rule. The builder synthesizes it by first adjointing the
+    // base decomposition (adjoint gen) and then controlling that (controlled gen).
+    const OperatorNode root = makeControlled(makeAdjoint(myOp));
+    const DecompositionGraph graph({root}, gateset, rules);
+
+    REQUIRE(graph.getAllRulesFor(root).size() == 1);
+
+    DecompositionSolver solver(graph);
+    const auto result = solver.solve();
+    REQUIRE(result.find(root) != result.end());
+    const auto &chosen = result.at(root);
+    REQUIRE(chosen.ruleName == "myop_decomp_adjoint_controlled_1");
+    REQUIRE(chosen.origin == RuleOrigin::ControlGenerated);
+    REQUIRE(chosen.totalCost == 2.0);
+    REQUIRE(chosen.basisCounts.at(makeControlled(a)) == 1);
+    REQUIRE(chosen.basisCounts.at(makeControlled(b)) == 1);
 }

--- a/mlir/unittests/DecompGraphSolver/Test_DecompGraphSolverSymbolicOps.cpp
+++ b/mlir/unittests/DecompGraphSolver/Test_DecompGraphSolverSymbolicOps.cpp
@@ -226,3 +226,118 @@ TEST_CASE("Test Adjoint: adjoint pushed through a decomposition", "[DecompGraph:
     REQUIRE(chosen.basisCounts.at(a) == 1);
     REQUIRE(chosen.basisCounts.at(b) == 1);
 }
+
+TEST_CASE("Test DecompositionGraph synthesizes controlled rules from base rules",
+          "[DecompGraph::Solver]")
+{
+    const OperatorNode rot{"Rot", 1, 3, false};
+    const OperatorNode rz{"RZ", 1, 1, false};
+    const OperatorNode ry{"RY", 1, 1, false};
+
+    const WeightedGateset gateset{{{makeControlled(rz), 1.0}, {makeControlled(ry), 1.0}}};
+    const std::vector<RuleNode> rules{{"rot_decomp", rot, {{rz, 2}, {ry, 1}}}};
+
+    // Controlled(Rot) is a root, so the builder synthesizes its controlled decomposition.
+    const DecompositionGraph graph({makeControlled(rot)}, gateset, rules);
+
+    REQUIRE(graph.getNumRules() == 2);
+    REQUIRE(graph.hasOperator(makeControlled(rot)));
+
+    const auto &ctrlRules = graph.getAllRulesFor(makeControlled(rot));
+    REQUIRE(ctrlRules.size() == 1);
+    REQUIRE(ctrlRules[0].name == "rot_decomp_controlled_1");
+    REQUIRE(ctrlRules[0].origin == RuleOrigin::ControlGenerated);
+    REQUIRE(ctrlRules[0].output == makeControlled(rot));
+    REQUIRE(ctrlRules[0].inputs[0].op == makeControlled(rz));
+    REQUIRE(ctrlRules[0].inputs[1].op == makeControlled(ry));
+}
+
+TEST_CASE("Test Controlled: solver picks the cheaper", "[DecompGraph::Solver]")
+{
+    const OperatorNode rot{"Rot", 1, 3, false};
+    const OperatorNode rz{"RZ", 1, 1, false};
+    const OperatorNode ry{"RY", 1, 1, false};
+    const OperatorNode e{"E", 1, 0, false};
+
+    const std::vector<RuleNode> baseRules{{"rot_decomp", rot, {{rz, 2}, {ry, 1}}}};
+
+    SECTION("rot_decomp_controlled_1 is cheaper")
+    {
+        const WeightedGateset gateset{
+            {{makeControlled(rz), 1.0}, {makeControlled(ry), 1.0}, {e, 10.0}}};
+        std::vector<RuleNode> rules = baseRules;
+        rules.push_back({"crot_direct", makeControlled(rot), {{e, 1}}}); // cost 10
+
+        const DecompositionGraph graph({makeControlled(rot)}, gateset, rules);
+
+        // Both an explicit controlled rule and the synthesized one exist for Controlled(Rot).
+        REQUIRE(graph.getAllRulesFor(makeControlled(rot)).size() == 2);
+
+        DecompositionSolver solver(graph);
+        const auto result = solver.solve();
+        const auto &chosen = result.at(makeControlled(rot));
+        REQUIRE(chosen.ruleName == "rot_decomp_controlled_1");
+        REQUIRE(chosen.origin == RuleOrigin::ControlGenerated);
+        REQUIRE(chosen.totalCost == 3.0);
+        REQUIRE(chosen.basisCounts.at(makeControlled(rz)) == 2);
+        REQUIRE(chosen.basisCounts.at(makeControlled(ry)) == 1);
+    }
+
+    SECTION("crot_direct is cheaper")
+    {
+        const WeightedGateset gateset{{{makeControlled(rz), 1.0}, {makeControlled(ry), 1.0}}};
+        std::vector<RuleNode> rules = baseRules;
+        rules.push_back({"crot_direct", makeControlled(rot), {{makeControlled(rz), 1}}}); // cost 1
+
+        const DecompositionGraph graph({makeControlled(rot)}, gateset, rules);
+        DecompositionSolver solver(graph);
+        const auto result = solver.solve();
+        const auto &chosen = result.at(makeControlled(rot));
+        REQUIRE(chosen.ruleName == "crot_direct");
+        REQUIRE(chosen.origin == RuleOrigin::Default);
+        REQUIRE(chosen.totalCost == 1.0);
+    }
+}
+
+TEST_CASE("Test Controlled: control pushed through a decomposition", "[DecompGraph::Solver]")
+{
+    const OperatorNode myOp{"MyOp", 2, 0, false};
+    const OperatorNode a{"A", 1, 0, false};
+    const OperatorNode b{"B", 1, 0, false};
+
+    const WeightedGateset gateset{{{makeControlled(a), 1.0}, {makeControlled(b), 1.0}}};
+    const std::vector<RuleNode> rules{{"myop_decomp", myOp, {{a, 1}, {b, 1}}}};
+
+    const DecompositionGraph graph({makeControlled(myOp)}, gateset, rules);
+
+    REQUIRE(graph.getAllRulesFor(makeControlled(myOp)).size() == 1);
+
+    DecompositionSolver solver(graph);
+    const auto result = solver.solve();
+    const auto &chosen = result.at(makeControlled(myOp));
+    REQUIRE(chosen.ruleName == "myop_decomp_controlled_1");
+    REQUIRE(chosen.origin == RuleOrigin::ControlGenerated);
+    REQUIRE(chosen.totalCost == 2.0);
+    REQUIRE(chosen.basisCounts.at(makeControlled(a)) == 1);
+    REQUIRE(chosen.basisCounts.at(makeControlled(b)) == 1);
+}
+
+TEST_CASE("Test Controlled: suppressed Ctrl rule for special-cased operators",
+          "[DecompGraph::Solver]")
+{
+    const OperatorNode globalPhase{"GlobalPhase", -1, -1, false};
+    const OperatorNode rz{"RZ", 1, 1, false};
+
+    const WeightedGateset gateset{{{makeControlled(rz), 1.0}}};
+    const std::vector<RuleNode> rules{
+        {"gp_decomp", globalPhase, {{rz, 1}}},
+        {"cgp_direct", makeControlled(globalPhase), {{makeControlled(rz), 1}}},
+    };
+
+    const DecompositionGraph graph({makeControlled(globalPhase)}, gateset, rules);
+
+    const auto &ctrlRules = graph.getAllRulesFor(makeControlled(globalPhase));
+    REQUIRE(ctrlRules.size() == 1);
+    REQUIRE(ctrlRules[0].name == "cgp_direct");
+    REQUIRE(ctrlRules[0].origin == RuleOrigin::Default);
+}


### PR DESCRIPTION
**Context:**
The decomposition graph solver could not decompose Controlled ops. This PR adds this support to the graph solver to handle them, mirroring the two decomposition families used by PL:

1. Decompose `C(Op)` directly: Rules registered against the controlled operator itself: e.g. a dedicated CRX rule, C(SWAP), C(PhaseShift), etc. in PL. These were already supported by the graph. A `RuleNode` whose output has `numControlWires > 0` is registered and solved like any other rule; so no new logic was needed to the solver; they just need to be provided as rules. I'll take care of this in a follow-up PR to integrate the support with the graph-decomposition pass.

2. Decompose `Op`, then control each produced gate: From each base rule Op, the graph builder should synthesize `C(Op)` with the same `k` control wires applied to every produced gate and the same multiplicities. I assumed that only the cost of controlling each produced gate matters here; the actual control-each-gate wrapping happens in the follow-up PR when integrating with the pass.

Both pathways coexist in the graph, and the solver picks the cheapest decomp pathway! :)

Unlike the adjoint case #3001, there is no build-time short-circuit that suppresses one pathway in general; both are always added and left to compete. The one exception mirrors PL's control-specific special cases (e.g. `GlobalPhase`, `ChangeOpBasis`): controlling their decomposition is not semantically valid, so I added a static method to the graph to suppress them (`isCtrlRuleRequired`) and they must be decomposed by a dedicated controlled rule. Since the graph reasons about resource cost and not the semantics of rules, this suppression is required to keep the solver from picking a cheap but invalid controlled decomposition.

**Benefits:**
- Support `C(Op)` decomposition and resource estimation
- Composes with existing operator identity (`numControlWires` is matched exactly, like `adjoint`), so multi-controlled operators is also supported in the graph.
- Support adjoint + ctrl composition ops (e.g., `Adjoint(C(Op))` and `C(Adjoint(Op))`)

**Possible Drawbacks:**
- For circuits with many `Ctrl` ops, the graph grows as we add synthesized controlled rules for each `C(Op)` and track them across multiple decomp pathways.
- I'm using explicit rules for the special ops (`GlobalPhase`, ...), and the suppression list is currently hard-coded. This can be revisited later after integration with the graph-decomposition pass.
- `control_values are not supported yet. This can be added later.

**Related GitHub Issues:**
[sc-125401]