### PR TITLE
[WIP] Make resource analysis extensible

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -37,6 +37,8 @@
   (`any_commuting_depth` / `qubit_disjoint_depth`) per function and lifted loop entry.
   [(#2967)](https://github.com/PennyLaneAI/catalyst/pull/2967)
 
+* The `ResourceAnalysis` pass is now extensible. 
+
 * The `--adjoint-lowering` pass no longer turns statically bounded for loops into
   dynamically bounded ones. In this way they remain analyzable by functionality like `qp.specs`.
   [(#2959)](https://github.com/PennyLaneAI/catalyst/issues/2959)


### PR DESCRIPTION
**Context:**

The current `ResourceAnalysis` in Catalyst only works on specific dialects. Any new dialect needs to be explicitly added to `ResourceAnalysis` to be supported. This becomes an issue when we need to support programs in the form of PBC, vISA, and so on, as these introduce new metrics (such as depth) that might differ from one another.

The objective here is to build plug-and-play analysis that inherit from the base `ResourceAnalysis` (for example, `PBCResourceAnalysis` and `vISAResourceAnalysis`). The `ResourceTrackerPass` will then check and dispatch the appropriate resource analysis based on the MLIR program type. 

**PRs:**
- [x] Remove duplicate JSON serializer 
- [x] Add `ResourceExtension` mechanism
- [ ] Add `ResourceInstruction` op interface
- [ ] Reshape JSON format to new target format.
- [ ] Migrate PBC ops to `ResourceInstruction`
- [ ] Migrate quantum/qref gates to `ResourceInstruction`

**Related GitHub Issues:**
TBD

[sc-118007]