### PR TITLE
[Experimental Backline] Adds a backend-agnostic transport loader to the runtime

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -15,6 +15,7 @@ option(RUNTIME_ENABLE_WARNINGS "Enable -Wall and -Werror" ON)
 
 option(ENABLE_OPENQASM "Build OpenQasm backend device" OFF)
 option(ENABLE_OQD "Build OQD backend device" OFF)
+option(ENABLE_TRANSPORT "Build the backend-agnostic transport loader (rt_transport)" OFF)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/runtime/include/Transport.hpp
+++ b/runtime/include/Transport.hpp
@@ -23,32 +23,26 @@ namespace catalyst::transport {
  * @brief Data-plane strategy: which engine issues the transfer.
  */
 enum class DataPath : std::uint8_t {
-    CpuVerbs,  // Plain ibverbs on CPU.
-    GpuEngine, // Gpu-initiated comms.
-    Other,
+    CpuVerbs,    // Plain ibverbs on CPU.
+    NicEngine,   // Hardware-embedded RNIC (e.g. ERNIC hardware handshake).
+    KernelFused, // Fused with a kernel (e.g. on GPU). The decode runs
+                 // inside this fused kernel.
 };
 
 /**
  * @brief Memory kind: selects the allocation and registration path.
  */
 enum class MemKind : std::uint8_t {
-    CpuRam,
-    GpuHbm,
-    Ddr,
-    Other,
+    CpuRam,   // Plain host RAM.
+    GpuHbm,   // GPU HBM, registered via dma-buf.
+    FpgaDdr,  // FPGA DDR, allocated via the Xilinx UMM allocator.
+    FpgaBram, // FPGA on-chip block RAM.
 };
 
-/**
- * @brief Out-of-band connection parameters for bringing up a session.
- */
 struct ConnectInfo {
     std::string peer;
     std::uint16_t oob_port;
 };
-
-/**
- * @brief Locally allocated and registered memory region.
- */
 struct MemRegion {
     void *addr = nullptr;
     std::uint64_t size = 0;
@@ -56,124 +50,89 @@ struct MemRegion {
     std::uint32_t rkey = 0;
     MemKind kind = MemKind::CpuRam;
 };
-
-/**
- * @brief Handle to a peer's memory region, exchanged over the out-of-band channel.
- */
 struct PeerRef {
     std::uint32_t rkey = 0;
     std::uint64_t remote_addr = 0;
     std::uint64_t size = 0;
 };
-
-/**
- * @brief Configuration for the data-movement channel a session uses.
- */
 struct ChannelDesc {
     DataPath data_path = DataPath::CpuVerbs;
+    bool persistent = true;
 };
 
-/**
- * @brief Stateful transport session shared by the controller and coprocessor roles.
- *
- * Methods must be called in this order:
- *   1. connect           - bring up QPs + the out-of-band channel
- *   2. alloc_memory      - register the region (needs the connected context)
- *   3. exchange_keys     - swap region handles over the out-of-band channel
- *   4. establish_channel - program the channel from the local + peer regions
- *   5. (coprocessor) set_coprocessor_fn before start()
- *   6. start / collect / stop
- */
+// Stateful session: methods must be called in this order:
+//   1. connect            - bring up QPs + the out-of-band channel
+//   2. alloc_memory       - register the region (needs the connected context)
+//   3. exchange_keys      - swap region handles over the out-of-band channel
+//   4. establish_channel  - bring QPs to RTS from the local + peer regions
+//   5. (controller) set_max_in_flight; (coprocessor) set_decoder_schema
+//   6. (controller) commit_work_item(idx) - build + arm each work item (one or more slots)
+//   7. start() - begin the session (no-op today; future warm-up)
+//   8. per round: (controller) write data_slot() -> kick(idx) -> collect();
+// TODO: how about the coprocessor?
+//   9. stop
+
 class TransportSession {
   public:
     virtual ~TransportSession() = default;
 
-    /**
-     * @brief Bring up the connection (out-of-band handshake and QP transition to RTS).
-     *
-     * @param info Peer address and out-of-band port.
-     *
-     * @return `int`
-     */
+    // Bring up the connection (out-of-band handshake and QP transition to RTS).
     virtual int connect(const ConnectInfo &info) = 0;
 
-    /**
-     * @brief Allocate and register a memory region on the device.
-     *
-     * @param size Size of the region in bytes.
-     * @param kind Memory kind selecting the allocation and registration path.
-     * @param access Access flags for the registration.
-     *
-     * @return `MemRegion` The allocated and registered region.
-     */
+    // Allocate and register a memory region on the device.
     virtual MemRegion alloc_memory(std::size_t size, MemKind kind, std::uint32_t access) = 0;
 
-    /**
-     * @brief Advertise a local region and receive the peer's region over the out-of-band channel.
-     *
-     * @param local The local region to advertise.
-     *
-     * @return `PeerRef` The peer's advertised region.
-     */
+    // Advertise a local region and receive the peer's region over the out-of-band channel.
     virtual PeerRef exchange_keys(const MemRegion &local) = 0;
 
-    /**
-     * @brief Program the data movement this session will run (single channel per session).
-     *
-     * @param desc Channel configuration.
-     * @param local The local memory region.
-     * @param peer The peer's memory region.
-     */
+    // Program the data movement this session will run (single channel per session).
     virtual void establish_channel(const ChannelDesc &desc, const MemRegion &local,
                                    const PeerRef &peer) = 0;
 
-    /**
-     * @brief Launch the engine (non-blocking; runs until stop()).
-     */
-    virtual void start() = 0;
+    // Launch the engine (non-blocking; runs until stop()).
+    virtual int start() = 0;
 
-    /**
-     * @brief Wait for a result and write it out.
-     *
-     * @param outputs Array of output buffers to write into.
-     * @param n Number of output buffers.
-     *
-     * @return `int`
-     */
-    virtual int collect(void *const *outputs, std::size_t n) = 0;
+    // Wait for a result and write it out.
+    virtual int collect(void *const *outputs, const std::size_t *output_bytes, std::size_t n) = 0;
 
-    /**
-     * @brief Stop the engine and join. Idempotent.
-     */
+    // Stop the engine and join. Idempotent.
     virtual void stop() = 0;
+
+    // Last round-trip time, in nanoseconds (for testing purposes).
+    virtual std::uint64_t last_rtt_ns() const { return 0; }
 };
 
-/**
- * @brief Controller role: writes messages out and receives corrections.
- */
-class ControllerSession : public TransportSession {};
+// The decode I/O contract: a guarantee pinned by the frontend/compiler and
+// carried down to the coprocessor.
+struct DecoderSchema {
+    std::uint64_t in_bytes = 0;  // syndrome length (decode input)
+    std::uint64_t out_bytes = 0; // correction length (decode output)
+};
 
-/**
- * @brief Opaque function to run on the coprocessor. May include a persistent kernel on the GPU.
- */
-using CoprocessorFn = std::size_t (*)(const void *in, std::size_t in_len, void *out,
-                                      std::size_t out_cap, void *ctx);
+// Controller role: writes syndrome out and receive correction.
+class ControllerSession : public TransportSession {
+  public:
+    // Sliding-window depth: how many rounds to keep in flight. 1 = strict one-in-flight.
+    virtual void set_max_in_flight(std::uint32_t n) = 0;
 
-/**
- * @brief Coprocessor role: receives messages, process, and returns corrections.
- */
+    // Build the work item in slot `work_item_idx` from `schema`.
+    virtual void commit_work_item(std::uint32_t work_item_idx, const DecoderSchema &schema) = 0;
+
+    // Fire one round using work item `work_item_idx` and whatever payload is currently in
+    // data_slot(). Pairs with a subsequent collect(). Returns 0 on success.
+    virtual int kick(std::uint32_t work_item_idx = 0) = 0;
+
+    // Current round's outbound slot in the transport-owned ring.
+    virtual void *data_slot() = 0;
+};
+
+// Coprocessor role: receives syndromes, decodes, returns corrections. The decode
+// definition is implemented on by the device; only the decode
+// schema (I/O shape guarantee) is part of this contract.
 class CoprocessorSession : public TransportSession {
   public:
-    /**
-     * @brief Bind the coprocessor function this session runs.
-     *
-     * Call before start(). `fn` is a local function pointer; `ctx` is passed
-     * back to `fn` on every invocation and may be null.
-     *
-     * @param fn The coprocessor function to run per received message.
-     * @param ctx Opaque context passed to `fn` on each invocation; may be null.
-     */
-    virtual void set_coprocessor_fn(CoprocessorFn fn, void *ctx) = 0;
+    // Pin the decode I/O shape this coprocessor must honor. Call before start().
+    virtual void set_decoder_schema(const DecoderSchema &schema) = 0;
 };
 
 } // namespace catalyst::transport

--- a/runtime/include/Transport.hpp
+++ b/runtime/include/Transport.hpp
@@ -23,26 +23,32 @@ namespace catalyst::transport {
  * @brief Data-plane strategy: which engine issues the transfer.
  */
 enum class DataPath : std::uint8_t {
-    CpuVerbs,    // Plain ibverbs on CPU.
-    NicEngine,   // Hardware-embedded RNIC (e.g. ERNIC hardware handshake).
-    KernelFused, // Fused with a kernel (e.g. on GPU). The decode runs
-                 // inside this fused kernel.
+    CpuVerbs,  // Plain ibverbs on CPU.
+    GpuEngine, // Gpu-initiated comms.
+    Other,
 };
 
 /**
  * @brief Memory kind: selects the allocation and registration path.
  */
 enum class MemKind : std::uint8_t {
-    CpuRam,   // Plain host RAM.
-    GpuHbm,   // GPU HBM, registered via dma-buf.
-    FpgaDdr,  // FPGA DDR, allocated via the Xilinx UMM allocator.
-    FpgaBram, // FPGA on-chip block RAM.
+    CpuRam,
+    GpuHbm,
+    Ddr,
+    Other,
 };
 
+/**
+ * @brief Out-of-band connection parameters for bringing up a session.
+ */
 struct ConnectInfo {
     std::string peer;
     std::uint16_t oob_port;
 };
+
+/**
+ * @brief Locally allocated and registered memory region.
+ */
 struct MemRegion {
     void *addr = nullptr;
     std::uint64_t size = 0;
@@ -50,73 +56,114 @@ struct MemRegion {
     std::uint32_t rkey = 0;
     MemKind kind = MemKind::CpuRam;
 };
+
+/**
+ * @brief Handle to a peer's memory region, exchanged over the out-of-band channel.
+ */
 struct PeerRef {
     std::uint32_t rkey = 0;
     std::uint64_t remote_addr = 0;
     std::uint64_t size = 0;
 };
+
+/**
+ * @brief Configuration for the data-movement channel a session uses.
+ */
 struct ChannelDesc {
     DataPath data_path = DataPath::CpuVerbs;
-    bool persistent = true;
 };
 
-// Stateful session: methods must be called in this order:
-//   1. connect            - bring up QPs + the out-of-band channel
-//   2. alloc_memory       - register the region (needs the connected context)
-//   3. exchange_keys      - swap region handles over the out-of-band channel
-//   4. establish_channel  - bring QPs to RTS from the local + peer regions
-//   5. (controller) set_max_in_flight; (coprocessor) set_decoder_schema
-//   6. (controller) commit_work_item(idx) - build + arm each work item (one or more slots)
-//   7. start() - begin the session (no-op today; future warm-up)
-//   8. per round: (controller) write data_slot() -> kick(idx) -> collect();
-// TODO: how about the coprocessor?
-//   9. stop
-
+/**
+ * @brief Stateful transport session shared by the controller and coprocessor roles.
+ *
+ * Methods must be called in this order:
+ *   1. connect           - bring up QPs + the out-of-band channel
+ *   2. alloc_memory      - register the region (needs the connected context)
+ *   3. exchange_keys     - swap region handles over the out-of-band channel
+ *   4. establish_channel - program the channel from the local + peer regions
+ *   5. (coprocessor) set_coprocessor_fn before start()
+ *   6. start / collect / stop
+ */
 class TransportSession {
   public:
     virtual ~TransportSession() = default;
 
-    // Bring up the connection (out-of-band handshake and QP transition to RTS).
+    /**
+     * @brief Bring up the connection (out-of-band handshake and QP transition to RTS).
+     *
+     * @param info Peer address and out-of-band port.
+     *
+     * @return `int`
+     */
     virtual int connect(const ConnectInfo &info) = 0;
 
-    // Allocate and register a memory region on the device.
+    /**
+     * @brief Allocate and register a memory region on the device.
+     *
+     * @param size Size of the region in bytes.
+     * @param kind Memory kind selecting the allocation and registration path.
+     * @param access Access flags for the registration.
+     *
+     * @return `MemRegion` The allocated and registered region.
+     */
     virtual MemRegion alloc_memory(std::size_t size, MemKind kind, std::uint32_t access) = 0;
 
-    // Advertise a local region and receive the peer's region over the out-of-band channel.
+    /**
+     * @brief Advertise a local region and receive the peer's region over the out-of-band channel.
+     *
+     * @param local The local region to advertise.
+     *
+     * @return `PeerRef` The peer's advertised region.
+     */
     virtual PeerRef exchange_keys(const MemRegion &local) = 0;
 
-    // Program the data movement this session will run (single channel per session).
+    /**
+     * @brief Program the data movement this session will run (single channel per session).
+     *
+     * @param desc Channel configuration.
+     * @param local The local memory region.
+     * @param peer The peer's memory region.
+     */
     virtual void establish_channel(const ChannelDesc &desc, const MemRegion &local,
                                    const PeerRef &peer) = 0;
 
-    // Launch the engine (non-blocking; runs until stop()).
-    virtual int start() = 0;
+    /**
+     * @brief Launch the engine (non-blocking; runs until stop()).
+     */
+    virtual void start() = 0;
 
-    // Wait for a result and write it out.
+    /**
+     * @brief Wait for a result and write it out.
+     *
+     * @param outputs Array of output buffers to write into.
+     * @param output_bytes Array of output buffer sizes.
+     * @param n Number of output buffers.
+     *
+     * @return `int`
+     */
     virtual int collect(void *const *outputs, const std::size_t *output_bytes, std::size_t n) = 0;
 
-    // Stop the engine and join. Idempotent.
+    /**
+     * @brief Stop the engine and join. Idempotent.
+     */
     virtual void stop() = 0;
 
-    // Last round-trip time, in nanoseconds (for testing purposes).
+    /**
+     * @brief Last round-trip time, in nanoseconds (for testing purposes).
+     *
+     * @return `std::uint64_t`
+     */
     virtual std::uint64_t last_rtt_ns() const { return 0; }
 };
 
-// The decode I/O contract: a guarantee pinned by the frontend/compiler and
-// carried down to the coprocessor.
-struct DecoderSchema {
-    std::uint64_t in_bytes = 0;  // syndrome length (decode input)
-    std::uint64_t out_bytes = 0; // correction length (decode output)
-};
-
-// Controller role: writes syndrome out and receive correction.
+/**
+ * @brief Controller role: writes messages out and receives corrections.
+ */
 class ControllerSession : public TransportSession {
   public:
-    // Sliding-window depth: how many rounds to keep in flight. 1 = strict one-in-flight.
-    virtual void set_max_in_flight(std::uint32_t n) = 0;
-
     // Build the work item in slot `work_item_idx` from `schema`.
-    virtual void commit_work_item(std::uint32_t work_item_idx, const DecoderSchema &schema) = 0;
+    virtual void commit_work_item(std::uint32_t work_item_idx, std::uint64_t in_bytes,
+                                  std::uint64_t out_bytes) = 0;
 
     // Fire one round using work item `work_item_idx` and whatever payload is currently in
     // data_slot(). Pairs with a subsequent collect(). Returns 0 on success.
@@ -126,13 +173,27 @@ class ControllerSession : public TransportSession {
     virtual void *data_slot() = 0;
 };
 
-// Coprocessor role: receives syndromes, decodes, returns corrections. The decode
-// definition is implemented on by the device; only the decode
-// schema (I/O shape guarantee) is part of this contract.
+/**
+ * @brief Opaque function to run on the coprocessor. May include a persistent kernel on the GPU.
+ */
+using CoprocessorFn = std::size_t (*)(const void *in, std::size_t in_len, void *out,
+                                      std::size_t out_cap, void *ctx);
+
+/**
+ * @brief Coprocessor role: receives messages, process, and returns corrections.
+ */
 class CoprocessorSession : public TransportSession {
   public:
-    // Pin the decode I/O shape this coprocessor must honor. Call before start().
-    virtual void set_decoder_schema(const DecoderSchema &schema) = 0;
+    /**
+     * @brief Bind the coprocessor function this session runs.
+     *
+     * Call before start(). `fn` is a local function pointer; `ctx` is passed
+     * back to `fn` on every invocation and may be null.
+     *
+     * @param fn The coprocessor function to run per received message.
+     * @param ctx Opaque context passed to `fn` on each invocation; may be null.
+     */
+    virtual void set_coprocessor_fn(CoprocessorFn fn, void *ctx) = 0;
 };
 
 } // namespace catalyst::transport

--- a/runtime/include/TransportBackend.h
+++ b/runtime/include/TransportBackend.h
@@ -1,0 +1,55 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The plugin ABI for out-of-tree transport backends.
+//
+// A transport backend is a shared library that implements a TransportSession role and exports a
+// factory symbol.
+
+#pragma once
+#ifndef TRANSPORTBACKEND_H
+#define TRANSPORTBACKEND_H
+
+#include <cstdio>
+#include <exception>
+
+#include "Transport.hpp"
+
+#define CATALYST_TRANSPORT_CONTROLLER_FACTORY_SYMBOL "CatalystTransportControllerFactory"
+
+// The factory signature backends must export with C linkage.
+extern "C" {
+using CatalystTransportControllerFactoryFn = catalyst::transport::ControllerSession *(const char *);
+}
+
+// A helper template macro to generate the <IDENTIFIER>Factory function.
+// e.g. GENERATE_TRANSPORT_CONTROLLER_FACTORY(CatalystTransportController, make_controller)
+// where `make_controller(const std::string &config) -> ControllerSession*`.
+#define GENERATE_TRANSPORT_CONTROLLER_FACTORY(IDENTIFIER, BUILDER)                                 \
+    extern "C" catalyst::transport::ControllerSession *IDENTIFIER##Factory(const char *config)     \
+    {                                                                                              \
+        try {                                                                                      \
+            return (BUILDER)(config ? std::string(config) : std::string());                        \
+        }                                                                                          \
+        catch (const std::exception &e) {                                                          \
+            std::fprintf(stderr, "[transport] controller factory failed: %s\n", e.what());         \
+            return nullptr;                                                                        \
+        }                                                                                          \
+        catch (...) {                                                                              \
+            std::fprintf(stderr, "[transport] controller factory failed: unknown exception\n");    \
+            return nullptr;                                                                        \
+        }                                                                                          \
+    }
+
+#endif // TRANSPORTBACKEND_H

--- a/runtime/include/TransportCAPI.h
+++ b/runtime/include/TransportCAPI.h
@@ -1,0 +1,108 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// TransportCAPI.h - C entry points the Catalyst compiler emits to drive a transport session.
+//
+// The backend is a separate plugin `.so` the runtime dlopen's at session create (see
+// TransportBackend.h)
+
+#pragma once
+#ifndef TRANSPORTCAPI_H
+#define TRANSPORTCAPI_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Opaque transport session handle
+typedef struct CatalystTransportSession CatalystTransportSession;
+
+// Return codes: 0 == success; negative == error
+enum {
+    CATALYST_TRANSPORT_OK = 0,
+    CATALYST_TRANSPORT_ERR = -1,         // Generic exception
+    CATALYST_TRANSPORT_ERR_AXI = -2,     // AXI error
+    CATALYST_TRANSPORT_ERR_TIMEOUT = -3, // Reply timeout
+    CATALYST_TRANSPORT_ERR_STUCK = -4,   // Host poll timeout
+};
+
+// DataPath enum
+enum {
+    CATALYST_TRANSPORT_PATH_CPU_VERBS = 0,
+    CATALYST_TRANSPORT_PATH_NIC_ENGINE = 1,
+    CATALYST_TRANSPORT_PATH_KERNEL_FUSED = 2,
+};
+
+// MemKind enum
+enum {
+    CATALYST_TRANSPORT_MEM_CPU_RAM = 0,
+    CATALYST_TRANSPORT_MEM_GPU_HBM = 1,
+    CATALYST_TRANSPORT_MEM_FPGA_DDR = 2,
+    CATALYST_TRANSPORT_MEM_FPGA_BRAM = 3,
+};
+
+// ibverbs access flags for the advertised reply region
+enum {
+    CATALYST_TRANSPORT_ACCESS_REPLY = 7,
+};
+
+// Registered memory region handed back to the caller
+typedef struct {
+    void *addr;
+    uint64_t size;
+    uint32_t lkey;
+    uint32_t rkey;
+    int32_t kind; // one of MemKind enum values
+} CatalystTransportMemRegion;
+
+// Remote peer region descriptor
+typedef struct {
+    uint32_t rkey;
+    uint64_t remote_addr;
+    uint64_t size;
+} CatalystTransportPeerRef;
+
+// Create a controller session from a named backend plugin `.so` (dlopen'd by the runtime).
+// `config` is the backend's "key=value;..." string. Returns NULL on failure.
+CatalystTransportSession *__catalyst__transport__controller_create(const char *backend_lib,
+                                                                   const char *config);
+
+void __catalyst__transport__close(CatalystTransportSession *s);
+int __catalyst__transport__connect(CatalystTransportSession *s, const char *peer,
+                                   uint16_t oob_port);
+int __catalyst__transport__alloc_reply(CatalystTransportSession *s, uint64_t size, int32_t mem_kind,
+                                       uint32_t access, CatalystTransportMemRegion *out);
+
+int __catalyst__transport__exchange_keys(CatalystTransportSession *s,
+                                         CatalystTransportPeerRef *out);
+int __catalyst__transport__establish_channel(CatalystTransportSession *s, int32_t data_path,
+                                             const CatalystTransportPeerRef *peer);
+int __catalyst__transport__set_max_in_flight(CatalystTransportSession *s, uint32_t n);
+int __catalyst__transport__commit_work_item(CatalystTransportSession *s, uint32_t work_item_idx,
+                                            uint64_t in_bytes, uint64_t out_bytes);
+void *__catalyst__transport__data_slot(CatalystTransportSession *s);
+int __catalyst__transport__kick(CatalystTransportSession *s, uint32_t work_item_idx);
+int __catalyst__transport__collect(CatalystTransportSession *s, void *correction, uint64_t bytes);
+uint64_t __catalyst__transport__last_rtt_ns(CatalystTransportSession *s);
+void __catalyst__transport__stop(CatalystTransportSession *s);
+void __catalyst__transport__destroy(CatalystTransportSession *s);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // TRANSPORTCAPI_H

--- a/runtime/include/TransportCAPI.h
+++ b/runtime/include/TransportCAPI.h
@@ -35,24 +35,24 @@ typedef struct CatalystTransportSession CatalystTransportSession;
 enum {
     CATALYST_TRANSPORT_OK = 0,
     CATALYST_TRANSPORT_ERR = -1,         // Generic exception
-    CATALYST_TRANSPORT_ERR_AXI = -2,     // AXI error
-    CATALYST_TRANSPORT_ERR_TIMEOUT = -3, // Reply timeout
-    CATALYST_TRANSPORT_ERR_STUCK = -4,   // Host poll timeout
+    CATALYST_TRANSPORT_ERR_MEMORY = -2,  // Memory error
+    CATALYST_TRANSPORT_ERR_TIMEOUT = -3, // Timeout error
+    CATALYST_TRANSPORT_ERR_STUCK = -4,   // Something got stuck
 };
 
-// DataPath enum
+// DataPath enum (mirrors catalyst::transport::DataPath)
 enum {
     CATALYST_TRANSPORT_PATH_CPU_VERBS = 0,
-    CATALYST_TRANSPORT_PATH_NIC_ENGINE = 1,
-    CATALYST_TRANSPORT_PATH_KERNEL_FUSED = 2,
+    CATALYST_TRANSPORT_PATH_GPU_ENGINE = 1,
+    CATALYST_TRANSPORT_PATH_OTHER = 2,
 };
 
-// MemKind enum
+// MemKind enum (mirrors catalyst::transport::MemKind)
 enum {
     CATALYST_TRANSPORT_MEM_CPU_RAM = 0,
     CATALYST_TRANSPORT_MEM_GPU_HBM = 1,
-    CATALYST_TRANSPORT_MEM_FPGA_DDR = 2,
-    CATALYST_TRANSPORT_MEM_FPGA_BRAM = 3,
+    CATALYST_TRANSPORT_MEM_DDR = 2,
+    CATALYST_TRANSPORT_MEM_OTHER = 3,
 };
 
 // ibverbs access flags for the advertised reply region
@@ -91,7 +91,6 @@ int __catalyst__transport__exchange_keys(CatalystTransportSession *s,
                                          CatalystTransportPeerRef *out);
 int __catalyst__transport__establish_channel(CatalystTransportSession *s, int32_t data_path,
                                              const CatalystTransportPeerRef *peer);
-int __catalyst__transport__set_max_in_flight(CatalystTransportSession *s, uint32_t n);
 int __catalyst__transport__commit_work_item(CatalystTransportSession *s, uint32_t work_item_idx,
                                             uint64_t in_bytes, uint64_t out_bytes);
 void *__catalyst__transport__data_slot(CatalystTransportSession *s);

--- a/runtime/lib/CMakeLists.txt
+++ b/runtime/lib/CMakeLists.txt
@@ -68,3 +68,7 @@ add_subdirectory(QEC)
 if(ENABLE_OQD)
 add_subdirectory(OQDcapi)
 endif()
+
+if(ENABLE_TRANSPORT)
+add_subdirectory(transport)
+endif()

--- a/runtime/lib/transport/CMakeLists.txt
+++ b/runtime/lib/transport/CMakeLists.txt
@@ -1,0 +1,19 @@
+###############################################
+# library rt_transport                        #
+###############################################
+
+add_library(rt_transport SHARED TransportCAPI.cpp)
+
+target_include_directories(rt_transport
+    PUBLIC
+    ${runtime_includes}
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/lib/backend/common  # DynamicLibraryLoader.hpp
+)
+
+target_link_libraries(rt_transport PRIVATE
+    ${CMAKE_DL_LIBS}  # dlopen/dlsym for backend plugins
+)
+
+set_property(TARGET rt_transport PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/runtime/lib/transport/TransportCAPI.cpp
+++ b/runtime/lib/transport/TransportCAPI.cpp
@@ -68,7 +68,7 @@ DataPath to_data_path(std::int32_t p)
         return DataPath::GpuEngine;
     case CATALYST_TRANSPORT_PATH_OTHER:
     default:
-        return DataPath::Other; // Other == hardware RNIC engine (e.g. ERNIC HH)
+        return DataPath::Other;
     }
 }
 

--- a/runtime/lib/transport/TransportCAPI.cpp
+++ b/runtime/lib/transport/TransportCAPI.cpp
@@ -53,7 +53,7 @@ MemKind to_mem_kind(std::int32_t k)
     case CATALYST_TRANSPORT_MEM_DDR:
         return MemKind::Ddr;
     case CATALYST_TRANSPORT_MEM_OTHER:
-        return MemKind::Other; // Other == FPGA on-chip BRAM
+        return MemKind::Other;
     default:
         return MemKind::Ddr;
     }

--- a/runtime/lib/transport/TransportCAPI.cpp
+++ b/runtime/lib/transport/TransportCAPI.cpp
@@ -29,7 +29,6 @@ using catalyst::transport::ChannelDesc;
 using catalyst::transport::ConnectInfo;
 using catalyst::transport::ControllerSession;
 using catalyst::transport::DataPath;
-using catalyst::transport::DecoderSchema;
 using catalyst::transport::MemKind;
 using catalyst::transport::MemRegion;
 using catalyst::transport::PeerRef;
@@ -51,12 +50,12 @@ MemKind to_mem_kind(std::int32_t k)
         return MemKind::CpuRam;
     case CATALYST_TRANSPORT_MEM_GPU_HBM:
         return MemKind::GpuHbm;
-    case CATALYST_TRANSPORT_MEM_FPGA_DDR:
-        return MemKind::FpgaDdr;
-    case CATALYST_TRANSPORT_MEM_FPGA_BRAM:
-        return MemKind::FpgaBram;
+    case CATALYST_TRANSPORT_MEM_DDR:
+        return MemKind::Ddr;
+    case CATALYST_TRANSPORT_MEM_OTHER:
+        return MemKind::Other; // Other == FPGA on-chip BRAM
     default:
-        return MemKind::FpgaDdr;
+        return MemKind::Ddr;
     }
 }
 
