### PR TITLE
Cond primitive's default "else" branch no longer has a literal `True` predicate 

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.238
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.46.0.dev54
+pennylane=0.46.0.dev55
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -230,6 +230,10 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* The `cond` PLxPR primitive's lowering rule no longer expects a `True` Literal for the predicate
+  of the default else branch.
+  [(#3018)](https://github.com/PennyLaneAI/catalyst/pull/3018)
+
 * The `graph-decomposition` pass eliminates three redundant IR manipulations:
   the cloning, removal, and re-insertion of user rules. This optimization is particularly
   beneficial when the pass is executed multiple times within the compilation pipeline.

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -34,4 +34,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.46.0-dev15
 pennylane-lightning==0.46.0-dev15
-pennylane==0.46.0.dev54
+pennylane==0.46.0.dev55

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -2296,7 +2296,7 @@ def _pl_cond_lowering(
     args_slice,
 ):
     result_types = [mlir.aval_to_ir_types(a)[0] for a in jax_ctx.avals_out]
-    num_preds = len(jaxpr_branches)
+    num_preds = len(jaxpr_branches) - 1
     preds = invals[:num_preds]
     args = invals[slice(*args_slice)]
 
@@ -2349,7 +2349,6 @@ def _pl_cond_lowering(
                 new_jaxpr = else_jaxpr.replace(
                     constvars=(), invars=else_jaxpr.constvars + else_jaxpr.invars
                 )
-
                 with ir.InsertionPoint(else_block):
                     out, _ = mlir.jaxpr_subcomp(
                         else_ctx.module_context,

--- a/frontend/test/pytest/test_conditionals.py
+++ b/frontend/test/pytest/test_conditionals.py
@@ -52,13 +52,13 @@ class TestCondToJaxpr:
                 { lambda ; a:i64[]. let
                     b:bool[] = eq a 5:i64[]
                     c:i64[] = cond[
-                    args_slice=(4, None, None)
-                    consts_slices=((2, 3, None), (3, 4, None))
+                    args_slice=(3, None, None)
+                    consts_slices=((1, 2, None), (2, 3, None))
                     jaxpr_branches=(
                         { lambda d:i64[]; . let e:i64[] = integer_pow[y=2] d in (e,) }
                         { lambda f:i64[]; . let g:i64[] = integer_pow[y=3] f in (g,) }
                     )
-                    ] b True:bool[] a a
+                    ] b a a
                 in (c,) }
                 """)
         else:


### PR DESCRIPTION
**Context:**
We recently removed the literal `True` predicate on the default else branch of the cond plxpr primitive. https://github.com/PennyLaneAI/pennylane/pull/9815

**Description of the Change:**
We update the lowering rule correspondingly.

**Benefits:**
Things are correct.