### PR TITLE
Decomp/gateset by name

### DIFF
--- a/frontend/test/lit/GraphDecomposition/TestAltDecomps.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestAltDecomps.mlir
@@ -34,7 +34,7 @@ func.func @circuit() -> !quantum.bit {
 }
 
 // CHECK-LABEL: y_to_ry
-func.func @y_to_ry(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="PauliY"} {
+func.func @y_to_ry(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="PauliY[][1]{}", resources = { operations = {"RY[f64][1]{}"=1, "GlobalPhase[][]{}"=1}}} {
     %pi = arith.constant 3.14 : f64
     %negpiby2 = arith.constant -1.57 : f64
     %q1 = quantum.custom "RY"(%pi) %q0 : !quantum.bit
@@ -43,7 +43,7 @@ func.func @y_to_ry(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="
 }
 
 // CHECK-LABEL: y_to_x_z
-func.func @y_to_x_z(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="PauliY"} {
+func.func @y_to_x_z(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="PauliY[][1]{}", resources = { operations = {"PauliX[][1]{}"=1, "PauliZ[][1]{}"=1}}} {
     %q1 = quantum.custom "PauliX"() %q0 : !quantum.bit
     %q2 = quantum.custom "PauliZ"() %q1 : !quantum.bit
     return %q2 : !quantum.bit

--- a/frontend/test/lit/GraphDecomposition/TestAltDecomps.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestAltDecomps.mlir
@@ -1,0 +1,50 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RUN: catalyst --tool=opt --pass-pipeline='builtin.module(graph-decomposition{gate-set=RY=1.0,PauliX=3.0,PauliZ=3.0,GlobalPhase=1.0 alt-decomps=PauliY=[y_to_ry,y_to_x_z] bytecode-rules="%BYTECODE_PATH"})' %s | FileCheck %s --check-prefixes RY
+
+// RUN: catalyst --tool=opt --pass-pipeline='builtin.module(graph-decomposition{gate-set=RY=3.0,PauliX=1.0,PauliZ=1.0,GlobalPhase=1.0 alt-decomps=PauliY=[y_to_ry,y_to_x_z] bytecode-rules="%BYTECODE_PATH"})' %s | FileCheck %s --check-prefixes XZ
+
+func.func @circuit() -> !quantum.bit {
+    %0 = quantum.alloc(2) : !quantum.reg
+    %q = quantum.extract %0[0] : !quantum.reg -> !quantum.bit
+    // RY-NOT: PauliY
+    // RY: RY
+    // RY: gphase
+
+    // XZ-NOT: PauliY
+    // XZ: PauliX
+    // XZ: PauliZ
+    %qout = quantum.custom "PauliY"() %q : !quantum.bit
+
+    // needed to ensure we don't match in the following decomposition rules
+    // CHECK: return
+    return %qout : !quantum.bit
+}
+
+// CHECK-LABEL: y_to_ry
+func.func @y_to_ry(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="PauliY[][1]{}", resources = { operations = {"RY[f64][1]{}"=1, "GlobalPhase[][]{}"=1}}} {
+    %pi = arith.constant 3.14 : f64
+    %negpiby2 = arith.constant -1.57 : f64
+    %q1 = quantum.custom "RY"(%pi) %q0 : !quantum.bit
+    quantum.gphase(%negpiby2)
+    return %q1 : !quantum.bit
+}
+
+// CHECK-LABEL: y_to_x_z
+func.func @y_to_x_z(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="PauliY[][1]{}", resources = { operations = {"PauliX[][1]{}"=1, "PauliZ[][1]{}"=1}}} {
+    %q1 = quantum.custom "PauliX"() %q0 : !quantum.bit
+    %q2 = quantum.custom "PauliZ"() %q1 : !quantum.bit
+    return %q2 : !quantum.bit
+}

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGBuilder.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGBuilder.cpp
@@ -173,11 +173,6 @@ struct DecompositionGraph::Impl {
             registerOp(op);
         }
 
-        // Register all target gates
-        for (const auto &[op, _] : gateset.ops) {
-            registerOp(op);
-        }
-
         // Register all rules
         for (RuleId ruleId = 0; ruleId < rules.size(); ruleId++) {
             const auto &rule = rules[ruleId];
@@ -322,8 +317,8 @@ void DecompositionGraph::showGraph() const
 
     // Show target gateset
     std::cerr << "Target Gateset:\n";
-    for (const auto &[op, cost] : impl->gateset.ops) {
-        std::cerr << "  " << print_op(op) << " with cost " << cost << "\n";
+    for (const auto &[name, cost] : impl->gateset.ops) {
+        std::cerr << "  " << name << " with cost " << cost << "\n";
     }
 }
 

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGBuilder.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGBuilder.cpp
@@ -167,11 +167,6 @@ struct DecompositionGraph::Impl {
             registerOp(op);
         }
 
-        // Register all target gates
-        for (const auto &[op, _] : gateset.ops) {
-            registerOp(op);
-        }
-
         // Register all rules
         for (RuleId ruleId = 0; ruleId < rules.size(); ruleId++) {
             const auto &rule = rules[ruleId];
@@ -301,8 +296,8 @@ void DecompositionGraph::showGraph() const {
 
     // Show target gateset
     std::cerr << "Target Gateset:\n";
-    for (const auto &[op, cost] : impl->gateset.ops) {
-        std::cerr << "  " << print_op(op) << " with cost " << cost << "\n";
+    for (const auto &[name, cost] : impl->gateset.ops) {
+        std::cerr << "  " << name << " with cost " << cost << "\n";
     }
 }
 

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGTypes.hpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGTypes.hpp
@@ -54,10 +54,11 @@ namespace DecompGraph::Core {
  */
 struct OperatorNode {
     std::string id;
+    std::string name; // name is required for gateset checking
+
     bool adjoint{false};
 
     // optional params, primarily for debug use
-    std::string name{""};
     int numWires{-1};
     int numParams{-1};
     std::unordered_map<std::string, std::string> staticNamedArgs{};
@@ -92,15 +93,16 @@ struct OperatorNodeHash {
  * @brief This represents the weighted target gateset for the graph decomposition problem.
  */
 struct WeightedGateset {
-    // TODO: using ID here mandates that gatesets specify all legal IDs, rather than generic class
-    // like "PauliRot". This should be updated to work on generic names
-    std::unordered_map<OperatorNode, double, OperatorNodeHash> ops;
+    std::unordered_map<std::string, double> ops;
 
-    [[nodiscard]] bool contains(const OperatorNode &op) const { return ops.find(op) != ops.end(); }
+    [[nodiscard]] bool contains(const OperatorNode &op) const
+    {
+        return ops.find(op.name) != ops.end();
+    }
 
     [[nodiscard]] double getCost(const OperatorNode &op) const
     {
-        auto it = ops.find(op);
+        auto it = ops.find(op.name);
         return it != ops.end() ? it->second : std::numeric_limits<double>::infinity();
     }
 };

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGTypes.hpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompGraphSolver/DGTypes.hpp
@@ -51,10 +51,11 @@ namespace DecompGraph::Core {
  */
 struct OperatorNode {
     std::string id;
+    std::string name; // name is required for gateset checking
+
     bool adjoint{false};
 
     // optional params, primarily for debug use
-    std::string name{""};
     int numWires{-1};
     int numParams{-1};
     std::unordered_map<std::string, std::string> staticNamedArgs{};
@@ -88,14 +89,14 @@ struct OperatorNodeHash {
  * @brief This represents the weighted target gateset for the graph decomposition problem.
  */
 struct WeightedGateset {
-    // TODO: using ID here mandates that gatesets specify all legal IDs, rather than generic class
-    // like "PauliRot". This should be updated to work on generic names
-    std::unordered_map<OperatorNode, double, OperatorNodeHash> ops;
+    std::unordered_map<std::string, double> ops;
 
-    [[nodiscard]] bool contains(const OperatorNode &op) const { return ops.find(op) != ops.end(); }
+    [[nodiscard]] bool contains(const OperatorNode &op) const {
+        return ops.find(op.name) != ops.end();
+    }
 
     [[nodiscard]] double getCost(const OperatorNode &op) const {
-        auto it = ops.find(op);
+        auto it = ops.find(op.name);
         return it != ops.end() ? it->second : std::numeric_limits<double>::infinity();
     }
 };

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
@@ -220,7 +220,7 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
             cost.consume_back(": f64");
             cost = cost.trim();
 
-            bool success = to_float(cost, targetGateSet.ops[OperatorNode{opName.str()}]);
+            bool success = to_float(cost, targetGateSet.ops[opName.str()]);
 
             if (!success) {
                 return failure();

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
@@ -60,6 +60,7 @@
 #include "DGBuilder.hpp"
 #include "DGSolver.hpp"
 #include "DGTypes.hpp"
+#include "DGUtils.hpp"
 #include "DecompUtils.hpp"
 
 #define DEBUG_TYPE "graph-decomposition"
@@ -139,6 +140,7 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
                                  std::move(altDecomps));
         DecompositionSolver solver(graph);
         auto solution = solver.solve();
+        LLVM_DEBUG(showSolution(solution););
 
         ///////////////////////////
         // Step 3: Convert python-decompositions from reference to value semantics and run

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
@@ -139,7 +139,7 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
                                  std::move(altDecomps));
         DecompositionSolver solver(graph);
         auto solution = solver.solve();
-        LLVM_DEBUG(showSolution(solution););
+        LLVM_DEBUG(showSolution(solution));
 
         ///////////////////////////
         // Step 3: Convert python-decompositions from reference to value semantics and run

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
@@ -60,6 +60,7 @@
 #include "DGBuilder.hpp"
 #include "DGSolver.hpp"
 #include "DGTypes.hpp"
+#include "DGUtils.hpp"
 #include "DecompUtils.hpp"
 
 #define DEBUG_TYPE "graph-decomposition"
@@ -138,6 +139,7 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
                                  std::move(altDecomps));
         DecompositionSolver solver(graph);
         auto solution = solver.solve();
+        LLVM_DEBUG(showSolution(solution););
 
         ///////////////////////////
         // Step 3: Convert python-decompositions from reference to value semantics and run

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
@@ -216,7 +216,7 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
             cost.consume_back(": f64");
             cost = cost.trim();
 
-            bool success = to_float(cost, targetGateSet.ops[OperatorNode{opName.str()}]);
+            bool success = to_float(cost, targetGateSet.ops[opName.str()]);
 
             if (!success) {
                 return failure();

--- a/mlir/unittests/DecompGraphSolver/Test_DecompGraphCore.cpp
+++ b/mlir/unittests/DecompGraphSolver/Test_DecompGraphCore.cpp
@@ -26,22 +26,27 @@ using namespace DecompGraph::Core;
 
 TEST_CASE("Test OperatorNode construction", "[DecompGraph::Core]")
 {
-    const OperatorNode h{"Hadamard[][1]{}"};
-    const OperatorNode cnot{"CNOT[][2]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
+    const OperatorNode h{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode cnot{"CNOT[][2]{}", "CNOT"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
 
     REQUIRE(h.id == "Hadamard[][1]{}");
     REQUIRE(cnot.id == "CNOT[][2]{}");
     REQUIRE(rx.id == "RX[f64][1]{}");
     REQUIRE(rz.id == "RZ[f64][1]{}");
+
+    REQUIRE(h.name == "Hadamard");
+    REQUIRE(cnot.name == "CNOT");
+    REQUIRE(rx.name == "RX");
+    REQUIRE(rz.name == "RZ");
 }
 
 TEST_CASE("Test OperatorNode equality operator", "[DecompGraph::Core]")
 {
-    const OperatorNode h1{"Hadamard[][1]{}"};
-    const OperatorNode h2{"Hadamard[][1]{}"};
-    const OperatorNode cnot{"CNOT[][2]{}"};
+    const OperatorNode h1{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode h2{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode cnot{"CNOT[][2]{}", "CNOT"};
 
     REQUIRE(h1 == h2);
     REQUIRE(h1 != cnot);
@@ -49,10 +54,10 @@ TEST_CASE("Test OperatorNode equality operator", "[DecompGraph::Core]")
 
 TEST_CASE("Test OperatorNodeHash", "[DecompGraph::Core]")
 {
-    const OperatorNode h1{"Hadamard[][1]{}"};
-    const OperatorNode h2{"Hadamard[][1]{}"};
-    const OperatorNode h3{"Hadamard[][1]{}"};
-    const OperatorNode cnot{"CNOT[][2]{}"};
+    const OperatorNode h1{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode h2{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode h3{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode cnot{"CNOT[][2]{}", "CNOT"};
 
     const OperatorNodeHash hashFunc;
     REQUIRE(hashFunc(h1) == hashFunc(h2));
@@ -63,9 +68,9 @@ TEST_CASE("Test OperatorNodeHash", "[DecompGraph::Core]")
 TEST_CASE("Test OperatorNode in unordered_map", "[DecompGraph::Core]")
 {
     std::unordered_map<OperatorNode, double, OperatorNodeHash> opMap;
-    const OperatorNode h{"Hadamard[][1]{}"};
-    const OperatorNode cnot{"CNOT[][2]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
+    const OperatorNode h{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode cnot{"CNOT[][2]{}", "CNOT"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
     opMap[h] = 1.0;
     opMap[cnot] = 2.0;
@@ -77,9 +82,9 @@ TEST_CASE("Test OperatorNode in unordered_map", "[DecompGraph::Core]")
 
 TEST_CASE("Test RuleNode construction", "[DecompGraph::Core]")
 {
-    const OperatorNode h{"Hadamard[][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
+    const OperatorNode h{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
 
     const RuleNode h_to_rz_rx_rz{"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}};
     REQUIRE(h_to_rz_rx_rz.name == "h_to_rz_rx_rz");
@@ -93,11 +98,11 @@ TEST_CASE("Test RuleNode construction", "[DecompGraph::Core]")
 
 TEST_CASE("Test WeightedGateset construction and contains", "[DecompGraph::Core]")
 {
-    const OperatorNode h{"Hadamard[][1]{}"};
-    const OperatorNode cnot{"CNOT[][2]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
+    const OperatorNode h{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode cnot{"CNOT[][2]{}", "CNOT"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{h, 1.0}, {cnot, 2.0}}};
+    const WeightedGateset gateset{{{h.name, 1.0}, {cnot.name, 2.0}}};
 
     REQUIRE(gateset.contains(h));
     REQUIRE(gateset.contains(cnot));
@@ -109,9 +114,9 @@ TEST_CASE("Test WeightedGateset construction and contains", "[DecompGraph::Core]
 
 TEST_CASE("Test ChosenDecompRule construction", "[DecompGraph::Core]")
 {
-    const OperatorNode h{"Hadamard[][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
+    const OperatorNode h{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
 
     const RuleTerm term1{rz, 2};
     const RuleTerm term2{rx, 1};

--- a/mlir/unittests/DecompGraphSolver/Test_DecompGraphCore.cpp
+++ b/mlir/unittests/DecompGraphSolver/Test_DecompGraphCore.cpp
@@ -96,7 +96,7 @@ TEST_CASE("Test WeightedGateset construction and contains", "[DecompGraph::Core]
     const OperatorNode cnot{"CNOT[][2]{}", "CNOT"};
     const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{h.name, 1.0}, {cnot.name, 2.0}}};
+    const WeightedGateset gateset{{{"Hadamard", 1.0}, {"CNOT", 2.0}}};
 
     REQUIRE(gateset.contains(h));
     REQUIRE(gateset.contains(cnot));

--- a/mlir/unittests/DecompGraphSolver/Test_DecompGraphCore.cpp
+++ b/mlir/unittests/DecompGraphSolver/Test_DecompGraphCore.cpp
@@ -25,31 +25,36 @@ using namespace Catch::Matchers;
 using namespace DecompGraph::Core;
 
 TEST_CASE("Test OperatorNode construction", "[DecompGraph::Core]") {
-    const OperatorNode h{"Hadamard[][1]{}"};
-    const OperatorNode cnot{"CNOT[][2]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
+    const OperatorNode h{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode cnot{"CNOT[][2]{}", "CNOT"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
 
     REQUIRE(h.id == "Hadamard[][1]{}");
     REQUIRE(cnot.id == "CNOT[][2]{}");
     REQUIRE(rx.id == "RX[f64][1]{}");
     REQUIRE(rz.id == "RZ[f64][1]{}");
+
+    REQUIRE(h.name == "Hadamard");
+    REQUIRE(cnot.name == "CNOT");
+    REQUIRE(rx.name == "RX");
+    REQUIRE(rz.name == "RZ");
 }
 
 TEST_CASE("Test OperatorNode equality operator", "[DecompGraph::Core]") {
-    const OperatorNode h1{"Hadamard[][1]{}"};
-    const OperatorNode h2{"Hadamard[][1]{}"};
-    const OperatorNode cnot{"CNOT[][2]{}"};
+    const OperatorNode h1{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode h2{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode cnot{"CNOT[][2]{}", "CNOT"};
 
     REQUIRE(h1 == h2);
     REQUIRE(h1 != cnot);
 }
 
 TEST_CASE("Test OperatorNodeHash", "[DecompGraph::Core]") {
-    const OperatorNode h1{"Hadamard[][1]{}"};
-    const OperatorNode h2{"Hadamard[][1]{}"};
-    const OperatorNode h3{"Hadamard[][1]{}"};
-    const OperatorNode cnot{"CNOT[][2]{}"};
+    const OperatorNode h1{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode h2{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode h3{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode cnot{"CNOT[][2]{}", "CNOT"};
 
     const OperatorNodeHash hashFunc;
     REQUIRE(hashFunc(h1) == hashFunc(h2));
@@ -59,9 +64,9 @@ TEST_CASE("Test OperatorNodeHash", "[DecompGraph::Core]") {
 
 TEST_CASE("Test OperatorNode in unordered_map", "[DecompGraph::Core]") {
     std::unordered_map<OperatorNode, double, OperatorNodeHash> opMap;
-    const OperatorNode h{"Hadamard[][1]{}"};
-    const OperatorNode cnot{"CNOT[][2]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
+    const OperatorNode h{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode cnot{"CNOT[][2]{}", "CNOT"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
     opMap[h] = 1.0;
     opMap[cnot] = 2.0;
@@ -72,9 +77,9 @@ TEST_CASE("Test OperatorNode in unordered_map", "[DecompGraph::Core]") {
 }
 
 TEST_CASE("Test RuleNode construction", "[DecompGraph::Core]") {
-    const OperatorNode h{"Hadamard[][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
+    const OperatorNode h{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
 
     const RuleNode h_to_rz_rx_rz{"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}};
     REQUIRE(h_to_rz_rx_rz.name == "h_to_rz_rx_rz");
@@ -87,11 +92,11 @@ TEST_CASE("Test RuleNode construction", "[DecompGraph::Core]") {
 }
 
 TEST_CASE("Test WeightedGateset construction and contains", "[DecompGraph::Core]") {
-    const OperatorNode h{"Hadamard[][1]{}"};
-    const OperatorNode cnot{"CNOT[][2]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
+    const OperatorNode h{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode cnot{"CNOT[][2]{}", "CNOT"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{h, 1.0}, {cnot, 2.0}}};
+    const WeightedGateset gateset{{{h.name, 1.0}, {cnot.name, 2.0}}};
 
     REQUIRE(gateset.contains(h));
     REQUIRE(gateset.contains(cnot));
@@ -102,9 +107,9 @@ TEST_CASE("Test WeightedGateset construction and contains", "[DecompGraph::Core]
 }
 
 TEST_CASE("Test ChosenDecompRule construction", "[DecompGraph::Core]") {
-    const OperatorNode h{"Hadamard[][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
+    const OperatorNode h{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
 
     const RuleTerm term1{rz, 2};
     const RuleTerm term2{rx, 1};

--- a/mlir/unittests/DecompGraphSolver/Test_DecompGraphSolver.cpp
+++ b/mlir/unittests/DecompGraphSolver/Test_DecompGraphSolver.cpp
@@ -33,11 +33,11 @@ using namespace DecompGraph::Solver;
 
 TEST_CASE("Test DecompositionGraph construction", "[DecompGraph::Solver]")
 {
-    const auto h = OperatorNode{"H[][1]{}"};
-    const auto rz = OperatorNode{"RZ[f64][1]{}"};
-    const auto rx = OperatorNode{"RX[f64][1]{}"};
+    const auto h = OperatorNode{"H[][1]{}", "Hadamard"};
+    const auto rz = OperatorNode{"RZ[f64][1]{}", "RZ"};
+    const auto rx = OperatorNode{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{rz, 1.0}, {rx, 2.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 2.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -68,9 +68,9 @@ TEST_CASE("Test DecompositionGraph construction", "[DecompGraph::Solver]")
 TEST_CASE("Test DecompositionSolver solve method with incomplete gates in Gateset",
           "[DecompGraph::Solver]")
 {
-    const auto h = OperatorNode{"H[][1]{}"};
-    const auto h_gateset = OperatorNode{"H[][1]{}"};
-    const WeightedGateset gateset{{{h_gateset, 1.0}}};
+    const auto h = OperatorNode{"H[][1]{}", "Hadamard"};
+    const auto h_gateset = OperatorNode{"H[][1]{}", "Hadamard"};
+    const WeightedGateset gateset{{{h_gateset.name, 1.0}}};
     const std::vector<RuleNode> rules{
         {"h_to_h", h, {{h, 1}}},
     };
@@ -93,10 +93,10 @@ TEST_CASE("Test DecompositionSolver solve method with incomplete gates in Gatese
 
 TEST_CASE("Do not solve for target gates", "[DecompGraph::Solver]")
 {
-    const auto h = OperatorNode{"H[][1]{}"};
-    const auto rz = OperatorNode{"RZ[f64][1]{}"};
+    const auto h = OperatorNode{"H[][1]{}", "Hadamard"};
+    const auto rz = OperatorNode{"RZ[f64][1]{}", "RZ"};
 
-    const WeightedGateset gateset{{{h, 2.0}, {rz, 1.0}}};
+    const WeightedGateset gateset{{{h.name, 2.0}, {rz.name, 1.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz", h, {{rz, 1}}},
@@ -114,11 +114,11 @@ TEST_CASE("Do not solve for target gates", "[DecompGraph::Solver]")
 
 TEST_CASE("Test DecompositionGraph copy and move semantics", "[DecompGraph::Solver]")
 {
-    const auto h = OperatorNode{"H[][1]{}"};
-    const auto rz = OperatorNode{"RZ[f64][1]{}"};
-    const auto rx = OperatorNode{"RX[f64][1]{}"};
+    const auto h = OperatorNode{"H[][1]{}", "Hadamard"};
+    const auto rz = OperatorNode{"RZ[f64][1]{}", "RZ"};
+    const auto rx = OperatorNode{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{rz, 1.0}, {rx, 2.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 2.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -157,12 +157,12 @@ TEST_CASE("Test DecompositionGraph copy and move semantics", "[DecompGraph::Solv
 
 TEST_CASE("Test DecompositionGraph lookup and counting", "[DecompGraph::Solver]")
 {
-    const OperatorNode h{"H[][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
-    const OperatorNode ry{"RY[f64][1]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
+    const OperatorNode ry{"RY[f64][1]{}", "RY"};
 
-    const WeightedGateset gateset{{{rz, 1.0}, {ry, 2.0}, {rx, 3.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}, {ry.name, 2.0}, {rx.name, 3.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -181,7 +181,7 @@ TEST_CASE("Test DecompositionGraph lookup and counting", "[DecompGraph::Solver]"
     for (const auto &rule : graph.getAllRulesFor(h)) {
         double totalCost = 0.0;
         for (const auto &input : rule.inputs) {
-            totalCost += graph.getGateset().ops.at(input.op) * input.multiplicity;
+            totalCost += graph.getGateset().ops.at(input.op.name) * input.multiplicity;
         }
         if (rule.name == "h_to_rz_rx_rz") {
             REQUIRE(totalCost == 1.0 * 2 + 3.0 * 1);
@@ -195,15 +195,15 @@ TEST_CASE("Test DecompositionGraph lookup and counting", "[DecompGraph::Solver]"
 TEST_CASE("Test the graph construction with realistic ops and multiple rules from PennyLane",
           "[DecompGraph::Solver]")
 {
-    const OperatorNode h{"H[][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
-    const OperatorNode ry{"RY[f64][1]{}"};
-    const OperatorNode cnot{"CNOT[][2]{}"};
-    const OperatorNode swap{"SWAP[][2]{}"};
-    const OperatorNode customBellOp{"BellOp[][2]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
+    const OperatorNode ry{"RY[f64][1]{}", "RY"};
+    const OperatorNode cnot{"CNOT[][2]{}", "CNOT"};
+    const OperatorNode swap{"SWAP[][2]{}", "SWAP"};
+    const OperatorNode customBellOp{"BellOp[][2]{}", "BellOp"};
 
-    const WeightedGateset gateset{{{rz, 1.0}, {rx, 3.0}, {cnot, 5.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 3.0}, {cnot.name, 5.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -221,12 +221,12 @@ TEST_CASE("Test the graph construction with realistic ops and multiple rules fro
 
 TEST_CASE("Test DecompositionSolver with one single operator", "[DecompGraph::Solver]")
 {
-    const OperatorNode h{"H[][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
-    const OperatorNode ry{"RY[f64][1]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
+    const OperatorNode ry{"RY[f64][1]{}", "RY"};
 
-    const WeightedGateset gateset{{{rz, 1.0}, {ry, 2.0}, {rx, 3.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}, {ry.name, 2.0}, {rx.name, 3.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -260,15 +260,15 @@ TEST_CASE("Test DecompositionSolver with one single operator", "[DecompGraph::So
 
 TEST_CASE("Test the graph solver with intermediate ops and multiple rules", "[DecompGraph::Solver]")
 {
-    const OperatorNode h{"H[][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
-    const OperatorNode ry{"RY[f64][1]{}"};
-    const OperatorNode cnot{"CNOT[][2]{}"};
-    const OperatorNode swap{"SWAP[][2]{}"};
-    const OperatorNode customBellOp{"BellOp[][2]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
+    const OperatorNode ry{"RY[f64][1]{}", "RY"};
+    const OperatorNode cnot{"CNOT[][2]{}", "CNOT"};
+    const OperatorNode swap{"SWAP[][2]{}", "SWAP"};
+    const OperatorNode customBellOp{"BellOp[][2]{}", "BellOp"};
 
-    const WeightedGateset gateset{{{rz, 1.0}, {rx, 3.0}, {cnot, 5.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 3.0}, {cnot.name, 5.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -318,10 +318,10 @@ TEST_CASE("Test the graph solver with intermediate ops and multiple rules", "[De
 
 TEST_CASE("Test GraphSolveError for unsolvable operator", "[DecompGraph::Solver]")
 {
-    const OperatorNode h{"H[][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
 
-    const WeightedGateset gateset{{{rz, 1.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}}};
 
     const std::vector<RuleNode> rules{
         {"rz_to_rz", rz, {{rz, 1}}},
@@ -335,7 +335,7 @@ TEST_CASE("Test GraphSolveError for unsolvable operator", "[DecompGraph::Solver]
 
 TEST_CASE("Test GraphSolveError for cyclic decomposition", "[DecompGraph::Solver]")
 {
-    const OperatorNode h{"H[][1]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
 
     const WeightedGateset gateset{};
 
@@ -351,11 +351,11 @@ TEST_CASE("Test GraphSolveError for cyclic decomposition", "[DecompGraph::Solver
 
 TEST_CASE("Test PauliX -> GlobalPhase(1), RX(1) decomposition", "[DecompGraph::Solver]")
 {
-    const OperatorNode x{"X[][1]{}"};
-    const OperatorNode globalPhase{"GlobalPhase[][]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
+    const OperatorNode x{"X[][1]{}", "PauliX"};
+    const OperatorNode globalPhase{"GlobalPhase[][]{}", "GlobalPhase"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{globalPhase, 1.0}, {rx, 1.0}}};
+    const WeightedGateset gateset{{{globalPhase.name, 1.0}, {rx.name, 1.0}}};
 
     const std::vector<RuleNode> rules{
         {"x_to_globalPhase_rx", x, {{globalPhase, 1}, {rx, 1}}},
@@ -381,14 +381,14 @@ TEST_CASE("Test PauliX -> GlobalPhase(1), RX(1) decomposition", "[DecompGraph::S
 TEST_CASE("Test cyclic decomposition with multiple rules for the same operator",
           "[DecompGraph::Solver]")
 {
-    const OperatorNode hadamard{"Hadamard[][1]{}"};
-    const OperatorNode globalPhase{"GlobalPhase[][]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
-    const OperatorNode ry{"RY[f64][1]{}"};
-    const OperatorNode changeOpBasis{"ChangeOpBasis[][2]{}"};
-    const OperatorNode pauliRot{"PauliRot[f64][2]{pauli_word:XY}"};
-    const OperatorNode rot{"Rot[f64,f64,f64][3]{}"};
+    const OperatorNode hadamard{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode globalPhase{"GlobalPhase[][]{}", "GlobalPhase"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
+    const OperatorNode ry{"RY[f64][1]{}", "RY"};
+    const OperatorNode changeOpBasis{"ChangeOpBasis[][2]{}", "ChangeOpBasis"};
+    const OperatorNode pauliRot{"PauliRot[f64][2]{pauli_word:XY}", "PauliRot"};
+    const OperatorNode rot{"Rot[f64,f64,f64][3]{}", "Rot"};
 
     const std::vector<RuleNode> rules{
         {"__builtin__ry_to_rz_cliff", ry, {{changeOpBasis, 1}}},
@@ -400,7 +400,7 @@ TEST_CASE("Test cyclic decomposition with multiple rules for the same operator",
         {"__builtin__hadamard_to_rz_ry", hadamard, {{globalPhase, 1}, {ry, 1}, {rz, 1}}},
     };
 
-    const WeightedGateset gateset{{{globalPhase, 1.0}, {rx, 1.0}, {rz, 1.0}}};
+    const WeightedGateset gateset{{{globalPhase.name, 1.0}, {rx.name, 1.0}, {rz.name, 1.0}}};
     const DecompositionGraph graph({hadamard}, gateset, rules);
     DecompositionSolver solver(graph);
     const auto solutions = solver.solve();
@@ -409,7 +409,8 @@ TEST_CASE("Test cyclic decomposition with multiple rules for the same operator",
     REQUIRE(h_solution.ruleName == "__builtin__hadamard_to_rz_rx");
     REQUIRE(h_solution.totalCost == 1.0 * 1 + 1.0 * 1 + 1.0 * 2);
 
-    const WeightedGateset gateset2{{{globalPhase, 1.0}, {rx, 1.0}, {rz, 2.0}, {ry, 1.0}}};
+    const WeightedGateset gateset2{
+        {{globalPhase.name, 1.0}, {rx.name, 1.0}, {rz.name, 2.0}, {ry.name, 1.0}}};
     const DecompositionGraph graph2({hadamard}, gateset2, rules);
     DecompositionSolver solver2(graph2);
     const auto solutions2 = solver2.solve();
@@ -419,11 +420,11 @@ TEST_CASE("Test cyclic decomposition with multiple rules for the same operator",
 
 TEST_CASE("Test GraphBuilder with fixed decomposition", "[DecompGraph::Solver]")
 {
-    const OperatorNode h{"H[][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{rz, 1.0}, {rx, 3.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 3.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -441,11 +442,11 @@ TEST_CASE("Test GraphBuilder with fixed decomposition", "[DecompGraph::Solver]")
 
 TEST_CASE("Test GraphBuilder with alternative decomposition", "[DecompGraph::Solver]")
 {
-    const OperatorNode h{"H[][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{rz, 1.0}, {rx, 3.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 3.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -461,11 +462,11 @@ TEST_CASE("Test GraphBuilder with alternative decomposition", "[DecompGraph::Sol
 
 TEST_CASE("Test GraphSolver with fixed decomposition", "[DecompGraph::Solver]")
 {
-    const OperatorNode h{"H[][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{rz, 3.0}, {rx, 1.0}}};
+    const WeightedGateset gateset{{{rz.name, 3.0}, {rx.name, 1.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -487,11 +488,11 @@ TEST_CASE("Test GraphSolver with fixed decomposition", "[DecompGraph::Solver]")
 
 TEST_CASE("Test GraphSolver with alternative decomposition", "[DecompGraph::Solver]")
 {
-    const OperatorNode h{"H[][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{rz, 1.0}, {rx, 3.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 3.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -512,11 +513,11 @@ TEST_CASE("Test GraphSolver with alternative decomposition", "[DecompGraph::Solv
 
 TEST_CASE("Test GraphSolver with MultiRZ decompositions", "[DecompGraph::Solver]")
 {
-    const OperatorNode multiRZ3{"MultiRZ[f64][3]{}"};
-    const OperatorNode multiRZ5{"MultiRZ[f64][5]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
+    const OperatorNode multiRZ3{"MultiRZ[f64][3]{}", "MultiRZ"};
+    const OperatorNode multiRZ5{"MultiRZ[f64][5]{}", "MultiRZ"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
 
-    const WeightedGateset gateset{{{rz, 1.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}}};
 
     const std::vector<RuleNode> rules{
         {"multiRZ3_to_rz", multiRZ3, {{rz, 3}}},
@@ -539,10 +540,10 @@ TEST_CASE("Test GraphSolver with MultiRZ decompositions", "[DecompGraph::Solver]
 
 TEST_CASE("Test GraphSolver with empty decomposition rules", "[DecompGraph::Solver]")
 {
-    const OperatorNode hadamard{"Hadamard[][1]{}"};
-    const OperatorNode globalPhase{"GlobalPhase[][]{}"};
+    const OperatorNode hadamard{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode globalPhase{"GlobalPhase[][]{}", "GlobalPhase"};
 
-    const WeightedGateset gateset{{{globalPhase, 1.0}}};
+    const WeightedGateset gateset{{{globalPhase.name, 1.0}}};
 
     const std::vector<RuleNode> rules{
         {"hadamard_to_globalPhase", hadamard, {}},
@@ -561,9 +562,9 @@ TEST_CASE("Test GraphSolver with empty decomposition rules", "[DecompGraph::Solv
 
 TEST_CASE("Test OperatorNode equality with staticNamedArgs", "[DecompGraph::Core]")
 {
-    const OperatorNode pauliRotX{"PauliRot[f64][1]{pauli_word:X}"};
-    const OperatorNode pauliRotX2{"PauliRot[f64][1]{pauli_word:X}"};
-    const OperatorNode pauliRotY{"PauliRot[f64][1]{pauli_word:Y}"};
+    const OperatorNode pauliRotX{"PauliRot[f64][1]{pauli_word:X}", "PauliRot"};
+    const OperatorNode pauliRotX2{"PauliRot[f64][1]{pauli_word:X}", "PauliRot"};
+    const OperatorNode pauliRotY{"PauliRot[f64][1]{pauli_word:Y}", "PauliRot"};
 
     REQUIRE(pauliRotX == pauliRotX2);
     REQUIRE_FALSE(pauliRotX == pauliRotY);

--- a/mlir/unittests/DecompGraphSolver/Test_DecompGraphSolver.cpp
+++ b/mlir/unittests/DecompGraphSolver/Test_DecompGraphSolver.cpp
@@ -36,7 +36,7 @@ TEST_CASE("Test DecompositionGraph construction", "[DecompGraph::Solver]") {
     const auto rz = OperatorNode{"RZ[f64][1]{}", "RZ"};
     const auto rx = OperatorNode{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 2.0}}};
+    const WeightedGateset gateset{{{"RZ", 1.0}, {"RX", 2.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -68,7 +68,7 @@ TEST_CASE("Test DecompositionSolver solve method with incomplete gates in Gatese
           "[DecompGraph::Solver]") {
     const auto h = OperatorNode{"H[][1]{}", "Hadamard"};
     const auto h_gateset = OperatorNode{"H[][1]{}", "Hadamard"};
-    const WeightedGateset gateset{{{h_gateset.name, 1.0}}};
+    const WeightedGateset gateset{{{"Hadamard", 1.0}}};
     const std::vector<RuleNode> rules{
         {"h_to_h", h, {{h, 1}}},
     };
@@ -93,7 +93,7 @@ TEST_CASE("Do not solve for target gates", "[DecompGraph::Solver]") {
     const auto h = OperatorNode{"H[][1]{}", "Hadamard"};
     const auto rz = OperatorNode{"RZ[f64][1]{}", "RZ"};
 
-    const WeightedGateset gateset{{{h.name, 2.0}, {rz.name, 1.0}}};
+    const WeightedGateset gateset{{{"Hadamard", 2.0}, {"RZ", 1.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz", h, {{rz, 1}}},
@@ -114,7 +114,7 @@ TEST_CASE("Test DecompositionGraph copy and move semantics", "[DecompGraph::Solv
     const auto rz = OperatorNode{"RZ[f64][1]{}", "RZ"};
     const auto rx = OperatorNode{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 2.0}}};
+    const WeightedGateset gateset{{{"RZ", 1.0}, {"RX", 2.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -157,7 +157,7 @@ TEST_CASE("Test DecompositionGraph lookup and counting", "[DecompGraph::Solver]"
     const OperatorNode rx{"RX[f64][1]{}", "RX"};
     const OperatorNode ry{"RY[f64][1]{}", "RY"};
 
-    const WeightedGateset gateset{{{rz.name, 1.0}, {ry.name, 2.0}, {rx.name, 3.0}}};
+    const WeightedGateset gateset{{{"RZ", 1.0}, {"RY", 2.0}, {"RX", 3.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -196,7 +196,7 @@ TEST_CASE("Test the graph construction with realistic ops and multiple rules fro
     const OperatorNode swap{"SWAP[][2]{}", "SWAP"};
     const OperatorNode customBellOp{"BellOp[][2]{}", "BellOp"};
 
-    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 3.0}, {cnot.name, 5.0}}};
+    const WeightedGateset gateset{{{"RZ", 1.0}, {"RX", 3.0}, {"CNOT", 5.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -218,7 +218,7 @@ TEST_CASE("Test DecompositionSolver with one single operator", "[DecompGraph::So
     const OperatorNode rx{"RX[f64][1]{}", "RX"};
     const OperatorNode ry{"RY[f64][1]{}", "RY"};
 
-    const WeightedGateset gateset{{{rz.name, 1.0}, {ry.name, 2.0}, {rx.name, 3.0}}};
+    const WeightedGateset gateset{{{"RZ", 1.0}, {"RY", 2.0}, {"RX", 3.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -260,7 +260,7 @@ TEST_CASE("Test the graph solver with intermediate ops and multiple rules",
     const OperatorNode swap{"SWAP[][2]{}", "SWAP"};
     const OperatorNode customBellOp{"BellOp[][2]{}", "BellOp"};
 
-    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 3.0}, {cnot.name, 5.0}}};
+    const WeightedGateset gateset{{{"RZ", 1.0}, {"RX", 3.0}, {"CNOT", 5.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -308,7 +308,7 @@ TEST_CASE("Test GraphSolveError for unsolvable operator", "[DecompGraph::Solver]
     const OperatorNode h{"H[][1]{}", "Hadamard"};
     const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
 
-    const WeightedGateset gateset{{{rz.name, 1.0}}};
+    const WeightedGateset gateset{{{"RZ", 1.0}}};
 
     const std::vector<RuleNode> rules{
         {"rz_to_rz", rz, {{rz, 1}}},
@@ -340,7 +340,7 @@ TEST_CASE("Test PauliX -> GlobalPhase(1), RX(1) decomposition", "[DecompGraph::S
     const OperatorNode globalPhase{"GlobalPhase[][]{}", "GlobalPhase"};
     const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{globalPhase.name, 1.0}, {rx.name, 1.0}}};
+    const WeightedGateset gateset{{{"GlobalPhase", 1.0}, {"RX", 1.0}}};
 
     const std::vector<RuleNode> rules{
         {"x_to_globalPhase_rx", x, {{globalPhase, 1}, {rx, 1}}},
@@ -384,7 +384,7 @@ TEST_CASE("Test cyclic decomposition with multiple rules for the same operator",
         {"__builtin__hadamard_to_rz_ry", hadamard, {{globalPhase, 1}, {ry, 1}, {rz, 1}}},
     };
 
-    const WeightedGateset gateset{{{globalPhase.name, 1.0}, {rx.name, 1.0}, {rz.name, 1.0}}};
+    const WeightedGateset gateset{{{"GlobalPhase", 1.0}, {"RX", 1.0}, {"RZ", 1.0}}};
     const DecompositionGraph graph({hadamard}, gateset, rules);
     DecompositionSolver solver(graph);
     const auto solutions = solver.solve();
@@ -393,8 +393,7 @@ TEST_CASE("Test cyclic decomposition with multiple rules for the same operator",
     REQUIRE(h_solution.ruleName == "__builtin__hadamard_to_rz_rx");
     REQUIRE(h_solution.totalCost == 1.0 * 1 + 1.0 * 1 + 1.0 * 2);
 
-    const WeightedGateset gateset2{
-        {{globalPhase.name, 1.0}, {rx.name, 1.0}, {rz.name, 2.0}, {ry.name, 1.0}}};
+    const WeightedGateset gateset2{{{"GlobalPhase", 1.0}, {"RX", 1.0}, {"RZ", 2.0}, {"RY", 1.0}}};
     const DecompositionGraph graph2({hadamard}, gateset2, rules);
     DecompositionSolver solver2(graph2);
     const auto solutions2 = solver2.solve();
@@ -407,7 +406,7 @@ TEST_CASE("Test GraphBuilder with fixed decomposition", "[DecompGraph::Solver]")
     const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
     const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 3.0}}};
+    const WeightedGateset gateset{{{"RZ", 1.0}, {"RX", 3.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -428,7 +427,7 @@ TEST_CASE("Test GraphBuilder with alternative decomposition", "[DecompGraph::Sol
     const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
     const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 3.0}}};
+    const WeightedGateset gateset{{{"RZ", 1.0}, {"RX", 3.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -447,7 +446,7 @@ TEST_CASE("Test GraphSolver with fixed decomposition", "[DecompGraph::Solver]") 
     const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
     const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{rz.name, 3.0}, {rx.name, 1.0}}};
+    const WeightedGateset gateset{{{"RZ", 3.0}, {"RX", 1.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -472,7 +471,7 @@ TEST_CASE("Test GraphSolver with alternative decomposition", "[DecompGraph::Solv
     const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
     const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 3.0}}};
+    const WeightedGateset gateset{{{"RZ", 1.0}, {"RX", 3.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -496,7 +495,7 @@ TEST_CASE("Test GraphSolver with MultiRZ decompositions", "[DecompGraph::Solver]
     const OperatorNode multiRZ5{"MultiRZ[f64][5]{}", "MultiRZ"};
     const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
 
-    const WeightedGateset gateset{{{rz.name, 1.0}}};
+    const WeightedGateset gateset{{{"RZ", 1.0}}};
 
     const std::vector<RuleNode> rules{
         {"multiRZ3_to_rz", multiRZ3, {{rz, 3}}},
@@ -521,7 +520,7 @@ TEST_CASE("Test GraphSolver with empty decomposition rules", "[DecompGraph::Solv
     const OperatorNode hadamard{"Hadamard[][1]{}", "Hadamard"};
     const OperatorNode globalPhase{"GlobalPhase[][]{}", "GlobalPhase"};
 
-    const WeightedGateset gateset{{{globalPhase.name, 1.0}}};
+    const WeightedGateset gateset{{{"GlobalPhase", 1.0}}};
 
     const std::vector<RuleNode> rules{
         {"hadamard_to_globalPhase", hadamard, {}},

--- a/mlir/unittests/DecompGraphSolver/Test_DecompGraphSolver.cpp
+++ b/mlir/unittests/DecompGraphSolver/Test_DecompGraphSolver.cpp
@@ -32,11 +32,11 @@ using namespace DecompGraph::Core;
 using namespace DecompGraph::Solver;
 
 TEST_CASE("Test DecompositionGraph construction", "[DecompGraph::Solver]") {
-    const auto h = OperatorNode{"H[][1]{}"};
-    const auto rz = OperatorNode{"RZ[f64][1]{}"};
-    const auto rx = OperatorNode{"RX[f64][1]{}"};
+    const auto h = OperatorNode{"H[][1]{}", "Hadamard"};
+    const auto rz = OperatorNode{"RZ[f64][1]{}", "RZ"};
+    const auto rx = OperatorNode{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{rz, 1.0}, {rx, 2.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 2.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -66,9 +66,9 @@ TEST_CASE("Test DecompositionGraph construction", "[DecompGraph::Solver]") {
 
 TEST_CASE("Test DecompositionSolver solve method with incomplete gates in Gateset",
           "[DecompGraph::Solver]") {
-    const auto h = OperatorNode{"H[][1]{}"};
-    const auto h_gateset = OperatorNode{"H[][1]{}"};
-    const WeightedGateset gateset{{{h_gateset, 1.0}}};
+    const auto h = OperatorNode{"H[][1]{}", "Hadamard"};
+    const auto h_gateset = OperatorNode{"H[][1]{}", "Hadamard"};
+    const WeightedGateset gateset{{{h_gateset.name, 1.0}}};
     const std::vector<RuleNode> rules{
         {"h_to_h", h, {{h, 1}}},
     };
@@ -90,10 +90,10 @@ TEST_CASE("Test DecompositionSolver solve method with incomplete gates in Gatese
 }
 
 TEST_CASE("Do not solve for target gates", "[DecompGraph::Solver]") {
-    const auto h = OperatorNode{"H[][1]{}"};
-    const auto rz = OperatorNode{"RZ[f64][1]{}"};
+    const auto h = OperatorNode{"H[][1]{}", "Hadamard"};
+    const auto rz = OperatorNode{"RZ[f64][1]{}", "RZ"};
 
-    const WeightedGateset gateset{{{h, 2.0}, {rz, 1.0}}};
+    const WeightedGateset gateset{{{h.name, 2.0}, {rz.name, 1.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz", h, {{rz, 1}}},
@@ -110,11 +110,11 @@ TEST_CASE("Do not solve for target gates", "[DecompGraph::Solver]") {
 }
 
 TEST_CASE("Test DecompositionGraph copy and move semantics", "[DecompGraph::Solver]") {
-    const auto h = OperatorNode{"H[][1]{}"};
-    const auto rz = OperatorNode{"RZ[f64][1]{}"};
-    const auto rx = OperatorNode{"RX[f64][1]{}"};
+    const auto h = OperatorNode{"H[][1]{}", "Hadamard"};
+    const auto rz = OperatorNode{"RZ[f64][1]{}", "RZ"};
+    const auto rx = OperatorNode{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{rz, 1.0}, {rx, 2.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 2.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -152,12 +152,12 @@ TEST_CASE("Test DecompositionGraph copy and move semantics", "[DecompGraph::Solv
 }
 
 TEST_CASE("Test DecompositionGraph lookup and counting", "[DecompGraph::Solver]") {
-    const OperatorNode h{"H[][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
-    const OperatorNode ry{"RY[f64][1]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
+    const OperatorNode ry{"RY[f64][1]{}", "RY"};
 
-    const WeightedGateset gateset{{{rz, 1.0}, {ry, 2.0}, {rx, 3.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}, {ry.name, 2.0}, {rx.name, 3.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -176,7 +176,7 @@ TEST_CASE("Test DecompositionGraph lookup and counting", "[DecompGraph::Solver]"
     for (const auto &rule : graph.getAllRulesFor(h)) {
         double totalCost = 0.0;
         for (const auto &input : rule.inputs) {
-            totalCost += graph.getGateset().ops.at(input.op) * input.multiplicity;
+            totalCost += graph.getGateset().ops.at(input.op.name) * input.multiplicity;
         }
         if (rule.name == "h_to_rz_rx_rz") {
             REQUIRE(totalCost == 1.0 * 2 + 3.0 * 1);
@@ -188,15 +188,15 @@ TEST_CASE("Test DecompositionGraph lookup and counting", "[DecompGraph::Solver]"
 
 TEST_CASE("Test the graph construction with realistic ops and multiple rules from PennyLane",
           "[DecompGraph::Solver]") {
-    const OperatorNode h{"H[][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
-    const OperatorNode ry{"RY[f64][1]{}"};
-    const OperatorNode cnot{"CNOT[][2]{}"};
-    const OperatorNode swap{"SWAP[][2]{}"};
-    const OperatorNode customBellOp{"BellOp[][2]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
+    const OperatorNode ry{"RY[f64][1]{}", "RY"};
+    const OperatorNode cnot{"CNOT[][2]{}", "CNOT"};
+    const OperatorNode swap{"SWAP[][2]{}", "SWAP"};
+    const OperatorNode customBellOp{"BellOp[][2]{}", "BellOp"};
 
-    const WeightedGateset gateset{{{rz, 1.0}, {rx, 3.0}, {cnot, 5.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 3.0}, {cnot.name, 5.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -213,12 +213,12 @@ TEST_CASE("Test the graph construction with realistic ops and multiple rules fro
 }
 
 TEST_CASE("Test DecompositionSolver with one single operator", "[DecompGraph::Solver]") {
-    const OperatorNode h{"H[][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
-    const OperatorNode ry{"RY[f64][1]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
+    const OperatorNode ry{"RY[f64][1]{}", "RY"};
 
-    const WeightedGateset gateset{{{rz, 1.0}, {ry, 2.0}, {rx, 3.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}, {ry.name, 2.0}, {rx.name, 3.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -252,15 +252,15 @@ TEST_CASE("Test DecompositionSolver with one single operator", "[DecompGraph::So
 
 TEST_CASE("Test the graph solver with intermediate ops and multiple rules",
           "[DecompGraph::Solver]") {
-    const OperatorNode h{"H[][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
-    const OperatorNode ry{"RY[f64][1]{}"};
-    const OperatorNode cnot{"CNOT[][2]{}"};
-    const OperatorNode swap{"SWAP[][2]{}"};
-    const OperatorNode customBellOp{"BellOp[][2]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
+    const OperatorNode ry{"RY[f64][1]{}", "RY"};
+    const OperatorNode cnot{"CNOT[][2]{}", "CNOT"};
+    const OperatorNode swap{"SWAP[][2]{}", "SWAP"};
+    const OperatorNode customBellOp{"BellOp[][2]{}", "BellOp"};
 
-    const WeightedGateset gateset{{{rz, 1.0}, {rx, 3.0}, {cnot, 5.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 3.0}, {cnot.name, 5.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -305,10 +305,10 @@ TEST_CASE("Test the graph solver with intermediate ops and multiple rules",
 }
 
 TEST_CASE("Test GraphSolveError for unsolvable operator", "[DecompGraph::Solver]") {
-    const OperatorNode h{"H[][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
 
-    const WeightedGateset gateset{{{rz, 1.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}}};
 
     const std::vector<RuleNode> rules{
         {"rz_to_rz", rz, {{rz, 1}}},
@@ -321,7 +321,7 @@ TEST_CASE("Test GraphSolveError for unsolvable operator", "[DecompGraph::Solver]
 }
 
 TEST_CASE("Test GraphSolveError for cyclic decomposition", "[DecompGraph::Solver]") {
-    const OperatorNode h{"H[][1]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
 
     const WeightedGateset gateset{};
 
@@ -336,11 +336,11 @@ TEST_CASE("Test GraphSolveError for cyclic decomposition", "[DecompGraph::Solver
 }
 
 TEST_CASE("Test PauliX -> GlobalPhase(1), RX(1) decomposition", "[DecompGraph::Solver]") {
-    const OperatorNode x{"X[][1]{}"};
-    const OperatorNode globalPhase{"GlobalPhase[][]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
+    const OperatorNode x{"X[][1]{}", "PauliX"};
+    const OperatorNode globalPhase{"GlobalPhase[][]{}", "GlobalPhase"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{globalPhase, 1.0}, {rx, 1.0}}};
+    const WeightedGateset gateset{{{globalPhase.name, 1.0}, {rx.name, 1.0}}};
 
     const std::vector<RuleNode> rules{
         {"x_to_globalPhase_rx", x, {{globalPhase, 1}, {rx, 1}}},
@@ -365,14 +365,14 @@ TEST_CASE("Test PauliX -> GlobalPhase(1), RX(1) decomposition", "[DecompGraph::S
 
 TEST_CASE("Test cyclic decomposition with multiple rules for the same operator",
           "[DecompGraph::Solver]") {
-    const OperatorNode hadamard{"Hadamard[][1]{}"};
-    const OperatorNode globalPhase{"GlobalPhase[][]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
-    const OperatorNode ry{"RY[f64][1]{}"};
-    const OperatorNode changeOpBasis{"ChangeOpBasis[][2]{}"};
-    const OperatorNode pauliRot{"PauliRot[f64][2]{pauli_word:XY}"};
-    const OperatorNode rot{"Rot[f64,f64,f64][3]{}"};
+    const OperatorNode hadamard{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode globalPhase{"GlobalPhase[][]{}", "GlobalPhase"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
+    const OperatorNode ry{"RY[f64][1]{}", "RY"};
+    const OperatorNode changeOpBasis{"ChangeOpBasis[][2]{}", "ChangeOpBasis"};
+    const OperatorNode pauliRot{"PauliRot[f64][2]{pauli_word:XY}", "PauliRot"};
+    const OperatorNode rot{"Rot[f64,f64,f64][3]{}", "Rot"};
 
     const std::vector<RuleNode> rules{
         {"__builtin__ry_to_rz_cliff", ry, {{changeOpBasis, 1}}},
@@ -384,7 +384,7 @@ TEST_CASE("Test cyclic decomposition with multiple rules for the same operator",
         {"__builtin__hadamard_to_rz_ry", hadamard, {{globalPhase, 1}, {ry, 1}, {rz, 1}}},
     };
 
-    const WeightedGateset gateset{{{globalPhase, 1.0}, {rx, 1.0}, {rz, 1.0}}};
+    const WeightedGateset gateset{{{globalPhase.name, 1.0}, {rx.name, 1.0}, {rz.name, 1.0}}};
     const DecompositionGraph graph({hadamard}, gateset, rules);
     DecompositionSolver solver(graph);
     const auto solutions = solver.solve();
@@ -393,7 +393,8 @@ TEST_CASE("Test cyclic decomposition with multiple rules for the same operator",
     REQUIRE(h_solution.ruleName == "__builtin__hadamard_to_rz_rx");
     REQUIRE(h_solution.totalCost == 1.0 * 1 + 1.0 * 1 + 1.0 * 2);
 
-    const WeightedGateset gateset2{{{globalPhase, 1.0}, {rx, 1.0}, {rz, 2.0}, {ry, 1.0}}};
+    const WeightedGateset gateset2{
+        {{globalPhase.name, 1.0}, {rx.name, 1.0}, {rz.name, 2.0}, {ry.name, 1.0}}};
     const DecompositionGraph graph2({hadamard}, gateset2, rules);
     DecompositionSolver solver2(graph2);
     const auto solutions2 = solver2.solve();
@@ -402,11 +403,11 @@ TEST_CASE("Test cyclic decomposition with multiple rules for the same operator",
 }
 
 TEST_CASE("Test GraphBuilder with fixed decomposition", "[DecompGraph::Solver]") {
-    const OperatorNode h{"H[][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{rz, 1.0}, {rx, 3.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 3.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -423,11 +424,11 @@ TEST_CASE("Test GraphBuilder with fixed decomposition", "[DecompGraph::Solver]")
 }
 
 TEST_CASE("Test GraphBuilder with alternative decomposition", "[DecompGraph::Solver]") {
-    const OperatorNode h{"H[][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{rz, 1.0}, {rx, 3.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 3.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -442,11 +443,11 @@ TEST_CASE("Test GraphBuilder with alternative decomposition", "[DecompGraph::Sol
 }
 
 TEST_CASE("Test GraphSolver with fixed decomposition", "[DecompGraph::Solver]") {
-    const OperatorNode h{"H[][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{rz, 3.0}, {rx, 1.0}}};
+    const WeightedGateset gateset{{{rz.name, 3.0}, {rx.name, 1.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -467,11 +468,11 @@ TEST_CASE("Test GraphSolver with fixed decomposition", "[DecompGraph::Solver]") 
 }
 
 TEST_CASE("Test GraphSolver with alternative decomposition", "[DecompGraph::Solver]") {
-    const OperatorNode h{"H[][1]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
-    const OperatorNode rx{"RX[f64][1]{}"};
+    const OperatorNode h{"H[][1]{}", "Hadamard"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
+    const OperatorNode rx{"RX[f64][1]{}", "RX"};
 
-    const WeightedGateset gateset{{{rz, 1.0}, {rx, 3.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}, {rx.name, 3.0}}};
 
     const std::vector<RuleNode> rules{
         {"h_to_rz_rx_rz", h, {{rz, 2}, {rx, 1}}},
@@ -491,11 +492,11 @@ TEST_CASE("Test GraphSolver with alternative decomposition", "[DecompGraph::Solv
 }
 
 TEST_CASE("Test GraphSolver with MultiRZ decompositions", "[DecompGraph::Solver]") {
-    const OperatorNode multiRZ3{"MultiRZ[f64][3]{}"};
-    const OperatorNode multiRZ5{"MultiRZ[f64][5]{}"};
-    const OperatorNode rz{"RZ[f64][1]{}"};
+    const OperatorNode multiRZ3{"MultiRZ[f64][3]{}", "MultiRZ"};
+    const OperatorNode multiRZ5{"MultiRZ[f64][5]{}", "MultiRZ"};
+    const OperatorNode rz{"RZ[f64][1]{}", "RZ"};
 
-    const WeightedGateset gateset{{{rz, 1.0}}};
+    const WeightedGateset gateset{{{rz.name, 1.0}}};
 
     const std::vector<RuleNode> rules{
         {"multiRZ3_to_rz", multiRZ3, {{rz, 3}}},
@@ -517,10 +518,10 @@ TEST_CASE("Test GraphSolver with MultiRZ decompositions", "[DecompGraph::Solver]
 }
 
 TEST_CASE("Test GraphSolver with empty decomposition rules", "[DecompGraph::Solver]") {
-    const OperatorNode hadamard{"Hadamard[][1]{}"};
-    const OperatorNode globalPhase{"GlobalPhase[][]{}"};
+    const OperatorNode hadamard{"Hadamard[][1]{}", "Hadamard"};
+    const OperatorNode globalPhase{"GlobalPhase[][]{}", "GlobalPhase"};
 
-    const WeightedGateset gateset{{{globalPhase, 1.0}}};
+    const WeightedGateset gateset{{{globalPhase.name, 1.0}}};
 
     const std::vector<RuleNode> rules{
         {"hadamard_to_globalPhase", hadamard, {}},
@@ -538,9 +539,9 @@ TEST_CASE("Test GraphSolver with empty decomposition rules", "[DecompGraph::Solv
 }
 
 TEST_CASE("Test OperatorNode equality with staticNamedArgs", "[DecompGraph::Core]") {
-    const OperatorNode pauliRotX{"PauliRot[f64][1]{pauli_word:X}"};
-    const OperatorNode pauliRotX2{"PauliRot[f64][1]{pauli_word:X}"};
-    const OperatorNode pauliRotY{"PauliRot[f64][1]{pauli_word:Y}"};
+    const OperatorNode pauliRotX{"PauliRot[f64][1]{pauli_word:X}", "PauliRot"};
+    const OperatorNode pauliRotX2{"PauliRot[f64][1]{pauli_word:X}", "PauliRot"};
+    const OperatorNode pauliRotY{"PauliRot[f64][1]{pauli_word:Y}", "PauliRot"};
 
     REQUIRE(pauliRotX == pauliRotX2);
     REQUIRE_FALSE(pauliRotX == pauliRotY);


### PR DESCRIPTION
**Context:**
Support for `graphOpId` in the `graph-decomposition` pass (#3052) required that `graph-decomposition` gatesets be specified by ID, which is infeasible to work with.

**Description of the Change:**
This PR re-introduces the ability to specify gatesets by name rather than ID. The `WeightedGateset` struct now maps names to costs, and matches against node names rather than IDs. Functionality demonstrated by the `TestAltDecomps` test in `frontend/test/lit/GraphDecomposition`.

**Benefits:**
Returns the ability to specify gatesets by name to the `graph-decomposition` pass!

**Possible Drawbacks:**

**Related GitHub Issues:**
