### PR TITLE
Fix the 'Build and pack catalyst-mlir-dev' action

### DIFF
--- a/.github/workflows/pack-mlir-dev.yaml
+++ b/.github/workflows/pack-mlir-dev.yaml
@@ -61,16 +61,21 @@ jobs:
         fail-on-cache-miss: True
 
     - name: Build and pack catalyst-mlir-dev
+      env:
+        LLVM_BUILD_DIR: "${{ github.workspace }}/llvm-build"
+        LLVM_INSTALL_STAGING_DIR: "${{ github.workspace }}/llvm-build/install"
       run: |
-        LLVM_BUILD_DIR="${GITHUB_WORKSPACE}/llvm-build" \
-        LLVM_INSTALL_STAGING_DIR="${LLVM_BUILD_DIR}/install" \
-        DESTDIR=${LLVM_INSTALL_STAGING_DIR} cmake --build ${LLVM_BUILD_DIR} --target install-distribution
+        # Build and install
+        DESTDIR="${LLVM_INSTALL_STAGING_DIR}" cmake --build "${LLVM_BUILD_DIR}" --target install-distribution
 
-        LLVM_VERSION=$(${LLVM_INSTALL_STAGING_DIR}/bin/llvm-config --version) \
-        LLVM_COMMIT=$(grep llvm ${GITHUB_WORKSPACE}/.dep-versions | awk -F '=' '{ print $$2 }' | cut -c1-8) \
+        # Get version details
+        LLVM_VERSION=$("${LLVM_INSTALL_STAGING_DIR}/bin/llvm-config" --version)
+        LLVM_COMMIT=$(grep llvm "${GITHUB_WORKSPACE}/.dep-versions" | awk -F '=' '{ print $2 }' | cut -c1-8)
         LLVM_VERSION_FULL="${LLVM_VERSION}-${LLVM_COMMIT}"
-        tar -czf catalyst-mlir-dev_$(uname -s)_$(uname -m)_${LLVM_VERSION_FULL}.tar.gz
-            -C ${LLVM_INSTALL_STAGING_DIR} bin lib include
+
+        # Package archive
+        tar -czf "catalyst-mlir-dev_$(uname -s)_$(uname -m)_${LLVM_VERSION_FULL}.tar.gz" \
+          -C "${LLVM_INSTALL_STAGING_DIR}" bin lib include
 
     - name: Locate the archive
       id: archive
@@ -144,16 +149,21 @@ jobs:
         path: mlir/llvm-project
 
     - name: Build and pack catalyst-mlir-dev
+      env:
+        LLVM_BUILD_DIR: "${{ github.workspace }}/llvm-build"
+        LLVM_INSTALL_STAGING_DIR: "${{ github.workspace }}/llvm-build/install"
       run: |
-        LLVM_BUILD_DIR="${GITHUB_WORKSPACE}/llvm-build" \
-        LLVM_INSTALL_STAGING_DIR="${LLVM_BUILD_DIR}/install" \
-        DESTDIR=${LLVM_INSTALL_STAGING_DIR} cmake --build ${LLVM_BUILD_DIR} --target install-distribution
+        # Build and install
+        DESTDIR="${LLVM_INSTALL_STAGING_DIR}" cmake --build "${LLVM_BUILD_DIR}" --target install-distribution
 
-        LLVM_VERSION=$(${LLVM_INSTALL_STAGING_DIR}/bin/llvm-config --version) \
-        LLVM_COMMIT=$(grep llvm ${GITHUB_WORKSPACE}/.dep-versions | awk -F '=' '{ print $$2 }' | cut -c1-8) \
+        # Get version details
+        LLVM_VERSION=$("${LLVM_INSTALL_STAGING_DIR}/bin/llvm-config" --version)
+        LLVM_COMMIT=$(grep llvm "${GITHUB_WORKSPACE}/.dep-versions" | awk -F '=' '{ print $2 }' | cut -c1-8)
         LLVM_VERSION_FULL="${LLVM_VERSION}-${LLVM_COMMIT}"
-        tar -czf catalyst-mlir-dev_$(uname -s)_$(uname -m)_${LLVM_VERSION_FULL}.tar.gz
-            -C ${LLVM_INSTALL_STAGING_DIR} bin lib include
+
+        # Package archive
+        tar -czf "catalyst-mlir-dev_$(uname -s)_$(uname -m)_${LLVM_VERSION_FULL}.tar.gz" \
+          -C "${LLVM_INSTALL_STAGING_DIR}" bin lib include
 
     - name: Locate the archive
       id: archive


### PR DESCRIPTION
:construction: WIP :construction: 

**Context:** The "Build and pack catalyst-mlir-dev" CI workflow doesn't run because certain environment variables were not being set correctly. See for instance job [90074008937](https://github.com/PennyLaneAI/catalyst/actions/runs/30295083288/job/90074008937), where the variables `LLVM_BUILD_DIR` and `LLVM_INSTALL_STAGING_DIR` were evaluating to empty strings when running

```console
$ DESTDIR=${LLVM_INSTALL_STAGING_DIR} cmake --build ${LLVM_BUILD_DIR} --target install-distribution
```

Note that this workflow does not run automatically and must be triggered manually.

**Description of the Change:** This PR fixes the environment variables in the CI workflow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PennyLaneAI/codesmith/catalyst/pr/3072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787774378&installation_model_id=6322&pr_number=3072&repository=PennyLaneAI%2Fcatalyst&return_to=https%3A%2F%2Fgithub.com%2FPennyLaneAI%2Fcatalyst%2Fpull%2F3072&signature=36ea4356f838bea2a071cc75963309b4c5e3ce0bb1a4c899330346f62c986b94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->