### PR TITLE
Remove global phases

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -187,7 +187,7 @@
   a transport kick/collect round over its buffers.
   [(#3066)](https://github.com/PennyLaneAI/catalyst/pull/3066)
 
-* A `remove-global-phases` pass is added, which removes global phases by deleting phase 
+* A `remove-global-phases` pass is added, which removes global phases by deleting `quantum.gphase`  
   operations without control wires.
   [(#3143)](https://github.com/PennyLaneAI/catalyst/pull/3143)
 

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -187,6 +187,10 @@
   a transport kick/collect round over its buffers.
   [(#3066)](https://github.com/PennyLaneAI/catalyst/pull/3066)
 
+* A `remove-global-phases` pass is added, which removes global phases by deleting phase 
+  operations without control wires.
+  [(#3143)](https://github.com/PennyLaneAI/catalyst/pull/3143)
+
 * An X/Z syndrome decode can now be routed to its own decoder in a backline coprocessor.
   `qecp.decode_esm_css` carries an optional `check_type` attribute recording which check family a
   syndrome came from, which `lower-decode-to-transport` maps to a `decoder_id` on `transport.kick`.
@@ -713,6 +717,7 @@ Rylan Malarchick,
 Mehrdad Malekmohammadi,
 River McCubbin,
 Shuli Shu,
+Nikhil Sreekumar,
 Paul Haochen Wang,
 Jake Zaia,
 Hongsheng Zheng.

--- a/mlir/include/Quantum/Transforms/Passes.td
+++ b/mlir/include/Quantum/Transforms/Passes.td
@@ -76,6 +76,10 @@ def CtrlLoweringPass : Pass<"ctrl-lowering"> {
     let dependentDialects = ["scf::SCFDialect"];
 }
 
+def RemoveGlobalPhasesPass : Pass<"remove-global-phases"> {
+    let summary = "Remove global phases by deleting phase operations without control wires.";
+}
+
 def SplitMultipleTapesPass : Pass<"split-multiple-tapes"> {
     let summary = "Given a qnode containing multiple tapes, split each tape into its own function.";
 }

--- a/mlir/lib/Quantum/Transforms/CMakeLists.txt
+++ b/mlir/lib/Quantum/Transforms/CMakeLists.txt
@@ -10,6 +10,7 @@ file(GLOB SRC
     BufferizableOpInterfaceImpl.cpp
     CancelInversesPatterns.cpp
     CtrlLowering/CtrlLowering.cpp
+    RemoveGlobalPhasesPass.cpp
     ConversionPatterns.cpp
     GraphDecomposition/DecompUtils.cpp
     GraphDecomposition/DecomposeLoweringPatterns.cpp

--- a/mlir/lib/Quantum/Transforms/RemoveGlobalPhasesPass.cpp
+++ b/mlir/lib/Quantum/Transforms/RemoveGlobalPhasesPass.cpp
@@ -1,0 +1,26 @@
+#define DEBUG_TYPE "remove-global-phases"
+
+#include "llvm/Support/Debug.h"
+#include "Quantum/IR/QuantumOps.h"
+#include "mlir/Pass/Pass.h"
+
+using namespace llvm;
+using namespace mlir;
+
+namespace catalyst {
+namespace quantum {
+
+#define GEN_PASS_DECL_REMOVEGLOBALPHASESPASS
+#define GEN_PASS_DEF_REMOVEGLOBALPHASESPASS
+#include "Quantum/Transforms/Passes.h.inc"
+
+struct RemoveGlobalPhasesPass : public impl::RemoveGlobalPhasesPassBase<RemoveGlobalPhasesPass>{
+    using impl::RemoveGlobalPhasesPassBase<RemoveGlobalPhasesPass>::RemoveGlobalPhasesPassBase;
+
+    void runOnOperation() final {
+        llvm::errs() << "RemoveGlobalPhasesPass Executed\n";
+    }
+};
+    
+} // namespace quantum
+} // namespace catalyst

--- a/mlir/lib/Quantum/Transforms/RemoveGlobalPhasesPass.cpp
+++ b/mlir/lib/Quantum/Transforms/RemoveGlobalPhasesPass.cpp
@@ -1,17 +1,18 @@
 #define DEBUG_TYPE "remove-global-phases"
 
 #include "llvm/Support/Debug.h"
-#include "Quantum/IR/QuantumOps.h"
-#include "mlir/Pass/Pass.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#include "Quantum/IR/QuantumOps.h"
 
 using namespace llvm;
 using namespace mlir;
 using namespace catalyst::quantum;
 
-namespace{
+namespace {
 
 /// delete phase ops without control wires
 struct RemoveGlobalPhasesRewritePattern : public OpRewritePattern<GlobalPhaseOp> {
@@ -21,7 +22,7 @@ struct RemoveGlobalPhasesRewritePattern : public OpRewritePattern<GlobalPhaseOp>
         // Find out if there are any control regions in the parent chain,
         // Or if there are control qubits associated with this operation.
         // If so, it must be ignored
-        if(op->getParentOfType<CtrlOp>() || !op.getInCtrlQubits().empty()){
+        if (op->getParentOfType<CtrlOp>() || !op.getInCtrlQubits().empty()) {
             return failure();
         }
 
@@ -42,7 +43,7 @@ namespace quantum {
 #define GEN_PASS_DEF_REMOVEGLOBALPHASESPASS
 #include "Quantum/Transforms/Passes.h.inc"
 
-struct RemoveGlobalPhasesPass : public impl::RemoveGlobalPhasesPassBase<RemoveGlobalPhasesPass>{
+struct RemoveGlobalPhasesPass : public impl::RemoveGlobalPhasesPassBase<RemoveGlobalPhasesPass> {
     using impl::RemoveGlobalPhasesPassBase<RemoveGlobalPhasesPass>::RemoveGlobalPhasesPassBase;
 
     void runOnOperation() final {
@@ -51,9 +52,9 @@ struct RemoveGlobalPhasesPass : public impl::RemoveGlobalPhasesPassBase<RemoveGl
 
         if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
             return signalPassFailure();
-        }        
+        }
     }
 };
-    
+
 } // namespace quantum
 } // namespace catalyst

--- a/mlir/lib/Quantum/Transforms/RemoveGlobalPhasesPass.cpp
+++ b/mlir/lib/Quantum/Transforms/RemoveGlobalPhasesPass.cpp
@@ -3,9 +3,37 @@
 #include "llvm/Support/Debug.h"
 #include "Quantum/IR/QuantumOps.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 using namespace llvm;
 using namespace mlir;
+using namespace catalyst::quantum;
+
+namespace{
+
+/// delete phase ops without control wires
+struct RemoveGlobalPhasesRewritePattern : public OpRewritePattern<GlobalPhaseOp> {
+    using OpRewritePattern<GlobalPhaseOp>::OpRewritePattern;
+
+    LogicalResult matchAndRewrite(GlobalPhaseOp op, PatternRewriter &rewriter) const override {
+        // Find out if there are any control regions in the parent chain,
+        // Or if there are control qubits associated with this operation.
+        // If so, it must be ignored
+        if(op->getParentOfType<CtrlOp>() || !op.getInCtrlQubits().empty()){
+            return failure();
+        }
+
+        // Erase global phase op
+        rewriter.eraseOp(op);
+
+        // Successful application of pattern
+        return success();
+    }
+};
+
+} // namespace
 
 namespace catalyst {
 namespace quantum {
@@ -18,7 +46,12 @@ struct RemoveGlobalPhasesPass : public impl::RemoveGlobalPhasesPassBase<RemoveGl
     using impl::RemoveGlobalPhasesPassBase<RemoveGlobalPhasesPass>::RemoveGlobalPhasesPassBase;
 
     void runOnOperation() final {
-        llvm::errs() << "RemoveGlobalPhasesPass Executed\n";
+        RewritePatternSet patterns(&getContext());
+        patterns.add<RemoveGlobalPhasesRewritePattern>(patterns.getContext(), 1);
+
+        if (failed(applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+            return signalPassFailure();
+        }        
     }
 };
     

--- a/mlir/lib/Quantum/Transforms/RemoveGlobalPhasesPass.cpp
+++ b/mlir/lib/Quantum/Transforms/RemoveGlobalPhasesPass.cpp
@@ -15,6 +15,7 @@
 #define DEBUG_TYPE "remove-global-phases"
 
 #include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/Pass.h"
@@ -33,6 +34,13 @@ struct RemoveGlobalPhasesRewritePattern : public OpRewritePattern<GlobalPhaseOp>
     using OpRewritePattern<GlobalPhaseOp>::OpRewritePattern;
 
     LogicalResult matchAndRewrite(GlobalPhaseOp op, PatternRewriter &rewriter) const override {
+
+        // Cannot remove gphase ops in subroutines, as they might be called in a control region.
+        if (auto parentFunc = op->getParentOfType<func::FuncOp>();
+            !parentFunc || !parentFunc->hasAttr("quantum.node")) {
+            return failure();
+        }
+
         // Find out if there are any control regions in the parent chain,
         // Or if there are control qubits associated with this operation.
         // If so, it must be ignored

--- a/mlir/lib/Quantum/Transforms/RemoveGlobalPhasesPass.cpp
+++ b/mlir/lib/Quantum/Transforms/RemoveGlobalPhasesPass.cpp
@@ -1,3 +1,17 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #define DEBUG_TYPE "remove-global-phases"
 
 #include "llvm/Support/Debug.h"

--- a/mlir/test/Quantum/RemoveGlobalPhasesTest.mlir
+++ b/mlir/test/Quantum/RemoveGlobalPhasesTest.mlir
@@ -1,0 +1,65 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// RUN: quantum-opt --remove-global-phases --split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: func.func @remove_simple_global_phases
+func.func @remove_simple_global_phases(%arg0: f64) {
+
+    // CHECK-NOT: quantum.gphase
+    quantum.gphase(%arg0)
+
+    return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @remove_multiple_global_phases
+func.func @remove_multiple_global_phases(%arg0: f64, %arg1: f64) {
+
+    // CHECK-NOT: quantum.gphase
+    quantum.gphase(%arg0)
+    quantum.gphase(%arg1)
+
+    return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @keep_only_controlled_global_phases(
+// CHECK-SAME: [[CTRL:%.+]]: !quantum.bit, [[Q:%.+]]: !quantum.bit, [[THETA:%.+]]: f64) -> (!quantum.bit, !quantum.bit)
+func.func @keep_only_controlled_global_phases(%ctrl: !quantum.bit, %q: !quantum.bit, %theta: f64) -> (!quantum.bit, !quantum.bit){
+
+    // CHECK: [[TRUE:%.+]] = arith.constant true
+    %true = arith.constant true
+
+    // CHECK: [[OUTC:%.+]], [[OUTQ:%.+]] = quantum.ctrl([[CTRL]]) ctrlvals([[TRUE]]) ([[Q]]) : !quantum.bit -> !quantum.bit
+    %outc, %outq = quantum.ctrl(%ctrl) ctrlvals(%true) (%q) : !quantum.bit -> !quantum.bit {
+        ^bb0(%arg0: !quantum.bit):
+            %h = quantum.custom "Hadamard"() %arg0 : !quantum.bit
+            // CHECK: quantum.gphase([[THETA]])
+            quantum.gphase(%theta)
+            quantum.yield %h : !quantum.bit
+    }
+
+    // CHECK-NOT: quantum.gphase
+    quantum.gphase(%theta)
+
+    // CHECK: quantum.gphase([[THETA]]) ctrls([[OUTQ]]) ctrlvals([[TRUE]]) : ctrls !quantum.bit
+    %gphase = quantum.gphase(%theta) ctrls(%outq) ctrlvals(%true) : ctrls !quantum.bit
+
+    return %outq, %outc : !quantum.bit, !quantum.bit
+}
+
+// -----

--- a/mlir/test/Quantum/RemoveGlobalPhasesTest.mlir
+++ b/mlir/test/Quantum/RemoveGlobalPhasesTest.mlir
@@ -15,7 +15,7 @@
 // RUN: quantum-opt --remove-global-phases --split-input-file %s | FileCheck %s
 
 // CHECK-LABEL: func.func @remove_simple_global_phases
-func.func @remove_simple_global_phases(%arg0: f64) {
+func.func @remove_simple_global_phases(%arg0: f64) attributes {quantum.node} {
 
     // CHECK-NOT: quantum.gphase
     quantum.gphase(%arg0)
@@ -26,7 +26,7 @@ func.func @remove_simple_global_phases(%arg0: f64) {
 // -----
 
 // CHECK-LABEL: func.func @remove_multiple_global_phases
-func.func @remove_multiple_global_phases(%arg0: f64, %arg1: f64) {
+func.func @remove_multiple_global_phases(%arg0: f64, %arg1: f64) attributes {quantum.node}  {
 
     // CHECK-NOT: quantum.gphase
     quantum.gphase(%arg0)
@@ -39,7 +39,7 @@ func.func @remove_multiple_global_phases(%arg0: f64, %arg1: f64) {
 
 // CHECK-LABEL: func.func @keep_only_controlled_global_phases(
 // CHECK-SAME: [[CTRL:%.+]]: !quantum.bit, [[Q:%.+]]: !quantum.bit, [[THETA:%.+]]: f64) -> (!quantum.bit, !quantum.bit)
-func.func @keep_only_controlled_global_phases(%ctrl: !quantum.bit, %q: !quantum.bit, %theta: f64) -> (!quantum.bit, !quantum.bit){
+func.func @keep_only_controlled_global_phases(%ctrl: !quantum.bit, %q: !quantum.bit, %theta: f64) -> (!quantum.bit, !quantum.bit) attributes {quantum.node} {
 
     // CHECK: [[TRUE:%.+]] = arith.constant true
     %true = arith.constant true
@@ -60,6 +60,17 @@ func.func @keep_only_controlled_global_phases(%ctrl: !quantum.bit, %q: !quantum.
     %gphase = quantum.gphase(%theta) ctrls(%outq) ctrlvals(%true) : ctrls !quantum.bit
 
     return %outq, %outc : !quantum.bit, !quantum.bit
+}
+
+// -----
+
+// CHECK-LABEL: func.func @keep_global_phases_non_qnode
+func.func @keep_global_phases_non_qnode(%arg0: f64) {
+
+    // CHECK: quantum.gphase
+    quantum.gphase(%arg0)
+
+    return
 }
 
 // -----


### PR DESCRIPTION
**Context:**
Delete phase ops without control wires. This includes phase ops in control regions in the quantum dialect (`quantum.ctrl`), as well as the phase ops with `in_ctrl_qubits`

**Description of the Change:**
Added a new pass called `RemoveGlobalPhasesPass` that implements the above. Added tests for this pass to ensure that phase ops are being deleted, and the only ones that are being deleted have no associated control wires.

**Benefits:**
Eliminates ops that have no effect on the state. 

**Possible Drawbacks:**
Global phase ops may still be required to be retained in the `IR`. This should be used as an optional phase as a result.

**Related GitHub Issues:**
[#2613 ](https://github.com/PennyLaneAI/catalyst/issues/2613)

**Associated shortcut ticket**
[Create a pass to remove global phases](https://app.shortcut.com/xanaduai/story/114655/create-a-pass-to-remove-global-phases)
[sc-114655]