### PR TITLE
Fix SSH multiplexing silently disabled on macOS

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -105,6 +105,8 @@
   - A `catalyst.Executor` is added for deploying and managing the `catalyst-executor` process that
     cross-compiled objects are dispatched to.
     [(#3082)](https://github.com/PennyLaneAI/catalyst/pull/3082)
+    [(#3119)](https://github.com/PennyLaneAI/catalyst/pull/3119)
+
 
 * A `BufferizableOpInterface` implementation is now added for `catalyst.launch_kernel` operation and it is now bufferizable.
   [(#3024)](https://github.com/PennyLaneAI/catalyst/pull/3024)
@@ -346,6 +348,14 @@
 <h3>Deprecations 👋</h3>
 
 <h3>Bug fixes 🐛</h3>
+
+* Fixed a bug where an executor's SSH connection multiplexing was silently disabled on macOS,
+  making every remote operation pay a fresh authentication handshake. The control socket went in
+  the system temp dir, which macOS puts under a per-user `/var/folders/...` path long enough to
+  overrun the 104-byte `sun_path` limit on its own. Sockets now live in `~/.catalyst/cm`, created
+  `0700`, which is both short enough and reachable only by its owner. Where no such directory can
+  be made, multiplexing is skipped rather than falling back to a world-writable one.
+  [(#3110)](https://github.com/PennyLaneAI/catalyst/pull/3110)
 
 * Fixed a bug where `Operator2` operations with integer-valued scalar parameters were incorrectly
   lowered to `qref.operator` instead of `qref.custom`.

--- a/frontend/catalyst/executor/ssh.py
+++ b/frontend/catalyst/executor/ssh.py
@@ -32,10 +32,8 @@ from __future__ import annotations
 
 import getpass
 import logging
-import os
 import shlex
 import subprocess
-import tempfile
 import time
 from pathlib import Path
 
@@ -66,28 +64,46 @@ class SSHArgv:
     CONTROL_PATH_MAX = 104
     CONTROL_PATH_RESERVE = 20
 
+    # Per-user directory for control sockets, relative to the user's home. Anyone able to reach a
+    # control socket can open sessions on its remote host without authenticating, the master having
+    # done so already, so the directory it sits in is what protects it.
+    CONTROL_DIR = Path(".catalyst") / "cm"
+
     @staticmethod
-    def _ctl_dir() -> Path:
-        """Directory to put the control socket in: the system temp dir."""
-        return Path(tempfile.gettempdir())
+    def _private_dir(home: Path | None = None) -> Path | None:
+        """:data:`CONTROL_DIR` under ``home``, created ``0700``, or ``None`` if it cannot be.
+
+        Args:
+            home: Directory to place it under, defaulting to the user's own. Taken as an argument so
+                that creating it and locking it down is checkable against a real directory.
+        """
+        path = (home or Path.home()) / SSHArgv.CONTROL_DIR
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+            path.chmod(0o700)  # mkdir's mode is masked by umask, so set it outright
+        except OSError as exc:
+            logger.debug("control-socket dir %s unusable (%s); falling back", path, exc)
+            return None
+        return path
 
     @staticmethod
     def ctl_opts() -> list[str]:
         """``ControlMaster``/``ControlPath``/``ControlPersist`` flags for connection multiplexing.
 
-        The first op opens a master socket under :meth:`_ctl_dir`; later ops
+        The first op opens a master socket under :meth:`_private_dir`; later ops
         (probe/mkdir/scp/pkill) reuse it, skipping the auth handshake. ``%C`` (a hash of
         ``%l%h%p%r``) keeps the name short. Not applied to the long-lived executor session, whose
         close SIGHUPs the executor cleanly.
         """
-        return SSHArgv._ctl_flags(SSHArgv._ctl_dir())
+        private = SSHArgv._private_dir()
+        return SSHArgv._ctl_flags(private) if private is not None else []
 
     @staticmethod
     def _ctl_flags(base: Path) -> list[str]:
         """:meth:`ctl_opts` for a given socket dir, split out so the length rule is decidable
         without touching the environment or the filesystem.
         """
-        path = f"{base}/catalyst-cm-{os.getuid()}-%C"
+        path = f"{base}/%C"
         # %C expands to a 40-character hash.
         expanded = len(path) - len("%C") + 40 + SSHArgv.CONTROL_PATH_RESERVE
         if expanded > SSHArgv.CONTROL_PATH_MAX:

--- a/frontend/test/pytest/executor/test_ssh.py
+++ b/frontend/test/pytest/executor/test_ssh.py
@@ -16,7 +16,6 @@
 remote ``catalyst-executor`` argv assembler. Subprocess is mocked throughout; these tests do
 not open real SSH connections."""
 
-import os
 import subprocess
 import tempfile
 from pathlib import Path
@@ -59,7 +58,7 @@ class TestSSHCtlOpts:
         assert opts[0] == "-o"
         assert opts[1] == "ControlMaster=auto"
         assert opts[2] == "-o"
-        assert opts[3] == f"ControlPath=/tmp/cm/catalyst-cm-{os.getuid()}-%C"
+        assert opts[3] == "ControlPath=/tmp/cm/%C"
         assert opts[4] == "-o"
         assert opts[5] == f"ControlPersist={SSHArgv.CONTROL_PERSIST}"
 
@@ -67,24 +66,29 @@ class TestSSHCtlOpts:
         """No flags at all when the control path would overflow ``sun_path``."""
         assert SSHArgv._ctl_flags(Path("/tmp") / ("x" * 200)) == []
 
-    def test_ctl_opts_delegates_to_ctl_flags(self):
-        """``ctl_opts`` is :meth:`_ctl_flags` applied to the resolved socket dir."""
-        assert SSHArgv.ctl_opts() == SSHArgv._ctl_flags(SSHArgv._ctl_dir())
-
 
 class TestSSHCtlDir:
-    """Resolution of the control-socket directory :meth:`SSHArgv._ctl_dir`."""
+    """The per-user control-socket directory :meth:`SSHArgv._private_dir`."""
 
-    def test_is_the_system_temp_dir(self):
-        """The socket lives in the temp dir, which always exists, so nothing has to be made."""
-        assert SSHArgv._ctl_dir() == Path(tempfile.gettempdir())
+    def test_is_created_and_private(self, tmp_path):
+        """Created if absent, and closed to group and other.
 
-    def test_creates_nothing(self):
-        """Building the flags has no filesystem effect, so a run leaves nothing behind."""
-        base = SSHArgv._ctl_dir()
-        before = set(base.iterdir())
-        SSHArgv.ctl_opts()
-        assert set(base.iterdir()) == before
+        Reaching a control socket is enough to open sessions on its remote host, the master having
+        authenticated already, so the directory is the whole of what keeps other users out.
+        """
+        d = SSHArgv._private_dir(tmp_path)
+        assert d == tmp_path / SSHArgv.CONTROL_DIR
+        assert d.stat().st_mode & 0o077 == 0, oct(d.stat().st_mode)
+
+    def test_none_when_it_cannot_be_made(self, tmp_path):
+        """A home that cannot hold the directory yields ``None``, not an exception.
+
+        Blocked with a file standing where the directory would go, rather than by permissions,
+        which root would be free to ignore.
+        """
+        blocked = tmp_path / "home"
+        blocked.write_text("")
+        assert SSHArgv._private_dir(blocked) is None
 
 
 class TestSSHBaseCmd:
@@ -100,10 +104,12 @@ class TestSSHBaseCmd:
         cmd = SSHArgv.base("me", "h")
         assert cmd[-1] == "me@h"
 
-    def test_multiplex_true_includes_control_opts(self):
-        """``multiplex=True`` adds the ``ControlMaster`` option to the argv."""
-        cmd = SSHArgv.base("me", "h", multiplex=True)
-        assert "ControlMaster=auto" in cmd
+    def test_multiplex_true_inserts_the_control_opts(self):
+        """``multiplex=True`` splices :meth:`ctl_opts` in, whatever this machine's dirs allow."""
+        with_mux = SSHArgv.base("me", "h", multiplex=True)
+        without = SSHArgv.base("me", "h", multiplex=False)
+        n = len(SSHArgv.BASE_CMD)
+        assert with_mux == without[:n] + SSHArgv.ctl_opts() + without[n:]
 
     def test_multiplex_false_omits_control_opts(self):
         """``multiplex=False`` omits the ``ControlMaster`` option."""


### PR DESCRIPTION
**Context:**
macOS puts `$TMPDIR` under a `/var/folders/...` path long enough to overrun the
104-byte `sun_path` limit, so no control socket was ever created and every
remote op re-authenticated. 

**Description of the Change:**
Sockets now go in` ~/.catalyst/cm`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

Assisted by: Claude Code