### PR TITLE
Bump PL version (20260722)

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.238
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.46.0.dev58
+pennylane=0.46.0.dev62
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -34,4 +34,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.46.0-dev15
 pennylane-lightning==0.46.0-dev15
-pennylane==0.46.0.dev58
+pennylane==0.46.0.dev62


### PR DESCRIPTION
**Context:**
Bump PL version to one where `qp.S/T` have been migrated to `Operator2`.