### PR TITLE
fix:Missing <cstdint> header

### DIFF
--- a/frontend/catalyst/third_party/oqc/src/OQCDevice.cpp
+++ b/frontend/catalyst/third_party/oqc/src/OQCDevice.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "OQCDevice.hpp"
+
+#include <cstdint>
 
 #include "Exception.hpp"
 

--- a/frontend/catalyst/third_party/oqc/src/OQCDevice.cpp
+++ b/frontend/catalyst/third_party/oqc/src/OQCDevice.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "OQCDevice.hpp"
 
 #include "Exception.hpp"

--- a/frontend/catalyst/third_party/oqc/src/OQCDevice.hpp
+++ b/frontend/catalyst/third_party/oqc/src/OQCDevice.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <algorithm>
 #include <memory>
 #include <set>

--- a/frontend/catalyst/third_party/oqc/src/OQCDevice.hpp
+++ b/frontend/catalyst/third_party/oqc/src/OQCDevice.hpp
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include <cstdint>
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <set>
 #include <string>

--- a/frontend/catalyst/third_party/oqc/src/OpenQASM2Builder.hpp
+++ b/frontend/catalyst/third_party/oqc/src/OpenQASM2Builder.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <array>
 #include <iomanip>
 #include <sstream>

--- a/frontend/catalyst/third_party/oqc/src/OpenQASM2Builder.hpp
+++ b/frontend/catalyst/third_party/oqc/src/OpenQASM2Builder.hpp
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include <cstdint>
 #include <array>
+#include <cstdint>
 #include <iomanip>
 #include <sstream>
 #include <string>

--- a/frontend/catalyst/third_party/oqc/src/tests/Test_OQCDevice.cpp
+++ b/frontend/catalyst/third_party/oqc/src/tests/Test_OQCDevice.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cstdint>
+
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/matchers/catch_matchers_string.hpp"
 #include "pybind11/embed.h"

--- a/frontend/catalyst/third_party/oqc/src/tests/Test_OQCDevice.cpp
+++ b/frontend/catalyst/third_party/oqc/src/tests/Test_OQCDevice.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/matchers/catch_matchers_string.hpp"
 #include "pybind11/embed.h"

--- a/frontend/catalyst/utils/libcustom_calls.cpp
+++ b/frontend/catalyst/utils/libcustom_calls.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include <complex>
+#include <cstdint>
 
 #include "jax_cpu_lapack_kernels/lapack_kernels.hpp"
 

--- a/frontend/catalyst/utils/libcustom_calls.cpp
+++ b/frontend/catalyst/utils/libcustom_calls.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <complex>
 
 #include "jax_cpu_lapack_kernels/lapack_kernels.hpp"

--- a/mlir/lib/Catalyst/Analysis/ResourceAnalysis.cpp
+++ b/mlir/lib/Catalyst/Analysis/ResourceAnalysis.cpp
@@ -14,8 +14,9 @@
 
 #define DEBUG_TYPE "resource-analysis"
 
-#include <cstdint>
 #include "Catalyst/Analysis/ResourceAnalysis.h"
+
+#include <cstdint>
 
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/TypeSwitch.h"

--- a/mlir/lib/Catalyst/Analysis/ResourceAnalysis.cpp
+++ b/mlir/lib/Catalyst/Analysis/ResourceAnalysis.cpp
@@ -14,6 +14,7 @@
 
 #define DEBUG_TYPE "resource-analysis"
 
+#include <cstdint>
 #include "Catalyst/Analysis/ResourceAnalysis.h"
 
 #include "llvm/ADT/DenseSet.h"

--- a/mlir/lib/Catalyst/Analysis/ResourceResult.cpp
+++ b/mlir/lib/Catalyst/Analysis/ResourceResult.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "Catalyst/Analysis/ResourceResult.h"
 
 #include <algorithm>

--- a/mlir/lib/Catalyst/Analysis/ResourceResult.cpp
+++ b/mlir/lib/Catalyst/Analysis/ResourceResult.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "Catalyst/Analysis/ResourceResult.h"
 
 #include <algorithm>
+#include <cstdint>
 
 #include "llvm/ADT/Hashing.h"
 #include "llvm/Support/ErrorHandling.h"

--- a/mlir/lib/Catalyst/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Catalyst/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "Catalyst/Transforms/BufferizableOpInterfaceImpl.h"
 
 #include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"

--- a/mlir/lib/Catalyst/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Catalyst/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "Catalyst/Transforms/BufferizableOpInterfaceImpl.h"
+
+#include <cstdint>
 
 #include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"

--- a/mlir/lib/Catalyst/Transforms/RegisterInactiveCallbackPass.cpp
+++ b/mlir/lib/Catalyst/Transforms/RegisterInactiveCallbackPass.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cstdint>
+
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"

--- a/mlir/lib/Catalyst/Transforms/RegisterInactiveCallbackPass.cpp
+++ b/mlir/lib/Catalyst/Transforms/RegisterInactiveCallbackPass.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"

