### PR TITLE
Name a dispatched controller's device runtime by filename

### DIFF
--- a/frontend/catalyst/backline.py
+++ b/frontend/catalyst/backline.py
@@ -409,6 +409,20 @@ def attach_backline_attr(mlir_module, placement: Placement) -> None:
         )
 
 
+def remote_device_lib(device: Device, lpath: str) -> str | None:
+    """The filename a dispatched controller's device runtime is named by, ``None`` if it is local.
+
+    A remote node resolves it against its workspace, from what was deployed there, so the absolute
+    ``lpath`` into this installation would name a directory that exists only here. Always ``.so``,
+    as :func:`_resolve_backend_lib` does for a remote node's transport backend: the far machine is
+    Linux whatever this one is.
+    """
+    controller = getattr(getattr(device, "placement", None), "controller", None)
+    if controller is None or not controller.remote:
+        return None
+    return Path(lpath).with_suffix(".so").name
+
+
 def module_attributes(device: Device) -> dict[str, str]:
     """The MLIR attributes ``device`` puts on the module of a QNode that runs on it.
 

--- a/frontend/catalyst/from_plxpr/from_plxpr.py
+++ b/frontend/catalyst/from_plxpr/from_plxpr.py
@@ -30,7 +30,7 @@ from pennylane.capture.primitives import transform_prim
 from pennylane.decomposition.utils import to_name
 from pennylane.transforms import decompose as pl_decompose
 
-from catalyst.backline import device_pass_pipeline
+from catalyst.backline import device_pass_pipeline, remote_device_lib
 from catalyst.device import extract_backend_info
 from catalyst.device.qjit_device import is_dynamic_wires
 from catalyst.from_plxpr.decompose import DecompRuleInterpreter
@@ -129,9 +129,11 @@ def _get_device_kwargs(device) -> dict:
     # Note that the value of rtd_kwargs is a string version of
     # the info kwargs, not the info kwargs itself
     # this is due to ease of serialization to MLIR
+    # A dispatched controller loads its runtime from its workspace, so the program names it by
+    # filename. info.lpath describes this machine and is right for a controller running here.
     return {
         "rtd_kwargs": str(info.kwargs),
-        "rtd_lib": info.lpath,
+        "rtd_lib": remote_device_lib(device, info.lpath) or info.lpath,
         "rtd_name": info.c_interface_name,
     }
 

--- a/frontend/test/pytest/test_backline.py
+++ b/frontend/test/pytest/test_backline.py
@@ -23,9 +23,7 @@ import pytest
 from pennylane.backline import Transport
 
 from catalyst import Executor, qjit
-from catalyst.from_plxpr.from_plxpr import _get_device_kwargs
 from catalyst.backline import (
-    remote_device_lib,
     _EXECUTOR_RUNTIME_PLUGINS,
     _TRANSPORT_PASSES,
     _insert_passes,
@@ -36,9 +34,11 @@ from catalyst.backline import (
     device_pass_pipeline,
     launch_executors,
     placement_pipeline,
+    remote_device_lib,
     serialize_backline,
 )
 from catalyst.device.qjit_device import BackendInfo, extract_backend_info
+from catalyst.from_plxpr.from_plxpr import _get_device_kwargs
 from catalyst.utils.exceptions import CompileError
 
 if hasattr(qp, "backline"):

--- a/frontend/test/pytest/test_backline.py
+++ b/frontend/test/pytest/test_backline.py
@@ -15,6 +15,7 @@
 
 import os
 import platform
+from pathlib import Path
 from unittest import mock
 
 import pennylane as qp
@@ -22,7 +23,9 @@ import pytest
 from pennylane.backline import Transport
 
 from catalyst import Executor, qjit
+from catalyst.from_plxpr.from_plxpr import _get_device_kwargs
 from catalyst.backline import (
+    remote_device_lib,
     _EXECUTOR_RUNTIME_PLUGINS,
     _TRANSPORT_PASSES,
     _insert_passes,
@@ -771,6 +774,42 @@ class TestExecutorRealization:
             _realize_executor(node)
         plugins = node.executor._cfg.plugins  # pylint: disable=protected-access
         assert plugins[-1] == "librtd_null_qubit.so"
+
+    def test_a_dispatched_controller_names_its_runtime_by_filename(self):
+        """A program carrying this installation's path opens it on the far machine and fails."""
+        dev = qp.Backline(controller=_controller(remote=True), transport="rdma")
+        info = extract_backend_info(dev)
+        assert remote_device_lib(dev, info.lpath) == "librtd_null_qubit.so"
+        assert _get_device_kwargs(dev)["rtd_lib"] == "librtd_null_qubit.so"
+
+    def test_a_controller_in_this_process_keeps_its_full_path(self):
+        """Nothing was deployed, so the path into this installation is what resolves."""
+        dev = qp.Backline(controller=_controller(), transport="rdma")
+        info = extract_backend_info(dev)
+        assert remote_device_lib(dev, info.lpath) is None
+        assert _get_device_kwargs(dev)["rtd_lib"] == info.lpath
+
+    def test_a_device_with_no_placement_is_left_alone(self):
+        """Only a backline placement implies a remote node, so every other device is untouched."""
+        plain = qp.device("null.qubit", wires=1)
+        assert remote_device_lib(plain, "/opt/lib/librtd_null_qubit.so") is None
+
+    def test_a_dispatched_runtime_is_named_with_a_linux_extension(self):
+        """A node on another machine is Linux, so a macOS host's .dylib is not what it asks for."""
+        dev = qp.Backline(controller=_controller(remote=True), transport="rdma")
+        assert remote_device_lib(dev, "/opt/lib/librtd_null_qubit.dylib") == "librtd_null_qubit.so"
+
+    def test_a_remote_controllers_device_runtime_is_not_carried(self, no_launch):
+        """A node of another architecture needs the copy cross-built for its own bundle.
+
+        Sending this host's would land the wrong architecture in its workspace under that filename,
+        displacing the right one.
+        """
+        node = _controller(remote=True, executor_options={"host": "192.0.2.10", "port": 7810})
+        _realize_executor(node)
+        cfg = node.executor._cfg  # pylint: disable=protected-access
+        assert cfg.plugins[-1] == "librtd_null_qubit.so"
+        assert not cfg.deploy
 
     def test_a_dispatched_coprocessor_carries_its_function_library(self, tmp_path):
         """A decoder built for this run is not in the target's bundle, so it travels and is opened."""


### PR DESCRIPTION
**Context:**
A QNode whose controller runs on another machine failed to load its device:

```
dlopen failed to load /home/me/catalyst/.../librtd_null_qubit.so:
cannot open shared object file
```

`from_plxpr._get_device_kwargs` passed `extract_backend_info(...).lpath` straight into `rtd_lib`.
That path is correct locally and meaningless on the far machine, which resolves its libraries from
what was deployed into its workspace.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
