### PR TITLE
Revert and xfail `test_ctrl_before_custom_op`

### DIFF
--- a/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
+++ b/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
@@ -20,7 +20,6 @@ from jax._src.lib.mlir import ir
 from jax.extend.core import Primitive
 from jax.interpreters import mlir
 from jaxlib.mlir._mlir_libs import _mlir as _ods_cext
-from jaxlib.mlir.dialects.arith import ConstantOp
 from jaxlib.mlir.dialects.stablehlo import ConvertOp as StableHLOConvertOp
 from pennylane.pytrees import unflatten
 
@@ -314,35 +313,6 @@ def _multirz_lowering(theta, *qubits, ctrl_qubits, ctrl_values, adjoint):
         qubits=qubits,
         ctrl_qubits=ctrl_qubits,
         ctrl_values=ctrl_values,
-        adjoint=adjoint,
-    )
-    return []
-
-
-@_register_special_lowering("MultiControlledX")
-def _multicontrolledx_lowering(
-    control_values, *qubits, ctrl_qubits, ctrl_values, adjoint, work_wire_type
-):
-    """Lower a ``MultiControlledX`` to a controlled PauliX custom operation."""
-    num_controls = ir.RankedTensorType(control_values.type).shape[0]
-
-    mcx_ctrl_values = [
-        TensorExtractOp(
-            ir.IntegerType.get_signless(1),
-            control_values,
-            [ConstantOp(ir.IndexType.get(), index)],  # pylint: disable=too-many-function-args
-        ).result
-        for index in range(num_controls)
-    ]
-    mcx_ctrl_qubits = qubits[:num_controls]
-    target = qubits[num_controls]
-
-    CustomOp(
-        params=[],
-        qubits=[target],
-        gate_name=get_mlir_attribute_from_pyval("PauliX"),
-        ctrl_qubits=[*ctrl_qubits, *mcx_ctrl_qubits],
-        ctrl_values=[*ctrl_values, *mcx_ctrl_values],
         adjoint=adjoint,
     )
     return []

--- a/frontend/test/pytest/python_interface/inspection/test_draw_unified_compiler.py
+++ b/frontend/test/pytest/python_interface/inspection/test_draw_unified_compiler.py
@@ -255,6 +255,16 @@ class TestDraw:
 
         assert draw(circuit)() == expected
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "MultiControlledX must be canonicalized to X with controls at the PLXPR level. "
+            "The drawer pipeline cannot currently process the resulting qref.operator "
+            "MultiControlledX because it has no executable lowering. Lowering it directly to "
+            "qref.custom PauliX in Catalyst would instead give the frontend and MLIR different "
+            "GraphOpIDs."
+        ),
+    )
     def test_ctrl_before_custom_op(self):
         """
         Test the visualization of control operations before custom ops.


### PR DESCRIPTION
**Context:**
special lowering for MCX as a solution solved the issue with drawer, however introduced much more potential issues.
Given the fact that drawer module is not prioritized for now, we should instead xfail the corresponding test and explore other solutions

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
