### PR TITLE
Fix dialects build when using libstdc++ 14 from gcc

### DIFF
--- a/mlir/lib/Quantum/Transforms/dynamic_one_shot.cpp
+++ b/mlir/lib/Quantum/Transforms/dynamic_one_shot.cpp
@@ -415,7 +415,8 @@ void editKernelMCMProbs(IRRewriter &builder, func::FuncOp oneShotKernel, quantum
     auto totalIndex =
         arith::ConstantOp::create(builder, loc, i64Type, builder.getIntegerAttr(i64Type, 0));
     Operation *loopUpdater = totalIndex;
-    for (auto [i, mcm] : llvm::enumerate(llvm::reverse(mcmobs.getMcms()))) {
+    SmallVector<Value> mcms(mcmobs.getMcms());
+    for (auto [i, mcm] : llvm::enumerate(llvm::reverse(mcms))) {
         // Power of 2 for this bit position
         auto extuiOp = arith::ExtUIOp::create(builder, loc, builder.getI64Type(), mcm);
         auto shiftSize =


### PR DESCRIPTION
**Context:**
Fix dialects build with libstdc++ 14 headers

The follwing pattern fails when using clang with the libstdc++ 14 headers:
```
llvm::enumerate(llvm::reverse(mcmobs.getMcms()))
```
with this error:

```
    error: no matching constructor for initialization of
      'indexed_accessor_range_base<mlir::OperandRange, ...>::iterator'
```

This is a know issue of std::reverse_iterator` over libstdc++ 14 . The error shows up on Ubuntu 24.04 whenever the gcc-14 headers are installed.

**Description of the Change:**

Copies the operands into a `SmallVector<Value>` before reversing, so the reversed iterator is a plain `Value *`

**Description of the Change:**

**Benefits:**
`make dialects` builds on Ubuntu 24.04 with the gcc-14 headers present.

**Possible Drawbacks:**

**Related GitHub Issues:**
