### PR TITLE
[Jukebox] opt out of decomposition-rule collection in non-decomposition frontend tests

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -748,14 +748,6 @@
   `-stage` naming convention used when invoking them from the command line (e.g. `quantum-compilation-stage`).
   [#3002](https://github.com/PennyLaneAI/catalyst/pull/3002)
 
-* Frontend tests that do not exercise graph-based decomposition now pass
-  `collect_decomp_rules=False` to `qjit`. Collecting and lowering every decomposition rule
-  reachable from every gate in a circuit costs roughly 0.3 s per operator at trace time, and the
-  rules are dead code unless the `graph-decomposition` pass is applied, so this removes a large
-  amount of redundant work from CI. Tests that specifically cover rule collection and lowering
-  are unchanged.
-  [(#XXXX)](https://github.com/PennyLaneAI/catalyst/pull/XXXX)
-
 <h3>Documentation 📝</h3>
 
 * A broken link was removed in the [Compiler Core](https://docs.pennylane.ai/projects/catalyst/en/stable/modules/mlir.html) documentation page. The link referred to where precompiled decomposition rules were implemented, which has since been refactored.

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -748,6 +748,14 @@
   `-stage` naming convention used when invoking them from the command line (e.g. `quantum-compilation-stage`).
   [#3002](https://github.com/PennyLaneAI/catalyst/pull/3002)
 
+* Frontend tests that do not exercise graph-based decomposition now pass
+  `collect_decomp_rules=False` to `qjit`. Collecting and lowering every decomposition rule
+  reachable from every gate in a circuit costs roughly 0.3 s per operator at trace time, and the
+  rules are dead code unless the `graph-decomposition` pass is applied, so this removes a large
+  amount of redundant work from CI. Tests that specifically cover rule collection and lowering
+  are unchanged.
+  [(#XXXX)](https://github.com/PennyLaneAI/catalyst/pull/XXXX)
+
 <h3>Documentation 📝</h3>
 
 * A broken link was removed in the [Compiler Core](https://docs.pennylane.ai/projects/catalyst/en/stable/modules/mlir.html) documentation page. The link referred to where precompiled decomposition rules were implemented, which has since been refactored.

--- a/frontend/test/lit/test_dynamic_qubit_allocation.py
+++ b/frontend/test/lit/test_dynamic_qubit_allocation.py
@@ -23,7 +23,7 @@ import pennylane as qp
 from catalyst import qjit
 
 
-@qjit(target="mlir", capture=True)
+@qjit(target="mlir", capture=True, collect_decomp_rules=False)
 @qp.qnode(qp.device("lightning.qubit", wires=3))
 def test_basic_dynalloc():
     """
@@ -65,7 +65,7 @@ def test_basic_dynalloc():
 print(test_basic_dynalloc.mlir)
 
 
-@qjit(autograph=True, target="mlir", capture=True)
+@qjit(autograph=True, target="mlir", capture=True, collect_decomp_rules=False)
 @qp.qnode(qp.device("lightning.qubit", wires=3))
 def test_measure_with_reset():
     """
@@ -91,7 +91,7 @@ def test_measure_with_reset():
 print(test_measure_with_reset.mlir)
 
 
-@qjit(autograph=True, target="mlir", capture=True)
+@qjit(autograph=True, target="mlir", capture=True, collect_decomp_rules=False)
 @qp.qnode(qp.device("lightning.qubit", wires=2))
 def test_pass_reg_into_forloop():
     """
@@ -122,7 +122,7 @@ def test_pass_reg_into_forloop():
 print(test_pass_reg_into_forloop.mlir)
 
 
-@qjit(autograph=True, target="mlir", capture=True)
+@qjit(autograph=True, target="mlir", capture=True, collect_decomp_rules=False)
 @qp.qnode(qp.device("lightning.qubit", wires=3))
 def test_pass_multiple_regs_into_forloop():
     """
@@ -154,7 +154,7 @@ def test_pass_multiple_regs_into_forloop():
 print(test_pass_multiple_regs_into_forloop.mlir)
 
 
-@qjit(autograph=True, target="mlir", capture=True)
+@qjit(autograph=True, target="mlir", capture=True, collect_decomp_rules=False)
 @qp.qnode(qp.device("lightning.qubit", wires=2))
 def test_pass_multiple_regs_into_whileloop(N: int):
     """
@@ -218,7 +218,7 @@ def test_quantum_subroutine():
     # CHECK:  call @flip([[global_qreg]], [[q1_0]], [[q1_1]], [[q2_2]], [[angle]])
     # CHECK-SAME: (!qref.reg<1>, !qref.bit, !qref.bit, !qref.bit, tensor<f64>) -> ()
 
-    @qjit(target="mlir", capture=True)
+    @qjit(target="mlir", capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device("lightning.qubit", wires=1))
     def circuit():
         with qp.allocate(2) as q1:

--- a/frontend/test/lit/test_from_plxpr.py
+++ b/frontend/test/lit/test_from_plxpr.py
@@ -41,7 +41,7 @@ def test_conditional_capture():
         qp.cond(m, lambda: (qp.X(0), None)[1])()
         return qp.state()
 
-    @qp.qjit(capture=True)
+    @qp.qjit(capture=True, collect_decomp_rules=False)
     def main():
         return captured_circuit()
 
@@ -73,7 +73,7 @@ def test_loop_capture():
 
         return qp.state()
 
-    @qp.qjit(capture=True)
+    @qp.qjit(capture=True, collect_decomp_rules=False)
     def main():
         return captured_circuit()
 
@@ -115,7 +115,7 @@ def test_while_capture():
         loop((0, 1))
         return qp.state()
 
-    @qp.qjit(capture=True)
+    @qp.qjit(capture=True, collect_decomp_rules=False)
     def main():
         return captured_circuit()
 
@@ -130,7 +130,7 @@ def test_dynamic_wire():
 
     dev = qp.device("null.qubit", wires=3)
 
-    @qp.qjit(capture=True, target="mlir")
+    @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
     @qp.qnode(dev)
     def circuit(w1: int):
 
@@ -172,7 +172,7 @@ def test_two_dynamic_CNOTs():
 
     dev = qp.device("null.qubit", wires=3)
 
-    @qp.qjit(capture=True, target="mlir")
+    @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
     @qp.qnode(dev)
     def circuit(w1: int, w2: int):
         # CHECK: [[QREG:%.+]] = qref.alloc( 3) : !qref.reg<3>
@@ -203,7 +203,7 @@ def test_pass_application():
 
     dev = qp.device("null.qubit", wires=1)
 
-    @qp.qjit(capture=True, target="mlir")
+    @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
     @qp.transforms.cancel_inverses
     @qp.transforms.merge_rotations
     @qp.qnode(dev)
@@ -226,7 +226,7 @@ def test_pass_decomposition():
 
     qp.decomposition.enable_graph()
 
-    @qp.qjit(capture=True, target="mlir")
+    @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
     @qp.transforms.cancel_inverses
     @qp.transforms.merge_rotations
     @partial(qp.transforms.decompose, gate_set={"RX", "RZ"})
@@ -240,7 +240,7 @@ def test_pass_decomposition():
 
     print(circuit1.mlir)
 
-    @qp.qjit(capture=True, target="mlir")
+    @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
     @qp.transforms.cancel_inverses
     @partial(qp.transforms.decompose, gate_set={"RX", "RZ"})
     @qp.transforms.merge_rotations
@@ -254,7 +254,7 @@ def test_pass_decomposition():
 
     print(circuit2.mlir)
 
-    @qp.qjit(capture=True, target="mlir")
+    @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
     @partial(qp.transforms.decompose, gate_set={"RX", "RZ"})
     @qp.transforms.cancel_inverses
     @qp.transforms.merge_rotations
@@ -279,7 +279,7 @@ def test_two_qnodes_with_different_passes_in_one_workflow():
 
     dev = qp.device("null.qubit", wires=1)
 
-    @qp.qjit(capture=True, target="mlir")
+    @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
     def workflow():
         @qp.transforms.merge_rotations
         @qp.qnode(dev)

--- a/frontend/test/lit/test_gridsynth.py
+++ b/frontend/test/lit/test_gridsynth.py
@@ -202,7 +202,7 @@ def test_capture_workflow_clifford():
     """Test the capture workflow with qp.transforms.gridsynth (Clifford+T)."""
     qp.capture.enable()
 
-    @qjit(target="mlir", pipelines=pipe)
+    @qjit(target="mlir", pipelines=pipe, collect_decomp_rules=False)
     @partial(qp.transforms.gridsynth, epsilon=0.01, ppr_basis=False)
     @qp.qnode(qp.device("lightning.qubit", wires=1))
     def circuit(x: float):
@@ -238,7 +238,7 @@ def test_capture_workflow_ppr():
     """Test the capture workflow with qp.transforms.gridsynth (PPR)."""
     qp.capture.enable()
 
-    @qjit(target="mlir", pipelines=pipe)
+    @qjit(target="mlir", pipelines=pipe, collect_decomp_rules=False)
     @partial(qp.transforms.gridsynth, epsilon=0.01, ppr_basis=True)
     @qp.qnode(qp.device("lightning.qubit", wires=1))
     def circuit(x: float):

--- a/frontend/test/lit/test_mbqc.py
+++ b/frontend/test/lit/test_mbqc.py
@@ -39,7 +39,7 @@ def test_measure_x():
     qp.capture.enable()
 
     # CHECK-LABEL: @workload_measure_x
-    @qjit(target="mlir")
+    @qjit(target="mlir", collect_decomp_rules=False)
     @qp.qnode(dev)
     def workload_measure_x():
         # CHECK: [[angle:%.+]] = arith.constant 0.000000e+00 : f64
@@ -68,7 +68,7 @@ def test_measure_y():
     qp.capture.enable()
 
     # CHECK-LABEL: @workload_measure_y
-    @qjit(target="mlir")
+    @qjit(target="mlir", collect_decomp_rules=False)
     @qp.qnode(dev)
     def workload_measure_y():
         # CHECK: [[angle:%.+]] = arith.constant 1.5707963267948966 : f64
@@ -101,7 +101,7 @@ def test_measure_z():
     qp.capture.enable()
 
     # COM: CHECK-LABEL: @workload_measure_z
-    @qjit(target="mlir")
+    @qjit(target="mlir", collect_decomp_rules=False)
     @qp.qnode(dev)
     def workload_measure_z():
         # COM: CHECK: [[qreg:%.+]] = qref.alloc( 1) : !qref.reg<1>
@@ -133,7 +133,7 @@ def test_measure_arbitrary_basis(angle, plane):
 
     qp.capture.enable()
 
-    @qjit(target="mlir")
+    @qjit(target="mlir", collect_decomp_rules=False)
     @qp.qnode(dev)
     def workload_measure_arbitrary_basis():
         _ = plft.measure_arbitrary_basis(wires=0, angle=angle, plane=plane)
@@ -187,7 +187,7 @@ def test_measure_arbitrary_basis_dyn_angle(plane):
 
     qp.capture.enable()
 
-    @qjit(target="mlir")
+    @qjit(target="mlir", collect_decomp_rules=False)
     @qp.qnode(dev)
     def workload_measure_arbitrary_basis_dyn_angle(_angle: float):
         _ = plft.measure_arbitrary_basis(wires=0, angle=_angle, plane=plane)
@@ -219,7 +219,7 @@ def test_pseudo_mbqc_workload():
     qp.capture.enable()
 
     # CHECK-LABEL: public @workload_pseudo_mbqc(
-    @qjit(target="mlir")
+    @qjit(target="mlir", collect_decomp_rules=False)
     @qp.qnode(dev)
     def workload_pseudo_mbqc(rotation_angle: float):
         # CHECK: [[cst_zero:%.+]] = arith.constant 0.000000e+00 : f64

--- a/frontend/test/lit/test_meta_ops.py
+++ b/frontend/test/lit/test_meta_ops.py
@@ -35,7 +35,7 @@ print(adjoint_adjoint.mlir)
 
 
 # CHECK-LABEL: @adjoint_ctrl_adjoint
-@qjit(target="mlir", capture=True)
+@qjit(target="mlir", capture=True, collect_decomp_rules=False)
 @qp.qnode(qp.device("lightning.qubit", wires=2))
 def adjoint_ctrl_adjoint():
     qp.adjoint(qp.ctrl(qp.adjoint(qp.S(0)), control=1))

--- a/frontend/test/lit/test_mid_circuit_measurement.py
+++ b/frontend/test/lit/test_mid_circuit_measurement.py
@@ -99,7 +99,7 @@ def test_one_shot_with_passes():
 print(test_one_shot_with_passes.mlir)
 
 
-@qjit(capture=True, target="mlir")
+@qjit(capture=True, collect_decomp_rules=False, target="mlir")
 def test_mcm_obs():
     """
     Test generation of mcm observable operation.

--- a/frontend/test/lit/test_pauli_rot_and_measure.py
+++ b/frontend/test/lit/test_pauli_rot_and_measure.py
@@ -38,7 +38,7 @@ def test_pauli_rot_lowering():
 
     pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipeline, target="mlir")
+    @qjit(pipelines=pipeline, target="mlir", collect_decomp_rules=False)
     @qp.qnode(device=dev)
     def circuit():
         qp.PauliRot(np.pi / 4, "X", wires=0)
@@ -59,7 +59,7 @@ def test_single_qubit_pauli_rotations():
 
     pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipeline, target="mlir")
+    @qjit(pipelines=pipeline, target="mlir", collect_decomp_rules=False)
     @to_ppr
     @qp.qnode(device=dev)
     def circuit():
@@ -84,7 +84,7 @@ def test_arbitrary_angle_pauli_rotations():
 
     pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipeline, target="mlir")
+    @qjit(pipelines=pipeline, target="mlir", collect_decomp_rules=False)
     @to_ppr
     @qp.qnode(device=dev)
     def circuit():
@@ -106,7 +106,7 @@ def test_arbitrary_negative_angle_pauli_rotations():
 
     pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipeline, target="mlir")
+    @qjit(pipelines=pipeline, target="mlir", collect_decomp_rules=False)
     @to_ppr
     @qp.qnode(device=dev)
     def circuit():
@@ -128,7 +128,7 @@ def test_dynamic_angle_pauli_rotations():
 
     pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipeline, target="mlir")
+    @qjit(pipelines=pipeline, target="mlir", collect_decomp_rules=False)
     @to_ppr
     @qp.qnode(device=dev)
     def circuit(x: float):
@@ -152,7 +152,7 @@ def test_multi_qubit_pauli_rotations():
 
     pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipeline, target="mlir")
+    @qjit(pipelines=pipeline, target="mlir", collect_decomp_rules=False)
     @to_ppr
     @qp.qnode(device=dev)
     def circuit():
@@ -179,7 +179,7 @@ def test_arbitrary_angle_multi_qubit_pauli_rotations():
 
     pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipeline, target="mlir")
+    @qjit(pipelines=pipeline, target="mlir", collect_decomp_rules=False)
     @to_ppr
     @qp.qnode(device=dev)
     def circuit():
@@ -204,7 +204,7 @@ def test_dynamic_angle_multi_qubit_pauli_rotations():
 
     pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipeline, target="mlir")
+    @qjit(pipelines=pipeline, target="mlir", collect_decomp_rules=False)
     @to_ppr
     @qp.qnode(device=dev)
     def circuit(x: float):
@@ -232,7 +232,7 @@ def test_single_qubit_pauli_measurements():
 
     pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipeline, target="mlir")
+    @qjit(pipelines=pipeline, target="mlir", collect_decomp_rules=False)
     @to_ppr
     @qp.qnode(device=dev)
     def circuit():
@@ -257,7 +257,7 @@ def test_multi_qubit_pauli_measurements():
 
     pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipeline, target="mlir")
+    @qjit(pipelines=pipeline, target="mlir", collect_decomp_rules=False)
     @to_ppr
     @qp.qnode(device=dev)
     def circuit():
@@ -282,7 +282,7 @@ def test_pauli_rot_and_measure_combined():
 
     pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipeline, target="mlir")
+    @qjit(pipelines=pipeline, target="mlir", collect_decomp_rules=False)
     @to_ppr
     @qp.qnode(device=dev)
     def circuit():
@@ -313,7 +313,7 @@ def test_clifford_t_ppr_ppm_combined():
 
     pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipeline, target="mlir")
+    @qjit(pipelines=pipeline, target="mlir", collect_decomp_rules=False)
     @to_ppr
     @qp.qnode(device=dev)
     def circuit():
@@ -344,7 +344,7 @@ def test_commute_ppr():
 
     pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipeline, target="mlir")
+    @qjit(pipelines=pipeline, target="mlir", collect_decomp_rules=False)
     @commute_ppr
     @to_ppr
     @qp.qnode(device=dev)
@@ -371,7 +371,7 @@ def test_merge_ppr_ppm():
 
     pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipeline, target="mlir")
+    @qjit(pipelines=pipeline, target="mlir", collect_decomp_rules=False)
     @merge_ppr_ppm
     @to_ppr
     @qp.qnode(device=dev)
@@ -394,7 +394,7 @@ def test_ppr_to_ppm():
 
     pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipeline, target="mlir")
+    @qjit(pipelines=pipeline, target="mlir", collect_decomp_rules=False)
     @ppr_to_ppm
     @merge_ppr_ppm
     @to_ppr
@@ -423,7 +423,7 @@ def test_ppm_compilation():
 
     pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipeline, target="mlir")
+    @qjit(pipelines=pipeline, target="mlir", collect_decomp_rules=False)
     @ppm_compilation
     @qp.qnode(device=dev)
     def circuit():
