### PR TITLE
Run DCE before --ppm-compilation

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -476,9 +476,10 @@
 
 <h3>Internal changes ⚙️</h3>
 
-* The `--to-ppr` pass now runs `--symbol-dce` at the beginning, to eliminate unnecessary
-  decomposition rules that might contain gates that cannot be converted to PPRs.
+* The `--to-ppr` and `--ppm-compilation` passes now runs `--symbol-dce` at the beginning,
+  to eliminate unnecessary decomposition rules that might contain gates that cannot be converted to PPRs.
   [(#3125)](https://github.com/PennyLaneAI/catalyst/pull/3125)
+  [(#3135)](https://github.com/PennyLaneAI/catalyst/pull/3135)
 
 * The `dim` argument of the `quantum.pcphase` operation has been changed to a static integer attribute
   (previously a dynamic float operand). This allows, among other things, the decomposition graph to

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -476,7 +476,7 @@
 
 <h3>Internal changes ⚙️</h3>
 
-* The `--to-ppr` and `--ppm-compilation` passes now runs `--symbol-dce` at the beginning,
+* The `--to-ppr` and `--ppm-compilation` passes now run `--symbol-dce` at the beginning,
   to eliminate unnecessary decomposition rules that might contain gates that cannot be converted to PPRs.
   [(#3125)](https://github.com/PennyLaneAI/catalyst/pull/3125)
   [(#3135)](https://github.com/PennyLaneAI/catalyst/pull/3135)

--- a/mlir/lib/PBC/Transforms/ppm_compilation.cpp
+++ b/mlir/lib/PBC/Transforms/ppm_compilation.cpp
@@ -19,6 +19,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
 
 #include "PBC/IR/PBCDialect.h"
 #include "PBC/Transforms/Patterns.h"
@@ -42,6 +43,13 @@ struct PPMCompilationPass : public impl::PPMCompilationPassBase<PPMCompilationPa
     void runOnOperation() final {
         auto ctx = &getContext();
         auto module = getOperation();
+
+        // Remove all decomposition rules, they might involve gates we don't care about
+        OpPassManager pm("builtin.module");
+        pm.addPass(mlir::createSymbolDCEPass());
+        if (failed(runPipeline(pm, getOperation()))) {
+            return signalPassFailure();
+        }
 
         // Phase 1: Convert Clifford+T to PPR representation
         {

--- a/mlir/test/PBC/PPMCompilationTest.mlir
+++ b/mlir/test/PBC/PPMCompilationTest.mlir
@@ -112,3 +112,25 @@ func.func @game_of_surface_code() -> (tensor<i1>, tensor<i1>, tensor<i1>, tensor
 
 
 // -----
+
+
+func.func @test_dce_decomp_rule() {
+    %0 = quantum.alloc( 1) : !quantum.reg
+    %1 = quantum.extract %0[ 1] : !quantum.reg -> !quantum.bit
+    %out_qubit = quantum.custom "S"() %1 : !quantum.bit
+    %2 = quantum.insert %0[ 1], %out_qubit : !quantum.reg, !quantum.bit
+    quantum.dealloc %2 : !quantum.reg
+    return
+}
+
+func.func private @"some_decomp_rule"(%arg0: tensor<1xf64>, %arg1: tensor<1xi64>, %arg2: !quantum.reg) -> !quantum.reg attributes {resources = {operations = {"some_gate" = 1 : i64}}, target_gate = "Hadamard{}{wires:1}{}"} {
+    %0 = stablehlo.slice %arg1 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
+    %1 = stablehlo.reshape %0 : (tensor<1xi64>) -> tensor<i64>
+    %extracted = tensor.extract %1[] : tensor<i64>
+    %2 = quantum.extract %arg2[%extracted] : !quantum.reg -> !quantum.bit
+    %out_qubits = quantum.operator "some_gate"(%arg0: tensor<1xf64>) qubits(%2)
+      static_data = {}
+      param_map = {phi = [0]} qubit_map = {wires = [0]}
+    %3 = quantum.insert %arg2[%extracted], %out_qubits : !quantum.reg, !quantum.bit
+    return %3 : !quantum.reg
+}


### PR DESCRIPTION
**Context:**
Run DCE before `--ppm-compilation`. 

#3125 , but I didn't know that `--ppm-compilation` invokes the `to_ppr` pattern directly and doesn't call the `--to-ppr` pass. 
