### PR TITLE
[CI] Pin `lit` version

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -499,8 +499,7 @@
 <h3>Internal changes ⚙️</h3>
 
 * The `lit` test runner is now pinned to `lit<23` in `requirements.txt`. Starting with LLVM 23,
-  `lit` makes `ShTest(execute_external=True)` a fatal error, which prevented our lit suites from
-  running at all. Pinning keeps `lit` compatible with our LLVM 22 toolchain.
+  `lit` deprecates `ShTest(execute_external=True)`, which prevented our lit suites from running.
   [(#3154)](https://github.com/PennyLaneAI/catalyst/pull/3154)
 
 * A GPU CI workflow runs the runtime transport tests on the `single-gpu-x64` runner, gated by

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -501,7 +501,7 @@
 * The `lit` test runner is now pinned to `lit<23` in `requirements.txt`. Starting with LLVM 23,
   `lit` makes `ShTest(execute_external=True)` a fatal error, which prevented our lit suites from
   running at all. Pinning keeps `lit` compatible with our LLVM 22 toolchain.
-  [(#XXXX)](https://github.com/PennyLaneAI/catalyst/pull/XXXX)
+  [(#3154)](https://github.com/PennyLaneAI/catalyst/pull/3154)
 
 * A GPU CI workflow runs the runtime transport tests on the `single-gpu-x64` runner, gated by
   the `gpu` label.
@@ -719,5 +719,6 @@ Mehrdad Malekmohammadi,
 River McCubbin,
 Shuli Shu,
 Paul Haochen Wang,
+David Wierichs,
 Jake Zaia,
 Hongsheng Zheng.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -498,6 +498,11 @@
 
 <h3>Internal changes ⚙️</h3>
 
+* The `lit` test runner is now pinned to `lit<23` in `requirements.txt`. Starting with LLVM 23,
+  `lit` makes `ShTest(execute_external=True)` a fatal error, which prevented our lit suites from
+  running at all. Pinning keeps `lit` compatible with our LLVM 22 toolchain.
+  [(#XXXX)](https://github.com/PennyLaneAI/catalyst/pull/XXXX)
+
 * A GPU CI workflow runs the runtime transport tests on the `single-gpu-x64` runner, gated by
   the `gpu` label.
   [(#3113)](https://github.com/PennyLaneAI/catalyst/pull/3113)

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,9 @@ isort~=7.0.0
 
 # testing
 flaky
-lit
+# Pin below LLVM 23: lit>=23 makes `ShTest(execute_external=True)` a fatal error, which our lit
+# configs rely on. Our LLVM toolchain is v22, so keep lit compatible with it.
+lit<23
 pytest
 pytest-xdist
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,8 +26,8 @@ isort~=7.0.0
 
 # testing
 flaky
-# Pin below LLVM 23: lit>=23 makes `ShTest(execute_external=True)` a fatal error, which our lit
-# configs rely on. Our LLVM toolchain is v22, so keep lit compatible with it.
+# Pin below LLVM 23: lit>=23 makes `ShTest(execute_external=True)` an error, which our lit
+# configs rely on.
 lit<23
 pytest
 pytest-xdist


### PR DESCRIPTION
**Context:**
New `lit` release deprecates `execute_external=True`, we use that currently.

**Description of the Change:**
Pin the `lit` version to `<23` until we move to internal shell or sort things out in a different way.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
#3153 tries to move to the internal shell alternatively.