### PR TITLE
[backline] feat: add frontend sugar

### DIFF
--- a/frontend/catalyst/backline.py
+++ b/frontend/catalyst/backline.py
@@ -125,8 +125,8 @@ def _node_dict(node, role: str, transport: str) -> dict:
             the concrete backend. An explicit ``init_args["backend_lib"]`` path takes precedence.
     """
     d: dict = {"remote": bool(node.remote)}
-    if node.label is not None:
-        d["name"] = node.label
+    if node.name is not None:
+        d["name"] = node.name
     comm_host = getattr(node, "comm_host", None)
     if comm_host is not None:
         d["peer"] = comm_host
@@ -258,7 +258,7 @@ def backline_attr_text(placement) -> str:
     return "#transport.backline<" + ", ".join(parts) + ">"
 
 
-def _launch_executor(label, options):
+def _launch_executor(name, options):
     """Build and launch a ``catalyst.Executor`` from a node's executor options.
 
     The executor determines its own target triple, detecting it on the target host when the options
@@ -266,7 +266,7 @@ def _launch_executor(label, options):
     """
     from catalyst.executor import Executor
 
-    options.setdefault("name", label or "executor")
+    options.setdefault("name", name or "executor")
     return Executor(**options).launch()
 
 
@@ -283,6 +283,6 @@ def _realize_executor(node, role=None):
         plugins = list(options.get("plugins") or ())
         plugins.extend(plugin for plugin in _required_plugins(node, role) if plugin not in plugins)
         options["plugins"] = plugins
-    executor = _launch_executor(getattr(node, "label", None), options)
+    executor = _launch_executor(getattr(node, "name", None), options)
     object.__setattr__(node, "executor", executor)  # cache on the (frozen) node
     return executor

--- a/frontend/catalyst/backline.py
+++ b/frontend/catalyst/backline.py
@@ -27,7 +27,7 @@ from catalyst.device.qjit_device import extract_backend_info
 from catalyst.utils.runtime_environment import get_lib_path
 
 # Backend hints forwarded verbatim from a node's ``init_args`` to the attribute node.
-_INIT_KEYS = ("backend_lib", "config", "in_bytes", "out_bytes")
+_INIT_KEYS = ("backend_lib", "config")
 
 # Concrete runtime backends are a Catalyst implementation detail. PennyLane describes only the
 # transport protocol and the hardware on which each node runs.
@@ -127,6 +127,9 @@ def _node_dict(node, role: str, transport: str) -> dict:
     d: dict = {"remote": bool(node.remote)}
     if node.name is not None:
         d["name"] = node.name
+    if role == "controller":
+        d["in_bytes"] = node.in_bytes
+        d["out_bytes"] = node.out_bytes
     comm_host = getattr(node, "comm_host", None)
     if comm_host is not None:
         d["peer"] = comm_host

--- a/frontend/catalyst/backline.py
+++ b/frontend/catalyst/backline.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 """Serialize a PennyLane ``Placement`` into the ``catalyst.backline`` module attribute and
-build the pipelines that lower it. Backend hints in a node's ``init_args`` are forwarded verbatim,
-so a new backend needs no change here.
+build the pipelines that lower it. A node's hardware and the placement transport select the
+compiled transport backend.
 
 Note: "node" here is a backline participant (a controller or coprocessor), distinct from
 :class:`catalyst.Executor`, which deploys the ``catalyst-executor`` process a node may run on.
@@ -23,45 +23,64 @@ Note: "node" here is a backline participant (a controller or coprocessor), disti
 import os
 from pathlib import Path
 
+from catalyst.device.qjit_device import extract_backend_info
 from catalyst.utils.runtime_environment import get_lib_path
 
 # Backend hints forwarded verbatim from a node's ``init_args`` to the attribute node.
 _INIT_KEYS = ("backend_lib", "config", "in_bytes", "out_bytes")
 
+# Concrete runtime backends are a Catalyst implementation detail. PennyLane describes only the
+# transport protocol and the hardware on which each node runs.
+_BACKENDS = {
+    ("rdma", "cpu"): "cpu_verbs",
+    ("rdma", "gpu"): "gpu_verbs",
+    ("rdma", "fpga"): "hwhs",
+    ("memcpy", "cpu"): "memcpy",
+    ("memcpy", "gpu"): "memcpy_gpu",
+}
+
 # A transport backend library is named for its backend and role:
 #     libcatalyst_transport_<backend>_<role>.<ext>
 # A ``make -C runtime`` build passes ``CMAKE_LIBRARY_OUTPUT_DIRECTORY``, so in-tree backends land
-# flat in ``<RUNTIME_LIB_DIR>``; a bare ``cmake`` build instead mirrors the source tree, nesting them
-# under ``transport/<backend>/``. Both are searched. Out-of-tree backends build elsewhere entirely,
+# flat in ``<RUNTIME_LIB_DIR>``. A bare ``cmake`` build instead mirrors the source tree under
+# ``transport/<transport>/[<backend>/]``. Both are searched. Out-of-tree backends build elsewhere,
 # so ``CATALYST_TRANSPORT_PATH`` (``:``-separated, like ``PATH``) lists extra directories to search
 # first; each is searched directly, assuming no layout within it.
 _BACKEND_PATH_ENV = "CATALYST_TRANSPORT_PATH"
 _BACKEND_SUBDIR = "transport"
 _BACKEND_LIB_EXTS = ("so", "dylib")
+_EXECUTOR_RUNTIME_PLUGINS = ("librt_transport.so", "librt_capi.so")
 
 
-def _backend_search_dirs(backend: str) -> list[Path]:
-    """Directories to search for ``backend``'s libraries, most specific first."""
+def _backend_for(transport: str, hardware: str) -> str:
+    """Return Catalyst's concrete backend for a transport and hardware pair."""
+    try:
+        return _BACKENDS[(transport, hardware)]
+    except KeyError:
+        raise ValueError(
+            f"unsupported backline transport/hardware combination: "
+            f"transport={transport!r}, hardware={hardware!r}"
+        ) from None
+
+
+def _backend_search_dirs(transport: str, backend: str) -> list[Path]:
+    """Directories to search for a transport backend's libraries, most specific first."""
     override = os.environ.get(_BACKEND_PATH_ENV, "")
     dirs = [Path(p) for p in override.split(os.pathsep) if p]
     lib_dir = Path(get_lib_path("runtime", "RUNTIME_LIB_DIR"))
     dirs.append(lib_dir)
-    dirs.append(lib_dir / _BACKEND_SUBDIR / backend)
+    transport_dir = lib_dir / _BACKEND_SUBDIR / transport
+    dirs.append(transport_dir)
+    dirs.append(transport_dir / backend)
     return dirs
 
 
-def _resolve_backend_lib(backend: str, role: str, remote: bool) -> str:
-    """Resolve a backend name and node role to the transport library the node should load.
+def _resolve_backend_lib(transport: str, hardware: str, role: str, remote: bool) -> str:
+    """Resolve transport, hardware, and node role to the backend library the node should load.
 
     Args:
-        backend: Backend name as given on the node. The in-tree backends are:
-
-            * ``"cpu_verbs"`` - RDMA over InfiniBand; both roles.
-            * ``"gpu_verbs"`` - RDMA over InfiniBand with a GPU coprocessor; coprocessor only.
-            * ``"memcpy"`` - in-process shim; both roles.
-            * ``"memcpy_gpu"`` - in-process shim with a GPU coprocessor; coprocessor only.
-
-            Out-of-tree backends supply their own token and library.
+        transport: Placement transport name, such as ``"rdma"`` or ``"memcpy"``.
+        hardware: Node hardware name: ``"cpu"``, ``"gpu"``, or ``"fpga"``.
         role: ``"controller"`` or ``"coprocessor"``. Each backend ships one library per role.
         remote: Whether the node runs on another machine. A remote node loads the library from the
             bundle deployed alongside it, so it is named by filename only; a local node is given the
@@ -71,14 +90,14 @@ def _resolve_backend_lib(backend: str, role: str, remote: bool) -> str:
         str: The library path for a local node, or its bare filename for a remote one.
 
     Raises:
