### PR TITLE
FIx the name of remote backline rt nodes on macOS

### DIFF
--- a/frontend/catalyst/backline.py
+++ b/frontend/catalyst/backline.py
@@ -328,17 +328,19 @@ def _executor_plugins(node: Node, given) -> list[str]:
     implied = []
     fn_lib = _coprocessor_fn_lib(node)
     if fn_lib is not None:
-        implied.append(fn_lib)
+        implied.append((fn_lib, fn_lib.name))
     device = getattr(node, "device", None)
     if device is not None:
         # Last: plugins open RTLD_GLOBAL and the first definition of a symbol wins, and the device
         # runtime carries its own copy of the runtime's exception types.
-        implied.append(Path(extract_backend_info(device).lpath))
-    for lib in implied:
+        lib = Path(extract_backend_info(device).lpath)
+        implied.append((lib, lib.with_suffix(f".{_BACKEND_LIB_EXTS[0]}").name))
+    for lib, remote_name in implied:
         # A node on another machine resolves a library by filename, the deployed bundle supplying
         # the file; one running here resolves it by path into this installation.
-        if not any(Path(p).name == lib.name for p in plugins):
-            plugins.append(lib.name if remote else str(lib))
+        name = remote_name if remote else lib.name
+        if not any(Path(p).name == name for p in plugins):
+            plugins.append(name if remote else str(lib))
     return plugins
 
 

--- a/frontend/test/pytest/test_backline.py
+++ b/frontend/test/pytest/test_backline.py
@@ -14,6 +14,7 @@
 """Unit tests for the backline frontend: serialize_backline and the pipeline helpers."""
 
 import os
+import platform
 from unittest import mock
 
 import pennylane as qp
@@ -34,6 +35,7 @@ from catalyst.backline import (
     placement_pipeline,
     serialize_backline,
 )
+from catalyst.device.qjit_device import BackendInfo, extract_backend_info
 from catalyst.utils.exceptions import CompileError
 
 if hasattr(qp, "backline"):
@@ -757,6 +759,21 @@ class TestExecutorRealization:
         plugins = node.executor._cfg.plugins  # pylint: disable=protected-access
         assert plugins[-1] == "librtd_null_qubit.so"
 
+    def test_a_remote_nodes_device_runtime_drops_this_platforms_extension(self, no_launch):
+        """A node on another machine is Linux and loads the runtime from its deployed bundle, so a
+        macOS host's ``.dylib`` would not name the file there."""
+        node = _controller(remote=True, executor_options={"host": "h", "port": 1})
+        info = extract_backend_info(node.device)
+        macos = BackendInfo(
+            info.device_name, info.c_interface_name, "/opt/lib/librtd_null_qubit.dylib", info.kwargs
+        )
+        with mock.patch(
+            "catalyst.device.qjit_device.extract_backend_info", return_value=macos
+        ):
+            _realize_executor(node)
+        plugins = node.executor._cfg.plugins  # pylint: disable=protected-access
+        assert plugins[-1] == "librtd_null_qubit.so"
+
     def test_a_dispatched_coprocessor_carries_its_function_library(self, tmp_path):
         """A decoder built for this run is not in the target's bundle, so it travels and is opened."""
         lib = tmp_path / "libdecoder.so"
@@ -801,12 +818,14 @@ class TestExecutorRealization:
         assert plugins[-1] == "librtd_null_qubit.so"
 
     def test_a_node_on_this_machine_gets_full_library_paths(self, no_launch):
-        """Its libraries come from this installation, so a filename alone would not resolve."""
+        """Its libraries come from this installation, so a filename alone would not resolve, and the
+        device runtime keeps this platform's extension rather than a remote node's ``.so``."""
+        ext = "dylib" if platform.system() == "Darwin" else "so"
         node = _controller(executor_options={})
         _realize_executor(node)
         plugins = node.executor._cfg.plugins  # pylint: disable=protected-access
         assert all(p.startswith("/") for p in plugins)
-        assert [p.rsplit("/", 1)[-1] for p in plugins][-1] == "librtd_null_qubit.so"
+        assert [p.rsplit("/", 1)[-1] for p in plugins][-1] == f"librtd_null_qubit.{ext}"
 
     def test_an_attached_executor_is_taken_at_the_nodes_word(self):
         """An ``address`` may name either machine, so ``remote`` is not second-guessed for it."""

--- a/frontend/test/pytest/test_backline.py
+++ b/frontend/test/pytest/test_backline.py
@@ -767,9 +767,7 @@ class TestExecutorRealization:
         macos = BackendInfo(
             info.device_name, info.c_interface_name, "/opt/lib/librtd_null_qubit.dylib", info.kwargs
         )
-        with mock.patch(
-            "catalyst.device.qjit_device.extract_backend_info", return_value=macos
-        ):
+        with mock.patch("catalyst.device.qjit_device.extract_backend_info", return_value=macos):
             _realize_executor(node)
         plugins = node.executor._cfg.plugins  # pylint: disable=protected-access
         assert plugins[-1] == "librtd_null_qubit.so"


### PR DESCRIPTION
**Context:**
This PR fixes [this issue](https://github.com/PennyLaneAI/catalyst/actions/runs/32445121031/job/96666851212) on macOS wheels by not leaking the host's `.dylib` extension into a remote backline node's plugins.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-128428]