### PR TITLE
Bump PL to 0.46.0-dev88

### DIFF
--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.238
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.46.0.dev86
+pennylane=0.46.0-dev88
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/.dep-versions
+++ b/.dep-versions
@@ -8,7 +8,7 @@ enzyme=v0.0.238
 
 # For a custom PL version, update the package version here and at
 # 'doc/requirements.txt'
-pennylane=0.46.0-dev88
+pennylane=0.46.0.dev88
 
 # For a custom LQ/LK version, update the package version here and at
 # 'doc/requirements.txt'

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -34,4 +34,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.46.0-dev27
 pennylane-lightning==0.46.0-dev27
-pennylane==0.46.0-dev88
+pennylane==0.46.0.dev88

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -34,4 +34,4 @@ lxml_html_clean
 --extra-index-url https://test.pypi.org/simple/
 pennylane-lightning-kokkos==0.46.0-dev27
 pennylane-lightning==0.46.0-dev27
-pennylane==0.46.0.dev86
+pennylane==0.46.0-dev88

--- a/frontend/catalyst/decomposition/graph_op_id.py
+++ b/frontend/catalyst/decomposition/graph_op_id.py
@@ -24,7 +24,7 @@ from catalyst.decomposition.type_utils import (
     convert_item_to_mlir_type,
     format_dynamic_params_for_id,
     post_process_concretize_leaves,
-    replace_abstract_wires_with_concrete_wires,
+    replace_wires_with_placeholder_wires,
 )
 from catalyst.from_plxpr.uid import generate_uid
 
@@ -112,7 +112,7 @@ class GraphOpID:
             hybrid_trees = []
             hybrid_args = []
             for _, hybrid_argval in self.op.hybrid_args.items():
-                leaves, tree = flatten(replace_abstract_wires_with_concrete_wires(hybrid_argval))
+                leaves, tree = flatten(replace_wires_with_placeholder_wires(hybrid_argval))
                 leaves = post_process_concretize_leaves(leaves)
                 hybrid_lens.append(len(leaves))
                 hybrid_trees.append(tree)

--- a/frontend/catalyst/decomposition/type_utils.py
+++ b/frontend/catalyst/decomposition/type_utils.py
@@ -14,7 +14,6 @@
 
 """Type handling utilities for decomposition rule lowering."""
 
-import copy
 import re
 
 import jax.numpy as jnp
@@ -22,6 +21,7 @@ import numpy as np
 import pennylane as qp
 from jax._src.lib.mlir import ir
 from jax.core import ShapedArray