--- a/mlir/lib/Catalyst/Transforms/ResourceAnalysisPass.cpp
+++ b/mlir/lib/Catalyst/Transforms/ResourceAnalysisPass.cpp
@@ -14,6 +14,7 @@
 
 #define DEBUG_TYPE "resource-analysis"
 
+#include <cstdint>
 #include <fstream>
 #include <string>
 

--- a/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
+++ b/mlir/lib/Catalyst/Transforms/catalyst_to_llvm.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <unordered_map>
 
 #include "mlir/Conversion/LLVMCommon/ConversionTarget.h"

--- a/mlir/lib/Catalyst/Utils/ConstantResolve.cpp
+++ b/mlir/lib/Catalyst/Utils/ConstantResolve.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "Catalyst/Utils/ConstantResolve.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"

--- a/mlir/lib/Catalyst/Utils/ConstantResolve.cpp
+++ b/mlir/lib/Catalyst/Utils/ConstantResolve.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "Catalyst/Utils/ConstantResolve.h"
+
+#include <cstdint>
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"

--- a/mlir/lib/Catalyst/Utils/SCFUtils.cpp
+++ b/mlir/lib/Catalyst/Utils/SCFUtils.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <cmath> // std::ceil()
 #include <optional>
 

--- a/mlir/lib/Catalyst/Utils/SCFUtils.cpp
+++ b/mlir/lib/Catalyst/Utils/SCFUtils.cpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include <cmath> // std::ceil()
+#include <cstdint>
 #include <optional>
 
 #include "mlir/Dialect/SCF/IR/SCF.h"

--- a/mlir/lib/Gradient/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Gradient/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "Gradient/Transforms/BufferizableOpInterfaceImpl.h"
 
 #include <algorithm> // std::find

--- a/mlir/lib/Gradient/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Gradient/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "Gradient/Transforms/BufferizableOpInterfaceImpl.h"
 
 #include <algorithm> // std::find
+#include <cstdint>
 #include <vector>
 
 #include "mlir/Dialect/Bufferization/IR/BufferizableOpInterface.h"

--- a/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Gradient/Transforms/ConversionPatterns.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <deque>
 #include <iostream>
 #include <string>

--- a/mlir/lib/Gradient/Transforms/GradMethods/FiniteDifference.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/FiniteDifference.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "FiniteDifference.hpp"
 
 #include <algorithm>
+#include <cstdint>
 #include <sstream>
 #include <vector>
 

--- a/mlir/lib/Gradient/Transforms/GradMethods/FiniteDifference.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/FiniteDifference.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "FiniteDifference.hpp"
 
 #include <algorithm>

--- a/mlir/lib/Gradient/Transforms/GradMethods/HybridGradient.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/HybridGradient.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "HybridGradient.hpp"
 
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"

--- a/mlir/lib/Gradient/Transforms/GradMethods/HybridGradient.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/HybridGradient.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "HybridGradient.hpp"
+
+#include <cstdint>
 
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"

--- a/mlir/lib/Gradient/Transforms/GradMethods/JVPVJPPatterns.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/JVPVJPPatterns.cpp
@@ -14,10 +14,10 @@
 
 #define DEBUG_TYPE "jvpvjp"
 
-#include <cstdint>
 #include "JVPVJPPatterns.hpp"
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/mlir/lib/Gradient/Transforms/GradMethods/JVPVJPPatterns.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/JVPVJPPatterns.cpp
@@ -14,6 +14,7 @@
 
 #define DEBUG_TYPE "jvpvjp"
 
+#include <cstdint>
 #include "JVPVJPPatterns.hpp"
 
 #include <algorithm>

--- a/mlir/lib/Gradient/Transforms/GradMethods/PS_FunctionShifting.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/PS_FunctionShifting.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/mlir/lib/Gradient/Transforms/GradMethods/PS_QuantumGradient.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/PS_QuantumGradient.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <deque>
 #include <string>
 #include <vector>

--- a/mlir/lib/Gradient/Transforms/GradMethods/ParameterShift.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/ParameterShift.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "ParameterShift.hpp"
 
 #include "mlir/Dialect/SCF/IR/SCF.h"

--- a/mlir/lib/Gradient/Transforms/GradMethods/ParameterShift.cpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/ParameterShift.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "ParameterShift.hpp"
+
+#include <cstdint>
 
 #include "mlir/Dialect/SCF/IR/SCF.h"
 

--- a/mlir/lib/Gradient/Transforms/GradMethods/ParameterShift.hpp
+++ b/mlir/lib/Gradient/Transforms/GradMethods/ParameterShift.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <utility>
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"

--- a/mlir/lib/Gradient/Utils/EinsumLinalgGeneric.cpp
+++ b/mlir/lib/Gradient/Utils/EinsumLinalgGeneric.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "Gradient/Utils/EinsumLinalgGeneric.h"
+
+#include <cstdint>
 
 #include "llvm/ADT/ArrayRef.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"

