### PR TITLE
Add bufferization to launch_kernel

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -12,6 +12,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* A `BufferizableOpInterface` implementation is now added for `catalyst.launch_kernel` operation and it is now bufferizable.
+  [(#3024)](https://github.com/PennyLaneAI/catalyst/pull/3024)
+
 * Adds a `catalyst::symbolic_array` operation and integrates it with the new `qp.capture.symbolic_array` function.
   [(#2982)](https://github.com/PennyLaneAI/catalyst/pull/2982)
 

--- a/mlir/lib/Catalyst/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/mlir/lib/Catalyst/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -370,6 +370,87 @@ struct SymbolicArrayOpInterface
     }
 };
 
+/// Bufferization of catalyst.launch_kernel. The callee reads its operands and returns each result
+/// in its own freshly allocated buffer. Bufferization therefore converts the operands to buffers
+/// and the tensor results to memref results (return-by-value): no operand is written in place and
+/// no result aliases an operand.
+struct LaunchKernelOpInterface
+    : public bufferization::BufferizableOpInterface::ExternalModel<LaunchKernelOpInterface,
+                                                                   LaunchKernelOp> {
+    // Each result is returned in a buffer the op allocates.
+    bool bufferizesToAllocation(Operation *op, Value value) const { return true; }
+
+    // The callee reads its operands.
+    bool bufferizesToMemoryRead(Operation *op, OpOperand &opOperand,
+                                const bufferization::AnalysisState &state) const
+    {
+        return true;
+    }
+
+    // Operands are not written in place: every result is returned in a separate allocation.
+    bool bufferizesToMemoryWrite(Operation *op, OpOperand &opOperand,
+                                 const bufferization::AnalysisState &state) const
+    {
+        return false;
+    }
+
+    // Results are fresh allocations, so they alias none of the operands.
+    bufferization::AliasingValueList
+    getAliasingValues(Operation *op, OpOperand &opOperand,
+                      const bufferization::AnalysisState &state) const
+    {
+        return {};
+    }
+
+    LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
+                            const bufferization::BufferizationOptions &options,
+                            bufferization::BufferizationState &state) const
+    {
+        auto launchOp = cast<LaunchKernelOp>(op);
+
+        SmallVector<Value> bufferOperands;
+        for (Value operand : launchOp.getInputs()) {
+            Value buffer;
+            if (isa<TensorType>(operand.getType())) {
+                FailureOr<Value> opBuffer = getBuffer(rewriter, operand, options, state);
+                if (failed(opBuffer)) {
+                    return failure();
+                }
+                buffer = *opBuffer;
+            }
+            else {
+                buffer = operand;
+            }
+
+            // The callee receives each operand as a contiguous block, addressed through the
+            // memref's aligned pointer with its strides/offset ignored. Copy any
+            // non-identity-layout operand into a fresh contiguous buffer first so the callee sees
+            // the intended elements.
+            if (auto memrefTy = dyn_cast<MemRefType>(buffer.getType())) {
+                if (!memrefTy.getLayout().isIdentity()) {
+                    MemRefType contiguousTy =
+                        MemRefType::get(memrefTy.getShape(), memrefTy.getElementType());
+                    auto alloc = memref::AllocOp::create(rewriter, op->getLoc(), contiguousTy);
+                    memref::CopyOp::create(rewriter, op->getLoc(), buffer, alloc.getResult());
+                    buffer = alloc.getResult();
+                }
+            }
+            bufferOperands.push_back(buffer);
+        }
+
+        SmallVector<Type> memrefResultTypes;
+        convertTypes(SmallVector<Type>(launchOp.getResultTypes()), memrefResultTypes);
+
+        auto newLaunchOp = LaunchKernelOp::create(
+            rewriter, op->getLoc(), memrefResultTypes, launchOp.getCallee(), bufferOperands,
+            launchOp.getArgAttrsAttr(), launchOp.getResAttrsAttr());
+        // Carry over any discardable attributes, since create() only sets the declared ones.
+        newLaunchOp->setDiscardableAttrs(launchOp->getDiscardableAttrDictionary());
+        bufferization::replaceOpWithBufferizedValues(rewriter, op, newLaunchOp.getResults());
+        return success();
+    }
+};
+
 } // namespace
 
 void catalyst::registerBufferizableOpInterfaceExternalModels(DialectRegistry &registry)
