### PR TITLE
On-Demand Rules

### DIFF
--- a/frontend/test/lit/GraphDecomposition/QPD/S.mlir
+++ b/frontend/test/lit/GraphDecomposition/QPD/S.mlir
@@ -1,0 +1,25 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RUN: catalyst --tool=opt --pass-pipeline='builtin.module(graph-decomposition{gate-set=PhaseShift=1.0})' %s | FileCheck %s
+
+func.func @S() -> !quantum.bit {
+  %reg = quantum.alloc(1): !quantum.reg
+  %0 = quantum.extract %reg[0] : !quantum.reg -> !quantum.bit
+
+  // CHECK-NOT: quantum.custom "S"
+  // CHECK: quantum.custom "PhaseShift"
+  %out_qubits = quantum.custom "S"() %0 : !quantum.bit
+  return %out_qubits : !quantum.bit
+}

--- a/frontend/test/lit/GraphDecomposition/QPD/paulirot.mlir
+++ b/frontend/test/lit/GraphDecomposition/QPD/paulirot.mlir
@@ -12,19 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Test that graph-decomposition is able to use compile-time python decompositions
+// RUN: catalyst --tool=opt --pass-pipeline='builtin.module(graph-decomposition{gate-set=Hadamard=1.0,MultiRZ=1.0})' %s | FileCheck %s
 
-// RUN: catalyst --tool=opt --pass-pipeline='builtin.module(graph-decomposition{gate-set=PhaseShift=1.0})' %s | FileCheck %s
-
-
-func.func @circuit() -> !quantum.bit {
-  %reg = quantum.alloc(1): !quantum.reg
-  %0 = quantum.extract %reg[0] : !quantum.reg -> !quantum.bit
-
-  // CHECK-NOT: quantum.custom "S"
-  // CHECK: quantum.custom "PhaseShift"
-  %out_qubits = quantum.custom "S"() %0 : !quantum.bit
-  return %out_qubits : !quantum.bit
+func.func @paulirot(%angle: f64, %q1: !quantum.bit, %q2: !quantum.bit) {
+  // CHECK-NOT: quantum.paulirot
+  // CHECK: Hadamard
+  // CHECK: quantum.multirz
+  // CHECK: Hadamard
+  %qout:2 = quantum.paulirot ["Z", "X"](%angle) %q1, %q2 : !quantum.bit, !quantum.bit
+  return
 }
-
-// TODO: add a tests for more complicated operators once they're migrated

--- a/frontend/test/lit/GraphDecomposition/TestQPD.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestQPD.mlir
@@ -1,0 +1,30 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Test that graph-decomposition is able to use compile-time python decompositions
+
+// RUN: catalyst --tool=opt --pass-pipeline='builtin.module(graph-decomposition{gate-set=PhaseShift=1.0})' %s | FileCheck %s
+
+
+func.func @circuit() -> !quantum.bit {
+  %reg = quantum.alloc(1): !quantum.reg
+  %0 = quantum.extract %reg[0] : !quantum.reg -> !quantum.bit
+
+  // CHECK-NOT: quantum.custom "S"
+  // CHECK: quantum.custom "PhaseShift"
+  %out_qubits = quantum.custom "S"() %0 : !quantum.bit
+  return %out_qubits : !quantum.bit
+}
+
+// TODO: add a tests for more complicated operators once they're migrated

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
@@ -393,7 +393,7 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
             }
 
             moduleOp->walk([&](mlir::func::FuncOp func) {
-                if (func.getName().starts_with(opId)) {
+                if (func.getName().ends_with(opId)) {
                     mlir::OwningOpRef<mlir::func::FuncOp> outOp;
                     func->remove();
                     outOp = mlir::OwningOpRef<mlir::func::FuncOp>(func);

--- a/mlir/lib/Quantum/Transforms/QuantumPythonDecompositions/PythonFunction.cpp
+++ b/mlir/lib/Quantum/Transforms/QuantumPythonDecompositions/PythonFunction.cpp
@@ -16,8 +16,8 @@
 #include "nanobind/stl/string.h" // for type conversion
 
 #include <cstddef>
+#include <cstdint>
 #include <exception>
-#include <iostream>
 #include <string>
 
 #include "llvm/ADT/STLExtras.h"
@@ -26,12 +26,13 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Casting.h"
-#include "llvm/Support/DebugLog.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/TypeRange.h"
 #include "mlir/IR/Types.h"
+#include "mlir/Support/LLVM.h"
 
 #include "Quantum/IR/QuantumInterfaces.h"
 #include "Quantum/IR/QuantumOps.h"
@@ -44,23 +45,51 @@ namespace nb = nanobind;
 
 namespace {
 
-static nb::dict
-getPyvalFromDynamicShape(const llvm::StringMap<llvm::SmallVector<mlir::Type>> &map) {
-    nb::dict name_to_shape;
-    for (const auto &entry : map) {
-        nb::list types;
-        for (auto type : entry.getValue()) {
-            if (!type) {
-                continue;
-            }
-            std::string typestr;
-            llvm::raw_string_ostream ss(typestr);
-            type.print(ss);
-            types.append(typestr);
-        }
-        name_to_shape[nb::str(entry.getKey().str().c_str())] = types;
+nb::str getPyvalFromScalarType(mlir::Type type) {
+    std::string typestr;
+    llvm::raw_string_ostream ss(typestr);
+    type.print(ss);
+    return nb::str(typestr.c_str());
+}
+
+nb::list getPyvalFromShapedType(mlir::ArrayRef<int64_t> shape, int64_t dim, nb::str typestr) {
+    if (dim == shape.size()) {
+        return nb::list();
     }
-    return name_to_shape;
+    nb::list result;
+    for (int i = 0; i < shape[dim]; i++) {
+        result.append(typestr);
+    }
+    return result;
+}
+
+nb::object getPyvalFromType(mlir::Type type) {
+    return llvm::TypeSwitch<mlir::Type, nb::object>(type)
+        .Case<mlir::ShapedType>([&](mlir::ShapedType shapedType) {
+            return getPyvalFromShapedType(shapedType.getShape(), 0,
+                                          getPyvalFromScalarType(shapedType.getElementType()));
+        })
+        .Default([&](mlir::Type other) { return getPyvalFromScalarType(type); });
+}
+
+nb::dict getPyvalFromDynamicShape(const llvm::StringMap<llvm::SmallVector<mlir::Type>> &map) {
+    llvm::SmallVector<llvm::StringRef> keys;
+    for (const llvm::StringRef key : map.keys()) {
+        keys.push_back(key);
+    }
+    llvm::sort(keys);
+
+    nb::dict result;
+    for (auto [i, key] : llvm::enumerate(keys)) {
+        nb::list entry;
+
+        const auto &types = map.lookup(key);
+        for (auto [j, type] : llvm::enumerate(types)) {
+            entry.append(getPyvalFromType(type));
+        }
+        result[key.str().c_str()] = entry;
+    }
+    return result;
 }
 
 static nb::dict getPyvalFromWireLens(const llvm::StringMap<size_t> map) {


### PR DESCRIPTION
**Context:**
Decomposition rule lowering follows a three pronged approach - precompiled, lowering-time and on-demand.

**Description of the Change:**
Updates the on-demand rule lowering system to support Operator2 and graph op IDs.

**Benefits:**
On-demand rule lowering for any PennyLane built-in operator2 subclass.

**Possible Drawbacks:**

**Related GitHub Issues:**