--- a/mlir/lib/Gradient/Utils/EinsumLinalgGeneric.cpp
+++ b/mlir/lib/Gradient/Utils/EinsumLinalgGeneric.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "Gradient/Utils/EinsumLinalgGeneric.h"
 
 #include "llvm/ADT/ArrayRef.h"

--- a/mlir/lib/Gradient/Utils/GradientShape.cpp
+++ b/mlir/lib/Gradient/Utils/GradientShape.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "Gradient/Utils/GradientShape.h"
 
 #include "mlir/Dialect/Tensor/IR/Tensor.h"

--- a/mlir/lib/Gradient/Utils/GradientShape.cpp
+++ b/mlir/lib/Gradient/Utils/GradientShape.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "Gradient/Utils/GradientShape.h"
+
+#include <cstdint>
 
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 

--- a/mlir/lib/Ion/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Ion/Transforms/ConversionPatterns.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cstdint>
+
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/IRMapping.h"

--- a/mlir/lib/Ion/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Ion/Transforms/ConversionPatterns.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/IRMapping.h"

--- a/mlir/lib/Ion/Transforms/GatesToPulsesPatterns.cpp
+++ b/mlir/lib/Ion/Transforms/GatesToPulsesPatterns.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <cstdint>
 #include <optional>
 
 #include "mlir/Dialect/Arith/IR/Arith.h"

--- a/mlir/lib/Ion/Transforms/GatesToPulsesPatterns.cpp
+++ b/mlir/lib/Ion/Transforms/GatesToPulsesPatterns.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <algorithm>
 #include <cassert>
 #include <cmath>

--- a/mlir/lib/Ion/Transforms/IonToRTIOPatterns.cpp
+++ b/mlir/lib/Ion/Transforms/IonToRTIOPatterns.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"

--- a/mlir/lib/Ion/Transforms/IonToRTIOPatterns.cpp
+++ b/mlir/lib/Ion/Transforms/IonToRTIOPatterns.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cstdint>
+
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"

--- a/mlir/lib/Ion/Transforms/ion-to-rtio.cpp
+++ b/mlir/lib/Ion/Transforms/ion-to-rtio.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"

--- a/mlir/lib/Ion/Transforms/ion-to-rtio.cpp
+++ b/mlir/lib/Ion/Transforms/ion-to-rtio.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cstdint>
+
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"

--- a/mlir/lib/Mitigation/Transforms/MitigationMethods/Zne.cpp
+++ b/mlir/lib/Mitigation/Transforms/MitigationMethods/Zne.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "Zne.hpp"
 
 #include <algorithm>

--- a/mlir/lib/Mitigation/Transforms/MitigationMethods/Zne.cpp
+++ b/mlir/lib/Mitigation/Transforms/MitigationMethods/Zne.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "Zne.hpp"
 
 #include <algorithm>
+#include <cstdint>
 #include <deque>
 #include <iostream>
 #include <sstream>

--- a/mlir/lib/Mitigation/Transforms/MitigationMethods/Zne.hpp
+++ b/mlir/lib/Mitigation/Transforms/MitigationMethods/Zne.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstdint>
+
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/PatternMatch.h"

--- a/mlir/lib/Mitigation/Transforms/MitigationMethods/Zne.hpp
+++ b/mlir/lib/Mitigation/Transforms/MitigationMethods/Zne.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/PatternMatch.h"

--- a/mlir/lib/PBC/Transforms/CountPPMSpecs.cpp
+++ b/mlir/lib/PBC/Transforms/CountPPMSpecs.cpp
@@ -14,6 +14,7 @@
 
 #define DEBUG_TYPE "ppm-specs"
 
+#include <cstdint>
 #include <string>
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"

--- a/mlir/lib/PBC/Transforms/DecomposeArbitraryPPR.cpp
+++ b/mlir/lib/PBC/Transforms/DecomposeArbitraryPPR.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "mlir/Transforms/DialectConversion.h"
 
 #include "PBC/IR/PBCOps.h"

--- a/mlir/lib/PBC/Transforms/DecomposeArbitraryPPR.cpp
+++ b/mlir/lib/PBC/Transforms/DecomposeArbitraryPPR.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cstdint>
+
 #include "mlir/Transforms/DialectConversion.h"
 
 #include "PBC/IR/PBCOps.h"

--- a/mlir/lib/PBC/Transforms/DecomposeCliffordPPR.cpp
+++ b/mlir/lib/PBC/Transforms/DecomposeCliffordPPR.cpp
@@ -14,6 +14,7 @@
 
 #define DEBUG_TYPE "decompose-clifford-ppr"
 
+#include <cstdint>
 #include "mlir/Dialect/Arith/IR/Arith.h" // for arith::XOrIOp and arith::ConstantOp
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"

