### PR TITLE
Fix decomposition rule selection for static data and invalid resources

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -134,6 +134,7 @@
 
     With pathways 2 and 3, gates with static data only known at compile time can now be decomposed using the decomposition rule defined in PennyLane.
     For example, this includes `quantum.paulirot`, with Pauli words being the static data.
+    [(#3160)](https://github.com/PennyLaneAI/catalyst/pull/3160)
 
   - The `graph-decomposition` pass eliminated three redundant IR manipulations:
     the cloning, removal, and re-insertion of user rules.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -121,6 +121,7 @@
 
     2. When lowering a gate operation from JAXPR to MLIR, all rules reachable from that gate are injected into the IR.
     [(#3061)](https://github.com/PennyLaneAI/catalyst/pull/3061)
+    [(#3160)](https://github.com/PennyLaneAI/catalyst/pull/3160)
 
     This pathway of rule injection can be opted-out via a new keyword argument on `qp.qjit` named `collect_decomp_rules`.
     This kwarg controls whether or not to compile the decomposition rules during lower-time. Default value is `True`.
@@ -134,7 +135,6 @@
 
     With pathways 2 and 3, gates with static data only known at compile time can now be decomposed using the decomposition rule defined in PennyLane.
     For example, this includes `quantum.paulirot`, with Pauli words being the static data.
-    [(#3160)](https://github.com/PennyLaneAI/catalyst/pull/3160)
 
   - The `graph-decomposition` pass eliminated three redundant IR manipulations:
     the cloning, removal, and re-insertion of user rules.

--- a/frontend/catalyst/decomposition/decomposition_rules.py
+++ b/frontend/catalyst/decomposition/decomposition_rules.py
@@ -242,12 +242,18 @@ def compile_decomposition_rules(
 
         return qp.capture.subroutine(decomp_rule_no_static_args)
 
-    call_args, call_kwargs = split_call_args(kwargs, is_custom_op)
+    condition_args, condition_kwargs = split_call_args(
+        kwargs | static_data | extra_data, is_custom_op
+    )
 
     subroutines = []
     for rule in decomp_rules:
-        if rule.is_applicable(*call_args, **call_kwargs):
+        if rule.name in name_to_resource_ids and rule.is_applicable(
+            *condition_args, **condition_kwargs
+        ):
             subroutines.append(rule_to_subroutine(rule))
+
+    call_args, call_kwargs = split_call_args(kwargs, is_custom_op)
 
     @qp.qjit(target="mlir", capture=True, collect_decomp_rules=False)
     @qp.qnode(device=device)

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -14,6 +14,8 @@
 
 """Unit tests for the python decompositions module."""
 
+from unittest.mock import MagicMock
+
 import jax.numpy as jnp
 import pennylane as qp
 import pytest
@@ -140,6 +142,26 @@ class TestGenericUtilities:
             )
         assert isinstance(res, str)
 
+    def test_wrapper_passes_compilable_data_to_conditions(self, monkeypatch):
+        """Test that decomposition conditions receive compilable operator data."""
+        mock_decomp = MagicMock()
+        mock_decomp._impl.__name__ = "FakeRuleName"
+        mock_decomp.compute_resources.return_value.gate_counts = {}
+        mock_decomp.is_applicable.side_effect = (
+            lambda *, wires, a, b, thing: a and b == 3.14 and thing == "string"
+        )
+
+        monkeypatch.setattr(qp.decomposition, "list_decomps", lambda _: [mock_decomp])
+
+        res = compile_decomposition_rules_wrapper(
+            "CompilableData",
+            "CompilableData{}{wires:2}{a:True,b:3.14,thing:string}",
+            {},
+            {"wires": 2},
+            {"a": True, "b": 3.14, "thing": "string"},
+        )
+
+        assert isinstance(res, str)
 
 class TestPrecompiled:
     """Tests for precompiled decomposition rules."""

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -14,8 +14,6 @@
 
 """Unit tests for the python decompositions module."""
 
-from unittest.mock import MagicMock
-
 import jax.numpy as jnp
 import pennylane as qp
 import pytest
@@ -142,16 +140,16 @@ class TestGenericUtilities:
             )
         assert isinstance(res, str)
 
-    def test_wrapper_passes_compilable_data_to_conditions(self, monkeypatch):
+    def test_wrapper_passes_compilable_data_to_conditions(self, mocker):
         """Test that decomposition conditions receive compilable operator data."""
-        mock_decomp = MagicMock()
+        mock_decomp = mocker.MagicMock()
         mock_decomp._impl.__name__ = "FakeRuleName"
         mock_decomp.compute_resources.return_value.gate_counts = {}
         mock_decomp.is_applicable.side_effect = (
             lambda *, wires, a, b, thing: a and b == 3.14 and thing == "string"
         )
 
-        monkeypatch.setattr(qp.decomposition, "list_decomps", lambda _: [mock_decomp])
+        mocker.patch("pennylane.decomposition.list_decomps", return_value=[mock_decomp])
 
         res = compile_decomposition_rules_wrapper(
             "CompilableData",
@@ -161,7 +159,14 @@ class TestGenericUtilities:
             {"a": True, "b": 3.14, "thing": "string"},
         )
 
-        assert isinstance(res, str)
+        assert "FakeRuleName" in res
+        mock_decomp.is_applicable.assert_called_once()
+        call_kwargs = mock_decomp.is_applicable.call_args.kwargs
+        assert call_kwargs["a"] is True
+        assert call_kwargs["b"] == 3.14
+        assert call_kwargs["thing"] == "string"
+        assert call_kwargs["wires"].tolist() == [0, 1]
+
 
 class TestPrecompiled:
     """Tests for precompiled decomposition rules."""


### PR DESCRIPTION
**Context:**
Previously, when Operator2 has static data (e.g `mod` in `OutMultiplier`), Catalyst did not pass that data to the decomposition rules's applicability check (`is_applicable`). This caused errors because the rule expect to check static data such `_out_multiplier_with_qft_condition` that needs to verify the `mod`.