@@ -452,7 +452,7 @@ def test_pauli_rot_and_measure_with_cond():
 
     pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipeline, target="mlir")
+    @qjit(pipelines=pipeline, target="mlir", collect_decomp_rules=False)
     @to_ppr
     @qp.qnode(device=dev)
     def circuit():
@@ -484,7 +484,7 @@ def test_pauli_rot_with_adjoint_region():
     def f():
         qp.PauliRot(np.pi / 4, "XZ", wires=[0, 1])
 
-    @qjit(pipelines=pipeline, target="mlir")
+    @qjit(pipelines=pipeline, target="mlir", collect_decomp_rules=False)
     @to_ppr
     @qp.qnode(device=dev)
     def circuit():
@@ -507,7 +507,7 @@ def test_pauli_rot_with_adjoint_single_gate():
 
     pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipeline, target="mlir")
+    @qjit(pipelines=pipeline, target="mlir", collect_decomp_rules=False)
     @to_ppr
     @qp.qnode(device=dev)
     def circuit():

--- a/frontend/test/lit/test_ppr_ppm.py
+++ b/frontend/test/lit/test_ppr_ppm.py
@@ -440,7 +440,7 @@ def test_decompose_arbitrary_ppr():
     pipe = [("pipe", ["quantum-compilation-stage"])]
 
     # CHECK-LABEL: public @test_decompose_arbitrary_ppr_workflow
-    @qjit(pipelines=pipe, target="mlir")
+    @qjit(pipelines=pipe, target="mlir", collect_decomp_rules=False)
     @qp.transform(pass_name="decompose-arbitrary-ppr")
     @qp.transform(pass_name="to-ppr")
     @qp.qnode(qp.device("null.qubit", wires=3))

--- a/frontend/test/lit/test_ppr_ppm.py
+++ b/frontend/test/lit/test_ppr_ppm.py
@@ -435,12 +435,10 @@ def test_decompose_arbitrary_ppr():
     Test the `decompose_arbitrary_ppr` pass.
     """
 
-    qp.capture.enable()
-
     pipe = [("pipe", ["quantum-compilation-stage"])]
 
     # CHECK-LABEL: public @test_decompose_arbitrary_ppr_workflow
-    @qjit(pipelines=pipe, target="mlir", collect_decomp_rules=False)
+    @qjit(capture=True, pipelines=pipe, target="mlir", collect_decomp_rules=False)
     @qp.transform(pass_name="decompose-arbitrary-ppr")
     @qp.transform(pass_name="to-ppr")
     @qp.qnode(qp.device("null.qubit", wires=3))
@@ -458,7 +456,6 @@ def test_decompose_arbitrary_ppr():
         qp.PauliRot(0.123, pauli_word="XYZ", wires=[0, 1, 2])
 
     print(test_decompose_arbitrary_ppr_workflow.mlir_opt)
-    qp.capture.disable()
 
 
 test_decompose_arbitrary_ppr()

--- a/frontend/test/lit/test_qref/test_control_flow.py
+++ b/frontend/test/lit/test_qref/test_control_flow.py
@@ -26,7 +26,7 @@ from jax import numpy as jnp
 
 
 # CHECK: func.func public @test_for_loop_basic(%arg0: tensor<i64>, %arg1: tensor<f64>) -> tensor<8xcomplex<f64>>
-@qp.qjit(capture=True, autograph=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, autograph=True, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_for_loop_basic(size: int, angle: float):
     """
@@ -60,7 +60,7 @@ print(test_for_loop_basic.mlir)
 
 
 # CHECK: func.func public @test_for_loop_nested(%arg0: tensor<i64>) -> tensor<8xcomplex<f64>>
-@qp.qjit(capture=True, autograph=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, autograph=True, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_for_loop_nested(size: int):
     """
@@ -97,7 +97,7 @@ print(test_for_loop_nested.mlir)
 
 
 # CHECK: func.func public @test_for_loop_with_result(%arg0: tensor<i64>) -> tensor<8xcomplex<f64>>
-@qp.qjit(capture=True, autograph=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, autograph=True, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_for_loop_with_result(size: int):
     """
@@ -142,7 +142,7 @@ print(test_for_loop_with_result.mlir)
 
 
 # CHECK: func.func public @test_for_loop_with_dynamic_shapes(%arg0: tensor<i64>) -> tensor<8xcomplex<f64>>
-@qp.qjit(capture=True, autograph=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, autograph=True, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_for_loop_with_dynamic_shapes(size: int):
     """
@@ -180,7 +180,7 @@ print(test_for_loop_with_dynamic_shapes.mlir)
 
 
 # CHECK: func.func public @test_for_loop_with_dynamic_allocation() -> tensor<f64>
-@qp.qjit(capture=True, autograph=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, autograph=True, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_for_loop_with_dynamic_allocation():
     """
@@ -226,7 +226,7 @@ print(test_for_loop_with_dynamic_allocation.mlir)
 
 
 # CHECK: func.func public @test_while_loop_basic(%arg0: tensor<i64>, %arg1: tensor<f64>) -> tensor<8xcomplex<f64>>
-@qp.qjit(capture=True, autograph=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, autograph=True, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_while_loop_basic(i: int, angle: float):
     """
@@ -258,7 +258,7 @@ print(test_while_loop_basic.mlir)
 
 
 # CHECK: func.func public @test_while_loop_nested(%arg0: tensor<i64>, %arg1: tensor<f64>) -> tensor<8xcomplex<f64>>
-@qp.qjit(capture=True, autograph=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, autograph=True, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_while_loop_nested(i: int, angle: float):
     """
@@ -299,7 +299,7 @@ print(test_while_loop_nested.mlir)
 
 
 # CHECK: func.func public @test_while_loop_with_dynamic_shapes(%arg0: tensor<i64>) -> tensor<8xcomplex<f64>>
-@qp.qjit(capture=True, autograph=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, autograph=True, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_while_loop_with_dynamic_shapes(i: int):
     """
@@ -341,7 +341,7 @@ print(test_while_loop_with_dynamic_shapes.mlir)
 
 
 # CHECK: func.func public @test_while_loop_with_dynamic_allocation(%arg0: tensor<i64>) -> tensor<f64>
-@qp.qjit(capture=True, autograph=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, autograph=True, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_while_loop_with_dynamic_allocation(i: int):
     """
@@ -390,7 +390,7 @@ print(test_while_loop_with_dynamic_allocation.mlir)
 
 
 # CHECK: func.func public @test_loop_with_adjoint() -> tensor<f64>
-@qp.qjit(capture=True, autograph=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, autograph=True, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_loop_with_adjoint():
     """
@@ -430,7 +430,7 @@ print(test_loop_with_adjoint.mlir)
 
 
 # CHECK: func.func public @test_if_basic(%arg0: tensor<i64>, %arg1: tensor<f64>) -> tensor<8xcomplex<f64>>
-@qp.qjit(capture=True, autograph=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, autograph=True, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_if_basic(i: int, angle: float):
     """
@@ -475,7 +475,7 @@ print(test_if_basic.mlir)
 
 
 # CHECK: func.func public @test_if_nested(%arg0: tensor<i64>, %arg1: tensor<f64>) -> tensor<8xcomplex<f64>>
-@qp.qjit(capture=True, autograph=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, autograph=True, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_if_nested(i: int, angle: float):
     """
@@ -529,7 +529,7 @@ print(test_if_nested.mlir)
 
 
 # CHECK: func.func public @test_if_with_dynamic_shapes(%arg0: tensor<i64>) -> tensor<8xcomplex<f64>>
-@qp.qjit(capture=True, autograph=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, autograph=True, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_if_with_dynamic_shapes(i: int):
     """
@@ -588,7 +588,7 @@ print(test_if_with_dynamic_shapes.mlir)
 
 
 # CHECK: func.func public @test_if_with_dynamic_allocation(%arg0: tensor<i64>) -> tensor<8xcomplex<f64>>
-@qp.qjit(capture=True, autograph=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, autograph=True, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_if_with_dynamic_allocation(i: int):
     """
@@ -649,7 +649,7 @@ print(test_if_with_dynamic_allocation.mlir)
 
 
 # CHECK: func.func public @test_measurement_result_as_cond() -> tensor<8xcomplex<f64>>
-@qp.qjit(capture=True, autograph=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, autograph=True, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_measurement_result_as_cond():
     """
@@ -681,7 +681,7 @@ print(test_measurement_result_as_cond.mlir)
 
 
 # CHECK: func.func public @test_measurement_with_reset() -> tensor<8xcomplex<f64>>
-@qp.qjit(capture=True, autograph=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, autograph=True, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_measurement_with_reset():
     """

--- a/frontend/test/lit/test_qref/test_empty_circuits.py
+++ b/frontend/test/lit/test_qref/test_empty_circuits.py
@@ -29,7 +29,7 @@ import pennylane as qp
 
 
 # CHECK: func.func public @test_state0() -> tensor<8xcomplex<f64>>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_state0():
     """
@@ -49,7 +49,7 @@ print(test_state0.mlir)
 
 
 # CHECK: func.func public @test_probs0() -> tensor<8xf64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_probs0():
     """
@@ -69,7 +69,7 @@ print(test_probs0.mlir)
 
 
 # CHECK: func.func public @test_probs1() -> tensor<4xf64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_probs1():
     """
@@ -91,7 +91,7 @@ print(test_probs1.mlir)
 
 
 # CHECK: func.func public @test_probs2(%arg0: tensor<i64>) -> tensor<4xf64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_probs2(i: int):
     """
@@ -114,7 +114,7 @@ print(test_probs2.mlir)
 
 
 # CHECK: func.func public @test_sample0() -> tensor<1x3xi64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3), shots=1)
 def test_sample0():
     """
@@ -133,7 +133,7 @@ print(test_sample0.mlir)
 
 
 # CHECK: func.func public @test_sample1() -> tensor<1x2xi64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3), shots=1)
 def test_sample1():
     """
@@ -154,7 +154,7 @@ print(test_sample1.mlir)
 
 
 # CHECK: func.func public @test_sample2(%arg0: tensor<i64>) -> tensor<1x2xi64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3), shots=1)
 def test_sample2(i: int):
     """
@@ -176,7 +176,7 @@ print(test_sample2.mlir)
 
 
 # CHECK: func.func public @test_counts0() -> (tensor<8xi64>, tensor<8xi64>)
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3), shots=1)
 def test_counts0():
     """
@@ -195,7 +195,7 @@ print(test_counts0.mlir)
 
 
 # CHECK: func.func public @test_counts1() -> (tensor<4xi64>, tensor<4xi64>)
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3), shots=1)
 def test_counts1():
     """
@@ -216,7 +216,7 @@ print(test_counts1.mlir)
 
 
 # CHECK: func.func public @test_counts2(%arg0: tensor<i64>) -> (tensor<4xi64>, tensor<4xi64>)
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3), shots=1)
 def test_counts2(i: int):
     """
@@ -238,7 +238,7 @@ print(test_counts2.mlir)
 
 
 # CHECK: func.func public @expval1() -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=2))
 def expval1():
     """
@@ -256,7 +256,7 @@ print(expval1.mlir)
 
 
 # CHECK: func.func public @expval2() -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def expval2():
     """
@@ -279,7 +279,7 @@ print(expval2.mlir)
 
 
 # CHECK: func.func public @expval3(%arg0: tensor<2x2xcomplex<f64>>) -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=2))
 def expval3():
     """
@@ -299,7 +299,7 @@ print(expval3.mlir)
 
 
 # CHECK: func.func public @expval4(%arg0: tensor<4x4xcomplex<f64>>) -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=2))
 def expval4():
     """
@@ -328,7 +328,7 @@ print(expval4.mlir)
 
 
 # CHECK: func.func public @expval5(%arg0: tensor<4x4xcomplex<f64>>) -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def expval5():
     """
@@ -360,7 +360,7 @@ print(expval5.mlir)
 
 
 # CHECK: func.func public @expval6() -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def expval6():
     """
@@ -391,7 +391,7 @@ print(expval6.mlir)
 
 
 # CHECK: func.func public @expval7(%arg0: tensor<4x4xcomplex<f64>>) -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=2))
 def expval7():
     """
@@ -426,7 +426,7 @@ print(expval7.mlir)
 
 
 # CHECK: func.func public @var1(%arg0: tensor<i64>) -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=2))
 def var1(i: int):
     """
@@ -445,7 +445,7 @@ print(var1.mlir)
 
 
 # CHECK: func.func public @var2(%arg0: tensor<4x4xcomplex<f64>>, %arg1: tensor<i64>, %arg2: tensor<i64>) -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3))
 def var2(i: int, j: int):
     """
@@ -479,7 +479,7 @@ print(var2.mlir)
 
 
 # CHECK: func.func public @test_multiple_terminal_measurements() -> (tensor<8xf64>, tensor<1000x1xi64>, tensor<f64>, tensor<f64>)
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=3), shots=1000)
 def test_multiple_terminal_measurements():
     """
@@ -513,7 +513,7 @@ print(test_multiple_terminal_measurements.mlir)
 
 
 # CHECK: func.func public @jit_test_pre_post_processing(%arg0: tensor<i64>)
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 def test_pre_post_processing(i: int):
     """
     Test converting a workflow with pre and post processing.

--- a/frontend/test/lit/test_qref/test_flat_circuits.py
+++ b/frontend/test/lit/test_qref/test_flat_circuits.py
@@ -27,7 +27,7 @@ from catalyst.ftqc import mbqc_pipeline
 
 
 # CHECK: func.func public @test_custom_op(%arg0: tensor<i64>) -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, target="mlir", collect_decomp_rules=False)
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_custom_op(i: int):
     """
@@ -76,7 +76,7 @@ print(test_custom_op.mlir)
 
 
 # CHECK: func.func public @test_measure() -> tensor<2xf64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, target="mlir", collect_decomp_rules=False)
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_measure():
     """
@@ -100,7 +100,7 @@ def test_measure():
 print(test_measure.mlir)
 
 
-@qp.qjit(capture=True, target="mlir", pipelines=mbqc_pipeline())
+@qp.qjit(capture=True, target="mlir", collect_decomp_rules=False, pipelines=mbqc_pipeline())
 @qp.qnode(qp.device("null.qubit", wires=1))
 def test_mbqc_measurement_in_basis():
     """
@@ -118,7 +118,7 @@ print(test_mbqc_measurement_in_basis.mlir)
 
 
 # CHECK: func.func public @test_dynamic_qubit_allocation(%arg0: tensor<2x2xf64>, %arg1: tensor<i64>) -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, target="mlir", collect_decomp_rules=False)
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_dynamic_qubit_allocation(i: int):
     """
@@ -185,7 +185,7 @@ print(test_dynamic_qubit_allocation.mlir)
 
 
 # CHECK: func.func public @test_multirz() -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, target="mlir", collect_decomp_rules=False)
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_multirz():
     """
@@ -215,7 +215,7 @@ print(test_multirz.mlir)
 
 
 # CHECK: func.func public @test_pcphase() -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, target="mlir", collect_decomp_rules=False)
 @qp.qnode(qp.device("null.qubit", wires=3))
 def test_pcphase():
     """
@@ -247,7 +247,7 @@ print(test_pcphase.mlir)
 
 
 # CHECK: func.func public @test_pauli_rot() -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, target="mlir", collect_decomp_rules=False)
 @qp.qnode(qp.device("null.qubit", wires=4))
 def test_pauli_rot():
     """
@@ -284,7 +284,7 @@ print(test_pauli_rot.mlir)
 
 
 # CHECK: func.func public @test_pauli_measure() -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, target="mlir", collect_decomp_rules=False)
 @qp.qnode(qp.device("null.qubit", wires=4))
 def test_pauli_measure():
     """
@@ -308,7 +308,7 @@ print(test_pauli_measure.mlir)
 
 
 # CHECK: func.func public @test_global_phase() -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, target="mlir", collect_decomp_rules=False)
 @qp.qnode(qp.device("null.qubit", wires=4))
 def test_global_phase():
     """
@@ -332,10 +332,6 @@ def test_global_phase():
 print(test_global_phase.mlir)
 
 
-# COM: TODO: ControlledQubitUnitary's decomp rules are buggy and not jittable.
-# COM: https://app.shortcut.com/xanaduai/story/128492/ctrl-decomp-bisect-rule-of-controlledqubitunitary-is-not-jittable,
-# COM: https://app.shortcut.com/xanaduai/story/128494/controlled-two-qubit-unitary-rule-on-controlledqubitunitary-is-not-jittable
-# When fixed, turn collect_decomp_rules back on.
 # CHECK: func.func public @test_unitary(%arg0: tensor<2x2xf64>, %arg1: tensor<4x4xf64>, %arg2: tensor<1xi1>) -> tensor<f64>
 @qp.qjit(capture=True, target="mlir", collect_decomp_rules=False)
 @qp.qnode(qp.device("null.qubit", wires=4))
@@ -365,7 +361,7 @@ print(test_unitary.mlir)
 
 
 # CHECK: func.func public @test_set_state(%arg0: tensor<4xi64>, %arg1: tensor<4xi64>) -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, target="mlir", collect_decomp_rules=False)
 @qp.qnode(qp.device("null.qubit", wires=4))
 def test_set_state():
     """
@@ -395,7 +391,7 @@ print(test_set_state.mlir)
 
 
 # CHECK: func.func public @test_set_basis_state(%arg0: tensor<3xi1>, %arg1: tensor<2xi1>) -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, target="mlir", collect_decomp_rules=False)
 @qp.qnode(qp.device("null.qubit", wires=4))
 def test_set_basis_state():
     """
@@ -424,7 +420,7 @@ print(test_set_basis_state.mlir)
 
 
 # CHECK: func.func public @test_adjoint(%arg0: tensor<i64>) -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, target="mlir", collect_decomp_rules=False)
 @qp.qnode(qp.device("null.qubit", wires=4))
 def test_adjoint(i: int):
     """
@@ -474,7 +470,7 @@ print(test_adjoint.mlir)
 
 
 # CHECK: func.func public @test_adjoint_with_allocation() -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, target="mlir", collect_decomp_rules=False)
 @qp.qnode(qp.device("null.qubit", wires=4))
 def test_adjoint_with_allocation():
     """
@@ -526,7 +522,7 @@ print(test_adjoint_with_allocation.mlir)
 
 
 # CHECK: func.func public @test_adjoint_with_ctrl() -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, target="mlir", collect_decomp_rules=False)
 @qp.qnode(qp.device("null.qubit", wires=4))
 def test_adjoint_with_ctrl():
     """
@@ -570,7 +566,7 @@ print(test_adjoint_with_ctrl.mlir)
 
 
 # CHECK: func.func public @test_ctrl_with_allocation() -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, target="mlir", collect_decomp_rules=False)
 @qp.qnode(qp.device("null.qubit", wires=4))
 def test_ctrl_with_allocation():
     """

--- a/frontend/test/lit/test_qref/test_subroutines.py
+++ b/frontend/test/lit/test_qref/test_subroutines.py
@@ -30,7 +30,7 @@ def basic_subroutine(x, y, wires):  # pylint: disable=missing-function-docstring
 
 
 # CHECK: func.func public @test_basic_subroutine() -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("lightning.qubit", wires=3))
 def test_basic_subroutine():
     """
@@ -76,7 +76,7 @@ def subroutine_with_return(x, y, wires):  # pylint: disable=missing-function-doc
 
 
 # CHECK: func.func public @test_subroutine_with_return() -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("lightning.qubit", wires=3))
 def test_subroutine_with_return():
     """
@@ -123,7 +123,7 @@ def subroutine_with_allocation(wires):  # pylint: disable=missing-function-docst
 
 
 # CHECK: func.func public @test_subroutine_with_allocation() -> tensor<f64>
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("lightning.qubit", wires=3))
 def test_subroutine_with_allocation():
     """

--- a/frontend/test/lit/test_quantum_subroutine.py
+++ b/frontend/test/lit/test_quantum_subroutine.py
@@ -37,16 +37,13 @@ def test_subroutine_classical():
     def add_one(x):
         return x + 1
 
-    qp.capture.enable()
-
-    @qp.qjit
+    @qp.qjit(capture=True)
     # CHECK: module @main
     def main():
         # CHECK: %{{.*}} = call @add_one(%{{.*}}) : (tensor<i64>) -> tensor<i64>
         return add_one(0)
 
     print(main.mlir)
-    qp.capture.disable()
 
 
 test_subroutine_classical()
@@ -58,9 +55,7 @@ def test_quantum_subroutine_identity_restore_wires():
     @subroutine
     def identity(): ...
 
-    qp.capture.enable()
-
-    @qp.qjit
+    @qp.qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device("lightning.qubit", wires=1))
     # CHECK: module @main
     def main():
@@ -80,7 +75,6 @@ def test_quantum_subroutine_identity_restore_wires():
     # CHECK-NEXT: return
 
     print(main.mlir)
-    qp.capture.disable()
 
 
 test_quantum_subroutine_identity_restore_wires()
@@ -92,9 +86,7 @@ def test_quantum_subroutine_identity():
     @subroutine
     def identity(): ...
 
-    qp.capture.enable()
-
-    @qp.qjit
+    @qp.qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device("lightning.qubit", wires=1))
     # CHECK: module @main
     def main():