--- a/mlir/lib/PBC/Transforms/DecomposeCliffordPPR.cpp
+++ b/mlir/lib/PBC/Transforms/DecomposeCliffordPPR.cpp
@@ -15,6 +15,7 @@
 #define DEBUG_TYPE "decompose-clifford-ppr"
 
 #include <cstdint>
+
 #include "mlir/Dialect/Arith/IR/Arith.h" // for arith::XOrIOp and arith::ConstantOp
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Builders.h"

--- a/mlir/lib/PBC/Transforms/DecomposeNonCliffordPPR.cpp
+++ b/mlir/lib/PBC/Transforms/DecomposeNonCliffordPPR.cpp
@@ -14,6 +14,7 @@
 
 #define DEBUG_TYPE "decompose-non-clifford-ppr"
 #include <cstdint>
+
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "mlir/Dialect/Arith/IR/Arith.h" // for arith::XOrIOp and arith::ConstantOp

--- a/mlir/lib/PBC/Transforms/DecomposeNonCliffordPPR.cpp
+++ b/mlir/lib/PBC/Transforms/DecomposeNonCliffordPPR.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #define DEBUG_TYPE "decompose-non-clifford-ppr"
+#include <cstdint>
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "mlir/Dialect/Arith/IR/Arith.h" // for arith::XOrIOp and arith::ConstantOp

--- a/mlir/lib/PBC/Transforms/ToPPR.cpp
+++ b/mlir/lib/PBC/Transforms/ToPPR.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cstdint>
+
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/TypeRange.h"
 

--- a/mlir/lib/PBC/Transforms/ToPPR.cpp
+++ b/mlir/lib/PBC/Transforms/ToPPR.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/TypeRange.h"
 

--- a/mlir/lib/PBC/Utils/PBCLayer.cpp
+++ b/mlir/lib/PBC/Utils/PBCLayer.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "PBC/Utils/PBCLayer.h"
 
 #include <algorithm>
+#include <cstdint>
 
 #include "llvm/ADT/STLExtras.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"

--- a/mlir/lib/PBC/Utils/PBCLayer.cpp
+++ b/mlir/lib/PBC/Utils/PBCLayer.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "PBC/Utils/PBCLayer.h"
 
 #include <algorithm>

--- a/mlir/lib/PBC/Utils/PauliStringWrapper.cpp
+++ b/mlir/lib/PBC/Utils/PauliStringWrapper.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "PBC/Utils/PauliStringWrapper.h"
 
 #include "stim/mem/simd_word.h"

--- a/mlir/lib/PBC/Utils/PauliStringWrapper.cpp
+++ b/mlir/lib/PBC/Utils/PauliStringWrapper.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "PBC/Utils/PauliStringWrapper.h"
+
+#include <cstdint>
 
 #include "stim/mem/simd_word.h"
 #include "stim/stabilizers/flex_pauli_string.h"

--- a/mlir/lib/QRef/IR/QRefDialect.cpp
+++ b/mlir/lib/QRef/IR/QRefDialect.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "QRef/IR/QRefDialect.h"
+
+#include <cstdint>
 
 #include "llvm/ADT/TypeSwitch.h" // needed for generated type parser
 #include "mlir/IR/Builders.h"

--- a/mlir/lib/QRef/IR/QRefDialect.cpp
+++ b/mlir/lib/QRef/IR/QRefDialect.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "QRef/IR/QRefDialect.h"
 
 #include "llvm/ADT/TypeSwitch.h" // needed for generated type parser

--- a/mlir/lib/QRef/IR/QRefOps.cpp
+++ b/mlir/lib/QRef/IR/QRefOps.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "QRef/IR/QRefOps.h"
 
 #include "llvm/ADT/StringSet.h"

--- a/mlir/lib/QRef/IR/QRefOps.cpp
+++ b/mlir/lib/QRef/IR/QRefOps.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "QRef/IR/QRefOps.h"
+
+#include <cstdint>
 
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/LogicalResult.h"

--- a/mlir/lib/QecLogical/IR/QecLogicalOps.cpp
+++ b/mlir/lib/QecLogical/IR/QecLogicalOps.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "QecLogical/IR/QecLogicalOps.h"
 
 #include "llvm/Support/Casting.h"

--- a/mlir/lib/QecLogical/IR/QecLogicalOps.cpp
+++ b/mlir/lib/QecLogical/IR/QecLogicalOps.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "QecLogical/IR/QecLogicalOps.h"
+
+#include <cstdint>
 
 #include "llvm/Support/Casting.h"
 #include "mlir/IR/Builders.h"

--- a/mlir/lib/Quantum/IR/QuantumOps.cpp
+++ b/mlir/lib/Quantum/IR/QuantumOps.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "Quantum/IR/QuantumOps.h"
 
+#include <cstdint>
 #include <optional>
 #include <type_traits>
 #include <vector>

