### PR TITLE
Categorize `DecompRuleWarnings`

### DIFF
--- a/frontend/catalyst/decomposition/__init__.py
+++ b/frontend/catalyst/decomposition/__init__.py
@@ -1,0 +1,7 @@
+from .graph_op_id import GraphOpID
+from .rule_lowering_warning import RuleLoweringWarning
+
+__all__ = (
+    "RuleLoweringWarning",
+    "GraphOpID",
+)

--- a/frontend/catalyst/decomposition/decomposition_rules.py
+++ b/frontend/catalyst/decomposition/decomposition_rules.py
@@ -26,6 +26,7 @@ from jax._src.lib.mlir import ir
 from jaxlib.mlir.dialects.builtin import ModuleOp
 
 from catalyst.decomposition.graph_op_id import GraphOpID
+from catalyst.decomposition.rule_lowering_warning import RuleLoweringWarning
 from catalyst.decomposition.type_utils import get_dummy_values_for_arg
 from catalyst.jax_extras.lowering import get_mlir_attribute_from_pyval
 
@@ -260,7 +261,10 @@ def collect_resources_for_op(op_name, kwargs, is_custom_op=False, adjoint_resour
                 for op, count in resources.gate_counts.items()
             }
         except Exception as e:
-            warnings.warn(f"Failed to get resources for the {rule.name} decomposition rule: {e}")
+            warnings.warn(
+                f"Failed to get resources for the {rule.name} decomposition rule: {e}",
+                category=RuleLoweringWarning,
+            )
 
     return name_to_resources, name_to_resource_ids, decomp_rules
 
@@ -438,7 +442,10 @@ def adjoint_variant_rule_strings(
             )
         )
     except Exception as e:  # pylint: disable=broad-except
-        warnings.warn(f"Failed to lower the decomposition rules for {adj_name}: {e}")
+        warnings.warn(
+            f"Failed to lower the decomposition rules for {adj_name}: {e}",
+            category=RuleLoweringWarning,
+        )
     # (2) Rules for Adjoint(op_name) synthesized by adjointing each base rule of op_name:
     try:
         distributed = get_rule_strings_from_module(
@@ -461,7 +468,10 @@ def adjoint_variant_rule_strings(
         ]
         out.extend(distributed)
     except Exception as e:  # pylint: disable=broad-except
-        warnings.warn(f"Failed to synthesize distributed adjoint rules for {adj_name}: {e}")
+        warnings.warn(
+            f"Failed to synthesize distributed adjoint rules for {adj_name}: {e}",
+            category=RuleLoweringWarning,
+        )
     return out
 
 
@@ -508,7 +518,10 @@ def control_variant_rule_strings(
                 )
             )
         except Exception as e:  # pylint: disable=broad-except
-            warnings.warn(f"Failed to lower the decomposition rules for {ctrl_name}: {e}")
+            warnings.warn(
+                f"Failed to lower the decomposition rules for {ctrl_name}: {e}",
+                category=RuleLoweringWarning,
+            )
         # (2) <n>C(op_name) by controlling each base rule, and
         # (3) <n>C(Adjoint(op_name)) by controlling each adjointed base rule.
         for wrap_adjoint, label in ((False, ctrl_name), (True, f"{ctrl_mod}(Adjoint({op_name}))")):
@@ -535,7 +548,10 @@ def control_variant_rule_strings(
                 ]
                 out.extend(controlled)
             except Exception as e:  # pylint: disable=broad-except
-                warnings.warn(f"Failed to synthesize distributed control rules for {label}: {e}")
+                warnings.warn(
+                    f"Failed to synthesize distributed control rules for {label}: {e}",
+                    category=RuleLoweringWarning,
+                )
     return out
 
 
@@ -731,7 +747,8 @@ def fetch_all_reachable_decomposition_rules_from_op(
                             )
                 except Exception as e:
                     warnings.warn(
-                        f"Failed to lower the {_rule_name} decomposition rule for {this_name}: {e}"
+                        f"Failed to lower the {_rule_name} decomposition rule for {this_name}: {e}",
+                        category=RuleLoweringWarning,
                     )
                 continue
     return rules

