### PR TITLE
PCPhase op's `dim` parameter is static

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -178,7 +178,7 @@
 * Removes support for `Transform.plxpr_transform` from the `qp.qjit(capture=True)` capture pipeline.
   All transforms must now have a MLIR or XDSL implementation and a corresponding `pass_name`.
 
-* Support for `qjit` integration with `cudaq` has been removed in order to feasbily drop support 
+* Support for `qjit` integration with `cudaq` has been removed in order to feasbily drop support
   for Python 3.11.
   [(#2984)](https://github.com/PennyLaneAI/catalyst/pull/2984)
 
@@ -242,9 +242,15 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* The `dim` argument of the `quantum.pcphase` operation has been changed to a static integer attribute
+  (previously a dynamic float operand). This allows, among other things, the decomposition graph to
+  distinguish pcphase gates with different `dim` values, since they need different decomposition rules.
+  [(#3034)](https://github.com/PennyLaneAI/catalyst/pull/3034)
+
 * The `cond` PLxPR primitive's lowering rule no longer expects a `True` Literal for the predicate
   of the default else branch.
   [(#3018)](https://github.com/PennyLaneAI/catalyst/pull/3018)
+
 * Add the `DecomposableGate` op interface to allow generic handling of operations in the `graph-decomposition` pass. This allows arbitrary operations implementing the interface to be registered to and decomposed by the graph. This also allows the use of python-decompositions for any operator pre-registered in the frontend graph.
   [(#2983)](https://github.com/PennyLaneAI/catalyst/pull/2983)
 

--- a/frontend/catalyst/from_plxpr/qfunc_interpreter.py
+++ b/frontend/catalyst/from_plxpr/qfunc_interpreter.py
@@ -398,22 +398,20 @@ def _pcphase_bind_call(*invals, op, qubits_len, params_len, ctrl_len, adjoint, h
     # supporting general PL operations in the capture framework.
     # See https://docs.pennylane.ai/en/stable/code/api/pennylane.PCPhase.html
     dim = hyperparameters["dimension"][0]
-    params_len += 1
 
-    ctrl_inputs = invals[qubits_len + 2 :]
-    ctrl_wires = invals[qubits_len + 1 : -len(ctrl_inputs)]
+    # invals are [*wires, theta, *ctrl_wires, *ctrl_vals]
+    ctrl_inputs = invals[qubits_len + 1 :]
 
     return qref_qinst_p.bind(
         *wires,
         angle,
-        dim,
-        *ctrl_wires,
         *ctrl_inputs,
         op=op,
         qubits_len=qubits_len,
         params_len=params_len,
         ctrl_len=ctrl_len,
         adjoint=adjoint,
+        pcphase_dim=dim,
     )
 
 

--- a/frontend/catalyst/from_plxpr/qref_jax_primitives.py
+++ b/frontend/catalyst/from_plxpr/qref_jax_primitives.py
@@ -307,7 +307,7 @@ def _qref_qinst_abstract_eval(
     # does not need to carry the PCPhase around
     # Or as an alternative, expand the kwarg so that it can be an arbitrary kwarg list for a general
     # primitive's attributes
-    assert not (pcphase_dim is not None) ^ (op == "PCPhase")
+    assert (pcphase_dim is not None) == (op == "PCPhase"), "pcphase_dim must be provided exactly for PCPhase ops"
     return ()
 
 

--- a/frontend/catalyst/from_plxpr/qref_jax_primitives.py
+++ b/frontend/catalyst/from_plxpr/qref_jax_primitives.py
@@ -285,6 +285,7 @@ def _qref_set_basis_state_lowering(jax_ctx: mlir.LoweringRuleContext, *qubits_or
 #
 # qref_qinst_p
 #
+# pylint: disable=too-many-arguments
 @qref_qinst_p.def_abstract_eval
 def _qref_qinst_abstract_eval(
     *qubits_or_params,
@@ -306,7 +307,7 @@ def _qref_qinst_abstract_eval(
     # does not need to carry the PCPhase around
     # Or as an alternative, expand the kwarg so that it can be an arbitrary kwarg list for a general
     # primitive's attributes
-    assert not ((pcphase_dim is not None) ^ (op == "PCPhase"))
+    assert not (pcphase_dim is not None) ^ (op == "PCPhase")
     return ()
 
 

--- a/frontend/catalyst/from_plxpr/qref_jax_primitives.py
+++ b/frontend/catalyst/from_plxpr/qref_jax_primitives.py
@@ -287,7 +287,13 @@ def _qref_set_basis_state_lowering(jax_ctx: mlir.LoweringRuleContext, *qubits_or
 #
 @qref_qinst_p.def_abstract_eval
 def _qref_qinst_abstract_eval(
-    *qubits_or_params, op=None, qubits_len=0, params_len=0, ctrl_len=0, adjoint=False
+    *qubits_or_params,
+    op=None,
+    qubits_len=0,
+    params_len=0,
+    ctrl_len=0,
+    adjoint=False,
+    pcphase_dim=None,
 ):
     # The signature here is: (using * to denote zero or more)
     # qubits*, params*, ctrl_qubits*, ctrl_values*
@@ -295,6 +301,12 @@ def _qref_qinst_abstract_eval(
     ctrl_qubits = qubits_or_params[-2 * ctrl_len : -ctrl_len]
     all_qubits = qubits + ctrl_qubits
     assert all(isinstance(qubit, AbstractQubit) for qubit in all_qubits[: qubits_len + ctrl_len])
+
+    # TODO: make a specialized primitive for PCPhase so that the main qinst primitive's kwarg
+    # does not need to carry the PCPhase around
+    # Or as an alternative, expand the kwarg so that it can be an arbitrary kwarg list for a general
+    # primitive's attributes
+    assert not ((pcphase_dim is not None) ^ (op == "PCPhase"))
     return ()
 
 
@@ -307,6 +319,7 @@ def _qref_qinst_lowering(
     params_len=0,
     ctrl_len=0,
     adjoint=False,
+    pcphase_dim=None,
 ):
     ctx = jax_ctx.module_context.context
     ctx.allow_unregistered_dialects = True
@@ -354,12 +367,11 @@ def _qref_qinst_lowering(
         return ()
 
     if name_str == "PCPhase":
-        assert len(float_params) == 2, "PCPhase takes two float parameters"
-        float_param = float_params[0]
-        dim_param = float_params[1]
+        assert len(float_params) == 1, "PCPhase takes one float parameter (theta)"
+        theta = float_params[0]
         PCPhaseOp(
-            theta=float_param,
-            dim=dim_param,
+            theta=theta,
+            dim=ir.IntegerAttr.get(ir.IntegerType.get_signless(64, ctx), pcphase_dim),
             qubits=qubits,
             ctrl_qubits=ctrl_qubits,
             ctrl_values=ctrl_values_i1,

--- a/frontend/catalyst/from_plxpr/qref_jax_primitives.py
+++ b/frontend/catalyst/from_plxpr/qref_jax_primitives.py
@@ -307,7 +307,9 @@ def _qref_qinst_abstract_eval(
     # does not need to carry the PCPhase around
     # Or as an alternative, expand the kwarg so that it can be an arbitrary kwarg list for a general
     # primitive's attributes
-    assert (pcphase_dim is not None) == (op == "PCPhase"), "pcphase_dim must be provided exactly for PCPhase ops"
+    assert (pcphase_dim is not None) == (
+        op == "PCPhase"
+    ), "pcphase_dim must be provided exactly for PCPhase ops"
     return ()
 
 

--- a/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
+++ b/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
@@ -228,7 +228,6 @@ def _qref_operator_p_lowering(jax_ctx: mlir.LoweringRuleContext, *args, op_cls, 
     if op_cls.__name__ in _SPECIAL_LOWERINGS:
         expected_len = len(op_cls.dynamic_argnames) + sum(wire_lens)
         assert len(args) == expected_len, f"Incorrect number of operands for {op_cls.__name__}."
-
         return _SPECIAL_LOWERINGS[op_cls.__name__](
             *args, ctrl_qubits=ctrl_qubits, ctrl_values=ctrl_values, adjoint=adjoint, **kwargs
         )
@@ -317,10 +316,11 @@ def _multirz_lowering(theta, *qubits, ctrl_qubits, ctrl_values, adjoint):
 
 
 @_register_special_lowering("PCPhase")
-def _pcphase_lowering(theta, dim, *qubits, ctrl_qubits, ctrl_values, adjoint):
+def _pcphase_lowering(theta, *qubits, ctrl_qubits, ctrl_values, adjoint, dim):
+    dim = unflatten(*dim)
     PCPhaseOp(
         theta=extract_scalar(safe_cast_to_f64(theta, "PCPhase"), "PCPhase"),
-        dim=extract_scalar(safe_cast_to_f64(dim, "PCPhase"), "PCPhase"),
+        dim=get_mlir_attribute_from_pyval(dim),
         qubits=qubits,
         ctrl_qubits=ctrl_qubits,
         ctrl_values=ctrl_values,

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1352,7 +1352,13 @@ def _gphase_lowering(
 #
 @qinst_p.def_abstract_eval
 def _qinst_abstract_eval(
-    *qubits_or_params, op=None, qubits_len=0, params_len=0, ctrl_len=0, adjoint=False
+    *qubits_or_params,
+    op=None,
+    qubits_len=0,
+    params_len=0,
+    ctrl_len=0,
+    adjoint=False,
+    pcphase_dim=None,
 ):
     # The signature here is: (using * to denote zero or more)
     # qubits*, params*, ctrl_qubits*, ctrl_values*
@@ -1362,6 +1368,7 @@ def _qinst_abstract_eval(
     for idx in range(qubits_len + ctrl_len):
         qubit = all_qubits[idx]
         assert isinstance(qubit, AbstractQbit)
+    assert not ((pcphase_dim is not None) ^ (op == "PCPhase"))
     return (AbstractQbit(),) * (qubits_len + ctrl_len)
 
 
@@ -1379,6 +1386,7 @@ def _qinst_lowering(
     params_len=0,
     ctrl_len=0,
     adjoint=False,
+    pcphase_dim=None,
 ):
     ctx = jax_ctx.module_context.context
     ctx.allow_unregistered_dialects = True
@@ -1427,14 +1435,13 @@ def _qinst_lowering(
         ).results
 
     if name_str == "PCPhase":
-        assert len(float_params) == 2, "PCPhase takes two float parameters"
+        assert len(float_params) == 1, "PCPhase takes one float parameter (theta)"
         float_param = float_params[0]
-        dim_param = float_params[1]
         return PCPhaseOp(
             out_qubits=[qubit.type for qubit in qubits],
             out_ctrl_qubits=[qubit.type for qubit in ctrl_qubits],
             theta=float_param,
-            dim=dim_param,
+            dim=ir.IntegerAttr.get(ir.IntegerType.get_signless(64, ctx), pcphase_dim),
             in_qubits=qubits,
             in_ctrl_qubits=ctrl_qubits,
             in_ctrl_values=ctrl_values_i1,

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1368,7 +1368,9 @@ def _qinst_abstract_eval(
     for idx in range(qubits_len + ctrl_len):
         qubit = all_qubits[idx]
         assert isinstance(qubit, AbstractQbit)
-    assert (pcphase_dim is not None) == (op == "PCPhase"), "pcphase_dim must be provided exactly for PCPhase ops"
+    assert (pcphase_dim is not None) == (
+        op == "PCPhase"
+    ), "pcphase_dim must be provided exactly for PCPhase ops"
     return (AbstractQbit(),) * (qubits_len + ctrl_len)
 
 

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1368,7 +1368,7 @@ def _qinst_abstract_eval(
     for idx in range(qubits_len + ctrl_len):
         qubit = all_qubits[idx]
         assert isinstance(qubit, AbstractQbit)
-    assert not ((pcphase_dim is not None) ^ (op == "PCPhase"))
+    assert not (pcphase_dim is not None) ^ (op == "PCPhase")
     return (AbstractQbit(),) * (qubits_len + ctrl_len)
 
 

--- a/frontend/catalyst/jax_primitives.py
+++ b/frontend/catalyst/jax_primitives.py
@@ -1368,7 +1368,7 @@ def _qinst_abstract_eval(
     for idx in range(qubits_len + ctrl_len):
         qubit = all_qubits[idx]
         assert isinstance(qubit, AbstractQbit)
-    assert not (pcphase_dim is not None) ^ (op == "PCPhase")
+    assert (pcphase_dim is not None) == (op == "PCPhase"), "pcphase_dim must be provided exactly for PCPhase ops"
     return (AbstractQbit(),) * (qubits_len + ctrl_len)
 
 

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -910,11 +910,8 @@ def trace_quantum_operations(
             # which does not follow the same pattern as `qinst_p`.
             # We will revisit this once we have a better solution for
             # supporting general PL operations in Catalyst.
-            params = (
-                op.parameters + [op.hyperparameters["dimension"][0]]
-                if isinstance(op, qp.PCPhase)
-                else op.parameters
-            )
+            params = op.parameters
+            pcphase_dim = op.hyperparameters["dimension"][0] if isinstance(op, qp.PCPhase) else None
 
             qubits2 = qinst_p.bind(
                 *[*qubits, *params, *controlled_qubits, *controlled_values],
@@ -923,6 +920,7 @@ def trace_quantum_operations(
                 params_len=len(params),
                 ctrl_len=len(controlled_qubits),
                 adjoint=adjoint,
+                pcphase_dim=pcphase_dim,
             )
             qrp.insert(op.wires, qubits2[: len(qubits)])
             qrp.insert(controlled_wires, qubits2[len(qubits) :])

--- a/frontend/catalyst/python_interface/dialects/quantum/operations/gate_ops.py
+++ b/frontend/catalyst/python_interface/dialects/quantum/operations/gate_ops.py
@@ -20,9 +20,11 @@ from collections.abc import Sequence
 from typing import ClassVar
 
 from xdsl.dialects.builtin import (
+    I64,
     ArrayAttr,
     ComplexType,
     Float64Type,
+    IntegerAttr,
     IntegerType,
     MemRefType,
     StringAttr,
@@ -32,6 +34,7 @@ from xdsl.dialects.builtin import (
 )
 from xdsl.ir import Operation, SSAValue
 from xdsl.irdl import (
+    AtLeast,
     AttrSizedOperandSegments,
     AttrSizedResultSegments,
     IRDLOperation,
@@ -388,7 +391,7 @@ class PCPhaseOp(UnitaryGateOp):
     name = "quantum.pcphase"
 
     assembly_format = """
-        `(` $theta `,` $dim `)` $in_qubits
+        `(` $theta `,` `dim` `:` $dim `)` $in_qubits
         (`adj` $adjoint^)?
         attr-dict
         ( `ctrls` `(` $in_ctrl_qubits^ `)` )?
@@ -403,7 +406,7 @@ class PCPhaseOp(UnitaryGateOp):
 
     theta = operand_def(Float64Type())
 
-    dim = operand_def(Float64Type())
+    dim = opt_prop_def(IntegerAttr.constr(type=I64, value=AtLeast(0)))
 
     in_qubits = var_operand_def(QubitType)
 
@@ -424,7 +427,7 @@ class PCPhaseOp(UnitaryGateOp):
         self,
         *,
         theta: SSAValue[Float64Type],
-        dim: SSAValue[Float64Type],
+        dim: IntegerAttr | int,
         in_qubits: QubitSSAValue | Operation | Sequence[QubitSSAValue | Operation],
         in_ctrl_qubits: (
             QubitSSAValue | Operation | Sequence[QubitSSAValue | Operation] | None
@@ -450,10 +453,14 @@ class PCPhaseOp(UnitaryGateOp):
 
         out_qubits = tuple(QubitType() for _ in in_qubits)
         out_ctrl_qubits = tuple(QubitType() for _ in in_ctrl_qubits)
-        properties = {"adjoint": UnitAttr()} if adjoint else {}
+
+        dim_attr = IntegerAttr(dim, 64) if isinstance(dim, int) else dim
+        properties = {"dim": dim_attr}
+        if adjoint:
+            properties["adjoint"] = UnitAttr()
 
         super().__init__(
-            operands=(theta, dim, in_qubits, in_ctrl_qubits, in_ctrl_values),
+            operands=(theta, in_qubits, in_ctrl_qubits, in_ctrl_values),
             result_types=(out_qubits, out_ctrl_qubits),
             properties=properties,
         )

--- a/frontend/test/lit/test_from_plxpr.py
+++ b/frontend/test/lit/test_from_plxpr.py
@@ -156,7 +156,7 @@ def test_dynamic_wire():
 
         # CHECK: [[SCALAR:%.+]] = tensor.extract %arg0[] : tensor<i64>
         # CHECK: [[q_w1:%.+]] = qref.get [[QREG]][[[SCALAR]]] : !qref.reg<3>, i64 -> !qref.bit
-        # CHECK: qref.pcphase({{%.+}}, {{%.+}}) [[q_w1]] : !qref.bit
+        # CHECK: qref.pcphase({{%.+}}, dim : 1) [[q_w1]] : !qref.bit
         qp.PCPhase(0.5, wires=w1, dim=1)
 
         return qp.state()

--- a/frontend/test/lit/test_multi_qubit_gates.py
+++ b/frontend/test/lit/test_multi_qubit_gates.py
@@ -39,7 +39,7 @@ def circuit(x: float):
     # CHECK: {{%.+}} = quantum.multirz({{%.+}}) {{%.+}}, {{%.+}}, {{%.+}}, {{%.+}}, {{%.+}} : !quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit
     qp.MultiRZ(x, wires=[0, 1, 2, 3, 4])
 
-    # CHECK: {{%.+}} = quantum.pcphase({{%.+}}, {{%.+}}) {{%.+}}, {{%.+}}, {{%.+}} : !quantum.bit, !quantum.bit, !quantum.bit
+    # CHECK: {{%.+}} = quantum.pcphase({{%.+}}, dim : 0) {{%.+}}, {{%.+}}, {{%.+}} : !quantum.bit, !quantum.bit, !quantum.bit
     qp.PCPhase(x, dim=0, wires=[0, 1, 2])
 
     return measure(wires=0)

--- a/frontend/test/lit/test_operator.py
+++ b/frontend/test/lit/test_operator.py
@@ -499,7 +499,8 @@ print(circuit_qubitunitary.mlir)
 
 class PCPhase(qp.core.Operator2):
 
-    dynamic_argnames = ("phi", "dim")
+    dynamic_argnames = ("phi",)
+    compilable_argnames = ("dim",)
 
     def __init__(self, phi, dim, wires):
         super().__init__(phi, dim, wires)
@@ -507,15 +508,15 @@ class PCPhase(qp.core.Operator2):
 
 @qp.qjit(capture=True, target="mlir")
 @qp.qnode(qp.device("lightning.qubit", wires=3))
-def c_pcphase(x: float, dim: int):
+def c_pcphase(x: float):
     # CHECK-LABEL: func.func public @c_pcphase
     # CHECK: [[false:%.+]] = arith.constant false
 
     # CHECK: [[q11:%.+]] = qref.get {{%.+}}[ 0]
     # CHECK: [[q12:%.+]] = qref.get {{%.+}}[ 1]
-    # CHECK: qref.pcphase({{%.+}}, {{%.+}}) [[q11]], [[q12]] : !qref.bit, !qref.bit
+    # CHECK: qref.pcphase({{%.+}}, dim : 0) [[q11]], [[q12]] : !qref.bit, !qref.bit
 
-    PCPhase(x, dim, (0, 1))
+    PCPhase(x, 0, (0, 1))
 
     # CHECK: [[q3:%.+]] = qref.get {{%.+}}[ 0]
     # CHECK: [[q4:%.+]] = qref.get {{%.+}}[ 1]
@@ -523,10 +524,10 @@ def c_pcphase(x: float, dim: int):
 
     # PCPhase gets automatically canonicalized, so it will never have the `adj` attribute
     # CHECK: [[theta:%.+]] = arith.negf {{%.+}} : f64
-    # CHECK: qref.pcphase([[theta]], {{%.+}}) [[q3]], [[q4]] ctrls([[q5]]) ctrlvals([[false]]) :
+    # CHECK: qref.pcphase([[theta]], dim : 3) [[q3]], [[q4]] ctrls([[q5]]) ctrlvals([[false]]) :
     # CHECK-SAME: !qref.bit, !qref.bit ctrls !qref.bit
 
-    qp.ctrl(qp.adjoint(PCPhase(x, dim, (0, 1))), [2], [False])
+    qp.ctrl(qp.adjoint(PCPhase(x, 3, (0, 1))), [2], [False])
     return qp.state()
 
 

--- a/frontend/test/lit/test_qref/test_flat_circuits.py
+++ b/frontend/test/lit/test_qref/test_flat_circuits.py
@@ -143,7 +143,7 @@ def test_dynamic_qubit_allocation(i: int):
         # CHECK: qref.multirz({{%.+}}) [[alloc_q1]] : !qref.bit
         qp.MultiRZ(0.1, wires=q[1])
 
-        # CHECK: qref.pcphase({{%.+}}, {{%.+}}) [[alloc_q0]], [[alloc_q1]] : !qref.bit, !qref.bit
+        # CHECK: qref.pcphase({{%.+}}, dim : 0) [[alloc_q0]], [[alloc_q1]] : !qref.bit, !qref.bit
         qp.PCPhase(0.1, dim=0, wires=[q[0], q[1]])
 
         # CHECK: qref.gphase({{%.+}}) ctrls([[alloc_q0]]) ctrlvals({{%.+}}) : ctrls !qref.bit
@@ -213,8 +213,6 @@ def test_pcphase():
     Test pcphase.
     """
     # CHECK-DAG: [[true:%.+]] = arith.constant true
-    # CHECK-DAG: [[stablehlo_two:%.+]] = stablehlo.constant dense<2> : tensor<i64>
-    # CHECK-DAG: [[stablehlo_one:%.+]] = stablehlo.constant dense<1> : tensor<i64>
     # CHECK-DAG: [[angle:%.+]] = arith.constant 1.000000e-01 : f64
 
     # CHECK: [[reg:%.+]] = qref.alloc( 3) : !qref.reg<3>
@@ -222,17 +220,13 @@ def test_pcphase():
     # CHECK: [[q0:%.+]] = qref.get [[reg]][ 0] : !qref.reg<3> -> !qref.bit
     # CHECK: [[q1:%.+]] = qref.get [[reg]][ 1] : !qref.reg<3> -> !qref.bit
     # CHECK: [[q2:%.+]] = qref.get [[reg]][ 2] : !qref.reg<3> -> !qref.bit
-    # CHECK: [[_two:%.+]] = stablehlo.convert [[stablehlo_two]] : (tensor<i64>) -> tensor<f64>
-    # CHECK: [[dim_2:%.+]] = tensor.extract [[_two]][] : tensor<f64>
-    # CHECK: qref.pcphase([[angle]], [[dim_2]]) [[q0]], [[q1]], [[q2]] : !qref.bit, !qref.bit, !qref.bit
+    # CHECK: qref.pcphase([[angle]], dim : 2) [[q0]], [[q1]], [[q2]] : !qref.bit, !qref.bit, !qref.bit
     qp.PCPhase(0.1, dim=2, wires=[0, 1, 2])
 
     # CHECK: [[q1:%.+]] = qref.get [[reg]][ 1] : !qref.reg<3> -> !qref.bit
     # CHECK: [[q2:%.+]] = qref.get [[reg]][ 2] : !qref.reg<3> -> !qref.bit
     # CHECK: [[q0:%.+]] = qref.get [[reg]][ 0] : !qref.reg<3> -> !qref.bit
-    # CHECK: [[_one:%.+]] = stablehlo.convert [[stablehlo_one]] : (tensor<i64>) -> tensor<f64>
-    # CHECK: [[dim_1:%.+]] = tensor.extract [[_one]][] : tensor<f64>
-    # CHECK: qref.pcphase([[angle]], [[dim_1]]) [[q1]], [[q2]] ctrls([[q0]]) ctrlvals([[true]]) : !qref.bit, !qref.bit ctrls !qref.bit
+    # CHECK: qref.pcphase([[angle]], dim : 1) [[q1]], [[q2]] ctrls([[q0]]) ctrlvals([[true]]) : !qref.bit, !qref.bit ctrls !qref.bit
     qp.ctrl(qp.PCPhase, control=0, control_values=True)(0.1, dim=1, wires=[1, 2])
 
     return qp.expval(qp.X(0))

--- a/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
+++ b/frontend/test/pytest/python_interface/dialects/test_quantum_dialect.py
@@ -486,16 +486,16 @@ class TestAssemblyFormat:
 
         ////////////////// **PCPhaseOp tests** //////////////////
         // No control wires
-        // CHECK: {{%.+}}, {{%.+}}, {{%.+}} = quantum.pcphase([[PARAM1]], [[PARAM2]]) [[Q0]], [[Q1]], [[Q2]] : !quantum.bit, !quantum.bit, !quantum.bit
-        %qp1, %qp2, %qp3 = quantum.pcphase(%param1, %param2) %q0, %q1, %q2 : !quantum.bit, !quantum.bit, !quantum.bit
+        // CHECK: {{%.+}}, {{%.+}}, {{%.+}} = quantum.pcphase([[PARAM1]], dim : 1) [[Q0]], [[Q1]], [[Q2]] : !quantum.bit, !quantum.bit, !quantum.bit
+        %qp1, %qp2, %qp3 = quantum.pcphase(%param1, dim : 1) %q0, %q1, %q2 : !quantum.bit, !quantum.bit, !quantum.bit
 
         // Control wires and values
-        // CHECK: {{%.+}}, {{%.+}}, {{%.+}} = quantum.pcphase([[PARAM1]], [[PARAM2]]) [[Q0]], [[Q1]] ctrls([[Q2]]) ctrlvals([[TRUE_CST]]) : !quantum.bit, !quantum.bit ctrls !quantum.bit
-        %qp4, %qp5, %qp6 = quantum.pcphase(%param1, %param2) %q0, %q1 ctrls(%q2) ctrlvals(%true_cst) : !quantum.bit, !quantum.bit ctrls !quantum.bit
+        // CHECK: {{%.+}}, {{%.+}}, {{%.+}} = quantum.pcphase([[PARAM1]], dim : 0) [[Q0]], [[Q1]] ctrls([[Q2]]) ctrlvals([[TRUE_CST]]) : !quantum.bit, !quantum.bit ctrls !quantum.bit
+        %qp4, %qp5, %qp6 = quantum.pcphase(%param1, dim : 0) %q0, %q1 ctrls(%q2) ctrlvals(%true_cst) : !quantum.bit, !quantum.bit ctrls !quantum.bit
 
         // Adjoint
-        // CHECK: {{%.+}}, {{%.+}} = quantum.pcphase([[PARAM1]], [[PARAM2]]) [[Q0]], [[Q1]] adj : !quantum.bit, !quantum.bit
-        %qp7, %qp8 = quantum.pcphase(%param1, %param2) %q0, %q1 adj : !quantum.bit, !quantum.bit
+        // CHECK: {{%.+}}, {{%.+}} = quantum.pcphase([[PARAM1]], dim : 2) [[Q0]], [[Q1]] adj : !quantum.bit, !quantum.bit
+        %qp7, %qp8 = quantum.pcphase(%param1, dim : 2) %q0, %q1 adj : !quantum.bit, !quantum.bit
 
         ////////////////// **QubitUnitaryOp tests** //////////////////
         // No control wires

--- a/frontend/test/pytest/test_operator.py
+++ b/frontend/test/pytest/test_operator.py
@@ -176,8 +176,24 @@ class TestOperator2Execution:
         assert qp.math.allclose(r1, -1)
         assert qp.math.allclose(r2, -1)
 
-    @pytest.mark.parametrize("dim", [2, 3])
-    def test_PCPhase(self, dim):
+    @pytest.mark.parametrize(
+        "dim, expected",
+        [
+            (
+                2,
+                jnp.array(
+                    [jnp.exp(0.5j) / 2, jnp.exp(0.5j) / 2, jnp.exp(-0.5j) / 2, jnp.exp(-0.5j) / 2]
+                ),
+            ),
+            (
+                3,
+                jnp.array(
+                    [jnp.exp(0.5j) / 2, jnp.exp(0.5j) / 2, jnp.exp(0.5j) / 2, jnp.exp(-0.5j) / 2]
+                ),
+            ),
+        ],
+    )
+    def test_PCPhase(self, dim, expected):
         """Test that PCPhase can be executed."""
 
         @qp.qjit(capture=True)
@@ -189,12 +205,4 @@ class TestOperator2Execution:
             return qp.state()
 
         state = c(0.5)
-
-        plus = jnp.exp(0.5j) / 2
-        minus = jnp.exp(-0.5j) / 2
-        if dim == 2:
-            expected = jnp.array([plus, plus, minus, minus])
-        if dim == 3:
-            expected = jnp.array([plus, plus, plus, minus])
-
         assert qp.math.allclose(state, expected)

--- a/frontend/test/pytest/test_operator.py
+++ b/frontend/test/pytest/test_operator.py
@@ -16,7 +16,9 @@ Tests for the new Operator2 class.
 """
 
 # pylint: disable = useless-parent-delegation, missing-function-docstring, missing-class-docstring
+
 import pennylane as qp
+import pytest
 from jax import numpy as jnp
 
 
@@ -90,7 +92,8 @@ class QubitUnitary(qp.core.Operator2):
 
 class PCPhase(qp.core.Operator2):
 
-    dynamic_argnames = ("phi", "dim")
+    dynamic_argnames = ("phi",)
+    compilable_argnames = ("dim",)
 
     def __init__(self, phi, dim, wires):
         super().__init__(phi, dim, wires)
@@ -173,23 +176,25 @@ class TestOperator2Execution:
         assert qp.math.allclose(r1, -1)
         assert qp.math.allclose(r2, -1)
 
-    def test_PCPhase(self):
+    @pytest.mark.parametrize("dim", [2, 3])
+    def test_PCPhase(self, dim):
         """Test that PCPhase can be executed."""
 
         @qp.qjit(capture=True)
         @qp.qnode(qp.device("lightning.qubit", wires=2))
-        def c(x, dim):
+        def c(x):
             Hadamard(0)
             Hadamard(1)
             PCPhase(x, dim, (0, 1))
             return qp.state()
 
-        state2 = c(0.5, 2)
+        state = c(0.5)
+
         plus = jnp.exp(0.5j) / 2
         minus = jnp.exp(-0.5j) / 2
-        expected2 = jnp.array([plus, plus, minus, minus])
-        assert qp.math.allclose(state2, expected2)
+        if dim == 2:
+            expected = jnp.array([plus, plus, minus, minus])
+        if dim == 3:
+            expected = jnp.array([plus, plus, plus, minus])
 
-        state3 = c(0.5, 3)
-        expected3 = jnp.array([plus, plus, plus, minus])
-        assert qp.math.allclose(state3, expected3)
+        assert qp.math.allclose(state, expected)

--- a/mlir/include/QRef/IR/QRefOps.td
+++ b/mlir/include/QRef/IR/QRefOps.td
@@ -604,15 +604,11 @@ def PCPhaseOp : UnitaryGate_Op<"pcphase", [ParametrizedGate, AttrSizedOperandSeg
             to be handled in a special way during the lowering due to its C function being variadic
             on the number of qubits.
 
-        .. note::
-            `dim` is currently captured as a float number for compatibility with
-            runtime and device integration.
-
     }];
 
     let arguments = (ins
         F64:$theta,
-        F64:$dim,
+        I64Attr:$dim,
         Variadic<QubitRefType>:$qubits,
         UnitAttr:$adjoint,
         Variadic<QubitRefType>:$ctrl_qubits,
@@ -620,7 +616,7 @@ def PCPhaseOp : UnitaryGate_Op<"pcphase", [ParametrizedGate, AttrSizedOperandSeg
     );
 
     let assemblyFormat = [{
-        `(` $theta `,` $dim `)` $qubits (`adj` $adjoint^)? attr-dict
+        `(` $theta `,` `dim` `:` $dim `)` $qubits (`adj` $adjoint^)? attr-dict
         ( `ctrls` `(` $ctrl_qubits^ `)` )?
         ( `ctrlvals` `(` $ctrl_values^ `)` )?
         `:` type($qubits) (`ctrls` type($ctrl_qubits)^ )?

--- a/mlir/include/Quantum/IR/QuantumOps.td
+++ b/mlir/include/Quantum/IR/QuantumOps.td
@@ -832,15 +832,11 @@ def PCPhaseOp : UnitaryGate_Op<"pcphase", [DifferentiableGate, NoMemoryEffect,
             ``quantum.custom``. The reason for this is that it needs to be handled in a special
             way during the lowering due to its C function being variadic on the number of qubits.
 
-        .. note::
-            `dim` is currently captured as a float number for compatibility with
-            runtime and device integration.
-
     }];
 
     let arguments = (ins
         F64:$theta,
-        F64:$dim,
+        I64Attr:$dim,
         Variadic<QubitType>:$in_qubits,
         UnitAttr:$adjoint,
         Variadic<QubitType>:$in_ctrl_qubits,
@@ -853,7 +849,10 @@ def PCPhaseOp : UnitaryGate_Op<"pcphase", [DifferentiableGate, NoMemoryEffect,
     );
 
     let assemblyFormat = [{
-        `(` $theta `,` $dim `)` $in_qubits (`adj` $adjoint^)? attr-dict ( `ctrls` `(` $in_ctrl_qubits^ `)` )?  ( `ctrlvals` `(` $in_ctrl_values^ `)` )? `:` type($out_qubits) (`ctrls` type($out_ctrl_qubits)^ )?
+        `(` $theta `,` `dim` `:` $dim `)` $in_qubits (`adj` $adjoint^)? attr-dict
+        ( `ctrls` `(` $in_ctrl_qubits^ `)` )?
+        ( `ctrlvals` `(` $in_ctrl_values^ `)` )?
+        `:` type($out_qubits) (`ctrls` type($out_ctrl_qubits)^ )?
     }];
 
     let extraClassDeclaration = extraBaseClassDeclaration # [{

--- a/mlir/lib/QRef/IR/QRefOps.cpp
+++ b/mlir/lib/QRef/IR/QRefOps.cpp
@@ -103,8 +103,8 @@ LogicalResult PCPhaseOp::canonicalize(PCPhaseOp op, mlir::PatternRewriter &rewri
     if (op.getAdjoint()) {
         auto paramNeg = mlir::arith::NegFOp::create(rewriter, op.getLoc(), op.getTheta());
 
-        rewriter.replaceOpWithNewOp<PCPhaseOp>(op, paramNeg, op.getDim(), op.getQubits(), nullptr,
-                                               op.getCtrlQubits(), op.getCtrlValues());
+        rewriter.replaceOpWithNewOp<PCPhaseOp>(op, paramNeg, op.getDimAttr(), op.getQubits(),
+                                               nullptr, op.getCtrlQubits(), op.getCtrlValues());
 
         return success();
     };

--- a/mlir/lib/Quantum/IR/QuantumOps.cpp
+++ b/mlir/lib/Quantum/IR/QuantumOps.cpp
@@ -123,7 +123,7 @@ LogicalResult PCPhaseOp::canonicalize(PCPhaseOp op, mlir::PatternRewriter &rewri
 
         rewriter.replaceOpWithNewOp<PCPhaseOp>(
             op, op.getOutQubits().getTypes(), op.getOutCtrlQubits().getTypes(), paramNeg,
-            op.getDim(), op.getInQubits(), nullptr, op.getInCtrlQubits(), op.getInCtrlValues());
+            op.getDimAttr(), op.getInQubits(), nullptr, op.getInCtrlQubits(), op.getInCtrlValues());
 
         return success();
     };

--- a/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/ConversionPatterns.cpp
@@ -684,7 +684,7 @@ struct PCPhaseOpPattern : public OpConversionPattern<PCPhaseOp> {
         std::string qirName = "__catalyst__qis__PCPhase";
         Type qirSignature =
             LLVM::LLVMFunctionType::get(LLVM::LLVMVoidType::get(ctx),
-                                        {Float64Type::get(ctx), Float64Type::get(ctx),
+                                        {Float64Type::get(ctx), IntegerType::get(ctx, 64),
                                          modifiersPtr.getType(), IntegerType::get(ctx, 64)},
                                         /*isVarArg=*/true);
 
@@ -694,7 +694,8 @@ struct PCPhaseOpPattern : public OpConversionPattern<PCPhaseOp> {
         int64_t numQubits = op.getOutQubits().size();
         SmallVector<Value> args;
         args.insert(args.end(), adaptor.getTheta());
-        args.insert(args.end(), adaptor.getDim());
+        args.insert(args.end(), LLVM::ConstantOp::create(rewriter, loc,
+                                                         rewriter.getI64IntegerAttr(op.getDim())));
         args.insert(args.end(), modifiersPtr);
         args.insert(args.end(),
                     LLVM::ConstantOp::create(rewriter, loc, rewriter.getI64IntegerAttr(numQubits)));

--- a/mlir/test/QRef/CanonicalizationTest.mlir
+++ b/mlir/test/QRef/CanonicalizationTest.mlir
@@ -182,10 +182,10 @@ func.func @test_multirz_adjoint_canonicalize(%arg0: f64, %q0: !qref.bit, %q1: !q
 // -----
 
 // CHECK-LABEL: test_pcphase_adjoint_canonicalize
-func.func @test_pcphase_adjoint_canonicalize(%arg0: f64, %dim: f64, %q0: !qref.bit, %q1: !qref.bit) {
+func.func @test_pcphase_adjoint_canonicalize(%arg0: f64, %q0: !qref.bit, %q1: !qref.bit) {
     // CHECK: [[arg0neg:%.+]] = arith.negf %arg0 : f64
-    // CHECK: qref.pcphase([[arg0neg]], %arg1) %arg2, %arg3 : !qref.bit, !qref.bit
-    qref.pcphase (%arg0, %dim) %q0, %q1 adj : !qref.bit, !qref.bit
+    // CHECK: qref.pcphase([[arg0neg]], dim : 2) %arg1, %arg2 : !qref.bit, !qref.bit
+    qref.pcphase (%arg0, dim : 2) %q0, %q1 adj : !qref.bit, !qref.bit
     return
 }
 
@@ -218,7 +218,7 @@ func.func @test_canonicalize_no_dce(%arg0: tensor<2xcomplex<f64>>, %arg1 : tenso
     qref.multirz (%arg2) %q0, %q1 : !qref.bit, !qref.bit
 
     // CHECK: qref.pcphase
-    qref.pcphase (%arg2, %arg2) %q0 : !qref.bit
+    qref.pcphase (%arg2, dim : 0) %q0 : !qref.bit
 
     // CHECK: qref.unitary
     qref.unitary (%arg3 : tensor<2x2xcomplex<f64>>) %q0 : !qref.bit

--- a/mlir/test/QRef/SemanticConversion/TestFlatCircuits.mlir
+++ b/mlir/test/QRef/SemanticConversion/TestFlatCircuits.mlir
@@ -183,11 +183,11 @@ func.func @test_pcphase_op(%arg0: f64, %arg1: i1) attributes {quantum.node} {
 
     // CHECK: [[bit0:%.+]] = quantum.extract [[qreg]][ 0] : !quantum.reg -> !quantum.bit
     // CHECK: [[bit1:%.+]] = quantum.extract [[qreg]][ 1] : !quantum.reg -> !quantum.bit
-    // CHECK: [[gate0:%.+]]:2 = quantum.pcphase(%arg0, %arg0) [[bit0]], [[bit1]] : !quantum.bit, !quantum.bit
-    qref.pcphase (%arg0, %arg0) %q0, %q1 : !qref.bit, !qref.bit
+    // CHECK: [[gate0:%.+]]:2 = quantum.pcphase(%arg0, dim : 1) [[bit0]], [[bit1]] : !quantum.bit, !quantum.bit
+    qref.pcphase (%arg0, dim : 1) %q0, %q1 : !qref.bit, !qref.bit
 
-    // CHECK: [[gate1:%.+]], [[gate1Ctrl:%.+]] = quantum.pcphase(%arg0, %arg0) [[gate0]]#0 ctrls([[gate0]]#1) ctrlvals(%arg1) : !quantum.bit ctrls !quantum.bit
-    qref.pcphase (%arg0, %arg0) %q0 ctrls (%q1) ctrlvals (%arg1) : !qref.bit ctrls !qref.bit
+    // CHECK: [[gate1:%.+]], [[gate1Ctrl:%.+]] = quantum.pcphase(%arg0, dim : 1) [[gate0]]#0 ctrls([[gate0]]#1) ctrlvals(%arg1) : !quantum.bit ctrls !quantum.bit
+    qref.pcphase (%arg0, dim : 1) %q0 ctrls (%q1) ctrlvals (%arg1) : !qref.bit ctrls !qref.bit
 
     // CHECK: [[insert0:%.+]] = quantum.insert [[qreg]][ 0], [[gate1]] : !quantum.reg, !quantum.bit
     // CHECK: [[insert1:%.+]] = quantum.insert [[insert0]][ 1], [[gate1Ctrl]] : !quantum.reg, !quantum.bit

--- a/mlir/test/QRef/UnitTests.mlir
+++ b/mlir/test/QRef/UnitTests.mlir
@@ -176,23 +176,23 @@ func.func @test_multirz(%q0: !qref.bit, %q1: !qref.bit,
 // -----
 
 func.func @test_pcphase(%q0: !qref.bit, %q1: !qref.bit,
-    %q2: !qref.bit, %q3: !qref.bit, %theta: f64, %dim: f64) {
+    %q2: !qref.bit, %q3: !qref.bit, %theta: f64) {
 
     // Basic
-    qref.pcphase (%theta, %dim) %q0 : !qref.bit
-    qref.pcphase (%theta, %dim) %q0, %q1, %q2 : !qref.bit, !qref.bit, !qref.bit
+    qref.pcphase (%theta, dim : 1) %q0 : !qref.bit
+    qref.pcphase (%theta, dim : 1) %q0, %q1, %q2 : !qref.bit, !qref.bit, !qref.bit
 
     // With adjoint
-    qref.pcphase (%theta, %dim) %q0, %q1 adj : !qref.bit, !qref.bit
+    qref.pcphase (%theta, dim : 1) %q0, %q1 adj : !qref.bit, !qref.bit
 
     // With control
     %true = llvm.mlir.constant (1 : i1) :i1
     %false = llvm.mlir.constant (0 : i1) :i1
-    qref.pcphase (%theta, %dim) %q0 ctrls (%q1) ctrlvals (%true) : !qref.bit ctrls !qref.bit
-    qref.pcphase (%theta, %dim) %q0, %q1 ctrls (%q2, %q3) ctrlvals (%true, %false) : !qref.bit, !qref.bit ctrls !qref.bit, !qref.bit
+    qref.pcphase (%theta, dim : 1) %q0 ctrls (%q1) ctrlvals (%true) : !qref.bit ctrls !qref.bit
+    qref.pcphase (%theta, dim : 1) %q0, %q1 ctrls (%q2, %q3) ctrlvals (%true, %false) : !qref.bit, !qref.bit ctrls !qref.bit, !qref.bit
 
     // With control and adjoint
-    qref.pcphase (%theta, %dim) %q0, %q1 adj ctrls (%q2, %q3) ctrlvals (%true, %false) : !qref.bit, !qref.bit ctrls !qref.bit, !qref.bit
+    qref.pcphase (%theta, dim : 1) %q0, %q1 adj ctrls (%q2, %q3) ctrlvals (%true, %false) : !qref.bit, !qref.bit ctrls !qref.bit, !qref.bit
 
     return
 }

--- a/mlir/test/QRef/VerifierTests.mlir
+++ b/mlir/test/QRef/VerifierTests.mlir
@@ -121,19 +121,19 @@ func.func @test_multirz_duplicate_qubits(%q0: !qref.bit, %theta: f64) {
 
 // -----
 
-func.func @test_pcphase_control(%q0: !qref.bit, %q1: !qref.bit, %theta: f64, %dim: f64) {
+func.func @test_pcphase_control(%q0: !qref.bit, %q1: !qref.bit, %theta: f64) {
     %true = llvm.mlir.constant (1 : i1) :i1
     // expected-error@+1 {{number of controlling qubits in input (1) and controlling values (2) must be the same}}
-    qref.pcphase(%theta, %dim) %q0 ctrls (%q1) ctrlvals (%true, %true) : !qref.bit ctrls !qref.bit
+    qref.pcphase(%theta, dim : 1) %q0 ctrls (%q1) ctrlvals (%true, %true) : !qref.bit ctrls !qref.bit
     return
 }
 
 // -----
 
-func.func @test_pcphase_duplicate_qubits(%q0: !qref.bit, %theta: f64, %dim: f64) {
+func.func @test_pcphase_duplicate_qubits(%q0: !qref.bit, %theta: f64) {
     %true = llvm.mlir.constant (1 : i1) :i1
     // expected-error@+1 {{all qubits on a quantum gate must be distinct (including controls)}}
-    qref.pcphase(%theta, %dim) %q0, %q0 : !qref.bit, !qref.bit
+    qref.pcphase(%theta, dim : 1) %q0, %q0 : !qref.bit, !qref.bit
     return
 }
 

--- a/mlir/test/Quantum/ConversionTest.mlir
+++ b/mlir/test/Quantum/ConversionTest.mlir
@@ -363,25 +363,28 @@ func.func @controlled_paulirot(%q0 : !quantum.bit, %q1 : !quantum.bit, %angle : 
 
 // -----
 
-// CHECK: llvm.func @__catalyst__qis__PCPhase(f64, f64, !llvm.ptr, i64, ...)
+// CHECK: llvm.func @__catalyst__qis__PCPhase(f64, i64, !llvm.ptr, i64, ...)
 
 // CHECK-LABEL: @pcphase
-func.func @pcphase(%q0 : !quantum.bit, %p : f64, %d: f64) -> (!quantum.bit, !quantum.bit, !quantum.bit) {
-
-    // CHECK: [[d:%.+]] = llvm.mlir.zero : !llvm.ptr
-    // CHECK: [[c1:%.+]] = llvm.mlir.constant(1 : i64)
-    // CHECK: llvm.call @__catalyst__qis__PCPhase(%arg1, %arg2, [[d]], [[c1]], %arg0)
-    %q1 = quantum.pcphase(%p, %d) %q0 : !quantum.bit
+func.func @pcphase(%q0 : !quantum.bit, %p : f64) -> (!quantum.bit, !quantum.bit, !quantum.bit) {
 
     // CHECK: [[d:%.+]] = llvm.mlir.zero : !llvm.ptr
     // CHECK: [[c2:%.+]] = llvm.mlir.constant(2 : i64)
-    // CHECK: llvm.call @__catalyst__qis__PCPhase(%arg1, %arg2, [[d]], [[c2]], %arg0, %arg0)
-    %q2:2 = quantum.pcphase(%p, %d) %q1, %q1 : !quantum.bit, !quantum.bit
+    // CHECK: [[c1:%.+]] = llvm.mlir.constant(1 : i64)
+    // CHECK: llvm.call @__catalyst__qis__PCPhase(%arg1, [[c2]], [[d]], [[c1]], %arg0)
+    %q1 = quantum.pcphase(%p, dim : 2) %q0 : !quantum.bit
 
     // CHECK: [[d:%.+]] = llvm.mlir.zero : !llvm.ptr
     // CHECK: [[c3:%.+]] = llvm.mlir.constant(3 : i64)
-    // CHECK: llvm.call @__catalyst__qis__PCPhase(%arg1, %arg2, [[d]], [[c3]], %arg0, %arg0, %arg0)
-    %q3:3 = quantum.pcphase(%p, %d) %q2#0, %q2#1, %q2#1 : !quantum.bit, !quantum.bit, !quantum.bit
+    // CHECK: [[c2:%.+]] = llvm.mlir.constant(2 : i64)
+    // CHECK: llvm.call @__catalyst__qis__PCPhase(%arg1, [[c3]], [[d]], [[c2]], %arg0, %arg0)
+    %q2:2 = quantum.pcphase(%p, dim : 3) %q1, %q1 : !quantum.bit, !quantum.bit
+
+    // CHECK: [[d:%.+]] = llvm.mlir.zero : !llvm.ptr
+    // CHECK: [[c0:%.+]] = llvm.mlir.constant(0 : i64)
+    // CHECK: [[c3:%.+]] = llvm.mlir.constant(3 : i64)
+    // CHECK: llvm.call @__catalyst__qis__PCPhase(%arg1, [[c0]], [[d]], [[c3]], %arg0, %arg0, %arg0)
+    %q3:3 = quantum.pcphase(%p, dim : 0) %q2#0, %q2#1, %q2#1 : !quantum.bit, !quantum.bit, !quantum.bit
 
     // CHECK: [[st1:%.+]] = llvm.insertvalue %arg0
     // CHECK: [[st2:%.+]] = llvm.insertvalue %arg0, [[st1]]

--- a/mlir/test/Quantum/GraphDecomposition/TestFailedDecomp.mlir
+++ b/mlir/test/Quantum/GraphDecomposition/TestFailedDecomp.mlir
@@ -16,8 +16,7 @@
 
 func.func @circuit(%q0: !quantum.bit) {
     %pi = arith.constant 3.14 : f64
-    %dim = arith.constant 3.0 : f64
-    %out = quantum.pcphase (%pi, %dim) %q0 : !quantum.bit
+    %out = quantum.pcphase (%pi, dim : 3) %q0 : !quantum.bit
     // CHECK: GraphSolverFailedError
     // CHECK: Decomposition rule not found for operator 'pcphase
     return

--- a/mlir/test/Quantum/SemanticsConversion/TestFlatCircuits.mlir
+++ b/mlir/test/Quantum/SemanticsConversion/TestFlatCircuits.mlir
@@ -228,13 +228,13 @@ func.func @test_pcphase_op(%arg0: f64, %arg1: i1) attributes {quantum.node} {
     %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
     %2 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
 
-    // CHECK: qref.pcphase(%arg0, %arg0) [[q0]], [[q1]] : !qref.bit, !qref.bit
+    // CHECK: qref.pcphase(%arg0, dim : 1) [[q0]], [[q1]] : !qref.bit, !qref.bit
     // CHECK-NOT: quantum.pcphase
-    %out_qubits:2 = quantum.pcphase(%arg0, %arg0) %1, %2 : !quantum.bit, !quantum.bit
+    %out_qubits:2 = quantum.pcphase(%arg0, dim : 1) %1, %2 : !quantum.bit, !quantum.bit
 
-    // CHECK: qref.pcphase(%arg0, %arg0) [[q0]] ctrls([[q1]]) ctrlvals(%arg1) : !qref.bit ctrls !qref.bit
+    // CHECK: qref.pcphase(%arg0, dim : 1) [[q0]] ctrls([[q1]]) ctrlvals(%arg1) : !qref.bit ctrls !qref.bit
     // CHECK-NOT: quantum.pcphase
-    %out_qubits_0, %out_ctrl_qubits = quantum.pcphase(%arg0, %arg0) %out_qubits#0 ctrls(%out_qubits#1) ctrlvals(%arg1) : !quantum.bit ctrls !quantum.bit
+    %out_qubits_0, %out_ctrl_qubits = quantum.pcphase(%arg0, dim : 1) %out_qubits#0 ctrls(%out_qubits#1) ctrlvals(%arg1) : !quantum.bit ctrls !quantum.bit
 
     // CHECK-NOT: quantum.insert
     %3 = quantum.insert %0[ 0], %out_qubits_0 : !quantum.reg, !quantum.bit

--- a/runtime/include/RuntimeCAPI.h
+++ b/runtime/include/RuntimeCAPI.h
@@ -85,7 +85,7 @@ void __catalyst__qis__CSWAP(QUBIT *, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__Toffoli(QUBIT *, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__MultiRZ(double, const Modifiers *, int64_t, /*qubits*/...);
 void __catalyst__qis__GlobalPhase(double, const Modifiers *);
-void __catalyst__qis__PCPhase(double, double, const Modifiers *, int64_t, /*qubits*/...);
+void __catalyst__qis__PCPhase(double, int64_t, const Modifiers *, int64_t, /*qubits*/...);
 void __catalyst__qis__ISWAP(QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__PSWAP(double, QUBIT *, QUBIT *, const Modifiers *);
 void __catalyst__qis__PauliRot(const char *, double, const Modifiers *, bool, int64_t,

--- a/runtime/lib/capi/RuntimeCAPI.cpp
+++ b/runtime/lib/capi/RuntimeCAPI.cpp
@@ -509,11 +509,11 @@ void __catalyst__qis__SetState(MemRefT_CplxT_double_1d *data, uint64_t numQubits
     getQuantumDevicePtr()->SetState(data_view, wires);
 }
 
-void __catalyst__qis__PCPhase(double theta, double dim, const Modifiers *modifiers,
+void __catalyst__qis__PCPhase(double theta, int64_t dim, const Modifiers *modifiers,
                               int64_t numQubits, ...)
 {
     RT_ASSERT(numQubits >= 0);
-    RT_ASSERT(dim >= 0 && dim == static_cast<int64_t>(dim));
+    RT_ASSERT(dim >= 0);
 
     va_list args;
     va_start(args, numQubits);
@@ -523,7 +523,7 @@ void __catalyst__qis__PCPhase(double theta, double dim, const Modifiers *modifie
     }
     va_end(args);
 
-    getQuantumDevicePtr()->NamedOperation("PCPhase", {theta, dim}, wires,
+    getQuantumDevicePtr()->NamedOperation("PCPhase", {theta, static_cast<double>(dim)}, wires,
                                           /* modifiers */ MODIFIERS_ARGS(modifiers));
 }
 


### PR DESCRIPTION
**Context:**
The `dim` parameter on `PCPhase` op should be static. Like the Pauli word on `PauliRot` ops, different static instances of `dim` lead to different nodes in the decomposition graph. 

However, currently the `dim` parameter is taken in by `PCPhase` ops as a dynamic operand, not a static attribute.

**Description of the Change:**
Change `quantum/qref.pcphase` ops' `dim` operand into an attribute.
Primitives, lowerings, runtime CAPI and tests are updated accordingly. 

**Benefits:**
PCPhase op can better participate in decomp graph. This is because its decomp rule in python uses the dim as a piece of static data, and different values of `dim` give different decomp rules.

[sc-124926]