### PR TITLE
Support Qubits Crossing SCF Boundaries in Decompose-Lowering

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -113,6 +113,7 @@
     [(#2973)](https://github.com/PennyLaneAI/catalyst/pull/2973)
     [(#2836)](https://github.com/PennyLaneAI/catalyst/pull/2836)
     [(#2855)](https://github.com/PennyLaneAI/catalyst/pull/2855)
+    [(#3156)](https://github.com/PennyLaneAI/catalyst/pull/3156)
 
     1. The pass now supports applying a selection of the available decomposition rules via the `target_rules` parameter.
 
@@ -126,6 +127,8 @@
 
     5. The pass can now handle null decomposition rules, which are rule functions that do not have any quantum values as arguments or results.
     Gates with null decomposition rules are simply removed.
+
+    6. The pass can now handle register-mode rules that target gates in control flow regions whose qubits were extracted outside the region.
 
 * A failure during AOT compilation is now downgraded to a warning and logged.
   [(#3100)](https://github.com/PennyLaneAI/catalyst/pull/3100)

--- a/mlir/include/Quantum/Utils/QubitIndex.h
+++ b/mlir/include/Quantum/Utils/QubitIndex.h
@@ -84,6 +84,17 @@ class QubitIndex {
     }
 };
 
+template <typename OperandRangeT, typename ResultRangeT>
+static mlir::Value getMappedQubitOperand(mlir::Value qubit, const OperandRangeT qubitOperands,
+                                         const ResultRangeT qubitResults) {
+    auto it = llvm::find_if(qubitResults, [&](mlir::Value result) { return result == qubit; });
+
+    assert(it != qubitResults.end());
+    size_t resultIndex = std::distance(qubitResults.begin(), it);
+    assert(resultIndex < qubitOperands.size());
+    return qubitOperands[resultIndex];
+}
+
 /// Trace a qubit SSA value back to the quantum.extract that produced it and
 /// return the corresponding QubitIndex (with the originating qreg).
 ///
@@ -107,32 +118,39 @@ inline QubitIndex getExtractIndex(mlir::Value qubit) {
         }
 
         if (auto gate = mlir::dyn_cast_or_null<quantum::QuantumGate>(qubit.getDefiningOp())) {
-            auto qubitOperands = gate.getQubitOperands();
-            auto qubitResults = gate.getQubitResults();
-            auto it =
-                llvm::find_if(qubitResults, [&](mlir::Value result) { return result == qubit; });
-
-            if (it != qubitResults.end()) {
-                size_t resultIndex = std::distance(qubitResults.begin(), it);
-                if (resultIndex < qubitOperands.size()) {
-                    qubit = qubitOperands[resultIndex];
-                    continue;
-                }
-            }
+            qubit = getMappedQubitOperand(qubit, gate.getQubitOperands(), gate.getQubitResults());
+            continue;
         } else if (auto measureOp =
                        mlir::dyn_cast_or_null<quantum::MeasureOp>(qubit.getDefiningOp())) {
             qubit = measureOp.getInQubit();
             continue;
+        } else if (auto ifOp = mlir::dyn_cast_or_null<mlir::scf::IfOp>(qubit.getDefiningOp())) {
+            qubit = getMappedQubitOperand(qubit, ifOp.thenYield().getResults(), ifOp.getResults());
+            continue;
+        } else if (auto forOp = mlir::dyn_cast_or_null<mlir::scf::ForOp>(qubit.getDefiningOp())) {
+            qubit = getMappedQubitOperand(qubit, forOp.getInitArgs(), forOp.getResults());
+            continue;
+        } else if (auto whileOp =
+                       mlir::dyn_cast_or_null<mlir::scf::WhileOp>(qubit.getDefiningOp())) {
+            qubit = getMappedQubitOperand(qubit, whileOp.getConditionOp().getArgs(),
+                                          whileOp.getResults());
+            continue;
         } else if (auto blockArg = mlir::dyn_cast_or_null<mlir::BlockArgument>(qubit)) {
+            unsigned int blockArgIdx = blockArg.getArgNumber();
             if (auto forOp =
                     mlir::dyn_cast_or_null<mlir::scf::ForOp>(blockArg.getOwner()->getParentOp())) {
                 // ForOp Regions (and blocks) have args (iter_arg, *init_args), so the index is
                 // off-by-one
-                qubit = forOp.getInitArgs()[blockArg.getArgNumber() - 1];
+                qubit = forOp.getInitArgs()[blockArgIdx - 1];
                 continue;
             } else if (auto whileOp = mlir::dyn_cast_or_null<mlir::scf::WhileOp>(
                            blockArg.getOwner()->getParentOp())) {
-                qubit = whileOp.getInits()[blockArg.getArgNumber()];
+                mlir::Block *b = blockArg.getOwner();
+                if (b == whileOp.getBeforeBody()) {
+                    qubit = whileOp.getInits()[blockArgIdx];
+                } else if (b == whileOp.getAfterBody()) {
+                    qubit = whileOp.getConditionOp().getArgs()[blockArgIdx];
+                }
                 continue;
             }
         }

--- a/mlir/include/Quantum/Utils/QubitIndex.h
+++ b/mlir/include/Quantum/Utils/QubitIndex.h
@@ -130,6 +130,10 @@ inline QubitIndex getExtractIndex(mlir::Value qubit) {
                 // off-by-one
                 qubit = forOp.getInitArgs()[blockArg.getArgNumber() - 1];
                 continue;
+            } else if (auto whileOp = mlir::dyn_cast_or_null<mlir::scf::WhileOp>(
+                           blockArg.getOwner()->getParentOp())) {
+                qubit = whileOp.getInits()[blockArg.getArgNumber()];
+                continue;
             }
         }
 

--- a/mlir/include/Quantum/Utils/QubitIndex.h
+++ b/mlir/include/Quantum/Utils/QubitIndex.h
@@ -14,11 +14,15 @@
 
 #pragma once
 
+#include <cstddef>
+#include <iterator>
 #include <variant>
 
 #include "llvm/ADT/STLExtras.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
 
 #include "Quantum/IR/QuantumInterfaces.h"
 #include "Quantum/IR/QuantumOps.h"
@@ -119,6 +123,14 @@ inline QubitIndex getExtractIndex(mlir::Value qubit) {
                        mlir::dyn_cast_or_null<quantum::MeasureOp>(qubit.getDefiningOp())) {
             qubit = measureOp.getInQubit();
             continue;
+        } else if (auto blockArg = mlir::dyn_cast_or_null<mlir::BlockArgument>(qubit)) {
+            if (auto forOp =
+                    mlir::dyn_cast_or_null<mlir::scf::ForOp>(blockArg.getOwner()->getParentOp())) {
+                // ForOp Regions (and blocks) have args (iter_arg, *init_args), so the index is
+                // off-by-one
+                qubit = forOp.getInitArgs()[blockArg.getArgNumber() - 1];
+                continue;
+            }
         }
 
         break;

--- a/mlir/test/Quantum/DecomposeLoweringTest.mlir
+++ b/mlir/test/Quantum/DecomposeLoweringTest.mlir
@@ -817,7 +817,7 @@ module @different_qreg_values{
 
 // -----
 
-// CHECK-LABEL module @test_if
+// CHECK-LABEL: module @test_if
 
 module @test_if {
   func.func @circuit() -> !quantum.bit {

--- a/mlir/test/Quantum/DecomposeLoweringTest.mlir
+++ b/mlir/test/Quantum/DecomposeLoweringTest.mlir
@@ -814,3 +814,117 @@ module @different_qreg_values{
     return %7 : !quantum.reg
   }
 }
+
+// -----
+
+// CHECK-LABEL module @test_if
+
+module @test_if {
+  func.func @circuit() -> !quantum.bit {
+    %reg = quantum.alloc( 2) : !quantum.reg
+    %in = quantum.extract %reg[0]  : !quantum.reg -> !quantum.bit
+
+    %init_index = arith.constant 1 : index
+    %true = arith.constant 1 : i1 
+    %limit = arith.constant 10 : index
+
+    %out = scf.if %true -> !quantum.bit {
+      // CHECK-NOT: "T"
+      // CHECK: "PhaseShift"
+      %if_out = quantum.custom "T"() %in : !quantum.bit
+      scf.yield %if_out : !quantum.bit
+    } else {
+      scf.yield %in : !quantum.bit
+    }
+
+    return %out : !quantum.bit
+  }
+
+  func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"(%arg0: tensor<1xi64>, %arg1: !quantum.reg) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, resources = {operations = {"PhaseShift{0:[f64]}{wires:1}{}" = 1 : i64}}, target_gate = "T{}{wires:1}{}"} {
+    %cst = arith.constant 0.78539816339744828 : f64
+    %0 = stablehlo.slice %arg0 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
+    %1 = stablehlo.reshape %0 : (tensor<1xi64>) -> tensor<i64>
+    %extracted = tensor.extract %1[] : tensor<i64>
+    %2 = quantum.extract %arg1[%extracted] : !quantum.reg -> !quantum.bit
+    %out_qubits = quantum.custom "PhaseShift"(%cst) %2 : !quantum.bit
+    %3 = quantum.insert %arg1[%extracted], %out_qubits : !quantum.reg, !quantum.bit
+    return %3 : !quantum.reg
+  }
+}
+
+// -----
+
+// CHECK-LABEL: module @test_for_loop
+
+module @test_for_loop {
+  func.func @circuit() -> !quantum.bit {
+    %reg = quantum.alloc( 2) : !quantum.reg
+    %in = quantum.extract %reg[0]  : !quantum.reg -> !quantum.bit
+
+    %cond = arith.constant 1 : i1
+
+    %start = arith.constant 0 : index
+    %end = arith.constant 10 : index
+    %step = arith.constant 1 : index
+
+    %rout = scf.for %iter = %start to %end step %step iter_args(%for_in = %in) -> (!quantum.bit) {
+      // CHECK-NOT: "T"
+      // CHECK: "PhaseShift"
+      %out = quantum.custom "T"() %for_in : !quantum.bit
+      scf.yield %out : !quantum.bit
+    }
+
+    return %rout : !quantum.bit
+  }
+
+  func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"(%arg0: tensor<1xi64>, %arg1: !quantum.reg) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>,  target_gate = "T{}{wires:1}{}"} {
+    %cst = arith.constant 0.78539816339744828 : f64
+    %0 = stablehlo.slice %arg0 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
+    %1 = stablehlo.reshape %0 : (tensor<1xi64>) -> tensor<i64>
+    %extracted = tensor.extract %1[] : tensor<i64>
+    %2 = quantum.extract %arg1[%extracted] : !quantum.reg -> !quantum.bit
+    %out_qubits = quantum.custom "PhaseShift"(%cst) %2 : !quantum.bit
+    %3 = quantum.insert %arg1[%extracted], %out_qubits : !quantum.reg, !quantum.bit
+    return %3 : !quantum.reg
+  }
+}
+
+// -----
+
+// CHECK-LABEL: module @test_while_loop
+module @test_while_loop {
+  func.func @circuit() -> !quantum.bit {
+    %reg = quantum.alloc( 2) : !quantum.reg
+    %in = quantum.extract %reg[0]  : !quantum.reg -> !quantum.bit
+
+    %init_index = arith.constant 1 : index
+    %true = arith.constant 1 : i1 
+    %limit = arith.constant 10 : index
+
+    %out_index, %rout = scf.while (%before_index = %init_index, %before_qubit = %in) : (index, !quantum.bit) -> (index, !quantum.bit) {
+      // CHECK-NOT: "T"
+      // CHECK: "PhaseShift"
+      %out = quantum.custom "T"() %in: !quantum.bit
+      %increment = arith.constant 1 : index
+      %updated_index = index.add %before_index, %increment
+      %condition = index.cmp ult (%updated_index, %limit) 
+      scf.condition(%condition) %updated_index, %out: index, !quantum.bit
+    } do {
+      ^bb0(%after_index: index, %after_qubit : !quantum.bit):
+        scf.yield %after_index, %after_qubit : index, !quantum.bit
+    }
+
+    return %rout : !quantum.bit
+  }
+
+  func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"(%arg0: tensor<1xi64>, %arg1: !quantum.reg) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, resources = {operations = {"PhaseShift{0:[f64]}{wires:1}{}" = 1 : i64}}, target_gate = "T{}{wires:1}{}"} {
+    %cst = arith.constant 0.78539816339744828 : f64
+    %0 = stablehlo.slice %arg0 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
+    %1 = stablehlo.reshape %0 : (tensor<1xi64>) -> tensor<i64>
+    %extracted = tensor.extract %1[] : tensor<i64>
+    %2 = quantum.extract %arg1[%extracted] : !quantum.reg -> !quantum.bit
+    %out_qubits = quantum.custom "PhaseShift"(%cst) %2 : !quantum.bit
+    %3 = quantum.insert %arg1[%extracted], %out_qubits : !quantum.reg, !quantum.bit
+    return %3 : !quantum.reg
+  }
+}

--- a/mlir/test/Quantum/DecomposeLoweringTest.mlir
+++ b/mlir/test/Quantum/DecomposeLoweringTest.mlir
@@ -906,7 +906,7 @@ module @test_while_loop {
     %out_index, %rout = scf.while (%before_index = %init_index, %before_qubit = %in) : (index, !quantum.bit) -> (index, !quantum.bit) {
       // CHECK-NOT: "T"
       // CHECK: "PhaseShift"
-      %out = quantum.custom "T"() %in: !quantum.bit
+      %out = quantum.custom "T"() %before_qubit: !quantum.bit
       %increment = arith.constant 1 : index
       %updated_index = index.add %before_index, %increment
       %condition = index.cmp ult (%updated_index, %limit) 

--- a/mlir/test/Quantum/DecomposeLoweringTest.mlir
+++ b/mlir/test/Quantum/DecomposeLoweringTest.mlir
@@ -913,7 +913,8 @@ module @test_while_loop {
       scf.condition(%condition) %updated_index, %out: index, !quantum.bit
     } do {
       ^bb0(%after_index: index, %after_qubit : !quantum.bit):
-        scf.yield %after_index, %after_qubit : index, !quantum.bit
+        %after_out = quantum.custom "S"() %after_qubit : !quantum.bit
+        scf.yield %after_index, %after_out: index, !quantum.bit
     }
 
     return %rout : !quantum.bit

--- a/mlir/test/Quantum/DecomposeLoweringTest.mlir
+++ b/mlir/test/Quantum/DecomposeLoweringTest.mlir
@@ -825,7 +825,7 @@ module @test_if {
     %in = quantum.extract %reg[0]  : !quantum.reg -> !quantum.bit
 
     %init_index = arith.constant 1 : index
-    %true = arith.constant 1 : i1 
+    %true = arith.constant 1 : i1
     %limit = arith.constant 10 : index
 
     %out = scf.if %true -> !quantum.bit {
@@ -837,7 +837,11 @@ module @test_if {
       scf.yield %in : !quantum.bit
     }
 
-    return %out : !quantum.bit
+    // CHECK-NOT: "T"
+    // CHECK: "PhaseShift"
+    %post_out = quantum.custom "T"() %out : !quantum.bit
+
+    return %post_out : !quantum.bit
   }
 
   // CHECK-LABEL: func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"
@@ -875,7 +879,11 @@ module @test_for_loop {
       scf.yield %out : !quantum.bit
     }
 
-    return %rout : !quantum.bit
+    // CHECK-NOT: "T"
+    // CHECK: "PhaseShift"
+    %post_out = quantum.custom "T"() %rout : !quantum.bit
+
+    return %post_out : !quantum.bit
   }
 
   // CHECK-LABEL: func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"
@@ -900,7 +908,7 @@ module @test_while_loop {
     %in = quantum.extract %reg[0]  : !quantum.reg -> !quantum.bit
 
     %init_index = arith.constant 1 : index
-    %true = arith.constant 1 : i1 
+    %true = arith.constant 1 : i1
     %limit = arith.constant 10 : index
 
     %out_index, %rout = scf.while (%before_index = %init_index, %before_qubit = %in) : (index, !quantum.bit) -> (index, !quantum.bit) {
@@ -909,15 +917,21 @@ module @test_while_loop {
       %out = quantum.custom "T"() %before_qubit: !quantum.bit
       %increment = arith.constant 1 : index
       %updated_index = index.add %before_index, %increment
-      %condition = index.cmp ult (%updated_index, %limit) 
+      %condition = index.cmp ult (%updated_index, %limit)
       scf.condition(%condition) %updated_index, %out: index, !quantum.bit
     } do {
       ^bb0(%after_index: index, %after_qubit : !quantum.bit):
-        %after_out = quantum.custom "S"() %after_qubit : !quantum.bit
+        // CHECK-NOT: "T"
+        // CHECK: "PhaseShift"
+        %after_out = quantum.custom "T"() %after_qubit : !quantum.bit
         scf.yield %after_index, %after_out: index, !quantum.bit
     }
 
-    return %rout : !quantum.bit
+    // CHECK-NOT: "T"
+    // CHECK: "PhaseShift"
+    %post_out = quantum.custom "T"() %rout : !quantum.bit
+
+    return %post_out : !quantum.bit
   }
 
   // CHECK-LABEL: func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"

--- a/mlir/test/Quantum/DecomposeLoweringTest.mlir
+++ b/mlir/test/Quantum/DecomposeLoweringTest.mlir
@@ -840,6 +840,7 @@ module @test_if {
     return %out : !quantum.bit
   }
 
+  // CHECK-LABEL: func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"
   func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"(%arg0: tensor<1xi64>, %arg1: !quantum.reg) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, resources = {operations = {"PhaseShift{0:[f64]}{wires:1}{}" = 1 : i64}}, target_gate = "T{}{wires:1}{}"} {
     %cst = arith.constant 0.78539816339744828 : f64
     %0 = stablehlo.slice %arg0 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
@@ -877,6 +878,7 @@ module @test_for_loop {
     return %rout : !quantum.bit
   }
 
+  // CHECK-LABEL: func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"
   func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"(%arg0: tensor<1xi64>, %arg1: !quantum.reg) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>,  target_gate = "T{}{wires:1}{}"} {
     %cst = arith.constant 0.78539816339744828 : f64
     %0 = stablehlo.slice %arg0 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
@@ -917,6 +919,7 @@ module @test_while_loop {
     return %rout : !quantum.bit
   }
 
+  // CHECK-LABEL: func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"
   func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"(%arg0: tensor<1xi64>, %arg1: !quantum.reg) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, resources = {operations = {"PhaseShift{0:[f64]}{wires:1}{}" = 1 : i64}}, target_gate = "T{}{wires:1}{}"} {
     %cst = arith.constant 0.78539816339744828 : f64
     %0 = stablehlo.slice %arg0 [0:1] : (tensor<1xi64>) -> tensor<1xi64>


### PR DESCRIPTION
**Context:**
When inlining register-mode decomposition rules for gates in for-loop regions that use qubits extracted outside the region, decompose-lowering fails to locate the register, preventing the inlining.

Example:
```python
@qp.qjit(capture=True)
@catalyst.passes.graph_decomposition(gate_set=gate_set | {"GlobalPhase": 0})
@qp.qnode(null_qubit)
def circuit():
    """Documentation for a function.

    Extended documentation.
    """

    @qp.for_loop(0, 3)
    def loop(i):
        qp.X(0)
        qp.Y(1)
        qp.Z(2)
        qp.RZ(0.1, wires=0)
        qp.S(1)
        qp.T(2)
        qp.H(0)
        qp.SX(1)

    loop()

    return qp.expval(qp.X(0))


circuit()
```

**Description of the Change:**
Adds support for for-loop blocks to the `QubitIndex` walkback, allowing register locating through for-loop regions. Also adds tests for if and while operations, which pass without issue.

**Benefits:**
Improved reliability in `decompose-lowering` and `graph-decomposition`

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-128395]