--- a/mlir/lib/Quantum/IR/QuantumOps.cpp
+++ b/mlir/lib/Quantum/IR/QuantumOps.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "Quantum/IR/QuantumOps.h"
 
 #include <optional>

--- a/mlir/lib/Quantum/Transforms/AdjointLowering/ForwardPass.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointLowering/ForwardPass.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cstdint>
+
 #include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Index/IR/IndexOps.h"

--- a/mlir/lib/Quantum/Transforms/AdjointLowering/ForwardPass.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointLowering/ForwardPass.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Index/IR/IndexOps.h"

--- a/mlir/lib/Quantum/Transforms/AdjointLowering/QuantumCache.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointLowering/QuantumCache.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "QuantumCache.hpp"
 
 #include "mlir/Dialect/SCF/IR/SCF.h"

--- a/mlir/lib/Quantum/Transforms/AdjointLowering/QuantumCache.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointLowering/QuantumCache.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "QuantumCache.hpp"
+
+#include <cstdint>
 
 #include "mlir/Dialect/SCF/IR/SCF.h"
 

--- a/mlir/lib/Quantum/Transforms/AdjointLowering/ReversePass.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointLowering/ReversePass.cpp
@@ -14,8 +14,8 @@
 
 #define DEBUG_TYPE "adjoint"
 
-#include <cstdint>
 #include <algorithm>
+#include <cstdint>
 #include <queue>
 #include <string>
 #include <vector>

--- a/mlir/lib/Quantum/Transforms/AdjointLowering/ReversePass.cpp
+++ b/mlir/lib/Quantum/Transforms/AdjointLowering/ReversePass.cpp
@@ -14,6 +14,7 @@
 
 #define DEBUG_TYPE "adjoint"
 
+#include <cstdint>
 #include <algorithm>
 #include <queue>
 #include <string>

--- a/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <string>
 
 #include "mlir/Dialect/LLVMIR/FunctionCallUtils.h"

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGBuilder.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGBuilder.cpp
@@ -16,9 +16,9 @@
  * @file DGBuilder.cpp
  */
 
-#include <cstdint>
 #include "DGBuilder.hpp"
 
+#include <cstdint>
 #include <iostream>
 #include <variant>
 

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGBuilder.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGBuilder.cpp
@@ -16,6 +16,7 @@
  * @file DGBuilder.cpp
  */
 
+#include <cstdint>
 #include "DGBuilder.hpp"
 
 #include <iostream>

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompUtils.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompUtils.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "DecompUtils.hpp"
 
 #include "mlir/IR/BuiltinAttributes.h"

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompUtils.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompUtils.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "DecompUtils.hpp"
+
+#include <cstdint>
 
 #include "mlir/IR/BuiltinAttributes.h"
 

--- a/mlir/lib/Quantum/Transforms/GridsynthPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/GridsynthPatterns.cpp
@@ -14,6 +14,7 @@
 
 #define DEBUG_TYPE "gridsynth-patterns"
 
+#include <cstdint>
 #include <vector>
 
 #include "llvm/ADT/SmallVector.h"

--- a/mlir/lib/Quantum/Transforms/MergeRotationsPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/MergeRotationsPatterns.cpp
@@ -14,9 +14,9 @@
 
 #define DEBUG_TYPE "merge-rotations"
 
-#include <cstdint>
 #include <array>
 #include <cassert> // assert
+#include <cstdint>
 
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Debug.h"

--- a/mlir/lib/Quantum/Transforms/MergeRotationsPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/MergeRotationsPatterns.cpp
@@ -14,6 +14,7 @@
 
 #define DEBUG_TYPE "merge-rotations"
 
+#include <cstdint>
 #include <array>
 #include <cassert> // assert
 

--- a/mlir/lib/Quantum/Transforms/cp_global_buffers.cpp
+++ b/mlir/lib/Quantum/Transforms/cp_global_buffers.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"

--- a/mlir/lib/Quantum/Transforms/cp_global_buffers.cpp
+++ b/mlir/lib/Quantum/Transforms/cp_global_buffers.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cstdint>
+
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"

--- a/mlir/lib/Quantum/Transforms/dynamic_one_shot.cpp
+++ b/mlir/lib/Quantum/Transforms/dynamic_one_shot.cpp
@@ -14,6 +14,7 @@
 
 #define DEBUG_TYPE "dynamic-one-shot"
 
+#include <cstdint>
 #include <unordered_map>
 #include <unordered_set>
 

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -18,6 +18,7 @@
 #define VALUE_SEMANTICS_OBSERVABLE_OPS                                                             \
     quantum::ComputationalBasisOp, quantum::HermitianOp, quantum::NamedObsOp
 
+#include <cstdint>
 #include "reference_semantics_conversion.h"
 
 #include <optional>

--- a/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
+++ b/mlir/lib/Quantum/Transforms/reference_semantics_conversion.cpp
@@ -18,9 +18,9 @@
 #define VALUE_SEMANTICS_OBSERVABLE_OPS                                                             \
     quantum::ComputationalBasisOp, quantum::HermitianOp, quantum::NamedObsOp
 
