### PR TITLE
Capture Operator2 (abstract-wire) solution nodes in graph decomposition

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -505,6 +505,13 @@
 
 <h3>Bug fixes 🐛</h3>
 
+* Fixed a `ValueError` ("Could not capture ... without the number of wires") in the `capture=True`
+  graph-decomposition path when the decomposition-graph solution contains an `Operator2` (such as
+  `SemiAdder`) whose wire and parameter arguments are described by an abstract resource
+  representation. The wire count is now materialized from the abstract rep, and rule-internal
+  optional parameters (e.g. `carry_flip`) fall back to their defaults.
+  [(#3176)](https://github.com/PennyLaneAI/catalyst/pull/3176)
+
 * Fixed an `AttributeError` in the `capture=True` graph-decomposition path when a decomposition
   rule's resource representation uses abstract wires (`pennylane.typing.Wire[n]`), e.g. for
   `register_resources` rules that describe cost without concrete wires.

--- a/frontend/catalyst/from_plxpr/decompose.py
+++ b/frontend/catalyst/from_plxpr/decompose.py
@@ -250,6 +250,21 @@ class DecompRuleInterpreter(qp.capture.PlxprInterpreter):
                 # We use MLIR AdjointOp and ControlledOp primitives
                 # to deal with decomposition of symbolic operations at PLxPR.
                 continue
+            elif isinstance(op.op, qp.core.Operator2):
+                # The operator appears in the decomposition-graph solution with an abstract
+                # resource representation (an ``Operator2`` such as ``SemiAdder``), but it is
+                # not one of the ``COMPILER_OPS_FOR_DECOMPOSITION`` and it is not a skippable
+                # symbolic op. Its wire and parameter arguments are fully described by the
+                # resource rep, so we materialize the wire count from the abstract rep
+                # (``_resource_num_wires``) and build the decomposition rule directly from it.
+                _create_decomposition_rule(
+                    rule,
+                    op_name=op.op.name,
+                    op_rep=op.op,
+                    num_wires=_resource_num_wires(op.op),
+                    num_params=op.op.num_params,
+                    requires_copy=True,
+                )
             else:
                 raise ValueError(f"Could not capture {op.op} without the number of wires.")
 
@@ -296,7 +311,15 @@ def _create_decomposition_rule(
             elif name in op_rep.wire_args:
                 wire_spec = op_rep.wire_args[name]
                 args.append(qp.math.array([0] * len(wire_spec), like="jax"))
-            elif name not in op_rep.compilable_args:
+            elif name in op_rep.compilable_args:
+                # Compilable (static) args are baked into the rule; nothing to pass.
+                pass
+            elif sig_func.parameters[name].default is not inspect.Parameter.empty:
+                # Rule-internal optional parameters that are not part of the operator's
+                # arguments (e.g. ``carry_flip`` in the SemiAdder rule) fall back to their
+                # default value so the captured rule matches the standard decomposition.
+                args.append(sig_func.parameters[name].default)
+            else:
                 raise ValueError(f"Unknown Operator2 argument {name} in decomposition rule {func}.")
             continue
 

--- a/frontend/test/pytest/test_graph_decomposition_pass.py
+++ b/frontend/test/pytest/test_graph_decomposition_pass.py
@@ -23,6 +23,7 @@ import pytest
 from pennylane.decomposition import DecompositionRule, register_resources
 from pennylane.typing import Wire
 
+from catalyst import qjit
 from catalyst.from_plxpr.decompose import _resource_num_wires
 from catalyst.passes.builtin_passes import graph_decomposition_setup_inputs
 
@@ -135,6 +136,31 @@ class TestResourceReps:
 
         assert isinstance(op_rep, qp.core.Operator2)
         assert _resource_num_wires(op_rep) == 5
+
+
+class TestOperator2SolutionNodeCapture:
+    """Capturing decomposition solutions that contain an ``Operator2`` (abstract-wire) node."""
+
+    def test_operator2_solution_node_is_captured(self, use_capture_dgraph):
+        """An ``Operator2`` such as ``SemiAdder`` appearing in the decomposition-graph solution
+        is captured rather than aborting: its wire count is materialized from the abstract
+        resource rep and its rule-internal optional parameters (e.g. ``carry_flip``) fall back to
+        their defaults.
+
+        The ``target="jaxpr"`` capture runs the frontend graph-decomposition cleanup (where the
+        ``Operator2`` node is handled) without triggering the downstream C++ decompose-lowering
+        pass. Capture failures are swallowed by ``aot_compile`` and leave ``jaxpr`` as ``None``,
+        so a populated ``jaxpr`` is the signal that the ``Operator2`` node was captured.
+        """
+
+        @qjit(capture=True, target="jaxpr")
+        @qp.transforms.decompose(gate_set={"CNOT", "Toffoli", "X", "Hadamard", "PhaseShift"})
+        @qp.qnode(qp.device("null.qubit", wires=2))
+        def circuit():
+            qp.SemiAdder(x_wires=[0], y_wires=[1])
+            return qp.expval(qp.Z(0))
+
+        assert circuit.jaxpr is not None
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_graph_decomposition_pass.py
+++ b/frontend/test/pytest/test_graph_decomposition_pass.py
@@ -24,7 +24,12 @@ from pennylane.decomposition import DecompositionRule, register_resources
 from pennylane.typing import Wire
 
 from catalyst import qjit
-from catalyst.from_plxpr.decompose import _resource_num_wires
+from catalyst.from_plxpr import decompose as decompose_module
+from catalyst.from_plxpr.decompose import (
+    DecompRuleInterpreter,
+    _create_decomposition_rule,
+    _resource_num_wires,
+)
 from catalyst.passes.builtin_passes import graph_decomposition_setup_inputs
 
 # Dummy lib paths so building the options dict never hits the environment / installed libraries.
@@ -161,6 +166,47 @@ class TestOperator2SolutionNodeCapture:
             return qp.expval(qp.Z(0))
 
         assert circuit.jaxpr is not None
+
+    def test_unknown_operator2_argument_raises(self):
+        """A rule parameter that is neither a param/wire/compilable arg of the ``Operator2`` nor an
+        optional rule-internal parameter (no default) cannot be materialized, so building the rule
+        raises. This is the fallback of the ``Operator2`` argument-resolution branch."""
+        op_rep = qp.SemiAdder(Wire[2], Wire[2], Wire[1])
+        assert isinstance(op_rep, qp.core.Operator2)
+
+        def bad_rule(not_an_arg):  # required param not described by the resource rep
+            del not_an_arg
+
+        with pytest.raises(ValueError, match="Unknown Operator2 argument"):
+            _create_decomposition_rule(
+                bad_rule,
+                op_name=op_rep.name,
+                op_rep=op_rep,
+                num_wires=_resource_num_wires(op_rep),
+                num_params=op_rep.num_params,
+            )
+
+    def test_uncapturable_solution_node_raises(self, monkeypatch):
+        """A solution node that is not a compiler op, not a skippable symbolic op, and not an
+        ``Operator2`` has no way to recover its wire count, so ``cleanup`` raises rather than
+        silently emitting a bad rule."""
+
+        class _UncapturableOp:
+            name = "TotallyUnknownOp"
+            params = {}  # `_resource_num_wires` reads `params["num_wires"]` -> None
+
+        class _SolutionNode:
+            op = _UncapturableOp()
+
+        interpreter = DecompRuleInterpreter(gate_set={"CNOT"})
+        monkeypatch.setattr(
+            decompose_module,
+            "_solve_decomposition_graph",
+            lambda *args, **kwargs: {_SolutionNode(): (lambda: None)},
+        )
+
+        with pytest.raises(ValueError, match="Could not capture"):
+            interpreter.cleanup()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Context:**
Closes #3175. Stacked on top of #3168 (this fix calls `_resource_num_wires`, which relies on the abstract-wire `len()` fix from #3168). The PR is based on the #3168 branch and will retarget to `main` once #3168 merges.

**Description of the Change:**
Under `qml.qjit(capture=True)` with graph-based decomposition, when the decomposition-graph solution contained an `Operator2` (such as `SemiAdder`) whose wire and parameter arguments are described by an *abstract* resource representation, and that operator was neither in `COMPILER_OPS_FOR_DECOMPOSITION` nor a skippable symbolic op, `DecompRuleInterpreter.cleanup` fell into its final `else` branch and raised:

```
ValueError: Could not capture SemiAdder(...) without the number of wires.
```

This PR:

- Adds an `Operator2` branch to `cleanup` that materializes the wire count from the abstract resource rep (`_resource_num_wires`) and builds the decomposition rule directly, instead of aborting capture.
- Teaches `_create_decomposition_rule` to fall back to the default value for rule-internal *optional* parameters that are not part of the operator's arguments (e.g. `carry_flip` in the `SemiAdder` rule), so the captured rule matches the standard decomposition.

**Benefits:**
`Operator2` templates like `SemiAdder` can now be captured and decomposed under program capture.

**Possible Drawbacks:**
None anticipated.

**Related GitHub Issues:**
Closes #3175. Depends on #3168.

Made with [Cursor](https://cursor.com)