-        ValueError: If no library matches on a local node, naming every directory searched. A
-            backend shipping only one role (``gpu_verbs`` and ``local_gpu`` have no controller
-            library) fails here rather than later at ``dlopen``.
+        ValueError: If the transport/hardware pair is unsupported or no library matches on a local
+            node, naming every directory searched.
     """
+    backend = _backend_for(transport, hardware)
     names = [f"libcatalyst_transport_{backend}_{role}.{ext}" for ext in _BACKEND_LIB_EXTS]
     if remote:
         return names[0]
-    search = _backend_search_dirs(backend)
+    search = _backend_search_dirs(transport, backend)
     for directory in search:
         for name in names:
             candidate = directory / name
@@ -86,14 +105,14 @@ def _resolve_backend_lib(backend: str, role: str, remote: bool) -> str:
                 return str(candidate)
     searched = ", ".join(str(d) for d in search)
     raise ValueError(
-        f"no transport backend library for backend={backend!r} role={role!r}: looked for "
-        f"{names[0]} in {searched}. Transport backends are built with -DENABLE_TRANSPORT=ON "
-        f"and are not shipped in the wheel; set {_BACKEND_PATH_ENV} to point at an "
-        "out-of-tree build."
+        f"no transport backend library for transport={transport!r} hardware={hardware!r} "
+        f"backend={backend!r} role={role!r}: looked for {names[0]} in {searched}. "
+        "Transport backends are built with -DENABLE_TRANSPORT=ON and are not shipped in the "
+        f"wheel; set {_BACKEND_PATH_ENV} to point at an out-of-tree build."
     )
 
 
-def _node_dict(node, role: str) -> dict:
+def _node_dict(node, role: str, transport: str) -> dict:
     """Map a backline node to a ``catalyst.backline`` node dict. Reads ``node.executor`` as-is.
 
     ``comm_host``/``oob_port`` are coprocessor-only; a controller
@@ -101,8 +120,9 @@ def _node_dict(node, role: str) -> dict:
 
     Args:
         node: A backline node.
-        role: The node's role, used to resolve its ``backend`` to a library. An explicit
-            ``init_args["backend_lib"]`` path takes precedence over ``backend``.
+        role: The node's role, used when resolving the backend library.
+        transport: The placement's transport name. Together with ``node.hardware``, this selects
+            the concrete backend. An explicit ``init_args["backend_lib"]`` path takes precedence.
     """
     d: dict = {"remote": bool(node.remote)}
     if node.label is not None:
@@ -113,16 +133,15 @@ def _node_dict(node, role: str) -> dict:
     oob_port = getattr(node, "oob_port", None)
     if oob_port is not None:
         d["oob_port"] = oob_port
-    backend = getattr(node, "backend", None)
-    if backend is not None and not (node.init_args or {}).get("backend_lib"):
-        d["backend_lib"] = _resolve_backend_lib(backend, role, bool(node.remote))
+    init = node.init_args or {}
+    if not init.get("backend_lib"):
+        d["backend_lib"] = _resolve_backend_lib(transport, node.hardware, role, bool(node.remote))
     executor = getattr(node, "executor", None)
     triple = getattr(executor, "triple", None) if executor is not None else None
     if triple is not None:
         d["triple"] = triple
     if executor is not None and getattr(executor, "address", None):
         d["address"] = executor.address
-    init = node.init_args or {}
     d.update({k: init[k] for k in _INIT_KEYS if k in init})
     return d
 
@@ -139,17 +158,34 @@ def _load_coprocessor_fn_libs(placement) -> None:
             ctypes.CDLL(str(lib_path), mode=ctypes.RTLD_GLOBAL)
 
 
+def _controller_plugin(node) -> str | None:
+    """Return the controller device library that its executor must preload."""
+    backend = extract_backend_info(node.device)
+    return Path(backend.lpath).name if backend.lpath else None
+
+
+def _required_plugins(node, role: str) -> list[str]:
+    """Return plugins inferred from a backline node's role and function."""
+    plugins = list(_EXECUTOR_RUNTIME_PLUGINS)
+    if role == "controller":
+        if device_plugin := _controller_plugin(node):
+            plugins.append(device_plugin)
+    elif lib_path := getattr(node.coprocessor_fn, "lib_path", None):
+        plugins.append(Path(lib_path).name)
+    return plugins
+
+
 def realize_executors(placement) -> None:
     """Prepare ``placement`` for execution: launch the executors it asked for, and load the
     CoprocessorFn libraries its in-process coprocessors need. Idempotent."""
-    _realize_executor(placement.controller)
+    _realize_executor(placement.controller, "controller")
     for coproc in placement.coprocessors:
-        _realize_executor(coproc)
+        _realize_executor(coproc, "coprocessor")
     _load_coprocessor_fn_libs(placement)
 
 
 def add_transport_passes(stages):
-    """Insert the transport passes into ``stages`` (in place) at the stages where their inputs exist.
+    """Insert transport passes into ``stages`` at the stages where their inputs exist.
 
     Applies to any base pipeline (e.g. ``default_pipeline()`` or a QEC one), so backline stays
     independent of the base.
@@ -177,13 +213,14 @@ def backline_pipeline():
 
 def serialize_backline(placement) -> dict:
     """Serialize a ``Placement`` into the ``catalyst.backline`` attribute dict."""
+    transport = placement.transport.name
     result = {
-        "transport": placement.transport.name,
-        "controller": _node_dict(placement.controller, "controller"),
+        "transport": transport,
+        "controller": _node_dict(placement.controller, "controller", transport),
     }
     nodes = []
     for coproc in placement.coprocessors:
-        node = _node_dict(coproc, "coprocessor")
+        node = _node_dict(coproc, "coprocessor", transport)
         # ``symbol`` names the decode function; the library providing it is loaded as an executor
         # plugin, so it must not be written into ``backend_lib``, which is the transport backend.
         node["symbol"] = coproc.coprocessor_fn.symbol_name
@@ -233,20 +270,19 @@ def _launch_executor(label, options):
     return Executor(**options).launch()
 
 
-def _realize_executor(node):
+def _realize_executor(node, role=None):
     """Return the node's launched executor, building it on first use."""
-    from pennylane.backline import ExecutorSpec
-
     executor = getattr(node, "executor", None)
-    if executor is not None and not isinstance(executor, ExecutorSpec):
+    if executor is not None:
         return executor  # already launched
-    options = (
-        executor.options
-        if isinstance(executor, ExecutorSpec)
-        else getattr(node, "executor_options", None)
-    )
+    options = getattr(node, "executor_options", None)
     if options is None:
         return None
-    executor = _launch_executor(getattr(node, "label", None), dict(options))
+    options = dict(options)
+    if role is not None and not options.get("address"):
+        plugins = list(options.get("plugins") or ())
+        plugins.extend(plugin for plugin in _required_plugins(node, role) if plugin not in plugins)
+        options["plugins"] = plugins
+    executor = _launch_executor(getattr(node, "label", None), options)
     object.__setattr__(node, "executor", executor)  # cache on the (frozen) node
     return executor

--- a/frontend/test/pytest/test_backline.py
+++ b/frontend/test/pytest/test_backline.py
@@ -46,20 +46,20 @@ def _controller(**kw):
     if kw.pop("remote", False):
         kw.setdefault("executor", SimpleNamespace(address=None, triple=None))
     kw.setdefault("init_args", init)
-    return qp.Controller(device=qp.device("null.qubit", wires=2), label="ctrl", **kw)
+    return qp.Controller(device=qp.device("null.qubit", wires=2), name="ctrl", **kw)
 
 
-def _coproc(label, oob_port=18590, fn="coproc_fn", **kw):
+def _coproc(name, oob_port=18590, fn="coproc_fn", **kw):
     if kw.pop("remote", False):
         kw.setdefault("executor", SimpleNamespace(address=None, triple=None))
     kw.setdefault("init_args", {"backend_lib": "backend.so", "config": "cfg"})
     return qp.Coprocessor(
-        label=label, comm_host="127.0.0.1", oob_port=oob_port, coprocessor_fn=fn, **kw
+        name=name, comm_host="127.0.0.1", oob_port=oob_port, coprocessor_fn=fn, **kw
     )
 
 
 def test_controller_node_mapping():