@@ -65,11 +64,11 @@ DataPath to_data_path(std::int32_t p)
     switch (p) {
     case CATALYST_TRANSPORT_PATH_CPU_VERBS:
         return DataPath::CpuVerbs;
-    case CATALYST_TRANSPORT_PATH_KERNEL_FUSED:
-        return DataPath::KernelFused;
-    case CATALYST_TRANSPORT_PATH_NIC_ENGINE:
+    case CATALYST_TRANSPORT_PATH_GPU_ENGINE:
+        return DataPath::GpuEngine;
+    case CATALYST_TRANSPORT_PATH_OTHER:
     default:
-        return DataPath::NicEngine;
+        return DataPath::Other; // Other == hardware RNIC engine (e.g. ERNIC HH)
     }
 }
 
@@ -181,23 +180,11 @@ int __catalyst__transport__establish_channel(CatalystTransportSession *s, std::i
     return guard([&] {
         ChannelDesc desc;
         desc.data_path = to_data_path(data_path);
-        desc.persistent = true;
         PeerRef p;
         p.rkey = peer->rkey;
         p.remote_addr = peer->remote_addr;
         p.size = peer->size;
         s->sess->establish_channel(desc, s->have_reply ? s->reply : MemRegion{}, p);
-        return CATALYST_TRANSPORT_OK;
-    });
-}
-
-int __catalyst__transport__set_max_in_flight(CatalystTransportSession *s, std::uint32_t n)
-{
-    if (!s || !s->sess) {
-        return CATALYST_TRANSPORT_ERR;
-    }
-    return guard([&] {
-        s->sess->set_max_in_flight(n);
         return CATALYST_TRANSPORT_OK;
     });
 }
