### PR TITLE
Decomp/pbc decomposable interface

### DIFF
--- a/mlir/include/PBC/IR/PBCOpInterfaces.h
+++ b/mlir/include/PBC/IR/PBCOpInterfaces.h
@@ -14,8 +14,12 @@
 
 #pragma once
 
-#include "llvm/ADT/StringMap.h"   // for DecomposableGate interface
+#include "llvm/ADT/StringMap.h"     // for DecomposableGate interface
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/Types.h"
+#include "mlir/Support/LLVM.h"
 
 //===----------------------------------------------------------------------===//
 // PBC interface declarations.

--- a/mlir/include/PBC/IR/PBCOpInterfaces.h
+++ b/mlir/include/PBC/IR/PBCOpInterfaces.h
@@ -14,10 +14,10 @@
 
 #pragma once
 
-#include "llvm/ADT/StringMap.h"     // for DecomposableGate interface
-#include "mlir/IR/OpDefinition.h"
+#include "llvm/ADT/StringMap.h" // for DecomposableGate interface
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Support/LLVM.h"
 

--- a/mlir/include/PBC/IR/PBCOpInterfaces.h
+++ b/mlir/include/PBC/IR/PBCOpInterfaces.h
@@ -14,10 +14,19 @@
 
 #pragma once
 
+#include "llvm/ADT/StringMap.h"   // for DecomposableGate interface
 #include "mlir/IR/OpDefinition.h"
 
 //===----------------------------------------------------------------------===//
 // PBC interface declarations.
 //===----------------------------------------------------------------------===//
+
+namespace catalyst {
+namespace pbc {
+
+std::string defaultGetGraphOpId(mlir::Operation *op);
+
+}
+} // namespace catalyst
 
 #include "PBC/IR/PBCOpInterfaces.h.inc"

--- a/mlir/include/PBC/IR/PBCOpInterfaces.td
+++ b/mlir/include/PBC/IR/PBCOpInterfaces.td
@@ -56,4 +56,48 @@ def PBCOpInterface : OpInterface<"PBCOpInterface"> {
 
 }
 
+def DecomposableGate : OpInterface<"DecomposableGate"> {
+    let description = [{
+        This interface provides a generic way to query decomposition data from a quantum operation.
+        An operation must implement this interface in order to compatible with the `graph-decomposition` pass.
+        Note that implementing this interface does not guarantee that an operation will decomposed successfully, only that it will be registered with the graph.
+    }];
+
+    let cppNamespace = "::catalyst::pbc";
+
+    let methods = [
+        InterfaceMethod<
+            "Return the name of the corresponding frontend operator (i.e. the rule supplier).", "std::string", "getOperatorName"
+        >,
+        InterfaceMethod<
+            "Return a map of frontend parameter name to shape and dtype of dynamic data.",
+            "llvm::StringMap<llvm::SmallVector<mlir::Type>>", "getDynamicShape"
+        >,
+        InterfaceMethod<
+            "Return a map of frontend parameter name to number of wires (excluding control wires).",
+            "llvm::StringMap<size_t>", "getWireLens"
+        >,
+        InterfaceMethod<
+            "Return a map of frontend parameter name to static data values.",
+            "mlir::DictionaryAttr", "getStaticData"
+        >,
+        InterfaceMethod<
+            "Return a string representation of any additional data an operator may need to provide"
+            " for uniqueness (ex. UID), or emptystring if not applicable.",
+            "std::string", "getExtraData", (ins), [{}], [{ return ""; }]
+        >,
+        InterfaceMethod<
+            "Return the operation's ID for use with the graph. "
+            "This should be computed by the following convention:\n"
+            "```\n"
+            "name + {map params to list of types} + {map wire args to number of wires} + {static data} + [extra data]\n"
+            "```\n"
+            "Note that extra data is currently specific to `OperatorOp`s, and should only appear when present."
+            "Each of these maps should be sorted lexicographically by key."
+            "In general, this should be computed by the default here and not overridden.",
+            "std::string", "getGraphOpId", (ins), [{}], [{ return ::catalyst::pbc::defaultGetGraphOpId($_op.getOperation()); }]
+        >
+    ];
+}
+
 #endif // PBCOP_INTERFACES

--- a/mlir/include/PBC/IR/PBCOps.td
+++ b/mlir/include/PBC/IR/PBCOps.td
@@ -250,6 +250,15 @@ def PPRotationOp : PBC_Op<"ppr", [PBCOpInterface, AttrSizedOperandSegments,
         bool isClifford(){
             return hasPiOverTwoRotation() || hasPiOverFourRotation();  // π/2 and π/4 rotations are Clifford
         };
+        std::string getPauliWord()
+        {
+            std::string pauliWord;
+
+            for (mlir::Attribute pauliChar : getPauliProduct()) {
+                pauliWord += cast<mlir::StringAttr>(pauliChar).getValue();
+            }
+            return pauliWord;
+        }
     }];
     let extraClassDeclaration = extraBaseClassDeclaration;
 }