@@ -108,7 +100,6 @@ def test_quantum_subroutine_identity():
     # CHECK-NEXT: return
 
     print(main.mlir)
-    qp.capture.disable()
 
 
 test_quantum_subroutine_identity()
@@ -121,9 +112,7 @@ def test_quantum_subroutine_wire_param():
     def Hadamard0(wire):
         qp.Hadamard(wire)
 
-    qp.capture.enable()
-
-    @qp.qjit
+    @qp.qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device("lightning.qubit", wires=1))
     # CHECK: module @subroutine_test
     def subroutine_test(c: int):
@@ -142,8 +131,6 @@ def test_quantum_subroutine_wire_param():
 
     print(subroutine_test.mlir)
 
-    qp.capture.disable()
-
 
 test_quantum_subroutine_wire_param()
 
@@ -155,9 +142,7 @@ def test_quantum_subroutine_gate_param_param():
     def RX_on_wire_0(param):
         qp.RX(param, wires=[0])
 
-    qp.capture.enable()
-
-    @qp.qjit
+    @qp.qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device("lightning.qubit", wires=1))
     # CHECK: module @subroutine_test_2
     def subroutine_test_2():
@@ -175,16 +160,12 @@ def test_quantum_subroutine_gate_param_param():
     # CHECK-NEXT: return
     print(subroutine_test_2.mlir)
 
-    qp.capture.disable()
-
 
 test_quantum_subroutine_gate_param_param()
 
 
 def test_quantum_subroutine_with_control_flow():
     """Test control flow inside the subroutine"""
-
-    qp.capture.enable()
 
     @subroutine
     def conditional_RX(param: float):
@@ -196,7 +177,7 @@ def test_quantum_subroutine_with_control_flow():
 
         qp.cond(param != 0.0, true_path, false_path)()
 
-    @qp.qjit(autograph=False, collect_decomp_rules=False)
+    @qp.qjit(capture=True, autograph=False, collect_decomp_rules=False)
     @qp.qnode(qp.device("lightning.qubit", wires=1))
     # CHECK: module @subroutine_test_3
     def subroutine_test_3():
@@ -217,7 +198,6 @@ def test_quantum_subroutine_with_control_flow():
     # CHECK:        qref.custom "RX"([[PARAM]]) [[QUBIT]] : !qref.bit
     # CHECK:      return
     print(subroutine_test_3.mlir)
-    qp.capture.disable()
 
 
 test_quantum_subroutine_with_control_flow()
@@ -225,8 +205,6 @@ test_quantum_subroutine_with_control_flow()
 
 def test_nested_subroutine_call():
     """Test nested subroutine call"""
-
-    qp.capture.enable()
 
     @subroutine
     def Hadamard_subroutine():
@@ -236,7 +214,7 @@ def test_nested_subroutine_call():
     def Hadamard_caller():
         Hadamard_subroutine()
 
-    @qp.qjit(autograph=False, collect_decomp_rules=False)
+    @qp.qjit(capture=True, autograph=False, collect_decomp_rules=False)
     @qp.qnode(qp.device("lightning.qubit", wires=1))
     # CHECK: module @subroutine_test_4
     def subroutine_test_4():
@@ -255,7 +233,6 @@ def test_nested_subroutine_call():
     # CHECK-NEXT: qref.custom "Hadamard"() [[QUBIT]] : !qref.bit
     # CHECK-NEXT: return
     print(subroutine_test_4.mlir)
-    qp.capture.disable()
 
 
 test_nested_subroutine_call()
@@ -265,12 +242,10 @@ def test_two_callsites():
     """Test that two calls won't give multiple definitions
     in the classical setting"""
 
-    qp.capture.enable()
-
     @subroutine
     def identity(): ...
 
-    @qp.qjit(autograph=False, collect_decomp_rules=False)
+    @qp.qjit(capture=True, autograph=False, collect_decomp_rules=False)
     # CHECK: module @subroutine_test_5
     def subroutine_test_5():
         identity()
@@ -278,7 +253,6 @@ def test_two_callsites():
 
     # CHECK-NOT: func.func private @identity_0()
     print(subroutine_test_5.mlir)
-    qp.capture.disable()
 
 
 test_two_callsites()
@@ -288,12 +262,10 @@ def test_two_callsites_quantum():
     """Test that two calls won't give multiple definitions
     int the quantum setting"""
 
-    qp.capture.enable()
-
     @subroutine
     def identity(): ...
 
-    @qp.qjit(autograph=False, collect_decomp_rules=False)
+    @qp.qjit(capture=True, autograph=False, collect_decomp_rules=False)
     @qp.qnode(qp.device("lightning.qubit", wires=1))
     # CHECK: module @subroutine_test_6
     def subroutine_test_6():
@@ -307,7 +279,6 @@ def test_two_callsites_quantum():
 
     # CHECK-NOT: func.func private @identity_0
     print(subroutine_test_6.mlir)
-    qp.capture.disable()
 
 
 test_two_callsites_quantum()
@@ -342,15 +313,11 @@ def test_two_qnodes_one_subroutine():
 
         # CHECK: func.func private @identity_0
 
-    qp.capture.enable()
-
-    @qp.qjit(autograph=False, collect_decomp_rules=False)
+    @qp.qjit(capture=True, autograph=False, collect_decomp_rules=False)
     def main():
         return subroutine_test_7() + subroutine_test_8()
 
     print(main.mlir)
-
-    qp.capture.disable()
 
 
 test_two_qnodes_one_subroutine()
@@ -366,17 +333,13 @@ def test_with_constant():
         one = jax.numpy.array(1)
         qp.Hadamard(c + one)
 
-    qp.capture.enable()
-
-    @qp.qjit(autograph=False, collect_decomp_rules=False)
+    @qp.qjit(capture=True, autograph=False, collect_decomp_rules=False)
     @qp.qnode(qp.device("null.qubit", wires=2))
     def circ():
         Hadamard_plus_1(0)
         return qp.probs()
 
     print(circ.mlir)
-
-    qp.capture.disable()
 
 
 test_with_constant()

--- a/frontend/test/lit/test_quantum_subroutine.py
+++ b/frontend/test/lit/test_quantum_subroutine.py
@@ -196,7 +196,7 @@ def test_quantum_subroutine_with_control_flow():
 
         qp.cond(param != 0.0, true_path, false_path)()
 
-    @qp.qjit(autograph=False)
+    @qp.qjit(autograph=False, collect_decomp_rules=False)
     @qp.qnode(qp.device("lightning.qubit", wires=1))
     # CHECK: module @subroutine_test_3
     def subroutine_test_3():
@@ -236,7 +236,7 @@ def test_nested_subroutine_call():
     def Hadamard_caller():
         Hadamard_subroutine()
 
-    @qp.qjit(autograph=False)
+    @qp.qjit(autograph=False, collect_decomp_rules=False)
     @qp.qnode(qp.device("lightning.qubit", wires=1))
     # CHECK: module @subroutine_test_4
     def subroutine_test_4():
@@ -270,7 +270,7 @@ def test_two_callsites():
     @subroutine
     def identity(): ...
 
-    @qp.qjit(autograph=False)
+    @qp.qjit(autograph=False, collect_decomp_rules=False)
     # CHECK: module @subroutine_test_5
     def subroutine_test_5():
         identity()
@@ -293,7 +293,7 @@ def test_two_callsites_quantum():
     @subroutine
     def identity(): ...
 
-    @qp.qjit(autograph=False)
+    @qp.qjit(autograph=False, collect_decomp_rules=False)
     @qp.qnode(qp.device("lightning.qubit", wires=1))
     # CHECK: module @subroutine_test_6
     def subroutine_test_6():
@@ -344,7 +344,7 @@ def test_two_qnodes_one_subroutine():
 
     qp.capture.enable()
 
-    @qp.qjit(autograph=False)
+    @qp.qjit(autograph=False, collect_decomp_rules=False)
     def main():
         return subroutine_test_7() + subroutine_test_8()
 
@@ -368,7 +368,7 @@ def test_with_constant():
 
     qp.capture.enable()
 
-    @qp.qjit(autograph=False)
+    @qp.qjit(autograph=False, collect_decomp_rules=False)
     @qp.qnode(qp.device("null.qubit", wires=2))
     def circ():
         Hadamard_plus_1(0)
@@ -389,7 +389,7 @@ def test_basic_subroutine():
     def f(x, wires):
         qp.RX(x, wires)
 
-    @qp.qjit(capture=True, target="mlir")
+    @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
     @qp.qnode(qp.device("null.qubit", wires=1))
     # CHECK: module @circuit
     def circuit(x):
@@ -431,7 +431,7 @@ def test_multiple_metadata():
         else:
             qp.Z(wires)
 
-    @qp.qjit(capture=True, target="mlir")
+    @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
     @qp.qnode(qp.device("null.qubit", wires=1))
     # CHECK: module @circuit
     def circuit():
@@ -475,7 +475,7 @@ def test_different_shapes():
 
         loop()  # pylint: disable=no-value-for-parameter
 
-    @qp.qjit(capture=True, target="mlir")
+    @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
     @qp.qnode(qp.device("null.qubit", wires=1))
     # CHECK: module @circuit
     def circuit():

--- a/frontend/test/lit/test_symbolic_array.py
+++ b/frontend/test/lit/test_symbolic_array.py
@@ -22,7 +22,7 @@ import numpy as np
 import pennylane as qp
 
 
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=2))
 def c_mat():
     # CHECK-LABEL: func.func public @c_mat
@@ -38,7 +38,7 @@ def c_mat():
 print(c_mat.mlir)
 
 
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=2))
 def c_various_shapes():
     # CHECK-LABEL: func.func public @c_various_shapes
@@ -54,7 +54,7 @@ def c_various_shapes():
 print(c_various_shapes.mlir)
 
 
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=2))
 def c_manipulate_symbolic_array():
     # CHECK-LABEL: func.func public @c_manipulate_symbolic_array
@@ -76,7 +76,7 @@ def c_manipulate_symbolic_array():
 print(c_manipulate_symbolic_array.mlir)
 
 
-@qp.qjit(capture=True, target="mlir")
+@qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
 @qp.qnode(qp.device("null.qubit", wires=2))
 def c_symbolic_wire():
     # CHECK-LABEL: func.func public @c_symbolic_wire

--- a/frontend/test/lit/test_xdsl_passes.py
+++ b/frontend/test/lit/test_xdsl_passes.py
@@ -45,9 +45,8 @@ test_mlir_pass_no_attribute()
 
 def test_xdsl_pass_with_attribute():
     """Test that xDSL passes set uses_xdsl_passes and xdsl_pass attributes"""
-    qp.capture.enable()
 
-    @qp.qjit(target="mlir")
+    @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
     @merge_rotations_pass
     @qp.qnode(qp.device("lightning.qubit", wires=1))
     def circuit_with_xdsl_pass():
@@ -58,7 +57,6 @@ def test_xdsl_pass_with_attribute():
     print(circuit_with_xdsl_pass.mlir)
     # CHECK: catalyst.uses_xdsl_passes
     # CHECK: catalyst.xdsl_pass
-    qp.capture.disable()
 
 
 test_xdsl_pass_with_attribute()
@@ -66,9 +64,8 @@ test_xdsl_pass_with_attribute()
 
 def test_mixed_passes_with_attribute():
     """Test that mixing MLIR and xDSL passes sets uses_xdsl_passes and xdsl_pass attributes"""
-    qp.capture.enable()
 
-    @qp.qjit(target="mlir")
+    @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
     @qp.transforms.cancel_inverses
     @merge_rotations_pass
     @qp.qnode(qp.device("lightning.qubit", wires=1))
@@ -80,7 +77,6 @@ def test_mixed_passes_with_attribute():
     print(circuit_with_mixed_passes.mlir)
     # CHECK: catalyst.uses_xdsl_passes
     # CHECK: catalyst.xdsl_pass
-    qp.capture.disable()
 
 
 test_mixed_passes_with_attribute()

--- a/frontend/test/pytest/from_plxpr/test_capture_integration.py
+++ b/frontend/test/pytest/from_plxpr/test_capture_integration.py
@@ -30,7 +30,7 @@ pytestmark = pytest.mark.usefixtures("disable_capture")
 def circuit_aot_builder(dev):
     """Test AOT builder."""
 
-    @qjit(capture=True)
+    @qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(device=dev)
     def catalyst_circuit_aot(x: float):
         qp.Hadamard(wires=0)
@@ -73,7 +73,7 @@ def test_transforms_must_have_pass_name():
         return qp.state()
 
     with pytest.raises(ValueError, match="<transform: some_transform> does not have a pass_name"):
-        qp.qjit(c, capture=True)()
+        qp.qjit(c, capture=True, collect_decomp_rules=False)()
 
 
 # pylint: disable=too-many-public-methods
@@ -155,7 +155,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(device=dev)
         def captured_circuit(x):
             qp.Hadamard(wires=0)
@@ -198,7 +198,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(dev)
         def captured_circuit(_basis_state):
             qp.BasisState(_basis_state, wires=list(range(n_wires)))
@@ -234,7 +234,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(dev)
         def captured_circuit(init_state):
             qp.StatePrep(init_state, wires=list(range(n_wires)))
@@ -264,7 +264,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(device)
         def captured_circuit(theta, val):
             qp.adjoint(qp.RY)(jnp.pi, val)
@@ -291,7 +291,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(device)
         def captured_circuit(theta):
             qp.ctrl(qp.RX(theta, wires=0), control=[1], control_values=[False])
@@ -329,7 +329,7 @@ class TestCapture:
             qp.ctrl(qp.PCPhase, control=[1], control_values=[False])(theta, dim=2, wires=[0])
             return qp.state()
 
-        capture_result = qjit(circuit, capture=True)(theta)
+        capture_result = qjit(circuit, capture=True, collect_decomp_rules=False)(theta)
 
         # Capture disabled
 
