### PR TITLE
Update `DecomposableGate` Interface to use Dictionaries

### DIFF
--- a/frontend/catalyst/decomposition/decomposition_rules.py
+++ b/frontend/catalyst/decomposition/decomposition_rules.py
@@ -32,6 +32,7 @@ from catalyst.decomposition.type_utils import (
     post_process_concretize_leaves,
     replace_abstract_wires_with_concrete_wires,
 )
+from catalyst.from_plxpr.qref_operator2_primitives import _is_custom_op
 from catalyst.from_plxpr.uid import generate_uid
 from catalyst.jax_extras.lowering import get_mlir_attribute_from_pyval
 
@@ -160,11 +161,10 @@ class GraphOpID:
         return ID_string
 
 
-def collect_resources_for_op(op_name, kwargs):
-    """
-    Return resource data for all decomposition rules associated to op_name.
-    """
+def collect_resources_for_op(op_name, kwargs, is_custom_op=False):
+    """Return resource data for all decomposition rules associated to op_name."""
     decomp_rules = list(qp.decomposition.list_decomps(op_name))
+    args = ()
 
     # map rules to resource resources, in a more generic format
     name_to_resource_ids = {}
@@ -172,7 +172,10 @@ def collect_resources_for_op(op_name, kwargs):
     for rule in decomp_rules:
         # The `compute_resources` function's signature is the same as the Operator2 signature
         # for the original op of the rule