+from pennylane.pytrees import flatten, unflatten
 
 _MLIR_DTYPES_TO_PY_DTYPES = {
     "i1": jnp.bool_,
@@ -135,53 +135,28 @@ def get_dummy_values_for_arg(arg):
     raise TypeError(f"Unexpected type in container when creating dummy values: {type(arg)}")
 
 
+def _is_wires(node):
+    """Return whether ``node`` is a container of wires, abstract or concrete."""
+    return isinstance(node, (qp.typing.AbstractWires, qp.wires.Wires))
+
+
 def replace_wires_with_placeholder_wires(node):
     """
-    Replace every wire container (abstract or concrete) in ``node`` with placeholder wires.
+    Return a copy of the pytree ``node`` in which every wire container (abstract or concrete,
+    including the ones nested inside ``Operator2`` instances) is replaced by placeholder wires
+    labelled with negative integers.
 
     Wire labels never affect which decomposition rules apply to an operator: at lowering time
-    wires always show up as (abstract) qubit operands. Hence both `AbstractWires` and concrete
-    `Wires` are replaced with negative placeholder labels, so that operators only differing in
-    their (concrete) wire labels reduce to the same ``GraphOpId``.
+    wires always show up as (abstract) qubit operands. Replacing them with placeholders makes
+    operators that only differ in their (concrete) wire labels reduce to the same ``GraphOpId``.
     """
-    if isinstance(node, qp.core.Operator2):
-        return _replace_op_wires_with_placeholder_wires(node)
-
-    if isinstance(node, list):
-        return [replace_wires_with_placeholder_wires(item) for item in node]
-    elif isinstance(node, dict):
-        return {k: replace_wires_with_placeholder_wires(v) for k, v in node.items()}
-    elif isinstance(node, tuple):
-        return tuple(replace_wires_with_placeholder_wires(item) for item in node)
-    else:
-        if isinstance(node, (qp.typing.AbstractWires, qp.wires.Wires)):
-            return _placeholder_wires(len(node))
-        else:
-            return node
-
-
-def _placeholder_wires(num_wires):
-    """Return ``num_wires`` placeholder wires, labelled with negative integers."""
-    return qp.wires.Wires(range(-1, -num_wires - 1, -1))
-
-
-def _replace_op_wires_with_placeholder_wires(op2):
-    """
-    Given an Operator2 instance, return a copy of the same instance but with all fields whose value
-    is an ``AbstractWires`` or a concrete ``Wires`` replaced with placeholder ``Wires``.
-    """
-    new_op = copy.deepcopy(op2)
-    for wire_arg in new_op.wire_argnames:
-        wire_val = new_op.arguments[wire_arg]
-        if isinstance(wire_val, (qp.typing.AbstractWires, qp.wires.Wires)):
-            new_op.arguments[wire_arg] = _placeholder_wires(len(wire_val))
-    for hybrid_arg in new_op.hybrid_argnames:
-        if isinstance(new_op.arguments[hybrid_arg], qp.core.Operator2):
-            new_op.arguments[hybrid_arg] = _replace_op_wires_with_placeholder_wires(
-                new_op.arguments[hybrid_arg]
-            )
-
-    return new_op
+    # Wires is a pytree itself, so it has to be marked as a leaf to be replaced as a whole.
+    leaves, tree = flatten(node, is_leaf=_is_wires)
+    leaves = [
+        qp.wires.Wires(range(-1, -len(leaf) - 1, -1)) if _is_wires(leaf) else leaf
+        for leaf in leaves
+    ]
+    return unflatten(leaves, tree)
 
 
 def post_process_concretize_leaves(leaves):

--- a/frontend/catalyst/decomposition/type_utils.py
+++ b/frontend/catalyst/decomposition/type_utils.py
@@ -135,36 +135,49 @@ def get_dummy_values_for_arg(arg):
     raise TypeError(f"Unexpected type in container when creating dummy values: {type(arg)}")
 
 
-def replace_abstract_wires_with_concrete_wires(node):
+def replace_wires_with_placeholder_wires(node):
+    """
+    Replace every wire container (abstract or concrete) in ``node`` with placeholder wires.
+
+    Wire labels never affect which decomposition rules apply to an operator: at lowering time
+    wires always show up as (abstract) qubit operands. Hence both `AbstractWires` and concrete
+    `Wires` are replaced with negative placeholder labels, so that operators only differing in
+    their (concrete) wire labels reduce to the same ``GraphOpId``.
+    """
     if isinstance(node, qp.core.Operator2):
-        return _replace_op_abstract_wires_with_concrete_wires(node)
+        return _replace_op_wires_with_placeholder_wires(node)
 
     if isinstance(node, list):
-        return [replace_abstract_wires_with_concrete_wires(item) for item in node]
+        return [replace_wires_with_placeholder_wires(item) for item in node]
     elif isinstance(node, dict):
-        return {k: replace_abstract_wires_with_concrete_wires(v) for k, v in node.items()}
+        return {k: replace_wires_with_placeholder_wires(v) for k, v in node.items()}
     elif isinstance(node, tuple):
-        return tuple(replace_abstract_wires_with_concrete_wires(item) for item in node)
+        return tuple(replace_wires_with_placeholder_wires(item) for item in node)
     else:
-        if isinstance(node, qp.typing.AbstractWires):
-            return qp.wires.Wires(range(len(node)))
+        if isinstance(node, (qp.typing.AbstractWires, qp.wires.Wires)):
+            return _placeholder_wires(len(node))
         else:
             return node
 
 
-def _replace_op_abstract_wires_with_concrete_wires(op2):
+def _placeholder_wires(num_wires):
+    """Return `num_wires` placeholder wires, labelled with negative integers."""
+    return qp.wires.Wires(range(-1, -num_wires - 1, -1))
+
+
+def _replace_op_wires_with_placeholder_wires(op2):
     """
     Given an Operator2 instance, return a copy of the same instance but with all fields whose value
-    is an `AbstractWires` replaced with concrete `Wires`.
+    is an `AbstractWires` or a concrete `Wires` replaced with placeholder `Wires`.
     """
     new_op = copy.deepcopy(op2)
     for wire_arg in new_op.wire_argnames:
-        if isinstance(new_op.arguments[wire_arg], qp.typing.AbstractWires):
-            num_wires = len(new_op.arguments[wire_arg])
-            new_op.arguments[wire_arg] = qp.wires.Wires(range(-1, -num_wires - 1, -1))
+        wire_val = new_op.arguments[wire_arg]
+        if isinstance(wire_val, (qp.typing.AbstractWires, qp.wires.Wires)):
+            new_op.arguments[wire_arg] = _placeholder_wires(len(wire_val))
     for hybrid_arg in new_op.hybrid_argnames:
         if isinstance(new_op.arguments[hybrid_arg], qp.core.Operator2):
-            new_op.arguments[hybrid_arg] = _replace_op_abstract_wires_with_concrete_wires(
+            new_op.arguments[hybrid_arg] = _replace_op_wires_with_placeholder_wires(
                 new_op.arguments[hybrid_arg]
             )
 

--- a/frontend/catalyst/decomposition/type_utils.py
+++ b/frontend/catalyst/decomposition/type_utils.py
@@ -161,14 +161,14 @@ def replace_wires_with_placeholder_wires(node):
 
 
 def _placeholder_wires(num_wires):
-    """Return `num_wires` placeholder wires, labelled with negative integers."""
+    """Return ``num_wires`` placeholder wires, labelled with negative integers."""
     return qp.wires.Wires(range(-1, -num_wires - 1, -1))
 
 
 def _replace_op_wires_with_placeholder_wires(op2):
     """
     Given an Operator2 instance, return a copy of the same instance but with all fields whose value
-    is an `AbstractWires` or a concrete `Wires` replaced with placeholder `Wires`.
+    is an ``AbstractWires`` or a concrete ``Wires`` replaced with placeholder ``Wires``.
     """
     new_op = copy.deepcopy(op2)
     for wire_arg in new_op.wire_argnames:

--- a/frontend/catalyst/decomposition/type_utils.py
+++ b/frontend/catalyst/decomposition/type_utils.py
@@ -14,6 +14,7 @@
 
 """Type handling utilities for decomposition rule lowering."""
 
+import copy
 import re
 
 import jax.numpy as jnp
@@ -149,9 +150,11 @@ def replace_wires_with_placeholder_wires(node):
     Wire labels never affect which decomposition rules apply to an operator: at lowering time
     wires always show up as (abstract) qubit operands. Replacing them with placeholders makes
     operators that only differ in their (concrete) wire labels reduce to the same ``GraphOpId``.
+
+    Note that the result is a deep copy.
     """
     # Wires is a pytree itself, so it has to be marked as a leaf to be replaced as a whole.
-    leaves, tree = flatten(node, is_leaf=_is_wires)
+    leaves, tree = flatten(copy.deepcopy(node), is_leaf=_is_wires)
     leaves = [
         qp.wires.Wires(range(-1, -len(leaf) - 1, -1)) if _is_wires(leaf) else leaf
         for leaf in leaves

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -66,6 +66,10 @@ class TestGenericUtilities:
         op = qp.RX(0.5, original_wires)
         original_op_wires = op.wires
 
+        # NOTE: PennyLane re-wraps wire arguments on construction, so the stored wires are
+        # a different object than original wires.
+        original_wire_arg = op.arguments["wires"]
+
         new_op = replace_wires_with_placeholder_wires(op)
 
         # Check that the new op received the placeholder wires
@@ -75,7 +79,7 @@ class TestGenericUtilities:
         # Check original operator is not mutated
         assert op.wires == original_wires
         assert op.wires is original_op_wires
-        assert op.arguments["wires"] is original_wires
+        assert op.arguments["wires"] is original_wire_arg
 
     @pytest.mark.parametrize(
         "input, dtype, shape",

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -52,11 +52,30 @@ from catalyst.decomposition.graph_op_id import GraphOpID
 from catalyst.decomposition.type_utils import (
     convert_item_to_mlir_type,
     get_dummy_values_for_arg,
+    replace_wires_with_placeholder_wires,
 )
 
 
 class TestGenericUtilities:
     """Tests for common decomposition rule lowering utilities."""
+
+    def test_wires_replacement_doesnt_mutate_operator(self):
+        """Test that the wires replacement helper does not mutate the incoming operator."""
+
+        original_wires = qp.wires.Wires([0])
+        op = qp.RX(0.5, original_wires)
+        original_op_wires = op.wires
+
+        new_op = replace_wires_with_placeholder_wires(op)
+
+        # Check that the new op received the placeholder wires
+        assert new_op.wires == qp.wires.Wires([-1])
+        assert new_op is not op
+
+        # Check original operator is not mutated
+        assert op.wires == original_wires
+        assert op.wires is original_op_wires
+        assert op.arguments["wires"] is original_wires
 
     @pytest.mark.parametrize(
         "input, dtype, shape",

--- a/frontend/test/pytest/test_template.py
+++ b/frontend/test/pytest/test_template.py
@@ -1039,9 +1039,6 @@ def test_multiplier(backend):
     assert np.allclose(interpreted_fn(), jitted_fn())
 
 
-@pytest.mark.xfail(
-    reason="Legacy Catalyst frontend does not support PennyLane's 'borrowed' template argument"
-)
 def test_out_adder(backend):
     """Test OutAdder."""
     mod = 7


### PR DESCRIPTION
**Context:**
Bump the dep version of PL to 0.46.0-dev88 to benefit from the latest changes in Op2 and Abstract types.

[sc-129534]