### PR TITLE
fix: unify cpu/gpu CoprocessorFn ABI, both return status

### DIFF
--- a/runtime/include/Transport.hpp
+++ b/runtime/include/Transport.hpp
@@ -188,10 +188,11 @@ class ControllerSession : public TransportSession {
 /**
  * @brief Per-message coprocessor function (CPU-style). Invoked once per received
  * message: decode `in` (`in_len` bytes) into `out` (capacity `out_cap`) and
- * return the number of bytes written.
+ * return 0 on success or a nonzero status code on failure. The transport gets
+ * the reply length from the output size configured for the session.
  */
-using CoprocessorFn = std::size_t (*)(const void *in, std::size_t in_len, void *out,
-                                      std::size_t out_cap, void *ctx);
+using CoprocessorFn = int (*)(const void *in, std::size_t in_len, void *out, std::size_t out_cap,
+                              void *ctx);
 
 /**
  * @brief Data description for a persistent engine to receive and consume

--- a/runtime/lib/transport/TransportCAPI.cpp
+++ b/runtime/lib/transport/TransportCAPI.cpp
@@ -143,12 +143,15 @@ int do_exchange_keys(CatalystTransportSession *s) {
 }
 
 // Built-in fallback coprocessor function: echo the input back.
-std::size_t echo_fn(const void *in, std::size_t in_len, void *out, std::size_t out_cap, void *) {
+int echo_fn(const void *in, std::size_t in_len, void *out, std::size_t out_cap, void *) {
+    if ((in_len != 0 && !in) || (out_cap != 0 && !out)) {
+        return 1;
+    }
     std::size_t n = std::min(in_len, out_cap);
-    if (n && in && out) {
+    if (n != 0) {
         std::memcpy(out, in, n);
     }
-    return n;
+    return 0;
 }
 
 // Async task registry: connect_async / exchange_keys_async run on a worker thread and return a

--- a/runtime/lib/transport/common/coproc/cpu/echo_coprocessor_fn.cpp
+++ b/runtime/lib/transport/common/coproc/cpu/echo_coprocessor_fn.cpp
@@ -29,14 +29,16 @@
  * @param out Reply data area.
  * @param out_cap Bytes writable at @p out.
  * @param ctx Unused.
- * @return Bytes written, or 0 if either buffer is missing.
+ * @return 0 on success, nonzero if either buffer is missing.
  */
-extern "C" std::size_t echo_coprocessor(const void *in, std::size_t in_len, void *out,
-                                        std::size_t out_cap, void * /*ctx*/) {
-    if (in == nullptr || out == nullptr || in_len == 0 || out_cap == 0) {
-        return 0;
+extern "C" int echo_coprocessor(const void *in, std::size_t in_len, void *out, std::size_t out_cap,
+                                void * /*ctx*/) {
+    if ((in_len != 0 && in == nullptr) || (out_cap != 0 && out == nullptr)) {
+        return 1;
     }
     const std::size_t n = in_len < out_cap ? in_len : out_cap;
-    std::memcpy(out, in, n);
-    return n;
+    if (n != 0) {
+        std::memcpy(out, in, n);
+    }
+    return 0;
 }

--- a/runtime/lib/transport/common/coproc/cpu/steane_decoder_fn.cpp
+++ b/runtime/lib/transport/common/coproc/cpu/steane_decoder_fn.cpp
@@ -36,8 +36,7 @@ using catalyst::transport::coproc::STEANE_SYNDROME_TO_QUBIT;
  * @param out Buffer for the outbound error qubit index.
  * @param out_cap Capacity of the outbound buffer, in bytes.
  * @param ctx Opaque context (unused).
- * @return Bytes written to @p out, or 0 if the buffers are too small, which the
- *         caller reports as a failed round.
+ * @return 0 on success, nonzero if the buffers are too small.
  *
  * @note `in_len` is the payload capacity rather than the syndrome length, which
  * the wire does not carry; a decoder therefore has to know its own code's check
@@ -47,11 +46,11 @@ using catalyst::transport::coproc::STEANE_SYNDROME_TO_QUBIT;
 // decoder_id (a uint32 at byte offset 8) is not read: the [[7,1,3]] Steane code has
 // Hx == Hz, so one table serves both the X and Z checks. A code whose matrices differ
 // would read that field and switch on it here.
-extern "C" std::size_t steane_coprocessor(const void *in, std::size_t in_len, void *out,
-                                          std::size_t out_cap, void * /*ctx*/) {
+extern "C" int steane_coprocessor(const void *in, std::size_t in_len, void *out,
+                                  std::size_t out_cap, void * /*ctx*/) {
     if (in == nullptr || out == nullptr || in_len < STEANE_CHECKS ||
         out_cap < sizeof(std::int64_t)) {
-        return 0;
+        return 1;
     }
     const auto *checks = static_cast<const std::uint8_t *>(in);
     std::uint32_t syndrome = 0;
@@ -60,5 +59,5 @@ extern "C" std::size_t steane_coprocessor(const void *in, std::size_t in_len, vo
     }
     const std::int64_t err_idx = STEANE_SYNDROME_TO_QUBIT[syndrome];
     std::memcpy(out, &err_idx, sizeof(err_idx));
-    return sizeof(err_idx);
+    return 0;
 }

--- a/runtime/lib/transport/memcpy/MemcpyLink.hpp
+++ b/runtime/lib/transport/memcpy/MemcpyLink.hpp
@@ -42,12 +42,10 @@ struct MemcpyLink {
     // and CAPI Invoked once per controller kick(). Reads `in_len` bytes from `in` (a wire-shaped
     // `common::Payload` frame synthesized by the controller: value bytes at offset 0,
     // decoder_id at offset PAYLOAD_DATA_BYTES, seq_num right after), writes at most
-    // `out_cap` bytes into `out`, and returns the number of bytes actually written. A
-    // return value greater than `out_cap` means the fn overran the caller's buffer.
-    // Signature mirrors `CoprocessorFn` (Transport.hpp) minus the `ctx` slot; decoder_id
-    // travels inside `in` as it does over cpu_verbs.
-    using ProcessMessage = std::function<std::size_t(const void *in, std::size_t in_len, void *out,
-                                                     std::size_t out_cap)>;
+    // `out_cap` bytes into `out`, and returns 0 on success or a nonzero status on failure.
+    // decoder_id travels inside `in` as it does over cpu_verbs.
+    using ProcessMessage =
+        std::function<int(const void *in, std::size_t in_len, void *out, std::size_t out_cap)>;
 
     std::mutex mu;
     // Duplicate-binding sentinels: connect() throws if the field for its role is already set,

--- a/runtime/lib/transport/memcpy/cpu_controller/CpuControllerSession.cpp
+++ b/runtime/lib/transport/memcpy/cpu_controller/CpuControllerSession.cpp
@@ -129,16 +129,18 @@ int CpuControllerSession::kick(std::uint32_t work_item_idx) {
     frame.seq_num = static_cast<std::uint32_t>(next_send_ + 1);
     ++next_send_;
 
-    std::size_t reply_bytes = 0;
+    int status = 0;
     {
         // Held across check and call so teardown can't clear process_message mid-call.
         std::lock_guard<std::mutex> lock(link_->mu);
         TP_CHECK(link_->process_message, "No paired coprocessor");
-        reply_bytes = link_->process_message(&frame, sizeof(frame), local_reply_.addr,
-                                             static_cast<std::size_t>(out_bytes_));
+        status = link_->process_message(&frame, sizeof(frame), local_reply_.addr,
+                                        static_cast<std::size_t>(out_bytes_));
     }
-    reply_bytes_ = static_cast<std::uint64_t>(reply_bytes);
-    return 0;
+    if (status == 0) {
+        reply_bytes_ = out_bytes_;
+    }
+    return status;
 }
 
 void *CpuControllerSession::data_slot() {

--- a/runtime/lib/transport/memcpy/cpu_coprocessor/CpuCoprocessorSession.cpp
+++ b/runtime/lib/transport/memcpy/cpu_coprocessor/CpuCoprocessorSession.cpp
@@ -23,12 +23,15 @@
 namespace catalyst::transport::memcpy {
 namespace {
 
-std::size_t echo_fn(const void *in, std::size_t in_len, void *out, std::size_t out_cap, void *) {
+int echo_fn(const void *in, std::size_t in_len, void *out, std::size_t out_cap, void *) {
+    if ((in_len != 0 && !in) || (out_cap != 0 && !out)) {
+        return 1;
+    }
     const std::size_t n = std::min(in_len, out_cap);
-    if (n != 0 && in && out) {
+    if (n != 0) {
         std::memcpy(out, in, n);
     }
-    return n;
+    return 0;
 }
 
 } // namespace
@@ -148,16 +151,16 @@ void CpuCoprocessorSession::run(std::stop_token st) {
         out.p.value = 0;
         out.p.decoder_id = request_ring_[idx].p.decoder_id;
         CoprocessorFn fn = fn_ ? fn_ : &echo_fn;
-        const std::size_t nb = fn(&request_ring_[idx].p, sizeof(common::Payload), &out.p.value,
-                                  common::PAYLOAD_DATA_BYTES, ctx_);
-        TP_CHECK(nb <= common::PAYLOAD_DATA_BYTES, "Coprocessor fn overran reply");
+        const int status = fn(&request_ring_[idx].p, sizeof(common::Payload), &out.p.value,
+                              common::PAYLOAD_DATA_BYTES, ctx_);
+        TP_CHECK(status == 0, "Coprocessor fn returned nonzero status");
         std::atomic_thread_fence(std::memory_order_release);
         out.p.seq_num = expect; // publish
     }
 }
 
-std::size_t CpuCoprocessorSession::process_message(const void *in, std::size_t in_len, void *out,
-                                                   std::size_t out_cap) {
+int CpuCoprocessorSession::process_message(const void *in, std::size_t in_len, void *out,
+                                           std::size_t out_cap) {
     TP_CHECK(in_len == sizeof(common::Payload), "Expected one wire-shaped Payload");
     TP_CHECK(engine_.joinable(), "Call start() before process_message");
     if (failed_.load(std::memory_order_acquire)) {
@@ -186,7 +189,7 @@ std::size_t CpuCoprocessorSession::process_message(const void *in, std::size_t i
     if (n != 0 && out) {
         std::memcpy(out, &reply_ring_[idx].p.value, n);
     }
-    return n;
+    return 0;
 }
 
 } // namespace catalyst::transport::memcpy

--- a/runtime/lib/transport/memcpy/cpu_coprocessor/CpuCoprocessorSession.hpp
+++ b/runtime/lib/transport/memcpy/cpu_coprocessor/CpuCoprocessorSession.hpp
@@ -55,7 +55,7 @@ class CpuCoprocessorSession : public CoprocessorSession {
     void set_coprocessor_fn(CoprocessorFn fn, void *ctx) override;
 
     // Invoked inline from the controller's kick(). See MemcpyLink::ProcessMessage.
-    std::size_t process_message(const void *in, std::size_t in_len, void *out, std::size_t out_cap);
+    int process_message(const void *in, std::size_t in_len, void *out, std::size_t out_cap);
 
   private:
     // The worker loop; runs on engine_.

--- a/runtime/lib/transport/memcpy/gpu_coprocessor/GpuCoprocessorSession.cpp
+++ b/runtime/lib/transport/memcpy/gpu_coprocessor/GpuCoprocessorSession.cpp
@@ -192,8 +192,8 @@ void GpuCoprocessorSession::set_coprocessor_launcher(CoprocessorLauncherFn fn, v
     launcher_ctx_ = ctx;
 }
 
-std::size_t GpuCoprocessorSession::process_message(const void *in, std::size_t in_len, void *out,
-                                                   std::size_t out_cap) {
+int GpuCoprocessorSession::process_message(const void *in, std::size_t in_len, void *out,
+                                           std::size_t out_cap) {
     TP_CHECK(in_len == sizeof(common::Payload), "Expected one wire-shaped Payload");
     TP_CHECK(out_cap >= sizeof(std::int64_t), "Reply buffer too small for GPU correction");
     TP_CHECK(kernel_running_, "Call start() before process_message");
@@ -223,7 +223,7 @@ std::size_t GpuCoprocessorSession::process_message(const void *in, std::size_t i
     std::int64_t correction = 0;
     std::memcpy(&correction, &reply_ring_[idx].p.value, sizeof(correction));
     std::memcpy(out, &correction, sizeof(correction));
-    return sizeof(correction);
+    return 0;
 }
 
 } // namespace catalyst::transport::memcpy

--- a/runtime/lib/transport/memcpy/gpu_coprocessor/GpuCoprocessorSession.hpp
+++ b/runtime/lib/transport/memcpy/gpu_coprocessor/GpuCoprocessorSession.hpp
@@ -64,7 +64,7 @@ class GpuCoprocessorSession : public CoprocessorSession {
     // Expects `in_len == sizeof(common::Payload)` (16, a wire-shaped frame) and
     // `out_cap >= sizeof(int64_t)`; the reply is always `sizeof(int64_t)` bytes.
     // Anything else throws.
-    std::size_t process_message(const void *in, std::size_t in_len, void *out, std::size_t out_cap);
+    int process_message(const void *in, std::size_t in_len, void *out, std::size_t out_cap);
 
   private:
     void ensure_gpu_state();

--- a/runtime/lib/transport/rdma/cpu_verbs/coprocessor/CpuCoprocessorSession.cpp
+++ b/runtime/lib/transport/rdma/cpu_verbs/coprocessor/CpuCoprocessorSession.cpp
@@ -103,11 +103,9 @@ void CpuCoprocessorSession::run(std::stop_token st) {
         send->value = 0;
         send->decoder_id = r->decoder_id;
         if (coproc_fn_) {
-            const std::size_t nb =
+            const int status =
                 coproc_fn_(r, sizeof(Payload), &send->value, PAYLOAD_DATA_BYTES, coproc_ctx_);
-            TP_CHECK(nb > 0 && nb <= PAYLOAD_DATA_BYTES,
-                     "coprocessor function wrote %zu bytes, expected 1..%zu", nb,
-                     PAYLOAD_DATA_BYTES);
+            TP_CHECK(status == 0, "coprocessor function returned nonzero status %d", status);
         } else {
             send->value = r->value; // built-in echo
         }

--- a/runtime/tests/Test_TransportCpuVerbs.cpp
+++ b/runtime/tests/Test_TransportCpuVerbs.cpp
@@ -46,14 +46,14 @@ static bool have_rxe() {
 
 // A custom coprocessor function (bitwise-invert) to exercise the set_coprocessor_fn
 // path with a non-null, non-echo function.
-static std::size_t invert_fn(const void *in, std::size_t in_len, void *out, std::size_t out_cap,
-                             void * /*ctx*/) {
+static int invert_fn(const void *in, std::size_t in_len, void *out, std::size_t out_cap,
+                     void * /*ctx*/) {
     std::uint64_t v = 0;
     std::memcpy(&v, in, std::min(in_len, sizeof(v)));
     v = ~v;
     const std::size_t n = std::min(out_cap, sizeof(v));
     std::memcpy(out, &v, n);
-    return n;
+    return 0;
 }
 
 TEST_CASE("controller and coprocessor connect: both reach INIT and open the "

--- a/runtime/tests/Test_TransportCpuVerbs.cpp
+++ b/runtime/tests/Test_TransportCpuVerbs.cpp
@@ -57,9 +57,7 @@ static int invert_fn(const void *in, std::size_t in_len, void *out, std::size_t 
     return 0;
 }
 
-static int failing_fn(const void *, std::size_t, void *, std::size_t, void * /*ctx*/) {
-    return 1;
-}
+static int failing_fn(const void *, std::size_t, void *, std::size_t, void * /*ctx*/) { return 1; }
 
 TEST_CASE("controller and coprocessor connect: both reach INIT and open the "
           "OOB channel",
@@ -241,8 +239,7 @@ TEST_CASE("round-trip with a custom coprocessor function runs on the coprocessor
     REQUIRE(got != DEMO_SYNDROME);  // and it is not a mere echo
 }
 
-TEST_CASE("cpu_verbs treats the coprocessor return value as a status code",
-          "[cpu_libibverbs]") {
+TEST_CASE("cpu_verbs treats the coprocessor return value as a status code", "[cpu_libibverbs]") {
     if (!have_rxe()) {
         SKIP("no rxe0 RDMA device");
     }

--- a/runtime/tests/Test_TransportCpuVerbs.cpp
+++ b/runtime/tests/Test_TransportCpuVerbs.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <exception>
 #include <string>
 #include <thread>
 
@@ -54,6 +55,10 @@ static int invert_fn(const void *in, std::size_t in_len, void *out, std::size_t 
     const std::size_t n = std::min(out_cap, sizeof(v));
     std::memcpy(out, &v, n);
     return 0;
+}
+
+static int failing_fn(const void *, std::size_t, void *, std::size_t, void * /*ctx*/) {
+    return 1;
 }
 
 TEST_CASE("controller and coprocessor connect: both reach INIT and open the "
@@ -234,4 +239,61 @@ TEST_CASE("round-trip with a custom coprocessor function runs on the coprocessor
 
     REQUIRE(got == ~DEMO_SYNDROME); // controller received the coprocessor's result
     REQUIRE(got != DEMO_SYNDROME);  // and it is not a mere echo
+}
+
+TEST_CASE("cpu_verbs treats the coprocessor return value as a status code",
+          "[cpu_libibverbs]") {
+    if (!have_rxe()) {
+        SKIP("no rxe0 RDMA device");
+    }
+    const std::uint16_t port = 18596;
+    const std::size_t SIZE = REGION_BYTES;
+    bool coproc_failed = false;
+    std::string coproc_error;
+
+    std::thread t([&] {
+        try {
+            CpuCoprocessorSession coproc("rxe0", 1);
+            ConnectInfo ci{
+                .peer = "127.0.0.1",
+                .oob_port = port,
+            };
+            coproc.connect(ci);
+            MemRegion m = coproc.alloc_memory(SIZE, MemKind::CpuRam);
+            PeerRef p = coproc.exchange_keys(m);
+            ChannelDesc desc{
+                .transport = "rdma",
+            };
+            coproc.establish_channel(desc, m, p);
+            coproc.set_coprocessor_fn(failing_fn, nullptr);
+            coproc.start();
+            coproc.collect(nullptr, nullptr, 0);
+        } catch (const std::exception &e) {
+            coproc_failed = true;
+            coproc_error = e.what();
+        }
+    });
+
+    CpuControllerSession controller("rxe0", 1);
+    ConnectInfo ci{
+        .peer = "127.0.0.1",
+        .oob_port = port,
+    };
+    controller.connect(ci);
+    MemRegion m = controller.alloc_memory(SIZE, MemKind::CpuRam);
+    PeerRef p = controller.exchange_keys(m);
+    ChannelDesc desc{
+        .transport = "rdma",
+    };
+    controller.establish_channel(desc, m, p);
+    controller.commit_work_item(0, sizeof(std::uint64_t), sizeof(std::uint64_t));
+    controller.start();
+    const std::uint64_t syndrome = DEMO_SYNDROME;
+    controller.write_data_slot(&syndrome, sizeof(syndrome), 0);
+    REQUIRE(controller.kick(0) == 0);
+    controller.stop();
+    t.join();
+
+    REQUIRE(coproc_failed);
+    CHECK(coproc_error.find("status 1") != std::string::npos);
 }

--- a/runtime/tests/Test_TransportMemcpyCpu.cpp
+++ b/runtime/tests/Test_TransportMemcpyCpu.cpp
@@ -28,8 +28,8 @@ using namespace catalyst::transport::memcpy;
 
 // Provided by libsteane_coprocessor_cpu — the same CoprocessorFn plugin production
 // dlopens. Linking it in lets the test exercise a real decoder end-to-end.
-extern "C" std::size_t steane_coprocessor(const void *in, std::size_t in_len, void *out,
-                                          std::size_t out_cap, void *ctx);
+extern "C" int steane_coprocessor(const void *in, std::size_t in_len, void *out,
+                                  std::size_t out_cap, void *ctx);
 
 namespace {
 // Per-test pair keys. Matching keys between the controller and its paired coprocessor is what
@@ -37,15 +37,16 @@ namespace {
 // compile time as the `key` attribute on each transport.create.
 std::string pair_cfg(std::uint16_t port) { return "pair=p" + std::to_string(port); }
 
-std::size_t invert_fn(const void *in, std::size_t in_len, void *out, std::size_t out_cap,
-                      void * /*ctx*/) {
+int invert_fn(const void *in, std::size_t in_len, void *out, std::size_t out_cap, void * /*ctx*/) {
     std::uint64_t v = 0;
     std::memcpy(&v, in, std::min(in_len, sizeof(v)));
     v = ~v;
     const std::size_t n = std::min(out_cap, sizeof(v));
     std::memcpy(out, &v, n);
-    return n;
+    return 0;
 }
+
+int failing_fn(const void *, std::size_t, void *, std::size_t, void *) { return 1; }
 } // namespace
 
 TEST_CASE("memcpy round-trip echoes through peer memory", "[transport_memcpy]") {
@@ -116,6 +117,17 @@ TEST_CASE("memcpy uses the bound coprocessor function", "[transport_memcpy]") {
     REQUIRE(controller.collect(outs, out_bytes, 1) == 0);
 
     CHECK(reply_word == ~request_word);
+}
+
+TEST_CASE("memcpy treats the coprocessor return value as a status code", "[transport_memcpy]") {
+    CpuCoprocessorSession coprocessor("pair=status-code");
+    coprocessor.set_coprocessor_fn(failing_fn, nullptr);
+    coprocessor.start();
+
+    common::Payload request{};
+    std::uint64_t reply = 0;
+    REQUIRE_THROWS_AS(coprocessor.process_message(&request, sizeof(request), &reply, sizeof(reply)),
+                      std::runtime_error);
 }
 
 TEST_CASE("memcpy round-trip drives the steane decoder plugin", "[transport_memcpy]") {


### PR DESCRIPTION
## Summary

Rebases @kszenes's #3128 onto ``main``. Original PR was closed and had conflicts against a moving base; this reapplies the three commits (``fix: unifiy cpu/gpu ABI, both return status code`` / ``test: add coproc_fn ABI incompatibility CPU test`` / ``chore: format project``) with conflicts resolved.

Change: unifies the ``CoprocessorFn`` ABI across CPU and GPU. It now returns ``int`` (0 on success, nonzero status on failure) instead of ``std::size_t`` (bytes written). The reply length is taken from the session's configured output size rather than the return value, matching the GPU path's existing behavior.

Files touched: 13 under ``runtime/`` (Transport.hpp, TransportCAPI, memcpy + rdma sessions, coproc fns, tests).

## Conflict resolution notes

Four sessions had conflicts on ``main``:
- ``memcpy/cpu_controller/CpuControllerSession.cpp``
- ``memcpy/cpu_coprocessor/CpuCoprocessorSession.cpp``
- ``memcpy/gpu_coprocessor/GpuCoprocessorSession.cpp``
- ``rdma/cpu_verbs/coprocessor/CpuCoprocessorSession.cpp``

Resolved by keeping the ABI change (return ``int`` status, drop ``std::size_t`` byte-count reads) while retaining ``main``'s existing ``TP_CHECK`` / message conventions in place of the incoming ``throw std::runtime_error`` / ``RDMA_CHECK`` idioms (``RDMA_CHECK`` is not defined in this tree; the transport uses ``TP_CHECK`` throughout).

## Test plan

- [ ] ``make -C runtime test`` — the memcpy + cpu_verbs + gpu_coprocessor sessions link and their existing unit tests pass.
- [ ] New ``Test_TransportCpuVerbs.cpp`` ABI-incompatibility case (added by @kszenes) passes.
- [ ] ``Test_TransportMemcpyCpu.cpp`` additions pass.
- [ ] Check-Catalyst transport paths on this PR run cleanly.

Credit to @kszenes for the original change.