### PR TITLE
Attempt to fix the grad issue exposed by CRot

### DIFF
--- a/frontend/catalyst/device/decomposition.py
+++ b/frontend/catalyst/device/decomposition.py
@@ -54,19 +54,40 @@ logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())
 
 
-def check_alternative_support(op, capabilities: DeviceCapabilities):
+def check_alternative_support(
+    op, capabilities: DeviceCapabilities, grad_method: Union[str, None] = None
+):
     """Verify that aliased operations aren't supported via alternative definitions."""
 
     if isinstance(op, qp.ops.Controlled) and type(op) is not qp.ops.ControlledOp:
-        # "Cast" away the specialized class for gates like Toffoli, ControlledQubitUnitary, etc.
         supported = capabilities.operations.get(op.base.name)
         if supported and supported.controllable:
+            if isinstance(op, qp.ops.Controlled2):
+                # ``Controlled`` treats ``Controlled2`` as a virtual subclass for compatibility.
+                # Preserve a named Operator2 gate when differentiation requires its decomposition.
+                if not is_differentiable(op, capabilities, grad_method):
+                    return None
+
+                # Normalize the specialized gate to a generic control without crossing back into
+                # the legacy operator hierarchy. ``qp.ctrl`` is the public construction API, but
+                # it deliberately dispatches this back to the specialized gate we are replacing.
+                return [
+                    qp.ops.ControlledOp2(
+                        op.base,
+                        op.control_wires,
+                        op.control_values,
+                        op.work_wires,
+                        op.work_wire_type,
+                    )
+                ]
+
+            # "Cast" away legacy specialized classes such as CRX and ControlledQubitUnitary.
             return [qp.ops.Controlled(op.base, op.control_wires, op.control_values, op.work_wires)]
 
     return None
 
 
-def catalyst_decomposer(op, capabilities: DeviceCapabilities):
+def catalyst_decomposer(op, capabilities: DeviceCapabilities, grad_method: Union[str, None] = None):
     """A decomposer for catalyst, to be passed to the decompose transform. Takes an operator and
     returns the default decomposition, unless the operator should decompose to a QubitUnitary.
     Raises a CompileError for MidMeasureMP"""
@@ -74,7 +95,7 @@ def catalyst_decomposer(op, capabilities: DeviceCapabilities):
     if isinstance(op, MidMeasureMP):
         raise CompileError("Must use 'measure' from Catalyst instead of PennyLane.")
 
-    alternative_decomp = check_alternative_support(op, capabilities)
+    alternative_decomp = check_alternative_support(op, capabilities, grad_method)
     if alternative_decomp is not None:
         return alternative_decomp
 