--- a/frontend/catalyst/decomposition/rule_lowering_warning.py
+++ b/frontend/catalyst/decomposition/rule_lowering_warning.py
@@ -1,0 +1,21 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""This module provides a warning category for grouping decomposition rule lowering warnings."""
+
+import warnings
+
+
+class RuleLoweringWarning(Warning):
+    pass

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -35,6 +35,7 @@ from pennylane.typing import Bool, Complex, Float, Int, Wire
 from pennylane.wires import Wires
 
 from catalyst import qjit
+from catalyst.decomposition import GraphOpID, RuleLoweringWarning
 from catalyst.decomposition.decomposition_rules import (
     _MODIFIER_CANONICAL_ORDER,
     _control_modifier,
@@ -161,12 +162,13 @@ class TestGenericUtilities:
 
         mocker.patch("pennylane.decomposition.list_decomps", return_value=[mock_decomp])
 
-        with pytest.warns(match="Failed to get resources"):
+        with pytest.warns(RuleLoweringWarning, match="Failed to get resources"):
             res = compile_decomposition_rules_wrapper(
                 "MockOp", 'MockOp{}{"wires":1}{}', {}, {"wires": 1}, {}
             )
         assert isinstance(res, str)
 
+    @pytest.mark.filterwarnings("ignore::catalyst.decomposition.RuleLoweringWarning")
     def test_wrapper_passes_compilable_data_to_conditions(self, mocker):
         """Test that decomposition conditions receive compilable operator data."""
         mock_decomp = mocker.MagicMock()
@@ -244,6 +246,7 @@ class TestTraceTime:
         assert 'target_gate = "NoParams{}{reg:2}{}"' in mlir
         assert 'target_gate = "Adjoint(NoParams){}{reg:2}{}"' in mlir
 
+    @pytest.mark.filterwarnings("ignore::catalyst.decomposition.RuleLoweringWarning")
     def test_adjoint_gate_captures_base_and_adjoint(self):
         """Lowering the Adjoint of a gate captures the rules registered against both the plain gate
         and its adjoint."""
@@ -266,6 +269,7 @@ class TestTraceTime:
         assert 'target_gate = "NoParams{}{reg:2}{}"' in mlir
         assert 'target_gate = "Adjoint(NoParams){}{reg:2}{}"' in mlir
 
+    @pytest.mark.filterwarnings("ignore::catalyst.decomposition.RuleLoweringWarning")
     def test_distribution_rule_synthesized_from_base_only(self):
         """With only a base rule registered (no Adjoint(Op) rule), lowering still synthesizes a rule
         for Adjoint(Op) by distributing the base rule over adjoint (case 3): its resources are the
@@ -293,6 +297,7 @@ class TestTraceTime:
         )
         assert "qref.adjoint" in mlir
 
+    @pytest.mark.filterwarnings("ignore::catalyst.decomposition.RuleLoweringWarning")
     def test_no_distribution_rule_for_non_invertible_body(self):
         """A distribution rule is NOT synthesized when the base rule body is non-invertible (contains
         a mid-circuit measurement): the base rule is still lowered, but no Adjoint(Op) rule."""
@@ -365,6 +370,7 @@ class TestOnDemand:
         with pytest.raises(ValueError, match="not a control id"):
             name_unwrap_control("RX", "Adjoint(RX){0:[f64]}{wires:1}{}")
 
+    @pytest.mark.filterwarnings("ignore::catalyst.decomposition.RuleLoweringWarning")
     @pytest.mark.parametrize(
         "op_id, extra_ctrl_target",
         [
@@ -388,13 +394,14 @@ class TestOnDemand:
         if extra_ctrl_target is not None:
             assert extra_ctrl_target in module_str
 
+    @pytest.mark.filterwarnings("ignore::catalyst.decomposition.RuleLoweringWarning")
     def test_control_variant_warns_and_skips_on_failure(self, mocker):
         """control_variant_rule_strings warns and skips a rule when it fails to compile."""
 
         from catalyst.decomposition import decomposition_rules as dr
 
         mocker.patch.object(dr, "compile_decomposition_rules", side_effect=ValueError("boom"))
-        with pytest.warns(UserWarning, match="control rules"):
+        with pytest.warns(RuleLoweringWarning, match="control rules"):
             out = dr.control_variant_rule_strings(
                 "S", "S{}{wires:1}{}", [1], {}, {"wires": 1}, {}, is_custom_op=True
             )


### PR DESCRIPTION
**Context:**
Recent changes in the graph decomposition system result in attempting to lower all rules for all decomposition-reachable operators for the user circuit. When these rules fail to lower for any reason, we catch the exception and raise a warning, since one rule failure may not prevent compilation. These warnings are often caused by un-migrated PennyLane `Operator`s (need to be upgraded to `Operator2`) or capture/compilation-incompatible decomposition rules or resource functions.

**Description of the Change:**
Adds the `RuleLoweringWarning` warning category to allow silencing these warnings with 
```python
from catalyst.decomposition import RuleLoweringWarning
warnings.filterwarnings("ignore", category=RuleLoweringWarning)
```

**Benefits:**
Users can ignore decomposition rule warnings.

**Possible Drawbacks:**

**Related GitHub Issues:**

[sc-129420]