-        resources = rule.compute_resources(**kwargs)
+        if is_custom_op:
+            args = tuple(val for key, val in kwargs.items() if key != "wires")
+            kwargs = {"wires": kwargs["wires"]}
+        resources = rule.compute_resources(*args, **kwargs)
         name_to_resources[rule.name] = resources.gate_counts
         name_to_resource_ids[rule.name] = {
             GraphOpID(op).getID(): count for op, count in resources.gate_counts.items()
@@ -182,7 +185,13 @@ def collect_resources_for_op(op_name, kwargs):
 
 
 def compile_decomposition_rules(
-    op_name, op_id, dynamic_shape, wire_lens, static_data, extra_data=None
+    op_name,
+    op_id,
+    dynamic_shape,
+    wire_lens,
+    static_data,
+    extra_data=None,
+    is_custom_op=False,
 ) -> ModuleOp:
     """
     Return a ModuleOp containing the decomposition rules for an operator instance.
@@ -199,7 +208,7 @@ def compile_decomposition_rules(
         kwargs[arg_name] = get_dummy_values_for_container(arg_shape)
 
     _, name_to_resource_ids, decomp_rules = collect_resources_for_op(
-        op_name, kwargs | static_data | extra_data
+        op_name, kwargs | static_data | extra_data, is_custom_op
     )
 
     # The static_data was only needed to instantiate the correct decomp rule
@@ -256,11 +265,23 @@ def compile_decomposition_rules(
 
 
 def compile_decomposition_rules_wrapper(
-    op_name, op_id, dynamic_shape, wire_lens, static_data, extra_data=None
+    op_name,
+    op_id,
+    dynamic_shape,
+    wire_lens,
+    static_data,
+    extra_data=None,
+    is_custom_op=False,
 ) -> str:
     """Return a string MLIR module containing the decomposition rules for an operator instance."""
     return str(
         compile_decomposition_rules(
-            op_name, op_id, dynamic_shape, wire_lens, static_data, extra_data=extra_data
+            op_name,
+            op_id,
+            dynamic_shape,
+            wire_lens,
+            static_data,
+            extra_data=extra_data,
+            is_custom_op=is_custom_op,
         )
     )

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -488,7 +488,7 @@ def trace_from_pennylane(
             plxpr, out_type, out_treedef = make_jaxpr2(
                 fn, static_argnums=static_argnums, debug_info=debug_info
             )(*inner_args, **inner_kwargs)
-            breakpoint()
+
             flat_inputs = jax.tree.flatten((inner_args, inner_kwargs))[0]
             flat_inputs = [a for a in flat_inputs if qp.math.is_abstract(a)]
             abstract_shapes = _extract_abstract_shapes(flat_inputs)

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -488,7 +488,7 @@ def trace_from_pennylane(
             plxpr, out_type, out_treedef = make_jaxpr2(
                 fn, static_argnums=static_argnums, debug_info=debug_info
             )(*inner_args, **inner_kwargs)
-
+            breakpoint()
             flat_inputs = jax.tree.flatten((inner_args, inner_kwargs))[0]
             flat_inputs = [a for a in flat_inputs if qp.math.is_abstract(a)]
             abstract_shapes = _extract_abstract_shapes(flat_inputs)

--- a/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
+++ b/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
@@ -88,6 +88,8 @@ def _is_custom_op(op_cls, avals_in):
         return False
     if op_cls.wire_argnames != ("wires",):
         return False
+    if list(op_cls._sig.parameters.keys())[-1] != "wires":
+        return False
     return all(p.shape == () and "float" in p.dtype.name for p in avals_in)
 
 

--- a/frontend/test/lit/GraphDecomposition/TestAltDecomps.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestAltDecomps.mlir
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// RUN: catalyst --tool=opt --pass-pipeline='builtin.module(graph-decomposition{gate-set=testRY=1.0,testX=3.0,testZ=3.0 alt-decomps=PauliY=[y_to_ry,y_to_x_z] bytecode-rules="%BYTECODE_PATH"})' %s | FileCheck %s --check-prefixes RY
+// RUN: catalyst --tool=opt --pass-pipeline='builtin.module(graph-decomposition{gate-set=testRY=1.0,testX=3.0,testZ=3.0 alt-decomps=testY=[y_to_ry,y_to_x_z] bytecode-rules="%BYTECODE_PATH"})' %s | FileCheck %s --check-prefixes RY
 
-// RUN: catalyst --tool=opt --pass-pipeline='builtin.module(graph-decomposition{gate-set=testRY=3.0,testX=1.0,testZ=1.0 alt-decomps=PauliY=[y_to_ry,y_to_x_z] bytecode-rules="%BYTECODE_PATH"})' %s | FileCheck %s --check-prefixes XZ
+// RUN: catalyst --tool=opt --pass-pipeline='builtin.module(graph-decomposition{gate-set=testRY=3.0,testX=1.0,testZ=1.0 alt-decomps=testY=[y_to_ry,y_to_x_z] bytecode-rules="%BYTECODE_PATH"})' %s | FileCheck %s --check-prefixes XZ
 
 func.func @circuit() -> !quantum.bit {
     %0 = quantum.alloc(2) : !quantum.reg
     %q = quantum.extract %0[0] : !quantum.reg -> !quantum.bit
-    // RY-NOT: test 
+    // RY-NOT: test Y
     // RY: testRY
 
-    // XZ-NOT: test
+    // XZ-NOT: testY
     // XZ: testX
     // XZ: testZ
     %qout = quantum.custom "testY"() %q : !quantum.bit
@@ -33,7 +33,7 @@ func.func @circuit() -> !quantum.bit {
 }
 
 // CHECK-LABEL: y_to_ry
-func.func @y_to_ry(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="testY[][1]{}", resources = { operations = {"testRY[f64][1]{}"=1}}} {
+func.func @y_to_ry(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="testY{}{wires:1}{}", resources = { operations = {"testRY{0:[f64]}{wires:1}{}"=1}}} {
     %pi = arith.constant 3.14 : f64
     %negpiby2 = arith.constant -1.57 : f64
     %q1 = quantum.custom "testRY"(%pi) %q0 : !quantum.bit
@@ -41,7 +41,7 @@ func.func @y_to_ry(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="
 }
 
 // CHECK-LABEL: y_to_x_z
-func.func @y_to_x_z(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="testY[][1]{}", resources = { operations = {"testX[][1]{}"=1, "testZ[][1]{}"=1}}} {
+func.func @y_to_x_z(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="testY{}{wires:1}{}", resources = { operations = {"testX{}{wires:1}{}"=1, "testZ{}{wires:1}{}"=1}}} {
     %q1 = quantum.custom "testX"() %q0 : !quantum.bit
     %q2 = quantum.custom "testZ"() %q1 : !quantum.bit
     return %q2 : !quantum.bit

--- a/frontend/test/lit/GraphDecomposition/TestAltDecomps.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestAltDecomps.mlir
@@ -19,7 +19,7 @@
 func.func @circuit() -> !quantum.bit {
     %0 = quantum.alloc(2) : !quantum.reg
     %q = quantum.extract %0[0] : !quantum.reg -> !quantum.bit
-    // RY-NOT: test Y
+    // RY-NOT: testY
     // RY: testRY
 
     // XZ-NOT: testY

--- a/frontend/test/lit/GraphDecomposition/TestFailedDecomp.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestFailedDecomp.mlir
@@ -19,6 +19,6 @@ func.func @circuit(%q0: !quantum.bit) {
     %out = quantum.custom "failure"() %q0 : !quantum.bit
 
     // CHECK: GraphSolverFailedError
-    // CHECK: Decomposition rule not found for operator 'id: failure[][1]{}'
+    // CHECK: Decomposition rule not found for operator 'id: failure{}{wires:1}{}'
     return
 }

--- a/frontend/test/lit/GraphDecomposition/TestFailedDecomp.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestFailedDecomp.mlir
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// RUN: not --crash catalyst --tool=opt --split-input-file --pass-pipeline='builtin.module( graph-decomposition{gate-set=PauliX=1.0 bytecode-rules="%BYTECODE_PATH"})' %s 2>&1 | FileCheck %s
+// RUN: not --crash catalyst --tool=opt --split-input-file --pass-pipeline='builtin.module( graph-decomposition{gate-set=PauliX=1.0 alt-decomps=[failure=fail_decomp] bytecode-rules="%BYTECODE_PATH"})' %s 2>&1 | FileCheck %s
 
 func.func @circuit(%q0: !quantum.bit) {
     %pi = arith.constant 3.14 : f64
@@ -21,4 +21,9 @@ func.func @circuit(%q0: !quantum.bit) {
     // CHECK: GraphSolverFailedError
     // CHECK: Decomposition rule not found for operator 'id: failure{}{wires:1}{}'
     return
+}
+
+func.func private @fail_decomp(%q: !quantum.bit) -> !quantum.bit attributes { target_gate = "failure{}{wires:1}{}", resources = { operations = {"impossible"=1}}} {
+  %out = quantum.custom "impossible"() %q : !quantum.bit
+  return %out : !quantum.bit
 }

--- a/frontend/test/lit/GraphDecomposition/TestFixedDecomp.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestFixedDecomp.mlir
@@ -25,7 +25,7 @@ func.func @circuit() -> !quantum.bit {
     return %qout : !quantum.bit
 }
 
-func.func @custom_decomp(%q0 : !quantum.bit) -> !quantum.bit {
+func.func @custom_decomp(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate = "testHadamard{}{wires:1}{}", resources = { operations = { "testRX{0:1}{wires:1}{}"=2, "testRZ{0:1}{wires:1}{}"=1}}} {
     %cst = arith.constant 1.5707963267948966 : f64
     %q1 = quantum.custom "testRX"(%cst) %q0 : !quantum.bit
     %q2 = quantum.custom "testRZ"(%cst) %q1 : !quantum.bit

--- a/frontend/test/lit/GraphDecomposition/TestGraphOpId.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestGraphOpId.mlir
@@ -24,7 +24,7 @@ func.func @circuit(%q: !quantum.bit) -> !quantum.bit {
   return %out: !quantum.bit
 }
 
-func.func private @my_decomp(%q: !quantum.bit) -> !quantum.bit attributes {target_gate="testHadamard[][1]{}"} {
+func.func private @my_decomp(%q: !quantum.bit) -> !quantum.bit attributes {target_gate="testHadamard{}{wires:1}{}"} {
   %q0 = quantum.custom "testPauliX"() %q : !quantum.bit
   %q1 = quantum.custom "testPauliX"() %q0 : !quantum.bit
   return %q1 : !quantum.bit

--- a/frontend/test/lit/GraphDecomposition/TestIdentity.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestIdentity.mlir
@@ -45,7 +45,7 @@ module @test_module {
         return %q1 : !quantum.bit
     }
 
-    func.func private @false_decomp(%q : !quantum.bit) -> !quantum.bit attributes {target_gate="testHadamard[][1]{}"} {
+    func.func private @false_decomp(%q : !quantum.bit) -> !quantum.bit attributes {target_gate="testHadamard{}{wires:1}{}"} {
         %qout = quantum.custom "testPauliX"() %q : !quantum.bit
         return %qout : !quantum.bit
     }

--- a/frontend/test/lit/GraphDecomposition/TestMultiDecompUser.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestMultiDecompUser.mlir
@@ -24,12 +24,12 @@ func.func @circuit() -> !quantum.bit {
 }
 
 // CHECK-LABEL: h_to_x
-func.func @h_to_x(%q : !quantum.bit) -> !quantum.bit attributes {target_gate="testHadamard[][1]{}"} {
+func.func @h_to_x(%q : !quantum.bit) -> !quantum.bit attributes {target_gate="testHadamard{}{wires:1}{}"} {
     %q1 = quantum.custom "testPauliX"() %q : !quantum.bit
     return %q1 : !quantum.bit
 }
 
-func.func @x_to_h(%q : !quantum.bit) -> !quantum.bit attributes {target_gate="testPauliX[][1]{}"} {
+func.func @x_to_h(%q : !quantum.bit) -> !quantum.bit attributes {target_gate="testPauliX{}{wires:1}{}"} {
     %q1 = quantum.custom "testHadamard"() %q : !quantum.bit
     return %q1 : !quantum.bit
 }

--- a/frontend/test/lit/GraphDecomposition/test_rules.mlir
+++ b/frontend/test/lit/GraphDecomposition/test_rules.mlir
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 
-func.func @__builtin_h_to_rz_ry(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="testHadamard[][1]{}"} {
+func.func @__builtin_h_to_rz_ry(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="testHadamard{}{wires:1}{}"} {
     %piby2 = arith.constant 1.57 : f64
     %pi = arith.constant 3.14 : f64
     %negpiby2 = arith.constant -3.14 : f64
@@ -22,7 +22,7 @@ func.func @__builtin_h_to_rz_ry(%q0 : !quantum.bit) -> !quantum.bit attributes {
     return %q2 : !quantum.bit
 }
 
-func.func @__builtin_h_to_rz_rx(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="testHadamard[][1]{}"} {
+func.func @__builtin_h_to_rz_rx(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="testHadamard{}{wires:1}{}"} {
     %piby2 = arith.constant 1.57 : f64
     %negpiby2 = arith.constant -3.14 : f64
     %q1 = quantum.custom "testRZ"(%piby2) %q0 : !quantum.bit
@@ -31,14 +31,14 @@ func.func @__builtin_h_to_rz_rx(%q0 : !quantum.bit) -> !quantum.bit attributes {
     return %q3 : !quantum.bit
 }
 
-func.func @__builtin_x_to_rx(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="testPauliX[][1]{}"} {
+func.func @__builtin_x_to_rx(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="testPauliX{}{wires:1}{}"} {
     %pi = arith.constant 3.14 : f64
     %negpiby2 = arith.constant -3.14 : f64
     %q1 = quantum.custom "testRX"(%pi) %q0 : !quantum.bit
     return %q1 : !quantum.bit
 }
 
-func.func @__builtin_rx_to_rz_ry(%angle : f64, %q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="testRX[f64][1]{}"} {
+func.func @__builtin_rx_to_rz_ry(%angle : f64, %q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="testRX{0:[f64]}{wires:1}{}"} {
     %piby2 = arith.constant 1.57 : f64
     %negpiby2 = arith.constant -3.14 : f64
     %q1 = quantum.custom "testRZ"(%piby2) %q0 : !quantum.bit

--- a/frontend/test/lit/operator2_dummy_gates.py
+++ b/frontend/test/lit/operator2_dummy_gates.py
@@ -49,6 +49,14 @@ class SingleParamCustomOp(qp.core.Operator2):
         super().__init__(x, wires=wires)
 
 
+class SingleParamNoCustomOpBadOrder(qp.core.Operator2):
+
+    dynamic_argnames = ("x",)
+
+    def __init__(self, wires, x):
+        super().__init__(wires, x)
+
+
 class CompilableData(qp.core.Operator2):
 
     compilable_argnames = ("a", "b", "thing")
@@ -78,8 +86,8 @@ class MultiParamsCustom(qp.core.Operator2):
 
     dynamic_argnames = ("a", "b", "c")
 
-    def __init__(self, wires, a, b, c):
-        super().__init__(wires, a, b, c)
+    def __init__(self, a, b, c, wires):
+        super().__init__(a, b, c, wires)
 
 
 class MultiRZ(qp.core.Operator2):

--- a/frontend/test/lit/test_operator.py
+++ b/frontend/test/lit/test_operator.py
@@ -36,6 +36,7 @@ from operator2_dummy_gates import (
     QubitUnitary,
     SingleParam,
     SingleParamCustomOp,
+    SingleParamNoCustomOpBadOrder,
     StaticData,
 )
 
@@ -224,6 +225,30 @@ def c_single_param_custom(x: float):
 print(c_single_param_custom.mlir)
 
 
+@qp.qjit(target="mlir", capture=True)
+@qp.qnode(qp.device("null.qubit", wires=3))
+def c_single_param_no_custom_bad_order(x: float):
+    # CHECK-LABEL: func.func public @c_single_param_no_custom_bad_order
+
+    # CHECK: [[q0:%.+]] = qref.get {{%.+}}[ 0]
+    # CHECK: qref.operator "SingleParamNoCustomOpBadOrder"({{%.+}}) qubits([[q0]])
+    # CHECK:    static_data = {}
+    # CHECK:    param_map = {x = [0]} qubit_map = {wires = [0]}
+    SingleParamNoCustomOpBadOrder(x=x, wires=0)
+
+    # CHECK: [[q1:%.+]] = qref.get {{%.+}}[ 1]
+    # CHECK: [[q2:%.+]] = qref.get {{%.+}}[ 2]
+    # CHECK: qref.operator "SingleParamNoCustomOpBadOrder"({{%.+}}) qubits([[q1]], [[q2]])
+    # CHECK:  static_data = {}
+    # CHECK:  param_map = {x = [0]} qubit_map = {wires = [0, 1]}
+    SingleParamNoCustomOpBadOrder((1, 2), 0.5)
+
+    return qp.state()
+
+
+print(c_single_param_no_custom_bad_order.mlir)
+
+
 @qp.qjit(capture=True, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def c_compilable():
@@ -298,7 +323,7 @@ def c_multi_param_custom():
 
     # pylint: disable=line-too-long
     # CHECK: qref.custom "MultiParamsCustom"({{%.+}}, {{%.+}}, {{%.+}}) [[q0]] : !qref.bit
-    MultiParamsCustom(0, 0.5, c=0.7, b=2.4)
+    MultiParamsCustom(0.5, c=0.7, b=2.4, wires=0)
     return qp.state()
 
 

--- a/mlir/include/Quantum/IR/QuantumInterfaces.h
+++ b/mlir/include/Quantum/IR/QuantumInterfaces.h
@@ -16,7 +16,8 @@
 
 #include <string>
 
-#include "mlir/IR/OpDefinition.h" // for QuantumInterfaces.h..inc
+#include "llvm/ADT/StringMap.h"   // for DecomposableGate interface
+#include "mlir/IR/OpDefinition.h" // for QuantumInterfaces.h.inc
 #include "mlir/IR/Operation.h"
 
 #include "Catalyst/Analysis/ResourceInterfaces.h"

--- a/mlir/include/Quantum/IR/QuantumInterfaces.td
+++ b/mlir/include/Quantum/IR/QuantumInterfaces.td
@@ -192,29 +192,30 @@ def DecomposableGate : OpInterface<"DecomposableGate", [QuantumGate]> {
             "Return the name of the corresponding frontend operator (i.e. the rule supplier).", "std::string", "getOperatorName"
         >,
         InterfaceMethod<
-            "Return the shape and dtype of dynamic data.",
-            "mlir::TypeRange", "getDynamicShape"
+            "Return a map of frontend parameter name to shape and dtype of dynamic data.",
+            "llvm::StringMap<llvm::SmallVector<mlir::Type>>", "getDynamicShape"
         >,
         InterfaceMethod<
-            "Return the number of wires the operation acts on for each wire argument (excluding control wires).",
-            "std::vector<size_t>", "getWireLens"
+            "Return a map of frontend parameter name to number of wires (excluding control wires).",
+            "llvm::StringMap<size_t>", "getWireLens"
         >,
         InterfaceMethod<
-            "Return the values of static data.",
+            "Return a map of frontend parameter name to static data values.",
             "mlir::DictionaryAttr", "getStaticData"
         >,
         InterfaceMethod<
             "Return a string representation of any additional data an operator may need to provide"
-            " for uniqueness (ex. UID).",
+            " for uniqueness (ex. UID), or emptystring if not applicable.",
             "std::string", "getExtraData", (ins), [{}], [{ return ""; }]
         >,
         InterfaceMethod<
             "Return the operation's ID for use with the graph. "
             "This should be computed by the following convention:\n"
             "```\n"
-            "name + {dtype tree of args} + {number of wires per wires arg} + {static data} + {uid}\n"
+            "name + {map params to list of types} + {map wire args to number of wires} + {static data} + [extra data]\n"
             "```\n"
-            "Note that UID is currently specific to `OperatorOp`s.",
+            "Note that extra data is currently specific to `OperatorOp`s, and should only appear when present."
+            "In general, this should be computed by the default here and not overridden.",
             "std::string", "getGraphOpId", (ins), [{}], [{ return ::catalyst::quantum::defaultGetGraphOpId($_op.getOperation()); }]
         >
     ];

--- a/mlir/include/Quantum/IR/QuantumInterfaces.td
+++ b/mlir/include/Quantum/IR/QuantumInterfaces.td
@@ -215,6 +215,7 @@ def DecomposableGate : OpInterface<"DecomposableGate", [QuantumGate]> {
             "name + {map params to list of types} + {map wire args to number of wires} + {static data} + [extra data]\n"
             "```\n"
             "Note that extra data is currently specific to `OperatorOp`s, and should only appear when present."
+            "Each of these maps should be sorted lexicographically by key."
             "In general, this should be computed by the default here and not overridden.",
             "std::string", "getGraphOpId", (ins), [{}], [{ return ::catalyst::quantum::defaultGetGraphOpId($_op.getOperation()); }]
         >

--- a/mlir/lib/Quantum/IR/QuantumInterfaces.cpp
+++ b/mlir/lib/Quantum/IR/QuantumInterfaces.cpp
@@ -14,14 +14,18 @@
 
 #include "Quantum/IR/QuantumInterfaces.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/Types.h"
 #include "mlir/Support/LLVM.h"
 
 using namespace mlir;
@@ -104,16 +108,49 @@ void printType(mlir::Type type, llvm::raw_string_ostream &ss)
         .Default([&](mlir::Type other) { other.print(ss); });
 }
 
-void printTypeRange(mlir::TypeRange typerange, llvm::raw_string_ostream &ss)
+void printDynamicShape(const llvm::StringMap<llvm::SmallVector<mlir::Type>> &map,
+                       llvm::raw_string_ostream &ss)
 {
-    ss << "[";
-    for (auto [i, type] : llvm::enumerate(typerange)) {
+    llvm::SmallVector<llvm::StringRef> keys;
+    for (const llvm::StringRef key : map.keys()) {
+        keys.push_back(key);
+    }
+    llvm::sort(keys);
+
+    ss << "{";
+    for (auto [i, key] : llvm::enumerate(keys)) {
         if (i > 0) {
             ss << ",";
         }
-        printType(type, ss);
+        ss << key << ":[";
+        const auto &types = map.lookup(key);
+        for (auto [j, type] : llvm::enumerate(types)) {
+            if (j > 0) {
+                ss << ",";
+            }
+            printType(type, ss);
+        }
+        ss << "]";
     }
-    ss << "]";
+    ss << "}";
+}
+
+void printWireLens(const llvm::StringMap<size_t> &map, llvm::raw_string_ostream &ss)
+{
+    llvm::SmallVector<llvm::StringRef> keys;
+    for (const llvm::StringRef key : map.keys()) {
+        keys.push_back(key);
+    }
+    llvm::sort(keys);
+
+    ss << "{";
+    for (auto [i, key] : llvm::enumerate(keys)) {
+        if (i > 0) {
+            ss << ",";
+        }
+        ss << key << ":" << std::to_string(map.lookup(key));
+    }
+    ss << "}";
 }
 
 } // namespace
@@ -133,8 +170,8 @@ std::string defaultGetGraphOpId(Operation *op)
     DecomposableGate gate = cast<DecomposableGate>(op);
 
     ss << gate.getOperatorName();
-    printTypeRange(gate.getDynamicShape(), ss);
-    printIterable(gate.getWireLens(), ss);
+    printDynamicShape(gate.getDynamicShape(), ss);
+    printWireLens(gate.getWireLens(), ss);
     printAttr(gate.getStaticData(), ss);
     if (gate.getExtraData() != "") {
         ss << '[' << gate.getExtraData() << ']';

--- a/mlir/lib/Quantum/IR/QuantumOps.cpp
+++ b/mlir/lib/Quantum/IR/QuantumOps.cpp
@@ -25,6 +25,7 @@
 
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -38,6 +39,7 @@
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OpImplementation.h"
@@ -1237,9 +1239,19 @@ ParseResult OperatorOp::parse(OpAsmParser &parser, OperationState &result)
 
 std::string CustomOp::getOperatorName() { return getGateName().str(); }
 
-mlir::TypeRange CustomOp::getDynamicShape() { return getAllParams().getTypes(); }
+llvm::StringMap<llvm::SmallVector<mlir::Type>> CustomOp::getDynamicShape()
+{
+    llvm::StringMap<llvm::SmallVector<mlir::Type>> ret;
+    for (auto [i, param] : llvm::enumerate(getParams())) {
+        ret[std::to_string(i)] = llvm::SmallVector<mlir::Type>({param.getType()});
+    }
+    return ret;
+}
 
-std::vector<size_t> CustomOp::getWireLens() { return {getNonCtrlQubitOperands().size()}; }
+llvm::StringMap<size_t> CustomOp::getWireLens()
+{
+    return {{"wires", getNonCtrlQubitOperands().size()}};
+}
 
 mlir::DictionaryAttr CustomOp::getStaticData()
 {
@@ -1250,9 +1262,15 @@ mlir::DictionaryAttr CustomOp::getStaticData()
 
 std::string MultiRZOp::getOperatorName() { return "MultiRZ"; }
 
-mlir::TypeRange MultiRZOp::getDynamicShape() { return getAllParams().getTypes(); }
+llvm::StringMap<llvm::SmallVector<mlir::Type>> MultiRZOp::getDynamicShape()
+{
+    return {{"theta", {mlir::Float64Type::get(getContext())}}};
+}
 
-std::vector<size_t> MultiRZOp::getWireLens() { return {getNonCtrlQubitOperands().size()}; }
+llvm::StringMap<size_t> MultiRZOp::getWireLens()
+{
+    return {{"wires", getNonCtrlQubitOperands().size()}};
+}
 
 mlir::DictionaryAttr MultiRZOp::getStaticData()
 {
@@ -1263,9 +1281,15 @@ mlir::DictionaryAttr MultiRZOp::getStaticData()
 
 std::string PauliRotOp::getOperatorName() { return "PauliRot"; }
 
-mlir::TypeRange PauliRotOp::getDynamicShape() { return getAllParams().getTypes(); }
+llvm::StringMap<llvm::SmallVector<mlir::Type>> PauliRotOp::getDynamicShape()
+{
+    return {{"theta", {mlir::Float64Type::get(getContext())}}};
+}
 
-std::vector<size_t> PauliRotOp::getWireLens() { return {getNonCtrlQubitOperands().size()}; }
+llvm::StringMap<size_t> PauliRotOp::getWireLens()
+{
+    return {{"wires", getNonCtrlQubitOperands().size()}};
+}
 
 mlir::DictionaryAttr PauliRotOp::getStaticData()
 {
@@ -1279,9 +1303,15 @@ mlir::DictionaryAttr PauliRotOp::getStaticData()
 
 std::string PCPhaseOp::getOperatorName() { return "PCPhase"; }
 
-mlir::TypeRange PCPhaseOp::getDynamicShape() { return getAllParams().getTypes(); }
+llvm::StringMap<llvm::SmallVector<mlir::Type>> PCPhaseOp::getDynamicShape()
+{
+    return {{"phi", {mlir::Float64Type::get(getContext())}}};
+}
 
-std::vector<size_t> PCPhaseOp::getWireLens() { return {getNonCtrlQubitOperands().size()}; }
+llvm::StringMap<size_t> PCPhaseOp::getWireLens()
+{
+    return {{"wires", getNonCtrlQubitOperands().size()}};
+}
 
 mlir::DictionaryAttr PCPhaseOp::getStaticData()
 {
@@ -1295,9 +1325,12 @@ mlir::DictionaryAttr PCPhaseOp::getStaticData()
 
 std::string GlobalPhaseOp::getOperatorName() { return "GlobalPhase"; }
 
-mlir::TypeRange GlobalPhaseOp::getDynamicShape() { return getAllParams().getTypes(); }
+llvm::StringMap<llvm::SmallVector<mlir::Type>> GlobalPhaseOp::getDynamicShape()
+{
+    return {{"phi", {mlir::Float64Type::get(getContext())}}};
+}
 
-std::vector<size_t> GlobalPhaseOp::getWireLens() { return {0}; }
+llvm::StringMap<size_t> GlobalPhaseOp::getWireLens() { return {}; }
 
 mlir::DictionaryAttr GlobalPhaseOp::getStaticData()
 {
@@ -1308,9 +1341,15 @@ mlir::DictionaryAttr GlobalPhaseOp::getStaticData()
 
 std::string QubitUnitaryOp::getOperatorName() { return "QubitUnitary"; }
 
-mlir::TypeRange QubitUnitaryOp::getDynamicShape() { return getAllParams().getTypes(); }
+llvm::StringMap<llvm::SmallVector<mlir::Type>> QubitUnitaryOp::getDynamicShape()
+{
+    return {{"U", {getMatrix().getType()}}};
+}
 
-std::vector<size_t> QubitUnitaryOp::getWireLens() { return {getNonCtrlQubitOperands().size()}; }
+llvm::StringMap<size_t> QubitUnitaryOp::getWireLens()
+{
+    return {{"wires", getNonCtrlQubitOperands().size()}};
+}
 
 mlir::DictionaryAttr QubitUnitaryOp::getStaticData()
 {
@@ -1321,22 +1360,48 @@ mlir::DictionaryAttr QubitUnitaryOp::getStaticData()
 
 std::string OperatorOp::getOperatorName() { return getOpName().str(); }
 
-mlir::TypeRange OperatorOp::getDynamicShape() { return getParams().getTypes(); }
-
-std::vector<size_t> OperatorOp::getWireLens()
+llvm::StringMap<llvm::SmallVector<mlir::Type>> OperatorOp::getDynamicShape()
 {
-    if (getInQreg()) {
-        std::vector<size_t> lens;
-        // This assumes static lengths!
-        // If we enable support for dynamic lengths, we need to update this
-        for (mlir::Type indexTensor : getArrQubitIndices().getType()) {
-            for (size_t dim : cast<RankedTensorType>(indexTensor).getShape()) {
-                lens.push_back(size_t(dim));
+    llvm::StringMap<llvm::SmallVector<mlir::Type>> map;
+
+    auto params = getParams();
+
+    for (mlir::NamedAttribute entry : getParamMap()) {
+        mlir::ArrayRef<int64_t> indices =
+            cast<mlir::DenseI64ArrayAttr>(entry.getValue()).asArrayRef();
+        llvm::SmallVector<mlir::Type> types;
+        for (int64_t index : indices) {
+            types.push_back(params[index].getType());
+        }
+        map[entry.getName().str()] = std::move(types);
+    }
+
+    return map;
+}
+
+llvm::StringMap<size_t> OperatorOp::getWireLens()
+{
+    llvm::StringMap<size_t> wireLens;
+
+    for (mlir::NamedAttribute entry : getQubitMap()) {
+        auto indices = cast<mlir::DenseI64ArrayAttr>(entry.getValue());
+        size_t numQubits;
+        if (getInQreg()) {
+            numQubits = 0;
+            for (int64_t index : indices.asArrayRef()) {
+                auto indexTensorType =
+                    cast<mlir::RankedTensorType>(getArrQubitIndices()[index].getType());
+                numQubits += indexTensorType.getDimSize(0);
             }
         }
-        return lens;
+        else {
+            numQubits = indices.size();
+        }
+
+        wireLens[entry.getName()] = numQubits;
     }
-    return {getInQubits().size()};
+
+    return wireLens;
 }
 
 std::string OperatorOp::getExtraData()

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecomposeLoweringPatterns.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecomposeLoweringPatterns.cpp
@@ -20,7 +20,6 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/AllocatorBase.h"
-#include "llvm/Support/LogicalResult.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Block.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -123,7 +122,7 @@ struct DecomposableGatePattern final : public OpInterfaceRewritePattern<Decompos
             // Didn't find ID match, try matching gate name
             // TODO: remove multirz's special name editing
             if (isa<quantum::MultiRZOp>(op)) {
-                gateName = gateName + "_" + std::to_string(op.getWireLens()[0]);
+                gateName = gateName + "_" + std::to_string(op.getWireLens()["wires"]);
             }
             auto it_gateName = decompositionRegistry.find(gateName);
             if (it_gateName != decompositionRegistry.end()) {

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
@@ -370,7 +370,11 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
         });
 
         llvm::SmallVector<quantum::DecomposableGate> decomposableOps;
-        module.walk([&](quantum::DecomposableGate op) { decomposableOps.push_back(op); });
+        module.walk([&](quantum::DecomposableGate op) {
+            if (!DecompUtils::isInDecompRule(op)) {
+                decomposableOps.push_back(op);
+            }
+        });
 
         if (!decomposableOps.empty()) {
             if (!loadQPD(libQPDPath, libpythonPath)) {
@@ -419,11 +423,6 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
 
     void getOperators(std::vector<OperatorNode> &operators)
     {
-        // TODO: replace this with DecomposableGate interface. We will drop support for any other op
-        // types once the interface has been implemented for the core operations in the quantum
-        // dialect.
-        // The interface will provide one unified way of generating operator nodes from operations,
-        // with consistent getter methods for all relevant data fields.
         getOperation().walk([&](DecomposableGate op) {
             if (DecompUtils::isInDecompRule(op)) {
                 return;

--- a/mlir/lib/Quantum/Transforms/QuantumPythonDecompositions/PythonFunction.cpp
+++ b/mlir/lib/Quantum/Transforms/QuantumPythonDecompositions/PythonFunction.cpp
@@ -12,16 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "nanobind/STL/string.h" // for type conversion
 #include "nanobind/nanobind.h"
 
 #include <cstddef>
 #include <exception>
+#include <iostream>
 #include <string>
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/DebugLog.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -29,6 +34,7 @@
 #include "mlir/IR/Types.h"
 
 #include "Quantum/IR/QuantumInterfaces.h"
+#include "Quantum/IR/QuantumOps.h"
 
 #include "PythonDriverUtils.hpp"
 
@@ -40,27 +46,28 @@ namespace {
 
 static nb::dict getPyvalFromDynamicShape(const llvm::StringMap<llvm::SmallVector<mlir::Type>> &map)
 {
-    nb::dict dict;
+    nb::dict name_to_shape;
     for (const auto &entry : map) {
-        std::string typestr;
-        llvm::raw_string_ostream ss(typestr);
-        ss << "[";
-        for (auto [i, type] : llvm::enumerate(entry.getValue())) {
-            if (i > 0) {
-                ss << ",";
+        nb::list types;
+        for (auto type : entry.getValue()) {
+            if (!type) {
+                continue;
             }
+            std::string typestr;
+            llvm::raw_string_ostream ss(typestr);
             type.print(ss);
+            types.append(typestr);
         }
-        dict[nb::str(entry.getKey().data())] = ss.str();
+        name_to_shape[nb::str(entry.getKey().str().c_str())] = types;
     }
-    return dict;
+    return name_to_shape;
 }
 
 static nb::dict getPyvalFromWireLens(const llvm::StringMap<size_t> map)
 {
     nb::dict dict;
     for (const auto &entry : map) {
-        dict[nb::str(entry.getKey().data())] = entry.getValue();
+        dict[nb::str(entry.getKey().str().c_str())] = entry.getValue();
     }
     return dict;
 }
@@ -105,18 +112,20 @@ std::string pythonRuleLowering(catalyst::quantum::DecomposableGate op)
 {
     QuantumPythonDecompositions::PyInterpreterGuard guard;
     std::string mlirText = guard.withGil([&] -> std::string {
-        const char *moduleName = "catalyst.decomposition.python_decompositions";
-        const char *functionName = "compile_decomposition_rules";
+        const char *moduleName = "catalyst.decomposition.decomposition_rules";
+        const char *functionName = "compile_decomposition_rules_wrapper";
 
         try {
+            auto tmp = op.getDynamicShape();
             nb::module_ wrapperModule = nb::module_::import_(moduleName);
             nb::object wrapperFunction = wrapperModule.attr(functionName);
 
-            nb::object pythonResult =
-                wrapperFunction(op.getOperatorName(), op.getGraphOpId(),
-                                getPyvalFromDynamicShape(op.getDynamicShape()), op.getWireLens(),
-                                getPyvalFromMlirAttribute(op.getStaticData()));
-
+            nb::object pythonResult = wrapperFunction(
+                op.getOperatorName(), op.getGraphOpId(),
+                getPyvalFromDynamicShape(op.getDynamicShape()),
+                getPyvalFromWireLens(op.getWireLens()),
+                getPyvalFromMlirAttribute(op.getStaticData()), nb::arg("extra_data") = nb::none(),
+                nb::arg("is_custom_op") = isa<catalyst::quantum::CustomOp>(op));
             return nb::borrow<nb::str>(pythonResult).c_str();
         }
         catch (const nb::python_error &error) {

--- a/mlir/lib/Quantum/Transforms/QuantumPythonDecompositions/PythonFunction.cpp
+++ b/mlir/lib/Quantum/Transforms/QuantumPythonDecompositions/PythonFunction.cpp
@@ -105,8 +105,6 @@ std::string pythonRuleLowering(catalyst::quantum::DecomposableGate op)
 {
     QuantumPythonDecompositions::PyInterpreterGuard guard;
     std::string mlirText = guard.withGil([&] -> std::string {
-        nb::print("calling python to handle");
-        std::cerr << op.getGraphOpId();
         const char *moduleName = "catalyst.decomposition.python_decompositions";
         const char *functionName = "compile_decomposition_rules";
 
@@ -114,9 +112,6 @@ std::string pythonRuleLowering(catalyst::quantum::DecomposableGate op)
             nb::module_ wrapperModule = nb::module_::import_(moduleName);
             nb::object wrapperFunction = wrapperModule.attr(functionName);
 
-            nb::print(getPyvalFromDynamicShape(op.getDynamicShape()));
-            nb::print(getPyvalFromWireLens(op.getWireLens()));
-            nb::print(getPyvalFromMlirAttribute(op.getStaticData()));
             nb::object pythonResult =
                 wrapperFunction(op.getOperatorName(), op.getGraphOpId(),
                                 getPyvalFromDynamicShape(op.getDynamicShape()), op.getWireLens(),

--- a/mlir/lib/Quantum/Transforms/QuantumPythonDecompositions/PythonFunction.cpp
+++ b/mlir/lib/Quantum/Transforms/QuantumPythonDecompositions/PythonFunction.cpp
@@ -13,18 +13,20 @@
 // limitations under the License.
 
 #include "nanobind/nanobind.h"
-#include "nanobind/stl/string.h" // for automatic string conversion
-#include "nanobind/stl/vector.h" // for automatic vector conversion
 
+#include <cstddef>
 #include <exception>
 #include <string>
-#include <vector>
 
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/TypeRange.h"
+#include "mlir/IR/Types.h"
 
 #include "Quantum/IR/QuantumInterfaces.h"
 
@@ -35,6 +37,33 @@
 namespace nb = nanobind;
 
 namespace {
+
+static nb::dict getPyvalFromDynamicShape(const llvm::StringMap<llvm::SmallVector<mlir::Type>> &map)
+{
+    nb::dict dict;
+    for (const auto &entry : map) {
+        std::string typestr;
+        llvm::raw_string_ostream ss(typestr);
+        ss << "[";
+        for (auto [i, type] : llvm::enumerate(entry.getValue())) {
+            if (i > 0) {
+                ss << ",";
+            }
+            type.print(ss);
+        }
+        dict[nb::str(entry.getKey().data())] = ss.str();
+    }
+    return dict;
+}
+
+static nb::dict getPyvalFromWireLens(const llvm::StringMap<size_t> map)
+{
+    nb::dict dict;
+    for (const auto &entry : map) {
+        dict[nb::str(entry.getKey().data())] = entry.getValue();
+    }
+    return dict;
+}
 
 static nb::object getPyvalFromTypeRange(mlir::TypeRange typerange)
 {
@@ -76,6 +105,8 @@ std::string pythonRuleLowering(catalyst::quantum::DecomposableGate op)
 {
     QuantumPythonDecompositions::PyInterpreterGuard guard;
     std::string mlirText = guard.withGil([&] -> std::string {
+        nb::print("calling python to handle");
+        std::cerr << op.getGraphOpId();
         const char *moduleName = "catalyst.decomposition.python_decompositions";
         const char *functionName = "compile_decomposition_rules";
 
@@ -83,9 +114,12 @@ std::string pythonRuleLowering(catalyst::quantum::DecomposableGate op)
             nb::module_ wrapperModule = nb::module_::import_(moduleName);
             nb::object wrapperFunction = wrapperModule.attr(functionName);
 
+            nb::print(getPyvalFromDynamicShape(op.getDynamicShape()));
+            nb::print(getPyvalFromWireLens(op.getWireLens()));
+            nb::print(getPyvalFromMlirAttribute(op.getStaticData()));
             nb::object pythonResult =
                 wrapperFunction(op.getOperatorName(), op.getGraphOpId(),
-                                getPyvalFromTypeRange(op.getDynamicShape()), op.getWireLens(),
+                                getPyvalFromDynamicShape(op.getDynamicShape()), op.getWireLens(),
                                 getPyvalFromMlirAttribute(op.getStaticData()));
 
             return nb::borrow<nb::str>(pythonResult).c_str();

--- a/mlir/test/Quantum/DecomposeLoweringTest.mlir
+++ b/mlir/test/Quantum/DecomposeLoweringTest.mlir
@@ -605,15 +605,14 @@ module @circuit_with_operator_op {
     %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
     // CHECK: quantum.custom "RZ"
     // CHECK-NOT: quantum.operator
-    %out_qubits_0 = quantum.operator "DummyOp"(%arg0: f64) qubits(%1)
-      static_data = {metadata = "word"}
-    %2 = quantum.insert %0[ 0], %out_qubits_0 : !quantum.reg, !quantum.bit
+    %out_qubits_0 = quantum.operator "DummyOp"(%arg0: f64) qubits(%1) static_data = {metadata = "word"} param_map = {arg = [0]} qubit_map = {wires = [0]}
+%2 = quantum.insert %0[ 0], %out_qubits_0 : !quantum.reg, !quantum.bit
     return %2 : !quantum.reg
   }
 
   // CHECK-LABEL: func.func private @_my_dummy_decomp
   func.func private @_my_dummy_decomp(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes
-      {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "DummyOp[f64][1]{metadata:word}"} {
+      {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "DummyOp{arg:[f64]}{wires:1}{metadata:word}"} {
     %0 = stablehlo.slice %arg2 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
     %1 = stablehlo.reshape %0 : (tensor<1xi64>) -> tensor<i64>
     %extracted = tensor.extract %1[] : tensor<i64>
@@ -700,7 +699,7 @@ module @test_paulirot {
     }
 
     // CHECK: my_paulirot_decomp
-    func.func private @my_paulirot_decomp(%inreg : !quantum.reg, %angle_tensor : tensor<f64>, %q_tensor : tensor<3xi64>) -> !quantum.reg attributes {target_gate = "PauliRot[f64][3]{pauli_word:ZXY}"} {
+    func.func private @my_paulirot_decomp(%inreg : !quantum.reg, %angle_tensor : tensor<f64>, %q_tensor : tensor<3xi64>) -> !quantum.reg attributes {target_gate = "PauliRot{theta:[f64]}{wires:3}{pauli_word:ZXY}"} {
         %pi_by_2 = arith.constant 1.57 : f64
         %m_pi_by_2 = arith.constant -1.57 : f64
         %angle = tensor.extract %angle_tensor[] : tensor<f64>

--- a/mlir/unittests/Quantum/Interfaces/TestDecomposableGateInterface.cpp
+++ b/mlir/unittests/Quantum/Interfaces/TestDecomposableGateInterface.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2026 Xanadu Quantum Technologies Inc.
 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,10 +14,10 @@
 
 #include <cstddef>
 #include <string>
-#include <vector>
 
 #include "gtest/gtest.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/Support/Format.h" // for gtest printing on failure
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -71,17 +70,13 @@ module {
 
     ASSERT_EQ(customOp.getOperatorName(), "RX");
 
-    // This is needed to keep the backing array from being deleted
-    llvm::SmallVector<mlir::Type, 1> backing({mlir::Float64Type::get(&context)});
-    mlir::TypeRange expectedDynamicShape(backing);
-    ASSERT_EQ(llvm::SmallVector<mlir::Type>(customOp.getDynamicShape()),
-              llvm::SmallVector<mlir::Type>(expectedDynamicShape));
-
-    ASSERT_EQ(customOp.getWireLens(), std::vector<size_t>({2}));
+    llvm::StringMap<llvm::SmallVector<mlir::Type>> expectedDynamicShape = {
+        {"0", {Float64Type::get(&context)}}};
+    ASSERT_EQ(customOp.getDynamicShape(), expectedDynamicShape);
 
     ASSERT_EQ(customOp.getStaticData().size(), 0);
 
-    ASSERT_EQ(customOp.getGraphOpId(), "RX[f64][2]{}");
+    ASSERT_EQ(customOp.getGraphOpId(), "RX{0:[f64]}{wires:2}{}");
 }
 
 TEST(DecomposableGateInterfaceTests, MultiRZOp)
@@ -107,17 +102,16 @@ module {
 
     ASSERT_EQ(multiRZ.getOperatorName(), "MultiRZ");
 
-    // This is needed to keep the backing array from being deleted
-    llvm::SmallVector<mlir::Type, 1> backing({mlir::Float64Type::get(&context)});
-    mlir::TypeRange expectedDynamicShape(backing);
-    ASSERT_EQ(llvm::SmallVector<mlir::Type>(multiRZ.getDynamicShape()),
-              llvm::SmallVector<mlir::Type>(expectedDynamicShape));
+    llvm::StringMap<llvm::SmallVector<mlir::Type>> expectedDynamicShape = {
+        {"theta", {Float64Type::get(&context)}}};
+    ASSERT_EQ(multiRZ.getDynamicShape(), expectedDynamicShape);
 
-    ASSERT_EQ(multiRZ.getWireLens(), std::vector<size_t>({3}));
+    llvm::StringMap<size_t> expectedWires = {{"wires", 3}};
+    ASSERT_EQ(multiRZ.getWireLens(), expectedWires);
 
     ASSERT_EQ(multiRZ.getStaticData().size(), 0);
 
-    ASSERT_EQ(multiRZ.getGraphOpId(), "MultiRZ[f64][3]{}");
+    ASSERT_EQ(multiRZ.getGraphOpId(), "MultiRZ{theta:[f64]}{wires:3}{}");
 }
 
 TEST(DecomposableGateInterfaceTests, PauliRotOp)
@@ -143,20 +137,19 @@ module {
 
     ASSERT_EQ(paulirot.getOperatorName(), "PauliRot");
 
-    // This is needed to keep the backing array from being deleted
-    llvm::SmallVector<mlir::Type, 1> backing({mlir::Float64Type::get(&context)});
-    mlir::TypeRange expectedDynamicShape(backing);
-    ASSERT_EQ(llvm::SmallVector<mlir::Type>(paulirot.getDynamicShape()),
-              llvm::SmallVector<mlir::Type>(expectedDynamicShape));
+    llvm::StringMap<llvm::SmallVector<mlir::Type>> expectedDynamicShape = {
+        {"theta", {Float64Type::get(&context)}}};
+    ASSERT_EQ(paulirot.getDynamicShape(), expectedDynamicShape);
 
-    ASSERT_EQ(paulirot.getWireLens(), std::vector<size_t>({3}));
+    llvm::StringMap<size_t> expectedWires = {{"wires", 3}};
+    ASSERT_EQ(paulirot.getWireLens(), expectedWires);
 
     mlir::NamedAttribute entry(mlir::StringAttr::get(&context, "pauli_word"),
                                mlir::StringAttr::get(&context, "XYZ"));
     mlir::DictionaryAttr expectedStaticData = mlir::DictionaryAttr::get(&context, {entry});
     ASSERT_EQ(paulirot.getStaticData(), expectedStaticData);
 
-    ASSERT_EQ(paulirot.getGraphOpId(), "PauliRot[f64][3]{pauli_word:XYZ}");
+    ASSERT_EQ(paulirot.getGraphOpId(), "PauliRot{theta:[f64]}{wires:3}{pauli_word:XYZ}");
 }
 
 TEST(DecomposableGateInterfaceTests, PCPhaseOP)
@@ -182,22 +175,20 @@ module {
 
     ASSERT_EQ(pcphase.getOperatorName(), "PCPhase");
 
-    // This is needed to keep the backing array from being deleted
-    Type f64Type = mlir::Float64Type::get(&context);
-    llvm::SmallVector<mlir::Type, 1> backing({f64Type});
-    mlir::TypeRange expectedDynamicShape(backing);
-    ASSERT_EQ(llvm::SmallVector<mlir::Type>(pcphase.getDynamicShape()),
-              llvm::SmallVector<mlir::Type>(expectedDynamicShape));
+    llvm::StringMap<llvm::SmallVector<mlir::Type>> expectedDynamicShape = {
+        {"phi", {Float64Type::get(&context)}}};
+    ASSERT_EQ(pcphase.getDynamicShape(), expectedDynamicShape);
 
     // Controls are not part of the gate wires considered by the decomp interface
-    ASSERT_EQ(pcphase.getWireLens(), std::vector<size_t>({2}));
+    llvm::StringMap<size_t> expectedWires = {{"wires", 2}};
+    ASSERT_EQ(pcphase.getWireLens(), expectedWires);
 
     mlir::NamedAttribute entry(mlir::StringAttr::get(&context, "dim"),
                                mlir::IntegerAttr::get(mlir::IntegerType::get(&context, 64), 0));
     mlir::DictionaryAttr expectedStaticData = mlir::DictionaryAttr::get(&context, {entry});
     ASSERT_EQ(pcphase.getStaticData(), expectedStaticData);
 
-    ASSERT_EQ(pcphase.getGraphOpId(), "PCPhase[f64][2]{dim:0}");
+    ASSERT_EQ(pcphase.getGraphOpId(), "PCPhase{phi:[f64]}{wires:2}{dim:0}");
 }
 
 TEST(DecomposableGateInterfaceTests, GlobalPhaseOp)
@@ -220,17 +211,16 @@ module {
 
     ASSERT_EQ(gphase.getOperatorName(), "GlobalPhase");
 
-    // This is needed to keep the backing array from being deleted
-    llvm::SmallVector<mlir::Type, 1> backing({mlir::Float64Type::get(&context)});
-    mlir::TypeRange expectedDynamicShape(backing);
-    ASSERT_EQ(llvm::SmallVector<mlir::Type>(gphase.getDynamicShape()),
-              llvm::SmallVector<mlir::Type>(expectedDynamicShape));
+    llvm::StringMap<llvm::SmallVector<mlir::Type>> expectedDynamicShape = {
+        {"phi", {mlir::Float64Type::get(&context)}}};
+    ASSERT_EQ(gphase.getDynamicShape(), expectedDynamicShape);
 
-    ASSERT_EQ(gphase.getWireLens(), std::vector<size_t>({0}));
+    llvm::StringMap<size_t> expectedWires = {};
+    ASSERT_EQ(gphase.getWireLens(), expectedWires);
 
     ASSERT_EQ(gphase.getStaticData().size(), 0);
 
-    ASSERT_EQ(gphase.getGraphOpId(), "GlobalPhase[f64][0]{}");
+    ASSERT_EQ(gphase.getGraphOpId(), "GlobalPhase{phi:[f64]}{}{}");
 }
 
 TEST(DecomposableGateInterfaceTests, ControlledGlobalPhaseOp)
@@ -255,17 +245,16 @@ module {
 
     ASSERT_EQ(gphase.getOperatorName(), "GlobalPhase");
 
-    // This is needed to keep the backing array from being deleted
-    llvm::SmallVector<mlir::Type, 1> backing({mlir::Float64Type::get(&context)});
-    mlir::TypeRange expectedDynamicShape(backing);
-    ASSERT_EQ(llvm::SmallVector<mlir::Type>(gphase.getDynamicShape()),
-              llvm::SmallVector<mlir::Type>(expectedDynamicShape));
+    llvm::StringMap<llvm::SmallVector<mlir::Type>> expectedDynamicShape = {
+        {"phi", {mlir::Float64Type::get(&context)}}};
+    ASSERT_EQ(gphase.getDynamicShape(), expectedDynamicShape);
 
-    ASSERT_EQ(gphase.getWireLens(), std::vector<size_t>({0}));
+    llvm::StringMap<size_t> expectedWires = {};
+    ASSERT_EQ(gphase.getWireLens(), expectedWires);
 
     ASSERT_EQ(gphase.getStaticData().size(), 0);
 
-    ASSERT_EQ(gphase.getGraphOpId(), "GlobalPhase[f64][0]{}");
+    ASSERT_EQ(gphase.getGraphOpId(), "GlobalPhase{phi:[f64]}{}{}");
 }
 
 TEST(DecomposableGateInterfaceTests, QubitUnitaryOp)
@@ -292,24 +281,23 @@ module {
 
     ASSERT_EQ(unitary.getOperatorName(), "QubitUnitary");
 
-    // This is needed to keep the backing array from being deleted
-    Type f64type = mlir::Float64Type::get(&context);
-    Type tensorType = mlir::RankedTensorType::get({4, 4}, mlir::ComplexType::get(f64type));
-    llvm::SmallVector<mlir::Type, 1> backing({tensorType});
-    mlir::TypeRange expectedDynamicShape(backing);
-    ASSERT_EQ(llvm::SmallVector<mlir::Type>(unitary.getDynamicShape()),
-              llvm::SmallVector<mlir::Type>(expectedDynamicShape));
+    llvm::StringMap<llvm::SmallVector<mlir::Type>> expectedDynamicShape = {
+        {"U",
+         {mlir::RankedTensorType::get({4, 4},
+                                      mlir::ComplexType::get(mlir::Float64Type::get(&context)))}}};
+    ASSERT_EQ(unitary.getDynamicShape(), expectedDynamicShape);
 
-    ASSERT_EQ(unitary.getWireLens(), std::vector<size_t>({2}));
+    llvm::StringMap<size_t> expectedWires = {{"wires", 2}};
+    ASSERT_EQ(unitary.getWireLens(), expectedWires);
 
     ASSERT_EQ(unitary.getStaticData().size(), 0);
 
-    ASSERT_EQ(unitary.getGraphOpId(), "QubitUnitary["
+    ASSERT_EQ(unitary.getGraphOpId(), "QubitUnitary{U:["
                                       "[[complex<f64>,complex<f64>,complex<f64>,complex<f64>],"
                                       "[complex<f64>,complex<f64>,complex<f64>,complex<f64>],"
                                       "[complex<f64>,complex<f64>,complex<f64>,complex<f64>],"
                                       "[complex<f64>,complex<f64>,complex<f64>,complex<f64>]]"
-                                      "][2]{}");
+                                      "]}{wires:2}{}");
 }
 
 TEST(DecomposableGateInterfaceTests, OperatorOpQubits)
@@ -321,7 +309,7 @@ module {
   %index = arith.constant 5 : i64
   %q0 = quantum.alloc_qb : !quantum.bit
   %q1 = quantum.alloc_qb : !quantum.bit
-  %0:2 = quantum.operator "testInterfaceOp"(%flag: i1, %angle: f64, %index: i64) qubits(%q0, %q1) static_data = {"myStaticArray"=[1,2,3], "myStaticString"="Test", "myStaticInt"=4}
+  %0:2 = quantum.operator "testInterfaceOp"(%flag: i1, %angle: f64, %index: i64) qubits(%q0, %q1) static_data = {"myStaticArray"=[1,2,3], "myStaticString"="Test", "myStaticInt"=4} param_map = {flag = [0], angle = [1], index = [2]} qubit_map = {wire1 = [0], wire2 = [1]}
 }
     )mlir";
 
@@ -337,15 +325,14 @@ module {
 
     ASSERT_EQ(op.getOperatorName(), "testInterfaceOp");
 
-    // This is needed to keep the backing array from being deleted
-    llvm::SmallVector<mlir::Type, 1> backing({mlir::IntegerType::get(&context, 1),
-                                              mlir::Float64Type::get(&context),
-                                              mlir::IntegerType::get(&context, 64)});
-    mlir::TypeRange expectedDynamicShape(backing);
-    ASSERT_EQ(llvm::SmallVector<mlir::Type>(op.getDynamicShape()),
-              llvm::SmallVector<mlir::Type>(expectedDynamicShape));
+    llvm::StringMap<llvm::SmallVector<mlir::Type>> expectedDynamicShape = {
+        {"flag", {mlir::IntegerType::get(&context, 1)}},
+        {"angle", {mlir::Float64Type::get(&context)}},
+        {"index", {mlir::IntegerType::get(&context, 64)}}};
+    ASSERT_EQ(op.getDynamicShape(), expectedDynamicShape);
 
-    ASSERT_EQ(op.getWireLens(), std::vector<size_t>({2}));
+    llvm::StringMap<size_t> expectedWires = {{"wire1", 1}, {"wire2", 1}};
+    ASSERT_EQ(op.getWireLens(), expectedWires);
 
     IntegerType i64 = IntegerType::get(&context, 64);
     llvm::SmallVector<mlir::Attribute> arr({
@@ -365,9 +352,9 @@ module {
         mlir::DictionaryAttr::get(&context, {arrAttr, stringAttr, intAttr});
     ASSERT_EQ(op.getStaticData(), expectedStaticData);
 
-    ASSERT_EQ(
-        op.getGraphOpId(),
-        "testInterfaceOp[i1,f64,i64][2]{myStaticArray:[1,2,3],myStaticInt:4,myStaticString:Test}");
+    ASSERT_EQ(op.getGraphOpId(),
+              "testInterfaceOp{angle:[f64],flag:[i1],index:[i64]}{wire1:1,wire2:1}{"
+              "myStaticArray:[1,2,3],myStaticInt:4,myStaticString:Test}");
 }
 
 TEST(DecomposableGateInterfaceTests, OperatorOpQureg)
@@ -380,7 +367,7 @@ func.func @testfunc(%first : tensor<1xi64>, %secondthird : tensor<2xi64>) {
 
   %reg = quantum.alloc(4) : !quantum.reg
 
-  %0 = quantum.operator "testOperatorQreg"(%flag: i1, %angle: f64, %index: i64) quregs(%reg) indices(%first: tensor<1xi64>, %secondthird: tensor<2xi64>) static_data={"myStaticArray"=[4,2.4,4], "myStaticString"="string", "myStaticInt"=8}
+  %0 = quantum.operator "testOperatorQureg"(%flag: i1, %angle: f64, %index: i64) quregs(%reg) indices(%first: tensor<1xi64>, %secondthird: tensor<2xi64>) static_data={"myStaticArray"=[4,2.4,4], "myStaticString"="string", "myStaticInt"=8} param_map = {angle=[1], index=[2], flag=[0]} qubit_map = {reg=[0, 1]} 
   return
 }
     )mlir";
@@ -395,17 +382,16 @@ func.func @testfunc(%first : tensor<1xi64>, %secondthird : tensor<2xi64>) {
     DecomposableGate op;
     module->walk([&](OperatorOp walkOp) { op = walkOp; });
 
-    ASSERT_EQ(op.getOperatorName(), "testOperatorQreg");
+    ASSERT_EQ(op.getOperatorName(), "testOperatorQureg");
 
-    // This is needed to keep the backing array from being deleted
-    llvm::SmallVector<mlir::Type, 1> backing({mlir::IntegerType::get(&context, 1),
-                                              mlir::Float64Type::get(&context),
-                                              mlir::IntegerType::get(&context, 64)});
-    mlir::TypeRange expectedDynamicShape(backing);
-    ASSERT_EQ(llvm::SmallVector<mlir::Type>(op.getDynamicShape()),
-              llvm::SmallVector<mlir::Type>(expectedDynamicShape));
+    llvm::StringMap<llvm::SmallVector<mlir::Type>> expectedDynamicShape = {
+        {"flag", {mlir::IntegerType::get(&context, 1)}},
+        {"angle", {mlir::Float64Type::get(&context)}},
+        {"index", {mlir::IntegerType::get(&context, 64)}}};
+    ASSERT_EQ(op.getDynamicShape(), expectedDynamicShape);
 
-    ASSERT_EQ(op.getWireLens(), std::vector<size_t>({1, 2}));
+    llvm::StringMap<size_t> expectedWires = {{"reg", 3}};
+    ASSERT_EQ(op.getWireLens(), expectedWires);
 
     IntegerType i64 = IntegerType::get(&context, 64);
     Float64Type f64 = mlir::Float64Type::get(&context);
@@ -427,8 +413,8 @@ func.func @testfunc(%first : tensor<1xi64>, %secondthird : tensor<2xi64>) {
     ASSERT_EQ(op.getStaticData(), expectedStaticData);
 
     ASSERT_EQ(op.getGraphOpId(),
-              "testOperatorQreg[i1,f64,i64][1,2]{myStaticArray:[4,2.400000e+00,4],"
-              "myStaticInt:8,myStaticString:string}");
+              "testOperatorQureg{angle:[f64],flag:[i1],index:[i64]}{reg:3}{"
+              "myStaticArray:[4,2.400000e+00,4],myStaticInt:8,myStaticString:string}");
 }
 
 TEST(DecomposableGateInterfaceTests, OperatorOpUID)
@@ -443,7 +429,7 @@ func.func @testfunc(%first : tensor<1xi64>, %secondthird : tensor<2xi64>) {
   %q0 = quantum.extract %reg[0] : !quantum.reg -> !quantum.bit
 
   %0 = quantum.operator "testOperatorUID"(%flag: i1, %angle: f64, %index: i64)
-    UID(248) quregs(%reg) indices(%first: tensor<1xi64>, %secondthird: tensor<2xi64>)
+    UID(248) quregs(%reg) indices(%first: tensor<1xi64>, %secondthird: tensor<2xi64>) param_map = {flag=[0], angle=[1], index=[2]} qubit_map = {reg=[0, 1]}
   return
 }
     )mlir";
@@ -461,16 +447,20 @@ func.func @testfunc(%first : tensor<1xi64>, %secondthird : tensor<2xi64>) {
     ASSERT_EQ(op.getOperatorName(), "testOperatorUID");
 
     // This is needed to keep the backing array from being deleted
-    llvm::SmallVector<mlir::Type, 1> backing({mlir::IntegerType::get(&context, 1),
-                                              mlir::Float64Type::get(&context),
-                                              mlir::IntegerType::get(&context, 64)});
-    mlir::TypeRange expectedDynamicShape(backing);
-    ASSERT_EQ(llvm::SmallVector<mlir::Type>(op.getDynamicShape()),
-              llvm::SmallVector<mlir::Type>(expectedDynamicShape));
+    // llvm::SmallVector<llvm::SmallVector<mlir::Type>, 1> backing(
+    //     {mlir::IntegerType::get(&context, 1), mlir::Float64Type::get(&context),
+    //      mlir::IntegerType::get(&context, 64)});
+    llvm::StringMap<llvm::SmallVector<mlir::Type>> expectedDynamicShape = {
+        {"flag", {mlir::IntegerType::get(&context, 1)}},
+        {"angle", {mlir::Float64Type::get(&context)}},
+        {"index", {mlir::IntegerType::get(&context, 64)}}};
+    ASSERT_EQ(op.getDynamicShape(), expectedDynamicShape);
 
-    ASSERT_EQ(op.getWireLens(), std::vector<size_t>({1, 2}));
+    llvm::StringMap<size_t> expectedWires = {{"reg", 3}};
+    ASSERT_EQ(op.getWireLens(), expectedWires);
 
     ASSERT_EQ(op.getStaticData(), mlir::DictionaryAttr::get(&context, {}));
 
-    ASSERT_EQ(op.getGraphOpId(), "testOperatorUID[i1,f64,i64][1,2]{}[248]");
+    ASSERT_EQ(op.getGraphOpId(),
+              "testOperatorUID{angle:[f64],flag:[i1],index:[i64]}{reg:3}{}[248]");
 }

--- a/mlir/unittests/Quantum/Interfaces/TestDecomposableGateInterface.cpp
+++ b/mlir/unittests/Quantum/Interfaces/TestDecomposableGateInterface.cpp
@@ -74,6 +74,9 @@ module {
         {"0", {Float64Type::get(&context)}}};
     ASSERT_EQ(customOp.getDynamicShape(), expectedDynamicShape);
 
+    llvm::StringMap<size_t> expectedWires = {{"wires", 2}};
+    ASSERT_EQ(customOp.getWireLens(), expectedWires);
+
     ASSERT_EQ(customOp.getStaticData().size(), 0);
 
     ASSERT_EQ(customOp.getGraphOpId(), "RX{0:[f64]}{wires:2}{}");


### PR DESCRIPTION
TODO: update PennyLane version once TestPyPI uploads resume

**Context:**
Decomposition rule lowering requires correctly mapping parameters, which cannot be done reliably with the current `DecomposableGate` interface.

**Description of the Change:**
Update the `DecomposableGate` interface to return dictionaries (`llvm::StringMap`s) of data, to permit reconstruction.

**Benefits:**
python-decompositions are improved.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-125812]