### PR TITLE
MLIR-Style GOID Format

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -81,14 +81,15 @@
     [(#3053)](https://github.com/PennyLaneAI/catalyst/pull/3053)
 
     The format of `graphOpID` is as follows:
-        op_name{param_shaped_type_dictionary}{wire_lens_dictionary}{static_data_dictionary}[UID]
+        op_name{dynamic_shape_dictionary}{wire_lens_dictionary}{static_data_dictionary}[UID]
 
+    The types in the dynamic shape dictionary should be represented as a list of MLIR-style type annotations.
     The UID is a hash computed from the shapes, dtypes and pytree structures of any data on the Python operator that cannot be lowered to MLIR directly.
 
     For example, an operator with class name `HybridOpArg`, taking in one float param
     argument named `angle`, one wire argument named `cwires`, one static data argument
     `label="hello"`, and a computed UID of 10 would be parsed to the following graph op ID:
-        HybridOpArg{angle:[f64]}{cwires:1}{label:hello}[10]
+        HybridOpArg{angle:[tensor<f64>]}{cwires:1}{label:hello}[10]
 
     A node in the decomposition graph is completely identified by its `graphOpId`. For example,
         PauliRot{angle:[f64]}{wires:1}{pauli_word:X}
@@ -126,6 +127,7 @@
     [(#2973)](https://github.com/PennyLaneAI/catalyst/pull/2973)
     [(#2836)](https://github.com/PennyLaneAI/catalyst/pull/2836)
     [(#2855)](https://github.com/PennyLaneAI/catalyst/pull/2855)
+    [(#3158)](https://github.com/PennyLaneAI/catalyst/pull/3158)
 
     1. The pass now supports applying a selection of the available decomposition rules via the `target_rules` parameter.
 

--- a/frontend/catalyst/decomposition/decomposition_rules.py
+++ b/frontend/catalyst/decomposition/decomposition_rules.py
@@ -26,10 +26,7 @@ from jax._src.lib.mlir import ir
 from jaxlib.mlir.dialects.builtin import ModuleOp
 
 from catalyst.decomposition.graph_op_id import GraphOpID
-from catalyst.decomposition.type_utils import (
-    convert_types_to_mlir_strings,
-    get_dummy_values_for_arg,
-)
+from catalyst.decomposition.type_utils import get_dummy_values_for_arg
 from catalyst.jax_extras.lowering import get_mlir_attribute_from_pyval
 
 # Ops that make a decomposition body non-invertible
@@ -538,7 +535,7 @@ def fetch_all_reachable_decomposition_rules_from_op(
                         graph_op_id = GraphOpID(op)
                         probe = (
                             graph_op_id.get_operator_name(),
-                            convert_types_to_mlir_strings(graph_op_id.dynamic_shape),
+                            graph_op_id.dynamic_shape,
                             graph_op_id.wire_lens,
                             graph_op_id.static_data,
                             graph_op_id.extra_data,

--- a/frontend/catalyst/decomposition/graph_op_id.py
+++ b/frontend/catalyst/decomposition/graph_op_id.py
@@ -21,7 +21,7 @@ import pennylane as qp
 from pennylane.pytrees import flatten
 
 from catalyst.decomposition.type_utils import (
-    convert_types_to_mlir_strings,
+    convert_item_to_mlir_type,
     format_dynamic_params_for_id,
     post_process_concretize_leaves,
     replace_abstract_wires_with_concrete_wires,
@@ -79,9 +79,15 @@ class GraphOpID:
         if self.is_custom_op:
             return {str(i): ["f64"] for i in range(len(self.op.dynamic_args))}
         elif issubclass(type(self.op), tuple(_SPECIAL_LOWERINGS.keys())):  # special cases
-            return {argname: argtype for argname, argtype in sorted(self.op.dynamic_args.items())}
+            return {
+                argname: [convert_item_to_mlir_type(argtype, is_special_lowering=True)]
+                for argname, argtype in sorted(self.op.dynamic_args.items())
+            }
         else:
-            return {argname: [argtype] for argname, argtype in sorted(self.op.dynamic_args.items())}
+            return {
+                argname: [convert_item_to_mlir_type(argtype)]
+                for argname, argtype in sorted(self.op.dynamic_args.items())
+            }
 
     def parse_wire_lens(self) -> dict[str, int]:
         """Return a dictionary of wire arg names to lengths."""
@@ -154,7 +160,7 @@ class GraphOpID:
 
     def get_dynamic_shape_id_format(self) -> str:
         """Return the dynamic shape formatted for GraphOpId."""
-        return format_dynamic_params_for_id(convert_types_to_mlir_strings(self.dynamic_shape))
+        return format_dynamic_params_for_id(self.dynamic_shape)
 
     def get_wire_lens_id_format(self) -> str:
         """Return the wire lengths formatted for GraphOpId."""

--- a/frontend/catalyst/decomposition/graph_op_id.py
+++ b/frontend/catalyst/decomposition/graph_op_id.py
@@ -38,6 +38,7 @@ class GraphOpID:
     The format of the computed graph op ID string is as follows:
         op_name{param_shaped_type_dictionary}{wire_lens_dictionary}{static_data_dictionary}[UID]
 
+    The types in the dynamic shape dictionary should be represented as a list of MLIR-style type annotations.
     The UID is computed from the shapes, dtypes and pytree structures of the `hybrid_args` of
     the Operator2 instance.
 

--- a/frontend/catalyst/decomposition/graph_op_id.py
+++ b/frontend/catalyst/decomposition/graph_op_id.py
@@ -44,7 +44,7 @@ class GraphOpID:
     For example, an Operator2 instance with class name `HybridOpArg`, taking in one float param
     argument named `angle`, one wire argument named `cwires`, one static data argument
     `label="hello"`, and a computed UID of 10 would be parsed to the following graph op ID:
-        HybridOpArg{angle:[f64]}{cwires:1}{label:hello}[10]
+        HybridOpArg{angle:[tensor<f64>]}{cwires:1}{label:hello}[10]
 
     The defining trait of a graph op ID is that it has unique correspondence to decomposition rules.
     In other words, different graph op IDs have different sets of decomposition rules.

--- a/frontend/catalyst/decomposition/type_utils.py
+++ b/frontend/catalyst/decomposition/type_utils.py
@@ -23,16 +23,16 @@ from jax._src.lib.mlir import ir
 from jax.core import ShapedArray
 
 _MLIR_DTYPES_TO_PY_DTYPES = {
-    "tensor<i1>": jnp.bool_,
-    "tensor<i8>": jnp.int8,
-    "tensor<i16>": jnp.int16,
-    "tensor<i32>": jnp.int32,
-    "tensor<i64>": jnp.int64,
-    "tensor<f16>": jnp.float16,
-    "tensor<f32>": jnp.float32,
-    "tensor<f64>": jnp.float64,
-    "tensor<complex<f32>>": jnp.complex64,
-    "tensor<complex<f64>>": jnp.complex128,
+    "i1": jnp.bool_,
+    "i8": jnp.int8,
+    "i16": jnp.int16,
+    "i32": jnp.int32,
+    "i64": jnp.int64,
+    "f16": jnp.float16,
+    "f32": jnp.float32,
+    "f64": jnp.float64,
+    "complex<f32>": jnp.complex64,
+    "complex<f64>": jnp.complex128,
 }
 
 _PY_DTYPES_TO_MLIR_DTYPES = {v: k for k, v in _MLIR_DTYPES_TO_PY_DTYPES.items()} | {
@@ -48,67 +48,36 @@ _PY_DTYPES_TO_MLIR_DTYPES = {v: k for k, v in _MLIR_DTYPES_TO_PY_DTYPES.items()}
     ir.F32Type: "f32",
     ir.F64Type: "f64",
     (ir.ComplexType, ir.F64Type): "complex<f64>",
+    np.dtype("bool_"): "i1",
+    np.dtype("int8"): "i8",
+    np.dtype("int16"): "i16",
+    np.dtype("int32"): "i32",
+    np.dtype("int64"): "i64",
+    np.dtype("float16"): "f16",
+    np.dtype("float32"): "f32",
+    np.dtype("float64"): "f64",
+    np.dtype("complex64"): "complex<f32>",
+    np.dtype("complex128"): "complex<f64>",
 }
 
 
-def get_mlir_tensor_type_map_key(mlir_type):
-    if isinstance(mlir_type, ir.ComplexType):
-        return (type(mlir_type), type(mlir_type.element_type))
-    if isinstance(mlir_type, ir.IntegerType):
-        return (type(mlir_type), mlir_type.width)
-    return type(mlir_type)
+def convert_item_to_mlir_type(item, is_special_lowering=False):
+    """Convert a string or PennyLane AbstractArray to an mlir type annotation."""
+    if isinstance(item, str):
+        return item
 
+    if item.shape == ():
+        if is_special_lowering:
+            return _PY_DTYPES_TO_MLIR_DTYPES[item.dtype]
+        return "tensor<" + _PY_DTYPES_TO_MLIR_DTYPES[item.dtype] + ">"
 
-def convert_shaped_type_to_mlir_string(shaped_type, current_dim=0):
-    """Convert a shape of arbitrary dimension to a string with MLIR type strings for values."""
-    if isinstance(shaped_type, (ShapedArray, qp.typing.AbstractArray)):
-        if current_dim == shaped_type.ndim:
-            return _PY_DTYPES_TO_MLIR_DTYPES[shaped_type.dtype.type]
-
-        return [
-            convert_shaped_type_to_mlir_string(shaped_type, current_dim + 1)
-        ] * shaped_type.shape[current_dim]
-    elif isinstance(shaped_type, ir.RankedTensorType):
-        if current_dim == shaped_type.rank:
-            return _PY_DTYPES_TO_MLIR_DTYPES[get_mlir_tensor_type_map_key(shaped_type.element_type)]
-
-        return [
-            convert_shaped_type_to_mlir_string(shaped_type, current_dim + 1)
-        ] * shaped_type.shape[current_dim]
-
-
-def convert_types_to_mlir_strings(d: dict) -> dict:
-    """Convert the values of a dictionary to MLIR type strings."""
-
-    def handle_item(item):
-        match item:
-            case str():
-                return item
-            case type():
-                return _PY_DTYPES_TO_MLIR_DTYPES[item]
-            case ir.RankedTensorType():
-                if len(item.shape) == 0:
-                    return [
-                        _PY_DTYPES_TO_MLIR_DTYPES[get_mlir_tensor_type_map_key(item.element_type)]
-                    ]
-                return convert_shaped_type_to_mlir_string(item)
-            case float() | int() | complex():
-                # these need to be wrapped in an additional list to account for the tensor creation in lowering
-                return [_PY_DTYPES_TO_MLIR_DTYPES[type(item)]]
-            case list() | tuple():
-                return [handle_item(i) for i in item]
-            case ShapedArray() | qp.typing.AbstractArray():
-                if item.shape == ():
-                    return [_PY_DTYPES_TO_MLIR_DTYPES[item.dtype.type]]
-                return convert_shaped_type_to_mlir_string(item)
-            case _ if type(item) in _PY_DTYPES_TO_MLIR_DTYPES:
-                return _PY_DTYPES_TO_MLIR_DTYPES[type(item)]
-            case _:
-                raise TypeError(
-                    f"encountered unknown type {type(item)} of item {item} when converting to mlir strings."
-                )
-
-    return {k: handle_item(v) for k, v in d.items()}
+    return (
+        "tensor<"
+        + "x".join(str(dim_size) for dim_size in item.shape)
+        + "x"
+        + _PY_DTYPES_TO_MLIR_DTYPES[item.dtype]
+        + ">"
+    )
 
 
 def format_dynamic_params_for_id(d):
@@ -141,6 +110,11 @@ def get_dummy_values_for_arg(arg):
     """
     match arg:
         case str():
+            if arg.startswith("tensor"):
+                body = arg.removeprefix("tensor<").removesuffix(">")
+                ranks = tuple(map(int, body.split("x")[:-1]))
+                dtype = body.split("x")[-1]
+                return jnp.zeros(ranks, dtype=_MLIR_DTYPES_TO_PY_DTYPES[dtype])
             return jnp.zeros((), dtype=_MLIR_DTYPES_TO_PY_DTYPES[arg])
         case list() | tuple():
             dtype = get_dummy_values_for_arg(arg[0]).dtype

--- a/frontend/catalyst/decomposition/type_utils.py
+++ b/frontend/catalyst/decomposition/type_utils.py
@@ -39,15 +39,9 @@ _PY_DTYPES_TO_MLIR_DTYPES = {v: k for k, v in _MLIR_DTYPES_TO_PY_DTYPES.items()}
     float: "f64",
     int: "i64",
     complex: "complex<f64>",
-    (ir.IntegerType, 1): "i1",
-    (ir.IntegerType, 8): "i8",
-    (ir.IntegerType, 16): "i16",
-    (ir.IntegerType, 32): "i32",
-    (ir.IntegerType, 64): "i64",
     ir.F16Type: "f16",
     ir.F32Type: "f32",
     ir.F64Type: "f64",
-    (ir.ComplexType, ir.F64Type): "complex<f64>",
     np.dtype("bool_"): "i1",
     np.dtype("int8"): "i8",
     np.dtype("int16"): "i16",
@@ -81,7 +75,7 @@ def convert_item_to_mlir_type(item, is_special_lowering=False):
 
 
 def format_dynamic_params_for_id(d):
-    """Format a structure for ID, after calling convert_types_to_mlir_string on it."""
+    """Format a structure for ID."""
 
     def handle_item(item):
         match item:
@@ -100,13 +94,10 @@ def format_dynamic_params_for_id(d):
 
 
 def get_dummy_values_for_arg(arg):
-    """
-    Given a container of python or MLIR types, replace the types with corresponding dummy values.
+    """Given a container of python or MLIR types, replace the types with corresponding dummy values.
 
-    Each item in the container must be representible as an MLIR tensor with at most one layer of
-    nesting, i.e. cannot be nested and all elements must be of the same type.
-    Ex.
-    [[float, float], [int, int, int], [int32, int32, int32, int32]]
+    The types are expected to be formatted for GraphOpIDs. Lists/Tuples must contain homogeneous
+    data types (this is true for any operator).
     """
     match arg:
         case str():

--- a/frontend/catalyst/decomposition/type_utils.py
+++ b/frontend/catalyst/decomposition/type_utils.py
@@ -96,7 +96,7 @@ def format_dynamic_params_for_id(d):
 def get_dummy_values_for_arg(arg):
     """Given a container of python or MLIR types, replace the types with corresponding dummy values.
 
-    The types are expected to be formatted for GraphOpIDs. Lists/Tuples must contain homogeneous
+    The types are expected to be formatted for ``GraphOpId``s. Lists/Tuples must contain homogeneous
     data types (this is true for any operator).
     """
     match arg:

--- a/frontend/catalyst/decomposition/type_utils.py
+++ b/frontend/catalyst/decomposition/type_utils.py
@@ -23,16 +23,16 @@ from jax._src.lib.mlir import ir
 from jax.core import ShapedArray
 
 _MLIR_DTYPES_TO_PY_DTYPES = {
-    "i1": jnp.bool_,
-    "i8": jnp.int8,
-    "i16": jnp.int16,
-    "i32": jnp.int32,
-    "i64": jnp.int64,
-    "f16": jnp.float16,
-    "f32": jnp.float32,
-    "f64": jnp.float64,
-    "complex<f32>": jnp.complex64,
-    "complex<f64>": jnp.complex128,
+    "tensor<i1>": jnp.bool_,
+    "tensor<i8>": jnp.int8,
+    "tensor<i16>": jnp.int16,
+    "tensor<i32>": jnp.int32,
+    "tensor<i64>": jnp.int64,
+    "tensor<f16>": jnp.float16,
+    "tensor<f32>": jnp.float32,
+    "tensor<f64>": jnp.float64,
+    "tensor<complex<f32>>": jnp.complex64,
+    "tensor<complex<f64>>": jnp.complex128,
 }
 
 _PY_DTYPES_TO_MLIR_DTYPES = {v: k for k, v in _MLIR_DTYPES_TO_PY_DTYPES.items()} | {

--- a/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
+++ b/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
@@ -40,7 +40,7 @@ from catalyst.decomposition.decomposition_rules import (
 )
 from catalyst.decomposition.graph_op_id import _SPECIAL_LOWERINGS
 from catalyst.decomposition.type_utils import (
-    convert_types_to_mlir_strings,
+    convert_item_to_mlir_type,
     format_dynamic_params_for_id,
 )
 from catalyst.jax_extras.lowering import get_mlir_attribute_from_pyval
@@ -408,7 +408,7 @@ def compile_decomp_rules(
 
         for dynamic_argname, param in zip(op_cls.dynamic_argnames, non_hybrid_params, strict=True):
             non_hybrid_dynamic_shape[dynamic_argname] = param.type
-        non_hybrid_dynamic_shape = convert_types_to_mlir_strings(non_hybrid_dynamic_shape)
+        non_hybrid_dynamic_shape = {k: [str(v)] for k, v in non_hybrid_dynamic_shape.items()}
 
         non_hybrid_wire_argnames = []
         for wire_argname in op_cls.wire_argnames:
@@ -450,7 +450,9 @@ def compile_decomp_rules(
                 with_hybrid_dynamic_shape[named_attr.name] = [
                     params[idx].type for idx in named_attr.attr
                 ]
-            with_hybrid_dynamic_shape = convert_types_to_mlir_strings(with_hybrid_dynamic_shape)
+            with_hybrid_dynamic_shape = {
+                k: [str(item) for item in v] for k, v in with_hybrid_dynamic_shape.items()
+            }
 
         with_hybrid_wire_lens = {}
         if qubit_map is not None:

--- a/frontend/test/lit/test_operator2/test_adjoint_distribution_rule.py
+++ b/frontend/test/lit/test_operator2/test_adjoint_distribution_rule.py
@@ -50,7 +50,7 @@ def test_distribution_rule_synthesized_from_base():
     # CHECK-DAG: func.func private @"__builtin_base_rule_NoParams{}{reg:2}{}"
     # CHECK:   target_gate = "NoParams{}{reg:2}{}"
     # CHECK-DAG: func.func private @"__builtin_base_rule_Adjoint(NoParams){}{reg:2}{}"
-    # CHECK-SAME:   resources = {operations = {"Adjoint(SingleParam){x:{{\[\[f64\]\]}}}{reg:2}{}" = 2 : i64}
+    # CHECK-SAME:   resources = {operations = {"Adjoint(SingleParam){x:[tensor<f64>]}{reg:2}{}" = 2 : i64}
     # CHECK:   target_gate = "Adjoint(NoParams){}{reg:2}{}"
     # CHECK: qref.adjoint {
 

--- a/frontend/test/lit/test_operator2/test_decomposition_rule_entry_point.py
+++ b/frontend/test/lit/test_operator2/test_decomposition_rule_entry_point.py
@@ -96,7 +96,7 @@ def test_from_dynamic_argnames():
         qp.add_decomps(SingleParam, rule)
         result = compile_decomposition_rules_wrapper(
             "SingleParam",
-            "SingleParam{x:[[f64,f64]]}{reg:2}{}",
+            "SingleParam{x:[tensor<2xf64>]}{reg:2}{}",
             {"x": ["f64", "f64"]},
             {"reg": 2},
             {},
@@ -106,7 +106,7 @@ def test_from_dynamic_argnames():
 
 # CHECK: func.func private @"rule_SingleParam{x:[tensor<2xf64>]}{reg:2}{}"
 # CHECK-SAME:   resources = {operations = {"NoParams{}{reg:1}{}" = 1 : i64}}
-# CHECK-SAME:   target_gate = "SingleParam{x:[tensor<f64>]}{reg:2}{}"
+# CHECK-SAME:   target_gate = "SingleParam{x:[tensor<2xf64>]}{reg:2}{}"
 test_from_dynamic_argnames()
 
 
@@ -155,7 +155,7 @@ def test_from_multiple_dynamic_argnames():
         qp.add_decomps(MultiParams, rule)
         result = compile_decomposition_rules_wrapper(
             "MultiParams",
-            "MultiParams{a:[[f64]],b:[[i32,f64]],c:[[[i32],[f64]]]}{reg:2}{}",
+            "MultiParams{a:[tensor<f64>],b:[tensor<i32>,tensor<f64>],c:[tensor<i32>,tensor<f64>]}{reg:2}{}",
             {"b": ["i32", "f64"], "c": [["i32"], ["f64"]], "a": ["f64"]},
             {"reg": 2},
             {},
@@ -544,7 +544,7 @@ def test_from_hybrid_op():
         qp.add_decomps(HybridOpArg, rule)
         result = compile_decomposition_rules_wrapper(
             "HybridOpArg",
-            "HybridOpArg{angle:[[f64]]}{cwires:1}{}[5678]",
+            "HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[5678]",
             {"angle": ["f64"]},
             {"cwires": 1},
             {},
@@ -632,7 +632,7 @@ def test_from_hybrid_op_nested():
         qp.add_decomps(HybridOpArg, rule)
         result = compile_decomposition_rules_wrapper(
             "HybridOpArg",
-            "HybridOpArg{angle:[[f64]]}{cwires:1}{}[7654]",
+            "HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[7654]",
             {"angle": ["f64"]},
             {"cwires": 1},
             {},
@@ -744,7 +744,7 @@ def test_from_multiple_full_args_op():
         qp.add_decomps(MultipleFullArgs, rule)
         result = compile_decomposition_rules_wrapper(
             "MultipleFullArgs",
-            "MultipleFullArgs{angles1:[[f64]],angles2:[[f64,f64]]}{reg1:1,reg2:2}{}[4444]",
+            "MultipleFullArgs{angles1:[tensor<f64>],angles2:[tensor<2xf64>]}{reg1:1,reg2:2}{}[4444]",
             {"angles1": ["f64"], "angles2": ["f64", "f64"]},
             {"reg1": 1, "reg2": 2},
             {},
@@ -764,7 +764,7 @@ def test_from_multiple_full_args_op():
 # CHECK-SAME:   resources = {operations = {
 # CHECK-SAME:   "NoParams{}{reg:1}{}" = 1 : i64
 # CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64
-# CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64
+# CHECK-SAME:   "SingleParam{x:[tensor<i64>]}{reg:1}{}" = 1 : i64
 # CHECK-SAME:   target_gate = "MultipleFullArgs{angles1:[tensor<f64>],angles2:[tensor<2xf64>]}{reg1:1,reg2:2}{}[4444]"
 # CHECK: "qref.operator"({{%.+}}) {op_name = "SingleParam"
 # CHECK: "qref.operator"({{%.+}}) {op_name = "SingleParam"

--- a/frontend/test/lit/test_operator2/test_decomposition_rule_entry_point.py
+++ b/frontend/test/lit/test_operator2/test_decomposition_rule_entry_point.py
@@ -74,8 +74,8 @@ def test_to_dynamic_argnames():
 
 # CHECK: func.func private @"rule_NoParams{}{reg:2}{}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "SingleParam{x:{{\[\[f64,f64\]\]}}}{reg:2}{}" = 1 : i64,
-# CHECK-SAME:   "SingleParam{x:{{\[\[f64\]\]}}}{reg:2}{}" = 2 : i64
+# CHECK-SAME:   "SingleParam{x:[tensor<2xf64>]}{reg:2}{}" = 1 : i64,
+# CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:2}{}" = 2 : i64
 # CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
 test_to_dynamic_argnames()
 
@@ -104,9 +104,9 @@ def test_from_dynamic_argnames():
         print(result)
 
 
-# CHECK: func.func private @"rule_SingleParam{x:{{\[\[f64,f64\]\]}}}{reg:2}{}"
+# CHECK: func.func private @"rule_SingleParam{x:[tensor<2xf64>]}{reg:2}{}"
 # CHECK-SAME:   resources = {operations = {"NoParams{}{reg:1}{}" = 1 : i64}}
-# CHECK-SAME:   target_gate = "SingleParam{x:{{\[\[f64,f64\]\]}}}{reg:2}{}"
+# CHECK-SAME:   target_gate = "SingleParam{x:[tensor<f64>]}{reg:2}{}"
 test_from_dynamic_argnames()
 
 
@@ -134,7 +134,7 @@ def test_to_multiple_dynamic_argnames():
 
 # CHECK: func.func private @"rule_NoParams{}{reg:1}{}"
 # CHECK-SAME:   resources = {operations =
-# CHECK-SAME:   "MultiParams{a:{{\[\[f64\]\]}},b:{{\[\[\[i64,i64\],\[i64,i64\]\]\]}},c:{{\[\[complex<f64>\]\]}}}{reg:1}{}" = 1 : i64
+# CHECK-SAME:   "MultiParams{a:[tensor<f64>],b:[tensor<2x2xi64>],c:[tensor<complex<f64>>]}{reg:1}{}" = 1 : i64
 # CHECK-SAME:   target_gate = "NoParams{}{reg:1}{}"
 test_to_multiple_dynamic_argnames()
 
@@ -163,9 +163,9 @@ def test_from_multiple_dynamic_argnames():
         print(result)
 
 
-# CHECK: func.func private @"rule_MultiParams{a:{{\[\[f64\]\]}},b:{{\[\[i32,f64\]\]}},c:{{\[\[\[i32\],\[f64\]\]\]}}}{reg:2}{}"
+# CHECK: func.func private @"rule_MultiParams{a:[tensor<f64>],b:[tensor<i32>,tensor<f64>],c:[tensor<i32>,tensor<f64>]}{reg:2}{}"
 # CHECK-SAME:   resources = {operations = {"NoParamsCustomOp{}{wires:2}{}" = 1 : i64}
-# CHECK-SAME:   target_gate = "MultiParams{a:{{\[\[f64\]\]}},b:{{\[\[i32,f64\]\]}},c:{{\[\[\[i32\],\[f64\]\]\]}}}{reg:2}{}"
+# CHECK-SAME:   target_gate = "MultiParams{a:[tensor<f64>],b:[tensor<i32>,tensor<f64>],c:[tensor<i32>,tensor<f64>]}{reg:2}{}"
 test_from_multiple_dynamic_argnames()
 
 
@@ -301,13 +301,13 @@ def test_from_compilable_data():
 
 
 # CHECK: func.func private @"rule_CompilableData{}{wires:1}{a:1,b:2,thing:3}"
-# CHECK-SAME:   resources = {operations = {"SingleParam{x:{{\[\[f64\]\]}}}{reg:1}{}" = 1 : i64}
+# CHECK-SAME:   resources = {operations = {"SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64}
 # CHECK-SAME:   target_gate = "CompilableData{}{wires:1}{a:1,b:2,thing:3}"
 # CHECK: stablehlo.constant dense<1.000000e-01> : tensor<f64>
 # CHECK-NOT: stablehlo.constant dense<1.100000e+00> : tensor<f64>
 #
 # CHECK: func.func private @"rule_CompilableData{}{wires:1}{a:10,b:2,thing:3}"
-# CHECK-SAME:   resources = {operations = {"SingleParam{x:{{\[\[f64\]\]}}}{reg:1}{}" = 1 : i64}
+# CHECK-SAME:   resources = {operations = {"SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64}
 # CHECK-SAME:   target_gate = "CompilableData{}{wires:1}{a:10,b:2,thing:3}"
 # CHECK: stablehlo.constant dense<1.100000e+00> : tensor<f64>
 # CHECK-NOT: stablehlo.constant dense<1.000000e-01> : tensor<f64>
@@ -382,12 +382,12 @@ def test_from_static_data():
 
 
 # CHECK: func.func private @"rule_StaticData{}{reg:1}{}[1234]"
-# CHECK-SAME:   resources = {operations = {"SingleParam{x:{{\[\[f64\]\]}}}{reg:1}{}" = 1 : i64}
+# CHECK-SAME:   resources = {operations = {"SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64}
 # CHECK-SAME:   target_gate = "StaticData{}{reg:1}{}[1234]"
 # CHECK: stablehlo.constant dense<1.000000e-01> : tensor<f64>
 #
 # CHECK: func.func private @"rule_StaticData{}{reg:1}{}[4321]"
-# CHECK-SAME:   resources = {operations = {"SingleParam{x:{{\[\[f64\]\]}}}{reg:1}{}" = 2 : i64}
+# CHECK-SAME:   resources = {operations = {"SingleParam{x:[tensor<f64>]}{reg:1}{}" = 2 : i64}
 # CHECK-SAME:   target_gate = "StaticData{}{reg:1}{}[4321]"
 # CHECK: stablehlo.constant dense<1.100000e+00> : tensor<f64>
 # CHECK: stablehlo.constant dense<2.200000e+00> : tensor<f64>
@@ -518,8 +518,8 @@ def test_to_hybrid_op():
 
 
 # CHECK: func.func private @"rule_NoParams{}{reg:3}{}"
-# CHECK-DAG: "HybridOpArg{angle:{{\[\[f64\]\]}}}{cwires:1}{}[[[uid_1:[0-9]+]]]" = 1
-# CHECK-DAG: "HybridOpArg{angle:{{\[\[f64\]\]}}}{cwires:1}{}[[[uid_2:[0-9]+]]]" = 2
+# CHECK-DAG: "HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[[[uid_1:[0-9]+]]]" = 1
+# CHECK-DAG: "HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[[[uid_2:[0-9]+]]]" = 2
 # CHECK-DAG:   target_gate = "NoParams{}{reg:3}{}"
 # CHECK: "qref.operator"({{%.+}}) {UID = [[uid_2]]
 # CHECK: "qref.operator"({{%.+}}) {UID = [[uid_2]]
@@ -556,11 +556,11 @@ def test_from_hybrid_op():
         print(result)
 
 
-# CHECK: func.func private @"rule_HybridOpArg{angle:{{\[\[f64\]\]}}}{cwires:1}{}[5678]"
+# CHECK: func.func private @"rule_HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[5678]"
 # CHECK-SAME:   resources = {operations = {
 # CHECK-SAME:   "NoParams{}{reg:1}{}" = 1 : i64,
-# CHECK-SAME:   "StaticDataMultiReg{theta:{{\[\[f64\]\]}}}{reg:1,reg2:2}{}[[[uid:[0-9]+]]]" = 1 : i64
-# CHECK-SAME:   target_gate = "HybridOpArg{angle:{{\[\[f64\]\]}}}{cwires:1}{}[5678]"
+# CHECK-SAME:   "StaticDataMultiReg{theta:[tensor<f64>]}{reg:1,reg2:2}{}[[[uid:[0-9]+]]]" = 1 : i64
+# CHECK-SAME:   target_gate = "HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[5678]"
 # CHECK: "qref.operator"({{%.+}}) {UID = [[uid]] : i64, op_name = "StaticDataMultiReg"
 test_from_hybrid_op()
 
@@ -608,7 +608,7 @@ def test_to_hybrid_op_nested():
 
 
 # CHECK: func.func private @"rule_NoParams{}{reg:3}{}"
-# CHECK-SAME: "HybridOpArg{angle:{{\[\[f64\]\]}}}{cwires:1}{}[[[uid:[0-9]+]]]" = 1
+# CHECK-SAME: "HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[[[uid:[0-9]+]]]" = 1
 # CHECK-SAME:   target_gate = "NoParams{}{reg:3}{}"
 # CHECK: "qref.operator"({{%.+}}) {UID = [[uid]]
 test_to_hybrid_op_nested()
@@ -649,12 +649,12 @@ def test_from_hybrid_op_nested():
         print(result)
 
 
-# CHECK: func.func private @"rule_HybridOpArg{angle:{{\[\[f64\]\]}}}{cwires:1}{}[7654]"
+# CHECK: func.func private @"rule_HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[7654]"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "HybridOpArg{angle:{{\[\[f64\]\]}}}{cwires:1}{}[[[uid_outer:[0-9]+]]]" = 1 : i64,
+# CHECK-SAME:   "HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[[[uid_outer:[0-9]+]]]" = 1 : i64,
 # CHECK-SAME:   "NoParams{}{reg:1}{}" = 1 : i64,
-# CHECK-SAME:   "StaticDataMultiReg{theta:{{\[\[f64\]\]}}}{reg:1,reg2:2}{}[[[uid_inner:[0-9]+]]]" = 1 : i64
-# CHECK-SAME:   target_gate = "HybridOpArg{angle:{{\[\[f64\]\]}}}{cwires:1}{}[7654]"
+# CHECK-SAME:   "StaticDataMultiReg{theta:[tensor<f64>]}{reg:1,reg2:2}{}[[[uid_inner:[0-9]+]]]" = 1 : i64
+# CHECK-SAME:   target_gate = "HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[7654]"
 # CHECK: "qref.operator"({{%.+}}) {UID = [[uid_outer]] : i64, op_name = "HybridOpArg"
 # CHECK: "qref.operator"({{%.+}}) {UID = [[uid_inner]] : i64, op_name = "StaticDataMultiReg"
 test_from_hybrid_op_nested()
@@ -717,7 +717,7 @@ def test_to_multiple_full_args_op():
 
 
 # CHECK: func.func private @"rule_NoParams{}{reg:3}{}"
-# CHECK-DAG: "MultipleFullArgs{angles1:{{\[\[f64\]\]}},angles2:{{\[\[f64,f64\]\]}}}{reg1:1,reg2:2}{}[[[uid:[0-9]+]]]" = 2
+# CHECK-DAG: "MultipleFullArgs{angles1:[tensor<f64>],angles2:[tensor<2xf64>]}{reg1:1,reg2:2}{}[[[uid:[0-9]+]]]" = 2
 # CHECK-DAG:   target_gate = "NoParams{}{reg:3}{}"
 # CHECK: "qref.operator"({{%.+}}) {UID = [[uid]]
 # CHECK: "qref.operator"({{%.+}}) {UID = [[uid]]
@@ -760,12 +760,12 @@ def test_from_multiple_full_args_op():
         print(result)
 
 
-# CHECK: func.func private @"rule_MultipleFullArgs{angles1:{{\[\[f64\]\]}},angles2:{{\[\[f64,f64\]\]}}}{reg1:1,reg2:2}{}[4444]"
+# CHECK: func.func private @"rule_MultipleFullArgs{angles1:[tensor<f64>],angles2:[tensor<2xf64>]}{reg1:1,reg2:2}{}[4444]"
 # CHECK-SAME:   resources = {operations = {
 # CHECK-SAME:   "NoParams{}{reg:1}{}" = 1 : i64
-# CHECK-SAME:   "SingleParam{x:{{\[\[f64\]\]}}}{reg:1}{}" = 1 : i64
-# CHECK-SAME:   "SingleParam{x:{{\[\[i64\]\]}}}{reg:1}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "MultipleFullArgs{angles1:{{\[\[f64\]\]}},angles2:{{\[\[f64,f64\]\]}}}{reg1:1,reg2:2}{}[4444]"
+# CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64
+# CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64
+# CHECK-SAME:   target_gate = "MultipleFullArgs{angles1:[tensor<f64>],angles2:[tensor<2xf64>]}{reg1:1,reg2:2}{}[4444]"
 # CHECK: "qref.operator"({{%.+}}) {op_name = "SingleParam"
 # CHECK: "qref.operator"({{%.+}}) {op_name = "SingleParam"
 # CHECK: "qref.operator"({{%.+}}) {op_name = "NoParams"
@@ -805,7 +805,7 @@ def test_multiple_rules():
 
 
 # CHECK: func.func private @"rule1_NoParams{}{reg:1}{}"
-# CHECK-SAME:   resources = {operations = {"SingleParam{x:{{\[\[f64\]\]}}}{reg:1}{}" = 1 : i64}}
+# CHECK-SAME:   resources = {operations = {"SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64}}
 # CHECK-SAME:   target_gate = "NoParams{}{reg:1}{}"
 # CHECK: func.func private @"rule2_NoParams{}{reg:1}{}"
 # CHECK-SAME:   resources = {operations = {"CompilableData{}{wires:3}{a:a,b:b,thing:thing}" = 1 : i64}}

--- a/frontend/test/lit/test_operator2/test_lower_time_rules.py
+++ b/frontend/test/lit/test_operator2/test_lower_time_rules.py
@@ -72,8 +72,8 @@ def test_one_rule():
         # CHECK: qref.operator "NoParams"
         # CHECK: func.func private @"__builtin_rule_NoParams{}{reg:2}{}"
         # CHECK-SAME:   resources = {operations = {
-        # CHECK-SAME:   "SingleParam{x:{{\[\[f64,f64\]\]}}}{reg:2}{}" = 1 : i64,
-        # CHECK-SAME:   "SingleParam{x:{{\[\[f64\]\]}}}{reg:2}{}" = 2 : i64
+        # CHECK-SAME:   "SingleParam{x:[tensor<2xf64>]}{reg:2}{}" = 1 : i64,
+        # CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:2}{}" = 2 : i64
         # CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
         test_one_gate()
 
@@ -97,8 +97,8 @@ def test_one_rule():
         # CHECK: qref.operator "NoParams"
         # CHECK: func.func private @"__builtin_rule_NoParams{}{reg:2}{}"
         # CHECK-SAME:   resources = {operations = {
-        # CHECK-SAME:   "SingleParam{x:{{\[\[f64,f64\]\]}}}{reg:2}{}" = 1 : i64,
-        # CHECK-SAME:   "SingleParam{x:{{\[\[f64\]\]}}}{reg:2}{}" = 2 : i64
+        # CHECK-SAME:   "SingleParam{x:[tensor<2xf64>]}{reg:2}{}" = 1 : i64,
+        # CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:2}{}" = 2 : i64
         # CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
         # CHECK-NOT: func.func private @"__builtin_rule_NoParams{}{reg:2}{}"
         test_multiple_gates_same_id()
@@ -123,13 +123,13 @@ def test_one_rule():
         # CHECK: qref.operator "NoParams"
         # CHECK: func.func private @"__builtin_rule_NoParams{}{reg:2}{}"
         # CHECK-SAME:   resources = {operations = {
-        # CHECK-SAME:   "SingleParam{x:{{\[\[f64,f64\]\]}}}{reg:2}{}" = 1 : i64,
-        # CHECK-SAME:   "SingleParam{x:{{\[\[f64\]\]}}}{reg:2}{}" = 2 : i64
+        # CHECK-SAME:   "SingleParam{x:[tensor<2xf64>]}{reg:2}{}" = 1 : i64,
+        # CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:2}{}" = 2 : i64
         # CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
         # CHECK: func.func private @"__builtin_rule_NoParams{}{reg:3}{}"
         # CHECK-SAME:   resources = {operations = {
-        # CHECK-SAME:   "SingleParam{x:{{\[\[f64,f64\]\]}}}{reg:2}{}" = 1 : i64,
-        # CHECK-SAME:   "SingleParam{x:{{\[\[f64\]\]}}}{reg:2}{}" = 2 : i64
+        # CHECK-SAME:   "SingleParam{x:[tensor<2xf64>]}{reg:2}{}" = 1 : i64,
+        # CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:2}{}" = 2 : i64
         # CHECK-SAME:   target_gate = "NoParams{}{reg:3}{}"
         test_multiple_gates_different_ids()
 
@@ -176,22 +176,22 @@ def test_multiple_rules_same_gate():
 # CHECK: qref.operator "NoParams"
 # CHECK: func.func private @"__builtin_rule1_NoParams{}{reg:2}{}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "SingleParam{x:{{\[\[f64\]\]}}}{reg:2}{}" = 1 : i64
+# CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:2}{}" = 1 : i64
 # CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
 # CHECK: func.func private @"__builtin_rule2_NoParams{}{reg:2}{}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "SingleParam{x:{{\[\[f64,f64\]\]}}}{reg:1}{}" = 1 : i64
+# CHECK-SAME:   "SingleParam{x:[tensor<2xf64>]}{reg:1}{}" = 1 : i64
 # CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
 #
 # CHECK-NOT: func.func private @"__builtin_rule1_NoParams{}{reg:2}{}"
 #
 # CHECK: func.func private @"__builtin_rule1_NoParams{}{reg:3}{}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "SingleParam{x:{{\[\[f64\]\]}}}{reg:2}{}" = 1 : i64
+# CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:2}{}" = 1 : i64
 # CHECK-SAME:   target_gate = "NoParams{}{reg:3}{}"
 # CHECK: func.func private @"__builtin_rule2_NoParams{}{reg:3}{}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "SingleParam{x:{{\[\[f64,f64\]\]}}}{reg:1}{}" = 1 : i64
+# CHECK-SAME:   "SingleParam{x:[tensor<2xf64>]}{reg:1}{}" = 1 : i64
 # CHECK-SAME:   target_gate = "NoParams{}{reg:3}{}"
 test_multiple_rules_same_gate()
 
@@ -229,12 +229,12 @@ def test_multiple_rules_chained():
 # CHECK: qref.operator "NoParams"
 # CHECK: func.func private @"__builtin_rule1_NoParams{}{reg:2}{}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "SingleParam{x:{{\[\[f64\]\]}}}{reg:1}{}" = 1 : i64
+# CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64
 # CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
-# CHECK: func.func private @"__builtin_rule2_SingleParam{x:{{\[\[f64\]\]}}}{reg:1}{}"
+# CHECK: func.func private @"__builtin_rule2_SingleParam{x:[tensor<f64>]}{reg:1}{}"
 # CHECK-SAME:   resources = {operations = {
 # CHECK-SAME:   "CompilableData{}{wires:1}{a:a,b:b,thing:thing}" = 1 : i64
-# CHECK-SAME:   target_gate = "SingleParam{x:{{\[\[f64\]\]}}}{reg:1}{}"
+# CHECK-SAME:   target_gate = "SingleParam{x:[tensor<f64>]}{reg:1}{}"
 test_multiple_rules_chained()
 
 
@@ -282,16 +282,16 @@ def test_multiple_rules_chained_and_branch():
 # CHECK: qref.operator "NoParams"
 # CHECK: func.func private @"__builtin_ruleAB_NoParams{}{reg:2}{}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "SingleParam{x:{{\[\[f64\]\]}}}{reg:1}{}" = 1 : i64
+# CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64
 # CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
-# CHECK: func.func private @"__builtin_ruleBC_SingleParam{x:{{\[\[f64\]\]}}}{reg:1}{}"
+# CHECK: func.func private @"__builtin_ruleBC_SingleParam{x:[tensor<f64>]}{reg:1}{}"
 # CHECK-SAME:   resources = {operations = {
 # CHECK-SAME:   "CompilableData{}{wires:1}{a:a,b:b,thing:thing}" = 1 : i64
-# CHECK-SAME:   target_gate = "SingleParam{x:{{\[\[f64\]\]}}}{reg:1}{}"
-# CHECK: func.func private @"__builtin_ruleBD_SingleParam{x:{{\[\[f64\]\]}}}{reg:1}{}"
+# CHECK-SAME:   target_gate = "SingleParam{x:[tensor<f64>]}{reg:1}{}"
+# CHECK: func.func private @"__builtin_ruleBD_SingleParam{x:[tensor<f64>]}{reg:1}{}"
 # CHECK-SAME:   resources = {operations = {
 # CHECK-SAME:   "CompilableData{}{wires:1}{a:alpha,b:beta,thing:stuff}" = 1 : i64
-# CHECK-SAME:   target_gate = "SingleParam{x:{{\[\[f64\]\]}}}{reg:1}{}"
+# CHECK-SAME:   target_gate = "SingleParam{x:[tensor<f64>]}{reg:1}{}"
 test_multiple_rules_chained_and_branch()
 
 
@@ -339,19 +339,19 @@ def test_with_cycles():
 # CHECK: qref.operator "NoParams"
 # CHECK: func.func private @"__builtin_ruleAB_NoParams{}{reg:2}{}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "SingleParam{x:{{\[\[f64\]\]}}}{reg:1}{}" = 1 : i64
+# CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64
 # CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
-# CHECK: func.func private @"__builtin_ruleBC_SingleParam{x:{{\[\[f64\]\]}}}{reg:1}{}"
+# CHECK: func.func private @"__builtin_ruleBC_SingleParam{x:[tensor<f64>]}{reg:1}{}"
 # CHECK-SAME:   resources = {operations = {
 # CHECK-SAME:   "CompilableData{}{wires:1}{a:a,b:b,thing:thing}" = 1 : i64
-# CHECK-SAME:   target_gate = "SingleParam{x:{{\[\[f64\]\]}}}{reg:1}{}"
+# CHECK-SAME:   target_gate = "SingleParam{x:[tensor<f64>]}{reg:1}{}"
 # CHECK: func.func private @"__builtin_ruleCA_CompilableData{}{wires:1}{a:a,b:b,thing:thing}"
 # CHECK-SAME:   resources = {operations = {
 # CHECK-SAME:   "NoParams{}{reg:2}{}" = 1 : i64
 # CHECK-SAME:   target_gate = "CompilableData{}{wires:1}{a:a,b:b,thing:thing}"
 # CHECK: func.func private @"__builtin_ruleAB_NoParams{}{reg:3}{}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "SingleParam{x:{{\[\[f64\]\]}}}{reg:1}{}" = 1 : i64
+# CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64
 # CHECK-SAME:   target_gate = "NoParams{}{reg:3}{}"
 test_with_cycles()
 
@@ -420,7 +420,7 @@ def test_to_multiple_full_args_op():
 # CHECK: qref.operator "NoParams"
 # CHECK: func.func private @"__builtin_rule_NoParams{}{reg:3}{}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "MultipleFullArgs{angles1:{{\[\[f64\]\]}},angles2:{{\[\[f64,f64\]\]}}}{reg1:1,reg2:2}{}[[[uid:[0-9]+]]]" = 2 : i64
+# CHECK-SAME:   "MultipleFullArgs{angles1:[tensor<f64>],angles2:[tensor<2xf64>]}{reg1:1,reg2:2}{}[[[uid:[0-9]+]]]" = 2 : i64
 # CHECK-SAME:   target_gate = "NoParams{}{reg:3}{}"
 # CHECK: qref.operator "MultipleFullArgs"
 # CHECK-NEXT:  UID([[uid]]
@@ -474,10 +474,10 @@ def test_from_multiple_full_args_op():
 # CHECK:   param_map = {angles1 = [0], angles2 = [1]}
 # CHECK-SAME:  qubit_map = {hwires1 = [4, 5], hwires2 = [6], op1 = [2], op2 = [3], reg1 = [0], reg2 = [1]}
 #
-# CHECK: func.func private @"__builtin_rule_MultipleFullArgs{angles1:{{\[\[f64\]\]}},angles2:{{\[\[f64\]\]}}}{hwires1:2,hwires2:1,op1:1,op2:1,reg1:1,reg2:1}{}[[[uid]]]"
+# CHECK: func.func private @"__builtin_rule_MultipleFullArgs{angles1:[tensor<f64>],angles2:[tensor<f64>]}{hwires1:2,hwires2:1,op1:1,op2:1,reg1:1,reg2:1}{}[[[uid]]]"
 # CHECK-SAME:   resources = {operations = {
 # CHECK-SAME:   "NoParams{}{reg:1}{}" = 2 : i64
-# CHECK-SAME:   target_gate = "MultipleFullArgs{angles1:{{\[\[f64\]\]}},angles2:{{\[\[f64\]\]}}}{hwires1:2,hwires2:1,op1:1,op2:1,reg1:1,reg2:1}{}[[[uid]]]"
+# CHECK-SAME:   target_gate = "MultipleFullArgs{angles1:[tensor<f64>],angles2:[tensor<f64>]}{hwires1:2,hwires2:1,op1:1,op2:1,reg1:1,reg2:1}{}[[[uid]]]"
 test_from_multiple_full_args_op()
 
 

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -45,7 +45,10 @@ from catalyst.decomposition.decomposition_rules import (
     wrap_modifier_id,
 )
 from catalyst.decomposition.graph_op_id import GraphOpID
-from catalyst.decomposition.type_utils import get_dummy_values_for_arg
+from catalyst.decomposition.type_utils import (
+    convert_item_to_mlir_type,
+    get_dummy_values_for_arg,
+)
 
 
 class TestGenericUtilities:
@@ -83,6 +86,26 @@ class TestGenericUtilities:
         result = get_dummy_values_for_arg(input)
         assert result.dtype == dtype
         assert result.shape == shape
+
+    @pytest.mark.parametrize(
+        "item, is_custom_op, mlir_type",
+        [
+            (Float, True, "f64"),  # custom op is always float
+            (Float, False, "tensor<f64>"),
+            (Int, False, "tensor<i64>"),
+            (Bool, False, "tensor<i1>"),
+            (Complex, False, "tensor<complex<f64>>"),
+            (Float[1], False, "tensor<1xf64>"),
+            (Float[2], False, "tensor<2xf64>"),
+            (Int[3], False, "tensor<3xi64>"),
+            (Bool[4], False, "tensor<4xi1>"),
+            (Complex[5], False, "tensor<5xcomplex<f64>>"),
+            (Float[2, 2], False, "tensor<2x2xf64>"),
+            (Complex[3, 4, 5], False, "tensor<3x4x5xcomplex<f64>>"),
+        ],
+    )
+    def test_convert_item_to_mlir_type(self, item, is_custom_op, mlir_type):
+        assert convert_item_to_mlir_type(item, is_custom_op) == mlir_type
 
     @pytest.mark.parametrize(
         "op, id",

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -88,7 +88,7 @@ class TestGenericUtilities:
         assert result.shape == shape
 
     @pytest.mark.parametrize(
-        "item, is_custom_op, mlir_type",
+        "item, is_special_lowering, mlir_type",
         [
             (Float, True, "f64"),  # custom op is always float
             (Float, False, "tensor<f64>"),
@@ -104,8 +104,8 @@ class TestGenericUtilities:
             (Complex[3, 4, 5], False, "tensor<3x4x5xcomplex<f64>>"),
         ],
     )
-    def test_convert_item_to_mlir_type(self, item, is_custom_op, mlir_type):
-        assert convert_item_to_mlir_type(item, is_custom_op) == mlir_type
+    def test_convert_item_to_mlir_type(self, item, is_special_lowering, mlir_type):
+        assert convert_item_to_mlir_type(item, is_special_lowering) == mlir_type
 
     @pytest.mark.parametrize(
         "op, id",

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -258,7 +258,7 @@ class TestTraceTime:
         # A distribution rule for Adjoint(NoParams) is synthesized even though none was registered.
         assert 'target_gate = "Adjoint(NoParams){}{reg:2}{}"' in mlir
         assert (
-            'resources = {operations = {"Adjoint(SingleParam){x:[[f64]]}{reg:2}{}" = 1 : i64}'
+            'resources = {operations = {"Adjoint(SingleParam){x:[tensor<f64>]}{reg:2}{}" = 1 : i64}'
             in mlir
         )
         assert "qref.adjoint" in mlir

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -89,7 +89,7 @@ class TestGenericUtilities:
         [
             (NoParams(Wires(0)), "NoParams{}{reg:1}{}"),
             (NoParamsCustomOp(Wires([0, 1])), "NoParamsCustomOp{}{wires:2}{}"),
-            (SingleParam(Float, Wires([2, 3])), "SingleParam{x:[[f64]]}{reg:2}{}"),
+            (SingleParam(Float, Wires([2, 3])), "SingleParam{x:[tensor<f64>]}{reg:2}{}"),
             (
                 CompilableData(True, 3.14, "string", Wires([0, 1])),
                 "CompilableData{}{wires:2}{a:True,b:3.14,thing:string}",
@@ -100,7 +100,7 @@ class TestGenericUtilities:
             ),
             (
                 MultiParams(Wires([0, 2, 3]), Complex, Int, Float[2]),
-                "MultiParams{a:[[complex<f64>]],b:[[i64]],c:[[f64,f64]]}{reg:3}",
+                "MultiParams{a:[tensor<complex<f64>>],b:[tensor<i64>],c:[tensor<2xf64>]}{reg:3}",
             ),
             (qp.MultiRZ(Float, Wires([0, 2, 3, 4])), "MultiRZ{theta:[f64]}{wires:4}{}"),
             (
@@ -114,7 +114,7 @@ class TestGenericUtilities:
             ),  # NOTE: open brace to match uid
             (
                 HybridOpArg(Float, StaticData("innerop", Wires(0)), Wires([2, 3]), 12),
-                "HybridOpArg{angle:[[f64]]}{cwires:2}{}[",  # NOTE: open brace to match uid
+                "HybridOpArg{angle:[tensor<f64>]}{cwires:2}{}[",  # NOTE: open brace to match uid
             ),
             (
                 qp.Rot(Bool, Int, Float, Wires(0)),

--- a/mlir/lib/Quantum/IR/QuantumInterfaces.cpp
+++ b/mlir/lib/Quantum/IR/QuantumInterfaces.cpp
@@ -15,7 +15,6 @@
 #include "Quantum/IR/QuantumInterfaces.h"
 
 #include <cstddef>
-#include <cstdint>
 #include <string>
 
 #include "llvm/ADT/STLExtras.h"
@@ -24,7 +23,6 @@
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
-#include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Support/LLVM.h"
 

--- a/mlir/lib/Quantum/IR/QuantumInterfaces.cpp
+++ b/mlir/lib/Quantum/IR/QuantumInterfaces.cpp
@@ -69,42 +69,6 @@ void printAttr(mlir::Attribute attr, llvm::raw_string_ostream &ss) {
         .Default([&](mlir::Attribute attr) { attr.print(ss); });
 }
 
-void printShapedType(ArrayRef<int64_t> shape, int64_t dim, Type elementType,
-                     llvm::raw_string_ostream &ss) {
-    // Rank-0 tensors (e.g. tensor<f64>) have an empty shape; print the
-    // element type directly instead of indexing into the empty ArrayRef.
-    if (shape.empty()) {
-        ss << elementType;
-        return;
-    }
-
-    int64_t length = shape[dim];
-    auto printList = [&](auto printItem) {
-        ss << "[";
-        for (int64_t i = 0; i < length; i++) {
-            printItem();
-            if (i != length - 1) {
-                ss << ",";
-            }
-        }
-        ss << "]";
-    };
-
-    if (static_cast<int64_t>(shape.size()) == dim + 1) {
-        printList([&]() { ss << elementType; });
-    } else {
-        printList([&]() { printShapedType(shape, dim + 1, elementType, ss); });
-    }
-}
-
-void printType(mlir::Type type, llvm::raw_string_ostream &ss) {
-    llvm::TypeSwitch<mlir::Type, void>(type)
-        .Case<mlir::ShapedType>([&](mlir::ShapedType shapedType) {
-            printShapedType(shapedType.getShape(), 0, shapedType.getElementType(), ss);
-        })
-        .Default([&](mlir::Type other) { other.print(ss); });
-}
-
 template <typename T, typename PrintFunc>
 void printSortedMap(const llvm::StringMap<T> &map, llvm::raw_string_ostream &ss,
                     PrintFunc printValue) {
@@ -133,7 +97,7 @@ void printDynamicShape(const llvm::StringMap<llvm::SmallVector<mlir::Type>> &map
             if (j > 0) {
                 stream << ",";
             }
-            printType(type, stream);
+            stream << type;
         }
         stream << "]";
     });

--- a/mlir/unittests/Quantum/Interfaces/TestDecomposableGateInterface.cpp
+++ b/mlir/unittests/Quantum/Interfaces/TestDecomposableGateInterface.cpp
@@ -361,13 +361,7 @@ module {
 
     ASSERT_EQ(unitary.getStaticData().size(), 0);
 
-    // Controlled unitary: the control wire is folded into the id (control-outermost).
-    ASSERT_EQ(unitary.getGraphOpId(), "C(QubitUnitary){U:["
-                                      "[[complex<f64>,complex<f64>,complex<f64>,complex<f64>],"
-                                      "[complex<f64>,complex<f64>,complex<f64>,complex<f64>],"
-                                      "[complex<f64>,complex<f64>,complex<f64>,complex<f64>],"
-                                      "[complex<f64>,complex<f64>,complex<f64>,complex<f64>]]"
-                                      "]}{wires:2}{}");
+    ASSERT_EQ(unitary.getGraphOpId(), "C(QubitUnitary){U:[tensor<4x4xcomplex<f64>>]}{wires:2}{}");
 }
 
 TEST(DecomposableGateInterfaceTests, OperatorOpQubits) {
@@ -487,16 +481,16 @@ func.func @testfunc(%first : tensor<1xi64>, %secondthird : tensor<2xi64>) {
 
 TEST(DecomposableGateInterfaceTests, OperatorOpUID) {
     std::string moduleStr = R"mlir(
-func.func @testfunc(%first : tensor<1xi64>, %secondthird : tensor<2xi64>) {
-  %angle = arith.constant 3.1 : f64
-  %flag = arith.constant 0 : i1
-  %index = arith.constant 5 : i64
+func.func @testfunc(%first : tensor<1xi64>, %secondthird : tensor<2xi64>, %arg1 : tensor<i1>, %arg2: tensor<f64>, %arg3: tensor<i64>) {
 
   %reg = quantum.alloc(4) : !quantum.reg
   %q0 = quantum.extract %reg[0] : !quantum.reg -> !quantum.bit
 
-  %0 = quantum.operator "testOperatorUID"(%flag: i1, %angle: f64, %index: i64)
-    UID(248) quregs(%reg) indices(%first: tensor<1xi64>, %secondthird: tensor<2xi64>) param_map = {flag=[0], angle=[1], index=[2]} qubit_map = {reg=[0, 1]}
+    // testOperatorUID(angle=float, index=[bool, int])
+  %0 = quantum.operator "testOperatorUID"(%arg1: tensor<i1>, %arg2: tensor<f64>, %arg3: tensor<i64>)
+    UID(248) quregs(%reg) indices(%first: tensor<1xi64>, %secondthird: tensor<2xi64>) param_map = {angle=[1], index=[0, 2]} qubit_map = {reg=[0, 1]}
+    // old style: testOperatorUID{angle:[[f64]],index:[[i1],[i64]]}{reg:2}{}
+    // new style: testOperatorUID{angle:[tensor<f64>],index:[tensor<i1>,tensor<i64>]}{reg:2}{}
   return
 }
     )mlir";
@@ -513,14 +507,11 @@ func.func @testfunc(%first : tensor<1xi64>, %secondthird : tensor<2xi64>) {
 
     ASSERT_EQ(op.getOperatorName(), "testOperatorUID");
 
-    // This is needed to keep the backing array from being deleted
-    // llvm::SmallVector<llvm::SmallVector<mlir::Type>, 1> backing(
-    //     {mlir::IntegerType::get(&context, 1), mlir::Float64Type::get(&context),
-    //      mlir::IntegerType::get(&context, 64)});
     llvm::StringMap<llvm::SmallVector<mlir::Type>> expectedDynamicShape = {
-        {"flag", {mlir::IntegerType::get(&context, 1)}},
-        {"angle", {mlir::Float64Type::get(&context)}},
-        {"index", {mlir::IntegerType::get(&context, 64)}}};
+        {"angle", {mlir::RankedTensorType::get({}, mlir::Float64Type::get(&context))}},
+        {"index",
+         {mlir::RankedTensorType::get({}, mlir::IntegerType::get(&context, 1)),
+          mlir::RankedTensorType::get({}, mlir::IntegerType::get(&context, 64))}}};
     ASSERT_EQ(op.getDynamicShape(), expectedDynamicShape);
 
     llvm::StringMap<size_t> expectedWires = {{"reg", 3}};
@@ -528,6 +519,7 @@ func.func @testfunc(%first : tensor<1xi64>, %secondthird : tensor<2xi64>) {
 
     ASSERT_EQ(op.getStaticData(), mlir::DictionaryAttr::get(&context, {}));
 
-    ASSERT_EQ(op.getGraphOpId(),
-              "testOperatorUID{angle:[f64],flag:[i1],index:[i64]}{reg:3}{}[248]");
+    ASSERT_EQ(op.getGraphOpId(), "testOperatorUID{angle:[tensor<f64>],index:["
+                                 "tensor<i1>,tensor<i64>]}{reg:3}{}[248]");
+    // TODO: better separate these tests to unittests
 }

--- a/mlir/unittests/Quantum/Interfaces/TestDecomposableGateInterface.cpp
+++ b/mlir/unittests/Quantum/Interfaces/TestDecomposableGateInterface.cpp
@@ -489,8 +489,6 @@ func.func @testfunc(%first : tensor<1xi64>, %secondthird : tensor<2xi64>, %arg1 
     // testOperatorUID(angle=float, index=[bool, int])
   %0 = quantum.operator "testOperatorUID"(%arg1: tensor<i1>, %arg2: tensor<f64>, %arg3: tensor<i64>)
     UID(248) quregs(%reg) indices(%first: tensor<1xi64>, %secondthird: tensor<2xi64>) param_map = {angle=[1], index=[0, 2]} qubit_map = {reg=[0, 1]}
-    // old style: testOperatorUID{angle:[[f64]],index:[[i1],[i64]]}{reg:2}{}
-    // new style: testOperatorUID{angle:[tensor<f64>],index:[tensor<i1>,tensor<i64>]}{reg:2}{}
   return
 }
     )mlir";


### PR DESCRIPTION
**Context:**
GOIDs currently use python-style type annotations, which cause confusion with nested lists in dynamic args ( ex. `[[[f64,f64],f64]]`. Worse yet, there is a collision with `tensor<f64> -> [[f64]] <- tensor<1xf64>`.

**Description of the Change:**
To fix these issues, we migrate GOID to use mlir-style type annotations (ex. `tensor<f64>` as opposed to `[f64]`).

**Benefits:**
Solves the collision issue, improves readability for debugging (GOIDs should still be considered opaque for all implementation purposes), and simplifies lit tests.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-129176]