### PR TITLE
Add `clang-format` Precommit Hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: gitleaks
         name: "🔒 gitleaks · Detect hardcoded secrets"
-repos:
+
 -   repo: https://github.com/psf/black
     rev: 26.3.1
     hooks:
@@ -14,6 +14,7 @@ repos:
               "--config",
               "./pyproject.toml",
             ]
+
 -   repo: https://github.com/PyCQA/isort
     rev: 7.0.0
     hooks:
@@ -24,6 +25,7 @@ repos:
           "--settings-path",
           "./pyproject.toml",
         ]
+
 - repo: local
   hooks:
     - id: pylint
@@ -44,3 +46,5 @@ repos:
   rev: v22.1.8
   hooks:
     - id: clang-format
+      name: "⚡️ clang-format · Format code"
+      types_or: [c, c++]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,3 +39,8 @@ repos:
           "--rcfile=.pylintrc",  # link to the repo config
         ]
       files: ^frontend/
+
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v22.1.8
+  hooks:
+    - id: clang-format


### PR DESCRIPTION
**Context:**
Since https://github.com/PennyLaneAI/catalyst/pull/3008 added precommit with python-style hooks, we can now extend this functionality to the C++ side of the code-base!

**Description of the Change:**
Adds a [precommit](https://github.com/pre-commit/pre-commit) hook for [clang-format](https://clang.llvm.org/docs/ClangFormat.html)!

**Benefits:**
Simplified commit histories (no more `format` commits), improved developer QoL!

**Possible Drawbacks:**

**Related GitHub Issues:**