-#include <cstdint>
 #include "reference_semantics_conversion.h"
 
+#include <cstdint>
 #include <optional>
 
 #include "llvm/ADT/DenseMap.h"

--- a/mlir/lib/Quantum/Transforms/split_non_commuting.cpp
+++ b/mlir/lib/Quantum/Transforms/split_non_commuting.cpp
@@ -40,6 +40,7 @@
 
 #define DEBUG_TYPE "split-non-commuting"
 
+#include <cstdint>
 #include <deque>
 
 #include "llvm/ADT/DenseMap.h"

--- a/mlir/lib/Quantum/Transforms/split_to_single_terms.cpp
+++ b/mlir/lib/Quantum/Transforms/split_to_single_terms.cpp
@@ -15,6 +15,7 @@
 #define DEBUG_TYPE "split-to-single-terms"
 
 #include <cstdint>
+
 #include "llvm/ADT/DenseMap.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"

--- a/mlir/lib/Quantum/Transforms/split_to_single_terms.cpp
+++ b/mlir/lib/Quantum/Transforms/split_to_single_terms.cpp
@@ -14,6 +14,7 @@
 
 #define DEBUG_TYPE "split-to-single-terms"
 
+#include <cstdint>
 #include "llvm/ADT/DenseMap.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"

--- a/mlir/lib/RTIO/IR/RTIODialect.cpp
+++ b/mlir/lib/RTIO/IR/RTIODialect.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "RTIO/IR/RTIODialect.h"
 
 #include "llvm/ADT/TypeSwitch.h"

--- a/mlir/lib/RTIO/IR/RTIODialect.cpp
+++ b/mlir/lib/RTIO/IR/RTIODialect.cpp
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "RTIO/IR/RTIODialect.h"
+
+#include <cstdint>
 
 #include "llvm/ADT/TypeSwitch.h"
 #include "mlir/IR/Builders.h"

--- a/mlir/lib/RTIO/Transforms/ARTIQRuntimeBuilder.hpp
+++ b/mlir/lib/RTIO/Transforms/ARTIQRuntimeBuilder.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstdint>
+
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Math/IR/Math.h"

--- a/mlir/lib/RTIO/Transforms/ARTIQRuntimeBuilder.hpp
+++ b/mlir/lib/RTIO/Transforms/ARTIQRuntimeBuilder.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Math/IR/Math.h"

--- a/mlir/lib/RTIO/Transforms/RTIOEventToARTIQ.cpp
+++ b/mlir/lib/RTIO/Transforms/RTIOEventToARTIQ.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <deque>
 
 #include "mlir/Analysis/TopologicalSortUtils.h"

--- a/mlir/lib/RTIO/Transforms/RTIOEventToARTIQPatterns.cpp
+++ b/mlir/lib/RTIO/Transforms/RTIOEventToARTIQPatterns.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"

--- a/mlir/lib/RTIO/Transforms/RTIOEventToARTIQPatterns.cpp
+++ b/mlir/lib/RTIO/Transforms/RTIOEventToARTIQPatterns.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cstdint>
+
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"

--- a/mlir/lib/RTIO/Transforms/RTIORPCPatterns.cpp
+++ b/mlir/lib/RTIO/Transforms/RTIORPCPatterns.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cstdint>
+
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"

--- a/mlir/lib/RTIO/Transforms/RTIORPCPatterns.cpp
+++ b/mlir/lib/RTIO/Transforms/RTIORPCPatterns.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"

--- a/mlir/lib/RTIO/Transforms/Utils.hpp
+++ b/mlir/lib/RTIO/Transforms/Utils.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <cstdint>
+
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Matchers.h"
 

--- a/mlir/lib/RTIO/Transforms/Utils.hpp
+++ b/mlir/lib/RTIO/Transforms/Utils.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Matchers.h"
 

--- a/mlir/lib/hlo-extensions/Transforms/HloCustomCallPatterns.cpp
+++ b/mlir/lib/hlo-extensions/Transforms/HloCustomCallPatterns.cpp
@@ -14,6 +14,7 @@
 
 #define DEBUG_TYPE "scatter"
 
+#include <cstdint>
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"

--- a/mlir/lib/hlo-extensions/Transforms/HloCustomCallPatterns.cpp
+++ b/mlir/lib/hlo-extensions/Transforms/HloCustomCallPatterns.cpp
@@ -15,6 +15,7 @@
 #define DEBUG_TYPE "scatter"
 
 #include <cstdint>
+
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"

--- a/mlir/lib/hlo-extensions/Transforms/ScatterPatterns.cpp
+++ b/mlir/lib/hlo-extensions/Transforms/ScatterPatterns.cpp
@@ -14,8 +14,8 @@
 
 #define DEBUG_TYPE "scatter"
 
-#include <cstdint>
 #include <algorithm>