@@ -141,7 +162,9 @@ def catalyst_decompose(
         def stopping_condition(op):
             return catalyst_acceptance(op, capabilities, grad_method)
 
-        decomposer = partial(catalyst_decomposer, capabilities=capabilities)
+        decomposer = partial(
+            catalyst_decomposer, capabilities=capabilities, grad_method=grad_method
+        )
 
     decompose_kwargs = {
         "num_work_wires": num_work_wires,
@@ -260,7 +283,7 @@ def catalyst_acceptance(
     # There are cases where a custom controlled gate, e.g., CH, is supported, but its
     # base, i.e., H, is not labeled controllable. In this case, we don't want to use
     # this branch to check the support for this operation.
-    elif type(op) is qp.ops.ControlledOp:
+    elif type(op) in (qp.ops.ControlledOp, qp.ops.ControlledOp2):
         match = catalyst_acceptance(op.base, capabilities, grad_method)
         if match and is_controllable(op.base, capabilities):
             return match

--- a/frontend/catalyst/device/op_support.py
+++ b/frontend/catalyst/device/op_support.py
@@ -31,7 +31,12 @@ EMPTY_PROPERTIES = OperatorProperties()
 
 def get_base_operation_name(op: Operator) -> str:
     """Get the base operation name, handling controlled and adjoint operations."""
-    if type(op) in (qp.ops.Controlled, qp.ops.ControlledOp) or isinstance(op, qp.ops.Adjoint):
+    if type(op) in (
+        qp.ops.Controlled,
+        qp.ops.ControlledOp,
+        qp.ops.Controlled2,
+        qp.ops.ControlledOp2,
+    ) or isinstance(op, qp.ops.Adjoint):
         return op.base.name
     return op.name
 
@@ -120,7 +125,12 @@ def _paramshift_op_checker(op):
         # Cannot take param shift of qubit unitary.
         return False
 
-    if type(op) in (qp.ops.Controlled, qp.ops.ControlledOp):
+    if type(op) in (
+        qp.ops.Controlled,
+        qp.ops.ControlledOp,
+        qp.ops.Controlled2,
+        qp.ops.ControlledOp2,
+    ):
         # Cannot take param shift of controlled ops.
         # It will always be at least a four term shift rule.
         return False

--- a/frontend/catalyst/from_plxpr/qfunc_interpreter.py
+++ b/frontend/catalyst/from_plxpr/qfunc_interpreter.py
@@ -163,7 +163,7 @@ class PLxPRToQuantumJaxprInterpreter(PlxprInterpreter):
                 control_values=control_values,
                 control_wires=control_wires,
             )
-        if type(op) in {qp.ops.Controlled, qp.ops.ControlledOp}:
+        if type(op) in {qp.ops.Controlled, qp.ops.ControlledOp, qp.ops.ControlledOp2}:
             return self.interpret_operation(
                 op.base,
                 is_adjoint=is_adjoint,

--- a/frontend/catalyst/jax_tracer.py
+++ b/frontend/catalyst/jax_tracer.py
@@ -47,7 +47,7 @@ from pennylane.measurements import (
     VarianceMP,
 )
 from pennylane.operation import Operation, Operator, Wires
-from pennylane.ops import Adjoint, Controlled, ControlledOp
+from pennylane.ops import Adjoint, Controlled, ControlledOp, ControlledOp2
 from pennylane.tape import QuantumTape
 
 import catalyst
@@ -849,12 +849,12 @@ def trace_quantum_operations(
     def bind_native_operation(qrp, op, controlled_wires, controlled_values, adjoint=False):
         # For named-controlled operations (e.g. CNOT, CY, CZ) - bind directly by name. For
         # Controlled(OP) bind OP with native quantum control syntax, and similarly for Adjoint(OP).
-        if type(op) in (Controlled, ControlledOp):
+        if type(op) in (Controlled, ControlledOp, ControlledOp2):
             return bind_native_operation(
                 qrp,
                 op.base,
-                controlled_wires + op.control_wires,
-                controlled_values + op.control_values,
+                tuple(controlled_wires) + tuple(op.control_wires),
+                tuple(controlled_values) + tuple(op.control_values),
                 adjoint,
             )
         elif isinstance(op, Adjoint):

--- a/frontend/test/pytest/device/test_decomposition.py
+++ b/frontend/test/pytest/device/test_decomposition.py
@@ -75,7 +75,10 @@ class TestGateAliases:
         decomp = catalyst_decomposer(gate, capabilities)
 
         assert len(decomp) == 1
-        assert type(decomp[0]) is qp.ops.ControlledOp
+        expected_type = (
+            qp.ops.ControlledOp2 if isinstance(gate, qp.ops.Controlled2) else qp.ops.ControlledOp
+        )
+        assert type(decomp[0]) is expected_type
         assert type(decomp[0].base) is base
 
 

--- a/frontend/test/pytest/test_gradient.py
+++ b/frontend/test/pytest/test_gradient.py
@@ -908,21 +908,7 @@ def test_ps_probs(backend, capture_mode):
     assert np.allclose(result, reference)
 
 
-@pytest.mark.parametrize(
-    "gate_n_inputs",
-    [
-        (qp.CRX, [1]),
-        pytest.param(
-            (qp.CRot, [1, 2, 3]),
-            marks=pytest.mark.xfail(
-                reason=(
-                    "MemrefToLLVMWithTBAAPass cannot legalize the complex<f64> "
-                    "memref.load generated from the CRot decomposition [sc-127749]"
-                )
-            ),
-        ),
-    ],
-)
+@pytest.mark.parametrize("gate_n_inputs", [(qp.CRX, [1]), (qp.CRot, [1, 2, 3])])
 def test_ps_four_term_rule(backend, gate_n_inputs):
     """Operations with the 4-term shift rule need to be decomposed to be differentiated."""
     gate, inputs = gate_n_inputs


### PR DESCRIPTION
**Context:**
So Catalyst's capability checking as well as grad validation have been quite spaghatized due to the strict requirement of parameter shift. Quite some issues exposed due to special branches failed after certain controlled operators e.g. `CRot` got ported as `Operator2`. But basically what we need to do is carefully branching out Controlled2/ControlledOp2 cases, teaching the existing grad validation, dev preprocessing, and alias conversion the correct ways

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-127749]