@@ -210,7 +197,7 @@ int __catalyst__transport__commit_work_item(CatalystTransportSession *s,
         return CATALYST_TRANSPORT_ERR;
     }
     return guard([&] {
-        s->sess->commit_work_item(work_item_idx, DecoderSchema{in_bytes, out_bytes});
+        s->sess->commit_work_item(work_item_idx, in_bytes, out_bytes);
         return CATALYST_TRANSPORT_OK;
     });
 }

--- a/runtime/lib/transport/TransportCAPI.cpp
+++ b/runtime/lib/transport/TransportCAPI.cpp
@@ -1,0 +1,294 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "TransportCAPI.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <exception>
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "DynamicLibraryLoader.hpp"
+#include "Transport.hpp"
+#include "TransportBackend.h"
+
+using catalyst::transport::ChannelDesc;
+using catalyst::transport::ConnectInfo;
+using catalyst::transport::ControllerSession;
+using catalyst::transport::DataPath;
+using catalyst::transport::DecoderSchema;
+using catalyst::transport::MemKind;
+using catalyst::transport::MemRegion;
+using catalyst::transport::PeerRef;
+
+// The opaque handle
+struct CatalystTransportSession {
+    std::unique_ptr<DynamicLibraryLoader> backend;
+    ControllerSession *sess = nullptr; // heap-allocated by the backend factory
+    MemRegion reply = {};
+    bool have_reply = false;
+};
+
+namespace {
+
+MemKind to_mem_kind(std::int32_t k)
+{
+    switch (k) {
+    case CATALYST_TRANSPORT_MEM_CPU_RAM:
+        return MemKind::CpuRam;
+    case CATALYST_TRANSPORT_MEM_GPU_HBM:
+        return MemKind::GpuHbm;
+    case CATALYST_TRANSPORT_MEM_FPGA_DDR:
+        return MemKind::FpgaDdr;
+    case CATALYST_TRANSPORT_MEM_FPGA_BRAM:
+        return MemKind::FpgaBram;
+    default:
+        return MemKind::FpgaDdr;
+    }
+}
+
+DataPath to_data_path(std::int32_t p)
+{
+    switch (p) {
+    case CATALYST_TRANSPORT_PATH_CPU_VERBS:
+        return DataPath::CpuVerbs;
+    case CATALYST_TRANSPORT_PATH_KERNEL_FUSED:
+        return DataPath::KernelFused;
+    case CATALYST_TRANSPORT_PATH_NIC_ENGINE:
+    default:
+        return DataPath::NicEngine;
+    }
+}
+
+template <typename Fn> int guard(Fn &&fn)
+{
+    try {
+        return fn();
+    }
+    catch (const std::exception &e) {
+        std::cerr << "[transport] " << e.what() << "\n";
+        return CATALYST_TRANSPORT_ERR;
+    }
+    catch (...) {
+        return CATALYST_TRANSPORT_ERR;
+    }
+}
+
+} // namespace
+
+extern "C" {
+
+CatalystTransportSession *__catalyst__transport__controller_create(const char *backend_lib,
+                                                                   const char *config)
+{
+    try {
+        if (!backend_lib || !*backend_lib) {
+            std::cerr << "[transport] no backend library given\n";
+            return nullptr;
+        }
+        auto h = std::make_unique<CatalystTransportSession>();
+        h->backend = std::make_unique<DynamicLibraryLoader>(backend_lib);
+        auto *factory = h->backend->getSymbol<CatalystTransportControllerFactoryFn *>(
+            CATALYST_TRANSPORT_CONTROLLER_FACTORY_SYMBOL);
+        h->sess = factory(config ? config : "");
+        if (!h->sess) {
+            std::cerr << "[transport] backend factory returned null for config: "
+                      << (config ? config : "") << "\n";
+            return nullptr;
+        }
+        return h.release();
+    }
+    catch (const std::exception &e) {
+        std::cerr << "[transport] controller_create: " << e.what() << "\n";
+        return nullptr;
+    }
+    catch (...) {
+        return nullptr;
+    }
+}
+
+int __catalyst__transport__connect(CatalystTransportSession *s, const char *peer,
+                                   std::uint16_t oob_port)
+{
+    if (!s || !s->sess) {
+        return CATALYST_TRANSPORT_ERR;
+    }
+    return guard([&] {
+        ConnectInfo info;
+        info.peer = peer ? peer : "";
+        info.oob_port = oob_port;
+        return s->sess->connect(info);
+    });
+}
+
+int __catalyst__transport__alloc_reply(CatalystTransportSession *s, std::uint64_t size,
+                                       std::int32_t mem_kind, std::uint32_t access,
+                                       CatalystTransportMemRegion *out)
+{
+    if (!s || !s->sess) {
+        return CATALYST_TRANSPORT_ERR;
+    }
+    return guard([&] {
+        MemRegion r = s->sess->alloc_memory(size, to_mem_kind(mem_kind), access);
+        s->reply = r;
+        s->have_reply = true;
+        if (out) {
+            out->addr = r.addr;
+            out->size = r.size;
+            out->lkey = r.lkey;
+            out->rkey = r.rkey;
+            out->kind = mem_kind;
+        }
+        return CATALYST_TRANSPORT_OK;
+    });
+}
+
+int __catalyst__transport__exchange_keys(CatalystTransportSession *s, CatalystTransportPeerRef *out)
+{
+    if (!s || !s->sess) {
+        return CATALYST_TRANSPORT_ERR;
+    }
+    return guard([&] {
+        PeerRef p = s->sess->exchange_keys(s->have_reply ? s->reply : MemRegion{});
+        if (out) {
+            out->rkey = p.rkey;
+            out->remote_addr = p.remote_addr;
+            out->size = p.size;
+        }
+        return CATALYST_TRANSPORT_OK;
+    });
+}
+
+int __catalyst__transport__establish_channel(CatalystTransportSession *s, std::int32_t data_path,
+                                             const CatalystTransportPeerRef *peer)
+{
+    if (!s || !s->sess || !peer) {
+        return CATALYST_TRANSPORT_ERR;
+    }
+    return guard([&] {
+        ChannelDesc desc;
+        desc.data_path = to_data_path(data_path);
+        desc.persistent = true;
+        PeerRef p;
+        p.rkey = peer->rkey;
+        p.remote_addr = peer->remote_addr;
+        p.size = peer->size;
+        s->sess->establish_channel(desc, s->have_reply ? s->reply : MemRegion{}, p);
+        return CATALYST_TRANSPORT_OK;
+    });
+}
+
+int __catalyst__transport__set_max_in_flight(CatalystTransportSession *s, std::uint32_t n)
+{
+    if (!s || !s->sess) {
+        return CATALYST_TRANSPORT_ERR;
+    }
+    return guard([&] {
+        s->sess->set_max_in_flight(n);
+        return CATALYST_TRANSPORT_OK;
+    });
+}
+
+int __catalyst__transport__commit_work_item(CatalystTransportSession *s,
+                                            std::uint32_t work_item_idx, std::uint64_t in_bytes,
+                                            std::uint64_t out_bytes)
+{
+    if (!s || !s->sess) {
+        return CATALYST_TRANSPORT_ERR;
+    }
+    return guard([&] {
+        s->sess->commit_work_item(work_item_idx, DecoderSchema{in_bytes, out_bytes});
+        return CATALYST_TRANSPORT_OK;
+    });
+}
+
+void *__catalyst__transport__data_slot(CatalystTransportSession *s)
+{
+    if (!s || !s->sess) {
+        return nullptr;
+    }
+
+    void *slot = nullptr;
+    try {
+        slot = s->sess->data_slot();
+    }
+    catch (const std::exception &e) {
+        std::cerr << "[transport] data_slot: " << e.what() << "\n";
+        return nullptr;
+    }
+    catch (...) {
+        return nullptr;
+    }
+    return slot;
+}
+
+int __catalyst__transport__kick(CatalystTransportSession *s, std::uint32_t work_item_idx)
+{
+    if (!s || !s->sess) {
+        return CATALYST_TRANSPORT_ERR;
+    }
+    return guard([&] { return s->sess->kick(work_item_idx); });
+}
+
+int __catalyst__transport__collect(CatalystTransportSession *s, void *correction,
+                                   std::uint64_t bytes)
+{
+    if (!s || !s->sess) {
+        return CATALYST_TRANSPORT_ERR;
+    }
+    return guard([&] {
+        void *outputs[1] = {correction};
+        std::size_t caps[1] = {static_cast<std::size_t>(bytes)};
+        return s->sess->collect(outputs, caps, 1);
+    });
+}
+
+std::uint64_t __catalyst__transport__last_rtt_ns(CatalystTransportSession *s)
+{
+    if (!s || !s->sess) {
+        return 0;
+    }
+    return s->sess->last_rtt_ns();
+}
+
+void __catalyst__transport__stop(CatalystTransportSession *s)
+{
+    if (s && s->sess) {
+        try {
+            s->sess->stop();
+        }
+        catch (...) {
+        }
+    }
+}
+
+void __catalyst__transport__destroy(CatalystTransportSession *s)
+{
+    if (!s) {
+        return;
+    }
+    delete s->sess; // owned by the backend factory
+    s->backend.reset();
+    delete s;
+}
+
+void __catalyst__transport__close(CatalystTransportSession *s)
+{
+    __catalyst__transport__stop(s);
+    __catalyst__transport__destroy(s);
+}
+
+} // extern "C"


### PR DESCRIPTION
**Context:**

**Description of the Change:**

Adds a backend-agnostic transport loader to the runtime:

`TransportCAPI.h/.cpp`: The ABI the compiler/codegen can emit against.
`TransportBackend.h`: the plugin factory contract; backends are separate `.so` the runtime dlopens at session create, selected via backend_lib.

`make all -DENABLE_TRANSPORT=ON` (default OFF) to build

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-123779]