### PR TITLE
Remove Precompiled Rule Copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,7 @@ wheel:
 	$(PYTHON) -m catalyst.decomposition.precompile_decomposition_rules
 
 	mkdir -p $(MK_DIR)/frontend/catalyst/resources
+	# TODO: re-enable this once pre-compiled rules are migrated for Operator2 compatibility
 	# cp $$($(PYTHON) -c 'from catalyst.utils.runtime_environment import BYTECODE_FILE_PATH; print(BYTECODE_FILE_PATH)') $(MK_DIR)/frontend/catalyst/resources/
 
 	$(PYTHON) -m pip wheel --no-deps . -w dist

--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ wheel:
 	$(PYTHON) -m catalyst.decomposition.precompile_decomposition_rules
 
 	mkdir -p $(MK_DIR)/frontend/catalyst/resources
-	cp $$($(PYTHON) -c 'from catalyst.utils.runtime_environment import BYTECODE_FILE_PATH; print(BYTECODE_FILE_PATH)') $(MK_DIR)/frontend/catalyst/resources/
+	# cp $$($(PYTHON) -c 'from catalyst.utils.runtime_environment import BYTECODE_FILE_PATH; print(BYTECODE_FILE_PATH)') $(MK_DIR)/frontend/catalyst/resources/
 
 	$(PYTHON) -m pip wheel --no-deps . -w dist
 


### PR DESCRIPTION
**Context:**
Precompiled rules were temporarily removed by #3053 to be reintroduced later, but the makefile still performs an unconditional copy of the generated file. This crashes when building wheels since the file does not exist.

**Description of the Change:**
Removes the `cp` command from the `make wheel` directive, to be reintroduced once precompiled rules are migrated for PL2.

**Benefits:**
Wheels!

**Possible Drawbacks:**

**Related GitHub Issues:**
