### PR TITLE
Remove use of Transform.plxpr_transform

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -221,6 +221,7 @@
 <h3>Internal changes ⚙️</h3>
 
 * `from_plxpr` no longer depends on the `Transform.plxpr_transform` property.
+  [(#3004)](https://github.com/PennyLaneAI/catalyst/pull/3004)
 
 * Update tests to not use global capture toggle where possible.
   [(#2964)](https://github.com/PennyLaneAI/catalyst/pull/2964)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -220,6 +220,8 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* `from_plxpr` no longer depends on the `Transform.plxpr_transform` property.
+
 * Update tests to not use global capture toggle where possible.
   [(#2964)](https://github.com/PennyLaneAI/catalyst/pull/2964)
 

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -28,6 +28,7 @@ from jax.extend.core import ClosedJaxpr, Jaxpr
 from pennylane.capture import PlxprInterpreter, qnode_prim
 from pennylane.capture.primitives import transform_prim
 from pennylane.transforms import decompose as pl_decompose
+from pennylane.transforms.decompose import DecomposeInterpreter
 
 from catalyst.device import extract_backend_info
 from catalyst.device.qjit_device import is_dynamic_wires
@@ -594,8 +595,10 @@ def _apply_compiler_decompose_to_plxpr(
     if stopping_condition:
         kwargs["stopping_condition"] = stopping_condition
 
-    final_jaxpr = qp.transforms.decompose.plxpr_transform(inner_jaxpr, consts, (), kwargs, *ncargs)
 
+    interpreter = DecomposeInterpreter(**kwargs)
+    f = partial(interpreter.eval, inner_jaxpr, consts)
+    final_jaxpr = jax.make_jaxpr(f)(*ncargs)
     if graph_enabled:
         qp.decomposition.enable_graph()
 

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -595,7 +595,6 @@ def _apply_compiler_decompose_to_plxpr(
     if stopping_condition:
         kwargs["stopping_condition"] = stopping_condition
 
-
     interpreter = DecomposeInterpreter(**kwargs)
     f = partial(interpreter.eval, inner_jaxpr, consts)
     final_jaxpr = jax.make_jaxpr(f)(*ncargs)


### PR DESCRIPTION
**Context:**

Trying to get rid of a lot of plxpr_transform code in https://github.com/PennyLaneAI/pennylane/pull/9797 . This will allow us to get rid of `Transform.plxpr_transform`.

Tried to copy the interpreter as a whole to catalyst, but was depending on 

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

[sc-124152]
