### PR TITLE
Update `operator_p` lowering to pop work wire related arguments

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.238
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.46.0.dev84
+pennylane=0.46.0.dev86
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -57,6 +57,7 @@
   [(#2981)](https://github.com/PennyLaneAI/catalyst/pull/2981)
   [(#3109)](https://github.com/PennyLaneAI/catalyst/pull/3109)
   [(#3075)](https://github.com/PennyLaneAI/catalyst/pull/3075)
+  [(#3162)](https://github.com/PennyLaneAI/catalyst/pull/3162)
 
 * The graph-based decomposition system has been greatly improved.
 
@@ -223,7 +224,7 @@
   a transport kick/collect round over its buffers.
   [(#3066)](https://github.com/PennyLaneAI/catalyst/pull/3066)
 
-* A `remove-global-phases` pass is added, which removes global phases by deleting `quantum.gphase`  
+* A `remove-global-phases` pass is added, which removes global phases by deleting `quantum.gphase`
   operations without control wires.
   [(#3143)](https://github.com/PennyLaneAI/catalyst/pull/3143)
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -34,4 +34,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.46.0-dev27
 pennylane-lightning==0.46.0-dev27
-pennylane==0.46.0.dev84
+pennylane==0.46.0.dev86

--- a/frontend/catalyst/from_plxpr/qfunc_interpreter.py
+++ b/frontend/catalyst/from_plxpr/qfunc_interpreter.py
@@ -337,7 +337,7 @@ def _new_hybrid_arg(interp: PLxPRToQuantumJaxprInterpreter, arg) -> list:
     return new_args
 
 
-# pylint: disable=too-many-arguments
+# pylint: disable=too-many-arguments,unused-argument
 def _apply_operator2_gate(
     self,
     *args,
@@ -347,13 +347,20 @@ def _apply_operator2_gate(
     hybrid_trees,
     forward_mask,
     adjoint,
-    n_ctrls,
+    n_ctrls=0,
+    n_ctrl_work_wires=0,
+    ctrl_work_wire_type="borrowed",
     **kwargs,
 ):
     """Apply an Operator2 as a gate instruction using qref_operator_p."""
     n_wires = sum(wire_lens)
     wire_inputs = args[len(op_cls.dynamic_argnames) : len(op_cls.dynamic_argnames) + n_wires]
     if n_ctrls:
+        if n_ctrl_work_wires:
+            # MLIR operations do not currently handle work wires for controlled operators,
+            # so they are ignored.
+            args = args[:-n_ctrl_work_wires]
+
         control_wire_inputs = args[-2 * n_ctrls : -n_ctrls]
         control_values = args[-n_ctrls:]
     else:

--- a/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
+++ b/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
@@ -496,10 +496,6 @@ def _qref_operator_p_lowering(jax_ctx: mlir.LoweringRuleContext, *args, op_cls, 
     wire_lens = kwargs.pop("wire_lens")
     collect_decomp_rules = kwargs.pop("collect_decomp_rules")
 
-    # Work wires for controlled operators are not used by the MLIR operation yet
-    _ = kwargs.pop("n_ctrl_work_wires", None)
-    _ = kwargs.pop("ctrl_work_wire_type", None)
-
     repack_static_data = {k: unflatten(*v) for k, v in kwargs.items()}
 
     if n_ctrls:

--- a/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
+++ b/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
@@ -496,6 +496,10 @@ def _qref_operator_p_lowering(jax_ctx: mlir.LoweringRuleContext, *args, op_cls, 
     wire_lens = kwargs.pop("wire_lens")
     collect_decomp_rules = kwargs.pop("collect_decomp_rules")
 
+    # Work wires for controlled operators are not used by the MLIR operation yet
+    _ = kwargs.pop("n_ctrl_work_wires", None)
+    _ = kwargs.pop("ctrl_work_wire_type", None)
+
     repack_static_data = {k: unflatten(*v) for k, v in kwargs.items()}
 
     if n_ctrls:


### PR DESCRIPTION
**Context:**
`operator_p` now has two new parameters to provide information related to the work wires of controlled operators. This caused the operator lowering for controlled operators to fail, as they were incorrectly being identified as static arguments to the underlying operator.

**Description of the Change:**
* Pop `n_ctrl_work_wires` and `ctrl_work_wires_type` from the keyword arguments in `from_plxpr`. They're not used by the MLIR operation, so they don't need to be used, just ignored. So the lowering rule never receives them.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**


[sc-128897]