### PR TITLE
Single-source of truth GraphOpID generation

### DIFF
--- a/frontend/catalyst/decomposition/decomposition_rules.py
+++ b/frontend/catalyst/decomposition/decomposition_rules.py
@@ -26,7 +26,11 @@ from jax._src.lib.mlir import ir
 from jaxlib.mlir.dialects.builtin import ModuleOp
 
 from catalyst.compiler import _quantum_opt
-from catalyst.decomposition.graph_op_id import GraphOpID
+from catalyst.decomposition.graph_op_id import (
+    GraphOpID,
+    graph_op_id_modifiers,
+    with_graph_op_id_modifiers,
+)
 from catalyst.decomposition.rule_lowering_warning import RuleLoweringWarning
 from catalyst.decomposition.type_utils import get_dummy_values_for_arg
 from catalyst.jax_extras.lowering import get_mlir_attribute_from_pyval
@@ -40,9 +44,8 @@ _NON_INVERTIBLE_MARKERS = (
 )
 
 
-# Canonical nesting order for op-level modifiers, listed OUTERMOST first. The compiler's
-# ``wrapModifiers`` (mlir/lib/Quantum/IR/QuantumInterfaces.cpp) folds modifiers into a graphOpId
-# in this exact order:
+# Canonical nesting order for op-level modifiers, listed OUTERMOST first. GraphOpIDs store
+# modifiers as fields but retain this order when deriving an operator's display name:
 # 1. control outermost
 # 2. adjoint innermost
 # So a single op that is both controlled and adjointed always spells as ``C(Adjoint(Op))``,
@@ -63,8 +66,8 @@ def _modifier_kind(modifier: str) -> str:
 def _control_modifier(n_ctrl: int) -> str:
     """Return the graphOpId control-modifier token for ``n_ctrl`` controls.
 
-    A single control is written ``C`` and ``n > 1`` controls ``<n>C``, mirroring the compiler's
-    ``wrapModifiers``. Used with :func:`wrap_modifier_id`, e.g. ``wrap_modifier_id(op_id, "2C")``.
+    A single control is written ``C`` and ``n > 1`` controls ``<n>C``. Used with
+    :func:`wrap_modifier_id`, e.g. ``wrap_modifier_id(op_id, "2C")``.
     """
     assert n_ctrl >= 1, "control modifier requires at least one control"
     return "C" if n_ctrl == 1 else f"{n_ctrl}C"
@@ -72,24 +75,14 @@ def _control_modifier(n_ctrl: int) -> str:
 
 def _leading_modifier_kind(op_id: str) -> str | None:
     """Return the canonical kind of ``op_id``'s current outermost modifier, or None if bare."""
-    if op_id.startswith("Adjoint("):
-        return "Adjoint"
-    i = 0
-    while i < len(op_id) and op_id[i].isdigit():
-        i += 1
-    if op_id[i:].startswith("C("):
+    _, adjoint, num_controls = graph_op_id_modifiers(op_id)
+    if num_controls:
         return "C"
-    return None
+    return "Adjoint" if adjoint else None
 
 
 def wrap_modifier_id(op_id: str, modifier: str) -> str:
-    """Name-wrap an op-level ``modifier`` around a graphOpId's operator name.
-
-    The modifier decorates the operator name only; the ``{param}{wire}{static}`` groups (and an
-    optional ``[uid]``) follow it, matching the compiler's ``defaultGetGraphOpId``. This applies to
-    any modifier (e.g. ``"Adjoint"``, ``"C"``), so nested ids compose as ``C(Adjoint(RX)){...}``.
-    Extend callers here to support future op-level modifiers.
-    """
+    """Apply an op-level modifier to a structured GraphOpID."""
     new_kind = _modifier_kind(modifier)
     inner_kind = _leading_modifier_kind(op_id)
     # The modifier is added as the new *outermost* layer. To keep graphOpIds canonical (see
@@ -106,41 +99,36 @@ def wrap_modifier_id(op_id: str, modifier: str) -> str:
                 f"Apply modifiers outermost-last in the order {_MODIFIER_CANONICAL_ORDER}."
             )
 
-    # Only the operator name is wrapped; the first '{' begins the {param}{wire}{static}[uid] suffix
-    # (the dynamic-shape group is always present), which is carried through untouched.
-    assert "{" in op_id, f"Malformed op id for graph decomposition, got {op_id}"
-    split = op_id.find("{")
-    return f"{modifier}({op_id[:split]}){op_id[split:]}"
+    if new_kind == "Adjoint":
+        return with_graph_op_id_modifiers(op_id, adjoint=True)
+
+    _, _, existing_controls = graph_op_id_modifiers(op_id)
+    if existing_controls:
+        raise ValueError(f"GraphOpID already has controls: {op_id!r}")
+    control_prefix = modifier.removesuffix("C")
+    num_controls = int(control_prefix) if control_prefix else 1
+    return with_graph_op_id_modifiers(op_id, num_controls=num_controls)
 
 
 def name_wrap_adjoint(op_id: str) -> str:
-    """Name-wrap the adjoint modifier around a graphOpId (``RX{...}`` -> ``Adjoint(RX){...}``)."""
+    """Set the adjoint field on a GraphOpID."""
     return wrap_modifier_id(op_id, "Adjoint")
 
 
 def name_unwrap_adjoint(op_name: str, op_id: str) -> str:
     """Inverse of :func:`name_wrap_adjoint` given the base ``op_name``."""
-    prefix = f"Adjoint({op_name})"
-    if not op_id.startswith(prefix):
+    base_name, adjoint, _ = graph_op_id_modifiers(op_id)
+    if base_name != op_name or not adjoint:
         raise ValueError(f"{op_id!r} is not an adjoint id for base op {op_name!r}")
-    return op_name + op_id[len(prefix) :]
+    return with_graph_op_id_modifiers(op_id, adjoint=False)
 
 
 def name_unwrap_control(op_name: str, op_id: str):
-    """Inverse of control name-wrapping given the base ``op_name``.
-
-    ``("RX", "2C(RX){...}")`` -> ``("RX{...}", 2)`` and ``("RX", "C(RX){...}")`` -> ``("RX{...}", 1)``.
-    Raises if ``op_id`` is not a control id for ``op_name``.
-    """
-    i = 0
-    while i < len(op_id) and op_id[i].isdigit():
-        i += 1
-    digits = op_id[:i]
-    n_ctrl = int(digits) if digits else 1
-    prefix = f"{digits}C({op_name})"
-    if not op_id.startswith(prefix):
+    """Clear the control field and return the previous control count."""
+    base_name, _, num_controls = graph_op_id_modifiers(op_id)
+    if base_name != op_name or num_controls == 0:
         raise ValueError(f"{op_id!r} is not a control id for base op {op_name!r}")
-    return op_name + op_id[len(prefix) :], n_ctrl
+    return with_graph_op_id_modifiers(op_id, num_controls=0), num_controls
 
 
 def get_rule_strings_from_module(module: ir.Module) -> list[str]:
