### PR TITLE
Lower stablehlo.fft to linalg DFT stages to support jax.numpy.fft under qjit

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -2,12 +2,6 @@
 
 <h3>New features since last release</h3>
 
-* `jax.numpy.fft` functions (`fft`, `ifft`, `rfft`, `irfft` and their 2D/ND variants) can now be
-  compiled with `@qjit`. Upstream StableHLO provides no legalization for `stablehlo.fft`, so a new
-  `fft-lowering` pass lowers it to `linalg.generic` reductions computing the discrete Fourier
-  transform with one batched 1D stage per transform axis. All four transform types are supported
-  for any transform length and the generated code is differentiable with `catalyst.grad`.
-
 * The `local-random` unitary folding option for :func:`~.mitigate_with_zne` is now implemented,
   reproducing Mitiq's ``fold_gates_at_random``: every gate is folded ``floor((scale_factor-1)/2)``
   times, then a random subset is folded once more (without replacement) to reach ``scale_factor * n``
@@ -15,6 +9,11 @@
   operation's `numFolds` operand is now always a floating-point tensor; the integer folding methods
   require integral values and convert the count internally.
   [(#2956)](https://github.com/PennyLaneAI/catalyst/pull/2956)
+
+* `jax.numpy.fft` functions (`fft`, `ifft`, `rfft`, `irfft` and their 2D/ND variants) can now be
+  compiled with `@qjit`. All four transform types are supported for any transform length and the generated
+  code is differentiable with `catalyst.grad`.
+  [(#3077)](https://github.com/PennyLaneAI/catalyst/pull/3077)
 
 <h3>Improvements 🛠</h3>
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -2,6 +2,13 @@
 
 <h3>New features since last release</h3>
 
+* `jax.numpy.fft` functions (`fft`, `ifft`, `rfft`, `irfft` and their 2D/ND variants) can now be
+  compiled with `@qjit`. Upstream StableHLO provides no legalization for `stablehlo.fft`, so a new
+  `fft-lowering` pass lowers it to `linalg.generic` reductions computing the discrete Fourier
+  transform with one batched 1D stage per transform axis. All four transform types are supported
+  for any transform length.
+  [(#2521)](https://github.com/PennyLaneAI/catalyst/issues/2521)
+
 * The `local-random` unitary folding option for :func:`~.mitigate_with_zne` is now implemented,
   reproducing Mitiq's ``fold_gates_at_random``: every gate is folded ``floor((scale_factor-1)/2)``
   times, then a random subset is folded once more (without replacement) to reach ``scale_factor * n``

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -6,8 +6,7 @@
   compiled with `@qjit`. Upstream StableHLO provides no legalization for `stablehlo.fft`, so a new
   `fft-lowering` pass lowers it to `linalg.generic` reductions computing the discrete Fourier
   transform with one batched 1D stage per transform axis. All four transform types are supported
-  for any transform length.
-  [(#2521)](https://github.com/PennyLaneAI/catalyst/issues/2521)
+  for any transform length and the generated code is differentiable with `catalyst.grad`.
 
 * The `local-random` unitary folding option for :func:`~.mitigate_with_zne` is now implemented,
   reproducing Mitiq's ``fold_gates_at_random``: every gate is folded ``floor((scale_factor-1)/2)``
@@ -247,6 +246,10 @@
 <h3>Deprecations 👋</h3>
 
 <h3>Bug fixes 🐛</h3>
+
+* Fixed a bug where `catalyst.grad` failed to compile functions with complex valued intermediate
+  results. The TBAA lowering used for gradient modules now accepts loads and stores of complex
+  element types and leaves them untagged instead of rejecting them.
 
 * Fixed a bug where the `ResourceAnalysis` pass only analyzed functions directly contained in
   the top-level module. Functions inside nested modules, such as kernels called through

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -246,10 +246,6 @@
 
 <h3>Bug fixes 🐛</h3>
 
-* Fixed a bug where `catalyst.grad` failed to compile functions with complex valued intermediate
-  results. The TBAA lowering used for gradient modules now accepts loads and stores of complex
-  element types and leaves them untagged instead of rejecting them.
-
 * Fixed a bug where the `ResourceAnalysis` pass only analyzed functions directly contained in
   the top-level module. Functions inside nested modules, such as kernels called through
   `catalyst.launch_kernel`, are now included in the output.
@@ -303,6 +299,11 @@
 
 * Fixed the assembly format for `quantum.adjoint` when it has no quantum operands/results.
   [(#2938)](https://github.com/PennyLaneAI/catalyst/pull/2938)
+
+* Fixed a bug where `catalyst.grad` failed to compile functions with complex valued intermediate
+  results. The TBAA lowering used for gradient modules now accepts loads and stores of complex
+  element types and leaves them untagged instead of rejecting them.
+  [(#3077)](https://github.com/PennyLaneAI/catalyst/pull/3077)
 
 <h3>Internal changes ⚙️</h3>
 

--- a/frontend/test/pytest/test_fft.py
+++ b/frontend/test/pytest/test_fft.py
@@ -1,0 +1,261 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test that jax.numpy.fft functions compile and produce correct results under qjit."""
+
+import jax
+import numpy as np
+import pytest
+from jax import numpy as jnp
+
+from catalyst import qjit
+
+# The direct DFT lowering with exactly reduced twiddle angles keeps f64 errors
+# near the 1e-12 scale for these sizes so 1e-8 gives ample slack. f32 twiddles
+# are accurate to f64 but the accumulation is f32 hence the looser tolerance.
+TOL_F64 = {"atol": 1e-8, "rtol": 1e-8}
+TOL_F32 = {"atol": 1e-3, "rtol": 1e-3}
+
+LENGTHS = [1, 2, 3, 6, 8, 13, 16, 100]
+
+
+def random_complex(rng, shape, dtype=np.complex128):
+    """Uniform random complex array in the unit square."""
+    return (rng.random(shape) + 1j * rng.random(shape)).astype(dtype)
+
+
+class TestFFTC2C:
+    """Complex-to-complex forward and inverse transforms."""
+
+    @pytest.mark.parametrize("n", LENGTHS)
+    def test_fft_1d(self, n):
+        """Forward FFT matches NumPy and plain JAX for all length classes."""
+        rng = np.random.default_rng(42)
+        x = random_complex(rng, (n,))
+
+        def f(x):
+            return jnp.fft.fft(x)
+
+        observed = qjit(f)(x)
+        assert np.allclose(observed, np.fft.fft(x), **TOL_F64)
+        assert np.allclose(observed, f(x), **TOL_F64)
+
+    @pytest.mark.parametrize("n", [1, 6, 8, 13])
+    def test_ifft_1d(self, n):
+        """Inverse FFT carries the 1/n normalization."""
+        rng = np.random.default_rng(7)
+        x = random_complex(rng, (n,))
+
+        def f(x):
+            return jnp.fft.ifft(x)
+
+        observed = qjit(f)(x)
+        assert np.allclose(observed, np.fft.ifft(x), **TOL_F64)
+
+    def test_fft_ifft_roundtrip(self):
+        """ifft(fft(x)) recovers x."""
+        rng = np.random.default_rng(3)
+        x = random_complex(rng, (17,))
+
+        def f(x):
+            return jnp.fft.ifft(jnp.fft.fft(x))
+
+        assert np.allclose(qjit(f)(x), x, **TOL_F64)
+
+    def test_fft_complex64(self):
+        """Single-precision transform stays in complex64 and is f32-accurate."""
+        rng = np.random.default_rng(11)
+        x = random_complex(rng, (16,), dtype=np.complex64)
+
+        def f(x):
+            return jnp.fft.fft(x)
+
+        observed = qjit(f)(x)
+        assert observed.dtype == np.complex64
+        assert np.allclose(observed, np.fft.fft(x.astype(np.complex128)), **TOL_F32)
+
+    def test_fft_real_input_promotes(self):
+        """A real input to fft is promoted to complex, like NumPy."""
+        rng = np.random.default_rng(5)
+        x = rng.random(10)
+
+        def f(x):
+            return jnp.fft.fft(x)
+
+        assert np.allclose(qjit(f)(x), np.fft.fft(x), **TOL_F64)
+
+    def test_fft_batched(self):
+        """Leading dimensions are batch dimensions."""
+        rng = np.random.default_rng(13)
+        x = random_complex(rng, (4, 5, 6))
+
+        def f(x):
+            return jnp.fft.fft(x, axis=-1)
+
+        assert np.allclose(qjit(f)(x), np.fft.fft(x, axis=-1), **TOL_F64)
+
+    def test_fft2(self):
+        """2D transform lowered separably with one stage per axis."""
+        rng = np.random.default_rng(17)
+        x = random_complex(rng, (4, 6))
+
+        def f(x):
+            return jnp.fft.fft2(x)
+
+        assert np.allclose(qjit(f)(x), np.fft.fft2(x), **TOL_F64)
+
+    def test_ifft2_batched(self):
+        """Batched 2D inverse transform with 1/(n1*n2) normalization."""
+        rng = np.random.default_rng(19)
+        x = random_complex(rng, (3, 4, 6))
+
+        def f(x):
+            return jnp.fft.ifft2(x, axes=(-2, -1))
+
+        assert np.allclose(qjit(f)(x), np.fft.ifft2(x, axes=(-2, -1)), **TOL_F64)
+
+
+class TestFFTReal:
+    """Real-to-complex (rfft) and complex-to-real (irfft) transforms."""
+
+    @pytest.mark.parametrize("n", LENGTHS)
+    def test_rfft_1d(self, n):
+        """rfft stores floor(n/2)+1 bins and matches NumPy."""
+        rng = np.random.default_rng(23)
+        x = rng.random(n)
+
+        def f(x):
+            return jnp.fft.rfft(x)
+
+        observed = qjit(f)(x)
+        assert observed.shape == (n // 2 + 1,)
+        assert np.allclose(observed, np.fft.rfft(x), **TOL_F64)
+
+    @pytest.mark.parametrize("n", [1, 2, 6, 8, 9, 13, 16])
+    def test_irfft_1d_non_hermitian_input(self, n):
+        """irfft on arbitrary complex input matches NumPy exactly. The
+        imaginary parts of the DC and Nyquist bins are discarded and interior
+        bins contribute via their conjugate pairs."""
+        rng = np.random.default_rng(29)
+        x = random_complex(rng, (n // 2 + 1,))
+
+        def f(x):
+            return jnp.fft.irfft(x, n=n)
+
+        observed = qjit(f)(x)
+        assert observed.shape == (n,)
+        assert np.allclose(observed, np.fft.irfft(x, n=n), **TOL_F64)
+
+    @pytest.mark.parametrize("n", [8, 9])
+    def test_rfft_irfft_roundtrip(self, n):
+        """irfft(rfft(x), n) == x for even and odd n."""
+        rng = np.random.default_rng(31)
+        x = rng.random(n)
+
+        def f(x):
+            return jnp.fft.irfft(jnp.fft.rfft(x), n=n)
+
+        assert np.allclose(qjit(f)(x), x, **TOL_F64)
+
+    def test_rfft_batched(self):
+        """rfft with leading batch dimensions."""
+        rng = np.random.default_rng(37)
+        x = rng.random((3, 10))
+
+        def f(x):
+            return jnp.fft.rfft(x, axis=-1)
+
+        assert np.allclose(qjit(f)(x), np.fft.rfft(x, axis=-1), **TOL_F64)
+
+    def test_rfft2(self):
+        """2D real transform with r2c along the last axis and c2c along the other."""
+        rng = np.random.default_rng(41)
+        x = rng.random((5, 6))
+
+        def f(x):
+            return jnp.fft.rfft2(x)
+
+        assert np.allclose(qjit(f)(x), np.fft.rfft2(x), **TOL_F64)
+
+    def test_irfft2(self):
+        """2D complex to real inverse transform."""
+        rng = np.random.default_rng(43)
+        x = random_complex(rng, (5, 4))
+
+        def f(x):
+            return jnp.fft.irfft2(x, s=(5, 6))
+
+        assert np.allclose(qjit(f)(x), np.fft.irfft2(x, s=(5, 6)), **TOL_F64)
+
+    def test_rfft_float32(self):
+        """Single-precision rfft."""
+        rng = np.random.default_rng(47)
+        x = rng.random(12).astype(np.float32)
+
+        def f(x):
+            return jnp.fft.rfft(x)
+
+        observed = qjit(f)(x)
+        assert observed.dtype == np.complex64
+        assert np.allclose(observed, np.fft.rfft(x.astype(np.float64)), **TOL_F32)
+
+
+class TestFFTIndirectCall:
+    """FFT called through a plain function inside a qjit block."""
+
+    def test_fft_indirect_call(self):
+        """A wrapped fft on real f64 input compiles and matches NumPy."""
+
+        def jax_fft(x):
+            return jnp.fft.fft(x)
+
+        @qjit
+        def test(x):
+            fft_result = jax_fft(x)
+            return fft_result
+
+        data = jnp.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0], dtype=jnp.float64)
+        assert np.allclose(test(data), np.fft.fft(np.asarray(data)), **TOL_F64)
+
+
+class TestFFTGradient:
+    """The emitted linalg loops are transparent to Enzyme and the DFT is a
+    linear map so reverse mode differentiation through an FFT is exact once
+    complex intermediates are supported by the gradient pipeline."""
+
+    @pytest.mark.xfail(
+        reason="catalyst.grad through complex intermediates fails to lower "
+        "memref.load of complex element types independently of FFT",
+        strict=True,
+    )
+    def test_grad_through_fft(self):
+        """d/dx sum(|fft(x)|^2) == 2*n*x by Parseval's theorem."""
+        from catalyst import grad
+
+        rng = np.random.default_rng(53)
+        n = 8
+        x = rng.random(n)
+
+        def loss(x):
+            return jnp.sum(jnp.abs(jnp.fft.fft(x)) ** 2)
+
+        observed = qjit(grad(loss, argnums=0))(x)
+        expected = jax.grad(loss)(x)
+        assert np.allclose(observed, expected, **TOL_F64)
+        # Parseval gives sum |X_k|^2 = n * sum x_j^2 so the gradient is 2*n*x.
+        assert np.allclose(observed, 2 * n * x, **TOL_F64)
+
+
+if __name__ == "__main__":
+    pytest.main(["-x", __file__])

--- a/frontend/test/pytest/test_fft.py
+++ b/frontend/test/pytest/test_fft.py
@@ -231,14 +231,8 @@ class TestFFTIndirectCall:
 
 class TestFFTGradient:
     """The emitted linalg loops are transparent to Enzyme and the DFT is a
-    linear map so reverse mode differentiation through an FFT is exact once
-    complex intermediates are supported by the gradient pipeline."""
+    linear map so reverse mode differentiation through an FFT is exact."""
 
-    @pytest.mark.xfail(
-        reason="catalyst.grad through complex intermediates fails to lower "
-        "memref.load of complex element types independently of FFT",
-        strict=True,
-    )
     def test_grad_through_fft(self):
         """d/dx sum(|fft(x)|^2) == 2*n*x by Parseval's theorem."""
         from catalyst import grad

--- a/mlir/include/Driver/DefaultPipelines/DefaultPipelines.h
+++ b/mlir/include/Driver/DefaultPipelines/DefaultPipelines.h
@@ -68,6 +68,7 @@ const PipelineList pipelineList{
       "func.func(stablehlo-legalize-sort)",
       "stablehlo-convert-to-signless",
       "canonicalize",
+      "fft-lowering",
       "scatter-lowering",
       "hlo-custom-call-lowering",
       "cse",

--- a/mlir/include/hlo-extensions/Transforms/Passes.td
+++ b/mlir/include/hlo-extensions/Transforms/Passes.td
@@ -50,6 +50,26 @@ def ScatterLoweringPass : Pass<"scatter-lowering"> {
     ];
 }
 
+def FFTLoweringPass : Pass<"fft-lowering"> {
+    let summary = "Lower fft op from Stable HLO to linalg generics computing the DFT.";
+    let description = [{
+        Upstream StableHLO provides no legalization of the fft op to linalg
+        since XLA lowers it to a runtime library call instead. This pass lowers
+        all four transform types FFT, IFFT, RFFT and IRFFT to chains of batched
+        1D discrete Fourier transform stages. Each stage is a linalg.generic
+        reduction with twiddle factors computed at runtime.
+    }];
+
+    let dependentDialects = [
+        "mlir::arith::ArithDialect",
+        "mlir::complex::ComplexDialect",
+        "mlir::linalg::LinalgDialect",
+        "mlir::math::MathDialect",
+        "mlir::tensor::TensorDialect",
+        "stablehlo::StablehloDialect"
+    ];
+}
+
 def HloCustomCallLoweringPass : Pass<"hlo-custom-call-lowering"> {
     let summary = "Lower custom calls op from Stable HLO to CallOp.";
 

--- a/mlir/include/hlo-extensions/Transforms/Patterns.h
+++ b/mlir/include/hlo-extensions/Transforms/Patterns.h
@@ -21,6 +21,8 @@
 namespace catalyst {
 namespace hlo_extensions {
 
+void populateFFTPatterns(mlir::RewritePatternSet &);
+
 void populateScatterPatterns(mlir::RewritePatternSet &);
 
 void populateHloCustomCallPatterns(mlir::RewritePatternSet &);

--- a/mlir/lib/Catalyst/Transforms/TBAAPatterns.cpp
+++ b/mlir/lib/Catalyst/Transforms/TBAAPatterns.cpp
@@ -148,6 +148,10 @@ struct MemrefLoadTBAARewritePattern : public ConvertOpToLLVMPattern<memref::Load
         else if (isAnyOf<IndexType, IntegerType, FloatType, MemRefType>(baseType)) {
             setTag(baseType, tree, loadOp.getContext(), op);
         }
+        else if (isa<ComplexType>(baseType)) {
+            // Complex loads become struct loads with no scalar TBAA node.
+            // Leave them untagged which conservatively may alias everything.
+        }
         else {
             return failure();
         }
@@ -184,6 +188,10 @@ struct MemrefStoreTBAARewritePattern : public ConvertOpToLLVMPattern<memref::Sto
         }
         else if (isAnyOf<IndexType, IntegerType, FloatType, MemRefType>(baseType)) {
             setTag(baseType, tree, storeOp.getContext(), op);
+        }
+        else if (isa<ComplexType>(baseType)) {
+            // Complex stores become struct stores with no scalar TBAA node.
+            // Leave them untagged which conservatively may alias everything.
         }
         else {
             return failure();

--- a/mlir/lib/Quantum/Transforms/dynamic_one_shot.cpp
+++ b/mlir/lib/Quantum/Transforms/dynamic_one_shot.cpp
@@ -14,6 +14,7 @@
 
 #define DEBUG_TYPE "dynamic-one-shot"
 
+#include <algorithm>
 #include <cstdint>
 #include <unordered_map>
 #include <unordered_set>
@@ -426,7 +427,9 @@ void editKernelMCMProbs(IRRewriter &builder, func::FuncOp oneShotKernel, quantum
     auto totalIndex =
         arith::ConstantOp::create(builder, loc, i64Type, builder.getIntegerAttr(i64Type, 0));
     Operation *loopUpdater = totalIndex;
-    for (auto [i, mcm] : llvm::enumerate(llvm::reverse(mcmobs.getMcms()))) {
+    SmallVector<Value> reversedMcms = llvm::to_vector(mcmobs.getMcms());
+    std::reverse(reversedMcms.begin(), reversedMcms.end());
+    for (auto [i, mcm] : llvm::enumerate(reversedMcms)) {
         // Power of 2 for this bit position
         auto extuiOp = arith::ExtUIOp::create(builder, loc, builder.getI64Type(), mcm);
         auto shiftSize =

--- a/mlir/lib/hlo-extensions/Transforms/CMakeLists.txt
+++ b/mlir/lib/hlo-extensions/Transforms/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(LIBRARY_NAME catalyst-stablehlo-transforms)
 
 file(GLOB SRC
+    fft_lowering.cpp
+    FFTPatterns.cpp
     hlo_custom_call_lowering.cpp
     HloCustomCallPatterns.cpp
     scatter_lowering.cpp

--- a/mlir/lib/hlo-extensions/Transforms/FFTPatterns.cpp
+++ b/mlir/lib/hlo-extensions/Transforms/FFTPatterns.cpp
@@ -1,0 +1,331 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define DEBUG_TYPE "fft"
+
+#include <cmath>
+#include <cstdint>
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Complex/IR/Complex.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StructuredOpsUtils.h"
+#include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/AffineMap.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+using namespace mlir;
+
+namespace catalyst {
+namespace hlo_extensions {
+
+namespace {
+
+// The multidimensional DFT is separable so stablehlo.fft is lowered to a
+// chain of batched 1D stages with one stage per transform axis.
+enum class StageKind {
+    C2CForward, // complex to complex with twiddle exp(-2*pi*i*j*k/L) and no scale
+    C2CInverse, // complex to complex with twiddle exp(+2*pi*i*j*k/L) scaled by 1/L
+    R2C,        // real to complex forward producing bins k = 0..floor(L/2)
+    C2R         // complex to real inverse from the floor(L/2)+1 stored bins scaled by 1/L
+};
+
+bool isForwardStage(StageKind kind)
+{
+    return kind == StageKind::C2CForward || kind == StageKind::R2C;
+}
+
+Value createFloatConst(OpBuilder &builder, Location loc, FloatType type, double value)
+{
+    APFloat apValue(value);
+    bool losesInfo = false;
+    apValue.convert(type.getFloatSemantics(), APFloat::rmNearestTiesToEven, &losesInfo);
+    return arith::ConstantFloatOp::create(builder, loc, type, apValue);
+}
+
+// Emit a batched 1D DFT stage along `axis` of `input` as a linalg.generic
+// reduction in destination passing style:
+//
+//   out[b..., k, b'...] = scale * sum_j in[b..., j, b'...] * T(j, k)
+//
+// The twiddle T(j, k) = exp(sign * 2*pi*i * ((j*k) mod L) / L) is computed per
+// index with L given by `modulus`. The exponent is reduced mod L in exact
+// integer arithmetic before the float conversion so the twiddle phase error
+// stays O(eps) independent of the magnitude of j*k. The reduction extent is
+// the input extent along `axis` and `outLen` is the output extent along it.
+// Inverse direction stages fold the 1/L normalization into the twiddles.
+//
+// All arithmetic is componentwise on the real and imaginary parts to avoid
+// complex.mul whose default lowering carries inf and nan fixup branches.
+// Angles are evaluated in f64 and truncated at the end so f32 transforms do
+// not lose twiddle accuracy.
+Value emitDFTStage(OpBuilder &builder, Location loc, Value input, int64_t axis, int64_t modulus,
+                   int64_t outLen, StageKind kind, Type outElemType)
+{
+    MLIRContext *ctx = builder.getContext();
+    auto inType = cast<RankedTensorType>(input.getType());
+    int64_t rank = inType.getRank();
+    int64_t numBins = inType.getDimSize(axis);
+
+    SmallVector<int64_t> outShape(inType.getShape());
+    outShape[axis] = outLen;
+    auto outType = RankedTensorType::get(outShape, outElemType);
+
+    FloatType realType;
+    if (auto complexType = dyn_cast<ComplexType>(outElemType)) {
+        realType = cast<FloatType>(complexType.getElementType());
+    }
+    else {
+        realType = cast<FloatType>(outElemType);
+    }
+
+    // Batch dims may be dynamic. The transform axis is static by construction.
+    SmallVector<Value> dynSizes;
+    for (int64_t dim = 0; dim < rank; ++dim) {
+        if (outType.isDynamicDim(dim)) {
+            dynSizes.push_back(tensor::DimOp::create(builder, loc, input, dim));
+        }
+    }
+    Value initTensor = tensor::EmptyOp::create(builder, loc, outShape, outElemType, dynSizes);
+
+    Value zero;
+    if (isa<ComplexType>(outElemType)) {
+        auto zeroAttr = builder.getFloatAttr(realType, 0.0);
+        zero = complex::ConstantOp::create(builder, loc, outElemType,
+                                           builder.getArrayAttr({zeroAttr, zeroAttr}));
+    }
+    else {
+        zero = createFloatConst(builder, loc, realType, 0.0);
+    }
+    Value accInit = linalg::FillOp::create(builder, loc, zero, initTensor).getResult(0);
+
+    // Loop dims d0..d_{rank-1} index the output and d_rank is the reduction.
+    // The input map substitutes the reduction dim for the transform axis.
+    SmallVector<AffineExpr> inExprs, outExprs;
+    for (int64_t dim = 0; dim < rank; ++dim) {
+        inExprs.push_back(getAffineDimExpr(dim == axis ? rank : dim, ctx));
+        outExprs.push_back(getAffineDimExpr(dim, ctx));
+    }
+    SmallVector<AffineMap> indexingMaps = {AffineMap::get(rank + 1, 0, inExprs, ctx),
+                                           AffineMap::get(rank + 1, 0, outExprs, ctx)};
+    SmallVector<utils::IteratorType> iteratorTypes(rank, utils::IteratorType::parallel);
+    iteratorTypes.push_back(utils::IteratorType::reduction);
+
+    double sign = isForwardStage(kind) ? -1.0 : 1.0;
+    double angleFactor = sign * 2.0 * M_PI / static_cast<double>(modulus);
+    double scale = isForwardStage(kind) ? 1.0 : 1.0 / static_cast<double>(modulus);
+
+    auto bodyBuilder = [&](OpBuilder &b, Location bodyLoc, ValueRange args) {
+        Value x = args[0];
+        Value acc = args[1];
+        auto f64Type = b.getF64Type();
+
+        Value k = linalg::IndexOp::create(b, bodyLoc, axis);
+        Value j = linalg::IndexOp::create(b, bodyLoc, rank);
+
+        // Twiddle angle with exact integer reduction of the exponent.
+        Value modulusCst = arith::ConstantIndexOp::create(b, bodyLoc, modulus);
+        Value jk = arith::MulIOp::create(b, bodyLoc, j, k);
+        Value m = arith::RemUIOp::create(b, bodyLoc, jk, modulusCst);
+        Value mInt = arith::IndexCastOp::create(b, bodyLoc, b.getI64Type(), m);
+        Value mFloat = arith::SIToFPOp::create(b, bodyLoc, f64Type, mInt);
+        Value angleCst = createFloatConst(b, bodyLoc, f64Type, angleFactor);
+        Value theta = arith::MulFOp::create(b, bodyLoc, mFloat, angleCst);
+
+        Value twiddleRe = math::CosOp::create(b, bodyLoc, theta);
+        Value twiddleIm = math::SinOp::create(b, bodyLoc, theta);
+        if (scale != 1.0) {
+            Value scaleCst = createFloatConst(b, bodyLoc, f64Type, scale);
+            twiddleRe = arith::MulFOp::create(b, bodyLoc, twiddleRe, scaleCst);
+            twiddleIm = arith::MulFOp::create(b, bodyLoc, twiddleIm, scaleCst);
+        }
+        if (!realType.isF64()) {
+            twiddleRe = arith::TruncFOp::create(b, bodyLoc, realType, twiddleRe);
+            twiddleIm = arith::TruncFOp::create(b, bodyLoc, realType, twiddleIm);
+        }
+
+        switch (kind) {
+        case StageKind::C2CForward:
+        case StageKind::C2CInverse: {
+            Value xRe = complex::ReOp::create(b, bodyLoc, realType, x);
+            Value xIm = complex::ImOp::create(b, bodyLoc, realType, x);
+            Value accRe = complex::ReOp::create(b, bodyLoc, realType, acc);
+            Value accIm = complex::ImOp::create(b, bodyLoc, realType, acc);
+            // (xRe + i*xIm) * (tRe + i*tIm)
+            Value prodRe = arith::SubFOp::create(
+                b, bodyLoc, arith::MulFOp::create(b, bodyLoc, xRe, twiddleRe),
+                arith::MulFOp::create(b, bodyLoc, xIm, twiddleIm));
+            Value prodIm = arith::AddFOp::create(
+                b, bodyLoc, arith::MulFOp::create(b, bodyLoc, xRe, twiddleIm),
+                arith::MulFOp::create(b, bodyLoc, xIm, twiddleRe));
+            Value newRe = arith::AddFOp::create(b, bodyLoc, accRe, prodRe);
+            Value newIm = arith::AddFOp::create(b, bodyLoc, accIm, prodIm);
+            Value result = complex::CreateOp::create(b, bodyLoc, outElemType, newRe, newIm);
+            linalg::YieldOp::create(b, bodyLoc, result);
+            break;
+        }
+        case StageKind::R2C: {
+            Value accRe = complex::ReOp::create(b, bodyLoc, realType, acc);
+            Value accIm = complex::ImOp::create(b, bodyLoc, realType, acc);
+            Value newRe = arith::AddFOp::create(b, bodyLoc, accRe,
+                                                arith::MulFOp::create(b, bodyLoc, x, twiddleRe));
+            Value newIm = arith::AddFOp::create(b, bodyLoc, accIm,
+                                                arith::MulFOp::create(b, bodyLoc, x, twiddleIm));
+            Value result = complex::CreateOp::create(b, bodyLoc, outElemType, newRe, newIm);
+            linalg::YieldOp::create(b, bodyLoc, result);
+            break;
+        }
+        case StageKind::C2R: {
+            Value xRe = complex::ReOp::create(b, bodyLoc, realType, x);
+            Value xIm = complex::ImOp::create(b, bodyLoc, realType, x);
+            // Re(x * e^{i*theta}) with the 1/L scale already in the twiddle.
+            Value base = arith::SubFOp::create(
+                b, bodyLoc, arith::MulFOp::create(b, bodyLoc, xRe, twiddleRe),
+                arith::MulFOp::create(b, bodyLoc, xIm, twiddleIm));
+            // Hermitian symmetry weight. Interior bins stand in for their
+            // conjugate mirror as well and count twice. The DC bin at j = 0
+            // and for even L the Nyquist bin at j = L/2 are self conjugate
+            // and count once.
+            Value one = createFloatConst(b, bodyLoc, realType, 1.0);
+            Value two = createFloatConst(b, bodyLoc, realType, 2.0);
+            Value zeroIdx = arith::ConstantIndexOp::create(b, bodyLoc, 0);
+            Value isDC =
+                arith::CmpIOp::create(b, bodyLoc, arith::CmpIPredicate::eq, j, zeroIdx);
+            Value weight = arith::SelectOp::create(b, bodyLoc, isDC, one, two);
+            if (modulus % 2 == 0) {
+                Value nyquistIdx = arith::ConstantIndexOp::create(b, bodyLoc, numBins - 1);
+                Value isNyquist =
+                    arith::CmpIOp::create(b, bodyLoc, arith::CmpIPredicate::eq, j, nyquistIdx);
+                weight = arith::SelectOp::create(b, bodyLoc, isNyquist, one, weight);
+            }
+            Value contrib = arith::MulFOp::create(b, bodyLoc, base, weight);
+            Value result = arith::AddFOp::create(b, bodyLoc, acc, contrib);
+            linalg::YieldOp::create(b, bodyLoc, result);
+            break;
+        }
+        }
+    };
+
+    auto genericOp =
+        linalg::GenericOp::create(builder, loc, TypeRange{outType}, ValueRange{input},
+                                  ValueRange{accInit}, indexingMaps, iteratorTypes, bodyBuilder);
+    return genericOp.getResult(0);
+}
+
+struct FftOpRewritePattern : public OpRewritePattern<stablehlo::FftOp> {
+    using OpRewritePattern<stablehlo::FftOp>::OpRewritePattern;
+
+    LogicalResult matchAndRewrite(stablehlo::FftOp op, PatternRewriter &rewriter) const override
+    {
+        auto operandType = dyn_cast<RankedTensorType>(op.getOperand().getType());
+        auto resultType = dyn_cast<RankedTensorType>(op.getType());
+        if (!operandType || !resultType) {
+            return rewriter.notifyMatchFailure(op, "expected ranked tensor operand and result");
+        }
+
+        ArrayRef<int64_t> fftLength = op.getFftLength();
+        int64_t rank = operandType.getRank();
+        int64_t numAxes = static_cast<int64_t>(fftLength.size());
+        if (numAxes < 1 || numAxes > rank) {
+            return rewriter.notifyMatchFailure(op, "invalid fft_length rank");
+        }
+        for (int64_t i = 0; i < numAxes; ++i) {
+            int64_t axis = rank - numAxes + i;
+            if (fftLength[i] <= 0) {
+                return rewriter.notifyMatchFailure(op, "non-positive fft length");
+            }
+            if (operandType.isDynamicDim(axis) || resultType.isDynamicDim(axis)) {
+                return rewriter.notifyMatchFailure(op, "dynamic extent on a transform axis");
+            }
+        }
+        // The stablehlo verifier guarantees the shape relations below. Check
+        // them anyway so a violation degrades into an op that is not lowered
+        // rather than silently wrong IR.
+        stablehlo::FftType fftType = op.getFftType();
+        int64_t lastLength = fftLength[numAxes - 1];
+        for (int64_t i = 0; i < numAxes; ++i) {
+            int64_t axis = rank - numAxes + i;
+            int64_t expected = fftLength[i];
+            if (fftType == stablehlo::FftType::IRFFT && i == numAxes - 1) {
+                expected = lastLength / 2 + 1;
+            }
+            if (operandType.getDimSize(axis) != expected) {
+                return rewriter.notifyMatchFailure(op, "operand shape inconsistent w/ fft_length");
+            }
+        }
+
+        Location loc = op.getLoc();
+        Value current = op.getOperand();
+
+        switch (fftType) {
+        case stablehlo::FftType::FFT:
+        case stablehlo::FftType::IFFT: {
+            Type complexElemType = operandType.getElementType();
+            StageKind kind = fftType == stablehlo::FftType::FFT ? StageKind::C2CForward
+                                                                : StageKind::C2CInverse;
+            for (int64_t i = 0; i < numAxes; ++i) {
+                int64_t axis = rank - numAxes + i;
+                current = emitDFTStage(rewriter, loc, current, axis, fftLength[i], fftLength[i],
+                                       kind, complexElemType);
+            }
+            break;
+        }
+        case stablehlo::FftType::RFFT: {
+            Type complexElemType = resultType.getElementType();
+            // Real to complex along the last axis first which produces the
+            // halved axis and then forward transforms along the other axes.
+            current = emitDFTStage(rewriter, loc, current, rank - 1, lastLength,
+                                   lastLength / 2 + 1, StageKind::R2C, complexElemType);
+            for (int64_t i = 0; i < numAxes - 1; ++i) {
+                int64_t axis = rank - numAxes + i;
+                current = emitDFTStage(rewriter, loc, current, axis, fftLength[i], fftLength[i],
+                                       StageKind::C2CForward, complexElemType);
+            }
+            break;
+        }
+        case stablehlo::FftType::IRFFT: {
+            Type complexElemType = operandType.getElementType();
+            // Mirror image of RFFT. Inverse transforms along the leading axes
+            // first and complex to real reconstruction along the last axis.
+            // Each stage folds its own 1/L factor and the product is 1/N.
+            for (int64_t i = 0; i < numAxes - 1; ++i) {
+                int64_t axis = rank - numAxes + i;
+                current = emitDFTStage(rewriter, loc, current, axis, fftLength[i], fftLength[i],
+                                       StageKind::C2CInverse, complexElemType);
+            }
+            current = emitDFTStage(rewriter, loc, current, rank - 1, lastLength, lastLength,
+                                   StageKind::C2R, resultType.getElementType());
+            break;
+        }
+        }
+
+        if (current.getType() != resultType) {
+            current = tensor::CastOp::create(rewriter, loc, resultType, current);
+        }
+        rewriter.replaceOp(op, current);
+        return success();
+    }
+};
+
+} // namespace
+
+void populateFFTPatterns(RewritePatternSet &patterns)
+{
+    patterns.add<FftOpRewritePattern>(patterns.getContext());
+}
+
+} // namespace hlo_extensions
+} // namespace catalyst

--- a/mlir/lib/hlo-extensions/Transforms/FFTPatterns.cpp
+++ b/mlir/lib/hlo-extensions/Transforms/FFTPatterns.cpp
@@ -165,12 +165,12 @@ Value emitDFTStage(OpBuilder &builder, Location loc, Value input, int64_t axis, 
             Value accRe = complex::ReOp::create(b, bodyLoc, realType, acc);
             Value accIm = complex::ImOp::create(b, bodyLoc, realType, acc);
             // (xRe + i*xIm) * (tRe + i*tIm)
-            Value prodRe = arith::SubFOp::create(
-                b, bodyLoc, arith::MulFOp::create(b, bodyLoc, xRe, twiddleRe),
-                arith::MulFOp::create(b, bodyLoc, xIm, twiddleIm));
-            Value prodIm = arith::AddFOp::create(
-                b, bodyLoc, arith::MulFOp::create(b, bodyLoc, xRe, twiddleIm),
-                arith::MulFOp::create(b, bodyLoc, xIm, twiddleRe));
+            Value prodRe =
+                arith::SubFOp::create(b, bodyLoc, arith::MulFOp::create(b, bodyLoc, xRe, twiddleRe),
+                                      arith::MulFOp::create(b, bodyLoc, xIm, twiddleIm));
+            Value prodIm =
+                arith::AddFOp::create(b, bodyLoc, arith::MulFOp::create(b, bodyLoc, xRe, twiddleIm),
+                                      arith::MulFOp::create(b, bodyLoc, xIm, twiddleRe));
             Value newRe = arith::AddFOp::create(b, bodyLoc, accRe, prodRe);
             Value newIm = arith::AddFOp::create(b, bodyLoc, accIm, prodIm);
             Value result = complex::CreateOp::create(b, bodyLoc, outElemType, newRe, newIm);
@@ -192,9 +192,9 @@ Value emitDFTStage(OpBuilder &builder, Location loc, Value input, int64_t axis, 
             Value xRe = complex::ReOp::create(b, bodyLoc, realType, x);
             Value xIm = complex::ImOp::create(b, bodyLoc, realType, x);
             // Re(x * e^{i*theta}) with the 1/L scale already in the twiddle.
-            Value base = arith::SubFOp::create(
-                b, bodyLoc, arith::MulFOp::create(b, bodyLoc, xRe, twiddleRe),
-                arith::MulFOp::create(b, bodyLoc, xIm, twiddleIm));
+            Value base =
+                arith::SubFOp::create(b, bodyLoc, arith::MulFOp::create(b, bodyLoc, xRe, twiddleRe),
+                                      arith::MulFOp::create(b, bodyLoc, xIm, twiddleIm));
             // Hermitian symmetry weight. Interior bins stand in for their
             // conjugate mirror as well and count twice. The DC bin at j = 0
             // and for even L the Nyquist bin at j = L/2 are self conjugate
@@ -202,8 +202,7 @@ Value emitDFTStage(OpBuilder &builder, Location loc, Value input, int64_t axis, 
             Value one = createFloatConst(b, bodyLoc, realType, 1.0);
             Value two = createFloatConst(b, bodyLoc, realType, 2.0);
             Value zeroIdx = arith::ConstantIndexOp::create(b, bodyLoc, 0);
-            Value isDC =
-                arith::CmpIOp::create(b, bodyLoc, arith::CmpIPredicate::eq, j, zeroIdx);
+            Value isDC = arith::CmpIOp::create(b, bodyLoc, arith::CmpIPredicate::eq, j, zeroIdx);
             Value weight = arith::SelectOp::create(b, bodyLoc, isDC, one, two);
             if (modulus % 2 == 0) {
                 Value nyquistIdx = arith::ConstantIndexOp::create(b, bodyLoc, numBins - 1);
@@ -274,8 +273,8 @@ struct FftOpRewritePattern : public OpRewritePattern<stablehlo::FftOp> {
         case stablehlo::FftType::FFT:
         case stablehlo::FftType::IFFT: {
             Type complexElemType = operandType.getElementType();
-            StageKind kind = fftType == stablehlo::FftType::FFT ? StageKind::C2CForward
-                                                                : StageKind::C2CInverse;
+            StageKind kind =
+                fftType == stablehlo::FftType::FFT ? StageKind::C2CForward : StageKind::C2CInverse;
             for (int64_t i = 0; i < numAxes; ++i) {
                 int64_t axis = rank - numAxes + i;
                 current = emitDFTStage(rewriter, loc, current, axis, fftLength[i], fftLength[i],
@@ -287,8 +286,8 @@ struct FftOpRewritePattern : public OpRewritePattern<stablehlo::FftOp> {
             Type complexElemType = resultType.getElementType();
             // Real to complex along the last axis first which produces the
             // halved axis and then forward transforms along the other axes.
-            current = emitDFTStage(rewriter, loc, current, rank - 1, lastLength,
-                                   lastLength / 2 + 1, StageKind::R2C, complexElemType);
+            current = emitDFTStage(rewriter, loc, current, rank - 1, lastLength, lastLength / 2 + 1,
+                                   StageKind::R2C, complexElemType);
             for (int64_t i = 0; i < numAxes - 1; ++i) {
                 int64_t axis = rank - numAxes + i;
                 current = emitDFTStage(rewriter, loc, current, axis, fftLength[i], fftLength[i],

--- a/mlir/lib/hlo-extensions/Transforms/fft_lowering.cpp
+++ b/mlir/lib/hlo-extensions/Transforms/fft_lowering.cpp
@@ -1,0 +1,56 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define DEBUG_TYPE "fft"
+
+#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Complex/IR/Complex.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "stablehlo/dialect/StablehloOps.h"
+
+#include "hlo-extensions/Transforms/Patterns.h"
+
+using namespace llvm;
+using namespace mlir;
+using namespace catalyst;
+
+namespace catalyst {
+namespace hlo_extensions {
+
+#define GEN_PASS_DEF_FFTLOWERINGPASS
+#include "hlo-extensions/Transforms/Passes.h.inc"
+
+struct FFTLoweringPass : impl::FFTLoweringPassBase<FFTLoweringPass> {
+    using FFTLoweringPassBase::FFTLoweringPassBase;
+
+    void runOnOperation() final
+    {
+        LLVM_DEBUG(dbgs() << "fft lowering pass"
+                          << "\n");
+
+        RewritePatternSet patterns(&getContext());
+        populateFFTPatterns(patterns);
+        if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+            return signalPassFailure();
+        }
+    }
+};
+
+} // namespace hlo_extensions
+} // namespace catalyst

--- a/mlir/test/Catalyst/FFTTest.mlir
+++ b/mlir/test/Catalyst/FFTTest.mlir
@@ -1,0 +1,138 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RUN: quantum-opt %s --fft-lowering --split-input-file --verify-diagnostics | FileCheck %s
+
+// 1D complex-to-complex forward FFT on a non-power-of-two length.
+// The forward twiddle angle factor is -2*pi/6.
+// CHECK-LABEL: func.func @fft_1d
+func.func @fft_1d(%arg0: tensor<6xcomplex<f64>>) -> tensor<6xcomplex<f64>> {
+    // CHECK-NOT: stablehlo.fft
+    // CHECK-DAG: arith.constant -1.0471975511965976 : f64
+    // CHECK-DAG: [[INIT:%.+]] = tensor.empty() : tensor<6xcomplex<f64>>
+    // CHECK-DAG: [[ZERO:%.+]] = complex.constant [0.000000e+00, 0.000000e+00] : complex<f64>
+    // CHECK:     [[FILLED:%.+]] = linalg.fill ins([[ZERO]] : complex<f64>) outs([[INIT]] : tensor<6xcomplex<f64>>)
+    // CHECK:     [[RES:%.+]] = linalg.generic
+    // CHECK-SAME: indexing_maps = [#map, #map1]
+    // CHECK-SAME: iterator_types = ["parallel", "reduction"]
+    // CHECK-SAME: ins(%arg0 : tensor<6xcomplex<f64>>) outs([[FILLED]] : tensor<6xcomplex<f64>>)
+    // CHECK-DAG:    linalg.index 0
+    // CHECK-DAG:    linalg.index 1
+    // CHECK-DAG:    arith.muli
+    // CHECK-DAG:    arith.remui
+    // CHECK-DAG:    math.cos
+    // CHECK-DAG:    math.sin
+    // CHECK:        complex.create
+    // CHECK:     return [[RES]]
+    %0 = stablehlo.fft %arg0, type = FFT, length = [6] : (tensor<6xcomplex<f64>>) -> tensor<6xcomplex<f64>>
+    return %0 : tensor<6xcomplex<f64>>
+}
+
+// -----
+
+// 1D inverse FFT with positive twiddle angle +2*pi/6 and the 1/6
+// normalization folded into the twiddles.
+// CHECK-LABEL: func.func @ifft_1d
+func.func @ifft_1d(%arg0: tensor<6xcomplex<f64>>) -> tensor<6xcomplex<f64>> {
+    // CHECK-NOT: stablehlo.fft
+    // CHECK-DAG: arith.constant 1.0471975511965976 : f64
+    // CHECK-DAG: arith.constant 0.16666666666666666 : f64
+    // CHECK:     linalg.generic
+    // CHECK:     complex.create
+    %0 = stablehlo.fft %arg0, type = IFFT, length = [6] : (tensor<6xcomplex<f64>>) -> tensor<6xcomplex<f64>>
+    return %0 : tensor<6xcomplex<f64>>
+}
+
+// -----
+
+// 1D real-to-complex FFT where odd length 9 stores floor(9/2)+1 = 5 bins.
+// CHECK-LABEL: func.func @rfft_1d
+func.func @rfft_1d(%arg0: tensor<9xf64>) -> tensor<5xcomplex<f64>> {
+    // CHECK-NOT: stablehlo.fft
+    // CHECK:     tensor.empty() : tensor<5xcomplex<f64>>
+    // CHECK:     [[RES:%.+]] = linalg.generic
+    // CHECK-SAME: ins(%arg0 : tensor<9xf64>)
+    // CHECK-SAME: outs({{.*}} : tensor<5xcomplex<f64>>)
+    // CHECK:        complex.create
+    // CHECK:     return [[RES]]
+    %0 = stablehlo.fft %arg0, type = RFFT, length = [9] : (tensor<9xf64>) -> tensor<5xcomplex<f64>>
+    return %0 : tensor<5xcomplex<f64>>
+}
+
+// -----
+
+// 1D complex-to-real inverse FFT reading 5 stored bins to reconstruct
+// length 8. Interior bins are double weighted due to Hermitian symmetry
+// while the DC bin and the Nyquist bin count once.
+// CHECK-LABEL: func.func @irfft_1d
+func.func @irfft_1d(%arg0: tensor<5xcomplex<f64>>) -> tensor<8xf64> {
+    // CHECK-NOT: stablehlo.fft
+    // CHECK-DAG: arith.constant 1.250000e-01 : f64
+    // CHECK-DAG: arith.constant 4 : index
+    // CHECK:     tensor.empty() : tensor<8xf64>
+    // CHECK:     [[RES:%.+]] = linalg.generic
+    // CHECK-SAME: ins(%arg0 : tensor<5xcomplex<f64>>)
+    // CHECK-SAME: outs({{.*}} : tensor<8xf64>)
+    // CHECK-DAG:    arith.cmpi eq
+    // CHECK-DAG:    arith.select
+    // CHECK:     return [[RES]]
+    %0 = stablehlo.fft %arg0, type = IRFFT, length = [8] : (tensor<5xcomplex<f64>>) -> tensor<8xf64>
+    return %0 : tensor<8xf64>
+}
+
+// -----
+
+// 2D transform. The separable lowering emits one batched 1D stage per axis.
+// CHECK-LABEL: func.func @fft_2d
+func.func @fft_2d(%arg0: tensor<4x6xcomplex<f64>>) -> tensor<4x6xcomplex<f64>> {
+    // CHECK-NOT: stablehlo.fft
+    // CHECK:     [[S1:%.+]] = linalg.generic
+    // CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction"]
+    // CHECK:     [[S2:%.+]] = linalg.generic
+    // CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction"]
+    // CHECK-SAME: ins([[S1]] : tensor<4x6xcomplex<f64>>)
+    // CHECK:     return [[S2]]
+    %0 = stablehlo.fft %arg0, type = FFT, length = [4, 6] : (tensor<4x6xcomplex<f64>>) -> tensor<4x6xcomplex<f64>>
+    return %0 : tensor<4x6xcomplex<f64>>
+}
+
+// -----
+
+// Batched transform with a dynamic batch dimension.
+// CHECK-LABEL: func.func @fft_batched_dynamic
+func.func @fft_batched_dynamic(%arg0: tensor<?x6xcomplex<f64>>) -> tensor<?x6xcomplex<f64>> {
+    // CHECK-NOT: stablehlo.fft
+    // CHECK-DAG: [[C0:%.+]] = arith.constant 0 : index
+    // CHECK-DAG: [[DIM:%.+]] = tensor.dim %arg0, [[C0]]
+    // CHECK:     tensor.empty([[DIM]]) : tensor<?x6xcomplex<f64>>
+    // CHECK:     [[RES:%.+]] = linalg.generic
+    // CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction"]
+    // CHECK:     return [[RES]]
+    %0 = stablehlo.fft %arg0, type = FFT, length = [6] : (tensor<?x6xcomplex<f64>>) -> tensor<?x6xcomplex<f64>>
+    return %0 : tensor<?x6xcomplex<f64>>
+}
+
+// -----
+
+// f32 transforms compute twiddles in f64 and truncate.
+// CHECK-LABEL: func.func @fft_f32
+func.func @fft_f32(%arg0: tensor<6xcomplex<f32>>) -> tensor<6xcomplex<f32>> {
+    // CHECK-NOT: stablehlo.fft
+    // CHECK:     linalg.generic
+    // CHECK-DAG:    math.cos {{.*}} : f64
+    // CHECK-DAG:    arith.truncf {{.*}} : f64 to f32
+    // CHECK:        complex.create {{.*}} : complex<f32>
+    %0 = stablehlo.fft %arg0, type = FFT, length = [6] : (tensor<6xcomplex<f32>>) -> tensor<6xcomplex<f32>>
+    return %0 : tensor<6xcomplex<f32>>
+}

--- a/mlir/test/Catalyst/MemrefLoadStoreLoweringTBAA.mlir
+++ b/mlir/test/Catalyst/MemrefLoadStoreLoweringTBAA.mlir
@@ -154,3 +154,19 @@ module @my_model {
         return %0, %alloc: memref<f64>, memref<memref<f64>>
     }
 }
+
+// -----
+
+// Complex loads and stores lower to struct accesses and stay untagged
+
+module @my_model {
+    llvm.func @__enzyme_autodiff4(...)
+    func.func @func_complex(%arg0: memref<complex<f64>>, %arg1: memref<4xcomplex<f64>>) -> memref<4xcomplex<f64>> {
+        // CHECK: llvm.load [[ANY:%[0-9]+]] : !llvm.ptr -> !llvm.struct<(f64, f64)>
+        %0 = memref.load %arg0[] : memref<complex<f64>>
+        %idx0 = index.constant 0
+        // CHECK: llvm.store [[ANY:%[0-9]+]], [[ANY:%[0-9]+]] : !llvm.struct<(f64, f64)>, !llvm.ptr
+        memref.store %0, %arg1[%idx0] : memref<4xcomplex<f64>>
+        return %arg1: memref<4xcomplex<f64>>
+    }
+}


### PR DESCRIPTION
**Context:**

Using `jnp.fft.fft` (or `ifft`, `rfft`, `irfft`) inside `@qjit` fails with
`op was not bufferized: stablehlo.fft` the upstream StableHLO has no legalization for the op
at all since XLA just calls a runtime FFT library (DUCC) so it survives every HLO lowering
pass and dies at bufferization what I realized is the DFT is just a linear reduction with
weights depending only on `j*k mod n`, so it maps directly onto `linalg.generic` and can be
lowered in pure MLIR with no runtime library. While testing gradients I also found that
`catalyst.grad` of any function with a complex valued intermediate (no FFT needed) fails
with `memref.load` of `complex<f64>` marked illegal, because the TBAA lowering used in
gradient modules rejects element types it can't tag.

**Description of the Change:**

* A new `fft-lowering` pass lowers all four transform types (`FFT`, `IFFT`, `RFFT`,
  `IRFFT`) to `linalg.generic` reductions computing the DFT, twiddles computed at runtime
  from `linalg.index` (`j*k mod n` before the sin/cos keeps the argument small for float
  accuracy). Registered in `hlo-lowering-stage` before `scatter-lowering`.
* Multi dimensional `fft_length` uses separability, one batched 1D stage per axis, the
  innermost axis handling the R2C/C2R endpoint shapes.
* `rfft` stores only `n/2 + 1` outputs (real input gives a Hermitian spectrum), and `irfft`
  folds that symmetry into the reduction weights (every stored bin counts twice except DC
  and Nyquist) instead of materializing the mirrored half. Non Hermitian input to `irfft`
  behaves like NumPy, iethe imaginary part drops out.
* The TBAA patterns in `MemrefToLLVMWithTBAAPass` now accept complex element types and emit
  ordinary LLVM struct loads/stores with no TBAA tag untagged accesses may-alias so this
  can't miscompile, and it unblocks `catalyst.grad` through complex intermediates. Since
  the DFT is linear its adjoint is the conjugate transform, so Enzyme differentiates the
  emitted loops.
* I also fixed a clang 21 build error in `dynamic_one_shot.cpp` (`llvm::enumerate` over a
  reversed `OperandRange`).

**Benefits:**

`jnp.fft` now compiles and runs under `@qjit` for any length, batched and N-D, f32 and
f64, matching NumPy/JAX and `grad` of `sum(|fft(x)|^2)` matches both
un-jitted JAX autodiff and the analytic answer.

**Possible Drawbacks:**

The direct DFT is O(n^2) per axis fine through a few thousand points and slow past that
(~13 ms at n=1024, ~3 s at n=16384 locally) a Cooley-Tukey/Bluestein fast path drops into
the same per-axis stage structure later without user facing changes so I left it for a
follow-up rather than doubling the correctness surface here.

**Related GitHub Issues:**

Fixes #2521