### PR TITLE
Get a proper path to the python shared library for the QPD plugin 

### DIFF
--- a/frontend/catalyst/utils/runtime_environment.py
+++ b/frontend/catalyst/utils/runtime_environment.py
@@ -14,7 +14,6 @@
 
 """Utility code for keeping paths."""
 
-import glob
 import importlib.util
 import os
 import os.path
@@ -96,16 +95,13 @@ def get_libpython_path() -> str:   # pragma: no cover
         if os.path.exists(ldlibrary_path):
             return ldlibrary_path
 
-    # Fall back to the conventionally-named shared library (e.g. libpython3.14.so).
+    # Fall back to the conventionally-named shared library (e.g. libpython3.12.so). This is
+    # the case that a static-preferring build (e.g. conda) hits: LDLIBRARY names the .a, but
+    # the .so is present under its canonical, version-derived name.
     ldversion = sysconfig.get_config_var("LDVERSION") or sysconfig.get_config_var("VERSION") or ""
     conventional_path = os.path.join(libdir, f"libpython{ldversion}{shlib_suffix}")
     if os.path.exists(conventional_path):
         return conventional_path
-
-    # If the fallback fails, try any shared libpython in LIBDIR:
-    matches = sorted(glob.glob(os.path.join(libdir, f"libpython*{shlib_suffix}*")))
-    if matches:
-        return matches[0]
 
     return ""
 

--- a/frontend/catalyst/utils/runtime_environment.py
+++ b/frontend/catalyst/utils/runtime_environment.py
@@ -14,6 +14,7 @@
 
 """Utility code for keeping paths."""
 
+import glob
 import importlib.util
 import os
 import os.path
@@ -63,23 +64,48 @@ BYTECODE_FILE_PATH = os.path.join(
 )
 
 
-def get_libpython_path() -> str:  # pragma: no cover
-    """Return the path to the python shared library, or empty string if failed to find."""
-    libdir = sysconfig.get_config_var("LIBDIR")
+def get_libpython_path() -> str:   # pragma: no cover
+    """Return the path to the python *shared* library, or empty string if failed to find.
+
+    The QPD plugin uses dlopen by the standalone ``catalyst`` compiler process, which does
+    not embed Python, so it needs ``libpython`` loaded with ``RTLD_GLOBAL`` to resolve CPython
+    symbols. So, this path needs to return a shared object instead of the static python library.
+
+    ``LDLIBRARY`` in ``sysconfig`` is not reliably the shared library: some builds (notably
+    conda envs) report the static archive ``libpythonX.Y.a`` there even though a ``.so``
+    is present alongside it. We accept ``LDLIBRARY`` only when it is a shared object
+    that exists, and otherwise fall back to locating the shared library in ``LIBDIR``.
+    """
     ldlibrary = sysconfig.get_config_var("LDLIBRARY")
     framework_prefix = sysconfig.get_config_var("PYTHONFRAMEWORKPREFIX")
+    shlib_suffix = sysconfig.get_config_var("SHLIB_SUFFIX") or ".so"
 
     # macOS framework-style installations
-    if framework_prefix:
-        return os.path.join(framework_prefix, ldlibrary)
+    if framework_prefix and ldlibrary:
+        framework_path = os.path.join(framework_prefix, ldlibrary)
+        if os.path.exists(framework_path):
+            return framework_path
 
-    if not (libdir and ldlibrary):
+    libdir = sysconfig.get_config_var("LIBDIR")
+    if not libdir:
         return ""
 
-    # standard installation
-    ldlibrary_path = os.path.join(libdir, ldlibrary)
-    if os.path.exists(ldlibrary_path):
-        return ldlibrary_path
+    # Default: the library sysconfig reports, but only if it is a shared object.
+    if ldlibrary and shlib_suffix in ldlibrary:
+        ldlibrary_path = os.path.join(libdir, ldlibrary)
+        if os.path.exists(ldlibrary_path):
+            return ldlibrary_path
+
+    # Fall back to the conventionally-named shared library (e.g. libpython3.14.so).
+    ldversion = sysconfig.get_config_var("LDVERSION") or sysconfig.get_config_var("VERSION") or ""
+    conventional_path = os.path.join(libdir, f"libpython{ldversion}{shlib_suffix}")
+    if os.path.exists(conventional_path):
+        return conventional_path
+
+    # If the fallback fails, try any shared libpython in LIBDIR:
+    matches = sorted(glob.glob(os.path.join(libdir, f"libpython*{shlib_suffix}*")))
+    if matches:
+        return matches[0]
 
     return ""
 

--- a/frontend/catalyst/utils/runtime_environment.py
+++ b/frontend/catalyst/utils/runtime_environment.py
@@ -68,12 +68,7 @@ def get_libpython_path() -> str:   # pragma: no cover
 
     The QPD plugin uses dlopen by the standalone ``catalyst`` compiler process, which does
     not embed Python, so it needs ``libpython`` loaded with ``RTLD_GLOBAL`` to resolve CPython
-    symbols. So, this path needs to return a shared object instead of the static python library.
-
-    ``LDLIBRARY`` in ``sysconfig`` is not reliably the shared library: some builds (notably
-    conda envs) report the static archive ``libpythonX.Y.a`` there even though a ``.so``
-    is present alongside it. We accept ``LDLIBRARY`` only when it is a shared object
-    that exists, and otherwise fall back to locating the shared library in ``LIBDIR``.
+    symbols. Therefore, this path needs to return a shared object.
     """
     ldlibrary = sysconfig.get_config_var("LDLIBRARY")
     framework_prefix = sysconfig.get_config_var("PYTHONFRAMEWORKPREFIX")
@@ -98,6 +93,10 @@ def get_libpython_path() -> str:   # pragma: no cover
     # Fall back to the conventionally-named shared library (e.g. libpython3.12.so). This is
     # the case that a static-preferring build (e.g. conda) hits: LDLIBRARY names the .a, but
     # the .so is present under its canonical, version-derived name.
+    # ``LDLIBRARY`` in ``sysconfig`` is not reliably the shared library: some builds (notably
+    # conda envs) report the static archive ``libpythonX.Y.a`` there even though a ``.so``
+    # is present alongside it. We accept ``LDLIBRARY`` only when it is a shared object
+    # that exists, and otherwise fall back to locating the shared library in ``LIBDIR``.
     ldversion = sysconfig.get_config_var("LDVERSION") or sysconfig.get_config_var("VERSION") or ""
     conventional_path = os.path.join(libdir, f"libpython{ldversion}{shlib_suffix}")
     if os.path.exists(conventional_path):


### PR DESCRIPTION
**Context:**
The current `get_libpython_path()` trusts `LDLIBRARY`, and if it finds nothing, then it returns an empty string. This causes the QPD plugin fails on envs when `LDLIBRARY` sets to the static archived python library instead of the shared one (e.g., on conda envs: `LDLIBRARY = libpython3.14.a`). 

This PR fixes this with a minimal patch to `get_libpython_path()` that it now only accepts `LDLIBRARY` when it's actually a shared object, and otherwise falls back to the conventional `libpython{LDVERSION}.so` in `LIBDIR`. This fixes the issues on conda envs while preserving the current behaviour on other envs.

**Benefits:**
- Fix the QPD plugin on conda envs.

**Possible Drawbacks:**
n/a

**Related GitHub Issues:**
[sc-124573]