@@ -310,7 +298,7 @@ def compile_decomposition_rules(
 
     Note that ``wrap_adjoint`` and ``wrap_control`` may be combined to synthesize the nested modifier
     ``<n>C(Adjoint(op_name))``: adjoint is applied innermost and control outermost (the canonical
-    order matching the compiler's ``wrapModifiers``).
+    order used when deriving an operator display name from the structured fields).
     """
     kwargs = prepare_dynamic_op_kwargs(dynamic_shape, wire_lens)
     extra_data = extra_data or {}
@@ -321,11 +309,7 @@ def compile_decomposition_rules(
         op_name, kwargs | static_data | extra_data, is_custom_op, adjoint_resources=wrap_adjoint
     )
 
-    # TODO: The modified target id and the wrapped resource ids are derived here by string-wrapping
-    # the graphOpId (via wrap_modifier_id). Ideally they would be generated via
-    # GraphOpID.getGraphOpId which requires missing steps in the GraphOpID object.
-    # Note it needs changes not just in this function, also in the string id and across
-    # the on-demand C++ loader boundary.
+    # Regenerate target and resource IDs by modifying their structured modifier fields.
     target_id = name_wrap_adjoint(op_id) if wrap_adjoint else op_id
     if wrap_control:
         ctrl_mod = _control_modifier(n_ctrl)
@@ -637,10 +621,9 @@ def compile_reachable_decomposition_rules_wrapper(
     ``pythonRuleLowering``), which passes the op's *base* name (``getOperatorName()``) together with
     its full graphOpId (``getGraphOpId()``). Two things matter here:
 
-    * **Modifier ids.** For a plain op the name and id agree (``"S"`` / ``"S{...}"``). For an
-      op-level modifier the graphOpId is name-wrapped (``"Adjoint(S){...}"``) while the name stays
-      the base (``"S"``). We recover the base id so the closure explores the base op *and* its
-      adjoint variants; otherwise ``Adjoint(S)`` would be decomposed as if it were ``S``.
+    * **Modifier ids.** The graphOpId stores adjoint and control state as structured fields while
+      ``op_name`` remains the base name. We clear those fields to recover the base id so the closure
+      can synthesize the requested variants.
     * **The whole closure, not just this op's direct rules.** The loader does not recurse into a
       rule's resource ops, so it needs every rule reachable from this op down to the gate set in one
       shot. For ``Adjoint(S)`` that includes ``Adjoint(S) -> Adjoint(PhaseShift)`` *and*
@@ -649,14 +632,12 @@ def compile_reachable_decomposition_rules_wrapper(
       (base + adjoint-registered + distributed-adjoint rules, transitively) and each returned func
       keeps its own ``target_gate``, which is how the loader registers them.
     """
-    base_id = op_id
-    n_ctrls = 0
-    if op_id.startswith("Adjoint(") and not op_name.startswith("Adjoint("):
-        base_id = name_unwrap_adjoint(op_name, op_id)
-    elif _leading_modifier_kind(op_id) == "C" and not op_name.startswith("Adjoint("):
-        # A controlled op-id (`C(op)` / `<n>C(op)`): recover the base id and control count so the
-        # closure synthesizes the matching `<n>C(...)` rules.
-        base_id, n_ctrls = name_unwrap_control(op_name, op_id)
+    base_name, _, n_ctrls = graph_op_id_modifiers(op_id)
+    if base_name != op_name:
+        raise ValueError(
+            f"GraphOpID base name {base_name!r} does not match operator name {op_name!r}"
+        )
+    base_id = with_graph_op_id_modifiers(op_id, adjoint=False, num_controls=0)
 
     rule_strings = fetch_all_reachable_decomposition_rules_from_op(
         op_name=op_name,

--- a/frontend/catalyst/decomposition/graph_op_id.py
+++ b/frontend/catalyst/decomposition/graph_op_id.py
@@ -14,46 +14,178 @@
 
 """Python implementation of Graph Operator ID."""
 
+from contextlib import contextmanager
 from typing import Any
 
-import jax.numpy as jnp
 import pennylane as qp
+from jax._src.lib.mlir import ir
 from pennylane.pytrees import flatten
 
 from catalyst.decomposition.type_utils import (
     convert_item_to_mlir_type,
-    format_dynamic_params_for_id,
     post_process_concretize_leaves,
     replace_wires_with_placeholder_wires,
 )
 from catalyst.from_plxpr.uid import generate_uid
+from catalyst.jax_extras.lowering import get_mlir_attribute_from_pyval
 
 _SPECIAL_LOWERINGS = {}
+
+
+@contextmanager
+def _mlir_context():
+    """Provide an MLIR context and location for attribute construction."""
+    if current := ir.Context.current:
+        with ir.Location.unknown(context=current):
+            yield current
+    else:
+        with ir.Context() as context, ir.Location.unknown(context=context):
+            yield context
+
+
+def build_graph_op_key(
+    base_name: str,
+    dynamic_types: dict[str, list[str]],
+    wire_lengths: dict[str, int],
+    static_data: dict[str, Any],
+    *,
+    adjoint: bool = False,
+    num_controls: int = 0,
+    uid: int | None = None,
+) -> str:
+    """Build the canonical structured GraphOpID string.
+
+    Parameter and wire groups are identified by their position, so both mappings must be in
+    frontend signature order.
+    """
+    if num_controls < 0:
+        raise ValueError("GraphOpID control count cannot be negative")
+
+    with _mlir_context():
+        fields = {"op": ir.StringAttr.get(base_name)}
+        traits = {}
+        if adjoint:
+            traits["adj"] = ir.BoolAttr.get(True)
+        if num_controls:
+            traits["controls"] = get_mlir_attribute_from_pyval(num_controls)
+        if dynamic_types:
+            fields["params"] = ir.ArrayAttr.get(
+                [
+                    ir.ArrayAttr.get(
+                        [ir.TypeAttr.get(ir.Type.parse(type_name)) for type_name in types]
+                    )
+                    for types in dynamic_types.values()
+                ]
+            )
+        if static_data:
+            fields["static"] = get_mlir_attribute_from_pyval(static_data)
+        if traits:
+            fields["traits"] = ir.DictAttr.get(traits)
+        if uid is not None:
+            fields["uid"] = get_mlir_attribute_from_pyval(uid)
+        if wire_lengths:
+            fields["wires"] = get_mlir_attribute_from_pyval(list(wire_lengths.values()))
+        return str(ir.DictAttr.get(fields))
+
+
+def _parse_graph_op_id(op_id: str) -> ir.DictAttr:
+    """Parse and minimally validate a structured GraphOpID."""
+    parsed = ir.Attribute.parse(op_id)
+    if not isinstance(parsed, ir.DictAttr):
+        raise ValueError(f"Malformed GraphOpID, expected a dictionary attribute: {op_id!r}")
+
+    fields = {entry.name for entry in parsed}
+    if "op" not in fields:
+        raise ValueError(f"Malformed GraphOpID, missing field 'op': {op_id!r}")
+    if unknown := fields.difference({"op", "params", "static", "traits", "uid", "wires"}):
+        raise ValueError(f"Malformed GraphOpID, unknown fields {sorted(unknown)}: {op_id!r}")
+    if "traits" in parsed:
+        traits = ir.DictAttr(parsed["traits"])
+        if unknown := {entry.name for entry in traits}.difference({"adj", "controls"}):
+            raise ValueError(
+                f"Malformed GraphOpID, unknown trait fields {sorted(unknown)}: {op_id!r}"
+            )
+    return parsed
+
+
+def graph_op_id_modifiers(op_id: str) -> tuple[str, bool, int]:
+    """Return ``(base_name, adjoint, num_controls)`` from a GraphOpID."""
+    with _mlir_context():
+        parsed = _parse_graph_op_id(op_id)
+        base_name = ir.StringAttr(parsed["op"]).value
+        traits = ir.DictAttr(parsed["traits"]) if "traits" in parsed else None
+        adjoint = ir.BoolAttr(traits["adj"]).value if traits and "adj" in traits else False
+        num_controls = (
+            ir.IntegerAttr(traits["controls"]).value if traits and "controls" in traits else 0
+        )
+        return base_name, adjoint, num_controls
+
+
+def with_graph_op_id_modifiers(
+    op_id: str, *, adjoint: bool | None = None, num_controls: int | None = None
+) -> str:
+    """Return ``op_id`` with selected modifier fields replaced."""
+    if num_controls is not None and num_controls < 0:
+        raise ValueError("GraphOpID control count cannot be negative")
+
+    with _mlir_context():
+        parsed = _parse_graph_op_id(op_id)
+        fields = {entry.name: entry.attr for entry in parsed}
+        traits = (
+            {entry.name: entry.attr for entry in ir.DictAttr(parsed["traits"])}
+            if "traits" in parsed
+            else {}
+        )
+        if adjoint is not None:
+            if adjoint:
+                traits["adj"] = ir.BoolAttr.get(True)
+            else:
+                traits.pop("adj", None)
+        if num_controls is not None:
+            if num_controls:
+                traits["controls"] = get_mlir_attribute_from_pyval(num_controls)
+            else:
+                traits.pop("controls", None)
+        if traits:
+            fields["traits"] = ir.DictAttr.get(traits)
+        else:
+            fields.pop("traits", None)
+        return str(ir.DictAttr.get(fields))
+
+
+def is_custom_op(op_cls: type[qp.core.Operator2], dynamic_args) -> bool:
+    """Return whether an Operator2 lowers to ``qref.custom``."""
+    if op_cls.static_argnames or op_cls.hybrid_argnames or op_cls.compilable_argnames:
+        return False
+    if op_cls.wire_argnames != ("wires",):
+        return False
+    if list(op_cls._sig.parameters.keys())[-1] != "wires":
+        return False
+    return all(
+        arg.shape == () and arg.dtype.kind in "ifu" for arg in dynamic_args
+    ) and not issubclass(op_cls, tuple(_SPECIAL_LOWERINGS.keys()))
 
 
 class GraphOpID:
     """
     A parser object to compute the graph operator id for an abstract operator2 instance `op`.
 
-    The format of the computed graph op ID string is as follows:
-        op_name{param_shaped_type_dictionary}{wire_lens_dictionary}{static_data_dictionary}[UID]
+    The ID is the canonical MLIR text of a dictionary containing the operator's base name and
+    non-default modifiers, dynamic types, wire lengths, static data, and UID.
 
-    The types in the dynamic shape dictionary should be represented as a list of MLIR-style type annotations.
+    The types in the dynamic shape dictionary should be represented as a list of MLIR-style type
+    annotations. Dynamic and wire dictionaries preserve frontend signature order; their names are
+    not part of the ID.
     The UID is computed from the shapes, dtypes and pytree structures of the `hybrid_args` of
     the Operator2 instance.
-
-    For example, an Operator2 instance with class name `HybridOpArg`, taking in one float param
-    argument named `angle`, one wire argument named `cwires`, one static data argument
-    `label="hello"`, and a computed UID of 10 would be parsed to the following graph op ID:
-        HybridOpArg{angle:[tensor<f64>]}{cwires:1}{label:hello}[10]
 
     The defining trait of a graph op ID is that it has unique correspondence to decomposition rules.
     In other words, different graph op IDs have different sets of decomposition rules.
 
     For example,
-        PauliRot{angle:[f64]}{wires:1}{pauli_word:X}
+        {op = "PauliRot", ..., wires = [1]}
     and
-        PauliRot{angle:[f64]}{wires:2}{pauli_word:XX}
+        {op = "PauliRot", ..., wires = [2]}
     will have different decomposition rules.
 
     Note that this function should not be updated without updating the corresponding method on the
@@ -66,7 +198,7 @@ class GraphOpID:
             op, qp.core.Operator2
         ), f"Graph-based decomposition expects an Operator2 instance, got {op} of type {type(op)}"
         self.op = op
-        self.is_custom_op = self.parse_is_custom_op()
+        self.is_custom_op = is_custom_op(type(op), op.dynamic_args.values())
 
         self.operator_name = op.name
         self.dynamic_shape = self.parse_dynamic_shape()
@@ -75,27 +207,31 @@ class GraphOpID:
         self.extra_data, self.uid = self.parse_extra_data()
 
     def parse_dynamic_shape(self) -> dict:
-        """Return a dictionary of dynamic arg names to list of dtypes."""
+        """Return dynamic argument type groups in frontend signature order."""
         # enters as {name: dtype}, we want the format {name: list[dtype]}
         if self.is_custom_op:
             return {str(i): ["f64"] for i in range(len(self.op.dynamic_args))}
         elif issubclass(type(self.op), tuple(_SPECIAL_LOWERINGS.keys())):  # special cases
             return {
-                argname: [convert_item_to_mlir_type(argtype, is_special_lowering=True)]
-                for argname, argtype in sorted(self.op.dynamic_args.items())
+                argname: [
+                    convert_item_to_mlir_type(
+                        self.op.dynamic_args[argname], is_special_lowering=True
+                    )
+                ]
+                for argname in self.op.dynamic_argnames
             }
         else:
             return {
-                argname: [convert_item_to_mlir_type(argtype)]
-                for argname, argtype in sorted(self.op.dynamic_args.items())
+                argname: [convert_item_to_mlir_type(self.op.dynamic_args[argname])]
+                for argname in self.op.dynamic_argnames
             }
 
     def parse_wire_lens(self) -> dict[str, int]:
-        """Return a dictionary of wire arg names to lengths."""
+        """Return wire argument lengths in frontend signature order."""
         wire_lens = {}
-        for wire_name, wire_arg in sorted(self.op.wire_args.items()):
+        for wire_name in self.op.wire_argnames:
             if wire_name not in self.op.hybrid_argnames:
-                wire_lens[wire_name] = len(wire_arg)
+                wire_lens[wire_name] = len(self.op.wire_args[wire_name])
         return wire_lens
 
     def parse_static_data(self) -> dict[str, Any]:
@@ -136,58 +272,27 @@ class GraphOpID:
         else:
             return {}, -1  # uid is unsigned, so use -1 for invalid uid
 
-    def parse_is_custom_op(self) -> bool:
-        """
-        Return whether the Operator2 instance is considered a custom op in MLIR.
-
-        The source of truth for the criteria is in qref_operator2_primitives.py,
-        in the _is_custom_op() helper function. However, that function cannot be directly used here
-        as that is a lowering time util, and only works with JAX-MLIR types.
-        """
-        if self.op.static_argnames or self.op.hybrid_argnames or self.op.compilable_argnames:
-            return False
-        if self.op.wire_argnames != ("wires",):
-            return False
-        if list(self.op._sig.parameters.keys())[-1] != "wires":
-            return False
-        return all(
-            arg.shape == () and arg.dtype.type == jnp.float64
-            for arg in self.op.dynamic_args.values()
-        ) and not issubclass(type(self.op), tuple(_SPECIAL_LOWERINGS.keys()))
-
     def get_operator_name(self) -> str:
         """Return the name of the operator."""
         return self.operator_name
 
-    def get_dynamic_shape_id_format(self) -> str:
-        """Return the dynamic shape formatted for GraphOpId."""
-        return format_dynamic_params_for_id(self.dynamic_shape)
-
-    def get_wire_lens_id_format(self) -> str:
-        """Return the wire lengths formatted for GraphOpId."""
-        return "{" + ",".join(f"{name}:{shape}" for name, shape in self.wire_lens.items()) + "}"
-
-    def get_static_data_id_format(self) -> str:
-        """Return the static data formatted for GraphOpId."""
-        return "{" + ",".join(f"{k}:{v}" for k, v in self.static_data.items()) + "}"
-
-    def getGraphOpId(self, adjoint: bool = False) -> str:
+    def getGraphOpId(self, adjoint: bool = False, num_controls: int = 0) -> str:
         """
         Return the GraphOpId as a string.
 
         NOTE: do not modify this method without also modifying the corresponding DecomposableGate
         interface in MLIR.
         """
-        name = self.get_operator_name()
-        if adjoint:
-            name = f"Adjoint({name})"
-        ID_string = (
-            name
-            + self.get_dynamic_shape_id_format()
-            + self.get_wire_lens_id_format()
-            + self.get_static_data_id_format()
-        )
+        uid = None
         if self.extra_data:
             assert self.uid >= 0, f"Failed to compute UID for operator {self.op}"
-            ID_string += "[" + str(self.uid) + "]"
-        return ID_string
+            uid = self.uid
+        return build_graph_op_key(
+            self.get_operator_name(),
+            self.dynamic_shape,
+            self.wire_lens,
+            self.static_data,
+            adjoint=adjoint,
+            num_controls=num_controls,
+            uid=uid,
+        )

--- a/frontend/catalyst/decomposition/type_utils.py
+++ b/frontend/catalyst/decomposition/type_utils.py
@@ -78,25 +78,6 @@ def convert_item_to_mlir_type(item, is_special_lowering=False):
     )
 
 
-def format_dynamic_params_for_id(d):
-    """Format a structure for ID."""
-
-    def handle_item(item):
-        match item:
-            case str():
-                return item
-            case list() | tuple():
-                return "[" + ",".join(handle_item(i) for i in item) + "]"
-
-    return (
-        "{"
-        + ",".join(
-            k + ":" + "[" + ",".join(handle_item(item) for item in v) + "]" for k, v in d.items()
-        )
-        + "}"
-    )
-
-
 def get_dummy_values_for_arg(arg):
     """Given a container of python or MLIR types, replace the types with corresponding dummy values.
 

--- a/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
+++ b/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
@@ -38,10 +38,13 @@ from catalyst.decomposition.decomposition_rules import (
     fetch_all_reachable_decomposition_rules_from_op,
     inject_new_rules_into_module,
 )
-from catalyst.decomposition.graph_op_id import _SPECIAL_LOWERINGS
+from catalyst.decomposition.graph_op_id import (
+    _SPECIAL_LOWERINGS,
+    build_graph_op_key,
+    is_custom_op,
+)
 from catalyst.decomposition.type_utils import (
     convert_item_to_mlir_type,
-    format_dynamic_params_for_id,
 )
 from catalyst.jax_extras.lowering import get_mlir_attribute_from_pyval
 from catalyst.jax_extras.patches import mock_attributes
@@ -94,17 +97,6 @@ def _qref_operator_p_abstract_eval(*args, **kwargs):
     return []
 
 
-def _is_custom_op(op_cls, avals_in):
-    if op_cls.static_argnames or op_cls.hybrid_argnames or op_cls.compilable_argnames:
-        return False
-    if op_cls.wire_argnames != ("wires",):
-        return False
-    if list(op_cls._sig.parameters.keys())[-1] != "wires":
-        return False
-    # Complex dtypes cannot be safely cast to float64
-    return all(p.shape == () and p.dtype.kind in "ifu" for p in avals_in)
-
-
 def _is_qref_qubit(val) -> bool:
     val_type = val.type
     return (
@@ -112,6 +104,11 @@ def _is_qref_qubit(val) -> bool:
         and ir.OpaqueType(val_type).dialect_namespace == "qref"
         and ir.OpaqueType(val_type).data == "bit"
     )
+
+
+def _group_start_index(named_attr) -> int:
+    """Return the first flattened operand position covered by an argument group."""
+    return min(int(index) for index in named_attr.attr)
 
 
 def _general_validation(*args, op_cls, wire_lens, **kwargs):
@@ -245,12 +242,11 @@ def compile_decomp_rules(
     if is_custom_op:
         dynamic_shape = {str(i): ["f64"] for i in range(len(op_cls.dynamic_argnames))}
 
-        op_id = (
-            op_cls.__name__
-            + format_dynamic_params_for_id(dynamic_shape)
-            + "{"
-            + f"wires:{wire_lens[0]}"
-            + "}{}"
+        op_id = build_graph_op_key(
+            op_cls.__name__,
+            dynamic_shape,
+            {"wires": wire_lens[0]},
+            {},
         )
 
         decomp_rules = fetch_all_reachable_decomposition_rules_from_op(
@@ -265,12 +261,11 @@ def compile_decomp_rules(
     elif op_cls is qp.MultiRZ:
         dynamic_shape = {qp.MultiRZ.dynamic_argnames[0]: ["f64"]}
         wire_argname = qp.MultiRZ.wire_argnames[0]
-        op_id = (
-            "MultiRZ"
-            + format_dynamic_params_for_id(dynamic_shape)
-            + "{"
-            + f"{wire_argname}:{wire_lens[0]}"
-            + "}{}"
+        op_id = build_graph_op_key(
+            "MultiRZ",
+            dynamic_shape,
+            {wire_argname: wire_lens[0]},
+            {},
         )
 
         decomp_rules = fetch_all_reachable_decomposition_rules_from_op(
@@ -285,15 +280,11 @@ def compile_decomp_rules(
         dynamic_shape = {qp.PauliRot.dynamic_argnames[0]: ["f64"]}
         wire_argname = qp.PauliRot.wire_argnames[0]
         pauliword_argname = qp.PauliRot.compilable_argnames[0]
-        op_id = (
-            "PauliRot"
-            + format_dynamic_params_for_id(dynamic_shape)
-            + "{"
-            + f"{wire_argname}:{wire_lens[0]}"
-            + "}"
-            + "{"
-            + f"{pauliword_argname}:{repack_static_data[pauliword_argname]}"
-            + "}"
+        op_id = build_graph_op_key(
+            "PauliRot",
+            dynamic_shape,
+            {wire_argname: wire_lens[0]},
+            repack_static_data,
         )
 
         decomp_rules = fetch_all_reachable_decomposition_rules_from_op(
@@ -307,14 +298,11 @@ def compile_decomp_rules(
     elif op_cls is qp.PCPhase:
         dynamic_shape = {qp.PCPhase.dynamic_argnames[0]: ["f64"]}
         wire_argname = qp.PCPhase.wire_argnames[0]
-        op_id = (
-            "PCPhase"
-            + format_dynamic_params_for_id(dynamic_shape)
-            + "{"
-            + f"{wire_argname}:{wire_lens[0]}"
-            + "}{"
-            + f"dim:{repack_static_data["dim"]}"
-            + "}"
+        op_id = build_graph_op_key(
+            "PCPhase",
+            dynamic_shape,
+            {wire_argname: wire_lens[0]},
+            repack_static_data,
         )
 
         decomp_rules = fetch_all_reachable_decomposition_rules_from_op(
@@ -327,7 +315,7 @@ def compile_decomp_rules(
 
     elif op_cls is qp.GlobalPhase:
         dynamic_shape = {qp.GlobalPhase.dynamic_argnames[0]: ["f64"]}
-        op_id = "GlobalPhase" + format_dynamic_params_for_id(dynamic_shape) + "{}{}"
+        op_id = build_graph_op_key("GlobalPhase", dynamic_shape, {}, {})
 
         decomp_rules = fetch_all_reachable_decomposition_rules_from_op(
             op_name="GlobalPhase",
@@ -346,12 +334,11 @@ def compile_decomp_rules(
             ]
         }
         wire_argname = qp.QubitUnitary.wire_argnames[0]
-        op_id = (
-            "QubitUnitary"
-            + format_dynamic_params_for_id(dynamic_shape)
-            + "{"
-            + f"{wire_argname}:{wire_lens[0]}"
-            + "}{}"
+        op_id = build_graph_op_key(
+            "QubitUnitary",
+            dynamic_shape,
+            {wire_argname: wire_lens[0]},
+            {},
         )
 
         decomp_rules = fetch_all_reachable_decomposition_rules_from_op(
@@ -414,7 +401,10 @@ def compile_decomp_rules(
 
         with_hybrid_dynamic_shape = {}
         if param_map is not None:
-            for named_attr in param_map:
+            # MLIR dictionary attributes print by name; recover frontend/operand order from the
+            # flattened parameter indices before constructing the positional GraphOpID payload.
+            ordered_param_groups = sorted(param_map, key=_group_start_index)
+            for named_attr in ordered_param_groups:
                 with_hybrid_dynamic_shape[named_attr.name] = [
                     params[idx].type for idx in named_attr.attr
                 ]
@@ -424,22 +414,17 @@ def compile_decomp_rules(
 
         with_hybrid_wire_lens = {}
         if qubit_map is not None:
-            for wire_attr in qubit_map:
+            ordered_wire_groups = sorted(qubit_map, key=_group_start_index)
+            for wire_attr in ordered_wire_groups:
                 with_hybrid_wire_lens[wire_attr.name] = len(wire_attr.attr)
 
-        op_id = (
-            op_cls.__name__
-            + format_dynamic_params_for_id(dict(sorted(with_hybrid_dynamic_shape.items())))
-            + "{"
-            + ",".join(f"{name}:{shape}" for name, shape in sorted(with_hybrid_wire_lens.items()))
-            + "}"
+        op_id = build_graph_op_key(
+            op_cls.__name__,
+            with_hybrid_dynamic_shape,
+            with_hybrid_wire_lens,
+            repack_static_data if not (op_cls.hybrid_argnames or op_cls.static_argnames) else {},
+            uid=uid,
         )
-        if not (op_cls.hybrid_argnames or op_cls.static_argnames):
-            op_id += "{" + ",".join(f"{k}:{v}" for k, v in sorted(repack_static_data.items())) + "}"
-        else:
-            op_id += "{}"
-        if uid is not None:
-            op_id += f"[{str(uid)}]"
 
         decomp_rules = fetch_all_reachable_decomposition_rules_from_op(
             op_name=op_cls.__name__,
@@ -503,7 +488,7 @@ def _qref_operator_p_lowering(jax_ctx: mlir.LoweringRuleContext, *args, op_cls, 
 
     # Lowering to qref.custom
     # Custom op only has float dynamic args, followed by a single wire argname "wires" at the end
-    if _is_custom_op(op_cls, jax_ctx.avals_in[: len(op_cls.dynamic_argnames)]):
+    if is_custom_op(op_cls, jax_ctx.avals_in[: len(op_cls.dynamic_argnames)]):
         expected_len = len(op_cls.dynamic_argnames) + sum(wire_lens)
         assert len(args) == expected_len, f"Incorrect number of operands for {op_cls.__name__}."
 

--- a/frontend/test/lit/GraphDecomposition/TestAdjointCompeting.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestAdjointCompeting.mlir
@@ -26,24 +26,24 @@ func.func @competing(%q: !quantum.bit) -> !quantum.bit {
 
 // pathway 1: Adjoint(testRot) -> testRZ (cost 1).
 func.func private @dedicated(%q: !quantum.bit) -> !quantum.bit attributes {
-    target_gate = "Adjoint(testRot){}{wires:1}{}",
-    resources = {operations = {"testRZ{}{wires:1}{}" = 1 : i64}} } {
+    target_gate = "{op = \"testRot\", traits = {adj = true}, wires = [1]}",
+    resources = {operations = {"{op = \"testRZ\", wires = [1]}" = 1 : i64}} } {
   %o = quantum.custom "testRZ"() %q : !quantum.bit
   return %o : !quantum.bit
 }
 
 // pathway 2: Adjoint(testRot) -> Adjoint(testRZ) Adjoint(testRZ) -> testRZ testRZ (cost 2).
 func.func private @distribute(%q: !quantum.bit) -> !quantum.bit attributes {
-    target_gate = "Adjoint(testRot){}{wires:1}{}",
-    resources = {operations = {"Adjoint(testRZ){}{wires:1}{}" = 2 : i64}} } {
+    target_gate = "{op = \"testRot\", traits = {adj = true}, wires = [1]}",
+    resources = {operations = {"{op = \"testRZ\", traits = {adj = true}, wires = [1]}" = 2 : i64}} } {
   %a = quantum.custom "testRZ"() %q adj : !quantum.bit
   %b = quantum.custom "testRZ"() %a adj : !quantum.bit
   return %b : !quantum.bit
 }
 
 func.func private @adj_rz(%q: !quantum.bit) -> !quantum.bit attributes {
-    target_gate = "Adjoint(testRZ){}{wires:1}{}",
-    resources = {operations = {"testRZ{}{wires:1}{}" = 1 : i64}} } {
+    target_gate = "{op = \"testRZ\", traits = {adj = true}, wires = [1]}",
+    resources = {operations = {"{op = \"testRZ\", wires = [1]}" = 1 : i64}} } {
   %o = quantum.custom "testRZ"() %q : !quantum.bit
   return %o : !quantum.bit
 }

--- a/frontend/test/lit/GraphDecomposition/TestAdjointDistributeRegion.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestAdjointDistributeRegion.mlir
@@ -28,8 +28,8 @@ func.func @distribute_region(%q: !quantum.bit) -> !quantum.bit {
 // Adjoint(U) via distribution:
 // CHECK-LABEL: func.func private @adj_u
 func.func private @adj_u(%q: !quantum.bit) -> !quantum.bit attributes {
-    target_gate = "Adjoint(U){}{wires:1}{}",
-    resources = {operations = {"Adjoint(Hadamard){}{wires:1}{}" = 2 : i64}} } {
+    target_gate = "{op = \"U\", traits = {adj = true}, wires = [1]}",
+    resources = {operations = {"{op = \"Hadamard\", traits = {adj = true}, wires = [1]}" = 2 : i64}} } {
   %out = quantum.adjoint(%q) : !quantum.bit {
   ^bb0(%arg0: !quantum.bit):
     %a = quantum.custom "Hadamard"() %arg0 : !quantum.bit
@@ -41,8 +41,8 @@ func.func private @adj_u(%q: !quantum.bit) -> !quantum.bit attributes {
 
 // Self-adjoint:
 func.func private @adj_h(%q: !quantum.bit) -> !quantum.bit attributes {
-    target_gate = "Adjoint(Hadamard){}{wires:1}{}",
-    resources = {operations = {"Hadamard{}{wires:1}{}" = 1 : i64}} } {
+    target_gate = "{op = \"Hadamard\", traits = {adj = true}, wires = [1]}",
+    resources = {operations = {"{op = \"Hadamard\", wires = [1]}" = 1 : i64}} } {
   %o = quantum.custom "Hadamard"() %q : !quantum.bit
   return %o : !quantum.bit
 }

--- a/frontend/test/lit/GraphDecomposition/TestAdjointFailedDecomp.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestAdjointFailedDecomp.mlir
@@ -14,7 +14,7 @@
 
 // RUN: not --crash catalyst --tool=opt --pass-pipeline='builtin.module(graph-decomposition{gate-set=testFoo=1.0})' %s 2>&1 | FileCheck %s
 
-// CHECK: Decomposition rule not found for operator 'id: Adjoint(testFoo){}{wires:1}{}'
+// CHECK: Decomposition rule not found for operator 'id: {op = "testFoo", traits = {adj = true}, wires = [1]}'
 func.func @circuit(%q: !quantum.bit) -> !quantum.bit {
   %out = quantum.custom "testFoo"() %q adj : !quantum.bit
   return %out: !quantum.bit

--- a/frontend/test/lit/GraphDecomposition/TestAdjointInGateset.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestAdjointInGateset.mlir
@@ -33,8 +33,8 @@ func.func @decompose_to_adjoint(%q: !quantum.bit) -> !quantum.bit {
 }
 
 func.func private @s_to_adjt(%q: !quantum.bit) -> !quantum.bit attributes {
-    target_gate = "testS{}{wires:1}{}",
-    resources = {operations = {"Adjoint(testT){}{wires:1}{}" = 1 : i64}} } {
+    target_gate = "{op = \"testS\", wires = [1]}",
+    resources = {operations = {"{op = \"testT\", traits = {adj = true}, wires = [1]}" = 1 : i64}} } {
   %o = quantum.custom "testT"() %q adj : !quantum.bit
   return %o : !quantum.bit
 }

--- a/frontend/test/lit/GraphDecomposition/TestAdjointParametric.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestAdjointParametric.mlir
@@ -25,8 +25,8 @@ func.func @parametric(%q: !quantum.bit, %theta: f64) -> !quantum.bit {
 }
 
 func.func private @adj_rz(%theta: f64, %q: !quantum.bit) -> !quantum.bit attributes {
-    target_gate = "Adjoint(testRZ){0:[f64]}{wires:1}{}",
-    resources = {operations = {"testRZ{0:[f64]}{wires:1}{}" = 1 : i64}} } {
+    target_gate = "{op = \"testRZ\", params = [[f64]], traits = {adj = true}, wires = [1]}",
+    resources = {operations = {"{op = \"testRZ\", params = [[f64]], wires = [1]}" = 1 : i64}} } {
   %neg = arith.negf %theta : f64
   %o = quantum.custom "testRZ"(%neg) %q : !quantum.bit
   return %o : !quantum.bit

--- a/frontend/test/lit/GraphDecomposition/TestAdjointToBasis.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestAdjointToBasis.mlir
@@ -34,15 +34,15 @@ func.func @distribution(%q: !quantum.bit) -> !quantum.bit {
 }
 
 func.func private @adj_h(%q: !quantum.bit) -> !quantum.bit attributes {
-    target_gate = "Adjoint(testHadamard){}{wires:1}{}",
-    resources = {operations = {"testHadamard{}{wires:1}{}" = 1 : i64}} } {
+    target_gate = "{op = \"testHadamard\", traits = {adj = true}, wires = [1]}",
+    resources = {operations = {"{op = \"testHadamard\", wires = [1]}" = 1 : i64}} } {
   %o = quantum.custom "testHadamard"() %q : !quantum.bit
   return %o : !quantum.bit
 }
 
 func.func private @adj_u(%q: !quantum.bit) -> !quantum.bit attributes {
-    target_gate = "Adjoint(testU){}{wires:1}{}",
-    resources = {operations = {"Adjoint(testHadamard){}{wires:1}{}" = 2 : i64}} } {
+    target_gate = "{op = \"testU\", traits = {adj = true}, wires = [1]}",
+    resources = {operations = {"{op = \"testHadamard\", traits = {adj = true}, wires = [1]}" = 2 : i64}} } {
   %a = quantum.custom "testHadamard"() %q adj : !quantum.bit
   %b = quantum.custom "testHadamard"() %a adj : !quantum.bit
   return %b : !quantum.bit

--- a/frontend/test/lit/GraphDecomposition/TestAltDecomps.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestAltDecomps.mlir
@@ -33,7 +33,7 @@ func.func @circuit() -> !quantum.bit {
 }
 
 // CHECK-LABEL: y_to_ry
-func.func @y_to_ry(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="testY{}{wires:1}{}", resources = { operations = {"testRY{0:[f64]}{wires:1}{}"=1}}} {
+func.func @y_to_ry(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="{op = \"testY\", wires = [1]}", resources = { operations = {"{op = \"testRY\", params = [[f64]], wires = [1]}" = 1}}} {
     %pi = arith.constant 3.14 : f64
     %negpiby2 = arith.constant -1.57 : f64
     %q1 = quantum.custom "testRY"(%pi) %q0 : !quantum.bit
@@ -41,7 +41,7 @@ func.func @y_to_ry(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="
 }
 
 // CHECK-LABEL: y_to_x_z
-func.func @y_to_x_z(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="testY{}{wires:1}{}", resources = { operations = {"testX{}{wires:1}{}"=1, "testZ{}{wires:1}{}"=1}}} {
+func.func @y_to_x_z(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="{op = \"testY\", wires = [1]}", resources = { operations = {"{op = \"testX\", wires = [1]}" = 1, "{op = \"testZ\", wires = [1]}" = 1}}} {
     %q1 = quantum.custom "testX"() %q0 : !quantum.bit
     %q2 = quantum.custom "testZ"() %q1 : !quantum.bit
     return %q2 : !quantum.bit

--- a/frontend/test/lit/GraphDecomposition/TestControlAdjoint.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestControlAdjoint.mlir
@@ -40,8 +40,8 @@ func.func @plain_controlled(%ctrl: !quantum.bit, %q: !quantum.bit) -> (!quantum.
 
 // C(Adjoint(U)) -> two C(Adjoint(H)).
 func.func private @ctrl_adj_u(%q: !quantum.bit, %ctrl: !quantum.bit) -> (!quantum.bit, !quantum.bit) attributes {
-    target_gate = "C(Adjoint(U)){}{wires:1}{}",
-    resources = {operations = {"C(Adjoint(H)){}{wires:1}{}" = 2 : i64}} } {
+    target_gate = "{op = \"U\", traits = {adj = true, controls = 1 : i64}, wires = [1]}",
+    resources = {operations = {"{op = \"H\", traits = {adj = true, controls = 1 : i64}, wires = [1]}" = 2 : i64}} } {
   %true = arith.constant true
   %a, %ac = quantum.custom "H"() %q adj ctrls(%ctrl) ctrlvals(%true) : !quantum.bit ctrls !quantum.bit
   %b, %bc = quantum.custom "H"() %a adj ctrls(%ac) ctrlvals(%true) : !quantum.bit ctrls !quantum.bit
@@ -50,8 +50,8 @@ func.func private @ctrl_adj_u(%q: !quantum.bit, %ctrl: !quantum.bit) -> (!quantu
 
 // C(U) -> a single C(H).
 func.func private @ctrl_u(%q: !quantum.bit, %ctrl: !quantum.bit) -> (!quantum.bit, !quantum.bit) attributes {
-    target_gate = "C(U){}{wires:1}{}",
-    resources = {operations = {"C(H){}{wires:1}{}" = 1 : i64}} } {
+    target_gate = "{op = \"U\", traits = {controls = 1 : i64}, wires = [1]}",
+    resources = {operations = {"{op = \"H\", traits = {controls = 1 : i64}, wires = [1]}" = 1 : i64}} } {
   %true = arith.constant true
   %o, %oc = quantum.custom "H"() %q ctrls(%ctrl) ctrlvals(%true) : !quantum.bit ctrls !quantum.bit
   return %o, %oc : !quantum.bit, !quantum.bit

--- a/frontend/test/lit/GraphDecomposition/TestControlAdjointRegion.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestControlAdjointRegion.mlir
@@ -28,8 +28,8 @@ func.func @composite_region(%ctrl: !quantum.bit, %q: !quantum.bit) -> (!quantum.
 
 // C(Adjoint(U)) rule: base decomposition (H; H) as adjoint gates inside a quantum.ctrl region.
 func.func private @ctrl_adj_u(%q: !quantum.bit, %ctrl: !quantum.bit) -> (!quantum.bit, !quantum.bit) attributes {
-    target_gate = "C(Adjoint(U)){}{wires:1}{}",
-    resources = {operations = {"C(Adjoint(H)){}{wires:1}{}" = 2 : i64}} } {
+    target_gate = "{op = \"U\", traits = {adj = true, controls = 1 : i64}, wires = [1]}",
+    resources = {operations = {"{op = \"H\", traits = {adj = true, controls = 1 : i64}, wires = [1]}" = 2 : i64}} } {
   %true = arith.constant true
   %oc, %oq = quantum.ctrl(%ctrl) ctrlvals(%true) (%q) : !quantum.bit -> !quantum.bit {
   ^bb0(%arg0: !quantum.bit):

--- a/frontend/test/lit/GraphDecomposition/TestControlCompeting.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestControlCompeting.mlir
@@ -27,8 +27,8 @@ func.func @competing(%ctrl: !quantum.bit, %q: !quantum.bit) -> (!quantum.bit, !q
 
 // Pathway 1: C(U) -> C(V) (cost 1).
 func.func private @dedicated(%q: !quantum.bit, %ctrl: !quantum.bit) -> (!quantum.bit, !quantum.bit) attributes {
-    target_gate = "C(U){}{wires:1}{}",
-    resources = {operations = {"C(V){}{wires:1}{}" = 1 : i64}} } {
+    target_gate = "{op = \"U\", traits = {controls = 1 : i64}, wires = [1]}",
+    resources = {operations = {"{op = \"V\", traits = {controls = 1 : i64}, wires = [1]}" = 1 : i64}} } {
   %true = arith.constant true
   %o, %oc = quantum.custom "V"() %q ctrls(%ctrl) ctrlvals(%true) : !quantum.bit ctrls !quantum.bit
   return %o, %oc : !quantum.bit, !quantum.bit
@@ -36,8 +36,8 @@ func.func private @dedicated(%q: !quantum.bit, %ctrl: !quantum.bit) -> (!quantum
 
 // Pathway 2: C(U) -> C(V) C(V) (cost 2).
 func.func private @distribute(%q: !quantum.bit, %ctrl: !quantum.bit) -> (!quantum.bit, !quantum.bit) attributes {
-    target_gate = "C(U){}{wires:1}{}",
-    resources = {operations = {"C(V){}{wires:1}{}" = 2 : i64}} } {
+    target_gate = "{op = \"U\", traits = {controls = 1 : i64}, wires = [1]}",
+    resources = {operations = {"{op = \"V\", traits = {controls = 1 : i64}, wires = [1]}" = 2 : i64}} } {
   %true = arith.constant true
   %a, %ac = quantum.custom "V"() %q ctrls(%ctrl) ctrlvals(%true) : !quantum.bit ctrls !quantum.bit
   %b, %bc = quantum.custom "V"() %a ctrls(%ac) ctrlvals(%true) : !quantum.bit ctrls !quantum.bit

--- a/frontend/test/lit/GraphDecomposition/TestControlDistributeRegion.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestControlDistributeRegion.mlir
@@ -29,8 +29,8 @@ func.func @distribute_region(%ctrl: !quantum.bit, %q: !quantum.bit) -> (!quantum
 // C(U) via distribution: reintroduce the control over the base decomposition of U (H; H).
 func.func private @ctrl_u(%q: !quantum.bit, %ctrl: !quantum.bit, %cv: i1)
     -> (!quantum.bit, !quantum.bit) attributes {
-    target_gate = "C(U){}{wires:1}{}",
-    resources = {operations = {"C(Hadamard){}{wires:1}{}" = 2 : i64}} } {
+    target_gate = "{op = \"U\", traits = {controls = 1 : i64}, wires = [1]}",
+    resources = {operations = {"{op = \"Hadamard\", traits = {controls = 1 : i64}, wires = [1]}" = 2 : i64}} } {
   %oc, %oq = quantum.ctrl(%ctrl) ctrlvals(%cv) (%q) : !quantum.bit -> !quantum.bit {
   ^bb0(%arg0: !quantum.bit):
     %a = quantum.custom "Hadamard"() %arg0 : !quantum.bit

--- a/frontend/test/lit/GraphDecomposition/TestControlFailedDecomp.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestControlFailedDecomp.mlir
@@ -14,7 +14,7 @@
 
 // RUN: not --crash catalyst --tool=opt --pass-pipeline='builtin.module(graph-decomposition{gate-set=Foo=1.0})' %s 2>&1 | FileCheck %s
 
-// CHECK: Decomposition rule not found for operator 'id: C(Bar){}{wires:1}{}'
+// CHECK: Decomposition rule not found for operator 'id: {op = "Bar", traits = {controls = 1 : i64}, wires = [1]}'
 func.func @circuit(%ctrl: !quantum.bit, %q: !quantum.bit) -> (!quantum.bit, !quantum.bit) {
   %true = arith.constant true
   %out, %outc = quantum.custom "Bar"() %q ctrls(%ctrl) ctrlvals(%true) : !quantum.bit ctrls !quantum.bit
@@ -24,8 +24,8 @@ func.func @circuit(%ctrl: !quantum.bit, %q: !quantum.bit) -> (!quantum.bit, !qua
 // A decomposition for the base Bar op. It is never applicable to the controlled
 // Bar above, illustrating that Bar and C(Bar) require separate rules.
 func.func private @bar_to_foo(%q: !quantum.bit) -> !quantum.bit attributes {
-    target_gate = "Bar{}{wires:1}{}",
-    resources = {operations = {"Foo{}{wires:1}{}" = 1 : i64}} } {
+    target_gate = "{op = \"Bar\", wires = [1]}",
+    resources = {operations = {"{op = \"Foo\", wires = [1]}" = 1 : i64}} } {
   %o = quantum.custom "Foo"() %q : !quantum.bit
   return %o : !quantum.bit
 }

--- a/frontend/test/lit/GraphDecomposition/TestControlInGateset.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestControlInGateset.mlir
@@ -36,8 +36,8 @@ func.func @decompose_to_controlled(%ctrl: !quantum.bit, %q: !quantum.bit) -> (!q
 }
 
 func.func private @v_to_ctrl_t(%q: !quantum.bit, %ctrl: !quantum.bit) -> (!quantum.bit, !quantum.bit) attributes {
-    target_gate = "C(V){}{wires:1}{}",
-    resources = {operations = {"C(T){}{wires:1}{}" = 1 : i64}} } {
+    target_gate = "{op = \"V\", traits = {controls = 1 : i64}, wires = [1]}",
+    resources = {operations = {"{op = \"T\", traits = {controls = 1 : i64}, wires = [1]}" = 1 : i64}} } {
   %true = arith.constant true
   %o, %oc = quantum.custom "T"() %q ctrls(%ctrl) ctrlvals(%true) : !quantum.bit ctrls !quantum.bit
   return %o, %oc : !quantum.bit, !quantum.bit

--- a/frontend/test/lit/GraphDecomposition/TestControlParametric.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestControlParametric.mlir
@@ -27,8 +27,8 @@ func.func @parametric(%ctrl: !quantum.bit, %q: !quantum.bit, %theta: f64) -> (!q
 
 // C(RZ)(theta) -> C(PhaseShift)(theta): the parameter passes through, the control is value-agnostic.
 func.func private @ctrl_rz(%theta: f64, %q: !quantum.bit, %ctrl: !quantum.bit) -> (!quantum.bit, !quantum.bit) attributes {
-    target_gate = "C(RZ){0:[f64]}{wires:1}{}",
-    resources = {operations = {"C(PhaseShift){0:[f64]}{wires:1}{}" = 1 : i64}} } {
+    target_gate = "{op = \"RZ\", params = [[f64]], traits = {controls = 1 : i64}, wires = [1]}",
+    resources = {operations = {"{op = \"PhaseShift\", params = [[f64]], traits = {controls = 1 : i64}, wires = [1]}" = 1 : i64}} } {
   %true = arith.constant true
   %o, %oc = quantum.custom "PhaseShift"(%theta) %q ctrls(%ctrl) ctrlvals(%true) : !quantum.bit ctrls !quantum.bit
   return %o, %oc : !quantum.bit, !quantum.bit

--- a/frontend/test/lit/GraphDecomposition/TestControlToBasis.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestControlToBasis.mlir
@@ -38,8 +38,8 @@ func.func @distribution(%ctrl: !quantum.bit, %q: !quantum.bit) -> (!quantum.bit,
 
 // C(U) distributed to two controlled Hadamards (value-agnostic: controls on all-ones).
 func.func private @ctrl_u(%q: !quantum.bit, %ctrl: !quantum.bit) -> (!quantum.bit, !quantum.bit) attributes {
-    target_gate = "C(U){}{wires:1}{}",
-    resources = {operations = {"C(Hadamard){}{wires:1}{}" = 2 : i64}} } {
+    target_gate = "{op = \"U\", traits = {controls = 1 : i64}, wires = [1]}",
+    resources = {operations = {"{op = \"Hadamard\", traits = {controls = 1 : i64}, wires = [1]}" = 2 : i64}} } {
   %true = arith.constant true
   %a, %ac = quantum.custom "Hadamard"() %q ctrls(%ctrl) ctrlvals(%true) : !quantum.bit ctrls !quantum.bit
   %b, %bc = quantum.custom "Hadamard"() %a ctrls(%ac) ctrlvals(%true) : !quantum.bit ctrls !quantum.bit

--- a/frontend/test/lit/GraphDecomposition/TestCtrlDistributeRegion.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestCtrlDistributeRegion.mlir
@@ -26,8 +26,8 @@ func.func @distribute_ctrl_region(%q0: !quantum.bit, %q1: !quantum.bit) -> (!qua
 // myCZ decomposes to a single controlled testT, expressed as a `quantum.ctrl` region over testT.
 // CHECK-LABEL: func.func private @cz_region
 func.func private @cz_region(%q0: !quantum.bit, %q1: !quantum.bit) -> (!quantum.bit, !quantum.bit) attributes {
-    target_gate = "myCZ{}{wires:2}{}",
-    resources = {operations = {"C(testT){}{wires:1}{}" = 1 : i64}} } {
+    target_gate = "{op = \"myCZ\", wires = [2]}",
+    resources = {operations = {"{op = \"testT\", traits = {controls = 1 : i64}, wires = [1]}" = 1 : i64}} } {
   %true = arith.constant true
   %oc, %oq = quantum.ctrl(%q0) ctrlvals(%true) (%q1) : !quantum.bit -> !quantum.bit {
   ^bb0(%arg0: !quantum.bit):

--- a/frontend/test/lit/GraphDecomposition/TestCtrlInGateset.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestCtrlInGateset.mlir
@@ -14,8 +14,8 @@
 
 // RUN: catalyst --tool=opt --pass-pipeline='builtin.module(graph-decomposition{gate-set=C(testT)=1.0 alt-decomps=myCZ{}{wires:2}{}=cz_to_ct})' %s | FileCheck %s
 
-// A controlled op that is already in the gate set stays untouched (its id `C(testT){}{wires:1}{}`
-// matches the `C(testT)` gate-set entry -- it is NOT stripped to its base `testT`).
+// A controlled op that is already in the gate set stays untouched: the controlled ID
+// matches the controlled gate-set entry and is not stripped to its base operator.
 // CHECK-LABEL: func.func @ctrl_in_gateset(
 // CHECK-SAME:  [[C:%.+]]: !quantum.bit, [[Q:%.+]]: !quantum.bit
 func.func @ctrl_in_gateset(%c: !quantum.bit, %q: !quantum.bit) -> (!quantum.bit, !quantum.bit) {
@@ -37,8 +37,8 @@ func.func @decompose_to_ctrl(%q0: !quantum.bit, %q1: !quantum.bit) -> (!quantum.
 }
 
 func.func private @cz_to_ct(%q0: !quantum.bit, %q1: !quantum.bit) -> (!quantum.bit, !quantum.bit) attributes {
-    target_gate = "myCZ{}{wires:2}{}",
-    resources = {operations = {"C(testT){}{wires:1}{}" = 1 : i64}} } {
+    target_gate = "{op = \"myCZ\", wires = [2]}",
+    resources = {operations = {"{op = \"testT\", traits = {controls = 1 : i64}, wires = [1]}" = 1 : i64}} } {
   %true = arith.constant true
   %oq, %oc = quantum.custom "testT"() %q1 ctrls(%q0) ctrlvals(%true) : !quantum.bit ctrls !quantum.bit
   return %oc, %oq : !quantum.bit, !quantum.bit

--- a/frontend/test/lit/GraphDecomposition/TestFailedDecomp.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestFailedDecomp.mlir
@@ -19,11 +19,11 @@ func.func @circuit(%q0: !quantum.bit) {
     %out = quantum.custom "failure"() %q0 : !quantum.bit
 
     // CHECK: GraphSolverFailedError
-    // CHECK: Decomposition rule not found for operator 'id: failure{}{wires:1}{}'
+    // CHECK: Decomposition rule not found for operator 'id: {op = "failure", wires = [1]}'
     return
 }
 
-func.func private @fail_decomp(%q: !quantum.bit) -> !quantum.bit attributes { target_gate = "failure{}{wires:1}{}", resources = { operations = {"impossible"=1}}} {
+func.func private @fail_decomp(%q: !quantum.bit) -> !quantum.bit attributes { target_gate = "{op = \"failure\", wires = [1]}", resources = { operations = {"{op = \"impossible\"}" = 1}}} {
   %out = quantum.custom "impossible"() %q : !quantum.bit
   return %out : !quantum.bit
 }

--- a/frontend/test/lit/GraphDecomposition/TestFixedDecomp.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestFixedDecomp.mlir
@@ -25,7 +25,7 @@ func.func @circuit() -> !quantum.bit {
     return %qout : !quantum.bit
 }
 
-func.func @custom_decomp(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate = "testHadamard{}{wires:1}{}", resources = { operations = { "testRX{0:1}{wires:1}{}"=2, "testRZ{0:1}{wires:1}{}"=1}}} {
+func.func @custom_decomp(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate = "{op = \"testHadamard\", wires = [1]}", resources = { operations = { "{op = \"testRX\", params = [[f64]], wires = [1]}" = 2, "{op = \"testRZ\", params = [[f64]], wires = [1]}" = 1}}} {
     %cst = arith.constant 1.5707963267948966 : f64
     %q1 = quantum.custom "testRX"(%cst) %q0 : !quantum.bit
     %q2 = quantum.custom "testRZ"(%cst) %q1 : !quantum.bit

--- a/frontend/test/lit/GraphDecomposition/TestGraphOpId.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestGraphOpId.mlir
@@ -24,7 +24,7 @@ func.func @circuit(%q: !quantum.bit) -> !quantum.bit {
   return %out: !quantum.bit
 }
 
-func.func private @my_decomp(%q: !quantum.bit) -> !quantum.bit attributes {target_gate="testHadamard{}{wires:1}{}"} {
+func.func private @my_decomp(%q: !quantum.bit) -> !quantum.bit attributes {target_gate="{op = \"testHadamard\", wires = [1]}"} {
   %q0 = quantum.custom "testPauliX"() %q : !quantum.bit
   %q1 = quantum.custom "testPauliX"() %q0 : !quantum.bit
   return %q1 : !quantum.bit

--- a/frontend/test/lit/GraphDecomposition/TestIdentity.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestIdentity.mlir
@@ -45,7 +45,7 @@ module @test_module {
         return %q1 : !quantum.bit
     }
 
-    func.func private @false_decomp(%q : !quantum.bit) -> !quantum.bit attributes {target_gate="testHadamard{}{wires:1}{}"} {
+    func.func private @false_decomp(%q : !quantum.bit) -> !quantum.bit attributes {target_gate="{op = \"testHadamard\", wires = [1]}"} {
         %qout = quantum.custom "testPauliX"() %q : !quantum.bit
         return %qout : !quantum.bit
     }

--- a/frontend/test/lit/GraphDecomposition/TestMultiControlRegion.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestMultiControlRegion.mlir
@@ -29,8 +29,8 @@ func.func @multi_region(%c1: !quantum.bit, %c2: !quantum.bit, %q: !quantum.bit)
 // 2C(U): base decomposition (H; H) inside a two-control quantum.ctrl region.
 func.func private @cc_u(%q: !quantum.bit, %c1: !quantum.bit, %c2: !quantum.bit)
     -> (!quantum.bit, !quantum.bit, !quantum.bit) attributes {
-    target_gate = "2C(U){}{wires:1}{}",
-    resources = {operations = {"2C(H){}{wires:1}{}" = 2 : i64}} } {
+    target_gate = "{op = \"U\", traits = {controls = 2 : i64}, wires = [1]}",
+    resources = {operations = {"{op = \"H\", traits = {controls = 2 : i64}, wires = [1]}" = 2 : i64}} } {
   %true = arith.constant true
   %oc:2, %oq = quantum.ctrl(%c1, %c2) ctrlvals(%true, %true) (%q) : !quantum.bit, !quantum.bit -> !quantum.bit {
   ^bb0(%arg0: !quantum.bit):

--- a/frontend/test/lit/GraphDecomposition/TestMultiControlToBasis.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestMultiControlToBasis.mlir
@@ -38,8 +38,8 @@ func.func @three_controls(%c1: !quantum.bit, %c2: !quantum.bit, %c3: !quantum.bi
 // 2C(U) -> two 2C(H).
 func.func private @cc_u(%q: !quantum.bit, %c1: !quantum.bit, %c2: !quantum.bit)
     -> (!quantum.bit, !quantum.bit, !quantum.bit) attributes {
-    target_gate = "2C(U){}{wires:1}{}",
-    resources = {operations = {"2C(H){}{wires:1}{}" = 2 : i64}} } {
+    target_gate = "{op = \"U\", traits = {controls = 2 : i64}, wires = [1]}",
+    resources = {operations = {"{op = \"H\", traits = {controls = 2 : i64}, wires = [1]}" = 2 : i64}} } {
   %true = arith.constant true
   %a, %ac:2 = quantum.custom "H"() %q ctrls(%c1, %c2) ctrlvals(%true, %true) : !quantum.bit ctrls !quantum.bit, !quantum.bit
   %b, %bc:2 = quantum.custom "H"() %a ctrls(%ac#0, %ac#1) ctrlvals(%true, %true) : !quantum.bit ctrls !quantum.bit, !quantum.bit
@@ -49,8 +49,8 @@ func.func private @cc_u(%q: !quantum.bit, %c1: !quantum.bit, %c2: !quantum.bit)
 // 3C(U) -> one 3C(H).
 func.func private @ccc_u(%q: !quantum.bit, %c1: !quantum.bit, %c2: !quantum.bit, %c3: !quantum.bit)
     -> (!quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit) attributes {
-    target_gate = "3C(U){}{wires:1}{}",
-    resources = {operations = {"3C(H){}{wires:1}{}" = 1 : i64}} } {
+    target_gate = "{op = \"U\", traits = {controls = 3 : i64}, wires = [1]}",
+    resources = {operations = {"{op = \"H\", traits = {controls = 3 : i64}, wires = [1]}" = 1 : i64}} } {
   %true = arith.constant true
   %o, %oc:3 = quantum.custom "H"() %q ctrls(%c1, %c2, %c3) ctrlvals(%true, %true, %true) : !quantum.bit ctrls !quantum.bit, !quantum.bit, !quantum.bit
   return %o, %oc#0, %oc#1, %oc#2 : !quantum.bit, !quantum.bit, !quantum.bit, !quantum.bit

--- a/frontend/test/lit/GraphDecomposition/TestMultiDecompUser.mlir
+++ b/frontend/test/lit/GraphDecomposition/TestMultiDecompUser.mlir
@@ -24,12 +24,12 @@ func.func @circuit() -> !quantum.bit {
 }
 
 // CHECK-LABEL: h_to_x
-func.func @h_to_x(%q : !quantum.bit) -> !quantum.bit attributes {target_gate="testHadamard{}{wires:1}{}"} {
+func.func @h_to_x(%q : !quantum.bit) -> !quantum.bit attributes {target_gate="{op = \"testHadamard\", wires = [1]}"} {
     %q1 = quantum.custom "testPauliX"() %q : !quantum.bit
     return %q1 : !quantum.bit
 }
 
-func.func @x_to_h(%q : !quantum.bit) -> !quantum.bit attributes {target_gate="testPauliX{}{wires:1}{}"} {
+func.func @x_to_h(%q : !quantum.bit) -> !quantum.bit attributes {target_gate="{op = \"testPauliX\", wires = [1]}"} {
     %q1 = quantum.custom "testHadamard"() %q : !quantum.bit
     return %q1 : !quantum.bit
 }

--- a/frontend/test/lit/GraphDecomposition/test_rules.mlir
+++ b/frontend/test/lit/GraphDecomposition/test_rules.mlir
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 
-func.func @__builtin_h_to_rz_ry(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="testHadamard{}{wires:1}{}"} {
+func.func @__builtin_h_to_rz_ry(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="{op = \"testHadamard\", wires = [1]}"} {
     %piby2 = arith.constant 1.57 : f64
     %pi = arith.constant 3.14 : f64
     %negpiby2 = arith.constant -3.14 : f64
@@ -22,7 +22,7 @@ func.func @__builtin_h_to_rz_ry(%q0 : !quantum.bit) -> !quantum.bit attributes {
     return %q2 : !quantum.bit
 }
 
-func.func @__builtin_h_to_rz_rx(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="testHadamard{}{wires:1}{}"} {
+func.func @__builtin_h_to_rz_rx(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="{op = \"testHadamard\", wires = [1]}"} {
     %piby2 = arith.constant 1.57 : f64
     %negpiby2 = arith.constant -3.14 : f64
     %q1 = quantum.custom "testRZ"(%piby2) %q0 : !quantum.bit
@@ -31,14 +31,14 @@ func.func @__builtin_h_to_rz_rx(%q0 : !quantum.bit) -> !quantum.bit attributes {
     return %q3 : !quantum.bit
 }
 
-func.func @__builtin_x_to_rx(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="testPauliX{}{wires:1}{}"} {
+func.func @__builtin_x_to_rx(%q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="{op = \"testPauliX\", wires = [1]}"} {
     %pi = arith.constant 3.14 : f64
     %negpiby2 = arith.constant -3.14 : f64
     %q1 = quantum.custom "testRX"(%pi) %q0 : !quantum.bit
     return %q1 : !quantum.bit
 }
 
-func.func @__builtin_rx_to_rz_ry(%angle : f64, %q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="testRX{0:[f64]}{wires:1}{}"} {
+func.func @__builtin_rx_to_rz_ry(%angle : f64, %q0 : !quantum.bit) -> !quantum.bit attributes {target_gate="{op = \"testRX\", params = [[f64]], wires = [1]}"} {
     %piby2 = arith.constant 1.57 : f64
     %negpiby2 = arith.constant -3.14 : f64
     %q1 = quantum.custom "testRZ"(%piby2) %q0 : !quantum.bit

--- a/frontend/test/lit/test_operator2/test_adjoint_distribution_rule.py
+++ b/frontend/test/lit/test_operator2/test_adjoint_distribution_rule.py
@@ -47,11 +47,11 @@ def test_distribution_rule_synthesized_from_base():
             return qp.state()
 
         print(c.mlir)
-    # CHECK-DAG: func.func private @"__builtin_base_rule_NoParams{}{reg:2}{}"
-    # CHECK:   target_gate = "NoParams{}{reg:2}{}"
-    # CHECK-DAG: func.func private @"__builtin_base_rule_Adjoint(NoParams){}{reg:2}{}"
-    # CHECK-SAME:   resources = {operations = {"Adjoint(SingleParam){x:[tensor<f64>]}{reg:2}{}" = 2 : i64}
-    # CHECK:   target_gate = "Adjoint(NoParams){}{reg:2}{}"
+    # CHECK-DAG: func.func private @"__builtin_base_rule_{op = \22NoParams\22, wires = [2]}"
+    # CHECK:   target_gate = "{op = \22NoParams\22, wires = [2]}"
+    # CHECK-DAG: func.func private @"__builtin_base_rule_{op = \22NoParams\22, traits = {adj = true}, wires = [2]}"
+    # CHECK-SAME:   resources = {operations = {"{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], traits = {adj = true}, wires = [2]}" = 2 : i64}
+    # CHECK:   target_gate = "{op = \22NoParams\22, traits = {adj = true}, wires = [2]}"
     # CHECK: qref.adjoint {
 
 

--- a/frontend/test/lit/test_operator2/test_decomposition_rule_entry_point.py
+++ b/frontend/test/lit/test_operator2/test_decomposition_rule_entry_point.py
@@ -97,9 +97,7 @@ def test_from_dynamic_argnames():
         qp.add_decomps(SingleParam, rule)
         result = compile_decomposition_rules_wrapper(
             "SingleParam",
-            build_graph_op_key(
-                "SingleParam", {"x": ["tensor<2xf64>"]}, {"reg": 2}, {}
-            ),
+            build_graph_op_key("SingleParam", {"x": ["tensor<2xf64>"]}, {"reg": 2}, {}),
             {"x": ["f64", "f64"]},
             {"reg": 2},
             {},
@@ -994,9 +992,7 @@ def test_while_loop():
     print(
         compile_decomposition_rules_wrapper(
             "WhileOp",
-            build_graph_op_key(
-                "WhileOp", {"angle": ["tensor<f64>"]}, {"wires": 1}, {}
-            ),
+            build_graph_op_key("WhileOp", {"angle": ["tensor<f64>"]}, {"wires": 1}, {}),
             {"angle": ["f64"]},
             {"wires": 1},
             {},

--- a/frontend/test/lit/test_operator2/test_decomposition_rule_entry_point.py
+++ b/frontend/test/lit/test_operator2/test_decomposition_rule_entry_point.py
@@ -45,6 +45,7 @@ from pennylane.typing import Complex, Float, Int, Wire
 from catalyst.decomposition.decomposition_rules import (
     compile_decomposition_rules_wrapper,
 )
+from catalyst.decomposition.graph_op_id import build_graph_op_key
 
 
 def test_to_dynamic_argnames():
@@ -67,16 +68,16 @@ def test_to_dynamic_argnames():
     with qp.decomposition.local_decomps():
         qp.add_decomps(NoParams, rule)
         result = compile_decomposition_rules_wrapper(
-            "NoParams", "NoParams{}{reg:2}{}", {}, {"reg": 2}, {}
+            "NoParams", build_graph_op_key("NoParams", {}, {"reg": 2}, {}), {}, {"reg": 2}, {}
         )
         print(result)
 
 
-# CHECK: func.func private @"rule_NoParams{}{reg:2}{}"
+# CHECK: func.func private @"rule_{op = \22NoParams\22, wires = [2]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "SingleParam{x:[tensor<2xf64>]}{reg:2}{}" = 1 : i64,
-# CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:2}{}" = 2 : i64
-# CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
+# CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<2xf64>]], wires = [2]}" = 1 : i64,
+# CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [2]}" = 2 : i64
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [2]}"
 test_to_dynamic_argnames()
 
 
@@ -96,7 +97,9 @@ def test_from_dynamic_argnames():
         qp.add_decomps(SingleParam, rule)
         result = compile_decomposition_rules_wrapper(
             "SingleParam",
-            "SingleParam{x:[tensor<2xf64>]}{reg:2}{}",
+            build_graph_op_key(
+                "SingleParam", {"x": ["tensor<2xf64>"]}, {"reg": 2}, {}
+            ),
             {"x": ["f64", "f64"]},
             {"reg": 2},
             {},
@@ -104,9 +107,9 @@ def test_from_dynamic_argnames():
         print(result)
 
 
-# CHECK: func.func private @"rule_SingleParam{x:[tensor<2xf64>]}{reg:2}{}"
-# CHECK-SAME:   resources = {operations = {"NoParams{}{reg:1}{}" = 1 : i64}}
-# CHECK-SAME:   target_gate = "SingleParam{x:[tensor<2xf64>]}{reg:2}{}"
+# CHECK: func.func private @"rule_{op = \22SingleParam\22, params = [{{\[}}tensor<2xf64>]], wires = [2]}"
+# CHECK-SAME:   resources = {operations = {"{op = \22NoParams\22, wires = [1]}" = 1 : i64}}
+# CHECK-SAME:   target_gate = "{op = \22SingleParam\22, params = [{{\[}}tensor<2xf64>]], wires = [2]}"
 test_from_dynamic_argnames()
 
 
@@ -127,15 +130,15 @@ def test_to_multiple_dynamic_argnames():
     with qp.decomposition.local_decomps():
         qp.add_decomps(NoParams, rule)
         result = compile_decomposition_rules_wrapper(
-            "NoParams", "NoParams{}{reg:1}{}", {}, {"reg": 1}, {}
+            "NoParams", build_graph_op_key("NoParams", {}, {"reg": 1}, {}), {}, {"reg": 1}, {}
         )
         print(result)
 
 
-# CHECK: func.func private @"rule_NoParams{}{reg:1}{}"
+# CHECK: func.func private @"rule_{op = \22NoParams\22, wires = [1]}"
 # CHECK-SAME:   resources = {operations =
-# CHECK-SAME:   "MultiParams{a:[tensor<f64>],b:[tensor<2x2xi64>],c:[tensor<complex<f64>>]}{reg:1}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "NoParams{}{reg:1}{}"
+# CHECK-SAME:   "{op = \22MultiParams\22, params = [{{\[}}tensor<f64>], [tensor<2x2xi64>], [tensor<complex<f64>>]], wires = [1]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [1]}"
 test_to_multiple_dynamic_argnames()
 
 
@@ -155,7 +158,16 @@ def test_from_multiple_dynamic_argnames():
         qp.add_decomps(MultiParams, rule)
         result = compile_decomposition_rules_wrapper(
             "MultiParams",
-            "MultiParams{a:[tensor<f64>],b:[tensor<i32>,tensor<i32>],c:[tensor<f64>,tensor<f64>]}{reg:2}{}",
+            build_graph_op_key(
+                "MultiParams",
+                {
+                    "a": ["tensor<f64>"],
+                    "b": ["tensor<i32>", "tensor<i32>"],
+                    "c": ["tensor<f64>", "tensor<f64>"],
+                },
+                {"reg": 2},
+                {},
+            ),
             {"b": ["i32", "i32"], "c": ["f64", "f64"], "a": ["f64"]},
             {"reg": 2},
             {},
@@ -163,9 +175,9 @@ def test_from_multiple_dynamic_argnames():
         print(result)
 
 
-# CHECK: func.func private @"rule_MultiParams{a:[tensor<f64>],b:[tensor<i32>,tensor<i32>],c:[tensor<f64>,tensor<f64>]}{reg:2}{}"
-# CHECK-SAME:   resources = {operations = {"NoParamsCustomOp{}{wires:2}{}" = 1 : i64}
-# CHECK-SAME:   target_gate = "MultiParams{a:[tensor<f64>],b:[tensor<i32>,tensor<i32>],c:[tensor<f64>,tensor<f64>]}{reg:2}{}"
+# CHECK: func.func private @"rule_{op = \22MultiParams\22, params = [{{\[}}tensor<f64>], [tensor<i32>, tensor<i32>], [tensor<f64>, tensor<f64>]], wires = [2]}"
+# CHECK-SAME:   resources = {operations = {"{op = \22NoParamsCustomOp\22, wires = [2]}" = 1 : i64}
+# CHECK-SAME:   target_gate = "{op = \22MultiParams\22, params = [{{\[}}tensor<f64>], [tensor<i32>, tensor<i32>], [tensor<f64>, tensor<f64>]], wires = [2]}"
 test_from_multiple_dynamic_argnames()
 
 
@@ -186,15 +198,15 @@ def test_to_multiple_wire_argnames():
     with qp.decomposition.local_decomps():
         qp.add_decomps(NoParams, rule)
         result = compile_decomposition_rules_wrapper(
-            "NoParams", "NoParams{}{reg:1}{}", {}, {"reg": 1}, {}
+            "NoParams", build_graph_op_key("NoParams", {}, {"reg": 1}, {}), {}, {"reg": 1}, {}
         )
         print(result)
 
 
-# CHECK: func.func private @"rule_NoParams{}{reg:1}{}"
+# CHECK: func.func private @"rule_{op = \22NoParams\22, wires = [1]}"
 # CHECK-SAME:   resources = {operations =
-# CHECK-SAME:   "MultipleRegisters{}{reg1:1,reg2:2}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "NoParams{}{reg:1}{}"
+# CHECK-SAME:   "{op = \22MultipleRegisters\22, wires = [1, 2]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [1]}"
 test_to_multiple_wire_argnames()
 
 
@@ -215,7 +227,7 @@ def test_from_multiple_wire_argnames():
         qp.add_decomps(MultipleRegisters, rule)
         result = compile_decomposition_rules_wrapper(
             "MultipleRegisters",
-            "MultipleRegisters{}{reg1:2,reg2:3}{}",
+            build_graph_op_key("MultipleRegisters", {}, {"reg1": 2, "reg2": 3}, {}),
             {},
             {"reg1": 2, "reg2": 3},
             {},
@@ -223,11 +235,11 @@ def test_from_multiple_wire_argnames():
         print(result)
 
 
-# CHECK: func.func private @"rule_MultipleRegisters{}{reg1:2,reg2:3}{}"
+# CHECK: func.func private @"rule_{op = \22MultipleRegisters\22, wires = [2, 3]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "NoParamsCustomOp{}{wires:2}{}" = 1 : i64
-# CHECK-SAME:   "NoParamsCustomOp{}{wires:3}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "MultipleRegisters{}{reg1:2,reg2:3}{}"
+# CHECK-SAME:   "{op = \22NoParamsCustomOp\22, wires = [2]}" = 1 : i64
+# CHECK-SAME:   "{op = \22NoParamsCustomOp\22, wires = [3]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22MultipleRegisters\22, wires = [2, 3]}"
 test_from_multiple_wire_argnames()
 
 
@@ -251,16 +263,16 @@ def test_to_compilable_data():
     with qp.decomposition.local_decomps():
         qp.add_decomps(NoParams, rule)
         result = compile_decomposition_rules_wrapper(
-            "NoParams", "NoParams{}{reg:2}{}", {}, {"reg": 2}, {}
+            "NoParams", build_graph_op_key("NoParams", {}, {"reg": 2}, {}), {}, {"reg": 2}, {}
         )
         print(result)
 
 
-# CHECK: func.func private @"rule_NoParams{}{reg:2}{}"
+# CHECK: func.func private @"rule_{op = \22NoParams\22, wires = [2]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:     "CompilableData{}{wires:1}{a:a,b:b,thing:thing}" = 1 : i64,
-# CHECK-SAME:     "CompilableData{}{wires:1}{a:aa,b:bb,thing:stuff}" = 2 : i64
-# CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
+# CHECK-SAME:     "{op = \22CompilableData\22, static = {a = \22a\22, b = \22b\22, thing = \22thing\22}, wires = [1]}" = 1 : i64,
+# CHECK-SAME:     "{op = \22CompilableData\22, static = {a = \22aa\22, b = \22bb\22, thing = \22stuff\22}, wires = [1]}" = 2 : i64
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [2]}"
 test_to_compilable_data()
 
 
@@ -283,7 +295,12 @@ def test_from_compilable_data():
         qp.add_decomps(CompilableData, rule)
         result_a1 = compile_decomposition_rules_wrapper(
             "CompilableData",
-            "CompilableData{}{wires:1}{a:1,b:2,thing:3}",
+            build_graph_op_key(
+                "CompilableData",
+                {},
+                {"wires": 1},
+                {"a": 1, "b": 2, "thing": 3},
+            ),
             {},
             {"wires": 1},
             {"a": 1, "b": 2, "thing": 3},
@@ -292,7 +309,12 @@ def test_from_compilable_data():
 
         result_a10 = compile_decomposition_rules_wrapper(
             "CompilableData",
-            "CompilableData{}{wires:1}{a:10,b:2,thing:3}",
+            build_graph_op_key(
+                "CompilableData",
+                {},
+                {"wires": 1},
+                {"a": 10, "b": 2, "thing": 3},
+            ),
             {},
             {"wires": 1},
             {"a": 10, "b": 2, "thing": 3},
@@ -300,15 +322,15 @@ def test_from_compilable_data():
         print(result_a10)
 
 
-# CHECK: func.func private @"rule_CompilableData{}{wires:1}{a:1,b:2,thing:3}"
-# CHECK-SAME:   resources = {operations = {"SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64}
-# CHECK-SAME:   target_gate = "CompilableData{}{wires:1}{a:1,b:2,thing:3}"
+# CHECK: func.func private @"rule_{op = \22CompilableData\22, static = {a = 1 : i64, b = 2 : i64, thing = 3 : i64}, wires = [1]}"
+# CHECK-SAME:   resources = {operations = {"{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [1]}" = 1 : i64}
+# CHECK-SAME:   target_gate = "{op = \22CompilableData\22, static = {a = 1 : i64, b = 2 : i64, thing = 3 : i64}, wires = [1]}"
 # CHECK: stablehlo.constant dense<1.000000e-01> : tensor<f64>
 # CHECK-NOT: stablehlo.constant dense<1.100000e+00> : tensor<f64>
 #
-# CHECK: func.func private @"rule_CompilableData{}{wires:1}{a:10,b:2,thing:3}"
-# CHECK-SAME:   resources = {operations = {"SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64}
-# CHECK-SAME:   target_gate = "CompilableData{}{wires:1}{a:10,b:2,thing:3}"
+# CHECK: func.func private @"rule_{op = \22CompilableData\22, static = {a = 10 : i64, b = 2 : i64, thing = 3 : i64}, wires = [1]}"
+# CHECK-SAME:   resources = {operations = {"{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [1]}" = 1 : i64}
+# CHECK-SAME:   target_gate = "{op = \22CompilableData\22, static = {a = 10 : i64, b = 2 : i64, thing = 3 : i64}, wires = [1]}"
 # CHECK: stablehlo.constant dense<1.100000e+00> : tensor<f64>
 # CHECK-NOT: stablehlo.constant dense<1.000000e-01> : tensor<f64>
 test_from_compilable_data()
@@ -334,15 +356,15 @@ def test_to_static_data():
     with qp.decomposition.local_decomps():
         qp.add_decomps(NoParams, rule)
         result = compile_decomposition_rules_wrapper(
-            "NoParams", "NoParams{}{reg:2}{}", {}, {"reg": 2}, {}
+            "NoParams", build_graph_op_key("NoParams", {}, {"reg": 2}, {}), {}, {"reg": 2}, {}
         )
         print(result)
 
 
-# CHECK: func.func private @"rule_NoParams{}{reg:2}{}"
-# CHECK-DAG: "StaticData{}{reg:1}{}[[[uid_1:[0-9]+]]]" = 1
-# CHECK-DAG: "StaticData{}{reg:1}{}[[[uid_2:[0-9]+]]]" = 2
-# CHECK-DAG:   target_gate = "NoParams{}{reg:2}{}"
+# CHECK: func.func private @"rule_{op = \22NoParams\22, wires = [2]}"
+# CHECK-DAG: "{op = \22StaticData\22, uid = [[uid_1:[0-9]+]] : i64, wires = [1]}" = 1
+# CHECK-DAG: "{op = \22StaticData\22, uid = [[uid_2:[0-9]+]] : i64, wires = [1]}" = 2
+# CHECK-DAG:   target_gate = "{op = \22NoParams\22, wires = [2]}"
 # CHECK: "qref.operator"
 # CHECK-SAME: UID = [[uid_1]]
 # CHECK: "qref.operator"
@@ -374,24 +396,34 @@ def test_from_static_data():
     with qp.decomposition.local_decomps():
         qp.add_decomps(StaticData, rule)
         result_1234 = compile_decomposition_rules_wrapper(
-            "StaticData", "StaticData{}{reg:1}{}[1234]", {}, {"reg": 1}, {}, {"label": 1234}
+            "StaticData",
+            build_graph_op_key("StaticData", {}, {"reg": 1}, {}, uid=1234),
+            {},
+            {"reg": 1},
+            {},
+            {"label": 1234},
         )
         print(result_1234)
 
         result_4321 = compile_decomposition_rules_wrapper(
-            "StaticData", "StaticData{}{reg:1}{}[4321]", {}, {"reg": 1}, {}, {"label": 4321}
+            "StaticData",
+            build_graph_op_key("StaticData", {}, {"reg": 1}, {}, uid=4321),
+            {},
+            {"reg": 1},
+            {},
+            {"label": 4321},
         )
         print(result_4321)
 
 
-# CHECK: func.func private @"rule_StaticData{}{reg:1}{}[1234]"
-# CHECK-SAME:   resources = {operations = {"SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64}
-# CHECK-SAME:   target_gate = "StaticData{}{reg:1}{}[1234]"
+# CHECK: func.func private @"rule_{op = \22StaticData\22, uid = 1234 : i64, wires = [1]}"
+# CHECK-SAME:   resources = {operations = {"{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [1]}" = 1 : i64}
+# CHECK-SAME:   target_gate = "{op = \22StaticData\22, uid = 1234 : i64, wires = [1]}"
 # CHECK: stablehlo.constant dense<1.000000e-01> : tensor<f64>
 #
-# CHECK: func.func private @"rule_StaticData{}{reg:1}{}[4321]"
-# CHECK-SAME:   resources = {operations = {"SingleParam{x:[tensor<f64>]}{reg:1}{}" = 2 : i64}
-# CHECK-SAME:   target_gate = "StaticData{}{reg:1}{}[4321]"
+# CHECK: func.func private @"rule_{op = \22StaticData\22, uid = 4321 : i64, wires = [1]}"
+# CHECK-SAME:   resources = {operations = {"{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [1]}" = 2 : i64}
+# CHECK-SAME:   target_gate = "{op = \22StaticData\22, uid = 4321 : i64, wires = [1]}"
 # CHECK-DAG: stablehlo.constant dense<1.100000e+00> : tensor<f64>
 # CHECK-DAG: stablehlo.constant dense<2.200000e+00> : tensor<f64>
 test_from_static_data()
@@ -419,15 +451,15 @@ def test_to_hybrid_wires():
     with qp.decomposition.local_decomps():
         qp.add_decomps(NoParams, rule)
         result = compile_decomposition_rules_wrapper(
-            "NoParams", "NoParams{}{reg:3}{}", {}, {"reg": 3}, {}
+            "NoParams", build_graph_op_key("NoParams", {}, {"reg": 3}, {}), {}, {"reg": 3}, {}
         )
         print(result)
 
 
-# CHECK: func.func private @"rule_NoParams{}{reg:3}{}"
-# CHECK-DAG: "HybridWires{}{}{}[[[uid_1:[0-9]+]]]" = 1
-# CHECK-DAG: "HybridWires{}{}{}[[[uid_2:[0-9]+]]]" = 2
-# CHECK-DAG:   target_gate = "NoParams{}{reg:3}{}"
+# CHECK: func.func private @"rule_{op = \22NoParams\22, wires = [3]}"
+# CHECK-DAG: "{op = \22HybridWires\22, uid = [[uid_1:[0-9]+]] : i64}" = 1
+# CHECK-DAG: "{op = \22HybridWires\22, uid = [[uid_2:[0-9]+]] : i64}" = 2
+# CHECK-DAG:   target_gate = "{op = \22NoParams\22, wires = [3]}"
 # CHECK: "qref.operator"
 # CHECK-SAME: UID = [[uid_2]]
 # CHECK: "qref.operator"
@@ -455,7 +487,7 @@ def test_from_hybrid_wires():
         qp.add_decomps(HybridWires, rule)
         result = compile_decomposition_rules_wrapper(
             "HybridWires",
-            "HybridWires{}{}{}[3742]",
+            build_graph_op_key("HybridWires", {}, {}, {}, uid=3742),
             {},
             {},
             {},
@@ -464,9 +496,9 @@ def test_from_hybrid_wires():
         print(result)
 
 
-# CHECK: func.func private @"rule_HybridWires{}{}{}[3742]"
-# CHECK-SAME:   resources = {operations = {"NoParams{}{reg:1}{}" = 3 : i64}}
-# CHECK-SAME:   target_gate = "HybridWires{}{}{}[3742]"
+# CHECK: func.func private @"rule_{op = \22HybridWires\22, uid = 3742 : i64}"
+# CHECK-SAME:   resources = {operations = {"{op = \22NoParams\22, wires = [1]}" = 3 : i64}}
+# CHECK-SAME:   target_gate = "{op = \22HybridWires\22, uid = 3742 : i64}"
 # CHECK: idx_attr = 1
 # CHECK: idx_attr = 2
 # CHECK: idx_attr = 3
@@ -518,15 +550,15 @@ def test_to_hybrid_op():
     with qp.decomposition.local_decomps():
         qp.add_decomps(NoParams, rule)
         result = compile_decomposition_rules_wrapper(
-            "NoParams", "NoParams{}{reg:3}{}", {}, {"reg": 3}, {}
+            "NoParams", build_graph_op_key("NoParams", {}, {"reg": 3}, {}), {}, {"reg": 3}, {}
         )
         print(result)
 
 
-# CHECK: func.func private @"rule_NoParams{}{reg:3}{}"
-# CHECK-DAG: "HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[[[uid_1:[0-9]+]]]" = 1
-# CHECK-DAG: "HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[[[uid_2:[0-9]+]]]" = 2
-# CHECK-DAG:   target_gate = "NoParams{}{reg:3}{}"
+# CHECK: func.func private @"rule_{op = \22NoParams\22, wires = [3]}"
+# CHECK-DAG: "{op = \22HybridOpArg\22, params = [{{\[}}tensor<f64>]], uid = [[uid_1:[0-9]+]] : i64, wires = [1]}" = 1
+# CHECK-DAG: "{op = \22HybridOpArg\22, params = [{{\[}}tensor<f64>]], uid = [[uid_2:[0-9]+]] : i64, wires = [1]}" = 2
+# CHECK-DAG:   target_gate = "{op = \22NoParams\22, wires = [3]}"
 # CHECK: "qref.operator"
 # CHECK-SAME: UID = [[uid_2]]
 # CHECK: "qref.operator"
@@ -553,7 +585,13 @@ def test_from_hybrid_op():
         qp.add_decomps(HybridOpArg, rule)
         result = compile_decomposition_rules_wrapper(
             "HybridOpArg",
-            "HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[5678]",
+            build_graph_op_key(
+                "HybridOpArg",
+                {"angle": ["tensor<f64>"]},
+                {"cwires": 1},
+                {},
+                uid=5678,
+            ),
             {"angle": ["f64"]},
             {"cwires": 1},
             {},
@@ -565,11 +603,11 @@ def test_from_hybrid_op():
         print(result)
 
 
-# CHECK: func.func private @"rule_HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[5678]"
+# CHECK: func.func private @"rule_{op = \22HybridOpArg\22, params = [{{\[}}tensor<f64>]], uid = 5678 : i64, wires = [1]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "NoParams{}{reg:1}{}" = 1 : i64,
-# CHECK-SAME:   "StaticDataMultiReg{theta:[tensor<f64>]}{reg:1,reg2:2}{}[[[uid:[0-9]+]]]" = 1 : i64
-# CHECK-SAME:   target_gate = "HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[5678]"
+# CHECK-SAME:   "{op = \22NoParams\22, wires = [1]}" = 1 : i64,
+# CHECK-SAME:   "{op = \22StaticDataMultiReg\22, params = [{{\[}}tensor<f64>]], uid = [[uid:[0-9]+]] : i64, wires = [1, 2]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22HybridOpArg\22, params = [{{\[}}tensor<f64>]], uid = 5678 : i64, wires = [1]}"
 # CHECK: "qref.operator"
 # CHECK-SAME:   UID = [[uid]] : i64, op_name = "StaticDataMultiReg"
 test_from_hybrid_op()
@@ -612,14 +650,14 @@ def test_to_hybrid_op_nested():
     with qp.decomposition.local_decomps():
         qp.add_decomps(NoParams, rule)
         result = compile_decomposition_rules_wrapper(
-            "NoParams", "NoParams{}{reg:3}{}", {}, {"reg": 3}, {}
+            "NoParams", build_graph_op_key("NoParams", {}, {"reg": 3}, {}), {}, {"reg": 3}, {}
         )
         print(result)
 
 
-# CHECK: func.func private @"rule_NoParams{}{reg:3}{}"
-# CHECK-SAME: "HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[[[uid:[0-9]+]]]" = 1
-# CHECK-SAME:   target_gate = "NoParams{}{reg:3}{}"
+# CHECK: func.func private @"rule_{op = \22NoParams\22, wires = [3]}"
+# CHECK-SAME: "{op = \22HybridOpArg\22, params = [{{\[}}tensor<f64>]], uid = [[uid:[0-9]+]] : i64, wires = [1]}" = 1
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [3]}"
 # CHECK: "qref.operator"
 # CHECK-SAME: UID = [[uid]]
 test_to_hybrid_op_nested()
@@ -643,7 +681,13 @@ def test_from_hybrid_op_nested():
         qp.add_decomps(HybridOpArg, rule)
         result = compile_decomposition_rules_wrapper(
             "HybridOpArg",
-            "HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[7654]",
+            build_graph_op_key(
+                "HybridOpArg",
+                {"angle": ["tensor<f64>"]},
+                {"cwires": 1},
+                {},
+                uid=7654,
+            ),
             {"angle": ["f64"]},
             {"cwires": 1},
             {},
@@ -660,12 +704,12 @@ def test_from_hybrid_op_nested():
         print(result)
 
 
-# CHECK: func.func private @"rule_HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[7654]"
+# CHECK: func.func private @"rule_{op = \22HybridOpArg\22, params = [{{\[}}tensor<f64>]], uid = 7654 : i64, wires = [1]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[[[uid_outer:[0-9]+]]]" = 1 : i64,
-# CHECK-SAME:   "NoParams{}{reg:1}{}" = 1 : i64,
-# CHECK-SAME:   "StaticDataMultiReg{theta:[tensor<f64>]}{reg:1,reg2:2}{}[[[uid_inner:[0-9]+]]]" = 1 : i64
-# CHECK-SAME:   target_gate = "HybridOpArg{angle:[tensor<f64>]}{cwires:1}{}[7654]"
+# CHECK-SAME:   "{op = \22HybridOpArg\22, params = [{{\[}}tensor<f64>]], uid = [[uid_outer:[0-9]+]] : i64, wires = [1]}" = 1 : i64,
+# CHECK-SAME:   "{op = \22NoParams\22, wires = [1]}" = 1 : i64,
+# CHECK-SAME:   "{op = \22StaticDataMultiReg\22, params = [{{\[}}tensor<f64>]], uid = [[uid_inner:[0-9]+]] : i64, wires = [1, 2]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22HybridOpArg\22, params = [{{\[}}tensor<f64>]], uid = 7654 : i64, wires = [1]}"
 # CHECK: "qref.operator"
 # CHECK-SAME:   UID = [[uid_outer]] : i64, op_name = "HybridOpArg"
 # CHECK: "qref.operator"
@@ -724,14 +768,14 @@ def test_to_multiple_full_args_op():
     with qp.decomposition.local_decomps():
         qp.add_decomps(NoParams, rule)
         result = compile_decomposition_rules_wrapper(
-            "NoParams", "NoParams{}{reg:3}{}", {}, {"reg": 3}, {}
+            "NoParams", build_graph_op_key("NoParams", {}, {"reg": 3}, {}), {}, {"reg": 3}, {}
         )
         print(result)
 
 
-# CHECK: func.func private @"rule_NoParams{}{reg:3}{}"
-# CHECK-DAG: "MultipleFullArgs{angles1:[tensor<f64>],angles2:[tensor<2xf64>]}{reg1:1,reg2:2}{}[[[uid:[0-9]+]]]" = 2
-# CHECK-DAG:   target_gate = "NoParams{}{reg:3}{}"
+# CHECK: func.func private @"rule_{op = \22NoParams\22, wires = [3]}"
+# CHECK-DAG: "{op = \22MultipleFullArgs\22, params = [{{\[}}tensor<f64>], [tensor<2xf64>]], uid = [[uid:[0-9]+]] : i64, wires = [1, 2]}" = 2
+# CHECK-DAG:   target_gate = "{op = \22NoParams\22, wires = [3]}"
 # CHECK: "qref.operator"
 # CHECK-SAME: UID = [[uid]]
 # CHECK: "qref.operator"
@@ -759,7 +803,16 @@ def test_from_multiple_full_args_op():
         qp.add_decomps(MultipleFullArgs, rule)
         result = compile_decomposition_rules_wrapper(
             "MultipleFullArgs",
-            "MultipleFullArgs{angles1:[tensor<f64>],angles2:[tensor<2xf64>]}{reg1:1,reg2:2}{}[4444]",
+            build_graph_op_key(
+                "MultipleFullArgs",
+                {
+                    "angles1": ["tensor<f64>"],
+                    "angles2": ["tensor<2xf64>"],
+                },
+                {"reg1": 1, "reg2": 2},
+                {},
+                uid=4444,
+            ),
             {"angles1": ["f64"], "angles2": ["f64", "f64"]},
             {"reg1": 1, "reg2": 2},
             {},
@@ -775,12 +828,12 @@ def test_from_multiple_full_args_op():
         print(result)
 
 
-# CHECK: func.func private @"rule_MultipleFullArgs{angles1:[tensor<f64>],angles2:[tensor<2xf64>]}{reg1:1,reg2:2}{}[4444]"
+# CHECK: func.func private @"rule_{op = \22MultipleFullArgs\22, params = [{{\[}}tensor<f64>], [tensor<2xf64>]], uid = 4444 : i64, wires = [1, 2]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "NoParams{}{reg:1}{}" = 1 : i64
-# CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64
-# CHECK-SAME:   "SingleParam{x:[tensor<i64>]}{reg:1}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "MultipleFullArgs{angles1:[tensor<f64>],angles2:[tensor<2xf64>]}{reg1:1,reg2:2}{}[4444]"
+# CHECK-SAME:   "{op = \22NoParams\22, wires = [1]}" = 1 : i64
+# CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [1]}" = 1 : i64
+# CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<i64>]], wires = [1]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22MultipleFullArgs\22, params = [{{\[}}tensor<f64>], [tensor<2xf64>]], uid = 4444 : i64, wires = [1, 2]}"
 # CHECK: "qref.operator"
 # CHECK-SAME:   op_name = "SingleParam"
 # CHECK: "qref.operator"
@@ -817,17 +870,17 @@ def test_multiple_rules():
         qp.add_decomps(NoParams, rule1)
         qp.add_decomps(NoParams, rule2)
         result = compile_decomposition_rules_wrapper(
-            "NoParams", "NoParams{}{reg:1}{}", {}, {"reg": 1}, {}
+            "NoParams", build_graph_op_key("NoParams", {}, {"reg": 1}, {}), {}, {"reg": 1}, {}
         )
         print(result)
 
 
-# CHECK: func.func private @"rule1_NoParams{}{reg:1}{}"
-# CHECK-SAME:   resources = {operations = {"SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64}}
-# CHECK-SAME:   target_gate = "NoParams{}{reg:1}{}"
-# CHECK: func.func private @"rule2_NoParams{}{reg:1}{}"
-# CHECK-SAME:   resources = {operations = {"CompilableData{}{wires:3}{a:a,b:b,thing:thing}" = 1 : i64}}
-# CHECK-SAME:   target_gate = "NoParams{}{reg:1}{}"
+# CHECK: func.func private @"rule1_{op = \22NoParams\22, wires = [1]}"
+# CHECK-SAME:   resources = {operations = {"{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [1]}" = 1 : i64}}
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [1]}"
+# CHECK: func.func private @"rule2_{op = \22NoParams\22, wires = [1]}"
+# CHECK-SAME:   resources = {operations = {"{op = \22CompilableData\22, static = {a = \22a\22, b = \22b\22, thing = \22thing\22}, wires = [3]}" = 1 : i64}}
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [1]}"
 test_multiple_rules()
 
 
@@ -860,14 +913,23 @@ def test_for_loop():
         qp.add_decomps(LayerRX, test_rule)
 
         result = compile_decomposition_rules_wrapper(
-            "LayerRX", "TestID", {"angles": ["f64", "f64", "f64"]}, {"wires": 3}, {}
+            "LayerRX",
+            build_graph_op_key(
+                "LayerRX",
+                {"angles": ["tensor<f64>", "tensor<f64>", "tensor<f64>"]},
+                {"wires": 3},
+                {},
+            ),
+            {"angles": ["f64", "f64", "f64"]},
+            {"wires": 3},
+            {},
         )
         print(result)
 
 
-# CHECK: func.func private @test_rule_TestID
-# CHECK-SAME:   resources = {operations = {"TestRX{0:[f64]}{wires:1}{}" = 3 : i64}}
-# CHECK-SAME:   target_gate = "TestID"
+# CHECK: func.func private @"test_rule_{op = \22LayerRX\22, params = [{{\[}}tensor<f64>, tensor<f64>, tensor<f64>]], wires = [3]}"
+# CHECK-SAME:   resources = {operations = {"{op = \22TestRX\22, params = [{{\[}}f64]], wires = [1]}" = 3 : i64}}
+# CHECK-SAME:   target_gate = "{op = \22LayerRX\22, params = [{{\[}}tensor<f64>, tensor<f64>, tensor<f64>]], wires = [3]}"
 # CHECK-DAG: arith.constant 0 : index
 # CHECK-DAG: arith.constant 3 : index
 # CHECK-DAG: arith.constant 1 : index
@@ -891,7 +953,15 @@ def test_if():
 
     qp.add_decomps(TestOp, if_decomp)
 
-    print(compile_decomposition_rules_wrapper("TestOp", "IfID", {"flag": ["i1"]}, {"wires": 1}, {}))
+    print(
+        compile_decomposition_rules_wrapper(
+            "TestOp",
+            build_graph_op_key("TestOp", {"flag": ["tensor<i1>"]}, {"wires": 1}, {}),
+            {"flag": ["i1"]},
+            {"wires": 1},
+            {},
+        )
+    )
 
 
 # CHECK: if_decomp
@@ -923,7 +993,13 @@ def test_while_loop():
 
     print(
         compile_decomposition_rules_wrapper(
-            "WhileOp", "whileID", {"angle": ["f64"]}, {"wires": 1}, {}
+            "WhileOp",
+            build_graph_op_key(
+                "WhileOp", {"angle": ["tensor<f64>"]}, {"wires": 1}, {}
+            ),
+            {"angle": ["f64"]},
+            {"wires": 1},
+            {},
         )
     )
 
@@ -944,7 +1020,7 @@ def test_custom_op_numbered_args():
     print(
         compile_decomposition_rules_wrapper(
             "RZ",
-            "RZ{0:[f64]}{wires:2}{}",
+            build_graph_op_key("RZ", {"0": ["f64"]}, {"wires": 2}, {}),
             {"0": ["f64"]},
             {"wires": 1},
             {},
@@ -972,15 +1048,15 @@ def test_rule_with_helper_functions():
     with qp.decomposition.local_decomps():
         qp.add_decomps(NoParams, rule)
         result = compile_decomposition_rules_wrapper(
-            "NoParams", "NoParams{}{reg:1}{}", {}, {"reg": 1}, {}
+            "NoParams", build_graph_op_key("NoParams", {}, {"reg": 1}, {}), {}, {"reg": 1}, {}
         )
         print(result)
 
 
-# CHECK: func.func private @"rule_NoParams{}{reg:1}{}"
+# CHECK: func.func private @"rule_{op = \22NoParams\22, wires = [1]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "MultiParams{a:[tensor<f64>],b:[tensor<f64>],c:[tensor<f64>]}{reg:1}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "NoParams{}{reg:1}{}"
+# CHECK-SAME:   "{op = \22MultiParams\22, params = [{{\[}}tensor<f64>], [tensor<f64>], [tensor<f64>]], wires = [1]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [1]}"
 # CHECK: stablehlo.constant dense<4.200000e+00> : tensor<f64>
 # CHECK-NOT: call
 # CHECK-NOT: my_helper

--- a/frontend/test/lit/test_operator2/test_lower_time_rules.py
+++ b/frontend/test/lit/test_operator2/test_lower_time_rules.py
@@ -70,11 +70,11 @@ def test_one_rule():
 
         # CHECK-LABEL: func.func public @one_gate()
         # CHECK: qref.operator "NoParams"
-        # CHECK: func.func private @"__builtin_rule_NoParams{}{reg:2}{}"
+        # CHECK: func.func private @"__builtin_rule_{op = \22NoParams\22, wires = [2]}"
         # CHECK-SAME:   resources = {operations = {
-        # CHECK-SAME:   "SingleParam{x:[tensor<2xf64>]}{reg:2}{}" = 1 : i64,
-        # CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:2}{}" = 2 : i64
-        # CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
+        # CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<2xf64>]], wires = [2]}" = 1 : i64,
+        # CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [2]}" = 2 : i64
+        # CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [2]}"
         test_one_gate()
 
         def test_multiple_gates_same_id():
@@ -95,12 +95,12 @@ def test_one_rule():
         # CHECK-LABEL: func.func public @same_id()
         # CHECK: qref.operator "NoParams"
         # CHECK: qref.operator "NoParams"
-        # CHECK: func.func private @"__builtin_rule_NoParams{}{reg:2}{}"
+        # CHECK: func.func private @"__builtin_rule_{op = \22NoParams\22, wires = [2]}"
         # CHECK-SAME:   resources = {operations = {
-        # CHECK-SAME:   "SingleParam{x:[tensor<2xf64>]}{reg:2}{}" = 1 : i64,
-        # CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:2}{}" = 2 : i64
-        # CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
-        # CHECK-NOT: func.func private @"__builtin_rule_NoParams{}{reg:2}{}"
+        # CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<2xf64>]], wires = [2]}" = 1 : i64,
+        # CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [2]}" = 2 : i64
+        # CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [2]}"
+        # CHECK-NOT: func.func private @"__builtin_rule_{op = \22NoParams\22, wires = [2]}"
         test_multiple_gates_same_id()
 
         def test_multiple_gates_different_ids():
@@ -121,16 +121,16 @@ def test_one_rule():
         # CHECK-LABEL: func.func public @different_id()
         # CHECK: qref.operator "NoParams"
         # CHECK: qref.operator "NoParams"
-        # CHECK: func.func private @"__builtin_rule_NoParams{}{reg:2}{}"
+        # CHECK: func.func private @"__builtin_rule_{op = \22NoParams\22, wires = [2]}"
         # CHECK-SAME:   resources = {operations = {
-        # CHECK-SAME:   "SingleParam{x:[tensor<2xf64>]}{reg:2}{}" = 1 : i64,
-        # CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:2}{}" = 2 : i64
-        # CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
-        # CHECK: func.func private @"__builtin_rule_NoParams{}{reg:3}{}"
+        # CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<2xf64>]], wires = [2]}" = 1 : i64,
+        # CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [2]}" = 2 : i64
+        # CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [2]}"
+        # CHECK: func.func private @"__builtin_rule_{op = \22NoParams\22, wires = [3]}"
         # CHECK-SAME:   resources = {operations = {
-        # CHECK-SAME:   "SingleParam{x:[tensor<2xf64>]}{reg:2}{}" = 1 : i64,
-        # CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:2}{}" = 2 : i64
-        # CHECK-SAME:   target_gate = "NoParams{}{reg:3}{}"
+        # CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<2xf64>]], wires = [2]}" = 1 : i64,
+        # CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [2]}" = 2 : i64
+        # CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [3]}"
         test_multiple_gates_different_ids()
 
 
@@ -174,25 +174,25 @@ def test_multiple_rules_same_gate():
 # CHECK: qref.operator "NoParams"
 # CHECK: qref.operator "NoParams"
 # CHECK: qref.operator "NoParams"
-# CHECK: func.func private @"__builtin_rule1_NoParams{}{reg:2}{}"
+# CHECK: func.func private @"__builtin_rule1_{op = \22NoParams\22, wires = [2]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:2}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
-# CHECK: func.func private @"__builtin_rule2_NoParams{}{reg:2}{}"
+# CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [2]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [2]}"
+# CHECK: func.func private @"__builtin_rule2_{op = \22NoParams\22, wires = [2]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "SingleParam{x:[tensor<2xf64>]}{reg:1}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
+# CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<2xf64>]], wires = [1]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [2]}"
 #
-# CHECK-NOT: func.func private @"__builtin_rule1_NoParams{}{reg:2}{}"
+# CHECK-NOT: func.func private @"__builtin_rule1_{op = \22NoParams\22, wires = [2]}"
 #
-# CHECK: func.func private @"__builtin_rule1_NoParams{}{reg:3}{}"
+# CHECK: func.func private @"__builtin_rule1_{op = \22NoParams\22, wires = [3]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:2}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "NoParams{}{reg:3}{}"
-# CHECK: func.func private @"__builtin_rule2_NoParams{}{reg:3}{}"
+# CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [2]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [3]}"
+# CHECK: func.func private @"__builtin_rule2_{op = \22NoParams\22, wires = [3]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "SingleParam{x:[tensor<2xf64>]}{reg:1}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "NoParams{}{reg:3}{}"
+# CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<2xf64>]], wires = [1]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [3]}"
 test_multiple_rules_same_gate()
 
 
@@ -227,14 +227,14 @@ def test_multiple_rules_chained():
 
 # CHECK-LABEL: func.func public @chained_rule()
 # CHECK: qref.operator "NoParams"
-# CHECK: func.func private @"__builtin_rule1_NoParams{}{reg:2}{}"
+# CHECK: func.func private @"__builtin_rule1_{op = \22NoParams\22, wires = [2]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
-# CHECK: func.func private @"__builtin_rule2_SingleParam{x:[tensor<f64>]}{reg:1}{}"
+# CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [1]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [2]}"
+# CHECK: func.func private @"__builtin_rule2_{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [1]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "CompilableData{}{wires:1}{a:a,b:b,thing:thing}" = 1 : i64
-# CHECK-SAME:   target_gate = "SingleParam{x:[tensor<f64>]}{reg:1}{}"
+# CHECK-SAME:   "{op = \22CompilableData\22, static = {a = \22a\22, b = \22b\22, thing = \22thing\22}, wires = [1]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [1]}"
 test_multiple_rules_chained()
 
 
@@ -280,18 +280,18 @@ def test_multiple_rules_chained_and_branch():
 
 # CHECK-LABEL: func.func public @chained_branched()
 # CHECK: qref.operator "NoParams"
-# CHECK: func.func private @"__builtin_ruleAB_NoParams{}{reg:2}{}"
+# CHECK: func.func private @"__builtin_ruleAB_{op = \22NoParams\22, wires = [2]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
-# CHECK: func.func private @"__builtin_ruleBC_SingleParam{x:[tensor<f64>]}{reg:1}{}"
+# CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [1]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [2]}"
+# CHECK: func.func private @"__builtin_ruleBC_{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [1]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "CompilableData{}{wires:1}{a:a,b:b,thing:thing}" = 1 : i64
-# CHECK-SAME:   target_gate = "SingleParam{x:[tensor<f64>]}{reg:1}{}"
-# CHECK: func.func private @"__builtin_ruleBD_SingleParam{x:[tensor<f64>]}{reg:1}{}"
+# CHECK-SAME:   "{op = \22CompilableData\22, static = {a = \22a\22, b = \22b\22, thing = \22thing\22}, wires = [1]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [1]}"
+# CHECK: func.func private @"__builtin_ruleBD_{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [1]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "CompilableData{}{wires:1}{a:alpha,b:beta,thing:stuff}" = 1 : i64
-# CHECK-SAME:   target_gate = "SingleParam{x:[tensor<f64>]}{reg:1}{}"
+# CHECK-SAME:   "{op = \22CompilableData\22, static = {a = \22alpha\22, b = \22beta\22, thing = \22stuff\22}, wires = [1]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [1]}"
 test_multiple_rules_chained_and_branch()
 
 
@@ -337,22 +337,22 @@ def test_with_cycles():
 
 # CHECK-LABEL: func.func public @cycle()
 # CHECK: qref.operator "NoParams"
-# CHECK: func.func private @"__builtin_ruleAB_NoParams{}{reg:2}{}"
+# CHECK: func.func private @"__builtin_ruleAB_{op = \22NoParams\22, wires = [2]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
-# CHECK: func.func private @"__builtin_ruleBC_SingleParam{x:[tensor<f64>]}{reg:1}{}"
+# CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [1]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [2]}"
+# CHECK: func.func private @"__builtin_ruleBC_{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [1]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "CompilableData{}{wires:1}{a:a,b:b,thing:thing}" = 1 : i64
-# CHECK-SAME:   target_gate = "SingleParam{x:[tensor<f64>]}{reg:1}{}"
-# CHECK: func.func private @"__builtin_ruleCA_CompilableData{}{wires:1}{a:a,b:b,thing:thing}"
+# CHECK-SAME:   "{op = \22CompilableData\22, static = {a = \22a\22, b = \22b\22, thing = \22thing\22}, wires = [1]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [1]}"
+# CHECK: func.func private @"__builtin_ruleCA_{op = \22CompilableData\22, static = {a = \22a\22, b = \22b\22, thing = \22thing\22}, wires = [1]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "NoParams{}{reg:2}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "CompilableData{}{wires:1}{a:a,b:b,thing:thing}"
-# CHECK: func.func private @"__builtin_ruleAB_NoParams{}{reg:3}{}"
+# CHECK-SAME:   "{op = \22NoParams\22, wires = [2]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22CompilableData\22, static = {a = \22a\22, b = \22b\22, thing = \22thing\22}, wires = [1]}"
+# CHECK: func.func private @"__builtin_ruleAB_{op = \22NoParams\22, wires = [3]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "NoParams{}{reg:3}{}"
+# CHECK-SAME:   "{op = \22SingleParam\22, params = [{{\[}}tensor<f64>]], wires = [1]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [3]}"
 test_with_cycles()
 
 
@@ -418,10 +418,10 @@ def test_to_multiple_full_args_op():
 
 # CHECK-LABEL: func.func public @to_full_args()
 # CHECK: qref.operator "NoParams"
-# CHECK: func.func private @"__builtin_rule_NoParams{}{reg:3}{}"
+# CHECK: func.func private @"__builtin_rule_{op = \22NoParams\22, wires = [3]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "MultipleFullArgs{angles1:[tensor<f64>],angles2:[tensor<2xf64>]}{reg1:1,reg2:2}{}[[[uid:[0-9]+]]]" = 2 : i64
-# CHECK-SAME:   target_gate = "NoParams{}{reg:3}{}"
+# CHECK-SAME:   "{op = \22MultipleFullArgs\22, params = [{{\[}}tensor<f64>], [tensor<2xf64>]], uid = [[uid:[0-9]+]] : i64, wires = [1, 2]}" = 2 : i64
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [3]}"
 # CHECK: qref.operator "MultipleFullArgs"
 # CHECK-NEXT:  UID([[uid]]
 # CHECK: qref.operator "MultipleFullArgs"
@@ -474,10 +474,10 @@ def test_from_multiple_full_args_op():
 # CHECK:   param_map = {angles1 = [0], angles2 = [1]}
 # CHECK-SAME:  qubit_map = {hwires1 = [4, 5], hwires2 = [6], op1 = [2], op2 = [3], reg1 = [0], reg2 = [1]}
 #
-# CHECK: func.func private @"__builtin_rule_MultipleFullArgs{angles1:[tensor<f64>],angles2:[tensor<f64>]}{hwires1:2,hwires2:1,op1:1,op2:1,reg1:1,reg2:1}{}[[[uid]]]"
+# CHECK: func.func private @"__builtin_rule_{op = \22MultipleFullArgs\22, params = [{{\[}}tensor<f64>], [tensor<f64>]], uid = [[uid]] : i64, wires = [1, 1, 1, 1, 2, 1]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "NoParams{}{reg:1}{}" = 2 : i64
-# CHECK-SAME:   target_gate = "MultipleFullArgs{angles1:[tensor<f64>],angles2:[tensor<f64>]}{hwires1:2,hwires2:1,op1:1,op2:1,reg1:1,reg2:1}{}[[[uid]]]"
+# CHECK-SAME:   "{op = \22NoParams\22, wires = [1]}" = 2 : i64
+# CHECK-SAME:   target_gate = "{op = \22MultipleFullArgs\22, params = [{{\[}}tensor<f64>], [tensor<f64>]], uid = [[uid]] : i64, wires = [1, 1, 1, 1, 2, 1]}"
 test_from_multiple_full_args_op()
 
 
@@ -507,10 +507,10 @@ def test_to_custom_op():
 
 # CHECK-LABEL: func.func public @to_custom()
 # CHECK: qref.operator "NoParams"
-# CHECK: func.func private @"__builtin_rule_NoParams{}{reg:3}{}"
+# CHECK: func.func private @"__builtin_rule_{op = \22NoParams\22, wires = [3]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "SingleParamCustomOp{0:[f64]}{wires:1}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "NoParams{}{reg:3}{}"
+# CHECK-SAME:   "{op = \22SingleParamCustomOp\22, params = [{{\[}}f64]], wires = [1]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [3]}"
 # CHECK: qref.custom "SingleParamCustomOp"
 test_to_custom_op()
 
@@ -541,10 +541,10 @@ def test_from_custom_op():
 
 # CHECK-LABEL: func.func public @from_custom()
 # CHECK: qref.custom "SingleParamCustomOp"
-# CHECK: func.func private @"__builtin_rule_SingleParamCustomOp{0:[f64]}{wires:2}{}"
+# CHECK: func.func private @"__builtin_rule_{op = \22SingleParamCustomOp\22, params = [{{\[}}f64]], wires = [2]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "NoParams{}{reg:1}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "SingleParamCustomOp{0:[f64]}{wires:2}{}"
+# CHECK-SAME:   "{op = \22NoParams\22, wires = [1]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22SingleParamCustomOp\22, params = [{{\[}}f64]], wires = [2]}"
 # CHECK: qref.operator "NoParams"
 test_from_custom_op()
 
@@ -578,18 +578,18 @@ def test_rule_with_helper_function():
 # CHECK-LABEL: func.func public @with_helper()
 # CHECK: qref.operator "NoParams"
 # CHECK: qref.operator "NoParams"
-# CHECK: func.func private @"__builtin_rule_NoParams{}{reg:1}{}"
+# CHECK: func.func private @"__builtin_rule_{op = \22NoParams\22, wires = [1]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "MultiParams{a:[tensor<f64>],b:[tensor<f64>],c:[tensor<f64>]}{reg:1}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "NoParams{}{reg:1}{}"
+# CHECK-SAME:   "{op = \22MultiParams\22, params = [{{\[}}tensor<f64>], [tensor<f64>], [tensor<f64>]], wires = [1]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [1]}"
 # CHECK: stablehlo.constant dense<4.200000e+00> : tensor<f64>
 # CHECK-NOT: call
 # CHECK-NOT: my_helper
 #
-# CHECK: func.func private @"__builtin_rule_NoParams{}{reg:2}{}"
+# CHECK: func.func private @"__builtin_rule_{op = \22NoParams\22, wires = [2]}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "MultiParams{a:[tensor<f64>],b:[tensor<f64>],c:[tensor<f64>]}{reg:1}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
+# CHECK-SAME:   "{op = \22MultiParams\22, params = [{{\[}}tensor<f64>], [tensor<f64>], [tensor<f64>]], wires = [1]}" = 1 : i64
+# CHECK-SAME:   target_gate = "{op = \22NoParams\22, wires = [2]}"
 # CHECK: stablehlo.constant dense<4.200000e+00> : tensor<f64>
 # CHECK-NOT: call
 # CHECK-NOT: my_helper
@@ -608,10 +608,10 @@ def test_phaseshift_to_rz():
 
 
 # CHECK-LABEL: test_phaseshift
-# CHECK: func.func private @"__builtin__phaseshift_to_rz_gp
+# CHECK: func.func private @"__builtin__phaseshift_to_rz_gp_{op = \22PhaseShift\22, params = [{{\[}}f64]], wires = [1]}"
 # CHECK-SAME: resources = {operations = {
-# CHECK-SAME: GlobalPhase{phi:[f64]}{}{}
-# CHECK-SAME: RZ{0:[f64]}{wires:1}{}
+# CHECK-SAME: "{op = \22GlobalPhase\22, params = [{{\[}}f64]], wires = [0]}"
+# CHECK-SAME: "{op = \22RZ\22, params = [{{\[}}f64]], wires = [1]}"
 # CHECK: qref.custom "RZ"
 # CHECK: qref.gphase
 test_phaseshift_to_rz()
@@ -636,6 +636,6 @@ def test_basis_rotation():
 
 
 # CHECK-LABEL: test_basis_rotation
-# CHECK: func.func private @"__builtin__basis_rotation_decomp_BasisRotation{unitary_matrix:[tensor<2x2xcomplex<f64>>]}{wires:2}{check:False}"
-# CHECK-SAME: target_gate = "BasisRotation{unitary_matrix:[tensor<2x2xcomplex<f64>>]}{wires:2}{check:False}"
+# CHECK: func.func private @"__builtin__basis_rotation_decomp_{op = \22BasisRotation\22, params = [{{\[}}tensor<2x2xcomplex<f64>>]], static = {check = false}, wires = [2]}"
+# CHECK-SAME: target_gate = "{op = \22BasisRotation\22, params = [{{\[}}tensor<2x2xcomplex<f64>>]], static = {check = false}, wires = [2]}"
 test_basis_rotation()

--- a/frontend/test/lit/test_operator2/test_lower_time_rules_adjoint.py
+++ b/frontend/test/lit/test_operator2/test_lower_time_rules_adjoint.py
@@ -68,9 +68,9 @@ def test_plain_gate_captures_base_and_adjoint():
     #   2. rule registered on Adjoint(..) -> target Adjoint(NoParams), two SingleParam
     #   3. synthesized (adjointed base)   -> target Adjoint(NoParams), one Adjoint(SingleParam)
     # CHECK: qref.operator "NoParams"()
-    # CHECK-DAG: func.func private @"__builtin_base_rule_NoParams{}{reg:2}{}"{{.*}}"SingleParam{{.*}}target_gate = "NoParams{}{reg:2}{}"
-    # CHECK-DAG: func.func private @"__builtin_adj_rule_Adjoint(NoParams){}{reg:2}{}"{{.*}}"SingleParam{{.*}} = 2 : i64{{.*}}target_gate = "Adjoint(NoParams){}{reg:2}{}"
-    # CHECK-DAG: func.func private @"__builtin_base_rule_Adjoint(NoParams){}{reg:2}{}"{{.*}}"Adjoint(SingleParam{{.*}}target_gate = "Adjoint(NoParams){}{reg:2}{}"
+    # CHECK-DAG: func.func private @"__builtin_base_rule_{op = \22NoParams\22, wires = [2]}"{{.*}}"{op = \22SingleParam\22{{.*}}target_gate = "{op = \22NoParams\22
+    # CHECK-DAG: func.func private @"__builtin_adj_rule_{op = \22NoParams\22, traits = {adj = true}, wires = [2]}"{{.*}}"{op = \22SingleParam\22{{.*}} = 2 : i64{{.*}}target_gate = "{op = \22NoParams\22, traits = {adj = true}
+    # CHECK-DAG: func.func private @"__builtin_base_rule_{op = \22NoParams\22, traits = {adj = true}, wires = [2]}"{{.*}}"{op = \22SingleParam\22{{.*}}traits = {adj = true}{{.*}}target_gate = "{op = \22NoParams\22, traits = {adj = true}
 
 
 test_plain_gate_captures_base_and_adjoint()
@@ -94,9 +94,9 @@ def test_adjoint_gate_captures_adjoint_rule():
     # keys off the base name `NoParams` regardless of the op-level adjoint modifier, so it always
     # explores NoParams + Adjoint(NoParams). Only the circuit body differs (the op carries `adj`).
     # CHECK: qref.operator "NoParams"() adj
-    # CHECK-DAG: func.func private @"__builtin_base_rule_NoParams{}{reg:2}{}"{{.*}}"SingleParam{{.*}}target_gate = "NoParams{}{reg:2}{}"
-    # CHECK-DAG: func.func private @"__builtin_adj_rule_Adjoint(NoParams){}{reg:2}{}"{{.*}}"SingleParam{{.*}} = 2 : i64{{.*}}target_gate = "Adjoint(NoParams){}{reg:2}{}"
-    # CHECK-DAG: func.func private @"__builtin_base_rule_Adjoint(NoParams){}{reg:2}{}"{{.*}}"Adjoint(SingleParam{{.*}}target_gate = "Adjoint(NoParams){}{reg:2}{}"
+    # CHECK-DAG: func.func private @"__builtin_base_rule_{op = \22NoParams\22, wires = [2]}"{{.*}}"{op = \22SingleParam\22{{.*}}target_gate = "{op = \22NoParams\22
+    # CHECK-DAG: func.func private @"__builtin_adj_rule_{op = \22NoParams\22, traits = {adj = true}, wires = [2]}"{{.*}}"{op = \22SingleParam\22{{.*}} = 2 : i64{{.*}}target_gate = "{op = \22NoParams\22, traits = {adj = true}
+    # CHECK-DAG: func.func private @"__builtin_base_rule_{op = \22NoParams\22, traits = {adj = true}, wires = [2]}"{{.*}}"{op = \22SingleParam\22{{.*}}traits = {adj = true}{{.*}}target_gate = "{op = \22NoParams\22, traits = {adj = true}
 
 
 test_adjoint_gate_captures_adjoint_rule()

--- a/frontend/test/lit/test_operator2/test_lower_time_rules_ctrl.py
+++ b/frontend/test/lit/test_operator2/test_lower_time_rules_ctrl.py
@@ -53,8 +53,8 @@ def controlled_op():
     return qp.state()
 
 
-# CHECK-DAG: target_gate = "S{}{wires:1}{}"
-# CHECK-DAG: target_gate = "C(S){}{wires:1}{}"
+# CHECK-DAG: target_gate = "{op = \22S\22, wires = [1]}"
+# CHECK-DAG: target_gate = "{op = \22S\22, traits = {controls = 1 : i64}, wires = [1]}"
 print(controlled_op.mlir)
 
 
@@ -68,8 +68,8 @@ def controlled_adjoint_op():
     return qp.state()
 
 
-# CHECK-DAG: target_gate = "Adjoint(S){}{wires:1}{}"
-# CHECK-DAG: target_gate = "C(Adjoint(S)){}{wires:1}{}"
+# CHECK-DAG: target_gate = "{op = \22S\22, traits = {adj = true}, wires = [1]}"
+# CHECK-DAG: target_gate = "{op = \22S\22, traits = {adj = true, controls = 1 : i64}, wires = [1]}"
 print(controlled_adjoint_op.mlir)
 
 
@@ -83,5 +83,5 @@ def controlled_op_fixed():
     return qp.state()
 
 
-# CHECK-DAG: target_gate = "C(S){}{wires:1}{}"
+# CHECK-DAG: target_gate = "{op = \22S\22, traits = {controls = 1 : i64}, wires = [1]}"
 print(controlled_op_fixed.mlir)

--- a/frontend/test/lit/test_operator2/test_on_demand_rules_adjoint.py
+++ b/frontend/test/lit/test_operator2/test_on_demand_rules_adjoint.py
@@ -27,6 +27,7 @@ from pennylane.typing import Float, Wire
 from catalyst.decomposition.decomposition_rules import (
     compile_reachable_decomposition_rules_wrapper,
 )
+from catalyst.decomposition.graph_op_id import build_graph_op_key
 
 
 def _base_rule():
@@ -61,16 +62,19 @@ def test_on_demand_adjoint_id_routes_to_adjoint_rules():
         qp.add_decomps(NoParams, _base_rule())
         qp.add_decomps("Adjoint(NoParams)", _adj_rule())
 
+        adjoint_id = build_graph_op_key(
+            "NoParams", {}, {"reg": 2}, {}, adjoint=True
+        )
         out = compile_reachable_decomposition_rules_wrapper(
-            "NoParams", "Adjoint(NoParams){}{reg:2}{}", {}, {"reg": 2}, {}, is_custom_op=False
+            "NoParams", adjoint_id, {}, {"reg": 2}, {}, is_custom_op=False
         )
 
         print(out)
 
     # CHECK: module {
-    # CHECK-DAG: func.func private @"__builtin_base_rule_NoParams{}{reg:2}{}"{{.*}}"SingleParam{{.*}}target_gate = "NoParams{}{reg:2}{}"
-    # CHECK-DAG: func.func private @"__builtin_adj_rule_Adjoint(NoParams){}{reg:2}{}"{{.*}}"SingleParam{{.*}} = 2 : i64{{.*}}target_gate = "Adjoint(NoParams){}{reg:2}{}"
-    # CHECK-DAG: func.func private @"__builtin_base_rule_Adjoint(NoParams){}{reg:2}{}"{{.*}}"Adjoint(SingleParam{{.*}}target_gate = "Adjoint(NoParams){}{reg:2}{}"
+    # CHECK-DAG: func.func private @"__builtin_base_rule_{op = \22NoParams\22, wires = [2]}"{{.*}}"{op = \22SingleParam\22{{.*}}target_gate = "{op = \22NoParams\22
+    # CHECK-DAG: func.func private @"__builtin_adj_rule_{op = \22NoParams\22, traits = {adj = true}, wires = [2]}"{{.*}}"{op = \22SingleParam\22{{.*}} = 2 : i64{{.*}}target_gate = "{op = \22NoParams\22, traits = {adj = true}
+    # CHECK-DAG: func.func private @"__builtin_base_rule_{op = \22NoParams\22, traits = {adj = true}, wires = [2]}"{{.*}}"{op = \22SingleParam\22{{.*}}traits = {adj = true}{{.*}}target_gate = "{op = \22NoParams\22, traits = {adj = true}
     # CHECK: qref.adjoint
 
 

--- a/frontend/test/lit/test_operator2/test_on_demand_rules_adjoint.py
+++ b/frontend/test/lit/test_operator2/test_on_demand_rules_adjoint.py
@@ -62,9 +62,7 @@ def test_on_demand_adjoint_id_routes_to_adjoint_rules():
         qp.add_decomps(NoParams, _base_rule())
         qp.add_decomps("Adjoint(NoParams)", _adj_rule())
 
-        adjoint_id = build_graph_op_key(
-            "NoParams", {}, {"reg": 2}, {}, adjoint=True
-        )
+        adjoint_id = build_graph_op_key("NoParams", {}, {"reg": 2}, {}, adjoint=True)
         out = compile_reachable_decomposition_rules_wrapper(
             "NoParams", adjoint_id, {}, {"reg": 2}, {}, is_custom_op=False
         )

--- a/frontend/test/lit/test_operator2/test_special_ops_decomp.py
+++ b/frontend/test/lit/test_operator2/test_special_ops_decomp.py
@@ -51,10 +51,10 @@ def test_multirz():
 # CHECK: func.func public @multirz()
 # CHECK: qref.multirz({{%.+}}) {{%.+}}, {{%.+}} : !qref.bit, !qref.bit
 # CHECK: qref.multirz({{%.+}}) {{%.+}} : !qref.bit
-# CHECK: func.func private @"__builtin__multi_rz_decomposition_MultiRZ{theta:[f64]}{wires:2}{}"
-# CHECK-SAME:   target_gate = "MultiRZ{theta:[f64]}{wires:2}{}"
-# CHECK: func.func private @"__builtin__multi_rz_decomposition_MultiRZ{theta:[f64]}{wires:1}{}"
-# CHECK-SAME:   target_gate = "MultiRZ{theta:[f64]}{wires:1}{}"
+# CHECK: func.func private @"__builtin__multi_rz_decomposition_{op = \22MultiRZ\22, params = [{{\[}}f64]], wires = [2]}"
+# CHECK-SAME:   target_gate = "{op = \22MultiRZ\22, params = [{{\[}}f64]], wires = [2]}"
+# CHECK: func.func private @"__builtin__multi_rz_decomposition_{op = \22MultiRZ\22, params = [{{\[}}f64]], wires = [1]}"
+# CHECK-SAME:   target_gate = "{op = \22MultiRZ\22, params = [{{\[}}f64]], wires = [1]}"
 test_multirz()
 
 
@@ -78,12 +78,12 @@ def test_paulirot():
 # CHECK: qref.paulirot ["X", "X"]({{%.+}}) {{%.+}}, {{%.+}} : !qref.bit, !qref.bit
 # CHECK: qref.paulirot ["Z"]({{%.+}}) {{%.+}} : !qref.bit
 # CHECK: qref.paulirot ["Y", "Z", "X"]({{%.+}}) {{%.+}}, {{%.+}}, {{%.+}} : !qref.bit, !qref.bit, !qref.bit
-# CHECK: func.func private @"__builtin__pauli_rot_decomposition_PauliRot{theta:[f64]}{wires:2}{pauli_word:XX}"
-# CHECK-SAME:   target_gate = "PauliRot{theta:[f64]}{wires:2}{pauli_word:XX}"
-# CHECK: func.func private @"__builtin__pauli_rot_decomposition_PauliRot{theta:[f64]}{wires:1}{pauli_word:Z}"
-# CHECK-SAME:   target_gate = "PauliRot{theta:[f64]}{wires:1}{pauli_word:Z}"
-# CHECK: func.func private @"__builtin__pauli_rot_decomposition_PauliRot{theta:[f64]}{wires:3}{pauli_word:YZX}"
-# CHECK-SAME:   target_gate = "PauliRot{theta:[f64]}{wires:3}{pauli_word:YZX}"
+# CHECK: func.func private @"__builtin__pauli_rot_decomposition_{op = \22PauliRot\22, params = [{{\[}}f64]], static = {pauli_word = \22XX\22}, wires = [2]}"
+# CHECK-SAME:   target_gate = "{op = \22PauliRot\22, params = [{{\[}}f64]], static = {pauli_word = \22XX\22}, wires = [2]}"
+# CHECK: func.func private @"__builtin__pauli_rot_decomposition_{op = \22PauliRot\22, params = [{{\[}}f64]], static = {pauli_word = \22Z\22}, wires = [1]}"
+# CHECK-SAME:   target_gate = "{op = \22PauliRot\22, params = [{{\[}}f64]], static = {pauli_word = \22Z\22}, wires = [1]}"
+# CHECK: func.func private @"__builtin__pauli_rot_decomposition_{op = \22PauliRot\22, params = [{{\[}}f64]], static = {pauli_word = \22YZX\22}, wires = [3]}"
+# CHECK-SAME:   target_gate = "{op = \22PauliRot\22, params = [{{\[}}f64]], static = {pauli_word = \22YZX\22}, wires = [3]}"
 test_paulirot()
 
 
@@ -105,10 +105,10 @@ def test_pcphase():
 # CHECK: func.func public @pcphase()
 # CHECK: qref.pcphase({{%.+}}, dim : 3) {{%.+}}, {{%.+}}, {{%.+}} : !qref.bit, !qref.bit, !qref.bit
 # CHECK: qref.pcphase({{%.+}}, dim : 0) {{%.+}} : !qref.bit
-# CHECK: func.func private @"__builtin__decompose_pcphase_PCPhase{phi:[f64]}{wires:3}{dim:3}"
-# CHECK-SAME:   target_gate = "PCPhase{phi:[f64]}{wires:3}{dim:3}"
-# CHECK: func.func private @"__builtin__decompose_pcphase_PCPhase{phi:[f64]}{wires:1}{dim:0}"
-# CHECK-SAME:   target_gate = "PCPhase{phi:[f64]}{wires:1}{dim:0}"
+# CHECK: func.func private @"__builtin__decompose_pcphase_{op = \22PCPhase\22, params = [{{\[}}f64]], static = {dim = 3 : i64}, wires = [3]}"
+# CHECK-SAME:   target_gate = "{op = \22PCPhase\22, params = [{{\[}}f64]], static = {dim = 3 : i64}, wires = [3]}"
+# CHECK: func.func private @"__builtin__decompose_pcphase_{op = \22PCPhase\22, params = [{{\[}}f64]], static = {dim = 0 : i64}, wires = [1]}"
+# CHECK-SAME:   target_gate = "{op = \22PCPhase\22, params = [{{\[}}f64]], static = {dim = 0 : i64}, wires = [1]}"
 test_pcphase()
 
 
@@ -133,23 +133,23 @@ def test_qubit_unitary():
 # CHECK: qref.unitary({{%.+}} : tensor<4x4xcomplex<f64>>)
 # CHECK: qref.unitary({{%.+}} : tensor<8x8xcomplex<f64>>)
 #
-# CHECK: func.func private @"__builtin_zyz_QubitUnitary{U:[tensor<2x2xcomplex<f64>>]}{wires:1}{}"
-# CHECK-SAME:   target_gate = "QubitUnitary{U:[tensor<2x2xcomplex<f64>>]}{wires:1}{}"
+# CHECK: func.func private @"__builtin_zyz_{op = \22QubitUnitary\22, params = [{{\[}}tensor<2x2xcomplex<f64>>]], wires = [1]}"
+# CHECK-SAME:   target_gate = "{op = \22QubitUnitary\22, params = [{{\[}}tensor<2x2xcomplex<f64>>]], wires = [1]}"
 #
-# CHECK: func.func private @"__builtin_zxz_QubitUnitary{U:[tensor<2x2xcomplex<f64>>]}{wires:1}{}"
-# CHECK-SAME:   target_gate = "QubitUnitary{U:[tensor<2x2xcomplex<f64>>]}{wires:1}{}"
+# CHECK: func.func private @"__builtin_zxz_{op = \22QubitUnitary\22, params = [{{\[}}tensor<2x2xcomplex<f64>>]], wires = [1]}"
+# CHECK-SAME:   target_gate = "{op = \22QubitUnitary\22, params = [{{\[}}tensor<2x2xcomplex<f64>>]], wires = [1]}"
 #
-# CHECK: func.func private @"__builtin_xzx_QubitUnitary{U:[tensor<2x2xcomplex<f64>>]}{wires:1}{}"
-# CHECK-SAME:   target_gate = "QubitUnitary{U:[tensor<2x2xcomplex<f64>>]}{wires:1}{}"
+# CHECK: func.func private @"__builtin_xzx_{op = \22QubitUnitary\22, params = [{{\[}}tensor<2x2xcomplex<f64>>]], wires = [1]}"
+# CHECK-SAME:   target_gate = "{op = \22QubitUnitary\22, params = [{{\[}}tensor<2x2xcomplex<f64>>]], wires = [1]}"
 #
-# CHECK: func.func private @"__builtin_xyx_QubitUnitary{U:[tensor<2x2xcomplex<f64>>]}{wires:1}{}"
-# CHECK-SAME:   target_gate = "QubitUnitary{U:[tensor<2x2xcomplex<f64>>]}{wires:1}{}"
+# CHECK: func.func private @"__builtin_xyx_{op = \22QubitUnitary\22, params = [{{\[}}tensor<2x2xcomplex<f64>>]], wires = [1]}"
+# CHECK-SAME:   target_gate = "{op = \22QubitUnitary\22, params = [{{\[}}tensor<2x2xcomplex<f64>>]], wires = [1]}"
 #
-# CHECK: func.func private @"__builtin_two_qubit_decomp_rule_QubitUnitary{U:[tensor<4x4xcomplex<f64>>]}{wires:2}{}"
-# CHECK-SAME:   target_gate = "QubitUnitary{U:[tensor<4x4xcomplex<f64>>]}{wires:2}{}"
+# CHECK: func.func private @"__builtin_two_qubit_decomp_rule_{op = \22QubitUnitary\22, params = [{{\[}}tensor<4x4xcomplex<f64>>]], wires = [2]}"
+# CHECK-SAME:   target_gate = "{op = \22QubitUnitary\22, params = [{{\[}}tensor<4x4xcomplex<f64>>]], wires = [2]}"
 #
-# CHECK: func.func private @"__builtin_multi_qubit_decomp_rule_QubitUnitary{U:[tensor<8x8xcomplex<f64>>]}{wires:3}{}"
-# CHECK-SAME:   target_gate = "QubitUnitary{U:[tensor<8x8xcomplex<f64>>]}{wires:3}{}"
+# CHECK: func.func private @"__builtin_multi_qubit_decomp_rule_{op = \22QubitUnitary\22, params = [{{\[}}tensor<8x8xcomplex<f64>>]], wires = [3]}"
+# CHECK-SAME:   target_gate = "{op = \22QubitUnitary\22, params = [{{\[}}tensor<8x8xcomplex<f64>>]], wires = [3]}"
 test_qubit_unitary()
 
 
@@ -196,8 +196,8 @@ def test_basis_state():
 # CHECK:   static_data = {}
 # CHECK:   param_map = {state = [0]} qubit_map = {wires = [0, 1]}
 #
-# CHECK: func.func private @"__builtin__basis_state_decomp_BasisState{state:[tensor<1xi1>]}{wires:1}{}"
-# CHECK-SAME:   target_gate = "BasisState{state:[tensor<1xi1>]}{wires:1}{}"
-# CHECK: func.func private @"__builtin__basis_state_decomp_BasisState{state:[tensor<2xi1>]}{wires:2}{}"
-# CHECK-SAME:   target_gate = "BasisState{state:[tensor<2xi1>]}{wires:2}{}"
+# CHECK: func.func private @"__builtin__basis_state_decomp_{op = \22BasisState\22, params = [{{\[}}tensor<1xi1>]], wires = [1]}"
+# CHECK-SAME:   target_gate = "{op = \22BasisState\22, params = [{{\[}}tensor<1xi1>]], wires = [1]}"
+# CHECK: func.func private @"__builtin__basis_state_decomp_{op = \22BasisState\22, params = [{{\[}}tensor<2xi1>]], wires = [2]}"
+# CHECK-SAME:   target_gate = "{op = \22BasisState\22, params = [{{\[}}tensor<2xi1>]], wires = [2]}"
 test_basis_state()

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -17,6 +17,7 @@
 import jax.numpy as jnp
 import pennylane as qp
 import pytest
+from jax._src.lib.mlir import ir
 from jax.core import ShapedArray
 from operator2_dummy_gates import (
     CompilableData,
@@ -48,12 +49,38 @@ from catalyst.decomposition.decomposition_rules import (
     name_wrap_adjoint,
     wrap_modifier_id,
 )
-from catalyst.decomposition.graph_op_id import GraphOpID
+from catalyst.decomposition.graph_op_id import GraphOpID, build_graph_op_key
 from catalyst.decomposition.type_utils import (
     convert_item_to_mlir_type,
     get_dummy_values_for_arg,
     replace_wires_with_placeholder_wires,
 )
+
+
+def _key(
+    base_name,
+    dynamic_types=None,
+    wire_lengths=None,
+    static_data=None,
+    *,
+    adjoint=False,
+    num_controls=0,
+    uid=None,
+):
+    return build_graph_op_key(
+        base_name,
+        dynamic_types or {},
+        wire_lengths or {},
+        static_data or {},
+        adjoint=adjoint,
+        num_controls=num_controls,
+        uid=uid,
+    )
+
+
+def _mlir_string(value):
+    with ir.Context():
+        return str(ir.StringAttr.get(value))
 
 
 class TestGenericUtilities:
@@ -142,47 +169,126 @@ class TestGenericUtilities:
         assert convert_item_to_mlir_type(item, is_special_lowering) == mlir_type
 
     @pytest.mark.parametrize(
-        "op, id",
+        "op, base_name, dynamic_types, wire_lengths, static_data",
         [
-            (NoParams(Wires(0)), "NoParams{}{reg:1}{}"),
-            (NoParamsCustomOp(Wires([0, 1])), "NoParamsCustomOp{}{wires:2}{}"),
-            (SingleParam(Float, Wires([2, 3])), "SingleParam{x:[tensor<f64>]}{reg:2}{}"),
+            (NoParams(Wires(0)), "NoParams", {}, {"reg": 1}, {}),
+            (NoParamsCustomOp(Wires([0, 1])), "NoParamsCustomOp", {}, {"wires": 2}, {}),
+            (
+                SingleParam(Float, Wires([2, 3])),
+                "SingleParam",
+                {"x": ["tensor<f64>"]},
+                {"reg": 2},
+                {},
+            ),
             (
                 CompilableData(True, 3.14, "string", Wires([0, 1])),
-                "CompilableData{}{wires:2}{a:True,b:3.14,thing:string}",
+                "CompilableData",
+                {},
+                {"wires": 2},
+                {"a": True, "b": 3.14, "thing": "string"},
             ),
             (
                 MultipleRegisters(Wires([0, 1, 2]), Wires([3, 4])),
-                "MultipleRegisters{}{reg1:3,reg2:2}{}",
+                "MultipleRegisters",
+                {},
+                {"reg1": 3, "reg2": 2},
+                {},
             ),
             (
                 MultiParams(Wires([0, 2, 3]), Complex, Int, Float[2]),
-                "MultiParams{a:[tensor<complex<f64>>],b:[tensor<i64>],c:[tensor<2xf64>]}{reg:3}",
+                "MultiParams",
+                {
+                    "a": ["tensor<complex<f64>>"],
+                    "b": ["tensor<i64>"],
+                    "c": ["tensor<2xf64>"],
+                },
+                {"reg": 3},
+                {},
             ),
-            (qp.MultiRZ(Float, Wires([0, 2, 3, 4])), "MultiRZ{theta:[f64]}{wires:4}{}"),
+            (
+                qp.MultiRZ(Float, Wires([0, 2, 3, 4])),
+                "MultiRZ",
+                {"theta": ["f64"]},
+                {"wires": 4},
+                {},
+            ),
             (
                 qp.PauliRot(Float, "XYZ", Wires([1, 2, 3])),
-                "PauliRot{theta:[f64]}{wires:3}{pauli_word:XYZ}",
+                "PauliRot",
+                {"theta": ["f64"]},
+                {"wires": 3},
+                {"pauli_word": "XYZ"},
             ),
-            (StaticData("mylabel", Wires([0, 1])), "StaticData{}{reg:2}{}["),
+            (StaticData("mylabel", Wires([0, 1])), "StaticData", {}, {"reg": 2}, {}),
             (
                 HybridWires(Wires([0, 1, 2])),
-                "HybridWires{}{}{}[",
-            ),  # NOTE: open brace to match uid
+                "HybridWires",
+                {},
+                {},
+                {},
+            ),
             (
                 HybridOpArg(Float, StaticData("innerop", Wires(0)), Wires([2, 3]), 12),
-                "HybridOpArg{angle:[tensor<f64>]}{cwires:2}{}[",  # NOTE: open brace to match uid
+                "HybridOpArg",
+                {"angle": ["tensor<f64>"]},
+                {"cwires": 2},
+                {},
             ),
             (
                 qp.Rot(Bool, Int, Float, Wires(0)),
-                "Rot{0:[f64],1:[f64],2:[f64]}{wires:1}{}",
-            ),  # custom ops should be promoted to f64
+                "Rot",
+                {"0": ["f64"], "1": ["f64"], "2": ["f64"]},
+                {"wires": 1},
+                {},
+            ),
         ],
     )
-    def test_GraphOpId(self, op, id):
+    def test_GraphOpId(self, op, base_name, dynamic_types, wire_lengths, static_data):
         """Test that GraphOpIds are generated correctly by the frontend."""
-        # NOTE: use startswith to match ops with uids/extra_data
-        assert GraphOpID(op).getGraphOpId().startswith(id)
+        graph_op_id = GraphOpID(op)
+        expected = build_graph_op_key(
+            base_name,
+            dynamic_types,
+            wire_lengths,
+            static_data,
+            uid=graph_op_id.uid if graph_op_id.extra_data else None,
+        )
+        assert graph_op_id.getGraphOpId() == expected
+
+    def test_build_graph_op_key_canonical_typed_payload(self):
+        """Match the typed C++ ``OperatorOpQubits`` fixture byte-for-byte."""
+        assert build_graph_op_key(
+            "testInterfaceOp",
+            {"flag": ["i1"], "angle": ["f64"], "index": ["i64"]},
+            {"wire1": 1, "wire2": 1},
+            {
+                "myDelimitedString": "a,b{c}",
+                "myStaticArray": [1, 2, 3],
+                "myStaticBool": True,
+                "myStaticFloat": 3.14,
+                "myStaticInt": 4,
+                "myStaticString": "Test",
+            },
+        ) == (
+            '{op = "testInterfaceOp", params = [[i1], [f64], [i64]], '
+            "static = "
+            '{myDelimitedString = "a,b{c}", myStaticArray = [1, 2, 3], myStaticBool = true, '
+            "myStaticFloat = 3.140000e+00 : f64, myStaticInt = 4 : i64, myStaticString = "
+            '"Test"}, wires = [1, 1]}'
+        )
+
+    def test_build_graph_op_key_uses_position_not_argument_names(self):
+        """Argument renaming does not change identity, while argument reordering does."""
+        original = build_graph_op_key(
+            "Op", {"angle": ["f64"], "index": ["i64"]}, {"left": 1, "right": 2}, {}
+        )
+        renamed = build_graph_op_key("Op", {"x": ["f64"], "y": ["i64"]}, {"a": 1, "b": 2}, {})
+        reordered = build_graph_op_key(
+            "Op", {"index": ["i64"], "angle": ["f64"]}, {"right": 2, "left": 1}, {}
+        )
+
+        assert original == renamed
+        assert original != reordered
 
     def test_wrapper_operator(self, mocker):
         """Test that compile_decomposition_rules_wrapper doesn't error on Operator1 instances."""
@@ -194,7 +300,7 @@ class TestGenericUtilities:
 
         with pytest.warns(RuleLoweringWarning, match="Failed to get resources"):
             res = compile_decomposition_rules_wrapper(
-                "MockOp", 'MockOp{}{"wires":1}{}', {}, {"wires": 1}, {}
+                "MockOp", _key("MockOp", wire_lengths={"wires": 1}), {}, {"wires": 1}, {}
             )
         assert isinstance(res, str)
 
@@ -212,7 +318,11 @@ class TestGenericUtilities:
 
         res = compile_decomposition_rules_wrapper(
             "CompilableData",
-            "CompilableData{}{wires:2}{a:True,b:3.14,thing:string}",
+            _key(
+                "CompilableData",
+                wire_lengths={"wires": 2},
+                static_data={"a": True, "b": 3.14, "thing": "string"},
+            ),
             {},
             {"wires": 2},
             {"a": True, "b": 3.14, "thing": "string"},
@@ -273,8 +383,10 @@ class TestTraceTime:
 
             mlir = circuit.mlir
 
-        assert 'target_gate = "NoParams{}{reg:2}{}"' in mlir
-        assert 'target_gate = "Adjoint(NoParams){}{reg:2}{}"' in mlir
+        base_id = _key("NoParams", wire_lengths={"reg": 2})
+        adjoint_id = _key("NoParams", wire_lengths={"reg": 2}, adjoint=True)
+        assert f"target_gate = {_mlir_string(base_id)}" in mlir
+        assert f"target_gate = {_mlir_string(adjoint_id)}" in mlir
 
     @pytest.mark.filterwarnings("ignore::catalyst.decomposition.RuleLoweringWarning")
     def test_adjoint_gate_captures_base_and_adjoint(self):
@@ -296,8 +408,10 @@ class TestTraceTime:
             mlir = circuit.mlir
 
         assert 'qref.operator "NoParams"() adj' in mlir
-        assert 'target_gate = "NoParams{}{reg:2}{}"' in mlir
-        assert 'target_gate = "Adjoint(NoParams){}{reg:2}{}"' in mlir
+        base_id = _key("NoParams", wire_lengths={"reg": 2})
+        adjoint_id = _key("NoParams", wire_lengths={"reg": 2}, adjoint=True)
+        assert f"target_gate = {_mlir_string(base_id)}" in mlir
+        assert f"target_gate = {_mlir_string(adjoint_id)}" in mlir
 
     @pytest.mark.filterwarnings("ignore::catalyst.decomposition.RuleLoweringWarning")
     def test_distribution_rule_synthesized_from_base_only(self):
@@ -318,13 +432,18 @@ class TestTraceTime:
 
             mlir = circuit.mlir
 
-        assert 'target_gate = "NoParams{}{reg:2}{}"' in mlir
+        base_id = _key("NoParams", wire_lengths={"reg": 2})
+        adjoint_id = _key("NoParams", wire_lengths={"reg": 2}, adjoint=True)
+        assert f"target_gate = {_mlir_string(base_id)}" in mlir
         # A distribution rule for Adjoint(NoParams) is synthesized even though none was registered.
-        assert 'target_gate = "Adjoint(NoParams){}{reg:2}{}"' in mlir
-        assert (
-            'resources = {operations = {"Adjoint(SingleParam){x:[tensor<f64>]}{reg:2}{}" = 1 : i64}'
-            in mlir
+        assert f"target_gate = {_mlir_string(adjoint_id)}" in mlir
+        resource_id = _key(
+            "SingleParam",
+            {"x": ["tensor<f64>"]},
+            {"reg": 2},
+            adjoint=True,
         )
+        assert _mlir_string(resource_id) in mlir
         assert "qref.adjoint" in mlir
 
     @pytest.mark.filterwarnings("ignore::catalyst.decomposition.RuleLoweringWarning")
@@ -352,8 +471,10 @@ class TestTraceTime:
 
             mlir = circuit.mlir
 
-        assert 'target_gate = "NoParams{}{reg:2}{}"' in mlir
-        assert 'target_gate = "Adjoint(NoParams){}{reg:2}{}"' not in mlir
+        base_id = _key("NoParams", wire_lengths={"reg": 2})
+        adjoint_id = _key("NoParams", wire_lengths={"reg": 2}, adjoint=True)
+        assert f"target_gate = {_mlir_string(base_id)}" in mlir
+        assert f"target_gate = {_mlir_string(adjoint_id)}" not in mlir
 
 
 class TestOnDemand:
@@ -362,17 +483,32 @@ class TestOnDemand:
     """
 
     @pytest.mark.parametrize(
-        "op_name, op_id, expected",
+        "op_name, op_id, expected, is_adjoint",
         [
-            ("S", "S{}{wires:1}{}", "S{}{wires:1}{}"),
-            ("S", "Adjoint(S){}{wires:1}{}", "S{}{wires:1}{}"),
-            ("RX", "Adjoint(RX){0:[f64]}{wires:1}{}", "RX{0:[f64]}{wires:1}{}"),
+            (
+                "S",
+                _key("S", wire_lengths={"wires": 1}),
+                _key("S", wire_lengths={"wires": 1}),
+                False,
+            ),
+            (
+                "S",
+                _key("S", wire_lengths={"wires": 1}, adjoint=True),
+                _key("S", wire_lengths={"wires": 1}),
+                True,
+            ),
+            (
+                "RX",
+                _key("RX", {"0": ["f64"]}, {"wires": 1}, adjoint=True),
+                _key("RX", {"0": ["f64"]}, {"wires": 1}),
+                True,
+            ),
         ],
     )
-    def test_name_unwrap_adjoint(self, op_name, op_id, expected):
+    def test_name_unwrap_adjoint(self, op_name, op_id, expected, is_adjoint):
         """name_unwrap_adjoint recovers the base op's id from an adjoint graphOpId, and is the
         inverse of name_wrap_adjoint for a base id."""
-        if op_id.startswith("Adjoint("):
+        if is_adjoint:
             assert name_unwrap_adjoint(op_name, op_id) == expected
             assert name_wrap_adjoint(expected) == op_id
         else:
@@ -382,9 +518,24 @@ class TestOnDemand:
     @pytest.mark.parametrize(
         "op_name, op_id, expected_base_id, expected_n_ctrl",
         [
-            ("RX", "C(RX){0:[f64]}{wires:1}{}", "RX{0:[f64]}{wires:1}{}", 1),
-            ("RX", "2C(RX){0:[f64]}{wires:1}{}", "RX{0:[f64]}{wires:1}{}", 2),
-            ("S", "10C(S){}{wires:1}{}", "S{}{wires:1}{}", 10),  # multi-digit control count
+            (
+                "RX",
+                _key("RX", {"0": ["f64"]}, {"wires": 1}, num_controls=1),
+                _key("RX", {"0": ["f64"]}, {"wires": 1}),
+                1,
+            ),
+            (
+                "RX",
+                _key("RX", {"0": ["f64"]}, {"wires": 1}, num_controls=2),
+                _key("RX", {"0": ["f64"]}, {"wires": 1}),
+                2,
+            ),
+            (
+                "S",
+                _key("S", wire_lengths={"wires": 1}, num_controls=10),
+                _key("S", wire_lengths={"wires": 1}),
+                10,
+            ),
         ],
     )
     def test_name_unwrap_control(self, op_name, op_id, expected_base_id, expected_n_ctrl):
@@ -398,15 +549,18 @@ class TestOnDemand:
         """A non-controlled id is rejected for the given base op."""
 
         with pytest.raises(ValueError, match="not a control id"):
-            name_unwrap_control("RX", "Adjoint(RX){0:[f64]}{wires:1}{}")
+            name_unwrap_control("RX", _key("RX", {"0": ["f64"]}, {"wires": 1}, adjoint=True))
 
     @pytest.mark.filterwarnings("ignore::catalyst.decomposition.RuleLoweringWarning")
     @pytest.mark.parametrize(
         "op_id, extra_ctrl_target",
         [
-            ("C(S){}{wires:1}{}", None),
+            (_key("S", wire_lengths={"wires": 1}, num_controls=1), None),
             # A multi-controlled id recovers n_ctrl=2 and additionally synthesizes the n=1 variant.
-            ("2C(S){}{wires:1}{}", 'target_gate = "C(S){}{wires:1}{}"'),
+            (
+                _key("S", wire_lengths={"wires": 1}, num_controls=2),
+                _key("S", wire_lengths={"wires": 1}, num_controls=1),
+            ),
         ],
     )
     def test_reachable_wrapper_controlled_op(self, op_id, extra_ctrl_target):
@@ -419,10 +573,10 @@ class TestOnDemand:
         )
         assert module_str.lstrip().startswith("module")
 
-        assert f'target_gate = "{op_id}"' in module_str
-        assert 'target_gate = "S{}{wires:1}{}"' in module_str
+        assert f"target_gate = {_mlir_string(op_id)}" in module_str
+        assert f"target_gate = {_mlir_string(_key('S', wire_lengths={'wires': 1}))}" in module_str
         if extra_ctrl_target is not None:
-            assert extra_ctrl_target in module_str
+            assert f"target_gate = {_mlir_string(extra_ctrl_target)}" in module_str
 
     @pytest.mark.filterwarnings("ignore::catalyst.decomposition.RuleLoweringWarning")
     def test_control_variant_warns_and_skips_on_failure(self, mocker):
@@ -433,7 +587,13 @@ class TestOnDemand:
         mocker.patch.object(dr, "compile_decomposition_rules", side_effect=ValueError("boom"))
         with pytest.warns(RuleLoweringWarning, match="control rules"):
             out = dr.control_variant_rule_strings(
-                "S", "S{}{wires:1}{}", [1], {}, {"wires": 1}, {}, is_custom_op=True
+                "S",
+                _key("S", wire_lengths={"wires": 1}),
+                [1],
+                {},
+                {"wires": 1},
+                {},
+                is_custom_op=True,
             )
         assert out == []
 
@@ -457,12 +617,11 @@ class TestModifierIds:
     @pytest.mark.parametrize(
         "op_id, expected",
         [
-            ("Adjoint(RX){0:[f64]}{wires:1}{}", "Adjoint"),
-            ("C(RX){0:[f64]}{wires:1}{}", "C"),
-            ("2C(RX){0:[f64]}{wires:1}{}", "C"),  # exercises the leading-digit scan
-            ("10C(RX){0:[f64]}{wires:1}{}", "C"),  # multi-digit control count
-            ("RX{0:[f64]}{wires:1}{}", None),  # bare id, no modifier
-            ("", None),  # empty edge case
+            (_key("RX", {"0": ["f64"]}, {"wires": 1}, adjoint=True), "Adjoint"),
+            (_key("RX", {"0": ["f64"]}, {"wires": 1}, num_controls=1), "C"),
+            (_key("RX", {"0": ["f64"]}, {"wires": 1}, num_controls=2), "C"),
+            (_key("RX", {"0": ["f64"]}, {"wires": 1}, num_controls=10), "C"),
+            (_key("RX", {"0": ["f64"]}, {"wires": 1}), None),
         ],
     )
     def test_leading_modifier_kind(self, op_id, expected):
@@ -472,18 +631,44 @@ class TestModifierIds:
     @pytest.mark.parametrize(
         "op_id, modifier, expected",
         [
-            # Wrapping a bare id with each modifier kind.
-            ("RX{0:[f64]}{wires:1}{}", "C", "C(RX){0:[f64]}{wires:1}{}"),
-            ("RX{0:[f64]}{wires:1}{}", "2C", "2C(RX){0:[f64]}{wires:1}{}"),
-            ("RX{0:[f64]}{wires:1}{}", "Adjoint", "Adjoint(RX){0:[f64]}{wires:1}{}"),
+            (
+                _key("RX", {"0": ["f64"]}, {"wires": 1}),
+                "C",
+                _key("RX", {"0": ["f64"]}, {"wires": 1}, num_controls=1),
+            ),
+            (
+                _key("RX", {"0": ["f64"]}, {"wires": 1}),
+                "2C",
+                _key("RX", {"0": ["f64"]}, {"wires": 1}, num_controls=2),
+            ),
+            (
+                _key("RX", {"0": ["f64"]}, {"wires": 1}),
+                "Adjoint",
+                _key("RX", {"0": ["f64"]}, {"wires": 1}, adjoint=True),
+            ),
             # Canonical nesting: control is outermost, so C may wrap an already-adjointed id.
             (
-                "Adjoint(RX){0:[f64]}{wires:1}{}",
+                _key("RX", {"0": ["f64"]}, {"wires": 1}, adjoint=True),
                 "C",
-                "C(Adjoint(RX)){0:[f64]}{wires:1}{}",
+                _key(
+                    "RX",
+                    {"0": ["f64"]},
+                    {"wires": 1},
+                    adjoint=True,
+                    num_controls=1,
+                ),
             ),
-            # Only the name is wrapped; the `{...}...[uid]` suffix is carried through untouched.
-            ("HybridOp{a:[[f64]]}{w:1}{}[42]", "C", "C(HybridOp){a:[[f64]]}{w:1}{}[42]"),
+            (
+                _key("HybridOp", {"a": ["tensor<f64>"]}, {"w": 1}, uid=42),
+                "C",
+                _key(
+                    "HybridOp",
+                    {"a": ["tensor<f64>"]},
+                    {"w": 1},
+                    num_controls=1,
+                    uid=42,
+                ),
+            ),
         ],
     )
     def test_wrap_modifier_id_canonical(self, op_id, modifier, expected):
@@ -492,7 +677,10 @@ class TestModifierIds:
 
     @pytest.mark.parametrize(
         "op_id",
-        ["C(RX){0:[f64]}{wires:1}{}", "2C(RX){0:[f64]}{wires:1}{}"],
+        [
+            _key("RX", {"0": ["f64"]}, {"wires": 1}, num_controls=1),
+            _key("RX", {"0": ["f64"]}, {"wires": 1}, num_controls=2),
+        ],
     )
     def test_wrap_modifier_id_rejects_non_canonical(self, op_id):
         """Wrapping the canonically-inner ``Adjoint`` around an already-controlled id is rejected."""

--- a/mlir/include/Quantum/IR/QuantumInterfaces.h
+++ b/mlir/include/Quantum/IR/QuantumInterfaces.h
@@ -31,7 +31,7 @@ namespace quantum {
 
 std::string defaultGetGraphOpId(mlir::Operation *op);
 
-}
+} // namespace quantum
 } // namespace catalyst
 
 #include "Quantum/IR/QuantumInterfaces.h.inc"

--- a/mlir/include/Quantum/IR/QuantumInterfaces.td
+++ b/mlir/include/Quantum/IR/QuantumInterfaces.td
@@ -207,17 +207,14 @@ def DecomposableGate : OpInterface<"DecomposableGate", [QuantumGate]> {
         >,
         InterfaceMethod<
             "Return a string representation of any additional data an operator may need to provide"
-            " for uniqueness (ex. UID), or emptystring if not applicable.",
+            " for uniqueness (ex. UID), or an empty string if not applicable.",
             "std::string", "getExtraData", (ins), [{}], [{ return ""; }]
         >,
         InterfaceMethod<
             "Return the operation's ID for use with the graph. "
-            "This should be computed by the following convention:\n"
-            "```\n"
-            "name + {map params to list of types} + {map wire args to number of wires} + {static data} + [extra data]\n"
-            "```\n"
-            "Note that extra data is currently specific to `OperatorOp`s, and should only appear when present."
-            "Each of these maps should be sorted lexicographically by key."
+            "Dynamic parameter type groups and wire lengths are identified positionally in "
+            "frontend-signature/operand order; frontend argument names are not part of identity. "
+            "Note that extra data is currently specific to `OperatorOp`s, and should only appear when present. "
             "In general, this should be computed by the default here and not overridden.",
             "std::string", "getGraphOpId", (ins), [{}], [{ return ::catalyst::quantum::defaultGetGraphOpId($_op.getOperation()); }]
         >

--- a/mlir/lib/Quantum/IR/QuantumInterfaces.cpp
+++ b/mlir/lib/Quantum/IR/QuantumInterfaces.cpp
@@ -15,16 +15,20 @@
 #include "Quantum/IR/QuantumInterfaces.h"
 
 #include <cstddef>
+#include <cstdint>
+#include <limits>
 #include <string>
+#include <utility>
 
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/StringMap.h"
-#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Types.h"
 #include "mlir/Support/LLVM.h"
+
+#include "Quantum/IR/QuantumOps.h"
 
 using namespace mlir;
 using namespace catalyst::quantum;
@@ -37,72 +41,151 @@ using namespace catalyst::quantum;
 
 namespace {
 
-void printAttr(mlir::Attribute attr, llvm::raw_string_ostream &ss) {
-    llvm::TypeSwitch<mlir::Attribute, void>(attr)
-        .Case<mlir::DictionaryAttr>([&](mlir::DictionaryAttr dict) {
-            ss << "{";
-            for (auto [i, entry] : llvm::enumerate(dict)) {
-                if (i > 0) {
-                    ss << ",";
-                }
-
-                ss << entry.getName().str() << ":";
-                printAttr(entry.getValue(), ss);
-            }
-            ss << "}";
-        })
-        .Case<mlir::ArrayAttr>([&](mlir::ArrayAttr arr) {
-            ss << "[";
-            for (auto [i, attr] : llvm::enumerate(arr)) {
-                if (i > 0) {
-                    ss << ",";
-                }
-                printAttr(attr, ss);
-            }
-            ss << "]";
-        })
-        .Case<mlir::StringAttr>([&](mlir::StringAttr attr) { ss << attr.str(); })
-        .Case<mlir::IntegerAttr>([&](mlir::IntegerAttr attr) { ss << attr.getInt(); })
-        .Case<mlir::FloatAttr>([&](mlir::FloatAttr attr) { ss << attr.getValueAsDouble(); })
-        .Default([&](mlir::Attribute attr) { attr.print(ss); });
+int64_t groupStartIndex(NamedAttribute entry) {
+    auto indices = cast<DenseI64ArrayAttr>(entry.getValue()).asArrayRef();
+    return indices.empty() ? std::numeric_limits<int64_t>::max() : *llvm::min_element(indices);
 }
 
-template <typename T, typename PrintFunc>
-void printSortedMap(const llvm::StringMap<T> &map, llvm::raw_string_ostream &ss,
-                    PrintFunc printValue) {
-    llvm::SmallVector<llvm::StringRef> keys;
-    for (const llvm::StringRef key : map.keys()) {
-        keys.push_back(key);
-    }
-    llvm::sort(keys);
+bool groupPrecedes(NamedAttribute lhs, NamedAttribute rhs) {
+    return std::pair(groupStartIndex(lhs), lhs.getName().getValue()) <
+           std::pair(groupStartIndex(rhs), rhs.getName().getValue());
+}
 
-    ss << "{";
-    for (auto [i, key] : llvm::enumerate(keys)) {
-        if (i > 0) {
-            ss << ",";
+SmallVector<NamedAttribute> getOrderedGroups(DictionaryAttr groups) {
+    SmallVector<NamedAttribute> ordered(groups.begin(), groups.end());
+    llvm::sort(ordered, groupPrecedes);
+    return ordered;
+}
+
+SmallVector<SmallVector<Type>> getOrderedDynamicTypes(DecomposableGate gate, Operation *op) {
+    if (auto custom = dyn_cast<CustomOp>(op)) {
+        SmallVector<SmallVector<Type>> result;
+        result.reserve(custom.getParams().size());
+        for (Value param : custom.getParams()) {
+            result.push_back({param.getType()});
         }
-        ss << key << ":";
-        printValue(map.lookup(key), ss);
+        return result;
     }
-    ss << "}";
-}
 
-void printDynamicShape(const llvm::StringMap<llvm::SmallVector<mlir::Type>> &map,
-                       llvm::raw_string_ostream &ss) {
-    printSortedMap(map, ss, [](const auto &types, llvm::raw_string_ostream &stream) {
-        stream << "[";
-        for (auto [j, type] : llvm::enumerate(types)) {
-            if (j > 0) {
-                stream << ",";
+    if (auto generic = dyn_cast<OperatorOp>(op)) {
+        SmallVector<NamedAttribute> groups = getOrderedGroups(generic.getParamMap());
+        SmallVector<SmallVector<Type>> result;
+        result.reserve(groups.size());
+        for (NamedAttribute group : groups) {
+            SmallVector<Type> types;
+            for (int64_t index : cast<DenseI64ArrayAttr>(group.getValue()).asArrayRef()) {
+                types.push_back(generic.getParams()[index].getType());
             }
-            stream << type;
+            result.push_back(std::move(types));
         }
-        stream << "]";
-    });
+        return result;
+    }
+
+    // Built-in decomposable operations currently have at most one parameter group. Sorting the
+    // fallback by name keeps future implementations deterministic until they expose operand order.
+    auto dynamicShape = gate.getDynamicShape();
+    SmallVector<StringRef> names;
+    names.reserve(dynamicShape.size());
+    for (const auto &[name, _] : dynamicShape) {
+        names.push_back(name);
+    }
+    llvm::sort(names);
+
+    SmallVector<SmallVector<Type>> result;
+    result.reserve(names.size());
+    for (StringRef name : names) {
+        result.push_back(dynamicShape.lookup(name));
+    }
+    return result;
 }
 
-void printWireLens(const llvm::StringMap<size_t> &map, llvm::raw_string_ostream &ss) {
-    printSortedMap(map, ss, [](size_t len, llvm::raw_string_ostream &stream) { stream << len; });
+SmallVector<size_t> getOrderedWireLengths(DecomposableGate gate, Operation *op) {
+    if (auto custom = dyn_cast<CustomOp>(op)) {
+        return {custom.getNonCtrlQubitOperands().size()};
+    }
+
+    if (auto generic = dyn_cast<OperatorOp>(op)) {
+        SmallVector<NamedAttribute> groups = getOrderedGroups(generic.getQubitMap());
+        auto wireLengths = gate.getWireLens();
+        SmallVector<size_t> result;
+        result.reserve(groups.size());
+        for (NamedAttribute group : groups) {
+            result.push_back(wireLengths.lookup(group.getName()));
+        }
+        return result;
+    }
+
+    auto wireLengths = gate.getWireLens();
+    SmallVector<StringRef> names;
+    names.reserve(wireLengths.size());
+    for (const auto &[name, _] : wireLengths) {
+        names.push_back(name);
+    }
+    llvm::sort(names);
+
+    SmallVector<size_t> result;
+    result.reserve(names.size());
+    for (StringRef name : names) {
+        result.push_back(wireLengths.lookup(name));
+    }
+    return result;
+}
+
+mlir::DictionaryAttr buildGraphOpKeyAttr(DecomposableGate gate, Operation *op) {
+    MLIRContext *context = op->getContext();
+    Builder builder(context);
+
+    SmallVector<Attribute> dynamicTypes;
+    for (const auto &types : getOrderedDynamicTypes(gate, op)) {
+        SmallVector<Attribute> typeNames;
+        typeNames.reserve(types.size());
+        for (Type type : types) {
+            typeNames.push_back(TypeAttr::get(type));
+        }
+        dynamicTypes.push_back(builder.getArrayAttr(typeNames));
+    }
+
+    SmallVector<Attribute> wireLengths;
+    for (size_t length : getOrderedWireLengths(gate, op)) {
+        wireLengths.push_back(builder.getI64IntegerAttr(length));
+    }
+
+    size_t numControls = 0;
+    if (auto quantumGate = mlir::dyn_cast<QuantumGate>(op)) {
+        numControls = quantumGate.getCtrlQubitOperands().size();
+    }
+
+    NamedAttrList fields;
+    fields.append("op", builder.getStringAttr(gate.getOperatorName()));
+    NamedAttrList traits;
+    if (op->hasAttr("adjoint")) {
+        traits.append("adj", builder.getBoolAttr(true));
+    }
+    if (!dynamicTypes.empty()) {
+        fields.append("params", builder.getArrayAttr(dynamicTypes));
+    }
+    if (numControls) {
+        traits.append("controls", builder.getI64IntegerAttr(numControls));
+    }
+    DictionaryAttr staticData = gate.getStaticData();
+    if (!staticData.empty()) {
+        fields.append("static", staticData);
+    }
+    if (!traits.empty()) {
+        fields.append("traits", traits.getDictionary(context));
+    }
+
+    if (std::string uid = gate.getExtraData(); !uid.empty()) {
+        uint64_t value = 0;
+        bool invalid = llvm::StringRef(uid).getAsInteger(10, value);
+        assert(!invalid && "DecomposableGate extra data must be an integer UID");
+        fields.append("uid", builder.getI64IntegerAttr(value));
+    }
+    if (!wireLengths.empty()) {
+        fields.append("wires", builder.getArrayAttr(wireLengths));
+    }
+
+    return fields.getDictionary(context);
 }
 
 } // namespace
@@ -114,49 +197,11 @@ void printWireLens(const llvm::StringMap<size_t> &map, llvm::raw_string_ostream 
 namespace catalyst {
 namespace quantum {
 
-// Wrap an operator's base name with its op-level modifiers (name-wrap), so that `Op`,
-// `Adjoint(Op)`, `C(Op)`, and nested combinations like `C(Adjoint(Op))` are distinct graph
-// identities. Modifiers are applied innermost-first in a canonical order (adjoint innermost,
-// control outermost) so a nested op has a single spelling.
-// An op that is both controlled and adjointed could otherwise be formed as
-// `C(Adjoint(Op))` or `Adjoint(C(Op))` which will produce two ids for one operator,
-// which would split the decomposition graph into two nodes and prevent rules from matching.
-// Always emitting the control-outermost form keeps such ops on a single node. The
-// caller appends the param/wire/static/uid groups. Extend this helper to support future op-level
-// modifiers, preserving the canonical order (mirror the Python side in decomposition_rules.py).
-static std::string wrapModifiers(std::string name, Operation *op) {
-    if (op->hasAttr("adjoint")) {
-        name = "Adjoint(" + name + ")";
-    }
-    if (auto gate = mlir::dyn_cast<QuantumGate>(op)) {
-        size_t numCtrl = gate.getCtrlQubitOperands().size();
-        if (numCtrl == 1) {
-            name = "C(" + name + ")";
-        } else if (numCtrl > 1) {
-            name = std::to_string(numCtrl) + "C(" + name + ")";
-        }
-    }
-    return name;
-}
-
 std::string defaultGetGraphOpId(Operation *op) {
-    std::string out;
-    llvm::raw_string_ostream ss(out);
-
     DecomposableGate gate = cast<DecomposableGate>(op);
-
-    // Fold op-level modifiers into the operator name so that `Op`, `Adjoint(Op)`, `C(Op)`, and
-    // nested combinations are distinct in the graphOpId. Modifiers wrap only the name; the
-    // param/wire/static/uid groups follow, e.g. `C(Adjoint(Rot)){...}{wires...}`.
-    ss << wrapModifiers(gate.getOperatorName(), op);
-    printDynamicShape(gate.getDynamicShape(), ss);
-    printWireLens(gate.getWireLens(), ss);
-    printAttr(gate.getStaticData(), ss);
-    if (gate.getExtraData() != "") {
-        ss << '[' << gate.getExtraData() << ']';
-    }
-    ss.flush();
-
+    std::string out;
+    llvm::raw_string_ostream stream(out);
+    buildGraphOpKeyAttr(gate, op).print(stream);
     return out;
 }
 

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
@@ -28,6 +28,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/DebugLog.h"
 #include "llvm/Support/raw_ostream.h"
+#include "mlir/AsmParser/AsmParser.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -75,6 +76,84 @@ namespace quantum {
 
 #define GEN_PASS_DEF_GRAPHDECOMPOSITIONPASS
 #include "Quantum/Transforms/Passes.h.inc"
+
+namespace {
+
+struct ParsedGraphOpId {
+    std::string baseName;
+    bool adjoint;
+    size_t numControls;
+
+    std::string getOperatorName() const {
+        std::string name = baseName;
+        if (adjoint) {
+            name = "Adjoint(" + name + ")";
+        }
+        if (numControls == 1) {
+            name = "C(" + name + ")";
+        } else if (numControls > 1) {
+            name = std::to_string(numControls) + "C(" + name + ")";
+        }
+        return name;
+    }
+};
+
+FailureOr<ParsedGraphOpId> parseGraphOpId(llvm::StringRef raw, MLIRContext *context) {
+    auto dictionary = dyn_cast_or_null<DictionaryAttr>(mlir::parseAttribute(raw, context));
+    if (!dictionary) {
+        return failure();
+    }
+
+    auto baseName = dictionary.getAs<StringAttr>("op");
+    auto traits = dictionary.getAs<DictionaryAttr>("traits");
+    auto adjoint = traits ? traits.getAs<BoolAttr>("adj") : BoolAttr();
+    auto numControls = traits ? traits.getAs<IntegerAttr>("controls") : IntegerAttr();
+    auto dynamicTypes = dictionary.getAs<ArrayAttr>("params");
+    auto wireLengths = dictionary.getAs<ArrayAttr>("wires");
+    auto staticData = dictionary.getAs<DictionaryAttr>("static");
+    auto uid = dictionary.getAs<IntegerAttr>("uid");
+    size_t knownFields = 1 + static_cast<size_t>(static_cast<bool>(traits)) +
+                         static_cast<size_t>(static_cast<bool>(dynamicTypes)) +
+                         static_cast<size_t>(static_cast<bool>(wireLengths)) +
+                         static_cast<size_t>(static_cast<bool>(staticData)) +
+                         static_cast<size_t>(static_cast<bool>(uid));
+    size_t knownTraits = static_cast<size_t>(static_cast<bool>(adjoint)) +
+                         static_cast<size_t>(static_cast<bool>(numControls));
+    if (!baseName || dictionary.size() != knownFields ||
+        (traits && (traits.empty() || traits.size() != knownTraits)) ||
+        (adjoint && !adjoint.getValue()) ||
+        (numControls &&
+         (!numControls.getType().isSignlessInteger(64) || numControls.getInt() <= 0)) ||
+        (dynamicTypes && dynamicTypes.empty()) || (wireLengths && wireLengths.empty()) ||
+        (staticData && staticData.empty())) {
+        return failure();
+    }
+
+    if (dynamicTypes) {
+        for (Attribute group : dynamicTypes) {
+            auto types = dyn_cast<ArrayAttr>(group);
+            if (!types || !llvm::all_of(types, llvm::IsaPred<TypeAttr>)) {
+                return failure();
+            }
+        }
+    }
+    if (wireLengths) {
+        for (Attribute value : wireLengths) {
+            auto length = dyn_cast<IntegerAttr>(value);
+            if (!length || !length.getType().isSignlessInteger(64) || length.getInt() < 0) {
+                return failure();
+            }
+        }
+    }
+    if (uid && (!uid.getType().isSignlessInteger(64) || uid.getInt() < 0)) {
+        return failure();
+    }
+
+    return ParsedGraphOpId{baseName.str(), adjoint ? adjoint.getValue() : false,
+                           numControls ? static_cast<size_t>(numControls.getInt()) : 0};
+}
+
+} // namespace
 
 struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDecompositionPass> {
     using GraphDecompositionPassBase::GraphDecompositionPassBase;
@@ -129,7 +208,9 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
         if (failed(getRuleNodes(bytecodeRulesFile, setOfRules, userRuleNames))) {
             return signalPassFailure();
         }
-        getOperators(setOfOps);
+        if (failed(getOperators(setOfOps))) {
+            return signalPassFailure();
+        }
 
         ///////////////////////////
         // Step 2: Build and solve the decomposition graph
@@ -329,12 +410,23 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
         // 3. Populate RuleNode
         RuleNode ruleNode;
         ruleNode.name = ruleName.str();
-        ruleNode.output = parseOperator(targetGateAttr.getValue());
+        FailureOr<OperatorNode> output = parseOperator(targetGateAttr.getValue());
+        if (failed(output)) {
+            rule.emitError() << "has malformed `target_gate` GraphOpID";
+            return failure();
+        }
+        ruleNode.output = std::move(*output);
 
         for (const auto &namedAttr : operations) {
             if (auto intAttr = mlir::dyn_cast<IntegerAttr>(namedAttr.getValue())) {
-                ruleNode.inputs.push_back({parseOperator(namedAttr.getName().strref()),
-                                           static_cast<uint32_t>(intAttr.getInt())});
+                FailureOr<OperatorNode> input = parseOperator(namedAttr.getName().strref());
+                if (failed(input)) {
+                    rule.emitError()
+                        << "has malformed resource GraphOpID " << namedAttr.getName().strref();
+                    return failure();
+                }
+                ruleNode.inputs.push_back(
+                    {std::move(*input), static_cast<uint32_t>(intAttr.getInt())});
             }
         }
 
@@ -492,18 +584,21 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
         return success();
     }
 
-    void getOperators(std::vector<OperatorNode> &operators) {
-        getOperation().walk([&](DecomposableGate op) {
+    LogicalResult getOperators(std::vector<OperatorNode> &operators) {
+        WalkResult result = getOperation().walk([&](DecomposableGate op) {
             if (DecompUtils::isInDecompRule(op)) {
-                return;
+                return WalkResult::advance();
             }
             assert(!op->getParentOfType<AdjointOp>() && !op->getParentOfType<CtrlOp>() &&
                    "graph-decomposition requires op-level modifiers: ctrl/adjoint regions must be "
                    "lowered before the decomposition graph is built");
 
-            // Derive the id and modifier-wrapped name from the single parse path, so operator nodes
-            // and rule nodes agree on the spelling of `C(...)`/`Adjoint(...)`.
-            OperatorNode node = parseOperator(op.getGraphOpId());
+            FailureOr<OperatorNode> parsed = parseOperator(op.getGraphOpId());
+            if (failed(parsed)) {
+                op.emitError("failed to parse generated GraphOpID");
+                return WalkResult::interrupt();
+            }
+            OperatorNode node = std::move(*parsed);
 
             // numWires/numParams are debug-only; parseOperator leaves them at defaults for the
             // graphOpId form, so we need to fill them accurately from the op here.
@@ -516,48 +611,26 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
             }
 
             operators.push_back(node);
+            return WalkResult::advance();
         });
+        return failure(result.wasInterrupted());
     }
 
     /**
      * @brief Parse a graphOpId string into an OperatorNode.
      *
-     * The graphOpId format is "<name>{params}{wires}{static}[uid]", where <name> already carries
-     * any name-wrapped op-level modifiers produced by `defaultGetGraphOpId`, e.g.
-     * "C(Adjoint(RX)){0:[f64]}{wires:1}{}".
+     * The GraphOpID is the canonical text of a dictionary attribute. The complete text remains the
+     * graph identity while the structured modifier fields determine the operator display name used
+     * for gate-set matching.
      */
-    OperatorNode parseOperator(llvm::StringRef raw) {
+    FailureOr<OperatorNode> parseOperator(llvm::StringRef raw) {
         OperatorNode node;
-
-        // Base op: either the graphOpId "Name{...}..." form or the legacy "Name(w,p)" form.
-        if (raw.contains('[') || raw.contains('{')) {
-            node.id = raw.str();
-            node.name = raw.take_until([](char c) { return c == '[' || c == '{'; });
-        } else {
-            auto openIdx = raw.find('(');
-            if (openIdx == llvm::StringRef::npos) {
-                node.name = raw.trim().str();
-                return node;
-            }
-            node.name = raw.take_front(openIdx).trim().str();
-            raw = raw.drop_front(openIdx); // leftover: "(w,p)" or "(w)"
+        FailureOr<ParsedGraphOpId> parsed = parseGraphOpId(raw, &getContext());
+        if (failed(parsed)) {
+            return failure();
         }
-
-        // Parse "(w,p)" (new) or "(w)" (legacy) suffix.
-        if (raw.consume_front("(") && raw.consume_back(")")) {
-            llvm::StringRef wStr, pStr;
-            std::tie(wStr, pStr) = raw.split(',');
-            int w = -1, p = -1;
-            if (!wStr.getAsInteger(10, w)) {
-                node.numWires = w;
-            }
-            if (!pStr.empty() && !pStr.getAsInteger(10, p)) {
-                node.numParams = p;
-            }
-            // If pStr is empty we were given the legacy "(w)" format; leave
-            // numParams at the wildcard default so old bytecode keeps working.
-        }
-
+        node.id = raw.str();
+        node.name = parsed->getOperatorName();
         return node;
     }
 

--- a/mlir/test/Catalyst/RegisterDecompRuleResourceTest.mlir
+++ b/mlir/test/Catalyst/RegisterDecompRuleResourceTest.mlir
@@ -17,7 +17,7 @@
 // Basic decomposition rule
 
 // CHECK: resources = {measurements = {}, num_alloc_qubits = 2 : i64, num_arg_qubits = 0 : i64, num_qubits = 2 : i64, 
-// CHECK-SAME: operations = {"CNOT{}{wires:2}{}" = 1 : i64, "Hadamard{}{wires:1}{}" = 1 : i64, "S{}{wires:1}{}" = 1 : i64, "T{}{wires:1}{}" = 1 : i64}}, target_gate = "basic"
+// CHECK-SAME: operations = {"{op = \22CNOT\22, wires = [2]}" = 1 : i64, "{op = \22Hadamard\22, wires = [1]}" = 1 : i64, "{op = \22S\22, wires = [1]}" = 1 : i64, "{op = \22T\22, wires = [1]}" = 1 : i64}}, target_gate = "basic"
 func.func @basic_gates() attributes {target_gate="basic"}  {
     %0 = quantum.alloc( 2) : !quantum.reg
     %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
@@ -59,7 +59,7 @@ func.func @pbc_operations() attributes {target_gate="pbc"} {
 // Rule with measure
 
 // CHECK: resources = {measurements = {}, num_alloc_qubits = 1 : i64, num_arg_qubits = 0 : i64, num_qubits = 1 : i64,
-// CHECK-SAME: operations = {"Hadamard{}{wires:1}{}" = 1 : i64, MidCircuitMeasure = 1 : i64}}, target_gate = "gate"
+// CHECK-SAME: operations = {MidCircuitMeasure = 1 : i64, "{op = \22Hadamard\22, wires = [1]}" = 1 : i64}}, target_gate = "gate"
 func.func @rule_mcm() attributes {target_gate="gate"} {
     %0 = quantum.alloc( 1) : !quantum.reg
     %1 = quantum.extract %0[ 0] : !quantum.reg -> !quantum.bit
@@ -91,7 +91,7 @@ func.func @rule(%arg0: !quantum.bit) -> !quantum.bit attributes {qnode, target_g
 
 // Rules with for loop (static)
 
-// CHECK: resources = {measurements = {}, num_alloc_qubits = 0 : i64, num_arg_qubits = 1 : i64, num_qubits = 1 : i64, operations = {"Hadamard{}{wires:1}{}" = 5 : i64}}
+// CHECK: resources = {measurements = {}, num_alloc_qubits = 0 : i64, num_arg_qubits = 1 : i64, num_qubits = 1 : i64, operations = {"{op = \22Hadamard\22, wires = [1]}" = 5 : i64}}
 func.func @rule_with_loop(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate="gate"} {
     %c5 = arith.constant 5 : index
     %c0 = arith.constant 0 : index
@@ -110,7 +110,7 @@ func.func @rule_with_loop(%arg0: !quantum.bit) -> !quantum.bit attributes {targe
 // Rules with branching (take max per op)
 
 // CHECK: resources = {measurements = {}, num_alloc_qubits = 0 : i64, num_arg_qubits = 1 : i64, num_qubits = 1 : i64, 
-// CHECK-SAME: operations = {"Hadamard{}{wires:1}{}" = 3 : i64, "PauliX{}{wires:1}{}" = 2 : i64}}
+// CHECK-SAME: operations = {"{op = \22Hadamard\22, wires = [1]}" = 3 : i64, "{op = \22PauliX\22, wires = [1]}" = 2 : i64}}
 func.func @rule_with_branching(%arg0: !quantum.bit, %cond: i1) -> !quantum.bit attributes {target_gate="gate"} {
     %q = scf.if %cond -> !quantum.bit {
         // True branch: 2 Hadamard, 1 PauliX
@@ -135,7 +135,7 @@ func.func @rule_with_branching(%arg0: !quantum.bit, %cond: i1) -> !quantum.bit a
 
 // Rules with static for loops
 
-// CHECK:  operations = {"PauliX{}{wires:1}{}" = 15 : i64}}
+// CHECK:  operations = {"{op = \22PauliX\22, wires = [1]}" = 15 : i64}}
 func.func @rule_with_nested_loop(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate="gate"} {
     %c3 = arith.constant 3 : index
     %c5 = arith.constant 5 : index
@@ -157,7 +157,7 @@ func.func @rule_with_nested_loop(%arg0: !quantum.bit) -> !quantum.bit attributes
 // -----
 
 // Rules with parametric ops
-// CHECK:  operations = {"2C(Adjoint(Rot)){0:[f64],1:[f64],2:[f64]}{wires:2}{}" = 1 : i64, "2C(Rot){0:[f64],1:[f64],2:[f64]}{wires:2}{}" = 1 : i64}
+// CHECK:  operations = {"{op = \22Rot\22, params = [{{\[}}f64], [f64], [f64]], traits = {adj = true, controls = 2 : i64}, wires = [2]}" = 1 : i64, "{op = \22Rot\22, params = [{{\[}}f64], [f64], [f64]], traits = {controls = 2 : i64}, wires = [2]}" = 1 : i64}
 func.func @rule_with_parametric_ops(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate="gate"} {
     %cst_0 = arith.constant 0.1 : f64
     %cst_1 = arith.constant 0.2 : f64

--- a/mlir/test/Quantum/AdjointDecompositionTest.mlir
+++ b/mlir/test/Quantum/AdjointDecompositionTest.mlir
@@ -27,7 +27,7 @@ func.func @self_adjoint(%q: !quantum.bit) -> !quantum.bit {
 }
 
 func.func private @adj_h(%q: !quantum.bit) -> !quantum.bit
-    attributes {target_gate = "Adjoint(Hadamard){}{wires:1}{}", llvm.linkage = #llvm.linkage<internal>} {
+    attributes {target_gate = "{op = \"Hadamard\", traits = {adj = true}, wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
   %o = quantum.custom "Hadamard"() %q : !quantum.bit
   return %o : !quantum.bit
 }
@@ -47,7 +47,7 @@ func.func @no_base_rule_fallback(%q: !quantum.bit, %theta: f64) -> !quantum.bit 
 }
 
 func.func private @plain_rx(%theta: f64, %q: !quantum.bit) -> !quantum.bit
-    attributes {target_gate = "RX", llvm.linkage = #llvm.linkage<internal>} {
+    attributes {target_gate = "{op = \"RX\", params = [[f64]], wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
   %o = quantum.custom "PauliX"() %q : !quantum.bit
   return %o : !quantum.bit
 }
@@ -67,7 +67,7 @@ func.func @parametric_negation(%q: !quantum.bit, %theta: f64) -> !quantum.bit {
 }
 
 func.func private @adj_rz(%theta: f64, %q: !quantum.bit) -> !quantum.bit
-    attributes {target_gate = "Adjoint(RZ){0:[f64]}{wires:1}{}", llvm.linkage = #llvm.linkage<internal>} {
+    attributes {target_gate = "{op = \"RZ\", params = [[f64]], traits = {adj = true}, wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
   %neg = arith.negf %theta : f64
   %o = quantum.custom "RZ"(%neg) %q : !quantum.bit
   return %o : !quantum.bit
@@ -92,13 +92,13 @@ func.func @distinct_from_base(%q0: !quantum.bit, %q1: !quantum.bit) -> (!quantum
 }
 
 func.func private @base_h(%q: !quantum.bit) -> !quantum.bit
-    attributes {target_gate = "Hadamard{}{wires:1}{}", llvm.linkage = #llvm.linkage<internal>} {
+    attributes {target_gate = "{op = \"Hadamard\", wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
   %o = quantum.custom "PauliX"() %q : !quantum.bit
   return %o : !quantum.bit
 }
 
 func.func private @adj_h2(%q: !quantum.bit) -> !quantum.bit
-    attributes {target_gate = "Adjoint(Hadamard){}{wires:1}{}", llvm.linkage = #llvm.linkage<internal>} {
+    attributes {target_gate = "{op = \"Hadamard\", traits = {adj = true}, wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
   %o = quantum.custom "PauliZ"() %q : !quantum.bit
   return %o : !quantum.bit
 }
@@ -118,7 +118,7 @@ func.func @non_self_adjoint(%q: !quantum.bit) -> !quantum.bit {
 }
 
 func.func private @adj_s(%q: !quantum.bit) -> !quantum.bit
-    attributes {target_gate = "Adjoint(S){}{wires:1}{}", llvm.linkage = #llvm.linkage<internal>} {
+    attributes {target_gate = "{op = \"S\", traits = {adj = true}, wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
   %angle = arith.constant -1.5707963267948966 : f64
   %o = quantum.custom "PhaseShift"(%angle) %q : !quantum.bit
   return %o : !quantum.bit
@@ -140,7 +140,7 @@ func.func @distribution(%q: !quantum.bit) -> !quantum.bit {
 }
 
 func.func private @adj_u(%q: !quantum.bit) -> !quantum.bit
-    attributes {target_gate = "Adjoint(U){}{wires:1}{}", llvm.linkage = #llvm.linkage<internal>} {
+    attributes {target_gate = "{op = \"U\", traits = {adj = true}, wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
   %a = quantum.custom "PauliX"() %q adj : !quantum.bit
   %b = quantum.custom "T"() %a adj : !quantum.bit
   %c = quantum.custom "Hadamard"() %b adj : !quantum.bit
@@ -148,19 +148,19 @@ func.func private @adj_u(%q: !quantum.bit) -> !quantum.bit
 }
 
 func.func private @adj_h3(%q: !quantum.bit) -> !quantum.bit
-    attributes {target_gate = "Adjoint(Hadamard){}{wires:1}{}", llvm.linkage = #llvm.linkage<internal>} {
+    attributes {target_gate = "{op = \"Hadamard\", traits = {adj = true}, wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
   %o = quantum.custom "Hadamard"() %q : !quantum.bit
   return %o : !quantum.bit
 }
 
 func.func private @adj_x(%q: !quantum.bit) -> !quantum.bit
-    attributes {target_gate = "Adjoint(PauliX){}{wires:1}{}", llvm.linkage = #llvm.linkage<internal>} {
+    attributes {target_gate = "{op = \"PauliX\", traits = {adj = true}, wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
   %o = quantum.custom "PauliX"() %q : !quantum.bit
   return %o : !quantum.bit
 }
 
 func.func private @adj_t(%q: !quantum.bit) -> !quantum.bit
-    attributes {target_gate = "Adjoint(T){}{wires:1}{}", llvm.linkage = #llvm.linkage<internal>} {
+    attributes {target_gate = "{op = \"T\", traits = {adj = true}, wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
   %angle = arith.constant -0.78539816339744828 : f64
   %o = quantum.custom "PhaseShift"(%angle) %q : !quantum.bit
   return %o : !quantum.bit
@@ -183,7 +183,7 @@ func.func @decomp_produces_adjoint(%q: !quantum.bit) -> !quantum.bit {
 }
 
 func.func private @mygate(%q: !quantum.bit) -> !quantum.bit
-    attributes {target_gate = "MyGate{}{wires:1}{}", llvm.linkage = #llvm.linkage<internal>} {
+    attributes {target_gate = "{op = \"MyGate\", wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
   %a = quantum.custom "Hadamard"() %q : !quantum.bit
   %b = quantum.custom "T"() %a adj : !quantum.bit
   %c = quantum.custom "Hadamard"() %b : !quantum.bit
@@ -191,7 +191,7 @@ func.func private @mygate(%q: !quantum.bit) -> !quantum.bit
 }
 
 func.func private @adj_t2(%q: !quantum.bit) -> !quantum.bit
-    attributes {target_gate = "Adjoint(T){}{wires:1}{}", llvm.linkage = #llvm.linkage<internal>} {
+    attributes {target_gate = "{op = \"T\", traits = {adj = true}, wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
   %angle = arith.constant -0.78539816339744828 : f64
   %o = quantum.custom "PhaseShift"(%angle) %q : !quantum.bit
   return %o : !quantum.bit

--- a/mlir/test/Quantum/CtrlDecompositionTest.mlir
+++ b/mlir/test/Quantum/CtrlDecompositionTest.mlir
@@ -26,7 +26,7 @@ func.func @controlled_id_match(%ctrl: !quantum.bit, %q: !quantum.bit) -> (!quant
 }
 
 func.func private @ctrl_u(%q: !quantum.bit, %ctrl: !quantum.bit, %cv: i1) -> (!quantum.bit, !quantum.bit)
-    attributes {target_gate = "C(U){}{wires:1}{}", llvm.linkage = #llvm.linkage<internal>} {
+    attributes {target_gate = "{op = \"U\", traits = {controls = 1 : i64}, wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
   %o, %oc = quantum.custom "Hadamard"() %q ctrls(%ctrl) ctrlvals(%cv) : !quantum.bit ctrls !quantum.bit
   return %o, %oc : !quantum.bit, !quantum.bit
 }
@@ -45,7 +45,7 @@ func.func @no_base_rule_fallback(%ctrl: !quantum.bit, %q: !quantum.bit, %theta: 
 }
 
 func.func private @plain_rx(%theta: f64, %q: !quantum.bit) -> !quantum.bit
-    attributes {target_gate = "RX", llvm.linkage = #llvm.linkage<internal>} {
+    attributes {target_gate = "{op = \"RX\", params = [[f64]], wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
   %o = quantum.custom "PauliX"() %q : !quantum.bit
   return %o : !quantum.bit
 }
@@ -68,13 +68,13 @@ func.func @distinct_from_base(%ctrl: !quantum.bit, %q0: !quantum.bit, %q1: !quan
 }
 
 func.func private @base_u(%q: !quantum.bit) -> !quantum.bit
-    attributes {target_gate = "U{}{wires:1}{}", llvm.linkage = #llvm.linkage<internal>} {
+    attributes {target_gate = "{op = \"U\", wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
   %o = quantum.custom "PauliX"() %q : !quantum.bit
   return %o : !quantum.bit
 }
 
 func.func private @ctrl_u2(%q: !quantum.bit, %ctrl: !quantum.bit, %cv: i1) -> (!quantum.bit, !quantum.bit)
-    attributes {target_gate = "C(U){}{wires:1}{}", llvm.linkage = #llvm.linkage<internal>} {
+    attributes {target_gate = "{op = \"U\", traits = {controls = 1 : i64}, wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
   %o, %oc = quantum.custom "PauliZ"() %q ctrls(%ctrl) ctrlvals(%cv) : !quantum.bit ctrls !quantum.bit
   return %o, %oc : !quantum.bit, !quantum.bit
 }

--- a/mlir/test/Quantum/DecomposeLoweringTargetRulesTest.mlir
+++ b/mlir/test/Quantum/DecomposeLoweringTargetRulesTest.mlir
@@ -18,21 +18,21 @@
 
 module @test_module {
     // CHECK: func.func private @my_X_decomp
-    func.func private @my_X_decomp(%q: !quantum.bit) -> !quantum.bit attributes {target_gate="X"} {
+    func.func private @my_X_decomp(%q: !quantum.bit) -> !quantum.bit attributes {target_gate="{op = \"X\", wires = [1]}"} {
         %angle = arith.constant 1.57 : f64
         %out = quantum.custom "RX"(%angle) %q : !quantum.bit
         return %out : !quantum.bit
     }
 
     // CHECK: func.func private @my_Y_decomp
-    func.func private @my_Y_decomp(%q: !quantum.bit) -> !quantum.bit attributes {target_gate="Y"} {
+    func.func private @my_Y_decomp(%q: !quantum.bit) -> !quantum.bit attributes {target_gate="{op = \"Y\", wires = [1]}"} {
         %angle = arith.constant 1.57 : f64
         %out = quantum.custom "RY"(%angle) %q : !quantum.bit
         return %out : !quantum.bit
     }
 
     // CHECK: func.func private @my_Z_decomp
-    func.func private @my_Z_decomp(%q: !quantum.bit) -> !quantum.bit attributes {target_gate="Z"} {
+    func.func private @my_Z_decomp(%q: !quantum.bit) -> !quantum.bit attributes {target_gate="{op = \"Z\", wires = [1]}"} {
         %angle = arith.constant 1.57 : f64
         %out = quantum.custom "RZ"(%angle) %q : !quantum.bit
         return %out : !quantum.bit

--- a/mlir/test/Quantum/DecomposeLoweringTest.mlir
+++ b/mlir/test/Quantum/DecomposeLoweringTest.mlir
@@ -43,7 +43,7 @@ module @two_hadamards {
 
   // Decomposition function should be retained for future passes
   // CHECK: func.func private @Hadamard_to_RY_decomp
-  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
+  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "{op = \"Hadamard\", wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
     %cst = arith.constant 3.1415926535897931 : f64
     %cst_0 = arith.constant 1.5707963267948966 : f64
     %out_qubits = quantum.custom "RZ"(%cst) %arg0 : !quantum.bit
@@ -77,7 +77,7 @@ module @single_hadamard {
 
   // Decomposition function should be retained for future passes
   // CHECK: func.func private @Hadamard_to_RY_decomp
-  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
+  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "{op = \"Hadamard\", wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
       %cst = arith.constant 3.1415926535897931 : f64
       %cst_0 = arith.constant 1.5707963267948966 : f64
       %out_qubits = quantum.custom "RZ"(%cst) %arg0 : !quantum.bit
@@ -118,14 +118,14 @@ module @recursive {
 
   // Decomposition function should be retained for future passes
   // CHECK: func.func private @Hadamard_to_RY_decomp
-  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
+  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "{op = \"Hadamard\", wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
     %out_qubits_0 = quantum.custom "RZRY"() %arg0 : !quantum.bit
     return %out_qubits_0 : !quantum.bit
   }
 
   // Decomposition function should be retained for future passes
   // CHECK: func.func private @RZRY_decomp
-  func.func private @RZRY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "RZRY", llvm.linkage = #llvm.linkage<internal>} {
+  func.func private @RZRY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "{op = \"RZRY\", wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
     %cst = arith.constant 3.1415926535897931 : f64
     %cst_0 = arith.constant 1.5707963267948966 : f64
     %out_qubits_1 = quantum.custom "RZ"(%cst) %arg0 : !quantum.bit
@@ -166,14 +166,14 @@ module @recursive {
 
   // Decomposition function should be retained for future passes
   // CHECK: func.func private @Hadamard_to_RY_decomp
-  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
+  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "{op = \"Hadamard\", wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
     %out_qubits_0 = quantum.custom "RZRY"() %arg0 : !quantum.bit
     return %out_qubits_0 : !quantum.bit
   }
 
   // Decomposition function should be retained for future passes
   // CHECK: func.func private @RZRY_decomp
-  func.func private @RZRY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "RZRY", llvm.linkage = #llvm.linkage<internal>} {
+  func.func private @RZRY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "{op = \"RZRY\", wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
     %cst = arith.constant 3.1415926535897931 : f64
     %cst_0 = arith.constant 1.5707963267948966 : f64
     %out_qubits_1 = quantum.custom "RZ"(%cst) %arg0 : !quantum.bit
@@ -219,7 +219,7 @@ module @param_rxry {
   // Decomposition function expects tensor<f64> while operation provides f64
   // CHECK: func.func private @ParametrizedRXRY_decomp
   func.func private @ParametrizedRXRY_decomp(%arg0: tensor<f64>, %arg1: !quantum.bit) -> !quantum.bit
-      attributes {target_gate = "ParametrizedRXRY", llvm.linkage = #llvm.linkage<internal>} {
+      attributes {target_gate = "{op = \"ParametrizedRXRY\", params = [[f64]], wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
     %extracted = tensor.extract %arg0[] : tensor<f64>
     %out_qubits = quantum.custom "RX"(%extracted) %arg1 : !quantum.bit
     %extracted_0 = tensor.extract %arg0[] : tensor<f64>
@@ -297,7 +297,7 @@ module @qreg_base_circuit {
     // Decomposition function should be retained for future passes
     // CHECK: func.func private @Test_rule_1
     func.func private @Test_rule_1(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg
-        attributes {target_gate = "Test", llvm.linkage = #llvm.linkage<internal>} {
+        attributes {target_gate = "{op = \"Test\", params = [[f64]], wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
       %cst = stablehlo.constant dense<0.000000e+00> : tensor<f64>
       %10 = quantum.extract %arg0[ 0] : !quantum.reg -> !quantum.bit
       %mres, %out_qubit = quantum.measure %10 : i1, !quantum.bit
@@ -331,7 +331,7 @@ module @qreg_base_circuit {
     // Decomposition function should be retained for future passes
     // CHECK: func.func private @RzDecomp_rule_1
     func.func private @RzDecomp_rule_1(%arg0: !quantum.reg, %arg1: tensor<f64>, %arg2: tensor<1xi64>) -> !quantum.reg
-        attributes {target_gate = "RzDecomp", llvm.linkage = #llvm.linkage<internal>} {
+        attributes {target_gate = "{op = \"RzDecomp\", params = [[f64]], wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
       %0 = stablehlo.slice %arg2 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
       %1 = stablehlo.reshape %0 : (tensor<1xi64>) -> tensor<i64>
       %extracted = tensor.extract %1[] : tensor<i64>
@@ -397,7 +397,7 @@ module @multi_wire_cnot_decomposition {
 
   // Decomposition function should be retained for future passes
   // CHECK: func.func private @CNOT_rule_cz_rz_ry
-  func.func private @CNOT_rule_cz_rz_ry(%arg0: !quantum.reg, %arg1: tensor<2xi64>) -> !quantum.reg attributes {target_gate = "CNOT", llvm.linkage = #llvm.linkage<internal>} {
+  func.func private @CNOT_rule_cz_rz_ry(%arg0: !quantum.reg, %arg1: tensor<2xi64>) -> !quantum.reg attributes {target_gate = "{op = \"CNOT\", wires = [2]}", llvm.linkage = #llvm.linkage<internal>} {
     // CNOT decomposition: CNOT = (I ⊗ H) * CZ * (I ⊗ H)
     %cst = arith.constant 1.5707963267948966 : f64
     %cst_0 = arith.constant 3.1415926535897931 : f64
@@ -473,7 +473,7 @@ module @cnot_alternative_decomposition {
 
   // Decomposition function should be retained for future passes
   // CHECK: func.func private @CNOT_rule_h_cnot_h
-  func.func private @CNOT_rule_h_cnot_h(%arg0: !quantum.bit, %arg1: !quantum.bit) -> (!quantum.bit, !quantum.bit) attributes {target_gate = "CNOT", llvm.linkage = #llvm.linkage<internal>} {
+  func.func private @CNOT_rule_h_cnot_h(%arg0: !quantum.bit, %arg1: !quantum.bit) -> (!quantum.bit, !quantum.bit) attributes {target_gate = "{op = \"CNOT\", wires = [2]}", llvm.linkage = #llvm.linkage<internal>} {
     // CNOT decomposition: CNOT = (I ⊗ H) * CZ * (I ⊗ H)
     %cst = arith.constant 1.5707963267948966 : f64
     %cst_0 = arith.constant 3.1415926535897931 : f64
@@ -519,7 +519,7 @@ module @mcm_example {
 
   // Decomposition function should be retained for future passes
   // CHECK: func.func public @rz_ry
-  func.func public @rz_ry(%arg0: !quantum.reg, %arg1: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "Hadamard"} {
+  func.func public @rz_ry(%arg0: !quantum.reg, %arg1: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "{op = \"Hadamard\", wires = [1]}"} {
     %cst = arith.constant 3.1415926535897931 : f64
     %cst_0 = arith.constant 1.5707963267948966 : f64
     %0 = stablehlo.slice %arg1 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
@@ -573,7 +573,7 @@ module @circuit_with_multirz {
   }
 
   // CHECK: func.func private @Hadamard_to_RY_decomp
-  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "Hadamard", llvm.linkage = #llvm.linkage<internal>} {
+  func.func private @Hadamard_to_RY_decomp(%arg0: !quantum.bit) -> !quantum.bit attributes {target_gate = "{op = \"Hadamard\", wires = [1]}", llvm.linkage = #llvm.linkage<internal>} {
     %cst = arith.constant 3.1415926535897931 : f64
     %cst_0 = arith.constant 1.5707963267948966 : f64
     %out_qubits = quantum.custom "RZ"(%cst) %arg0 : !quantum.bit
@@ -582,7 +582,7 @@ module @circuit_with_multirz {
   }
 
   // CHECK: func.func private @_multi_rz_decomposition_wires_1
-  func.func private @_multi_rz_decomposition_wires_1(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "MultiRZ"} {
+  func.func private @_multi_rz_decomposition_wires_1(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "{op = \"MultiRZ\", params = [[f64]], wires = [1]}"} {
     %0 = stablehlo.slice %arg2 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
     %1 = stablehlo.reshape %0 : (tensor<1xi64>) -> tensor<i64>
     %extracted = tensor.extract %1[] : tensor<i64>
@@ -612,7 +612,7 @@ module @circuit_with_operator_op {
 
   // CHECK-LABEL: func.func private @_my_dummy_decomp
   func.func private @_my_dummy_decomp(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes
-      {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "DummyOp{arg:[f64]}{wires:1}{metadata:word}"} {
+      {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "{op = \"DummyOp\", params = [[f64]], static = {metadata = \"word\"}, wires = [1]}"} {
     %0 = stablehlo.slice %arg2 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
     %1 = stablehlo.reshape %0 : (tensor<1xi64>) -> tensor<i64>
     %extracted = tensor.extract %1[] : tensor<i64>
@@ -655,7 +655,7 @@ module @qreg_at_not_first_arg {
   }
 
   // CHECK: func.func private @my_cnot
-  func.func private @my_cnot(%arg0: tensor<2xi64>, %arg1: !quantum.reg) -> !quantum.reg attributes {target_gate = "CNOT"} {
+  func.func private @my_cnot(%arg0: tensor<2xi64>, %arg1: !quantum.reg) -> !quantum.reg attributes {target_gate = "{op = \"CNOT\", wires = [2]}"} {
     %0 = stablehlo.slice %arg0 [0:1] : (tensor<2xi64>) -> tensor<1xi64>
     %1 = stablehlo.reshape %0 : (tensor<1xi64>) -> tensor<i64>
     %2 = stablehlo.slice %arg0 [1:2] : (tensor<2xi64>) -> tensor<1xi64>
@@ -699,7 +699,7 @@ module @test_paulirot {
     }
 
     // CHECK: my_paulirot_decomp
-    func.func private @my_paulirot_decomp(%inreg : !quantum.reg, %angle_tensor : tensor<f64>, %q_tensor : tensor<3xi64>) -> !quantum.reg attributes {target_gate = "PauliRot{theta:[f64]}{wires:3}{pauli_word:ZXY}"} {
+    func.func private @my_paulirot_decomp(%inreg : !quantum.reg, %angle_tensor : tensor<f64>, %q_tensor : tensor<3xi64>) -> !quantum.reg attributes {target_gate = "{op = \"PauliRot\", params = [[f64]], static = {pauli_word = \"ZXY\"}, wires = [3]}"} {
         %pi_by_2 = arith.constant 1.57 : f64
         %m_pi_by_2 = arith.constant -1.57 : f64
         %angle = tensor.extract %angle_tensor[] : tensor<f64>
@@ -755,7 +755,7 @@ module @null_decomp_rule{
   }
 
   // CHECK: func.func private @null_decomp
-  func.func private @null_decomp() attributes {target_gate = "PauliX"} {
+  func.func private @null_decomp() attributes {target_gate = "{op = \"PauliX\", wires = [1]}"} {
     return
   }
 }
@@ -799,7 +799,7 @@ module @different_qreg_values{
   }
 
   // CHECK: func.func private @my_cnot
-  func.func private @my_cnot(%arg0: tensor<2xi64>, %arg1: !quantum.reg) -> !quantum.reg attributes {target_gate = "CNOT"} {
+  func.func private @my_cnot(%arg0: tensor<2xi64>, %arg1: !quantum.reg) -> !quantum.reg attributes {target_gate = "{op = \"CNOT\", wires = [2]}"} {
     %0 = stablehlo.slice %arg0 [0:1] : (tensor<2xi64>) -> tensor<1xi64>
     %1 = stablehlo.reshape %0 : (tensor<1xi64>) -> tensor<i64>
     %2 = stablehlo.slice %arg0 [1:2] : (tensor<2xi64>) -> tensor<1xi64>
@@ -845,7 +845,7 @@ module @test_if {
   }
 
   // CHECK-LABEL: func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"
-  func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"(%arg0: tensor<1xi64>, %arg1: !quantum.reg) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, resources = {operations = {"PhaseShift{0:[f64]}{wires:1}{}" = 1 : i64}}, target_gate = "T{}{wires:1}{}"} {
+  func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"(%arg0: tensor<1xi64>, %arg1: !quantum.reg) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, resources = {operations = {"{op = \"PhaseShift\", params = [[f64]], wires = [1]}" = 1 : i64}}, target_gate = "{op = \"T\", wires = [1]}"} {
     %cst = arith.constant 0.78539816339744828 : f64
     %0 = stablehlo.slice %arg0 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
     %1 = stablehlo.reshape %0 : (tensor<1xi64>) -> tensor<i64>
@@ -887,7 +887,7 @@ module @test_for_loop {
   }
 
   // CHECK-LABEL: func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"
-  func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"(%arg0: tensor<1xi64>, %arg1: !quantum.reg) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>,  target_gate = "T{}{wires:1}{}"} {
+  func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"(%arg0: tensor<1xi64>, %arg1: !quantum.reg) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>,  target_gate = "{op = \"T\", wires = [1]}"} {
     %cst = arith.constant 0.78539816339744828 : f64
     %0 = stablehlo.slice %arg0 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
     %1 = stablehlo.reshape %0 : (tensor<1xi64>) -> tensor<i64>
@@ -935,7 +935,7 @@ module @test_while_loop {
   }
 
   // CHECK-LABEL: func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"
-  func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"(%arg0: tensor<1xi64>, %arg1: !quantum.reg) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, resources = {operations = {"PhaseShift{0:[f64]}{wires:1}{}" = 1 : i64}}, target_gate = "T{}{wires:1}{}"} {
+  func.func private @"__builtin__t_phaseshift_T{}{wires:1}{}"(%arg0: tensor<1xi64>, %arg1: !quantum.reg) -> !quantum.reg attributes {llvm.linkage = #llvm.linkage<internal>, resources = {operations = {"{op = \"PhaseShift\", params = [[f64]], wires = [1]}" = 1 : i64}}, target_gate = "{op = \"T\", wires = [1]}"} {
     %cst = arith.constant 0.78539816339744828 : f64
     %0 = stablehlo.slice %arg0 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
     %1 = stablehlo.reshape %0 : (tensor<1xi64>) -> tensor<i64>

--- a/mlir/unittests/Quantum/Interfaces/TestDecomposableGateInterface.cpp
+++ b/mlir/unittests/Quantum/Interfaces/TestDecomposableGateInterface.cpp
@@ -78,7 +78,7 @@ module {
 
     ASSERT_EQ(customOp.getStaticData().size(), 0);
 
-    ASSERT_EQ(customOp.getGraphOpId(), "RX{0:[f64]}{wires:2}{}");
+    ASSERT_EQ(customOp.getGraphOpId(), "{op = \"RX\", params = [[f64]], wires = [2]}");
 }
 
 TEST(DecomposableGateInterfaceTests, MultiControlledCustomOp) {
@@ -100,8 +100,7 @@ module {
 
     DecomposableGate op = *module->getOps<CustomOp>().begin();
 
-    // Two control wires fold as `2C(...)`
-    ASSERT_EQ(op.getGraphOpId(), "2C(PauliX){}{wires:1}{}");
+    ASSERT_EQ(op.getGraphOpId(), "{op = \"PauliX\", traits = {controls = 2 : i64}, wires = [1]}");
 }
 
 TEST(DecomposableGateInterfaceTests, ControlledAdjointCustomOp) {
@@ -123,8 +122,9 @@ module {
 
     DecomposableGate op = *module->getOps<CustomOp>().begin();
 
-    // Modifiers fold control-outermost
-    ASSERT_EQ(op.getGraphOpId(), "C(Adjoint(RX)){0:[f64]}{wires:1}{}");
+    ASSERT_EQ(op.getGraphOpId(),
+              "{op = \"RX\", params = [[f64]], traits = {adj = true, controls = 1 : "
+              "i64}, wires = [1]}");
 }
 
 TEST(DecomposableGateInterfaceTests, MultiControlledAdjointCustomOp) {
@@ -147,8 +147,9 @@ module {
 
     DecomposableGate op = *module->getOps<CustomOp>().begin();
 
-    // Controls + Adjoint folding
-    ASSERT_EQ(op.getGraphOpId(), "2C(Adjoint(RX)){0:[f64]}{wires:1}{}");
+    ASSERT_EQ(op.getGraphOpId(),
+              "{op = \"RX\", params = [[f64]], traits = {adj = true, controls = 2 : "
+              "i64}, wires = [1]}");
 }
 
 TEST(DecomposableGateInterfaceTests, MultiRZOp) {
@@ -182,7 +183,7 @@ module {
 
     ASSERT_EQ(multiRZ.getStaticData().size(), 0);
 
-    ASSERT_EQ(multiRZ.getGraphOpId(), "MultiRZ{theta:[f64]}{wires:3}{}");
+    ASSERT_EQ(multiRZ.getGraphOpId(), "{op = \"MultiRZ\", params = [[f64]], wires = [3]}");
 }
 
 TEST(DecomposableGateInterfaceTests, PauliRotOp) {
@@ -219,7 +220,9 @@ module {
     mlir::DictionaryAttr expectedStaticData = mlir::DictionaryAttr::get(&context, {entry});
     ASSERT_EQ(paulirot.getStaticData(), expectedStaticData);
 
-    ASSERT_EQ(paulirot.getGraphOpId(), "PauliRot{theta:[f64]}{wires:3}{pauli_word:XYZ}");
+    ASSERT_EQ(paulirot.getGraphOpId(),
+              "{op = \"PauliRot\", params = [[f64]], static = {pauli_word = \"XYZ\"}, "
+              "wires = [3]}");
 }
 
 TEST(DecomposableGateInterfaceTests, PCPhaseOP) {
@@ -257,8 +260,9 @@ module {
     mlir::DictionaryAttr expectedStaticData = mlir::DictionaryAttr::get(&context, {entry});
     ASSERT_EQ(pcphase.getStaticData(), expectedStaticData);
 
-    // The op carries one control wire, folded into the id (control-outermost).
-    ASSERT_EQ(pcphase.getGraphOpId(), "C(PCPhase){phi:[f64]}{wires:2}{dim:0}");
+    ASSERT_EQ(pcphase.getGraphOpId(),
+              "{op = \"PCPhase\", params = [[f64]], static = {dim = 0 : i64}, traits = "
+              "{controls = 1 : i64}, wires = [2]}");
 }
 
 TEST(DecomposableGateInterfaceTests, GlobalPhaseOp) {
@@ -289,7 +293,7 @@ module {
 
     ASSERT_EQ(gphase.getStaticData().size(), 0);
 
-    ASSERT_EQ(gphase.getGraphOpId(), "GlobalPhase{phi:[f64]}{}{}");
+    ASSERT_EQ(gphase.getGraphOpId(), "{op = \"GlobalPhase\", params = [[f64]]}");
 }
 
 TEST(DecomposableGateInterfaceTests, ControlledGlobalPhaseOp) {
@@ -322,9 +326,8 @@ module {
 
     ASSERT_EQ(gphase.getStaticData().size(), 0);
 
-    // Controlled global phase: the control wire is folded into the id (this is the `C(GlobalPhase)`
-    // operator, which a rule maps to `PhaseShift`/`ControlledPhaseShift`).
-    ASSERT_EQ(gphase.getGraphOpId(), "C(GlobalPhase){phi:[f64]}{}{}");
+    ASSERT_EQ(gphase.getGraphOpId(),
+              "{op = \"GlobalPhase\", params = [[f64]], traits = {controls = 1 : i64}}");
 }
 
 TEST(DecomposableGateInterfaceTests, QubitUnitaryOp) {
@@ -361,7 +364,9 @@ module {
 
     ASSERT_EQ(unitary.getStaticData().size(), 0);
 
-    ASSERT_EQ(unitary.getGraphOpId(), "C(QubitUnitary){U:[tensor<4x4xcomplex<f64>>]}{wires:2}{}");
+    ASSERT_EQ(unitary.getGraphOpId(),
+              "{op = \"QubitUnitary\", params = [[tensor<4x4xcomplex<f64>>]], traits = "
+              "{controls = 1 : i64}, wires = [2]}");
 }
 
 TEST(DecomposableGateInterfaceTests, OperatorOpQubits) {
@@ -372,7 +377,7 @@ module {
   %index = arith.constant 5 : i64
   %q0 = quantum.alloc_qb : !quantum.bit
   %q1 = quantum.alloc_qb : !quantum.bit
-  %0:2 = quantum.operator "testInterfaceOp"(%flag: i1, %angle: f64, %index: i64) qubits(%q0, %q1) static_data = {"myStaticArray"=[1,2,3], "myStaticString"="Test", "myStaticInt"=4} param_map = {flag = [0], angle = [1], index = [2]} qubit_map = {wire1 = [0], wire2 = [1]}
+  %0:2 = quantum.operator "testInterfaceOp"(%flag: i1, %angle: f64, %index: i64) qubits(%q0, %q1) static_data = {"myDelimitedString"="a,b{c}", "myStaticArray"=[1,2,3], "myStaticBool"=true, "myStaticFloat"=3.14, "myStaticString"="Test", "myStaticInt"=4} param_map = {flag = [0], angle = [1], index = [2]} qubit_map = {wire1 = [0], wire2 = [1]}
 }
     )mlir";
 
@@ -411,13 +416,24 @@ module {
 
     mlir::NamedAttribute intAttr(mlir::StringAttr::get(&context, "myStaticInt"),
                                  mlir::IntegerAttr::get(i64, 4));
-    mlir::DictionaryAttr expectedStaticData =
-        mlir::DictionaryAttr::get(&context, {arrAttr, stringAttr, intAttr});
+    mlir::NamedAttribute boolAttr(mlir::StringAttr::get(&context, "myStaticBool"),
+                                  mlir::BoolAttr::get(&context, true));
+    mlir::NamedAttribute floatAttr(mlir::StringAttr::get(&context, "myStaticFloat"),
+                                   mlir::FloatAttr::get(Float64Type::get(&context), 3.14));
+    mlir::NamedAttribute delimitedStringAttr(mlir::StringAttr::get(&context, "myDelimitedString"),
+                                             mlir::StringAttr::get(&context, "a,b{c}"));
+    mlir::DictionaryAttr expectedStaticData = mlir::DictionaryAttr::get(
+        &context, {arrAttr, stringAttr, intAttr, boolAttr, floatAttr, delimitedStringAttr});
     ASSERT_EQ(op.getStaticData(), expectedStaticData);
 
-    ASSERT_EQ(op.getGraphOpId(),
-              "testInterfaceOp{angle:[f64],flag:[i1],index:[i64]}{wire1:1,wire2:1}{"
-              "myStaticArray:[1,2,3],myStaticInt:4,myStaticString:Test}");
+    // Kept byte-for-byte in sync with the frontend typed-payload fixture.
+    ASSERT_EQ(
+        op.getGraphOpId(),
+        "{op = \"testInterfaceOp\", params = [[i1], [f64], "
+        "[i64]], static = {myDelimitedString = \"a,b{c}\", myStaticArray = [1, 2, 3], "
+        "myStaticBool = true, "
+        "myStaticFloat = 3.140000e+00 : f64, myStaticInt = 4 : i64, myStaticString = \"Test\"}, "
+        "wires = [1, 1]}");
 }
 
 TEST(DecomposableGateInterfaceTests, OperatorOpQureg) {
@@ -475,8 +491,9 @@ func.func @testfunc(%first : tensor<1xi64>, %secondthird : tensor<2xi64>) {
     ASSERT_EQ(op.getStaticData(), expectedStaticData);
 
     ASSERT_EQ(op.getGraphOpId(),
-              "testOperatorQureg{angle:[f64],flag:[i1],index:[i64]}{reg:3}{"
-              "myStaticArray:[4,2.400000e+00,4],myStaticInt:8,myStaticString:string}");
+              "{op = \"testOperatorQureg\", params = [[i1], [f64], [i64]], static = "
+              "{myStaticArray = [4, 2.400000e+00, 4], myStaticInt = 8 : i64, "
+              "myStaticString = \"string\"}, wires = [3]}");
 }
 
 TEST(DecomposableGateInterfaceTests, OperatorOpUID) {
@@ -517,7 +534,7 @@ func.func @testfunc(%first : tensor<1xi64>, %secondthird : tensor<2xi64>, %arg1 
 
     ASSERT_EQ(op.getStaticData(), mlir::DictionaryAttr::get(&context, {}));
 
-    ASSERT_EQ(op.getGraphOpId(), "testOperatorUID{angle:[tensor<f64>],index:["
-                                 "tensor<i1>,tensor<i64>]}{reg:3}{}[248]");
+    ASSERT_EQ(op.getGraphOpId(), "{op = \"testOperatorUID\", params = [[tensor<i1>, tensor<i64>], "
+                                 "[tensor<f64>]], uid = 248 : i64, wires = [3]}");
     // TODO: better separate these tests to unittests
 }


### PR DESCRIPTION
**Context:**

Graph operation identifiers were independently assembled as delimiter-based strings in the Python frontend and C++ compiler. This made the encoding sensitive to formatting differences, some of which are identified below:
<img width="1596" height="564" alt="image" src="https://github.com/user-attachments/assets/f50ab672-24b7-46e5-a221-a60a03e87e7b" />


**Description of the Change:**

This PR replaces the existing GraphOpID encodings across the frontend and compiler with the canonical MLIR representation of a typed dictionary attribute. It does this by converting Python values to MLIR attributes first, assembling the full GraphOpID attribute structure (the "struct"), and then converting to string via the builtin MLIR attribute printers. The conversion to string could be eliminated entirely, but to limit the scope of the PR I'm keeping the string representation in all the users of the GraphOpID.

The struct schema is roughly based on the following:

- stores the operation name under `op`,
- uses positional arrays for `wires` and `parameter` types instead of dictionaries to keep the ID shorter,
- adjoint and control modifiers are grouped under `traits` (this is mainly done to highlight the op name more, otherwise the adjoint field would be printed first by MLIR),
- omits fields containing default or empty values to keep the ID shorter,
- includes static data and UID as before.

All frontend producers use a shared `build_graph_op_key` helper. The `DecomposableGate` default implementation constructs the equivalent attribute in C++, but will still produce a string as a result.

**Benefits:**

- Single source of truth for generating GraphOpIDs across Python and C++.
- Less custom logic for the ID generation, which mostly reuses MLIR upstream printers.
- Makes parameter and wire names irrelevant to operator identity.
- Modifier handling now updates structured fields instead of adding or removing textual prefixes.

**Possible Drawbacks:**

To limit the scope of the PR, I didn't change any consumer code of the GraphOpID, so it still expects strings. As a result, we still have a conversion of the structured dictionary representation to string, and on the other side a parsing step currently used for two reasons: generating modified IDs (e.g. adding an adjoint), and obtaining a simplified name for gate set matching. Ideally, the ID should be fully opaque, and once generated not touched except to test equality. Hopefully something we can further improve in the future.