+#include <cstdint>
 #include <vector>
 
 #include "mlir/Dialect/Arith/IR/Arith.h"

--- a/mlir/lib/hlo-extensions/Transforms/ScatterPatterns.cpp
+++ b/mlir/lib/hlo-extensions/Transforms/ScatterPatterns.cpp
@@ -14,6 +14,7 @@
 
 #define DEBUG_TYPE "scatter"
 
+#include <cstdint>
 #include <algorithm>
 #include <vector>
 

--- a/mlir/lib/hlo-extensions/Transforms/stablehlo_legalize_control_flow.cpp
+++ b/mlir/lib/hlo-extensions/Transforms/stablehlo_legalize_control_flow.cpp
@@ -37,6 +37,7 @@ limitations under the License.
 // catalyst namespace.
 
 // This file implements logic for lowering Stablehlo dialect to SCF dialect.
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <utility>

--- a/mlir/lib/hlo-extensions/Transforms/stablehlo_legalize_sort.cpp
+++ b/mlir/lib/hlo-extensions/Transforms/stablehlo_legalize_sort.cpp
@@ -37,6 +37,7 @@ limitations under the License.
 // catalyst namespace.
 
 // This file implements logic for lowering stablehlo.sort to the SCF dialect.
+#include <cstdint>
 #include <iterator>
 #include <memory>
 #include <utility>

--- a/mlir/lib/hlo-extensions/Transforms/stablehlo_legalize_to_standard.cpp
+++ b/mlir/lib/hlo-extensions/Transforms/stablehlo_legalize_to_standard.cpp
@@ -38,6 +38,7 @@ limitations under the License.
 
 // This file implements logic for lowering Stablehlo dialect to Standard dialect.
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <utility>