@@ -349,7 +349,7 @@ class TestCapture:
         """
         device = qp.device(backend, wires=1)
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(device)
         def captured_circuit():
             op(wires=0)
@@ -367,7 +367,7 @@ class TestCapture:
         """
         device = qp.device(backend, wires=1)
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(device)
         def captured_circuit():
             qp.H(wires=0)
@@ -387,7 +387,7 @@ class TestCapture:
         """
         device = qp.device(backend, wires=1)
 
-        @qjit(capture=True, autograph=True)
+        @qjit(capture=True, collect_decomp_rules=False, autograph=True)
         @qp.qnode(device)
         def captured_circuit():
             m = qp.measure(wires=0)
@@ -405,7 +405,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device(backend, wires=4))
         def captured_circuit(x):
 
@@ -438,7 +438,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device(backend, wires=1))
         def captured_circuit(n, x):
 
@@ -477,7 +477,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device(backend, wires=4))
         def captured_circuit(n):
             # Input state: equal superposition
@@ -541,7 +541,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device(backend, wires=1))
         def capturted_circuit(x: float):
 
@@ -593,7 +593,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device(backend, wires=1))
         def captured_circuit(x: float, step: float):
 
@@ -640,7 +640,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device(backend, wires=1))
         def captured_circuit(x: float, y: float):
 
@@ -701,7 +701,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device(backend, wires=1))
         def captured_circuit(x: float):
 
@@ -742,7 +742,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device(backend, wires=1))
         def captured_circuit(x: float):
 
@@ -778,7 +778,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device(backend, wires=1))
         def captured_circuit(x: float):
 
@@ -824,7 +824,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device(backend, wires=1))
         def captured_circuit(x: float):
 
@@ -870,7 +870,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device(backend, wires=1))
         def captured_circuit(x: float):
 
@@ -915,7 +915,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device(backend, wires=1))
         def captured_circuit(x: float, y: float):
 
@@ -971,7 +971,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device(backend, wires=1))
         def captured_circuit(x: float):
 
@@ -1001,7 +1001,7 @@ class TestCapture:
 
         my_pass = qp.transform(pass_name="my-pass", setup_inputs=my_pass_setup_inputs)
 
-        @qjit(target="mlir", capture=True)
+        @qjit(target="mlir", capture=True, collect_decomp_rules=False)
         @partial(my_pass, my_option="my_option_value", my_other_option=False)
         @qp.qnode(qp.device(backend, wires=1))
         def captured_circuit():
@@ -1019,7 +1019,7 @@ class TestCapture:
 
         my_pass = qp.transform(pass_name="my-pass")
 
-        @qjit(target="mlir", capture=True)
+        @qjit(target="mlir", capture=True, collect_decomp_rules=False)
         @partial(my_pass, my_option="my_option_value", my_other_option=False)
         @qp.qnode(qp.device(backend, wires=1))
         def captured_circuit():
@@ -1037,7 +1037,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.transforms.cancel_inverses
         @qp.qnode(qp.device(backend, wires=1))
         def captured_circuit(x: float):
@@ -1067,7 +1067,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.transforms.merge_rotations
         @qp.qnode(qp.device(backend, wires=1))
         def captured_circuit(x: float):
@@ -1109,6 +1109,7 @@ class TestCapture:
         captured_inverses_rotations = qjit(
             qp.transforms.cancel_inverses(qp.transforms.merge_rotations(captured_circuit)),
             capture=True,
+            collect_decomp_rules=False,
         )
         captured_inverses_rotations_result = captured_inverses_rotations(0.1)
         assert has_catalyst_transforms(captured_inverses_rotations.mlir)
@@ -1116,6 +1117,7 @@ class TestCapture:
         captured_rotations_inverses = qjit(
             qp.transforms.merge_rotations(qp.transforms.cancel_inverses(captured_circuit)),
             capture=True,
+            collect_decomp_rules=False,
         )
         captured_rotations_inverses_result = captured_rotations_inverses(0.1)
         assert has_catalyst_transforms(captured_rotations_inverses.mlir)
@@ -1148,7 +1150,7 @@ class TestCapture:
     def test_transform_graph_decompose_workflow(self, backend):
         """Test the integration for a circuit with a 'decompose' graph transform."""
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @partial(qp.transforms.decompose, gate_set=[qp.RX, qp.RY, qp.RZ])
         @qp.qnode(qp.device(backend, wires=2))
         def captured_circuit(x: float, y: float, z: float):
@@ -1188,7 +1190,7 @@ class TestCapture:
 
         # Capture enabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.set_shots(10)
         @qp.qnode(qp.device(backend, wires=2))
         def captured_circuit():
@@ -1223,7 +1225,7 @@ class TestCapture:
         """Test the integration for a circuit with a static variable."""
 
         # Basic test
-        @qjit(capture=True, static_argnums=(0,))
+        @qjit(capture=True, collect_decomp_rules=False, static_argnums=(0,))
         @qp.qnode(qp.device(backend, wires=1))
         def captured_circuit_1(x, y):
             qp.RX(x, wires=0)
@@ -1237,7 +1239,7 @@ class TestCapture:
         assert "%cst = arith.constant 2.0" not in captured_circuit_1_mlir
 
         # Test that qjit static_argnums takes precedence over the one on the qnode
-        @qjit(capture=True, static_argnums=1)
+        @qjit(capture=True, collect_decomp_rules=False, static_argnums=1)
         @qp.qnode(qp.device(backend, wires=1), static_argnums=0)  # should be ignored
         def captured_circuit_2(x, y):
             qp.RX(x, wires=0)
@@ -1253,7 +1255,7 @@ class TestCapture:
         assert jnp.allclose(result_1, result_2)
 
         # Test under a non qnode workflow function
-        @qjit(capture=True, static_argnums=(0,))
+        @qjit(capture=True, collect_decomp_rules=False, static_argnums=(0,))
         def workflow(x, y):
             @qp.qnode(qp.device(backend, wires=1))
             def c():
@@ -1286,7 +1288,7 @@ class TestControlFlow:
             qp.RX(x, 0)
             return qp.expval(qp.Z(0))
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         def f(i0):
             @qp.for_loop(start, stop, step)
             def g(i, x):
@@ -1305,7 +1307,7 @@ class TestControlFlow:
             qp.RX(x, 0)
             return qp.expval(qp.Z(0))
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         def f(x):
 
             const = jnp.array([0, 1, 2])
@@ -1326,7 +1328,7 @@ class TestControlFlow:
         """This tests for kinda a weird edge case bug where the consts where getting
         reordered when translating the inner jaxpr."""
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=3))
         def circuit(x, n):
             @qp.for_loop(3)
@@ -1353,7 +1355,7 @@ class TestControlFlow:
     def test_for_loop_consts_outside_qnode(self):
         """Similar test as above for weird edge case, but not using a qnode."""
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         def f(x, n):
             @qp.for_loop(3)
             def outer(i, a):
@@ -1377,7 +1379,7 @@ def test_adjoint_transform_integration():
         qp.IsingXX(2 * x, wires=(0, 1))
         qp.H(0)
 
-    @qjit(capture=True)
+    @qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device("lightning.qubit", wires=3))
     def c(x):
         qp.adjoint(f)(x)
@@ -1397,7 +1399,7 @@ def test_ctrl_transform_integration(separate_funcs):
         qp.RY(3 * y, wires=3)
         qp.RX(2 * x, wires=3)
 
-    @qjit(capture=True)
+    @qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device("lightning.qubit", wires=4))
     def c(x, y):
         qp.X(1)
@@ -1427,7 +1429,7 @@ def test_different_static_argnums():
             qp.RZ(x, 0)
         return qp.state()
 
-    @qjit(capture=True)
+    @qjit(capture=True, collect_decomp_rules=False)
     def w(x):
         return c(x, "X"), c(x, "Y"), c(x, "Z")
 

--- a/frontend/test/pytest/python_interface/inspection/test_construct_circuit_dag.py
+++ b/frontend/test/pytest/python_interface/inspection/test_construct_circuit_dag.py
@@ -953,7 +953,7 @@ class TestCreateStaticOperatorNodes:
         dev = qp.device("null.qubit", wires=1)
 
         @xdsl_from_qjit
-        @qp.qjit(autograph=True, target="mlir", capture=True)
+        @qp.qjit(autograph=True, target="mlir", capture=True, collect_decomp_rules=False)
         @qp.qnode(dev)
         def my_circuit():
             qp.pauli_measure("X", wires=[0])
@@ -980,7 +980,7 @@ class TestCreateStaticOperatorNodes:
 
         multiplier = -1 if negative_angle else 1
 
-        @qp.qjit(pipelines=pipe, target="mlir", capture=True)
+        @qp.qjit(pipelines=pipe, target="mlir", capture=True, collect_decomp_rules=False)
         @qp.transform(pass_name="to-ppr")
         @qp.qnode(qp.device("null.qubit", wires=3))
         def cir():
@@ -1010,7 +1010,7 @@ class TestCreateStaticOperatorNodes:
 
         pipe = [("pipe", ["quantum-compilation-stage"])]
 
-        @qp.qjit(pipelines=pipe, target="mlir", capture=True)
+        @qp.qjit(pipelines=pipe, target="mlir", capture=True, collect_decomp_rules=False)
         @qp.transform(pass_name="to-ppr")
         @qp.qnode(qp.device("null.qubit", wires=3))
         def cir():
@@ -1039,7 +1039,7 @@ class TestCreateStaticOperatorNodes:
         dev = qp.device("null.qubit", wires=1)
 
         @xdsl_from_qjit
-        @qp.qjit(autograph=True, target="mlir", capture=True)
+        @qp.qjit(autograph=True, target="mlir", capture=True, collect_decomp_rules=False)
         @qp.qnode(dev)
         def my_circuit():
             qp.PauliRot(0.5, "X", wires=0)
@@ -1063,7 +1063,7 @@ class TestCreateStaticOperatorNodes:
         dev = qp.device("null.qubit", wires=1)
 
         @xdsl_from_qjit
-        @qp.qjit(autograph=True, capture=True)
+        @qp.qjit(autograph=True, capture=True, collect_decomp_rules=False)
         @qp.qnode(dev)
         def my_workflow():
             coeffs = [0.2, -0.543]
@@ -1334,7 +1334,7 @@ class TestCreateDynamicOperatorNodes:
         dev = qp.device("null.qubit", wires=1)
 
         @xdsl_from_qjit
-        @qp.qjit(autograph=True, target="mlir", capture=True)
+        @qp.qjit(autograph=True, target="mlir", capture=True, collect_decomp_rules=False)
         @qp.qnode(dev)
         def my_circuit(x, y):
             qp.pauli_measure("X", wires=[x])

--- a/frontend/test/pytest/python_interface/inspection/test_draw_unified_compiler.py
+++ b/frontend/test/pytest/python_interface/inspection/test_draw_unified_compiler.py
@@ -114,6 +114,7 @@ class TestDraw:
         transforms_circuit = qp.qjit(
             iterative_cancel_inverses_pass(merge_rotations_pass(transforms_circuit)),
             capture=True,
+            collect_decomp_rules=False,
         )
 
         assert draw(transforms_circuit, level=level)() == expected
@@ -145,6 +146,7 @@ class TestDraw:
         transforms_circuit = qp.qjit(
             qp.transforms.cancel_inverses(qp.transforms.merge_rotations(transforms_circuit)),
             capture=True,
+            collect_decomp_rules=False,
         )
 
         assert draw(transforms_circuit, level=level)() == expected
@@ -176,6 +178,7 @@ class TestDraw:
         transforms_circuit = qp.qjit(
             iterative_cancel_inverses_pass(qp.transforms.merge_rotations(transforms_circuit)),
             capture=True,
+            collect_decomp_rules=False,
         )
 
         assert draw(transforms_circuit, level=level)() == expected
@@ -217,7 +220,7 @@ class TestDraw:
     )
     def test_no_passes(self, transforms_circuit, level, expected):
         """Test that if no passes are applied, the circuit is still visualized."""
-        transforms_circuit = qp.qjit(transforms_circuit, capture=True)
+        transforms_circuit = qp.qjit(transforms_circuit, capture=True, collect_decomp_rules=False)
 
         assert draw(transforms_circuit, level=level)() == expected
 
@@ -247,7 +250,7 @@ class TestDraw:
         Test the visualization of control and adjoint variants.
         """
 
-        @qp.qjit(capture=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=3))
         def circuit():
             op()
@@ -270,7 +273,7 @@ class TestDraw:
         Test the visualization of control operations before custom ops.
         """
 
-        @qp.qjit(capture=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=3))
         def circuit():
             qp.ctrl(qp.X(3), control=[0, 1, 2], control_values=[1, 0, 1])
@@ -353,7 +356,7 @@ class TestDraw:
             else None
         )
 
-        @qp.qjit(capture=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=3), shots=shots)
         def circuit():
             qp.RX(0.1, 0)
@@ -366,7 +369,7 @@ class TestDraw:
     def test_global_phase(self):
         """Test the visualization of global phase shifts."""
 
-        @qp.qjit(capture=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=3))
         def circuit():
             qp.H(0)
@@ -392,7 +395,7 @@ class TestDraw:
     def test_draw_mid_circuit_measurement_postselect(self, postselect, mid_measure_label):
         """Test that mid-circuit measurements are drawn correctly."""
 
-        @qp.qjit(capture=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=2))
         def circuit():
             qp.Hadamard(0)
@@ -475,7 +478,7 @@ class TestDraw:
         Test the visualization of the quantum operations defined in the unified compiler dialect.
         """
 
-        @qp.qjit(capture=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=3))
         def circuit():
             for op, param, wires in ops:
@@ -490,7 +493,7 @@ class TestDraw:
         two_dim = jax.numpy.array([[0, 1], [1, 0]])
         eight_dim = jax.numpy.zeros((8, 8))
 
-        @qp.qjit(capture=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=2))
         def circuit():
             qp.RX(one_dim[0], wires=0)
@@ -509,7 +512,7 @@ class TestDraw:
         """Test that a warning is raised when dynamic arguments are used."""
 
         # pylint: disable=unused-argument
-        @qp.qjit(capture=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=3))
         def circ(arg):
             qp.RX(0.1, wires=0)
@@ -521,7 +524,7 @@ class TestDraw:
     def adjoint_op_not_implemented(self):
         """Test that NotImplementedError is raised when AdjointOp is used."""
 
-        @qp.qjit(capture=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=1))
         def circuit():
             qp.adjoint(qp.QubitUnitary)(jax.numpy.array([[0, 1], [1, 0]]), wires=[0])
@@ -533,7 +536,7 @@ class TestDraw:
     def test_cond_not_implemented(self):
         """Test that NotImplementedError is raised when cond is used."""
 
-        @qp.qjit(capture=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=2))
         def circuit():
             m0 = qp.measure(0, reset=False, postselect=0)
@@ -546,7 +549,7 @@ class TestDraw:
     def test_for_loop_not_implemented(self):
         """Test that NotImplementedError is raised when for loop is used."""
 
-        @qp.qjit(autograph=True, capture=True)
+        @qp.qjit(autograph=True, capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=1))
         def circuit():
             for _ in range(3):
@@ -559,7 +562,7 @@ class TestDraw:
     def test_while_loop_not_implemented(self):
         """Test that NotImplementedError is raised when while loop is used."""
 
-        @qp.qjit(autograph=True, capture=True)
+        @qp.qjit(autograph=True, capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=1))
         def circuit():
             i = 0

--- a/frontend/test/pytest/python_interface/test_unified_compiler.py
+++ b/frontend/test/pytest/python_interface/test_unified_compiler.py
@@ -233,7 +233,7 @@ class TestCatalystIntegration:
 
         assert capture_enabled()
 
-        @qjit(pass_plugins=[getXDSLPluginAbsolutePath()], capture=True)
+        @qjit(pass_plugins=[getXDSLPluginAbsolutePath()], capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=2))
         def f(x):
             qp.RX(x, 0)
@@ -264,7 +264,7 @@ class TestCatalystIntegration:
 
         assert capture_enabled()
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @hello_world_pass
         @qp.qnode(qp.device("lightning.qubit", wires=2))
         def f(x):
@@ -301,7 +301,7 @@ class TestCatalystIntegration:
 
         assert capture_enabled()
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @hello_world_pass
         @qp.transforms.cancel_inverses
         @qp.qnode(qp.device("lightning.qubit", wires=2))
@@ -462,7 +462,7 @@ class TestCallbackIntegration:
             print("=== Between Pass ===")
             print(module)
 
-        @qp.qjit(skip_preprocess=skip_preprocess, capture=True)
+        @qp.qjit(skip_preprocess=skip_preprocess, capture=True, collect_decomp_rules=False)
         @iterative_cancel_inverses_pass
         @merge_rotations_pass
         @qp.qnode(qp.device("null.qubit", wires=2))