-    """label -> name; init_args hints forwarded. A controller carries no endpoint of its own."""
+    """The node name and init arguments are forwarded; controllers carry no endpoint."""
     d = serialize_backline(qp.Backline(controller=_controller(), transport="rdma").placement)
     assert d["transport"] == "rdma"
     ctrl = d["controller"]
@@ -237,7 +237,7 @@ def test_remote_controller_module_tagged_with_role(use_capture):
     """
     ctrl = qp.Controller(
         device=qp.device("null.qubit", wires=2),
-        label="ctrl",
+        name="ctrl",
         executor=SimpleNamespace(address=None, triple=None),
         init_args={"backend_lib": "backend.so", "config": "cfg"},
     )
@@ -420,9 +420,9 @@ class TestBackendResolution:
             "rdma/cpu_verbs/libcatalyst_transport_cpu_verbs_controller.so",
             "rdma/gpu_verbs/libcatalyst_transport_gpu_verbs_coprocessor.so",
         )
-        ctrl = qp.Controller(device=qp.device("null.qubit", wires=2), label="ctrl", hardware="cpu")
+        ctrl = qp.Controller(device=qp.device("null.qubit", wires=2), name="ctrl", hardware="cpu")
         cop = qp.Coprocessor(
-            label="cop0", comm_host="127.0.0.1", coprocessor_fn="coproc_fn", hardware="gpu"
+            name="cop0", comm_host="127.0.0.1", coprocessor_fn="coproc_fn", hardware="gpu"
         )
         d = serialize_backline(
             qp.Backline(controller=ctrl, coprocessors=[cop], transport="rdma").placement
@@ -436,9 +436,9 @@ class TestBackendResolution:
             "memcpy/libcatalyst_transport_memcpy_controller.so",
             "memcpy/libcatalyst_transport_memcpy_coprocessor.so",
         )
-        ctrl = qp.Controller(device=qp.device("null.qubit", wires=2), label="ctrl", hardware="cpu")
+        ctrl = qp.Controller(device=qp.device("null.qubit", wires=2), name="ctrl", hardware="cpu")
         cop = qp.Coprocessor(
-            label="cop0", comm_host="127.0.0.1", coprocessor_fn="coproc_fn", hardware="cpu"
+            name="cop0", comm_host="127.0.0.1", coprocessor_fn="coproc_fn", hardware="cpu"
         )
         d = serialize_backline(
             qp.Backline(controller=ctrl, coprocessors=[cop], transport="memcpy").placement
@@ -453,9 +453,9 @@ class TestBackendResolution:
             "memcpy/libcatalyst_transport_memcpy_controller.so",
             "memcpy/libcatalyst_transport_memcpy_gpu_coprocessor.so",
         )
-        ctrl = qp.Controller(device=qp.device("null.qubit", wires=2), label="ctrl", hardware="cpu")
+        ctrl = qp.Controller(device=qp.device("null.qubit", wires=2), name="ctrl", hardware="cpu")
         cop = qp.Coprocessor(
-            label="cop0", comm_host="127.0.0.1", coprocessor_fn="coproc_fn", hardware="gpu"
+            name="cop0", comm_host="127.0.0.1", coprocessor_fn="coproc_fn", hardware="gpu"
         )
         d = serialize_backline(
             qp.Backline(controller=ctrl, coprocessors=[cop], transport="memcpy").placement
@@ -468,7 +468,7 @@ class TestBackendResolution:
         """An explicit backend library supports out-of-tree transport/hardware combinations."""
         ctrl = qp.Controller(
             device=qp.device("null.qubit", wires=2),
-            label="ctrl",
+            name="ctrl",
             hardware="fpga",
             init_args={"backend_lib": "/opt/explicit.so"},
         )
@@ -480,7 +480,7 @@ class TestBackendResolution:
     def test_default_cpu_hardware_selects_backend(self, fake_lib_dir):
         """Omitting hardware selects the CPU backend."""
         fake_lib_dir("rdma/cpu_verbs/libcatalyst_transport_cpu_verbs_controller.so")
-        ctrl = qp.Controller(device=qp.device("null.qubit", wires=2), label="ctrl")
+        ctrl = qp.Controller(device=qp.device("null.qubit", wires=2), name="ctrl")
         d = serialize_backline(qp.Backline(controller=ctrl, transport="rdma").placement)
         assert d["controller"]["backend_lib"].endswith("_cpu_verbs_controller.so")
 
@@ -516,8 +516,8 @@ class TestExecutorRealization:
         node = _controller(executor_options={"address": "10.0.0.9:1373"})
         assert _realize_executor(node) is _realize_executor(node)
 
-    def test_label_seeds_the_executor_name(self):
-        """The node's label names the executor, which uses it for its logs."""
+    def test_node_name_seeds_the_executor_name(self):
+        """The node's name names the executor."""
         node = _controller(executor_options={"address": "10.0.0.9:1373"})
         assert _realize_executor(node).name == "ctrl"
 
@@ -558,7 +558,7 @@ class TestExecutorRealization:
         )
         monkeypatch.setattr(
             "catalyst.backline._launch_executor",
-            lambda _label, options: captured.update(options) or launched,
+            lambda _name, options: captured.update(options) or launched,
         )
         node = _controller(executor_options={"host": "controller", "plugins": ["libcustom.so"]})
 

--- a/frontend/test/pytest/test_backline.py
+++ b/frontend/test/pytest/test_backline.py
@@ -13,12 +13,17 @@
 # limitations under the License.
 """Unit tests for the backline frontend: serialize_backline and the pipeline helpers."""
 
+from types import SimpleNamespace
+
 import pennylane as qp
 import pytest
