### PR TITLE
[CI] Migrate lit configs to lit's internal shell

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -498,12 +498,6 @@
 
 <h3>Internal changes ⚙️</h3>
 
-* The lit test configurations now use lit's internal shell (`execute_external=False`) instead of the
-  external shell. External shell execution is deprecated as of LLVM 23 and will be removed in LLVM 24,
-  where the previous `ShTest(True)` configuration raises an error and prevents the lit suites from
-  running.
-  [(#XXXX)](https://github.com/PennyLaneAI/catalyst/pull/XXXX)
-
 * A GPU CI workflow runs the runtime transport tests on the `single-gpu-x64` runner, gated by
   the `gpu` label.
   [(#3113)](https://github.com/PennyLaneAI/catalyst/pull/3113)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -498,6 +498,12 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* The lit test configurations now use lit's internal shell (`execute_external=False`) instead of the
+  external shell. External shell execution is deprecated as of LLVM 23 and will be removed in LLVM 24,
+  where the previous `ShTest(True)` configuration raises an error and prevents the lit suites from
+  running.
+  [(#XXXX)](https://github.com/PennyLaneAI/catalyst/pull/XXXX)
+
 * A GPU CI workflow runs the runtime transport tests on the `single-gpu-x64` runner, gated by
   the `gpu` label.
   [(#3113)](https://github.com/PennyLaneAI/catalyst/pull/3113)

--- a/frontend/test/lit/lit.cfg.py
+++ b/frontend/test/lit/lit.cfg.py
@@ -19,7 +19,7 @@ import lit.formats
 from lit.llvm import llvm_config
 
 config.name = "Frontend Tests"
-config.test_format = lit.formats.ShTest(True)
+config.test_format = lit.formats.ShTest(execute_external=False)
 
 # Define the file extensions to treat as test files (with the exception of this file).
 config.suffixes = [".py", ".mlir"]

--- a/frontend/test/lit/lit.cfg.py
+++ b/frontend/test/lit/lit.cfg.py
@@ -19,7 +19,7 @@ import lit.formats
 from lit.llvm import llvm_config
 
 config.name = "Frontend Tests"
-config.test_format = lit.formats.ShTest(execute_external=False)
+config.test_format = lit.formats.ShTest()
 
 # Define the file extensions to treat as test files (with the exception of this file).
 config.suffixes = [".py", ".mlir"]

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -5,7 +5,7 @@ import lit.formats
 from lit.llvm import llvm_config
 
 config.name = "Compiler test suite"
-config.test_format = lit.formats.ShTest(True)
+config.test_format = lit.formats.ShTest(execute_external=False)
 
 # Define the file extensions to treat as test files.
 config.suffixes = [".mlir", ".py"]

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -5,7 +5,7 @@ import lit.formats
 from lit.llvm import llvm_config
 
 config.name = "Compiler test suite"
-config.test_format = lit.formats.ShTest(execute_external=False)
+config.test_format = lit.formats.ShTest()
 
 # Define the file extensions to treat as test files.
 config.suffixes = [".mlir", ".py"]


### PR DESCRIPTION
External shell execution (`ShTest(execute_external=True)`) is deprecated as of LLVM 23 and removed in LLVM 24. With the newer lit installed in CI, the previous `ShTest(True)` raises a ValueError at config-load time, which prevents the frontend and MLIR lit suites from running at all.

Switch both lit configurations to the internal shell (`execute_external=False`), the LLVM-recommended migration path.