--- a/frontend/test/pytest/python_interface/transforms/mbqc/test_xdsl_convert_to_mbqc_formalism.py
+++ b/frontend/test/pytest/python_interface/transforms/mbqc/test_xdsl_convert_to_mbqc_formalism.py
@@ -382,6 +382,7 @@ class TestConvertToMBQCFormalismPass:
 
         @qp.qjit(
             capture=True,
+            collect_decomp_rules=False,
             target="mlir",
             pipelines=mbqc_pipeline(),
             autograph=True,
@@ -433,6 +434,7 @@ class TestConvertToMBQCFormalismPass:
 
         @qp.qjit(
             capture=True,
+            collect_decomp_rules=False,
             target="mlir",
             pipelines=mbqc_pipeline(),
             autograph=True,
@@ -478,6 +480,7 @@ class TestConvertToMBQCFormalismPass:
 
         @qp.qjit(
             capture=True,
+            collect_decomp_rules=False,
             target="mlir",
             pipelines=mbqc_pipeline(),
             autograph=True,
@@ -522,6 +525,7 @@ class TestConvertToMBQCFormalismPass:
 
         @qp.qjit(
             capture=True,
+            collect_decomp_rules=False,
             target="mlir",
             autograph=True,
         )
@@ -553,6 +557,7 @@ class TestConvertToMBQCFormalismPass:
 
         @qp.qjit(
             capture=True,
+            collect_decomp_rules=False,
             target="mlir",
             pipelines=mbqc_pipeline(),
             autograph=True,

--- a/frontend/test/pytest/python_interface/transforms/mbqc/test_xdsl_outline_state_evolution.py
+++ b/frontend/test/pytest/python_interface/transforms/mbqc/test_xdsl_outline_state_evolution.py
@@ -143,7 +143,7 @@ class TestOutlineStateEvolutionPass:
         """Test outline_state_evolution_pass does not raise error for circuit with classical
         operations only."""
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @outline_state_evolution_pass
         def circuit(x, y):
             return x * y + 5
@@ -157,7 +157,7 @@ class TestOutlineStateEvolutionPass:
         # the program is captured.
         dev = qp.device("null.qubit", wires=10)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @outline_state_evolution_pass
         @qp.qnode(dev)
         def circuit():
@@ -172,7 +172,7 @@ class TestOutlineStateEvolutionPass:
         """Test the outline_state_evolution_pass only."""
         dev = qp.device("lightning.qubit", wires=1000)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @outline_state_evolution_pass
         @qp.set_shots(1000)
         @qp.qnode(dev)
@@ -207,7 +207,7 @@ class TestOutlineStateEvolutionPass:
         on lightning.qubit."""
         dev = qp.device("lightning.qubit", wires=1000)
 
-        @qp.qjit(capture=True, target="mlir", pipelines=mbqc_pipeline())
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir", pipelines=mbqc_pipeline())
         @decompose_graph_state_pass
         @convert_to_mbqc_formalism_pass
         @outline_state_evolution_pass
@@ -252,7 +252,7 @@ class TestOutlineStateEvolutionPass:
         null.qubit."""
         dev = qp.device("null.qubit", wires=1000)
 
-        @qp.qjit(capture=True, target="mlir", pipelines=mbqc_pipeline())
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir", pipelines=mbqc_pipeline())
         @decompose_graph_state_pass
         @convert_to_mbqc_formalism_pass
         @measurements_from_samples_pass
@@ -297,7 +297,7 @@ class TestOutlineStateEvolutionPass:
         transform pipeline can be executed on null.qubit."""
         dev = qp.device("null.qubit", wires=1000)
 
-        @qp.qjit(capture=True, target="mlir", pipelines=mbqc_pipeline())
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir", pipelines=mbqc_pipeline())
         @decompose_graph_state_pass
         @convert_to_mbqc_formalism_pass
         @measurements_from_samples_pass
@@ -336,7 +336,7 @@ class TestOutlineStateEvolutionPass:
             i = i + 1
             return i
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @outline_state_evolution_pass
         @qp.qnode(dev)
         def circuit():
@@ -349,6 +349,7 @@ class TestOutlineStateEvolutionPass:
 
         @qp.qjit(
             capture=True,
+            collect_decomp_rules=False,
             target="mlir",
         )
         @qp.qnode(dev)

--- a/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
+++ b/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_convert_quantum_to_qecl.py
@@ -1498,7 +1498,7 @@ class TestMeasurementProcesses:
         """
         dev = qp.device("null.qubit", wires=1)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @convert_quantum_to_qecl_pass(k=1)
         @qp.qnode(dev, shots=100, mcm_method="one-shot")
         def circuit():
@@ -1523,7 +1523,7 @@ class TestMeasurementProcesses:
         """
         dev = qp.device("null.qubit", wires=1)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @convert_quantum_to_qecl_pass(k=1)
         @qp.qnode(dev, shots=100, mcm_method="one-shot")
         def circuit():
@@ -1548,7 +1548,7 @@ class TestMeasurementProcesses:
         """
         dev = qp.device("null.qubit", wires=2)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @convert_quantum_to_qecl_pass(k=1)
         @qp.qnode(dev, shots=100, mcm_method="one-shot")
         def circuit():
@@ -1579,7 +1579,7 @@ class TestMeasurementProcesses:
         """
         dev = qp.device("null.qubit", wires=2)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @convert_quantum_to_qecl_pass(k=1)
         @qp.qnode(dev, shots=100, mcm_method="one-shot")
         def circuit():
@@ -1599,7 +1599,7 @@ class TestMeasurementProcesses:
         """
         dev = qp.device("null.qubit", wires=1)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @convert_quantum_to_qecl_pass(k=1)
         @measurements_from_samples_pass
         @qp.qnode(dev, shots=100, mcm_method="one-shot")
@@ -1637,7 +1637,7 @@ class TestMeasurementProcesses:
         """
         dev = qp.device("null.qubit", wires=1)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @convert_quantum_to_qecl_pass(k=1)
         @measurements_from_samples_pass
         @qp.qnode(dev, shots=100, mcm_method="one-shot")
@@ -1671,7 +1671,7 @@ class TestMeasurementProcesses:
         """
         dev = qp.device("null.qubit", wires=1)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @convert_quantum_to_qecl_pass(k=1)
         @measurements_from_samples_pass
         @qp.qnode(dev, shots=100, mcm_method="one-shot")
@@ -1705,7 +1705,7 @@ class TestMeasurementProcesses:
         """
         dev = qp.device("null.qubit", wires=1)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @convert_quantum_to_qecl_pass(k=1)
         @measurements_from_samples_pass
         @qp.qnode(dev, shots=100, mcm_method="one-shot")
@@ -1740,7 +1740,7 @@ class TestMeasurementProcesses:
         """
         dev = qp.device("null.qubit", wires=2)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @convert_quantum_to_qecl_pass(k=1)
         @measurements_from_samples_pass
         @qp.qnode(dev, shots=100, mcm_method="one-shot")
@@ -1761,7 +1761,7 @@ class TestQuantumToQecLogicalPassIntegration:
         """Test the convert-quantum-to-qecl pass on the simplest possible, non-trivial circuit."""
         dev = qp.device("null.qubit", wires=1)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @convert_quantum_to_qecl_pass(k=1)
         @qp.qnode(dev, shots=1)
         def circuit():
@@ -1792,7 +1792,7 @@ class TestQuantumToQecLogicalPassIntegration:
         """Test the convert-quantum-to-qecl pass on a GHZ circuit."""
         dev = qp.device("null.qubit", wires=3)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @convert_quantum_to_qecl_pass(k=1)
         @qp.qnode(dev, shots=1)
         def circuit():

--- a/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_inject_noise_to_qecl.py
+++ b/frontend/test/pytest/python_interface/transforms/qecl/test_xdsl_inject_noise_to_qecl.py
@@ -59,7 +59,7 @@ class TestInjectNoiseToQECLPassIntegration:
         """Test the inject-noise-to-qecl pass on the simplest possible, non-trivial circuit."""
         dev = qp.device("null.qubit", wires=1)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @inject_noise_to_qecl_pass
         @convert_quantum_to_qecl_pass(k=1)
         @qp.qnode(dev, shots=1)

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecl_to_qecp.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecl_to_qecp.py
@@ -1311,7 +1311,7 @@ class TestControlFlow:
         """
         dev = qp.device("null.qubit", wires=1)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @convert_qecl_to_qecp_pass(qec_code="Steane")
         @qp.transform(pass_name="symbol-dce")
         @convert_quantum_to_qecl_pass(k=1)
@@ -1348,7 +1348,7 @@ class TestControlFlow:
         """
         dev = qp.device("null.qubit", wires=1)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @convert_qecl_to_qecp_pass(qec_code="Steane")
         @qp.transform(pass_name="symbol-dce")
         @convert_quantum_to_qecl_pass(k=1)
@@ -1382,7 +1382,7 @@ class TestControlFlow:
         """
         dev = qp.device("null.qubit", wires=1)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @convert_qecl_to_qecp_pass(qec_code="Steane")
         @qp.transform(pass_name="symbol-dce")
         @convert_quantum_to_qecl_pass(k=1)
@@ -1430,7 +1430,7 @@ class TestQECPLoweringIntegration:
         GHZ circuit."""
         dev = qp.device("null.qubit", wires=3)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @convert_qecl_to_qecp_pass(qec_code="Steane")
         @convert_quantum_to_qecl_pass(k=1)
         @qp.qnode(dev, shots=1)
@@ -1473,7 +1473,7 @@ class TestQECPLoweringIntegration:
         non-trivial circuit."""
         dev = qp.device("null.qubit", wires=1)
 
-        @qp.qjit(target="mlir", capture=True)
+        @qp.qjit(target="mlir", capture=True, collect_decomp_rules=False)
         @convert_qecl_to_qecp_pass(qec_code="Steane", number_errors=1)
         @inject_noise_to_qecl_pass
         @convert_quantum_to_qecl_pass(k=1)
@@ -1511,7 +1511,7 @@ class TestGenerality:
         dev = qp.device("lightning.qubit", wires=2)
         pipe = [("pipe", ["quantum-compilation-stage"])]
 
-        @qp.qjit(capture=True, pipelines=pipe, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, pipelines=pipe, target="mlir")
         @convert_qecl_to_qecp_pass(qec_code="Shor913", number_errors=0)
         @convert_quantum_to_qecl_pass(k=1)
         @qp.set_shots(1000)

--- a/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
+++ b/frontend/test/pytest/python_interface/transforms/qecp/test_xdsl_convert_qecp_to_quantum.py
@@ -788,7 +788,7 @@ class TestControlFlow:
         """
         dev = qp.device("null.qubit", wires=1)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @convert_qecp_to_quantum_pass
         @qp.transform(pass_name="symbol-dce")
         @convert_qecl_to_qecp_pass(qec_code="Steane")
@@ -833,7 +833,7 @@ class TestControlFlow:
         """
         dev = qp.device("null.qubit", wires=2)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @convert_qecp_to_quantum_pass
         @qp.transform(pass_name="symbol-dce")
         @convert_qecl_to_qecp_pass(qec_code="Steane")
@@ -887,7 +887,7 @@ class TestControlFlow:
         """
         dev = qp.device("null.qubit", wires=1)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @convert_qecp_to_quantum_pass
         @qp.transform(pass_name="symbol-dce")
         @convert_qecl_to_qecp_pass(qec_code="Steane")
@@ -923,7 +923,7 @@ class TestControlFlow:
         """
         dev = qp.device("null.qubit", wires=1)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @convert_qecp_to_quantum_pass
         @qp.transform(pass_name="symbol-dce")
         @convert_qecl_to_qecp_pass(qec_code="Steane")
@@ -972,7 +972,7 @@ class TestControlFlow:
 
         dev = qp.device("null.qubit", wires=N_WIRES)
 
-        @qp.qjit(capture=True, target="mlir", autograph=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir", autograph=True)
         @convert_qecp_to_quantum_pass
         @qp.transform(pass_name="symbol-dce")
         @convert_qecl_to_qecp_pass(qec_code="Steane")
@@ -1000,7 +1000,7 @@ class TestQECPassIntegration:
         """Integration tests for lowering a 3-logical qubit GHZ circuit on lightning.qubit."""
         dev = qp.device("lightning.qubit", wires=3)
 
-        @qp.qjit(capture=True, pipelines=qec_pipeline())
+        @qp.qjit(capture=True, collect_decomp_rules=False, pipelines=qec_pipeline())
         @convert_qecp_to_quantum_pass
         @convert_qecl_to_qecp_pass(qec_code="Steane", number_errors=1)
         @inject_noise_to_qecl_pass
@@ -1050,7 +1050,7 @@ class TestQECPassIntegration:
         """Integration tests for lowering a 3-logical qubit GHZ circuit on null.qubit."""
         dev = qp.device("null.qubit", wires=3)
 
-        @qp.qjit(capture=True, pipelines=qec_pipeline())
+        @qp.qjit(capture=True, collect_decomp_rules=False, pipelines=qec_pipeline())
         @convert_qecp_to_quantum_pass
         @convert_qecl_to_qecp_pass(qec_code="Steane", number_errors=1)
         @inject_noise_to_qecl_pass
@@ -1098,7 +1098,7 @@ class TestQECPassIntegration:
             convert_qecp_to_quantum_pass,
         )
 
-        @qp.qjit(capture=True, pipelines=qec_pipeline(), seed=123)
+        @qp.qjit(capture=True, collect_decomp_rules=False, pipelines=qec_pipeline(), seed=123)
         @qec_conversion_and_noise_passes
         @qp.set_shots(700)
         @qp.qnode(dev, mcm_method="one-shot")
@@ -1108,7 +1108,7 @@ class TestQECPassIntegration:
             qp.H(0)
             return qp.sample(wires=[0])
 
-        @qp.qjit(capture=True, pipelines=qec_pipeline(), seed=456)
+        @qp.qjit(capture=True, collect_decomp_rules=False, pipelines=qec_pipeline(), seed=456)
         @qec_conversion_and_noise_passes
         @qp.set_shots(700)
         @qp.qnode(dev, mcm_method="one-shot")
@@ -1120,7 +1120,7 @@ class TestQECPassIntegration:
             qp.H(0)
             return qp.sample(wires=[0])
 
-        @qp.qjit(capture=True, pipelines=qec_pipeline(), seed=789)
+        @qp.qjit(capture=True, collect_decomp_rules=False, pipelines=qec_pipeline(), seed=789)
         @qec_conversion_and_noise_passes
         @qp.set_shots(700)
         @qp.qnode(dev, mcm_method="one-shot")
@@ -1140,7 +1140,7 @@ class TestQECPassIntegration:
         """Test that sampling on MCMs returns correct results."""
         dev = qp.device("lightning.qubit", wires=2)
 
-        @qp.qjit(capture=True, pipelines=qec_pipeline(), seed=42)
+        @qp.qjit(capture=True, collect_decomp_rules=False, pipelines=qec_pipeline(), seed=42)
         @convert_qecp_to_quantum_pass
         @convert_qecl_to_qecp_pass(qec_code="Steane", number_errors=1)
         @inject_noise_to_qecl_pass
@@ -1162,7 +1162,7 @@ class TestQECPassIntegration:
         """Test that sampling on MCMs returns correct results."""
         dev = qp.device("lightning.qubit", wires=2)
 
-        @qp.qjit(capture=True, pipelines=qec_pipeline(), seed=42)
+        @qp.qjit(capture=True, collect_decomp_rules=False, pipelines=qec_pipeline(), seed=42)
         @convert_qecp_to_quantum_pass
         @convert_qecl_to_qecp_pass(qec_code="Steane", number_errors=1)
         @inject_noise_to_qecl_pass
@@ -1182,7 +1182,7 @@ class TestQECPassIntegration:
         """Test that expectation-value terminal measurements return correct results."""
         dev = qp.device("lightning.qubit", wires=2)
 
-        @qp.qjit(capture=True, pipelines=qec_pipeline())
+        @qp.qjit(capture=True, collect_decomp_rules=False, pipelines=qec_pipeline())
         @convert_qecp_to_quantum_pass
         @convert_qecl_to_qecp_pass(qec_code="Steane", number_errors=1)
         @inject_noise_to_qecl_pass
@@ -1202,7 +1202,7 @@ class TestQECPassIntegration:
         """Test that variance terminal measurements return correct results."""
         dev = qp.device("lightning.qubit", wires=2)
 
-        @qp.qjit(capture=True, pipelines=qec_pipeline())
+        @qp.qjit(capture=True, collect_decomp_rules=False, pipelines=qec_pipeline())
         @convert_qecp_to_quantum_pass
         @convert_qecl_to_qecp_pass(qec_code="Steane", number_errors=1)
         @inject_noise_to_qecl_pass
@@ -1231,7 +1231,7 @@ class TestQECPassIntegration:
         """Test that probability terminal measurements return correct results."""
         dev = qp.device("lightning.qubit", wires=2)
 
-        @qp.qjit(capture=True, pipelines=qec_pipeline())
+        @qp.qjit(capture=True, collect_decomp_rules=False, pipelines=qec_pipeline())
         @convert_qecp_to_quantum_pass
         @convert_qecl_to_qecp_pass(qec_code="Steane", number_errors=1)
         @inject_noise_to_qecl_pass
@@ -1266,7 +1266,7 @@ class TestQECPassIntegration:
 
         dev = qp.device("lightning.qubit", wires=1)
 
-        @qp.qjit(capture=True, pipelines=qec_pipeline(), seed=6)
+        @qp.qjit(capture=True, collect_decomp_rules=False, pipelines=qec_pipeline(), seed=6)
         @convert_qecp_to_quantum_pass
         @convert_qecl_to_qecp_pass(qec_code="Steane", number_errors=1)
         @inject_noise_to_qecl_pass
@@ -1299,7 +1299,7 @@ class TestQECPassIntegration:
         """
         dev = qp.device("null.qubit", wires=1)
 
-        @qp.qjit(capture=True, pipelines=qec_pipeline())
+        @qp.qjit(capture=True, collect_decomp_rules=False, pipelines=qec_pipeline())
         @qp.set_shots(10)
         @qp.qnode(dev, mcm_method="one-shot")
         def circ():
@@ -1329,7 +1329,7 @@ class TestQECPassIntegration:
 
         dev = qp.device("lightning.qubit", wires=1)
 
-        @qp.qjit(capture=True, pipelines=qec_pipeline(), seed=6)
+        @qp.qjit(capture=True, collect_decomp_rules=False, pipelines=qec_pipeline(), seed=6)
         @convert_qecp_to_quantum_pass
         @convert_qecl_to_qecp_pass(qec_code="Steane", number_errors=1)
         @inject_noise_to_qecl_pass

--- a/frontend/test/pytest/python_interface/transforms/quantum/test_xdsl_cancel_inverses.py
+++ b/frontend/test/pytest/python_interface/transforms/quantum/test_xdsl_cancel_inverses.py
@@ -204,7 +204,7 @@ class TestIterativeCancelInversesIntegration:
         """Test that the IterativeCancelInversesPass works correctly with qjit."""
         dev = qp.device("lightning.qubit", wires=2)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @iterative_cancel_inverses_pass
         @qp.qnode(dev)
         def circuit():
@@ -222,7 +222,7 @@ class TestIterativeCancelInversesIntegration:
         there are no operations that can be cancelled."""
         dev = qp.device("lightning.qubit", wires=2)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @iterative_cancel_inverses_pass
         @qp.qnode(dev)
         def circuit():

--- a/frontend/test/pytest/python_interface/transforms/quantum/test_xdsl_diagonalize_measurements.py
+++ b/frontend/test/pytest/python_interface/transforms/quantum/test_xdsl_diagonalize_measurements.py
@@ -591,6 +591,7 @@ class TestDiagonalizeFinalMeasurementsProgramCaptureExecution:
         circuit_compiled = qp.qjit(
             diagonalize_final_measurements_pass(circuit_ref),
             capture=True,
+            collect_decomp_rules=False,
         )
 
         assert np.allclose(expected_res(phi, theta), circuit_compiled(phi, theta))
@@ -808,6 +809,7 @@ class TestDiagonalizeFinalMeasurementsCatalystFrontend:
         circuit_compiled = qp.qjit(
             diagonalize_final_measurements_pass(circuit_ref),
             capture=True,
+            collect_decomp_rules=False,
         )
 
         assert np.allclose(expected_res(phi, theta), circuit_compiled(phi, theta))

--- a/frontend/test/pytest/python_interface/transforms/quantum/test_xdsl_merge_rotations.py
+++ b/frontend/test/pytest/python_interface/transforms/quantum/test_xdsl_merge_rotations.py
@@ -241,7 +241,7 @@ class TestMergeRotationsIntegration:
         """Test that the MergeRotationsPass works correctly with qjit."""
         dev = qp.device("lightning.qubit", wires=1)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @merge_rotations_pass
         @qp.qnode(dev)
         def circuit(x: float, y: float):

--- a/frontend/test/pytest/python_interface/transforms/quantum/test_xdsl_parity_synth.py
+++ b/frontend/test/pytest/python_interface/transforms/quantum/test_xdsl_parity_synth.py
@@ -512,8 +512,10 @@ class TestParitySynthIntegration:
             qp.CNOT((1, 0))
             return qp.state()
 
-        raw_circuit = qp.qjit(circuit, capture=True)
-        compiled_circuit = qp.qjit(parity_synth_pass(circuit), capture=True)
+        raw_circuit = qp.qjit(circuit, capture=True, collect_decomp_rules=False)
+        compiled_circuit = qp.qjit(
+            parity_synth_pass(circuit), capture=True, collect_decomp_rules=False
+        )
 
         run_filecheck_qjit(compiled_circuit)
         args = (0.6, 0.2, -1.8)
@@ -599,8 +601,10 @@ class TestParitySynthIntegration:
 
             return qp.state()
 
-        raw_circuit = qp.qjit(circuit, capture=True)
-        compiled_circuit = qp.qjit(parity_synth_pass(circuit), capture=True)
+        raw_circuit = qp.qjit(circuit, capture=True, collect_decomp_rules=False)
+        compiled_circuit = qp.qjit(
+            parity_synth_pass(circuit), capture=True, collect_decomp_rules=False
+        )
 
         run_filecheck_qjit(compiled_circuit)
         args = (0.6, 0.2, -1.8)
@@ -670,8 +674,10 @@ class TestParitySynthIntegration:
 
             return qp.state()
 
-        raw_circuit = qp.qjit(circuit, capture=True)
-        compiled_circuit = qp.qjit(parity_synth_pass(circuit), capture=True)
+        raw_circuit = qp.qjit(circuit, capture=True, collect_decomp_rules=False)
+        compiled_circuit = qp.qjit(
+            parity_synth_pass(circuit), capture=True, collect_decomp_rules=False
+        )
 
         run_filecheck_qjit(compiled_circuit)
         for x in [0.5, 1.5, 2.5, 3.5]:

--- a/frontend/test/pytest/test_autograph.py
+++ b/frontend/test/pytest/test_autograph.py
@@ -1960,7 +1960,12 @@ class TestAutographInclude:
 
         with pytest.raises(NotImplementedError, match="autograph_include"):
 
-            @qjit(autograph=True, autograph_include=["catalyst.utils.dummy"], capture=True)
+            @qjit(
+                autograph=True,
+                autograph_include=["catalyst.utils.dummy"],
+                capture=True,
+                collect_decomp_rules=False,
+            )
             def included(x: float, n: int):
                 for _ in range(n):
                     x = x + dummy_func(6)

--- a/frontend/test/pytest/test_backline.py
+++ b/frontend/test/pytest/test_backline.py
@@ -272,7 +272,7 @@ def test_backline_qnode_capture_path(use_capture):
     """A backline qnode compiles to MLIR carrying the catalyst.backline attribute."""
     dev = qp.Backline(controller=_controller(), coprocessors=[_coproc("cop0")], transport="rdma")
 
-    @qjit(target="mlir", capture=True)
+    @qjit(target="mlir", capture=True, collect_decomp_rules=False)
     @qp.qnode(dev)
     def circuit():
         qp.Hadamard(0)
@@ -290,7 +290,7 @@ def test_backline_qnode_capture_path_memcpy(use_capture):
     """
     dev = qp.Backline(controller=_controller(), coprocessors=[_coproc("cop0")], transport="memcpy")
 
-    @qjit(target="mlir", capture=True)
+    @qjit(target="mlir", capture=True, collect_decomp_rules=False)
     @qp.qnode(dev)
     def circuit():
         qp.Hadamard(0)
@@ -319,7 +319,7 @@ def test_placement_behind_a_wrapper_is_found(use_capture):
         qp.Hadamard(0)
         return qp.probs()
 
-    @qjit(target="mlir", capture=True)
+    @qjit(target="mlir", capture=True, collect_decomp_rules=False)
     def workflow():
         return 2.0 * circuit()
 
@@ -365,7 +365,7 @@ def test_qec_encoding_reaches_a_qnode_behind_a_wrapper(use_capture):
         qp.Hadamard(0)
         return qp.probs()
 
-    @qjit(target="mlir", capture=True)
+    @qjit(target="mlir", capture=True, collect_decomp_rules=False)
     def workflow():
         return 2.0 * circuit()
 
@@ -390,7 +390,7 @@ def test_remote_controller_behind_a_wrapper_is_still_tagged(use_capture):
         qp.Hadamard(0)
         return qp.probs()
 
-    @qjit(target="mlir", capture=True)
+    @qjit(target="mlir", capture=True, collect_decomp_rules=False)
     def workflow():
         return 2.0 * circuit()
 
@@ -411,7 +411,7 @@ def test_two_qnodes_over_one_placement_are_accepted(use_capture):
         qp.CNOT([0, 1])
         return qp.probs()
 
-    @qjit(target="mlir", capture=True)
+    @qjit(target="mlir", capture=True, collect_decomp_rules=False)
     def workflow():
         return circuit_a() + circuit_b()
 
@@ -437,7 +437,7 @@ def test_two_placements_in_one_program_are_rejected(use_capture):
 
     with pytest.raises(CompileError, match="2 different backline placements"):
 
-        @qjit(target="mlir", capture=True)
+        @qjit(target="mlir", capture=True, collect_decomp_rules=False)
         def workflow():
             return circuit_a() + circuit_b()
 
@@ -940,7 +940,7 @@ class TestExecutorRealization:
         cop = _coproc("cop0", oob_port=40000)
         dev = qp.Backline(controller=_controller(), coprocessors=[cop], transport="rdma")
 
-        @qjit(target="mlir", capture=True)
+        @qjit(target="mlir", capture=True, collect_decomp_rules=False)
         @qp.qnode(dev)
         def circuit():
             qp.Hadamard(0)

--- a/frontend/test/pytest/test_capture_kwarg.py
+++ b/frontend/test/pytest/test_capture_kwarg.py
@@ -38,7 +38,7 @@ class TestCaptureKwarg:
     def test_capture_kwarg_true(self):
         """Test that capture=True is accepted."""
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         def f(x):
             return x * 2
 
@@ -156,7 +156,7 @@ class TestCaptureKwargIntegration:
 
         dev = qp.device(backend, wires=2)
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(dev)
         def circuit(theta):
             assert qp.capture.enabled()
@@ -176,7 +176,7 @@ class TestCaptureKwargIntegration:
         try:
             dev = qp.device(backend, wires=2)
 
-            @qjit(capture=False)
+            @qjit(capture=False, collect_decomp_rules=False)
             @qp.qnode(dev)
             def circuit(theta):
                 assert not qp.capture.enabled()
@@ -210,7 +210,7 @@ class TestCaptureKwargIntegration:
         """Test that capture=True works for classical-only functions."""
         qp.capture.disable()
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         def classical_fn(x, y):
             assert qp.capture.enabled()
             return x**2 + y**2
@@ -223,7 +223,7 @@ class TestCaptureKwargIntegration:
         dev = qp.device(backend, wires=1)
         qp.capture.disable()
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(dev)
         def circuit_capture(theta):
             assert qp.capture.enabled()
@@ -255,10 +255,10 @@ class TestCaptureCompileOptionsIdentity:
     """
 
     def test_capture_flag_creates_distinct_compile_options(self):
-        """Test that qjit(capture=True) and qjit(capture=False) have distinct CompileOptions."""
+        """Test that qjit(capture=True, collect_decomp_rules=False) and qjit(capture=False) have distinct CompileOptions."""
         qp.capture.disable()  # Ensure global state doesn't affect the test
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         def fn_capture(x):
             return x * 2
 
@@ -286,7 +286,7 @@ class TestCaptureCompileOptionsIdentity:
         """
         qp.capture.disable()  # Global state is disabled
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         def circuit(x: float):  # Type hint enables AOT compilation
             return x * 2
 
@@ -306,7 +306,7 @@ class TestCaptureCompileOptionsIdentity:
         qp.capture.enable()
         try:
 
-            @qjit(capture=False)
+            @qjit(capture=False, collect_decomp_rules=False)
             def circuit(x: float):  # Type hint enables AOT compilation
                 return x * 2
 
@@ -345,7 +345,7 @@ class TestCaptureCompileOptionsIdentity:
         def make_circuit_capture():
             compilation_count["capture"] += 1
 
-            @qjit(capture=True)
+            @qjit(capture=True, collect_decomp_rules=False)
             @qp.qnode(dev)
             def circuit(x):
                 qp.RX(x, wires=0)

--- a/frontend/test/pytest/test_capture_kwarg.py
+++ b/frontend/test/pytest/test_capture_kwarg.py
@@ -255,7 +255,7 @@ class TestCaptureCompileOptionsIdentity:
     """
 
     def test_capture_flag_creates_distinct_compile_options(self):
-        """Test that qjit(capture=True, collect_decomp_rules=False) and qjit(capture=False) have distinct CompileOptions."""
+        """Test that qjit(capture=True) and qjit(capture=False) have distinct CompileOptions."""
         qp.capture.disable()  # Ensure global state doesn't affect the test
 
         @qjit(capture=True, collect_decomp_rules=False)

--- a/frontend/test/pytest/test_dynamic_qubit_allocation.py
+++ b/frontend/test/pytest/test_dynamic_qubit_allocation.py
@@ -34,7 +34,7 @@ def test_basic_dynamic_wire_alloc_plain_API(backend):
     Test basic qp.allocate and qp.deallocate.
     """
 
-    @qjit(capture=True)
+    @qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=3))
     def circuit():
         qp.X(1)  # |010>
@@ -57,7 +57,7 @@ def test_basic_dynamic_wire_alloc_ctx_API(backend):
     Test basic qp.allocate with context manager API.
     """
 
-    @qjit(capture=True)
+    @qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=3))
     def circuit():
         qp.X(1)
@@ -79,7 +79,7 @@ def test_measure(backend):
     Test qp.allocate with qp.Measure ops.
     """
 
-    @qjit(autograph=True, capture=True)
+    @qjit(autograph=True, capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=1))
     def circuit():
         with qp.allocate(1) as q:
@@ -102,7 +102,7 @@ def test_measure_with_reset(backend):
     Test qp.allocate with qp.Measure ops with resetting.
     """
 
-    @qjit(autograph=True, capture=True)
+    @qjit(autograph=True, capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=1))
     def circuit():
         with qp.allocate(1) as q:
@@ -132,7 +132,7 @@ def test_qp_ctrl(ctrl_val, expected, backend):
     Test qp.allocate with qp.ctrl ops.
     """
 
-    @qjit(capture=True)
+    @qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=1))
     def circuit():
         with qp.allocate(1) as q:
@@ -149,7 +149,7 @@ def test_QubitUnitary(backend):
     Test qp.allocate with qp.QubitUnitary ops.
     """
 
-    @qjit(capture=True)
+    @qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=1))
     def circuit():
         with qp.allocate(2) as qs:
@@ -167,7 +167,7 @@ def test_StatePrep(backend):
     Test qp.allocate with qp.StatePrep ops.
     """
 
-    @qjit(capture=True)
+    @qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=1))
     def circuit():
         with qp.allocate(1) as q:
@@ -185,7 +185,7 @@ def test_BasisState(backend):
     Test qp.allocate with qp.BasisState ops.
     """
 
-    @qjit(capture=True)
+    @qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=1))
     def circuit():
         with qp.allocate(1) as q:
@@ -204,7 +204,7 @@ def test_dynamic_wire_alloc_cond(cond, expected, backend):
     Test qp.allocate and qp.deallocate inside cond.
     """
 
-    @qjit(autograph=True, capture=True)
+    @qjit(autograph=True, capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=2))
     def circuit(c):
         if c:
@@ -231,7 +231,7 @@ def test_dynamic_wire_alloc_cond_outside(cond, expected, backend):
     Test passing dynamically allocated wires into a cond.
     """
 
-    @qjit(autograph=True, capture=True)
+    @qjit(autograph=True, capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=2))
     def circuit(c):
         with qp.allocate(1) as q1:
@@ -258,7 +258,7 @@ def test_dynamic_wire_alloc_forloop(num_iter, expected, backend):
     Test qp.allocate and qp.deallocate inside for loop.
     """
 
-    @qjit(autograph=True, capture=True)
+    @qjit(autograph=True, capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=3))
     def circuit(N):
         for _ in range(N):
@@ -279,7 +279,7 @@ def test_dynamic_wire_alloc_forloop_outside(backend):
     Test passing dynamically allocated wires into a for loop.
     """
 
-    @qjit(autograph=True, capture=True)
+    @qjit(autograph=True, capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=1))
     def circuit():
         with qp.allocate(1) as q:
@@ -300,7 +300,7 @@ def test_dynamic_wire_alloc_forloop_outside_multiple_regs(backend):
     Test using multiple dynamically allocated registers from inside for loop.
     """
 
-    @qjit(autograph=True, capture=True)
+    @qjit(autograph=True, capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=1))
     def circuit():
         with qp.allocate(1) as q1:
@@ -325,7 +325,7 @@ def test_dynamic_wire_alloc_whileloop(num_iter, expected, backend):
     Test qp.allocate and qp.deallocate inside while loop.
     """
 
-    @qjit(autograph=True, capture=True)
+    @qjit(autograph=True, capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=3))
     def circuit(N):
         i = 0
@@ -349,7 +349,7 @@ def test_dynamic_wire_alloc_whileloop_outside(num_iter, expected, backend):
     Test passing dynamically allocated wires into a while loop.
     """
 
-    @qjit(autograph=True, capture=True)
+    @qjit(autograph=True, capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=2))
     def circuit(N):
         i = 0
@@ -379,7 +379,7 @@ def test_subroutine(flip_again, expected, backend):
         qp.X(w)
         qp.CNOT(wires=[w, 0])
 
-    @qjit(capture=True)
+    @qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=1))
     def circuit():
         with qp.allocate(1) as q1:
@@ -404,7 +404,7 @@ def test_subroutine_multiple_args(backend):
         qp.X(w2)
         qp.ctrl(qp.RX, (w1, w2))(theta, wires=0)
 
-    @qjit(capture=True)
+    @qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=1))
     def circuit():
         with qp.allocate(1) as q1:
@@ -435,7 +435,7 @@ def test_subroutine_and_loop(backend):
 
         _ = loop(theta)
 
-    @qjit(capture=True)
+    @qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=1))
     def circuit():
         with qp.allocate(1) as q1:
@@ -466,7 +466,7 @@ def test_subroutine_and_loop_multiple_args(backend):
 
         _ = loop(theta)
 
-    @qjit(capture=True)
+    @qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=2))
     def circuit():
         with qp.allocate(2) as q1:
@@ -502,7 +502,7 @@ def test_non_probs_measurement_with_dynamic_wires(backend, measurement_fn, shots
     Test that non-probs measurements with dynamic wire allocations work.
     """
 
-    @qjit(capture=True)
+    @qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=1), shots=shots)
     def circuit():
         with qp.allocate(1) as q:
@@ -518,7 +518,7 @@ def test_adjoint(backend):
     Test adjoints work.
     """
 
-    @qjit(capture=True)
+    @qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device(backend, wires=2))
     def circuit():
         with qp.allocate(1) as q:
@@ -559,7 +559,7 @@ def test_use_after_free(backend):
 
     with pytest.warns(UserWarning, match="AOT.*failed"):
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device(backend, wires=1))
         def circuit():
             with qp.allocate(1) as q:
@@ -581,7 +581,7 @@ def test_terminal_MP_all_wires(backend):
 
     with pytest.warns(UserWarning, match="AOT.*failed"):
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device(backend, wires=1))
         def circuit():
             with qp.allocate(1) as _:
@@ -605,7 +605,7 @@ def test_terminal_MP_dynamic_wires(backend):
 
     with pytest.warns(UserWarning, match="AOT.*failed"):
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device(backend, wires=1))
         def circuit():
             q = qp.allocate(1)

--- a/frontend/test/pytest/test_gridsynth.py
+++ b/frontend/test/pytest/test_gridsynth.py
@@ -38,7 +38,7 @@ def test_PhaseShift_gridsynth(param, op, eps):
 
     expected = circuit(param)
     gridsynthed_circuit = qp.transforms.gridsynth(circuit, epsilon=eps)
-    qjitted_circuit = qp.qjit(gridsynthed_circuit, capture=True)
+    qjitted_circuit = qp.qjit(gridsynthed_circuit, capture=True, collect_decomp_rules=False)
     result = qjitted_circuit(param)
 
     assert qp.math.allclose(result, expected, atol=eps)
@@ -61,8 +61,10 @@ def test_gridsynth_ppr_basis(param, eps):
 
     gridsynthed_circuit = qp.transforms.gridsynth(circuit, epsilon=eps)
     gridsynthed_circuit_ppr = qp.transforms.gridsynth(circuit, epsilon=eps, ppr_basis=True)
-    qjitted_circuit = qp.qjit(gridsynthed_circuit, capture=True)
-    qjitted_circuit_with_ppr = qp.qjit(gridsynthed_circuit_ppr, capture=True)
+    qjitted_circuit = qp.qjit(gridsynthed_circuit, capture=True, collect_decomp_rules=False)
+    qjitted_circuit_with_ppr = qp.qjit(
+        gridsynthed_circuit_ppr, capture=True, collect_decomp_rules=False
+    )
     result = qjitted_circuit(param)
     result_with_ppr = qjitted_circuit_with_ppr(param)
     assert np.allclose(result, result_with_ppr, atol=eps)
@@ -80,7 +82,9 @@ def test_epsilon_warning_emitted_for_small_epsilon(capfd):
         qp.RZ(x, wires=0)
         return qp.state()
 
-    qp.qjit(qp.transforms.gridsynth(circuit, epsilon=1e-8), capture=True)(0.5)
+    qp.qjit(
+        qp.transforms.gridsynth(circuit, epsilon=1e-8), capture=True, collect_decomp_rules=False
+    )(0.5)
 
     captured = capfd.readouterr()
     assert _EPSILON_WARN_FRAGMENT in captured.err
@@ -95,7 +99,9 @@ def test_epsilon_warning_not_emitted_for_safe_epsilon(capfd):
         qp.RZ(x, wires=0)
         return qp.state()
 
-    qp.qjit(qp.transforms.gridsynth(circuit, epsilon=1e-4), capture=True)(0.5)
+    qp.qjit(
+        qp.transforms.gridsynth(circuit, epsilon=1e-4), capture=True, collect_decomp_rules=False
+    )(0.5)
 
     captured = capfd.readouterr()
     assert _EPSILON_WARN_FRAGMENT not in captured.err

--- a/frontend/test/pytest/test_jit_behaviour.py
+++ b/frontend/test/pytest/test_jit_behaviour.py
@@ -871,7 +871,7 @@ class TestDefaultAvailableIR:
         """Test that AbstractArray and AbstractWires can be used to specify the input
         shapes for AOT compilation."""
 
-        @qp.qjit(capture=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=4))
         def c(x: qp.typing.AbstractArray((3,), float), wires: qp.typing.Wire[4]):
             @qp.for_loop(x.shape[0])
@@ -933,7 +933,7 @@ class TestDefaultAvailableIR:
         # pylint: disable-next=import-outside-toplevel
         from catalyst.python_interface.transforms import iterative_cancel_inverses_pass
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @iterative_cancel_inverses_pass
         @qp.qnode(qp.device(backend, wires=1))
         def f():
@@ -1128,7 +1128,7 @@ class TestAOTFailures:
 
         with pytest.warns(UserWarning, match="AOT.*failed"):
 
-            @qp.qjit(capture=True)
+            @qp.qjit(capture=True, collect_decomp_rules=False)
             @qp.qnode(qp.device("null.qubit", wires=1))
             def c():
                 raise ValueError
@@ -1147,7 +1147,7 @@ class TestAOTFailures:
 
         with pytest.warns(UserWarning, match="AOT.*failed"):
 
-            @qp.qjit(capture=True)
+            @qp.qjit(capture=True, collect_decomp_rules=False)
             def c():
                 dummy_p.bind()
                 return 2
@@ -1159,7 +1159,7 @@ class TestAOTFailures:
 
         with pytest.warns(UserWarning, match="AOT.*failed"):
 
-            @qp.qjit(capture=True)
+            @qp.qjit(capture=True, collect_decomp_rules=False)
             @qp.qnode(qp.device("null.qubit", wires=1))
             def c():
                 qp.RX(qp.capture.symbolic_array((), float), 0)

--- a/frontend/test/pytest/test_loops.py
+++ b/frontend/test/pytest/test_loops.py
@@ -277,7 +277,7 @@ class TestWhileLoops:
         capture mode is enabled."""
         with pytest.raises(PlxprCaptureCFCompatibilityError) as exc_info:
 
-            @qjit(capture=True)
+            @qjit(capture=True, collect_decomp_rules=False)
             @qp.qnode(qp.device("lightning.qubit", wires=3))
             def test(n):
                 def condition(x):
@@ -455,7 +455,7 @@ class TestForLoops:
         capture mode is enabled."""
         with pytest.raises(PlxprCaptureCFCompatibilityError) as exc_info:
 
-            @qjit(capture=True)
+            @qjit(capture=True, collect_decomp_rules=False)
             @qp.qnode(qp.device("lightning.qubit", wires=3))
             def test(n):
                 @for_loop(0, n, 1)

--- a/frontend/test/pytest/test_mbqc.py
+++ b/frontend/test/pytest/test_mbqc.py
@@ -49,7 +49,7 @@ def test_measure_x(mbqc_pipeline):
     """
     dev = qp.device("null.qubit", wires=1)
 
-    @qjit(capture=True, pipelines=mbqc_pipeline)
+    @qjit(capture=True, collect_decomp_rules=False, pipelines=mbqc_pipeline)
     @qp.qnode(dev)
     def workload():
         _ = plft.measure_x(0)
@@ -72,7 +72,7 @@ def test_measure_y(mbqc_pipeline):
     """
     dev = qp.device("null.qubit", wires=1)
 
-    @qjit(capture=True, pipelines=mbqc_pipeline)
+    @qjit(capture=True, collect_decomp_rules=False, pipelines=mbqc_pipeline)
     @qp.qnode(dev)
     def workload():
         _ = plft.measure_y(0)
@@ -96,7 +96,7 @@ def test_measure_z(mbqc_pipeline):
     """
     dev = qp.device("null.qubit", wires=1)
 
-    @qjit(capture=True, pipelines=mbqc_pipeline)
+    @qjit(capture=True, collect_decomp_rules=False, pipelines=mbqc_pipeline)
     @qp.qnode(dev)
     def workload():
         _ = plft.measure_z(0)
@@ -122,7 +122,7 @@ def test_measure_measure_arbitrary_basis(angle, plane, mbqc_pipeline):
     """
     dev = qp.device("null.qubit", wires=1)
 
-    @qjit(capture=True, pipelines=mbqc_pipeline)
+    @qjit(capture=True, collect_decomp_rules=False, pipelines=mbqc_pipeline)
     @qp.qnode(dev)
     def workload():
         _ = plft.measure_arbitrary_basis(wires=0, angle=angle, plane=plane)
@@ -143,7 +143,7 @@ def test_measure_measure_arbitrary_basis_postselect(postselect, mbqc_pipeline):
     """
     dev = qp.device("null.qubit", wires=1)
 
-    @qjit(capture=True, pipelines=mbqc_pipeline)
+    @qjit(capture=True, collect_decomp_rules=False, pipelines=mbqc_pipeline)
     @qp.qnode(dev)
     def workload():
         _ = plft.measure_arbitrary_basis(wires=0, angle=0.1, plane="XY", postselect=postselect)
@@ -162,7 +162,7 @@ def test_measure_measure_arbitrary_basis_invalid_plane(mbqc_pipeline):
 
     with pytest.raises(ValueError, match=r"Measurement plane must be one of \['XY', 'YZ', 'ZX'\]"):
 
-        @qjit(capture=True, pipelines=mbqc_pipeline)
+        @qjit(capture=True, collect_decomp_rules=False, pipelines=mbqc_pipeline)
         @qp.qnode(dev)
         def workload():
             _ = plft.measure_arbitrary_basis(wires=0, angle=0.1, plane="YX")
@@ -182,7 +182,7 @@ def test_measure_measure_arbitrary_basis_invalid_postselect(postselect, mbqc_pip
         CompileError, match="op attribute 'postselect' failed to satisfy constraint"
     ):
 
-        @qjit(capture=True, pipelines=mbqc_pipeline)
+        @qjit(capture=True, collect_decomp_rules=False, pipelines=mbqc_pipeline)
         @qp.qnode(dev)
         def workload():
             _ = plft.measure_arbitrary_basis(wires=0, angle=0.1, plane="XY", postselect=postselect)
@@ -216,7 +216,7 @@ def test_explicit_rz_in_mbqc(rz_angle, mbqc_pipeline):
     lattice = plft.generate_lattice([4], "chain")
 
     # RZ circuit in the MBQC representation
-    @qjit(capture=True, pipelines=mbqc_pipeline)
+    @qjit(capture=True, collect_decomp_rules=False, pipelines=mbqc_pipeline)
     @qp.qnode(dev)
     def circuit_mbqc(start_state, angle):
         # prep input node
@@ -307,7 +307,7 @@ def test_cnot_in_mbqc_representation(mbqc_pipeline):
         return reduce(lambda a, b: a ^ b, args)
 
     # Equivalent CNOT circuit in the MBQC representation
-    @qjit(capture=True, pipelines=mbqc_pipeline)
+    @qjit(capture=True, collect_decomp_rules=False, pipelines=mbqc_pipeline)
     @qp.qnode(dev)
     def circuit_mbqc(start_state):
         # prep input nodes

--- a/frontend/test/pytest/test_mid_circuit_measurement.py
+++ b/frontend/test/pytest/test_mid_circuit_measurement.py
@@ -1058,7 +1058,7 @@ class TestDynamicOneShotMLIRPass:
         with expval
         """
 
-        @qjit(capture=True, seed=38)
+        @qjit(capture=True, collect_decomp_rules=False, seed=38)
         @qp.transform(pass_name="dynamic-one-shot")
         @qp.qnode(qp.device(backend, wires=2), shots=1000)
         def circuit():
@@ -1076,7 +1076,7 @@ class TestDynamicOneShotMLIRPass:
         with expval on a mid circuit measurement
         """
 
-        @qjit(capture=True, seed=38)
+        @qjit(capture=True, collect_decomp_rules=False, seed=38)
         @qp.transform(pass_name="dynamic-one-shot")
         @qp.qnode(qp.device(backend, wires=2), shots=1000)
         def circuit():
@@ -1095,7 +1095,7 @@ class TestDynamicOneShotMLIRPass:
         with probs
         """
 
-        @qjit(capture=True, seed=12345)
+        @qjit(capture=True, collect_decomp_rules=False, seed=12345)
         @qp.transform(pass_name="dynamic-one-shot")
         @qp.qnode(qp.device(backend, wires=2), shots=1000)
         def circuit():
@@ -1113,7 +1113,7 @@ class TestDynamicOneShotMLIRPass:
         with probs on a mid circuit measurement
         """
 
-        @qjit(capture=True, seed=12345)
+        @qjit(capture=True, collect_decomp_rules=False, seed=12345)
         @qp.transform(pass_name="dynamic-one-shot")
         @qp.qnode(qp.device(backend, wires=2), shots=1000)
         def circuit():
@@ -1133,7 +1133,7 @@ class TestDynamicOneShotMLIRPass:
         with variance on a mid circuit measurement
         """
 
-        @qjit(capture=True, seed=38)
+        @qjit(capture=True, collect_decomp_rules=False, seed=38)
         @qp.transform(pass_name="dynamic-one-shot")
         @qp.qnode(qp.device(backend, wires=2), shots=1000)
         def circuit():
@@ -1152,7 +1152,7 @@ class TestDynamicOneShotMLIRPass:
         with sample
         """
 
-        @qjit(capture=True, seed=12345)
+        @qjit(capture=True, collect_decomp_rules=False, seed=12345)
         @qp.transform(pass_name="dynamic-one-shot")
         @qp.qnode(qp.device(backend, wires=2), shots=1000)
         def circuit():
@@ -1173,7 +1173,7 @@ class TestDynamicOneShotMLIRPass:
         with sample on a mid circuit measurement
         """
 
-        @qjit(capture=True, seed=12345)
+        @qjit(capture=True, collect_decomp_rules=False, seed=12345)
         @qp.transform(pass_name="dynamic-one-shot")
         @qp.qnode(qp.device(backend, wires=2), shots=1000)
         def circuit():
@@ -1196,7 +1196,7 @@ class TestDynamicOneShotMLIRPass:
         with counts
         """
 
-        @qjit(capture=True, seed=12345)
+        @qjit(capture=True, collect_decomp_rules=False, seed=12345)
         @qp.transform(pass_name="dynamic-one-shot")
         @qp.qnode(qp.device(backend, wires=2), shots=1000)
         def circuit():
@@ -1216,7 +1216,7 @@ class TestDynamicOneShotMLIRPass:
         with counts on MCMs.
         """
 
-        @qjit(capture=True, seed=12345)
+        @qjit(capture=True, collect_decomp_rules=False, seed=12345)
         @qp.transform(pass_name="dynamic-one-shot")
         @qp.qnode(qp.device(backend, wires=2), shots=1000)
         def circuit():
@@ -1238,7 +1238,7 @@ class TestDynamicOneShotMLIRPass:
         multiple MPs
         """
 
-        @qjit(capture=True, seed=123456)
+        @qjit(capture=True, collect_decomp_rules=False, seed=123456)
         @qp.transform(pass_name="dynamic-one-shot")
         @qp.qnode(qp.device(backend, wires=2), shots=1000)
         def circuit():
@@ -1268,7 +1268,7 @@ class TestDynamicOneShotMLIRPass:
         multiple MPs on MCMs
         """
 
-        @qjit(capture=True, seed=12345)
+        @qjit(capture=True, collect_decomp_rules=False, seed=12345)
         @qp.transform(pass_name="dynamic-one-shot")
         @qp.qnode(qp.device(backend, wires=2), shots=1000)
         def circuit():
@@ -1305,7 +1305,7 @@ class TestDynamicOneShotMLIRPass:
         a dynamic number of shots with sample terminal MP.
         """
 
-        @qjit(capture=True, seed=12345)
+        @qjit(capture=True, collect_decomp_rules=False, seed=12345)
         def workflow(shots):
             @qp.transform(pass_name="dynamic-one-shot")
             @qp.set_shots(shots)
@@ -1329,7 +1329,7 @@ class TestDynamicOneShotMLIRPass:
         a dynamic number of shots with counts terminal MP.
         """
 
-        @qjit(capture=True, seed=12345)
+        @qjit(capture=True, collect_decomp_rules=False, seed=12345)
         def workflow(shots):
             @qp.transform(pass_name="dynamic-one-shot")
             @qp.set_shots(shots)
@@ -1360,7 +1360,7 @@ class TestDynamicOneShotMLIRPass:
         with some classical post processing
         """
 
-        @qjit(capture=True, seed=38)
+        @qjit(capture=True, collect_decomp_rules=False, seed=38)
         @qp.transform(pass_name="dynamic-one-shot")
         @qp.qnode(qp.device(backend, wires=2), shots=1000)
         def circuit():

--- a/frontend/test/pytest/test_pauli_rot_and_measure.py
+++ b/frontend/test/pytest/test_pauli_rot_and_measure.py
@@ -27,7 +27,7 @@ def test_pauli_rot_lowering():
     """Test that Pauli rotation is lowered to quantum.paulirot."""
     pipe = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipe, target="mlir", capture=True)
+    @qjit(pipelines=pipe, target="mlir", capture=True, collect_decomp_rules=False)
     def test_pauli_rot_lowering_workflow():
 
         @qp.qnode(qp.device("null.qubit", wires=1))
@@ -46,7 +46,7 @@ def test_pauli_rot_lowering_with_ctrl_qubits():
     """
     pipe = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipe, target="mlir", capture=True)