+from pennylane.backline import Transport
 
 from catalyst import qjit
 from catalyst.backline import (
+    _backend_for,
     _realize_executor,
+    _required_plugins,
     _resolve_backend_lib,
     add_transport_passes,
     backline_pipeline,
@@ -30,9 +35,6 @@ pytestmark = pytest.mark.skipif(
     not hasattr(qp, "backline"), reason="pennylane.backline UI not available"
 )
 
-if hasattr(qp, "backline"):
-    from pennylane.backline import Transport
-
 
 def _controller(**kw):
     init = {
@@ -41,13 +43,15 @@ def _controller(**kw):
         "in_bytes": 3,
         "out_bytes": 8,
     }
-    kw.setdefault("remote", False)
+    if kw.pop("remote", False):
+        kw.setdefault("executor", SimpleNamespace(address=None, triple=None))
     kw.setdefault("init_args", init)
     return qp.Controller(device=qp.device("null.qubit", wires=2), label="ctrl", **kw)
 
 
 def _coproc(label, oob_port=18590, fn="coproc_fn", **kw):
-    kw.setdefault("remote", False)
+    if kw.pop("remote", False):
+        kw.setdefault("executor", SimpleNamespace(address=None, triple=None))
     kw.setdefault("init_args", {"backend_lib": "backend.so", "config": "cfg"})
     return qp.Coprocessor(
         label=label, comm_host="127.0.0.1", oob_port=oob_port, coprocessor_fn=fn, **kw
@@ -56,7 +60,7 @@ def _coproc(label, oob_port=18590, fn="coproc_fn", **kw):
 
 def test_controller_node_mapping():
     """label -> name; init_args hints forwarded. A controller carries no endpoint of its own."""
-    d = serialize_backline(qp.backline(controller=_controller(), transport="rdma").placement)
+    d = serialize_backline(qp.Backline(controller=_controller(), transport="rdma").placement)
     assert d["transport"] == "rdma"
     ctrl = d["controller"]
     assert ctrl["name"] == "ctrl"
@@ -65,21 +69,32 @@ def test_controller_node_mapping():
     assert "peer" not in ctrl and "oob_port" not in ctrl
 
 
+def test_message_sizes_can_use_compiler_defaults():
+    """Omitted message sizes are left for the transport dialect's 8-byte defaults."""
+    controller = qp.Controller(init_args={"backend_lib": "backend.so"})
+    node = serialize_backline(qp.Backline(controller=controller, transport="rdma").placement)[
+        "controller"
+    ]
+
+    assert "in_bytes" not in node
+    assert "out_bytes" not in node
+
+
 def test_coprocessor_endpoint_mapping():
     """comm_host/oob_port -> peer/oob_port, and oob_port stays an int."""
-    dev = qp.backline(controller=_controller(), coprocessors=[_coproc("cop0")], transport="rdma")
+    dev = qp.Backline(controller=_controller(), coprocessors=[_coproc("cop0")], transport="rdma")
     cop = serialize_backline(dev.placement)["coprocessors"][0]
     assert cop["peer"] == "127.0.0.1"
     assert cop["oob_port"] == 18590 and isinstance(cop["oob_port"], int)
 
 
 def test_controller_only_has_no_coprocessors():
-    d = serialize_backline(qp.backline(controller=_controller(), transport="rdma").placement)
+    d = serialize_backline(qp.Backline(controller=_controller(), transport="rdma").placement)
     assert "coprocessors" not in d
 
 
 def test_single_coprocessor():
-    dev = qp.backline(controller=_controller(), coprocessors=[_coproc("cop0")], transport="rdma")
+    dev = qp.Backline(controller=_controller(), coprocessors=[_coproc("cop0")], transport="rdma")
     d = serialize_backline(dev.placement)
     assert len(d["coprocessors"]) == 1
     assert d["coprocessors"][0]["name"] == "cop0"
@@ -99,7 +114,7 @@ def test_in_process_coprocessor_fn_lib_is_loaded(monkeypatch):
     import ctypes  # pylint: disable=import-outside-toplevel
 
     fn = qp.CoprocessorFunction("decode_fn", lib_path="/opt/libdecode.so")
-    dev = qp.backline(
+    dev = qp.Backline(
         controller=_controller(), coprocessors=[_coproc("cop0", fn=fn)], transport="rdma"
     )
     realize_executors(dev.placement)
@@ -111,7 +126,7 @@ def test_remote_coprocessor_fn_lib_is_not_loaded_here(monkeypatch):
     loaded = []
     monkeypatch.setattr("ctypes.CDLL", lambda path, mode=None: loaded.append(path) or object())
     fn = qp.CoprocessorFunction("decode_fn", lib_path="/opt/libdecode.so")
-    dev = qp.backline(
+    dev = qp.Backline(
         controller=_controller(),
         coprocessors=[_coproc("cop0", fn=fn, remote=True)],
         transport="rdma",
@@ -124,14 +139,14 @@ def test_coprocessor_fn_without_lib_path_loads_nothing(monkeypatch):
     """No ``lib_path`` means resolve from what is already loaded, so nothing is opened."""
     loaded = []
     monkeypatch.setattr("ctypes.CDLL", lambda path, mode=None: loaded.append(path) or object())
-    dev = qp.backline(controller=_controller(), coprocessors=[_coproc("cop0")], transport="rdma")
+    dev = qp.Backline(controller=_controller(), coprocessors=[_coproc("cop0")], transport="rdma")
     realize_executors(dev.placement)
     assert loaded == []
 
 
 def test_multiple_coprocessors_all_serialized():
     """All coprocessors are serialized as a list, in order."""
-    dev = qp.backline(
+    dev = qp.Backline(
         controller=_controller(),
         coprocessors=[_coproc("cop0", 18590), _coproc("cop1", 18591)],
         transport="rdma",
@@ -143,14 +158,14 @@ def test_multiple_coprocessors_all_serialized():
 
 def test_transport_object_serializes_to_name():
     transport = Transport("rdma")
-    d = serialize_backline(qp.backline(controller=_controller(), transport=transport).placement)
+    d = serialize_backline(qp.Backline(controller=_controller(), transport=transport).placement)
     assert d["transport"] == "rdma"
 
 
 def test_transport_memcpy_object_serializes_to_name():
     """The in-process ``memcpy`` transport carries through the Transport enum verbatim."""
     transport = Transport("memcpy")
-    d = serialize_backline(qp.backline(controller=_controller(), transport=transport).placement)
+    d = serialize_backline(qp.Backline(controller=_controller(), transport=transport).placement)
     assert d["transport"] == "memcpy"
 
 
@@ -182,7 +197,7 @@ def test_backline_pipeline_carries_transport_passes():
 
 def test_backline_qnode_capture_path(use_capture):
     """A backline qnode compiles to MLIR carrying the catalyst.backline attribute."""
-    dev = qp.backline(controller=_controller(), coprocessors=[_coproc("cop0")], transport="rdma")
+    dev = qp.Backline(controller=_controller(), coprocessors=[_coproc("cop0")], transport="rdma")
 
     @qjit(target="mlir", capture=True)
     @qp.qnode(dev)
@@ -200,7 +215,7 @@ def test_backline_qnode_capture_path_memcpy(use_capture):
     """A backline qnode with the in-process ``memcpy`` transport compiles to MLIR carrying
     ``transport = "memcpy"``.
     """
-    dev = qp.backline(controller=_controller(), coprocessors=[_coproc("cop0")], transport="memcpy")
+    dev = qp.Backline(controller=_controller(), coprocessors=[_coproc("cop0")], transport="memcpy")
 
     @qjit(target="mlir", capture=True)
     @qp.qnode(dev)
@@ -223,10 +238,10 @@ def test_remote_controller_module_tagged_with_role(use_capture):
     ctrl = qp.Controller(
         device=qp.device("null.qubit", wires=2),
         label="ctrl",
-        remote=True,
+        executor=SimpleNamespace(address=None, triple=None),
         init_args={"backend_lib": "backend.so", "config": "cfg"},
     )
-    dev = qp.backline(controller=ctrl, transport="rdma")
+    dev = qp.Backline(controller=ctrl, transport="rdma")
 
     @qjit(target="mlir", capture=True)
     @qp.qnode(dev)
@@ -241,9 +256,9 @@ def test_remote_controller_module_tagged_with_role(use_capture):
 def fake_lib_dir(tmp_path, monkeypatch):
     """Stand in for the built runtime lib dir, laid out as a bare ``cmake`` build.
 
-    That build mirrors the source tree, nesting each backend under
-    ``<RUNTIME_LIB_DIR>/transport/<backend>/``, so entries are given as ``"<backend>/<libname>"``.
-    See :func:`flat_lib_dir` for the layout ``make -C runtime`` produces.
+    That build mirrors the source tree under ``<RUNTIME_LIB_DIR>/transport/<transport>/``.
+    Entries are paths relative to that ``transport`` directory. See :func:`flat_lib_dir` for the
+    layout ``make -C runtime`` produces.
     """
     monkeypatch.setattr("catalyst.backline.get_lib_path", lambda *_: str(tmp_path))
 
@@ -275,37 +290,69 @@ def flat_lib_dir(tmp_path, monkeypatch):
 
 
 class TestBackendResolution:
-    """``node.backend`` names a backend; the compiler resolves it to a library per role."""
+    """Transport and node hardware select a Catalyst backend library."""
 
-    def test_name_is_backend_and_role(self, fake_lib_dir):
-        """The library is named for its backend and role: no stem guessing, no glob."""
+    @pytest.mark.parametrize(
+        ("transport", "hardware", "backend"),
+        [
+            ("rdma", "cpu", "cpu_verbs"),
+            ("rdma", "gpu", "gpu_verbs"),
+            ("rdma", "fpga", "hwhs"),
+            ("memcpy", "cpu", "memcpy"),
+            ("memcpy", "gpu", "memcpy_gpu"),
+        ],
+    )
+    def test_transport_and_hardware_select_backend(self, transport, hardware, backend):
+        """Concrete backend names remain a Catalyst implementation detail."""
+        assert _backend_for(transport, hardware) == backend
+
+    def test_unsupported_transport_hardware_pair_is_rejected(self):
+        """A transport must have an implementation for the requested hardware."""
+        with pytest.raises(ValueError, match="transport='memcpy', hardware='fpga'"):
+            _backend_for("memcpy", "fpga")
+
+    def test_nested_cmake_backend_is_found(self, fake_lib_dir):
+        """A bare CMake build nests RDMA backends below the transport directory."""
         fake_lib_dir(
-            "cpu_verbs/libcatalyst_transport_cpu_verbs_controller.so",
-            "cpu_verbs/libcatalyst_transport_cpu_verbs_coprocessor.so",
+            "rdma/cpu_verbs/libcatalyst_transport_cpu_verbs_controller.so",
+            "rdma/cpu_verbs/libcatalyst_transport_cpu_verbs_coprocessor.so",
         )
-        assert _resolve_backend_lib("cpu_verbs", "controller", False).endswith(
-            "transport/cpu_verbs/libcatalyst_transport_cpu_verbs_controller.so"
+        assert _resolve_backend_lib("rdma", "cpu", "controller", False).endswith(
+            "transport/rdma/cpu_verbs/libcatalyst_transport_cpu_verbs_controller.so"
         )
-        assert _resolve_backend_lib("cpu_verbs", "coprocessor", False).endswith(
-            "transport/cpu_verbs/libcatalyst_transport_cpu_verbs_coprocessor.so"
+        assert _resolve_backend_lib("rdma", "cpu", "coprocessor", False).endswith(
+            "transport/rdma/cpu_verbs/libcatalyst_transport_cpu_verbs_coprocessor.so"
+        )
+
+    def test_memcpy_backends_share_transport_directory(self, fake_lib_dir):
+        """CPU and GPU memcpy libraries are emitted from the same CMake directory."""
+        fake_lib_dir(
+            "memcpy/libcatalyst_transport_memcpy_controller.so",
+            "memcpy/libcatalyst_transport_memcpy_gpu_coprocessor.so",
+        )
+        assert _resolve_backend_lib("memcpy", "cpu", "controller", False).endswith(
+            "transport/memcpy/libcatalyst_transport_memcpy_controller.so"
+        )
+        assert _resolve_backend_lib("memcpy", "gpu", "coprocessor", False).endswith(
+            "transport/memcpy/libcatalyst_transport_memcpy_gpu_coprocessor.so"
         )
 
     def test_flat_lib_dir_is_searched(self, flat_lib_dir):
         """``make -C runtime`` passes ``CMAKE_LIBRARY_OUTPUT_DIRECTORY``, flattening the lib dir.
 
         That is the layout a released or ``make``-built tree has, so it must resolve without the
-        ``transport/<backend>/`` nesting a bare ``cmake`` build produces.
+        ``transport/<transport>/[<backend>/]`` nesting a bare ``cmake`` build produces.
         """
         root = flat_lib_dir("libcatalyst_transport_cpu_verbs_controller.so")
-        assert _resolve_backend_lib("cpu_verbs", "controller", False) == str(
+        assert _resolve_backend_lib("rdma", "cpu", "controller", False) == str(
             root / "libcatalyst_transport_cpu_verbs_controller.so"
         )
 
     def test_remote_node_gets_the_bare_filename(self, fake_lib_dir):
         """A remote node loads from its deployed bundle, so it is given a name, not a local path."""
-        fake_lib_dir("cpu_verbs/libcatalyst_transport_cpu_verbs_coprocessor.so")
+        fake_lib_dir("rdma/cpu_verbs/libcatalyst_transport_cpu_verbs_coprocessor.so")
         assert (
-            _resolve_backend_lib("cpu_verbs", "coprocessor", True)
+            _resolve_backend_lib("rdma", "cpu", "coprocessor", True)
             == "libcatalyst_transport_cpu_verbs_coprocessor.so"
         )
 
@@ -317,7 +364,7 @@ class TestBackendResolution:
         """
         fake_lib_dir()  # nothing built locally
         assert (
-            _resolve_backend_lib("hwhs", "controller", True)
+            _resolve_backend_lib("rdma", "fpga", "controller", True)
             == "libcatalyst_transport_hwhs_controller.so"
         )
 
@@ -331,115 +378,111 @@ class TestBackendResolution:
         (outside / "libcatalyst_transport_hwhs_controller.so").write_bytes(b"")
         monkeypatch.setattr("catalyst.backline.get_lib_path", lambda *_: str(tmp_path / "empty"))
         monkeypatch.setenv("CATALYST_TRANSPORT_PATH", str(outside))
-        assert _resolve_backend_lib("hwhs", "controller", False) == str(
+        assert _resolve_backend_lib("rdma", "fpga", "controller", False) == str(
             outside / "libcatalyst_transport_hwhs_controller.so"
         )
 
     def test_search_path_takes_precedence_over_in_tree(self, tmp_path, monkeypatch, fake_lib_dir):
         """An override entry wins, so a local build can shadow an installed backend."""
-        fake_lib_dir("cpu_verbs/libcatalyst_transport_cpu_verbs_controller.so")
+        fake_lib_dir("rdma/cpu_verbs/libcatalyst_transport_cpu_verbs_controller.so")
         outside = tmp_path / "override"
         outside.mkdir()
         pinned = outside / "libcatalyst_transport_cpu_verbs_controller.so"
         pinned.write_bytes(b"")
         monkeypatch.setenv("CATALYST_TRANSPORT_PATH", str(outside))
-        assert _resolve_backend_lib("cpu_verbs", "controller", False) == str(pinned)
+        assert _resolve_backend_lib("rdma", "cpu", "controller", False) == str(pinned)
 
     def test_missing_backend_names_every_directory_searched(self, fake_lib_dir, monkeypatch):
         """The error is actionable: what was looked for, where, and how to fix it."""
-        fake_lib_dir("cpu_verbs/libcatalyst_transport_cpu_verbs_coprocessor.so")
+        fake_lib_dir("rdma/cpu_verbs/libcatalyst_transport_cpu_verbs_coprocessor.so")
         monkeypatch.setenv("CATALYST_TRANSPORT_PATH", "/opt/nowhere")
         with pytest.raises(ValueError, match="no transport backend library") as e:
-            _resolve_backend_lib("nope_verbs", "coprocessor", False)
+            _resolve_backend_lib("rdma", "gpu", "coprocessor", False)
         msg = str(e.value)
-        assert "libcatalyst_transport_nope_verbs_coprocessor.so" in msg
+        assert "libcatalyst_transport_gpu_verbs_coprocessor.so" in msg
         assert "/opt/nowhere" in msg
         assert "ENABLE_TRANSPORT=ON" in msg
         assert "CATALYST_TRANSPORT_PATH" in msg
 
     def test_role_mismatch_fails_before_dlopen(self, fake_lib_dir):
         """gpu_verbs ships no controller library, so a controller lookup fails here."""
-        fake_lib_dir("gpu_verbs/libcatalyst_transport_gpu_verbs_coprocessor.so")
+        fake_lib_dir("rdma/gpu_verbs/libcatalyst_transport_gpu_verbs_coprocessor.so")
         with pytest.raises(ValueError, match="role='controller'"):
-            _resolve_backend_lib("gpu_verbs", "controller", False)
+            _resolve_backend_lib("rdma", "gpu", "controller", False)
 
-    def test_backend_populates_backend_lib_per_role(self, fake_lib_dir):
-        """Each node's backend resolves against its own role.
+    def test_hardware_populates_backend_lib_per_role(self, fake_lib_dir):
+        """Each node's hardware resolves with the placement transport and its own role.
 
         The shared fixtures pin an explicit ``backend_lib``, which would take precedence, so these
         nodes are built without one.
         """
         fake_lib_dir(
-            "cpu_verbs/libcatalyst_transport_cpu_verbs_controller.so",
-            "gpu_verbs/libcatalyst_transport_gpu_verbs_coprocessor.so",
+            "rdma/cpu_verbs/libcatalyst_transport_cpu_verbs_controller.so",
+            "rdma/gpu_verbs/libcatalyst_transport_gpu_verbs_coprocessor.so",
         )
-        ctrl = qp.Controller(
-            device=qp.device("null.qubit", wires=2), label="ctrl", backend="cpu_verbs"
-        )
+        ctrl = qp.Controller(device=qp.device("null.qubit", wires=2), label="ctrl", hardware="cpu")
         cop = qp.Coprocessor(
-            label="cop0", comm_host="127.0.0.1", coprocessor_fn="coproc_fn", backend="gpu_verbs"
+            label="cop0", comm_host="127.0.0.1", coprocessor_fn="coproc_fn", hardware="gpu"
         )
         d = serialize_backline(
-            qp.backline(controller=ctrl, coprocessors=[cop], transport="rdma").placement
+            qp.Backline(controller=ctrl, coprocessors=[cop], transport="rdma").placement
         )
         assert d["controller"]["backend_lib"].endswith("_cpu_verbs_controller.so")
         assert d["coprocessors"][0]["backend_lib"].endswith("_gpu_verbs_coprocessor.so")
 
     def test_memcpy_cpu_to_cpu_backend_libs(self, fake_lib_dir):
-        """A CPU controller paired with a CPU coprocessor on the ``memcpy`` backend."""
+        """A CPU controller paired with a CPU coprocessor over ``memcpy``."""
         fake_lib_dir(
             "memcpy/libcatalyst_transport_memcpy_controller.so",
             "memcpy/libcatalyst_transport_memcpy_coprocessor.so",
         )
-        ctrl = qp.Controller(
-            device=qp.device("null.qubit", wires=2), label="ctrl", backend="memcpy"
-        )
+        ctrl = qp.Controller(device=qp.device("null.qubit", wires=2), label="ctrl", hardware="cpu")
         cop = qp.Coprocessor(
-            label="cop0", comm_host="127.0.0.1", coprocessor_fn="coproc_fn", backend="memcpy"
+            label="cop0", comm_host="127.0.0.1", coprocessor_fn="coproc_fn", hardware="cpu"
         )
         d = serialize_backline(
-            qp.backline(controller=ctrl, coprocessors=[cop], transport="memcpy").placement
+            qp.Backline(controller=ctrl, coprocessors=[cop], transport="memcpy").placement
         )
         assert d["transport"] == "memcpy"
         assert d["controller"]["backend_lib"].endswith("_memcpy_controller.so")
         assert d["coprocessors"][0]["backend_lib"].endswith("_memcpy_coprocessor.so")
 
     def test_memcpy_cpu_to_gpu_backend_libs(self, fake_lib_dir):
-        """A CPU controller paired with a GPU coprocessor via the ``memcpy_gpu`` backend."""
+        """A CPU controller paired with a GPU coprocessor over ``memcpy``."""
         fake_lib_dir(
             "memcpy/libcatalyst_transport_memcpy_controller.so",
-            "memcpy_gpu/libcatalyst_transport_memcpy_gpu_coprocessor.so",
+            "memcpy/libcatalyst_transport_memcpy_gpu_coprocessor.so",
         )
-        ctrl = qp.Controller(
-            device=qp.device("null.qubit", wires=2), label="ctrl", backend="memcpy"
-        )
+        ctrl = qp.Controller(device=qp.device("null.qubit", wires=2), label="ctrl", hardware="cpu")
         cop = qp.Coprocessor(
-            label="cop0", comm_host="127.0.0.1", coprocessor_fn="coproc_fn", backend="memcpy_gpu"
+            label="cop0", comm_host="127.0.0.1", coprocessor_fn="coproc_fn", hardware="gpu"
         )
         d = serialize_backline(
-            qp.backline(controller=ctrl, coprocessors=[cop], transport="memcpy").placement
+            qp.Backline(controller=ctrl, coprocessors=[cop], transport="memcpy").placement
         )
         assert d["transport"] == "memcpy"
         assert d["controller"]["backend_lib"].endswith("_memcpy_controller.so")
         assert d["coprocessors"][0]["backend_lib"].endswith("_memcpy_gpu_coprocessor.so")
 
-    def test_explicit_backend_lib_wins_over_backend(self, fake_lib_dir):
-        """An explicit ``init_args["backend_lib"]`` path is not overridden by ``backend``."""
-        fake_lib_dir("cpu_verbs/libcatalyst_transport_cpu_verbs_controller.so")
+    def test_explicit_backend_lib_bypasses_builtin_mapping(self):
+        """An explicit backend library supports out-of-tree transport/hardware combinations."""
         ctrl = qp.Controller(
             device=qp.device("null.qubit", wires=2),
             label="ctrl",
-            backend="cpu_verbs",
+            hardware="fpga",
             init_args={"backend_lib": "/opt/explicit.so"},
         )
-        d = serialize_backline(qp.backline(controller=ctrl, transport="rdma").placement)
+        d = serialize_backline(
+            qp.Backline(controller=ctrl, transport=Transport("custom")).placement
+        )
         assert d["controller"]["backend_lib"] == "/opt/explicit.so"
 
-    def test_no_backend_leaves_backend_lib_unset(self):
-        """Omitting ``backend`` leaves the field to ``init_args`` or the compiler default."""
+    def test_default_cpu_hardware_selects_backend(self, fake_lib_dir):
+        """Omitting hardware selects the CPU backend."""
+        fake_lib_dir("rdma/cpu_verbs/libcatalyst_transport_cpu_verbs_controller.so")
         ctrl = qp.Controller(device=qp.device("null.qubit", wires=2), label="ctrl")
-        d = serialize_backline(qp.backline(controller=ctrl, transport="rdma").placement)
-        assert "backend_lib" not in d["controller"]
+        d = serialize_backline(qp.Backline(controller=ctrl, transport="rdma").placement)
+        assert d["controller"]["backend_lib"].endswith("_cpu_verbs_controller.so")
 
 
 class TestExecutorRealization:
@@ -489,11 +532,48 @@ class TestExecutorRealization:
         node = _controller(executor=ex, executor_options={"address": "ignored:2"})
         assert _realize_executor(node) is ex
 
+    def test_required_plugins_follow_node_role(self, monkeypatch):
+        """Runtime, device, and coprocessor-function plugins are inferred from the placement."""
+        monkeypatch.setattr("catalyst.backline._controller_plugin", lambda _node: "libdevice.so")
+        assert _required_plugins(_controller(), "controller") == [
+            "librt_transport.so",
+            "librt_capi.so",
+            "libdevice.so",
+        ]
+
+        fn = qp.CoprocessorFunction("decode_fn", lib_path="/opt/libdecode.so")
+        assert _required_plugins(_coproc("cop0", fn=fn), "coprocessor") == [
+            "librt_transport.so",
+            "librt_capi.so",
+            "libdecode.so",
+        ]
+
+    def test_inferred_plugins_extend_executor_options(self, monkeypatch):
+        """Inferred plugins are added without replacing explicit user plugins."""
+        captured = {}
+        launched = SimpleNamespace(address="launched:1", triple="x86_64")
+        monkeypatch.setattr(
+            "catalyst.backline._required_plugins",
+            lambda _node, _role: ["librt_transport.so", "librt_capi.so"],
+        )
+        monkeypatch.setattr(
+            "catalyst.backline._launch_executor",
+            lambda _label, options: captured.update(options) or launched,
+        )
+        node = _controller(executor_options={"host": "controller", "plugins": ["libcustom.so"]})
+
+        assert _realize_executor(node, "controller") is launched
+        assert captured["plugins"] == [
+            "libcustom.so",
+            "librt_transport.so",
+            "librt_capi.so",
+        ]
+
     def test_realize_executors_walks_every_node(self):
         """``realize_executors`` covers the controller and each coprocessor."""
         ctrl = _controller(executor_options={"address": "ctrl:1"})
         cop = _coproc("cop0", executor_options={"address": "cop:2"})
-        dev = qp.backline(controller=ctrl, coprocessors=[cop], transport="rdma")
+        dev = qp.Backline(controller=ctrl, coprocessors=[cop], transport="rdma")
         realize_executors(dev.placement)
         assert ctrl.executor.address == "ctrl:1"
         assert cop.executor.address == "cop:2"
@@ -501,10 +581,9 @@ class TestExecutorRealization:
     def test_executor_address_and_triple_reach_the_serialized_node(self):
         """The launched executor supplies the node's dispatch address and target triple."""
         ctrl = _controller(
-            remote=True,
             executor_options={"address": "10.0.0.9:1373", "triple": "aarch64-unknown-linux-gnu"},
         )
-        dev = qp.backline(controller=ctrl, transport="rdma")
+        dev = qp.Backline(controller=ctrl, transport="rdma")
         realize_executors(dev.placement)
         node = serialize_backline(dev.placement)["controller"]
         assert node["address"] == "10.0.0.9:1373"
@@ -513,7 +592,7 @@ class TestExecutorRealization:
     def test_a_high_oob_port_survives_to_the_ir(self, use_capture):
         """A port above 32767 appears as itself, not as a negative number."""
         cop = _coproc("cop0", oob_port=40000)
-        dev = qp.backline(controller=_controller(), coprocessors=[cop], transport="rdma")
+        dev = qp.Backline(controller=_controller(), coprocessors=[cop], transport="rdma")
 
         @qjit(target="mlir", capture=True)
         @qp.qnode(dev)

--- a/frontend/test/pytest/test_backline.py
+++ b/frontend/test/pytest/test_backline.py
@@ -40,11 +40,11 @@ def _controller(**kw):
     init = {
         "backend_lib": "backend.so",
         "config": "cfg",
-        "in_bytes": 3,
-        "out_bytes": 8,
     }
     if kw.pop("remote", False):
         kw.setdefault("executor", SimpleNamespace(address=None, triple=None))
+    kw.setdefault("in_bytes", 3)
+    kw.setdefault("out_bytes", 8)
     kw.setdefault("init_args", init)
     return qp.Controller(device=qp.device("null.qubit", wires=2), name="ctrl", **kw)
 
@@ -69,15 +69,15 @@ def test_controller_node_mapping():
     assert "peer" not in ctrl and "oob_port" not in ctrl
 
 
-def test_message_sizes_can_use_compiler_defaults():
-    """Omitted message sizes are left for the transport dialect's 8-byte defaults."""
+def test_default_message_sizes_are_serialized():
+    """PennyLane's message-size defaults are explicit in the transport configuration."""
     controller = qp.Controller(init_args={"backend_lib": "backend.so"})
     node = serialize_backline(qp.Backline(controller=controller, transport="rdma").placement)[
         "controller"
     ]
 
-    assert "in_bytes" not in node
-    assert "out_bytes" not in node
+    assert node["in_bytes"] == 8
+    assert node["out_bytes"] == 8
 
 
 def test_coprocessor_endpoint_mapping():

--- a/mlir/include/Transport/IR/TransportDialect.td
+++ b/mlir/include/Transport/IR/TransportDialect.td
@@ -127,7 +127,7 @@ def Transport_NodeAttr : Transport_Attr<"Node", "node"> {
         /// True only when `remote` is present and set.
         bool isRemote() const;
 
-        /// Integer fields, with the defaults applied.
+        /// Integer field accessors.
         int64_t oobPort() const;
         int64_t inBytes() const;
         int64_t outBytes() const;

--- a/mlir/lib/Transport/IR/TransportDialect.cpp
+++ b/mlir/lib/Transport/IR/TransportDialect.cpp
@@ -58,12 +58,9 @@ bool NodeAttr::isRemote() const {
 
 static int64_t intOr(IntegerAttr field, int64_t dflt) { return field ? field.getInt() : dflt; }
 
-// Default per-message payload width, matching the current backend's defaults.
-constexpr int64_t kDefaultMessageBytes = 8;
-
 int64_t NodeAttr::oobPort() const { return intOr(getOobPort(), 0); }
-int64_t NodeAttr::inBytes() const { return intOr(getInBytes(), kDefaultMessageBytes); }
-int64_t NodeAttr::outBytes() const { return intOr(getOutBytes(), kDefaultMessageBytes); }
+int64_t NodeAttr::inBytes() const { return getInBytes().getInt(); }
+int64_t NodeAttr::outBytes() const { return getOutBytes().getInt(); }
 int64_t NodeAttr::workItemIdx() const { return intOr(getWorkItemIdx(), 0); }
 
 LogicalResult BacklineAttr::verify(function_ref<InFlightDiagnostic()> emitError,
@@ -89,6 +86,9 @@ LogicalResult BacklineAttr::verify(function_ref<InFlightDiagnostic()> emitError,
             return emitError()
                    << "memcpy transport requires controller and coprocessor on the same node";
         }
+    }
+    if (!controller.getInBytes() || !controller.getOutBytes()) {
+        return emitError() << "controller requires 'in_bytes' and 'out_bytes'";
     }
     return success();
 }

--- a/mlir/test/Transport/InjectTransportSession.mlir
+++ b/mlir/test/Transport/InjectTransportSession.mlir
@@ -110,7 +110,7 @@ module attributes {catalyst.backline = #transport.backline<transport = "rdma", c
 // CHECK:      func.func @teardown() {
 // CHECK-NEXT:   quantum.finalize
 // CHECK-NEXT:   return
-module attributes {catalyst.backline = #transport.backline<transport = "rdma", controller = #transport.node<backend_lib = "x", config = "c", triple = "aarch64-unknown-linux-gnu", address = "h:1", remote = true>>} {
+module attributes {catalyst.backline = #transport.backline<transport = "rdma", controller = #transport.node<backend_lib = "x", config = "c", triple = "aarch64-unknown-linux-gnu", address = "h:1", remote = true, in_bytes = 8 : i64, out_bytes = 8 : i64>>} {
   func.func public @jit_circuit() -> tensor<4xf64> attributes {llvm.emit_c_interface} {
     %0 = catalyst.launch_kernel @module_ctrl::@circuit() : () -> tensor<4xf64>
     return %0 : tensor<4xf64>
@@ -335,7 +335,7 @@ module attributes {catalyst.backline = #transport.backline<transport = "memcpy",
 // CHECK:         transport.destroy %{{.*}} : !transport.session<coprocessor>
 // CHECK:         catalyst.launch_kernel @module_ctrl::@teardown_transport()
 module attributes {catalyst.backline = #transport.backline<transport = "rdma",
-  controller = #transport.node<backend_lib = "x", remote = true, address = "h:1">,
+  controller = #transport.node<backend_lib = "x", remote = true, address = "h:1", in_bytes = 8 : i64, out_bytes = 8 : i64>,
   coprocessors = [#transport.node<backend_lib = "y", peer = "10.0.0.3", oob_port = 18560 : i16, symbol = "foo", name = "cop0">]>} {
   func.func public @jit_circuit() attributes {llvm.emit_c_interface} {
     catalyst.launch_kernel @module_ctrl::@circuit() : () -> ()
@@ -365,7 +365,7 @@ module attributes {catalyst.backline = #transport.backline<transport = "rdma",
 // CHECK-NEXT:    catalyst.launch_kernel @module_coproc::@coproc_stop()
 // CHECK:         transport.destroy %{{.*}} : !transport.session<controller>
 module attributes {catalyst.backline = #transport.backline<transport = "rdma",
-  controller = #transport.node<backend_lib = "x">,
+  controller = #transport.node<backend_lib = "x", in_bytes = 8 : i64, out_bytes = 8 : i64>,
   coprocessors = [#transport.node<backend_lib = "y", peer = "10.0.0.3", oob_port = 18560 : i16, symbol = "foo", name = "cop0", remote = true, address = "h:2", triple = "x86_64-unknown-linux-gnu">]>} {
   func.func public @jit_circuit() attributes {llvm.emit_c_interface} {
     return

--- a/mlir/test/Transport/InjectTransportSessionInvalid.mlir
+++ b/mlir/test/Transport/InjectTransportSessionInvalid.mlir
@@ -65,3 +65,13 @@ module attributes {catalyst.backline = #transport.backline<transport = "memcpy",
   func.func @setup() { quantum.init  return }
   func.func @teardown() { quantum.finalize  return }
 }
+
+// -----
+
+// Message sizes are resolved by the frontend and must be explicit in the compiler configuration.
+
+// expected-error @below {{controller requires 'in_bytes' and 'out_bytes'}}
+module attributes {catalyst.backline = #transport.backline<transport = "rdma", controller = #transport.node<backend_lib = "x">>} {
+  func.func @setup() { quantum.init  return }
+  func.func @teardown() { quantum.finalize  return }
+}

--- a/mlir/test/Transport/LowerDecodeToTransport.mlir
+++ b/mlir/test/Transport/LowerDecodeToTransport.mlir
@@ -28,7 +28,7 @@
 // CHECK:         memref.load %[[REP]]
 // CHECK-NOT:     memref.dealloc
 module attributes {catalyst.backline = #transport.backline<transport = "rdma",
-  controller = #transport.node<backend_lib = "x", config = "c", peer = "127.0.0.1", oob_port = 18590 : i16>,
+  controller = #transport.node<backend_lib = "x", config = "c", peer = "127.0.0.1", oob_port = 18590 : i16, in_bytes = 8 : i64, out_bytes = 8 : i64>,
   coprocessors = [#transport.node<backend_lib = "x", config = "c", name = "cop0", peer = "10.0.0.1", symbol = "decode">]>} {
   func.func @qec_circuit(%tanner: !qecp.tanner_graph<8, 6, i32>, %esm: memref<3xi1>) -> index {
     %c0 = arith.constant 0 : index
@@ -49,7 +49,7 @@ module attributes {catalyst.backline = #transport.backline<transport = "rdma",
 // CHECK:         qecp.decode_esm_css
 // CHECK-NOT:     {{[^#]}}transport.
 module attributes {catalyst.backline = #transport.backline<transport = "rdma",
-  controller = #transport.node<backend_lib = "x", config = "c", peer = "127.0.0.1", oob_port = 18590 : i16>>} {
+  controller = #transport.node<backend_lib = "x", config = "c", peer = "127.0.0.1", oob_port = 18590 : i16, in_bytes = 8 : i64, out_bytes = 8 : i64>>} {
   func.func @controller_only(%tanner: !qecp.tanner_graph<8, 6, i32>, %esm: memref<?xi1>, %erridx: memref<?xindex>) {
     qecp.decode_esm_css(%tanner : !qecp.tanner_graph<8, 6, i32>) %esm in (%erridx : memref<?xindex>) : memref<?xi1>
     return
@@ -79,7 +79,7 @@ module {
 // CHECK:         qecp.decode_esm_css
 // CHECK-NOT:     {{[^#]}}transport.
 module attributes {catalyst.backline = #transport.backline<transport = "rdma",
-  controller = #transport.node<backend_lib = "x", config = "c">,
+  controller = #transport.node<backend_lib = "x", config = "c", in_bytes = 8 : i64, out_bytes = 8 : i64>,
   coprocessors = [#transport.node<backend_lib = "x", config = "c", name = "cop0", peer = "10.0.0.1", symbol = "decode">]>} {
   func.func @not_bufferized(%tanner: !qecp.tanner_graph<8, 6, i32>, %esm: tensor<2xi1>) -> tensor<1xindex> {
     %erridx = qecp.decode_esm_css(%tanner : !qecp.tanner_graph<8, 6, i32>) %esm : tensor<2xi1> -> tensor<1xindex>
@@ -95,7 +95,7 @@ module attributes {catalyst.backline = #transport.backline<transport = "rdma",
 // CHECK:         transport.get_session {key = "cop0"} : !transport.session<controller>
 // CHECK:         transport.get_session {key = "cop1"} : !transport.session<controller>
 module attributes {catalyst.backline = #transport.backline<transport = "rdma",
-  controller = #transport.node<backend_lib = "x", config = "c">,
+  controller = #transport.node<backend_lib = "x", config = "c", in_bytes = 8 : i64, out_bytes = 8 : i64>,
   coprocessors = [#transport.node<backend_lib = "x", config = "c", name = "cop0", peer = "10.0.0.1", symbol = "decode">,
                   #transport.node<backend_lib = "x", config = "c", name = "cop1", peer = "10.0.0.2", symbol = "decode">]>} {
   func.func @qec_circuit(%tanner: !qecp.tanner_graph<8, 6, i32>,
@@ -116,7 +116,7 @@ module attributes {catalyst.backline = #transport.backline<transport = "rdma",
 // CHECK-NOT:     transport.reply_slot
 // CHECK:         transport.collect %{{.*}}, %arg2 : !transport.session<controller>, memref<1xindex>
 module attributes {catalyst.backline = #transport.backline<transport = "rdma",
-  controller = #transport.node<backend_lib = "x", config = "c">,
+  controller = #transport.node<backend_lib = "x", config = "c", in_bytes = 8 : i64, out_bytes = 8 : i64>,
   coprocessors = [#transport.node<backend_lib = "x", config = "c", name = "cop0", peer = "10.0.0.1", symbol = "decode">]>} {
   func.func @qec_circuit_out_param(%tanner: !qecp.tanner_graph<8, 6, i32>, %esm: memref<3xi1>,
                                    %erridx: memref<1xindex>) {
@@ -136,7 +136,7 @@ module attributes {catalyst.backline = #transport.backline<transport = "rdma",
 // CHECK:         %[[SZ:.*]] = transport.get_session {key = "cop0"} : !transport.session<controller>
 // CHECK:         transport.stage_payload %[[SZ]], %{{.*}} {decoder_id = 1 : i32}
 module attributes {catalyst.backline = #transport.backline<transport = "rdma",
-  controller = #transport.node<backend_lib = "x", config = "c">,
+  controller = #transport.node<backend_lib = "x", config = "c", in_bytes = 8 : i64, out_bytes = 8 : i64>,
   coprocessors = [#transport.node<backend_lib = "x", config = "c", name = "cop0", peer = "10.0.0.1", symbol = "decode">]>} {
   func.func @qec_cycle_css(%tannerX: !qecp.tanner_graph<8, 6, i32>,
                            %tannerZ: !qecp.tanner_graph<8, 6, i32>,
@@ -157,7 +157,7 @@ module attributes {catalyst.backline = #transport.backline<transport = "rdma",
 // CHECK-NOT:     transport.reply_slot
 // CHECK:         transport.collect %{{.*}}, %{{.*}} : !transport.session<controller>, memref<?xindex>
 module attributes {catalyst.backline = #transport.backline<transport = "rdma",
-  controller = #transport.node<backend_lib = "x", config = "c">,
+  controller = #transport.node<backend_lib = "x", config = "c", in_bytes = 8 : i64, out_bytes = 8 : i64>,
   coprocessors = [#transport.node<backend_lib = "x", config = "c", name = "cop0", peer = "10.0.0.1", symbol = "decode">]>} {
   func.func @qec_circuit_dynamic(%tanner: !qecp.tanner_graph<8, 6, i32>, %esm: memref<?xi1>, %erridx: memref<?xindex>) {
     qecp.decode_esm_css(%tanner : !qecp.tanner_graph<8, 6, i32>) %esm in (%erridx : memref<?xindex>) : memref<?xi1>
@@ -174,7 +174,7 @@ module attributes {catalyst.backline = #transport.backline<transport = "rdma",
 // CHECK:         transport.stage_payload
 // CHECK-NOT:     decoder_id
 module attributes {catalyst.backline = #transport.backline<transport = "rdma",
-  controller = #transport.node<backend_lib = "x", config = "c">,
+  controller = #transport.node<backend_lib = "x", config = "c", in_bytes = 8 : i64, out_bytes = 8 : i64>,
   coprocessors = [#transport.node<backend_lib = "x", config = "c", name = "cop0", peer = "10.0.0.1", symbol = "decode">]>} {
   func.func @untagged(%tanner: !qecp.tanner_graph<8, 6, i32>, %esm: memref<?xi1>, %erridx: memref<?xindex>) {
     qecp.decode_esm_css(%tanner : !qecp.tanner_graph<8, 6, i32>) %esm in (%erridx : memref<?xindex>) : memref<?xi1>


### PR DESCRIPTION
- Derives the concrete transport backend from each node’s hardware and the placement’s transport (for example, rdma + cpu → cpu_verbs and memcpy + gpu → memcpy_gpu).
- Automatically adds librt_transport.so and librt_capi.so to Catalyst-launched executors, while resolving the controller’s device runtime library from its PennyLane device. User-provided plugins are preserved.


### Before submitting

Please complete the following checklist when submitting a PR:

- [ ] All new functions and code must be clearly commented and documented.

- [ ] Ensure that code is properly formatted by running `make format`.
      The latest version of black and `clang-format-20` are used in CI/CD to check formatting.

- [ ] All new features must include a unit test.
      Integration and frontend tests should be added to [`frontend/test`](../frontend/test/),
      Quantum dialect and MLIR tests should be added to [`mlir/test`](../mlir/test/), and
      Runtime tests should be added to [`runtime/tests`](../runtime/tests/).

When all the above are checked, delete everything above the dashed
line and fill in the pull request template.

------------------------------------------------------------------------------------------------------------

**Context:**

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
