### PR TITLE
Fix:Python headers defined after system headers cause aliasing of _POSIX_C_SOURCE macro definition

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,7 +15,7 @@ IncludeBlocks: Regroup
 IncludeCategories:
   # Python & nanobind & pybind11
   - Regex: '^(")(pybind11|Python|nanobind)(\/.*)?\.([hp]+)(")$'
-    Priority: 0  
+    Priority: -1  
 
   # System/STL
   - Regex:    '^(<)(([^.]+)|((std.*|complex|sys.*|dlfcn)\.h))(>)$'

--- a/.clang-format
+++ b/.clang-format
@@ -13,12 +13,16 @@ IncludeBlocks: Regroup
 # NOTE: Ensure that lists are always sorted alphabetically.
 
 IncludeCategories:
+  # Python & nanobind & pybind11
+  - Regex: '^(")(Python|nanobind)(\/.*)?\.([hp]+)(")$'
+    Priority: 0  
+
   # System/STL
   - Regex:    '^(<)(([^.]+)|((std.*|complex|sys.*|dlfcn)\.h))(>)$'
     Priority: 1
 
   # Dependencies
-  - Regex:    '^(")(llvm|Enzyme|absl|boost|catch2|gmock|gtest|jax_cpu_lapack_kernels|mlir|nanobind|nlohmann|numpy|pybind11|Python|stablehlo|stim|toml\+\+|xla)(\/.*)?\.([hcp]+)(")$'
+  - Regex:    '^(")(llvm|Enzyme|absl|boost|catch2|gmock|gtest|jax_cpu_lapack_kernels|mlir|nlohmann|numpy|pybind11|stablehlo|stim|toml\+\+|xla)(\/.*)?\.([hcp]+)(")$'
     Priority: 2
 
   # Local headers

--- a/.clang-format
+++ b/.clang-format
@@ -14,7 +14,7 @@ IncludeBlocks: Regroup
 
 IncludeCategories:
   # Python & nanobind & pybind11
-  - Regex: '^(")(Python|nanobind)(\/.*)?\.([hp]+)(")$'
+  - Regex: '^(")(pybind11|Python|nanobind)(\/.*)?\.([hp]+)(")$'
     Priority: 0  
 
   # System/STL
@@ -22,7 +22,7 @@ IncludeCategories:
     Priority: 1
 
   # Dependencies
-  - Regex:    '^(")(llvm|Enzyme|absl|boost|catch2|gmock|gtest|jax_cpu_lapack_kernels|mlir|nlohmann|numpy|pybind11|stablehlo|stim|toml\+\+|xla)(\/.*)?\.([hcp]+)(")$'
+  - Regex:    '^(")(llvm|Enzyme|absl|boost|catch2|gmock|gtest|jax_cpu_lapack_kernels|mlir|nlohmann|numpy|stablehlo|stim|toml\+\+|xla)(\/.*)?\.([hcp]+)(")$'
     Priority: 2
 
   # Local headers

--- a/frontend/catalyst/third_party/oqc/src/oqc_python_module.cpp
+++ b/frontend/catalyst/third_party/oqc/src/oqc_python_module.cpp
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "pybind11/eval.h"
+#include "pybind11/pybind11.h"
+
 #include <algorithm>
 #include <cstring>
 #include <string>
 #include <vector>
-
-#include "pybind11/eval.h"
-#include "pybind11/pybind11.h"
 
 std::string program = R"(
 

--- a/frontend/catalyst/third_party/oqc/src/tests/Test_OQCDevice.cpp
+++ b/frontend/catalyst/third_party/oqc/src/tests/Test_OQCDevice.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "pybind11/embed.h"
+
 #include <cstdint>
 
 #include "catch2/catch_test_macros.hpp"

--- a/frontend/catalyst/third_party/oqc/src/tests/Test_OQCDevice.cpp
+++ b/frontend/catalyst/third_party/oqc/src/tests/Test_OQCDevice.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "pybind11/embed.h"
-
 #include <cstdint>
 
 #include "catch2/catch_test_macros.hpp"

--- a/frontend/catalyst/third_party/oqc/src/tests/Test_OQCDevice.cpp
+++ b/frontend/catalyst/third_party/oqc/src/tests/Test_OQCDevice.cpp
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "pybind11/embed.h"
+
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/matchers/catch_matchers_string.hpp"
-#include "pybind11/embed.h"
 
 #include "OQCDevice.cpp"
 

--- a/frontend/catalyst/utils/wrapper.cpp
+++ b/frontend/catalyst/utils/wrapper.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <csignal>
-
 #include "nanobind/nanobind.h"
+
+#include <csignal>
 
 // TODO: Periodically check and increment version.
 // https://endoflife.date/numpy

--- a/mlir/lib/Driver/DefaultPipelines/DefaultPipelines.cpp
+++ b/mlir/lib/Driver/DefaultPipelines/DefaultPipelines.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "Driver/DefaultPipelines/DefaultPipelines.h"
-
 #include "nanobind/nanobind.h"
 #include "nanobind/stl/string.h"
 #include "nanobind/stl/vector.h"

--- a/mlir/lib/Driver/DefaultPipelines/DefaultPipelines.cpp
+++ b/mlir/lib/Driver/DefaultPipelines/DefaultPipelines.cpp
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "Driver/DefaultPipelines/DefaultPipelines.h"
 #include "nanobind/nanobind.h"
 #include "nanobind/stl/string.h"
 #include "nanobind/stl/vector.h"
