### PR TITLE
Add rbram type for reply buffer

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -27,6 +27,9 @@
 
 <h3>Improvements 🛠</h3>
 
+* Add the `XMEM_REPLY_BRAM` memory type and use it to allocate reply buffers in dedicated BRAM.
+  [(#3148)](https://github.com/PennyLaneAI/catalyst/pull/3148)
+
 * a PennyLane `Backline` is serialized to the `catalyst.backline` module attribute and compiled
   through the transport passes.
   [(#3068)](https://github.com/PennyLaneAI/catalyst/pull/3068)

--- a/runtime/lib/transport/rdma/fpga_hwhs/HwhsAbi.h
+++ b/runtime/lib/transport/rdma/fpga_hwhs/HwhsAbi.h
@@ -27,6 +27,7 @@ enum {
     XMEM_PL_DDR = 1,
     XMEM_PS_DDR = 2,
     XMEM_BRAM = 5,
+    XMEM_REPLY_BRAM = 6,
 };
 #define XMEM_INVALID_VIRT_ADD 0
 #define XMEM_IS_INVALID_VADDR(va) ((va) == XMEM_INVALID_VIRT_ADD)

--- a/runtime/lib/transport/rdma/fpga_hwhs/HwhsControllerSession.cpp
+++ b/runtime/lib/transport/rdma/fpga_hwhs/HwhsControllerSession.cpp
@@ -143,7 +143,7 @@ Region HwhsControllerSession::region_alloc(std::uint64_t size, int mem_type, int
     // For case we need to allocate a BRAM on MR
     // we need to allocate a placeholder chunk in PL-DDR
     // and then rebase the MR onto the BRAM PA
-    bool bram_mr = access && (mem_type == XMEM_BRAM);
+    bool bram_mr = access && (mem_type == XMEM_BRAM || mem_type == XMEM_REPLY_BRAM);
     if (bram_mr) {
         r.mr_chunk = umm_.alloc_chunk(ctx, XMEM_PL_DDR, size, size, false);
         RT_FAIL_IF(r.mr_chunk < 0, "xib_umem_alloc_chunk (MR placeholder) failed");
@@ -280,8 +280,9 @@ int HwhsControllerSession::connect(const ConnectInfo &info) {
     // So that the MR is valid before the exchange_keys() call
     std::uint64_t reply_bytes = static_cast<std::uint64_t>(ring_slots_) * stride_;
     MemKind kind = reply_kind_.value_or(MemKind::Ddr);
+    int reply_mem_type = (kind == MemKind::Other) ? XMEM_REPLY_BRAM : mem_type_of(kind);
     reply_ =
-        region_alloc(reply_bytes, mem_type_of(kind),
+        region_alloc(reply_bytes, reply_mem_type,
                      IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_REMOTE_READ);
 
     return kOk;


### PR DESCRIPTION
**Context:**

**Description of the Change:**

Add a memory type `rbram` for allocating reply buffer in dedicated memory of FPGA

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
