### PR TITLE
Fix LLL 13 July: pop `forward_mask`

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.238
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.46.0.dev48
+pennylane=0.46.0.dev54
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -34,4 +34,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.46.0-dev15
 pennylane-lightning==0.46.0-dev15
-pennylane==0.46.0.dev48
+pennylane==0.46.0.dev54

--- a/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
+++ b/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
@@ -110,6 +110,7 @@ def _qref_operator_p_lowering(
 
     hybrid_lens = kwargs.pop("hybrid_lens")  # pylint: disable=unused-variable
     hybrid_trees = kwargs.pop("hybrid_trees")  # pylint: disable=unused-variable
+    forward_mask = kwargs.pop("forward_mask")  # pylint: disable=unused-variable
     adjoint = kwargs.pop("adjoint")
     n_ctrls = kwargs.pop("n_ctrls")
     wire_lens = kwargs.pop("wire_lens")


### PR DESCRIPTION
### Before submitting
**Context:**
LLL failure see the log [here](https://github.com/PennyLaneAI/catalyst/actions/runs/29246246483/job/86803756065)

**Root cause**
An upstream PennyLane change, not a Catalyst bug. PennyLane PR #9808 (merged 2026-07-10, one day before this run) added a new forward_mask parameter to the operator_p capture primitive:

https://github.com/PennyLaneAI/pennylane/pull/9808

**Description of the Change:**

- bumped PL version to latest
- popped `forward_mask` from `_qref_operator_p_lowering`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