+
+#include "Driver/DefaultPipelines/DefaultPipelines.h"
 
 NB_MODULE(default_pipelines, m)
 {

--- a/mlir/lib/Quantum/Transforms/QuantumPythonDecompositions/PythonDriverUtils.hpp
+++ b/mlir/lib/Quantum/Transforms/QuantumPythonDecompositions/PythonDriverUtils.hpp
@@ -14,13 +14,13 @@
 
 #pragma once
 
+#include "nanobind/eval.h"
+#include "nanobind/nanobind.h"
+
 #include <functional>
 #include <iostream>
 #include <stdexcept>
 #include <string>
-
-#include "nanobind/eval.h"
-#include "nanobind/nanobind.h"
 
 constexpr const char sitePackagesScript[] = R"(
 import os

--- a/mlir/lib/Quantum/Transforms/QuantumPythonDecompositions/PythonFunction.cpp
+++ b/mlir/lib/Quantum/Transforms/QuantumPythonDecompositions/PythonFunction.cpp
@@ -12,20 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "nanobind/nanobind.h"
-#include "nanobind/stl/string.h" // for automatic string conversion
-#include "nanobind/stl/vector.h" // for automatic vector conversion
-
 #include <exception>
 #include <string>
-#include <vector>
 
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/TypeRange.h"
+#include "nanobind/nanobind.h"
+#include "nanobind/stl/string.h" // for automatic string conversion
+#include "nanobind/stl/vector.h" // for automatic vector conversion
 
+#include <string>
+#include <vector>
 #include "Quantum/IR/QuantumInterfaces.h"
 
 #include "PythonDriverUtils.hpp"

--- a/mlir/lib/Quantum/Transforms/QuantumPythonDecompositions/PythonFunction.cpp
+++ b/mlir/lib/Quantum/Transforms/QuantumPythonDecompositions/PythonFunction.cpp
@@ -12,20 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "nanobind/nanobind.h"
+#include "nanobind/stl/string.h" // for automatic string conversion
+#include "nanobind/stl/vector.h" // for automatic vector conversion
+
 #include <exception>
 #include <string>
+#include <vector>
 
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/TypeRange.h"
-#include "nanobind/nanobind.h"
-#include "nanobind/stl/string.h" // for automatic string conversion
-#include "nanobind/stl/vector.h" // for automatic vector conversion
 
-#include <string>
-#include <vector>
 #include "Quantum/IR/QuantumInterfaces.h"
 
 #include "PythonDriverUtils.hpp"

--- a/mlir/lib/Quantum/Transforms/QuantumPythonDecompositions/PythonFunction.cpp
+++ b/mlir/lib/Quantum/Transforms/QuantumPythonDecompositions/PythonFunction.cpp
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <string>
-#include <vector>
-
 #include "nanobind/nanobind.h"
 #include "nanobind/stl/string.h" // for automatic string conversion
 #include "nanobind/stl/vector.h" // for automatic vector conversion
+
+#include <string>
+#include <vector>
 
 #include "PythonDriverUtils.hpp"
 

--- a/runtime/lib/backend/openqasm/openqasm_python_module.cpp
+++ b/runtime/lib/backend/openqasm/openqasm_python_module.cpp
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "nanobind/eval.h"
+#include "nanobind/nanobind.h"
+#include "nanobind/stl/string.h"
+
 #include <cmath>
 #include <cstring>
 #include <string>
 #include <vector>
-
-#include "nanobind/eval.h"
-#include "nanobind/nanobind.h"
-#include "nanobind/stl/string.h"
 
 const std::string program = R"(
 import numpy as np

--- a/runtime/lib/registry/Registry.cpp
+++ b/runtime/lib/registry/Registry.cpp
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "nanobind/nanobind.h"
+#include "nanobind/stl/string.h"
+
 #include <cstdint>
 #include <dlfcn.h>
 #include <string>
 #include <unordered_map>
-
-#include "nanobind/nanobind.h"
-#include "nanobind/stl/string.h"
 
 namespace nb = nanobind;
 

--- a/runtime/tests/Test_OpenQasmDevice.cpp
+++ b/runtime/tests/Test_OpenQasmDevice.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "pybind11/embed.h"
+
 #include <cstdint>
 
 #include "catch2/catch_test_macros.hpp"

--- a/runtime/tests/Test_OpenQasmDevice.cpp
+++ b/runtime/tests/Test_OpenQasmDevice.cpp
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "pybind11/embed.h"
-
 #include <cstdint>
 
 #include "catch2/catch_test_macros.hpp"

--- a/runtime/tests/Test_OpenQasmDevice.cpp
+++ b/runtime/tests/Test_OpenQasmDevice.cpp
@@ -12,10 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "pybind11/embed.h"
+
 #include "catch2/catch_test_macros.hpp"
 #include "catch2/matchers/catch_matchers_floating_point.hpp"
 #include "catch2/matchers/catch_matchers_string.hpp"
-#include "pybind11/embed.h"
 
 #include "MemRefUtils.hpp"
 #include "OpenQasmBuilder.hpp"


### PR DESCRIPTION
**Context:**
Python headers defined after system headers cause aliasing of _POSIX_C_SOURCE macro definition
**Description of the Change:**
Reordered includes: moved Python and nanobind headers to the top of the include list.
**Benefits:**
building with recent version of gcc/clang (15/22)
**Possible Drawbacks:**

**Related GitHub Issues:**
Closes #2962