--- a/runtime/include/DataView.hpp
+++ b/runtime/include/DataView.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 /**

--- a/runtime/include/QuantumDevice.hpp
+++ b/runtime/include/QuantumDevice.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <complex>
 #include <optional>
 #include <random>

--- a/runtime/include/QuantumDevice.hpp
+++ b/runtime/include/QuantumDevice.hpp
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include <cstdint>
 #include <complex>
+#include <cstdint>
 #include <optional>
 #include <random>
 #include <vector>

--- a/runtime/lib/QEC/Decoder/LUTDecoder.cpp
+++ b/runtime/lib/QEC/Decoder/LUTDecoder.cpp
@@ -23,10 +23,10 @@
 // operation definition in the MLIR layer.
 // 3. The LUT decoder is not scalable in both spatial and temporal complexity.
 
-#include <cstdint>
 #include "LUTDecoder.hpp"
 
 #include <algorithm>
+#include <cstdint>
 #include <vector>
 
 #include "DataView.hpp"

--- a/runtime/lib/QEC/Decoder/LUTDecoder.cpp
+++ b/runtime/lib/QEC/Decoder/LUTDecoder.cpp
@@ -23,6 +23,7 @@
 // operation definition in the MLIR layer.
 // 3. The LUT decoder is not scalable in both spatial and temporal complexity.
 
+#include <cstdint>
 #include "LUTDecoder.hpp"
 
 #include <algorithm>

--- a/runtime/lib/QEC/Decoder/LUTDecoderUtils.hpp
+++ b/runtime/lib/QEC/Decoder/LUTDecoderUtils.hpp
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #pragma once
-#include <cstdint>
 #include <algorithm>
+#include <cstdint>
 #include <mutex>
 #include <numeric>
 #include <string>

--- a/runtime/lib/QEC/Decoder/LUTDecoderUtils.hpp
+++ b/runtime/lib/QEC/Decoder/LUTDecoderUtils.hpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #pragma once
+#include <cstdint>
 #include <algorithm>
 #include <mutex>
 #include <numeric>

--- a/runtime/lib/backend/common/Utils.hpp
+++ b/runtime/lib/backend/common/Utils.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <algorithm>
 #include <array>
 #include <optional>

--- a/runtime/lib/backend/common/Utils.hpp
+++ b/runtime/lib/backend/common/Utils.hpp
@@ -14,9 +14,9 @@
 
 #pragma once
 
-#include <cstdint>
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <optional>
 #include <random>
 #include <sstream>

--- a/runtime/lib/backend/null_qubit/NullQubit.hpp
+++ b/runtime/lib/backend/null_qubit/NullQubit.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <algorithm> // generate_n
 #include <cmath>
 #include <complex>

--- a/runtime/lib/backend/null_qubit/NullQubit.hpp
+++ b/runtime/lib/backend/null_qubit/NullQubit.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include <cstdint>
 #include <algorithm> // generate_n
 #include <cmath>
 #include <complex>
+#include <cstdint>
 #include <cstdio>
 #include <optional>
 #include <random>

--- a/runtime/lib/backend/openqasm/OpenQasmBuilder.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmBuilder.hpp
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include <cstdint>
 #include <algorithm>
 #include <array>
 #include <complex>
+#include <cstdint>
 #include <iomanip>
 #include <memory>
 #include <sstream>

--- a/runtime/lib/backend/openqasm/OpenQasmBuilder.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmBuilder.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <algorithm>
 #include <array>
 #include <complex>

--- a/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
+++ b/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "OpenQasmDevice.hpp"
 
 #include <bitset>
+#include <cstdint>
 
 #include "Exception.hpp"
 

--- a/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
+++ b/runtime/lib/backend/openqasm/OpenQasmDevice.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "OpenQasmDevice.hpp"
 
 #include <bitset>

--- a/runtime/lib/backend/openqasm/OpenQasmDevice.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmDevice.hpp
@@ -16,8 +16,8 @@
 
 #define __device_openqasm
 
-#include <cstdint>
 #include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <set>
 #include <string>

--- a/runtime/lib/backend/openqasm/OpenQasmDevice.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmDevice.hpp
@@ -16,6 +16,7 @@
 
 #define __device_openqasm
 
+#include <cstdint>
 #include <algorithm>
 #include <memory>
 #include <set>

--- a/runtime/lib/backend/openqasm/OpenQasmObsManager.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmObsManager.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <array>
 #include <utility>
 

--- a/runtime/lib/backend/openqasm/OpenQasmObsManager.hpp
+++ b/runtime/lib/backend/openqasm/OpenQasmObsManager.hpp
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include <cstdint>
 #include <array>
+#include <cstdint>
 #include <utility>
 
 #include "Exception.hpp"

--- a/runtime/lib/backend/oqd/OQDDevice.cpp
+++ b/runtime/lib/backend/oqd/OQDDevice.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "OQDDevice.hpp"
 
 #include <algorithm>
+#include <cstdint>
 
 #include "OQDRuntimeCAPI.h"
 

--- a/runtime/lib/backend/oqd/OQDDevice.cpp
+++ b/runtime/lib/backend/oqd/OQDDevice.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "OQDDevice.hpp"
 
 #include <algorithm>

--- a/runtime/lib/backend/oqd/OQDDevice.hpp
+++ b/runtime/lib/backend/oqd/OQDDevice.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <algorithm>
 #include <set>
 #include <string>

--- a/runtime/lib/backend/oqd/OQDDevice.hpp
+++ b/runtime/lib/backend/oqd/OQDDevice.hpp
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include <cstdint>
 #include <algorithm>
+#include <cstdint>
 #include <set>
 #include <string>
 #include <unordered_map>

--- a/runtime/lib/capi/ExecutionContext.hpp
+++ b/runtime/lib/capi/ExecutionContext.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <cstdio>
 #include <dlfcn.h>
 #include <memory>

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "RuntimeCAPI.h"
 
 #include <cstdarg>

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <cstdint>
 #include "RuntimeCAPI.h"
 
 #include <cstdarg>
+#include <cstdint>
 #include <cstdlib>
 #include <ctime>
 #include <memory>

--- a/runtime/tests/TestUtils.hpp
+++ b/runtime/tests/TestUtils.hpp
@@ -18,6 +18,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/runtime/tests/Test_DecoderLUTDecoder.cpp
+++ b/runtime/tests/Test_DecoderLUTDecoder.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <unordered_map>
 #include <vector>
 

--- a/runtime/tests/Test_DecoderLUTDecoderUtils.cpp
+++ b/runtime/tests/Test_DecoderLUTDecoderUtils.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 #include <vector>

--- a/runtime/tests/Test_MBQC.cpp
+++ b/runtime/tests/Test_MBQC.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cstdint>
+
 #include "catch2/catch_test_macros.hpp"
 
 #include "RuntimeCAPI.h"

--- a/runtime/tests/Test_MBQC.cpp
+++ b/runtime/tests/Test_MBQC.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "catch2/catch_test_macros.hpp"
 
 #include "RuntimeCAPI.h"

--- a/runtime/tests/Test_OQDDevice.cpp
+++ b/runtime/tests/Test_OQDDevice.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 

--- a/runtime/tests/Test_OpenQasmDevice.cpp
+++ b/runtime/tests/Test_OpenQasmDevice.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <cstdint>
+
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/matchers/catch_matchers_floating_point.hpp"
 #include "catch2/matchers/catch_matchers_string.hpp"

--- a/runtime/tests/Test_OpenQasmDevice.cpp
+++ b/runtime/tests/Test_OpenQasmDevice.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdint>
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/matchers/catch_matchers_floating_point.hpp"
 #include "catch2/matchers/catch_matchers_string.hpp"


### PR DESCRIPTION


**Context:**
Missing <cstdint> header for usage of uint8_t and realted types

**Description of the Change:**
Updated various files across the frontend, MLIR libraries , and runtime backends.

**Benefits:**
Compatibility,Robustness,Standards Compliance.

**Related GitHub Issues:**
Closes #2963

[sc-122739]