@@ -380,5 +461,6 @@ void catalyst::registerBufferizableOpInterfaceExternalModels(DialectRegistry &re
         CallbackOp::attachInterface<CallbackOpInterface>(*ctx);
         CallbackCallOp::attachInterface<CallbackCallOpInterface>(*ctx);
         SymbolicArrayOp::attachInterface<SymbolicArrayOpInterface>(*ctx);
+        LaunchKernelOp::attachInterface<LaunchKernelOpInterface>(*ctx);
     });
 }

--- a/mlir/test/Catalyst/LaunchKernelBufferization.mlir
+++ b/mlir/test/Catalyst/LaunchKernelBufferization.mlir
@@ -1,0 +1,55 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RUN: quantum-opt --split-input-file \
+// RUN:   --pass-pipeline="builtin.module( \
+// RUN:     one-shot-bufferize{unknown-type-conversion=identity-layout-map} \
+// RUN:   )" %s | FileCheck %s
+
+// CHECK-LABEL: func.func @host
+// CHECK: %[[ARG:.*]] = bufferization.to_buffer %{{.*}} : tensor<4xf64> to memref<4xf64>
+// CHECK: %[[RES:.*]] = catalyst.launch_kernel @target::@entry(%[[ARG]]) : (memref<4xf64>) -> memref<4xf64>
+// CHECK: bufferization.to_tensor %[[RES]]
+func.func @host(%arg0: tensor<4xf64>) -> tensor<4xf64> {
+  %0 = catalyst.launch_kernel @target::@entry(%arg0) : (tensor<4xf64>) -> tensor<4xf64>
+  return %0 : tensor<4xf64>
+}
+
+module @target {
+  func.func public @entry(%arg0: tensor<4xf64>) -> tensor<4xf64> {
+    return %arg0 : tensor<4xf64>
+  }
+}
+
+// -----
+
+// A non-identity-layout (strided/offset) operand must be copied into a fresh contiguous buffer
+// before the call.
+
+// CHECK-LABEL: func.func @host_strided
+// CHECK: %[[SUB:.*]] = memref.subview %{{.*}} : memref<8xf64> to memref<4xf64, strided<[1], offset: 2>>
+// CHECK: %[[ALLOC:.*]] = memref.alloc() : memref<4xf64>
+// CHECK: memref.copy %[[SUB]], %[[ALLOC]]
+// CHECK: catalyst.launch_kernel @target::@entry(%[[ALLOC]]) : (memref<4xf64>) -> memref<4xf64>
+func.func @host_strided(%arg0: tensor<8xf64>) -> tensor<4xf64> {
+  %slice = tensor.extract_slice %arg0[2] [4] [1] : tensor<8xf64> to tensor<4xf64>
+  %0 = catalyst.launch_kernel @target::@entry(%slice) : (tensor<4xf64>) -> tensor<4xf64>
+  return %0 : tensor<4xf64>
+}
+
+module @target {
+  func.func public @entry(%arg0: tensor<4xf64>) -> tensor<4xf64> {
+    return %arg0 : tensor<4xf64>
+  }
+}


### PR DESCRIPTION
**Context:**
Currently `catalyst.launch_kernel` has no BufferizableOpInterface implementation, so it can not pass through one-shot bufferization. This is needed for the remote-execution path, where a qnode is launched via launch_kernel and its tensor operands/results must be lowered to memrefs.

**Description of the Change:**
Adds a LaunchKernelOpInterface external model and registers it.

**Benefits:**
The `catalyst.launch_kernel` operation is now bufferizable.

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-124786]