+    @qjit(pipelines=pipe, target="mlir", capture=True, collect_decomp_rules=False)
     def test_pauli_rot_lowering_with_ctrl_qubits_workflow():
 
         @qp.qnode(qp.device("null.qubit", wires=2))
@@ -64,7 +64,7 @@ def test_pauli_rot_to_ppr():
     """Test that Pauli rotation is converted to pbc.ppr."""
     pipe = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipe, target="mlir", capture=True)
+    @qjit(pipelines=pipe, target="mlir", capture=True, collect_decomp_rules=False)
     @to_ppr
     def test_pauli_rot_to_ppr_workflow():
 
@@ -82,7 +82,7 @@ def test_pauli_rot_with_arbitrary_angle_to_ppr():
     """Test that Pauli rotation for arbitrary angle."""
     pipe = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipe, target="mlir", capture=True)
+    @qjit(pipelines=pipe, target="mlir", capture=True, collect_decomp_rules=False)
     @to_ppr
     def test_pauli_rot_with_arbitrary_angle_to_ppr_workflow():
 
@@ -100,7 +100,7 @@ def test_pauli_rot_with_dynamic_angle_to_ppr():
     """Test that Pauli rotation for dynamic angle."""
     pipe = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipe, target="mlir", capture=True)
+    @qjit(pipelines=pipe, target="mlir", capture=True, collect_decomp_rules=False)
     @to_ppr
     def test_pauli_rot_with_dynamic_angle_to_ppr_workflow():
 
@@ -118,7 +118,7 @@ def test_pauli_measure_to_ppm():
     """Test that Pauli measurement is converted to pbc.ppm."""
     pipe = [("pipe", ["quantum-compilation-stage"])]
 
-    @qjit(pipelines=pipe, target="mlir", capture=True)
+    @qjit(pipelines=pipe, target="mlir", capture=True, collect_decomp_rules=False)
     @to_ppr
     def test_pauli_measure_to_ppr_workflow():
 
@@ -138,7 +138,7 @@ def test_pauli_rot_to_ppr_pauli_word_error():
 
     with pytest.warns(UserWarning, match="AOT.*failed"):
 
-        @qjit(pipelines=pipe, target="mlir", capture=True)
+        @qjit(pipelines=pipe, target="mlir", capture=True, collect_decomp_rules=False)
         def test_pauli_rot_to_ppr_pauli_word_error_workflow():
 
             @qp.qnode(qp.device("null.qubit", wires=1))
@@ -161,7 +161,7 @@ def test_pauli_measure_to_ppr_pauli_word_error():
 
     with pytest.warns(UserWarning, match="AOT.*failed"):
 
-        @qjit(pipelines=pipe, target="mlir", capture=True)
+        @qjit(pipelines=pipe, target="mlir", capture=True, collect_decomp_rules=False)
         def test_pauli_measure_to_ppr_pauli_word_error_workflow():
 
             @qp.qnode(qp.device("null.qubit", wires=1))
@@ -182,7 +182,7 @@ def test_controlled_pauli_rot_failure():
     Test that controlled PauliRot fails at runtime.
     """
 
-    @qjit(capture=True)
+    @qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device("lightning.qubit", wires=2))
     def workflow():
         qp.ctrl(qp.PauliRot(np.pi / 4, "X", wires=0), control=1)

--- a/frontend/test/pytest/test_peephole_optimizations.py
+++ b/frontend/test/pytest/test_peephole_optimizations.py
@@ -462,7 +462,7 @@ def test_merge_rotation_ppr():
 
     my_pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qp.qjit(pipelines=my_pipeline, target="mlir", capture=True)
+    @qp.qjit(pipelines=my_pipeline, target="mlir", capture=True, collect_decomp_rules=False)
     def test_merge_rotation_ppr_workflow():
         @qp.transforms.merge_rotations  # have to use qp to be capture-compatible
         @qp_to_ppr
@@ -486,7 +486,7 @@ def test_merge_rotation_arbitrary_angle_ppr():
 
     my_pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qp.qjit(pipelines=my_pipeline, target="mlir", capture=True)
+    @qp.qjit(pipelines=my_pipeline, target="mlir", capture=True, collect_decomp_rules=False)
     def test_merge_rotation_ppr_workflow():
         @qp.transforms.merge_rotations
         @qp_to_ppr
@@ -531,9 +531,9 @@ def test_clifford_to_ppm():
 
     pauli_corrected_cir = ppr_to_ppm_transform(decompose_method="pauli-corrected")(to_ppr_cir)
 
-    auto_qjit_cir = qp.qjit(auto_corrected_cir, capture=True)
-    clifford_qjit_cir = qp.qjit(clifford_corrected_cir, capture=True)
-    pauli_qjit_cir = qp.qjit(pauli_corrected_cir, capture=True)
+    auto_qjit_cir = qp.qjit(auto_corrected_cir, capture=True, collect_decomp_rules=False)
+    clifford_qjit_cir = qp.qjit(clifford_corrected_cir, capture=True, collect_decomp_rules=False)
+    pauli_qjit_cir = qp.qjit(pauli_corrected_cir, capture=True, collect_decomp_rules=False)
 
     baseline_cir = cir()
 
@@ -549,7 +549,7 @@ def test_decompose_arbitrary_ppr():
 
     my_pipeline = [("pipe", ["quantum-compilation-stage"])]
 
-    @qp.qjit(pipelines=my_pipeline, target="mlir", capture=True)
+    @qp.qjit(pipelines=my_pipeline, target="mlir", capture=True, collect_decomp_rules=False)
     def test_decompose_arbitrary_ppr_workflow():
         @qp.transform(pass_name="decompose-arbitrary-ppr")
         @qp.transform(pass_name="to-ppr")
@@ -600,9 +600,9 @@ class TestLowerPBCInitOps:
         to_ppr_circuit = qp.transform(pass_name="to-ppr")(baseline_circuit)
         lowered_circuit = qp.transform(pass_name="ppr-to-ppm")(to_ppr_circuit)
 
-        baseline_circuit = qp.qjit(baseline_circuit, capture=True)
-        to_ppr_circuit = qp.qjit(to_ppr_circuit, capture=True)
-        lowered_circuit = qp.qjit(lowered_circuit, capture=True)
+        baseline_circuit = qp.qjit(baseline_circuit, capture=True, collect_decomp_rules=False)
+        to_ppr_circuit = qp.qjit(to_ppr_circuit, capture=True, collect_decomp_rules=False)
+        lowered_circuit = qp.qjit(lowered_circuit, capture=True, collect_decomp_rules=False)
 
         baseline_result = baseline_circuit()
         to_ppr_result = to_ppr_circuit()

--- a/frontend/test/pytest/test_quantum_subroutine.py
+++ b/frontend/test/pytest/test_quantum_subroutine.py
@@ -35,7 +35,7 @@ class TestSubroutineHOP:
         def identity(x):
             return x
 
-        @qp.qjit(capture=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False)
         def subroutine_test():
             return identity(1)
 
@@ -48,7 +48,7 @@ class TestSubroutineHOP:
         def Hadamard0(wire):
             qp.Hadamard(wire)
 
-        @qp.qjit(capture=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=1))
         def subroutine_test(c: int):
             Hadamard0(c)
@@ -64,7 +64,7 @@ class TestSubroutineHOP:
         def Hadamard0(wire):
             qp.Hadamard(wire)
 
-        @qp.qjit(capture=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=1))
         def subroutine_test(c: int):
             Hadamard0(c)
@@ -85,7 +85,7 @@ class TestSubroutineHOP:
         msg = "inside subroutine"
         with pytest.warns(UserWarning, match="AOT.*failed"):
 
-            @qp.qjit(autograph=False, capture=True)
+            @qp.qjit(autograph=False, capture=True, collect_decomp_rules=False)
             def subroutine_test():
                 Hadamard0()
 
@@ -104,7 +104,7 @@ class TestSubroutineHOP:
 
             qp.cond(wire != 0, true_path, false_path)()
 
-        @qp.qjit(autograph=False, capture=True)
+        @qp.qjit(autograph=False, capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=1))
         def subroutine_test(c: int):
             Hadamard0(c)
@@ -126,7 +126,7 @@ class TestSubroutineClass:
         def f(x, wires):
             qp.RX(x, wires)
 
-        @qp.qjit(capture=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=3))
         def c(x):
             f(x, 0)
@@ -149,7 +149,7 @@ class TestSubroutineClass:
             else:
                 qp.Z(wires)
 
-        @qp.qjit(capture=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=3))
         def c():
             f(0, "X")
@@ -173,7 +173,7 @@ class TestSubroutineClass:
 
             l()
 
-        @qp.qjit(capture=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("lightning.qubit", wires=4))
         def c():
             f(register=(0, 1, 3))

--- a/frontend/test/pytest/test_specs.py
+++ b/frontend/test/pytest/test_specs.py
@@ -182,7 +182,7 @@ class TestDeviceLevelSpecs:
 
         dev = qp.device("null.qubit", wires=2)
 
-        @qjit(capture=True)
+        @qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(dev)
         def circuit():
             qp.PauliRot(0.42, pauli_word="Y", wires=0)  # arbitrary angle
@@ -938,7 +938,7 @@ class TestPassByPassSpecs:
         def subroutine():
             qp.Hadamard(wires=0)
 
-        @qp.qjit(autograph=True, capture=True)
+        @qp.qjit(autograph=True, capture=True, collect_decomp_rules=False)
         @qp.qnode(dev)
         def circuit():
             qp.PauliX(wires=1)
@@ -977,7 +977,7 @@ class TestPassByPassSpecs:
             def __init__(self, phi, reg1, reg2, metadata):
                 super().__init__(phi, reg1, reg2, metadata)
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @qp.transforms.merge_rotations
         @qp.qnode(qp.device("null.qubit", wires=10))
         def c():
@@ -993,7 +993,7 @@ class TestPassByPassSpecs:
     def test_symbolic_array(self):
         """Test using specs with symbolic_array."""
 
-        @qp.qjit(capture=True, target="mlir")
+        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
         @qp.transforms.merge_rotations
         @qp.qnode(qp.device("null.qubit", wires=1))
         def c():
@@ -1045,7 +1045,7 @@ class TestSpecsWithPPR:
     def test_arbitrary_ppr(self):
         """Test that PPRs are handled correctly."""
 
-        @qp.qjit(target="mlir", capture=True)
+        @qp.qjit(target="mlir", capture=True, collect_decomp_rules=False)
         @qp.transforms.decompose_arbitrary_ppr
         @qp.transforms.to_ppr
         @qp.qnode(qp.device("null.qubit", wires=3))
@@ -1254,7 +1254,7 @@ class TestSymbolicSpecs:
     def test_symbolic_array_inside_loop(self):
         """Test dynamic loop with symbolic_array in a loop."""
 
-        @qp.qjit(capture=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("null.qubit", wires=1))
         def c(n):
 
@@ -1274,7 +1274,7 @@ class TestSymbolicSpecs:
     def test_symbolic_array_loop_arguemtn(self):
         """Test dynamic loop with a symbolic array as a loop argument."""
 
-        @qp.qjit(capture=True)
+        @qp.qjit(capture=True, collect_decomp_rules=False)
         @qp.qnode(qp.device("null.qubit", wires=1))
         def c(n):
 
@@ -1771,7 +1771,7 @@ class TestMarkerIntegration:
 def test_abstract_array_inputs():
     """Test that AbstractArray and AbstractWires can be used with specs when level!= device."""
 
-    @qp.qjit(capture=True)
+    @qp.qjit(capture=True, collect_decomp_rules=False)
     @qp.qnode(qp.device("lightning.qubit", wires=4))
     def c(x, wires):
         @qp.for_loop(x.shape[0])

--- a/frontend/test/pytest/test_specs.py
+++ b/frontend/test/pytest/test_specs.py
@@ -182,7 +182,7 @@ class TestDeviceLevelSpecs:
 
         dev = qp.device("null.qubit", wires=2)
 
-        @qjit(capture=True, collect_decomp_rules=False)
+        @qjit(capture=True)
         @qp.qnode(dev)
         def circuit():
             qp.PauliRot(0.42, pauli_word="Y", wires=0)  # arbitrary angle
@@ -938,7 +938,7 @@ class TestPassByPassSpecs:
         def subroutine():
             qp.Hadamard(wires=0)
 
-        @qp.qjit(autograph=True, capture=True, collect_decomp_rules=False)
+        @qp.qjit(autograph=True, capture=True)
         @qp.qnode(dev)
         def circuit():
             qp.PauliX(wires=1)
@@ -977,7 +977,7 @@ class TestPassByPassSpecs:
             def __init__(self, phi, reg1, reg2, metadata):
                 super().__init__(phi, reg1, reg2, metadata)
 
-        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
+        @qp.qjit(capture=True, target="mlir")
         @qp.transforms.merge_rotations
         @qp.qnode(qp.device("null.qubit", wires=10))
         def c():
@@ -993,7 +993,7 @@ class TestPassByPassSpecs:
     def test_symbolic_array(self):
         """Test using specs with symbolic_array."""
 
-        @qp.qjit(capture=True, collect_decomp_rules=False, target="mlir")
+        @qp.qjit(capture=True, target="mlir")
         @qp.transforms.merge_rotations
         @qp.qnode(qp.device("null.qubit", wires=1))
         def c():
@@ -1045,7 +1045,7 @@ class TestSpecsWithPPR:
     def test_arbitrary_ppr(self):
         """Test that PPRs are handled correctly."""
 
-        @qp.qjit(target="mlir", capture=True, collect_decomp_rules=False)
+        @qp.qjit(target="mlir", capture=True)
         @qp.transforms.decompose_arbitrary_ppr
         @qp.transforms.to_ppr
         @qp.qnode(qp.device("null.qubit", wires=3))
@@ -1254,7 +1254,7 @@ class TestSymbolicSpecs:
     def test_symbolic_array_inside_loop(self):
         """Test dynamic loop with symbolic_array in a loop."""
 
-        @qp.qjit(capture=True, collect_decomp_rules=False)
+        @qp.qjit(capture=True)
         @qp.qnode(qp.device("null.qubit", wires=1))
         def c(n):
 
@@ -1274,7 +1274,7 @@ class TestSymbolicSpecs:
     def test_symbolic_array_loop_arguemtn(self):
         """Test dynamic loop with a symbolic array as a loop argument."""
 
-        @qp.qjit(capture=True, collect_decomp_rules=False)
+        @qp.qjit(capture=True)
         @qp.qnode(qp.device("null.qubit", wires=1))
         def c(n):
 
@@ -1771,7 +1771,7 @@ class TestMarkerIntegration:
 def test_abstract_array_inputs():
     """Test that AbstractArray and AbstractWires can be used with specs when level!= device."""
 
-    @qp.qjit(capture=True, collect_decomp_rules=False)
+    @qp.qjit(capture=True)
     @qp.qnode(qp.device("lightning.qubit", wires=4))
     def c(x, wires):
         @qp.for_loop(x.shape[0])

--- a/frontend/test/pytest/test_switch.py
+++ b/frontend/test/pytest/test_switch.py
@@ -394,7 +394,7 @@ class TestClassicalCompiled:
 
         with pytest.raises(PlxprCaptureCFCompatibilityError) as exc_info:
 
-            @qjit(capture=True)
+            @qjit(capture=True, collect_decomp_rules=False)
             @qp.qnode(qp.device(backend, wires=1))
             def circuit(i):
                 @switch(i)
@@ -644,7 +644,7 @@ class TestQuantum:
 
         with pytest.raises(PlxprCaptureCFCompatibilityError) as exc_info:
 
-            @qjit(capture=True)
+            @qjit(capture=True, collect_decomp_rules=False)
             @qp.qnode(qp.device(backend, wires=1))
             def circuit(i):
                 @switch(i)

--- a/frontend/test/pytest/test_xdsl_passes.py
+++ b/frontend/test/pytest/test_xdsl_passes.py
@@ -169,7 +169,7 @@ class TestXDSLPassesIntegration:
         # pylint: disable-next=import-outside-toplevel
         from catalyst.python_interface.transforms import merge_rotations_pass
 
-        @qjit(keep_intermediate="changed", verbose=True, capture=True)
+        @qjit(keep_intermediate="changed", verbose=True, capture=True, collect_decomp_rules=False)
         def workflow(x):
             @merge_rotations_pass
             @qp.transforms.cancel_inverses


### PR DESCRIPTION
Every qjit trace under program capture collects and lowers all decomposition rules reachable from every operator in the circuit. Those rules are dead code unless the -graph-decomposition pass is applied, but they still cost roughly 0.3 s per operator at trace time, which the frontend test suite pays thousands of times over.

Pass collect_decomp_rules=False in tests that do not exercise rule collection:

- every qjit(..., capture=True) call site in non-decomposition test files
- qjit call sites inside tests that enable capture via a fixture or an explicit qp.capture.enable()

Tests that cover rule collection and lowering are deliberately untouched: frontend/test/lit/test_operator2/**, lit/test_from_plxpr.py, pytest/test_decomposition.py, pytest/test_operator.py, pytest/from_plxpr/test_from_plxpr.py, pytest/test_graph_decomposition_pass.py and pytest/test_builtin_passes.py.

Measured on the touched files, same pass/fail set before and after:
- pytest (29 files, -n 4): 360 s -> 182 s
- lit (12 files, serial):   93 s ->  30 s

-------------------
Disclaimer: this PR and the above description are generated by Jukebox via the following prompt:
```
Can you add as many `collect_decomp_rules=False` as possible to the catalyst frontend test suite? Especially the tests that have nothing to do with decomp. This will alleviate CI pressure significantly.
```

But I'll massage it.