@@ -356,6 +365,19 @@ def PPRotationArbitraryOp : PBC_Op<"ppr.arbitrary", [PBCOpInterface, AttrSizedOp
 
     let hasVerifier = 1;
     let hasCanonicalizeMethod = 1;
+
+    code extraBaseClassDeclaration = [{
+        std::string getPauliWord()
+        {
+            std::string pauliWord;
+
+            for (mlir::Attribute pauliChar : getPauliProduct()) {
+                pauliWord += cast<mlir::StringAttr>(pauliChar).getValue();
+            }
+            return pauliWord;
+        }
+    }];
+    let extraClassDeclaration = extraBaseClassDeclaration;
 }
 
 def PPMeasurementOp : PBC_Op<"ppm", [PBCOpInterface,

--- a/mlir/include/PBC/IR/PBCOps.td
+++ b/mlir/include/PBC/IR/PBCOps.td
@@ -136,7 +136,8 @@ def FabricateOp : PBC_Op<"fabricate",
 }
 
 def PPRotationOp : PBC_Op<"ppr", [PBCOpInterface, AttrSizedOperandSegments,
-    DeclareOpInterfaceMethods<ResourceQuantumOpInterface, ["getResourceAdjointFlag", "getResourceDetailedName"]>]> {
+    DeclareOpInterfaceMethods<ResourceQuantumOpInterface, ["getResourceAdjointFlag", "getResourceDetailedName"]>,
+    DeclareOpInterfaceMethods<DecomposableGate>]> {
     let summary = "Pauli Product Rotation on qubits.";
 
     let description = [{
@@ -254,7 +255,8 @@ def PPRotationOp : PBC_Op<"ppr", [PBCOpInterface, AttrSizedOperandSegments,
 }
 
 def PPRotationArbitraryOp : PBC_Op<"ppr.arbitrary", [PBCOpInterface, AttrSizedOperandSegments,
-    DeclareOpInterfaceMethods<ResourceQuantumOpInterface, ["getResourceDetailedName"]>]> {
+    DeclareOpInterfaceMethods<ResourceQuantumOpInterface, ["getResourceDetailedName"]>,
+    DeclareOpInterfaceMethods<DecomposableGate>]> {
     let summary = "Pauli Product Rotation with arbitrary angle.";
     let description = [{
         The PPRotationArbitraryOp represents a Pauli product rotation operation with an arbitrary angle.

--- a/mlir/include/PBC/IR/PBCOps.td
+++ b/mlir/include/PBC/IR/PBCOps.td
@@ -381,7 +381,8 @@ def PPRotationArbitraryOp : PBC_Op<"ppr.arbitrary", [PBCOpInterface, AttrSizedOp
 }
 
 def PPMeasurementOp : PBC_Op<"ppm", [PBCOpInterface,
-    DeclareOpInterfaceMethods<ResourceQuantumOpInterface, ["getResourceAdjointFlag", "getResourceDetailedName"]>]> {
+    DeclareOpInterfaceMethods<ResourceQuantumOpInterface, ["getResourceAdjointFlag", "getResourceDetailedName"]>,
+    DeclareOpInterfaceMethods<DecomposableGate>]> {
     let summary = "Pauli Product Measurement on qubits.";
 
     let description = [{
@@ -448,6 +449,18 @@ def PPMeasurementOp : PBC_Op<"ppm", [PBCOpInterface,
     }];
 
     let hasVerifier = 1;
+    code extraBaseClassDeclaration = [{
+        std::string getPauliWord()
+        {
+            std::string pauliWord;
+
+            for (mlir::Attribute pauliChar : getPauliProduct()) {
+                pauliWord += cast<mlir::StringAttr>(pauliChar).getValue();
+            }
+            return pauliWord;
+        }
+    }];
+    let extraClassDeclaration = extraBaseClassDeclaration;
 }
 
 def SelectPPMeasurementOp : PBC_Op<"select.ppm", [DeclareOpInterfaceMethods<ResourceQuantumOpInterface, ["getResourceDetailedName"]>]> {

--- a/mlir/lib/PBC/IR/PBCOpInterfaces.cpp
+++ b/mlir/lib/PBC/IR/PBCOpInterfaces.cpp
@@ -30,6 +30,8 @@
 
 using namespace mlir;
 using namespace catalyst::pbc;
+
+#include "PBC/IR/PBCOpInterfaces.cpp.inc"
 //===----------------------------------------------------------------------===//
 // Helpers
 //===----------------------------------------------------------------------===//
@@ -170,4 +172,4 @@ std::string defaultGetGraphOpId(Operation *op) {
 
 }
 } // namespace catalyst
-#include "PBC/IR/PBCOpInterfaces.cpp.inc"
+

--- a/mlir/lib/PBC/IR/PBCOpInterfaces.cpp
+++ b/mlir/lib/PBC/IR/PBCOpInterfaces.cpp
@@ -36,7 +36,7 @@ using namespace catalyst::pbc;
 // Helpers
 //===----------------------------------------------------------------------===//
 
-namespace { 
+namespace {
 
 void printAttr(mlir::Attribute attr, llvm::raw_string_ostream &ss) {
     llvm::TypeSwitch<mlir::Attribute, void>(attr)
@@ -124,7 +124,6 @@ void printSortedMap(const llvm::StringMap<T> &map, llvm::raw_string_ostream &ss,
     ss << "}";
 }
 
-
 void printDynamicShape(const llvm::StringMap<llvm::SmallVector<mlir::Type>> &map,
                        llvm::raw_string_ostream &ss) {
     printSortedMap(map, ss, [](const auto &types, llvm::raw_string_ostream &stream) {
@@ -143,7 +142,7 @@ void printWireLens(const llvm::StringMap<size_t> &map, llvm::raw_string_ostream 
     printSortedMap(map, ss, [](size_t len, llvm::raw_string_ostream &stream) { stream << len; });
 }
 
-}
+} // namespace
 
 //===----------------------------------------------------------------------===//
 // PBC interface definitions.
@@ -166,10 +165,9 @@ std::string defaultGetGraphOpId(Operation *op) {
         ss << '[' << gate.getExtraData() << ']';
     }
     ss.flush();
-    
+
     return out;
 }
 
-}
+} // namespace pbc
 } // namespace catalyst
-

--- a/mlir/lib/PBC/IR/PBCOpInterfaces.cpp
+++ b/mlir/lib/PBC/IR/PBCOpInterfaces.cpp
@@ -16,9 +16,36 @@
 
 using namespace mlir;
 using namespace catalyst::pbc;
+//===----------------------------------------------------------------------===//
+// Helpers
+//===----------------------------------------------------------------------===//
+
+namespace { 
+
+
+}
 
 //===----------------------------------------------------------------------===//
 // PBC interface definitions.
 //===----------------------------------------------------------------------===//
 
+namespace catalyst {
+namespace pbc {
+    return name;
+}
+
+std::string defaultGetGraphOpId(Operation *op) {
+    std::string out;
+    llvm::raw_string_ostream ss(out);
+
+    DecomposableGate gate = cast<DecomposableGate>(op);
+
+    ss << gate.getOperatorName();
+
+    
+    return op->getName().getStringRef().str();
+}
+
+}
+} // namespace catalyst
 #include "PBC/IR/PBCOpInterfaces.cpp.inc"

--- a/mlir/lib/PBC/IR/PBCOpInterfaces.cpp
+++ b/mlir/lib/PBC/IR/PBCOpInterfaces.cpp
@@ -14,6 +14,20 @@
 
 #include "PBC/IR/PBCOpInterfaces.h"
 
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/Types.h"
+#include "mlir/Support/LLVM.h"
+
 using namespace mlir;
 using namespace catalyst::pbc;
 //===----------------------------------------------------------------------===//
@@ -22,6 +36,110 @@ using namespace catalyst::pbc;
 
 namespace { 
 
+void printAttr(mlir::Attribute attr, llvm::raw_string_ostream &ss) {
+    llvm::TypeSwitch<mlir::Attribute, void>(attr)
+        .Case<mlir::DictionaryAttr>([&](mlir::DictionaryAttr dict) {
+            ss << "{";
+            for (auto [i, entry] : llvm::enumerate(dict)) {
+                if (i > 0) {
+                    ss << ",";
+                }
+
+                ss << entry.getName().str() << ":";
+                printAttr(entry.getValue(), ss);
+            }
+            ss << "}";
+        })
+        .Case<mlir::ArrayAttr>([&](mlir::ArrayAttr arr) {
+            ss << "[";
+            for (auto [i, attr] : llvm::enumerate(arr)) {
+                if (i > 0) {
+                    ss << ",";
+                }
+                printAttr(attr, ss);
+            }
+            ss << "]";
+        })
+        .Case<mlir::StringAttr>([&](mlir::StringAttr attr) { ss << attr.str(); })
+        .Case<mlir::IntegerAttr>([&](mlir::IntegerAttr attr) { ss << attr.getInt(); })
+        .Case<mlir::FloatAttr>([&](mlir::FloatAttr attr) { ss << attr.getValueAsDouble(); })
+        .Default([&](mlir::Attribute attr) { attr.print(ss); });
+}
+
+void printShapedType(ArrayRef<int64_t> shape, int64_t dim, Type elementType,
+                     llvm::raw_string_ostream &ss) {
+    // Rank-0 tensors (e.g. tensor<f64>) have an empty shape; print the
+    // element type directly instead of indexing into the empty ArrayRef.
+    if (shape.empty()) {
+        ss << elementType;
+        return;
+    }
+
+    int64_t length = shape[dim];
+    auto printList = [&](auto printItem) {
+        ss << "[";
+        for (int64_t i = 0; i < length; i++) {
+            printItem();
+            if (i != length - 1) {
+                ss << ",";
+            }
+        }
+        ss << "]";
+    };
+
+    if (static_cast<int64_t>(shape.size()) == dim + 1) {
+        printList([&]() { ss << elementType; });
+    } else {
+        printList([&]() { printShapedType(shape, dim + 1, elementType, ss); });
+    }
+}
+
+void printType(mlir::Type type, llvm::raw_string_ostream &ss) {
+    llvm::TypeSwitch<mlir::Type, void>(type)
+        .Case<mlir::ShapedType>([&](mlir::ShapedType shapedType) {
+            printShapedType(shapedType.getShape(), 0, shapedType.getElementType(), ss);
+        })
+        .Default([&](mlir::Type other) { other.print(ss); });
+}
+
+template <typename T, typename PrintFunc>
+void printSortedMap(const llvm::StringMap<T> &map, llvm::raw_string_ostream &ss,
+                    PrintFunc printValue) {
+    llvm::SmallVector<llvm::StringRef> keys;
+    for (const llvm::StringRef key : map.keys()) {
+        keys.push_back(key);
+    }
+    llvm::sort(keys);
+
+    ss << "{";
+    for (auto [i, key] : llvm::enumerate(keys)) {
+        if (i > 0) {
+            ss << ",";
+        }
+        ss << key << ":";
+        printValue(map.lookup(key), ss);
+    }
+    ss << "}";
+}
+
+
+void printDynamicShape(const llvm::StringMap<llvm::SmallVector<mlir::Type>> &map,
+                       llvm::raw_string_ostream &ss) {
+    printSortedMap(map, ss, [](const auto &types, llvm::raw_string_ostream &stream) {
+        stream << "[";
+        for (auto [j, type] : llvm::enumerate(types)) {
+            if (j > 0) {
+                stream << ",";
+            }
+            printType(type, stream);
+        }
+        stream << "]";
+    });
+}
+
+void printWireLens(const llvm::StringMap<size_t> &map, llvm::raw_string_ostream &ss) {
+    printSortedMap(map, ss, [](size_t len, llvm::raw_string_ostream &stream) { stream << len; });
+}
 
 }
 
@@ -31,8 +149,6 @@ namespace {
 
 namespace catalyst {
 namespace pbc {
-    return name;
-}
 
 std::string defaultGetGraphOpId(Operation *op) {
     std::string out;
@@ -41,9 +157,15 @@ std::string defaultGetGraphOpId(Operation *op) {
     DecomposableGate gate = cast<DecomposableGate>(op);
 
     ss << gate.getOperatorName();
-
+    printDynamicShape(gate.getDynamicShape(), ss);
+    printWireLens(gate.getWireLens(), ss);
+    printAttr(gate.getStaticData(), ss);
+    if (gate.getExtraData() != "") {
+        ss << '[' << gate.getExtraData() << ']';
+    }
+    ss.flush();
     
-    return op->getName().getStringRef().str();
+    return out;
 }
 
 }

--- a/mlir/lib/PBC/IR/PBCOps.cpp
+++ b/mlir/lib/PBC/IR/PBCOps.cpp
@@ -232,6 +232,18 @@ void LayerOp::print(OpAsmPrinter &p) {
 }
 
 //===----------------------------------------------------------------------===//
+// PBC op interface methods.
+//===----------------------------------------------------------------------===//
+
+// PPRotationOp
+std::string PPRotationOp::getOperatorName() { return "PPRotation"; }
+llvm::StringMap<llvm::SmallVector<mlir::Type>> PPRotationOp::getDynamicShape() {
+    return {};
+}
+llvm::StringMap<size_t>  PPRotationOp::getWireLens() { return {}; }
+mlir::DictionaryAttr PPRotationOp::getStaticData() { return {}; }
+
+//===----------------------------------------------------------------------===//
 // Implement ResourceQuantumOpInterface methods.
 //===----------------------------------------------------------------------===//
 llvm::StringRef PrepareStateOp::getResourceName() { return "pbc.prepare"; }

--- a/mlir/lib/PBC/IR/PBCOps.cpp
+++ b/mlir/lib/PBC/IR/PBCOps.cpp
@@ -236,12 +236,30 @@ void LayerOp::print(OpAsmPrinter &p) {
 //===----------------------------------------------------------------------===//
 
 // PPRotationOp
-std::string PPRotationOp::getOperatorName() { return "PPRotation"; }
+std::string PPRotationOp::getOperatorName() { return "PauliRot"; }
 llvm::StringMap<llvm::SmallVector<mlir::Type>> PPRotationOp::getDynamicShape() {
-    return {};
+    return {{"theta", {mlir::Float64Type::get(getContext())}}};
 }
-llvm::StringMap<size_t>  PPRotationOp::getWireLens() { return {}; }
-mlir::DictionaryAttr PPRotationOp::getStaticData() { return {}; }
+llvm::StringMap<size_t> PPRotationOp::getWireLens() { return {{"wires", getInQubits().size()}}; }
+mlir::DictionaryAttr PPRotationOp::getStaticData() {
+    mlir::MLIRContext *ctx = getContext();
+    mlir::NamedAttribute pauliWordEntry = mlir::NamedAttribute(
+        mlir::StringAttr::get(ctx, "pauli_word"), mlir::StringAttr::get(ctx, getPauliWord()));
+    return mlir::DictionaryAttr::get(ctx, {pauliWordEntry});
+}
+
+// PPRotationArbitraryOp
+std::string PPRotationArbitraryOp::getOperatorName() { return "PauliRot"; }
+llvm::StringMap<llvm::SmallVector<mlir::Type>> PPRotationArbitraryOp::getDynamicShape() {
+    return {{"theta", {mlir::Float64Type::get(getContext())}}};
+}
+llvm::StringMap<size_t> PPRotationArbitraryOp::getWireLens() { return {{"wires", getInQubits().size()}}; }
+mlir::DictionaryAttr PPRotationArbitraryOp::getStaticData() {
+    mlir::MLIRContext *ctx = getContext();
+    mlir::NamedAttribute pauliWordEntry = mlir::NamedAttribute(
+        mlir::StringAttr::get(ctx, "pauli_word"), mlir::StringAttr::get(ctx, getPauliWord()));
+    return mlir::DictionaryAttr::get(ctx, {pauliWordEntry});
+}
 
 //===----------------------------------------------------------------------===//
 // Implement ResourceQuantumOpInterface methods.

--- a/mlir/lib/PBC/IR/PBCOps.cpp
+++ b/mlir/lib/PBC/IR/PBCOps.cpp
@@ -253,7 +253,9 @@ std::string PPRotationArbitraryOp::getOperatorName() { return "PauliRot"; }
 llvm::StringMap<llvm::SmallVector<mlir::Type>> PPRotationArbitraryOp::getDynamicShape() {
     return {{"theta", {mlir::Float64Type::get(getContext())}}};
 }
-llvm::StringMap<size_t> PPRotationArbitraryOp::getWireLens() { return {{"wires", getInQubits().size()}}; }
+llvm::StringMap<size_t> PPRotationArbitraryOp::getWireLens() {
+    return {{"wires", getInQubits().size()}};
+}
 mlir::DictionaryAttr PPRotationArbitraryOp::getStaticData() {
     mlir::MLIRContext *ctx = getContext();
     mlir::NamedAttribute pauliWordEntry = mlir::NamedAttribute(

--- a/mlir/lib/PBC/IR/PBCOps.cpp
+++ b/mlir/lib/PBC/IR/PBCOps.cpp
@@ -272,6 +272,7 @@ mlir::DictionaryAttr PPMeasurementOp::getStaticData() {
     mlir::NamedAttribute pauliWordEntry = mlir::NamedAttribute(
         mlir::StringAttr::get(ctx, "pauli_word"), mlir::StringAttr::get(ctx, getPauliWord()));
 
+    // meas_uid and postselect are not lowered into PPMeasurementOp, so we set them to None
     mlir::StringAttr noneStr = mlir::StringAttr::get(ctx, "None");
     mlir::NamedAttribute measUidEntry =
         mlir::NamedAttribute(mlir::StringAttr::get(ctx, "meas_uid"), noneStr);

--- a/mlir/lib/PBC/IR/PBCOps.cpp
+++ b/mlir/lib/PBC/IR/PBCOps.cpp
@@ -263,6 +263,25 @@ mlir::DictionaryAttr PPRotationArbitraryOp::getStaticData() {
     return mlir::DictionaryAttr::get(ctx, {pauliWordEntry});
 }
 
+// PPMeasurementOp
+std::string PPMeasurementOp::getOperatorName() { return "PauliMeasure"; }
+llvm::StringMap<llvm::SmallVector<mlir::Type>> PPMeasurementOp::getDynamicShape() { return {}; }
+llvm::StringMap<size_t> PPMeasurementOp::getWireLens() { return {{"wires", getInQubits().size()}}; }
+mlir::DictionaryAttr PPMeasurementOp::getStaticData() {
+    mlir::MLIRContext *ctx = getContext();
+    mlir::NamedAttribute pauliWordEntry = mlir::NamedAttribute(
+        mlir::StringAttr::get(ctx, "pauli_word"), mlir::StringAttr::get(ctx, getPauliWord()));
+
+    mlir::StringAttr noneStr = mlir::StringAttr::get(ctx, "None");
+    mlir::NamedAttribute measUidEntry =
+        mlir::NamedAttribute(mlir::StringAttr::get(ctx, "meas_uid"), noneStr);
+
+    mlir::NamedAttribute postselectEntry =
+        mlir::NamedAttribute(mlir::StringAttr::get(ctx, "postselect"), noneStr);
+
+    return mlir::DictionaryAttr::get(ctx, {measUidEntry, pauliWordEntry, postselectEntry});
+}
+
 //===----------------------------------------------------------------------===//
 // Implement ResourceQuantumOpInterface methods.
 //===----------------------------------------------------------------------===//

--- a/mlir/unittests/CMakeLists.txt
+++ b/mlir/unittests/CMakeLists.txt
@@ -11,6 +11,7 @@ endfunction()
 
 if (CATALYST_GTEST_AVAILABLE)
   add_subdirectory(Example)
+  add_subdirectory(PBC)
   add_subdirectory(QRef)
   add_subdirectory(Quantum)
   add_subdirectory(Utils)

--- a/mlir/unittests/PBC/CMakeLists.txt
+++ b/mlir/unittests/PBC/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Interfaces)

--- a/mlir/unittests/PBC/Interfaces/CMakeLists.txt
+++ b/mlir/unittests/PBC/Interfaces/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_catalyst_unittest(CatalystPBCInterfaceTests
+    TestDecomposableGateInterface.cpp
+)
+
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+
+target_link_libraries(CatalystPBCInterfaceTests PRIVATE
+    ${dialect_libs}
+    MLIRQuantum
+    MLIRQRef
+    MLIRPBC
+    MLIRMBQC
+)

--- a/mlir/unittests/PBC/Interfaces/TestDecomposableGateInterface.cpp
+++ b/mlir/unittests/PBC/Interfaces/TestDecomposableGateInterface.cpp
@@ -1,0 +1,111 @@
+// Copyright 2026 Xanadu Quantum Technologies Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstddef>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/Support/Format.h" // for gtest printing on failure
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/DialectRegistry.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/OwningOpRef.h"
+#include "mlir/IR/Types.h"
+#include "mlir/Parser/Parser.h"
+
+#include "PBC/IR/PBCDialect.h"
+#include "PBC/IR/PBCOpInterfaces.h"
+#include "PBC/IR/PBCOps.h"
+#include "Quantum/IR/QuantumDialect.h"
+
+using namespace mlir;
+using namespace catalyst::pbc;
+
+TEST(DecomposableGateInterfaceTests, PPRotationOp) {
+    std::string moduleStr = R"mlir(
+module {
+  %q0 = quantum.alloc_qb : !quantum.bit
+  %q1 = quantum.alloc_qb : !quantum.bit
+  %q2 = quantum.alloc_qb : !quantum.bit
+  %0:3 = pbc.ppr ["X", "Y", "Z"](4) %q0, %q1, %q2 : !quantum.bit, !quantum.bit, !quantum.bit
+}
+    )mlir";
+
+    DialectRegistry registry;
+    registry.insert<mlir::arith::ArithDialect, catalyst::quantum::QuantumDialect, PBCDialect>();
+    MLIRContext context(registry);
+    ParserConfig config(&context, /*verifyAfterParse=*/false);
+    OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(moduleStr, config);
+
+    DecomposableGate ppr = *module->getOps<PPRotationOp>().begin();
+
+    ASSERT_EQ(ppr.getOperatorName(), "PauliRot");
+
+    llvm::StringMap<llvm::SmallVector<mlir::Type>> expectedDynamicShape = {
+        {"theta", {Float64Type::get(&context)}}};
+    ASSERT_EQ(ppr.getDynamicShape(), expectedDynamicShape);
+
+    llvm::StringMap<size_t> expectedWires = {{"wires", 3}};
+    ASSERT_EQ(ppr.getWireLens(), expectedWires);
+
+    mlir::NamedAttribute entry(mlir::StringAttr::get(&context, "pauli_word"),
+                               mlir::StringAttr::get(&context, "XYZ"));
+    mlir::DictionaryAttr expectedStaticData = mlir::DictionaryAttr::get(&context, {entry});
+    ASSERT_EQ(ppr.getStaticData(), expectedStaticData);
+
+    ASSERT_EQ(ppr.getGraphOpId(), "PauliRot{theta:[f64]}{wires:3}{pauli_word:XYZ}");
+}
+
+TEST(DecomposableGateInterfaceTests, PPRotationArbitraryOp) {
+    std::string moduleStr = R"mlir(
+module {
+  %angle = arith.constant 3.1 : f64
+  %q0 = quantum.alloc_qb : !quantum.bit
+  %q1 = quantum.alloc_qb : !quantum.bit
+  %q2 = quantum.alloc_qb : !quantum.bit
+  %0:3 = pbc.ppr.arbitrary ["X", "Y", "Z"](%angle) %q0, %q1, %q2 : !quantum.bit, !quantum.bit, !quantum.bit
+}
+    )mlir";
+
+    DialectRegistry registry;
+    registry.insert<mlir::arith::ArithDialect, catalyst::quantum::QuantumDialect, PBCDialect>();
+    MLIRContext context(registry);
+    ParserConfig config(&context, /*verifyAfterParse=*/false);
+    OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(moduleStr, config);
+
+    DecomposableGate ppr = *module->getOps<PPRotationArbitraryOp>().begin();
+
+    ASSERT_EQ(ppr.getOperatorName(), "PauliRot");
+
+    llvm::StringMap<llvm::SmallVector<mlir::Type>> expectedDynamicShape = {
+        {"theta", {Float64Type::get(&context)}}};
+    ASSERT_EQ(ppr.getDynamicShape(), expectedDynamicShape);
+
+    llvm::StringMap<size_t> expectedWires = {{"wires", 3}};
+    ASSERT_EQ(ppr.getWireLens(), expectedWires);
+
+    mlir::NamedAttribute entry(mlir::StringAttr::get(&context, "pauli_word"),
+                               mlir::StringAttr::get(&context, "XYZ"));
+    mlir::DictionaryAttr expectedStaticData = mlir::DictionaryAttr::get(&context, {entry});
+    ASSERT_EQ(ppr.getStaticData(), expectedStaticData);
+
+    ASSERT_EQ(ppr.getGraphOpId(), "PauliRot{theta:[f64]}{wires:3}{pauli_word:XYZ}");
+}

--- a/mlir/unittests/PBC/Interfaces/TestDecomposableGateInterface.cpp
+++ b/mlir/unittests/PBC/Interfaces/TestDecomposableGateInterface.cpp
@@ -109,3 +109,43 @@ module {
 
     ASSERT_EQ(ppr.getGraphOpId(), "PauliRot{theta:[f64]}{wires:3}{pauli_word:XYZ}");
 }
+
+TEST(DecomposableGateInterfaceTests, PPMeasurementOp) {
+    std::string moduleStr = R"mlir(
+module {
+  %q1 = quantum.alloc_qb : !quantum.bit
+  %q2 = quantum.alloc_qb : !quantum.bit
+  %mres, %out_qubits:2 = pbc.ppm ["X", "Y"] %q1, %q2 : i1, !quantum.bit, !quantum.bit
+}
+    )mlir";
+
+    DialectRegistry registry;
+    registry.insert<mlir::arith::ArithDialect, catalyst::quantum::QuantumDialect, PBCDialect>();
+    MLIRContext context(registry);
+    ParserConfig config(&context, /*verifyAfterParse=*/false);
+    OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(moduleStr, config);
+
+    DecomposableGate ppm = *module->getOps<PPMeasurementOp>().begin();
+
+    ASSERT_EQ(ppm.getOperatorName(), "PauliMeasure");
+
+    llvm::StringMap<llvm::SmallVector<mlir::Type>> expectedDynamicShape = {};
+    ASSERT_EQ(ppm.getDynamicShape(), expectedDynamicShape);
+
+    llvm::StringMap<size_t> expectedWires = {{"wires", 2}};
+    ASSERT_EQ(ppm.getWireLens(), expectedWires);
+
+    mlir::NamedAttribute pauliWordEntry(mlir::StringAttr::get(&context, "pauli_word"),
+                                        mlir::StringAttr::get(&context, "XY"));
+    mlir::NamedAttribute measUidEntry(mlir::StringAttr::get(&context, "meas_uid"),
+                                      mlir::StringAttr::get(&context, "None"));
+    mlir::NamedAttribute postselectEntry(mlir::StringAttr::get(&context, "postselect"),
+                                         mlir::StringAttr::get(&context, "None"));
+
+    mlir::DictionaryAttr expectedStaticData =
+        mlir::DictionaryAttr::get(&context, {measUidEntry, pauliWordEntry, postselectEntry});
+    ASSERT_EQ(ppm.getStaticData(), expectedStaticData);
+
+    ASSERT_EQ(ppm.getGraphOpId(),
+              "PauliMeasure{}{wires:2}{meas_uid:None,pauli_word:XY,postselect:None}");
+}

--- a/mlir/unittests/PBC/Interfaces/TestDecomposableGateInterface.cpp
+++ b/mlir/unittests/PBC/Interfaces/TestDecomposableGateInterface.cpp
@@ -149,3 +149,50 @@ module {
     ASSERT_EQ(ppm.getGraphOpId(),
               "PauliMeasure{}{wires:2}{meas_uid:None,pauli_word:XY,postselect:None}");
 }
+
+TEST(DecomposableGateInterfaceTests, PPRotationOpAdjoint) {
+    std::string moduleStr = R"mlir(
+module {
+  %q0 = quantum.alloc_qb : !quantum.bit
+  %q1 = quantum.alloc_qb : !quantum.bit
+  %q2 = quantum.alloc_qb : !quantum.bit
+  %0:3 = pbc.ppr ["X", "Y", "Z"](-4) %q0, %q1, %q2 : !quantum.bit, !quantum.bit, !quantum.bit
+}
+    )mlir";
+
+    DialectRegistry registry;
+    registry.insert<mlir::arith::ArithDialect, catalyst::quantum::QuantumDialect, PBCDialect>();
+    MLIRContext context(registry);
+    ParserConfig config(&context, /*verifyAfterParse=*/false);
+    OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(moduleStr, config);
+
+    DecomposableGate ppr = *module->getOps<PPRotationOp>().begin();
+
+    // Inverse is encoded as a negative rotation_kind, not an Adjoint(...) wrap.
+    ASSERT_EQ(ppr.getOperatorName(), "PauliRot");
+    ASSERT_EQ(ppr.getGraphOpId(), "PauliRot{theta:[f64]}{wires:3}{pauli_word:XYZ}");
+}
+
+TEST(DecomposableGateInterfaceTests, PPRotationArbitraryOpAdjoint) {
+    std::string moduleStr = R"mlir(
+module {
+  %angle = arith.constant -3.1 : f64
+  %q0 = quantum.alloc_qb : !quantum.bit
+  %q1 = quantum.alloc_qb : !quantum.bit
+  %q2 = quantum.alloc_qb : !quantum.bit
+  %0:3 = pbc.ppr.arbitrary ["X", "Y", "Z"](%angle) %q0, %q1, %q2 : !quantum.bit, !quantum.bit, !quantum.bit
+}
+    )mlir";
+
+    DialectRegistry registry;
+    registry.insert<mlir::arith::ArithDialect, catalyst::quantum::QuantumDialect, PBCDialect>();
+    MLIRContext context(registry);
+    ParserConfig config(&context, /*verifyAfterParse=*/false);
+    OwningOpRef<ModuleOp> module = parseSourceString<ModuleOp>(moduleStr, config);
+
+    DecomposableGate ppr = *module->getOps<PPRotationArbitraryOp>().begin();
+
+    // Inverse is encoded as a negated angle operand, not an Adjoint(...) wrap.
+    ASSERT_EQ(ppr.getOperatorName(), "PauliRot");
+    ASSERT_EQ(ppr.getGraphOpId(), "PauliRot{theta:[f64]}{wires:3}{pauli_word:XYZ}");
+}


### PR DESCRIPTION

**Context:**
The DecomposableGate interface was introduced to provide a generic interface for decomposition of [quantum gates](https://github.com/PennyLaneAI/catalyst/blob/main/mlir/include/Quantum/IR/QuantumInterfaces.td). We want the graph-decomposition to be able to decompose to the PBC dialect, but this will require the DecomposableGate interface be implemented for [PBC gates](https://github.com/PennyLaneAI/catalyst/blob/8e196b734ac7b67285913f99c0ae7fcd0839b541/mlir/include/PBC/IR/PBCOpInterfaces.td).

**Description of the Change:**
This PR extends the `DecomposableGate` interface to the PBC dialect. It uses the same template for how the interface is extended for Quantum and Qref dialects. 

I added the DecomposableGate interface to `PBCOpInterfaces.td` (this does not inherit `QuantumGate` unlike in `QuantumInterface.td`), then extend the two PPR operations in `PBCOps.td`, `PPRotationOp` and `PPRotationArbitraryOp`. Currently only these two operations in the PBC dialect have decomposition rules, `PPMeasurementOp` is `qp.PauliMeasure`, but it has no `add_decomps` in PennyLane yet.

`PBCOpInterfaces.cpp` is slightly different than `QuantumInterfances.cpp`. For `defaultGetGraphOpId` because the PPR operations don't have adjoint in its `arguments` in the `PBCOps.td`, it is not an attribute. Also the operation will never be a QuantumGate, thus there is no need for a `wrapModifiers` function around `getOperatorName()`.
I used the same helpers from `QuantumInterfances.cpp` in `PBCOpInterfaces.cpp`, but from comparing with the QRef those helpers are slightly different, so I held off on moving the helpers into their own file.

In `PBCOps.cpp` I implement two operations `PPRotationOp` and `PPRotationArbitraryOp`. I use the same implementation from `QuantumOps.cpp` for `PauliRotOp` except because DecomposableGate for PBC does not inherit `QuantumGate`, for `getWireLens()` I used `getInQubits().size()` to get wires instead of `getNonCtrlQubitOperands().size()`.


**Benefits:**
Allows PBC operations to be compatible with the `graph-decomposition` pass.

**Possible Drawbacks:**
Code duplication with Quantum and Qref dialect, especially for the helper functions.

**Related GitHub Issues:**
[sc-129100]