### PR TITLE
[GOID] Use unified printing for the static data portion

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -108,12 +108,12 @@
     For example, an operator with class name `HybridOpArg`, taking in one float param
     argument named `angle`, one wire argument named `cwires`, one static data argument
     `label="hello"`, and a computed UID of 10 would be parsed to the following graph op ID:
-        HybridOpArg{angle:[tensor<f64>]}{cwires:1}{label:hello}[10]
+        HybridOpArg{angle:[tensor<f64>]}{cwires:1}{label = "hello"}[10]
 
     A node in the decomposition graph is completely identified by its `graphOpId`. For example,
-        PauliRot{angle:[f64]}{wires:1}{pauli_word:X}
+        PauliRot{angle:[f64]}{wires:1}{pauli_word = "X"}
     and
-        PauliRot{angle:[f64]}{wires:2}{pauli_word:XX}
+        PauliRot{angle:[f64]}{wires:2}{pauli_word = "XX"}
     will have different decomposition rules.
 
   - A decomposition rule function can arrive in a piece of MLIR in one of three ways:
@@ -578,7 +578,7 @@
 
 * Update calls to `GlobalPhase` to no longer use the `wires` argument.
   [(#3108)](https://github.com/PennyLaneAI/catalyst/pull/3108)
-  
+
 * A GPU CI workflow runs the runtime transport tests on the `single-gpu-x64` runner, gated by
   the `gpu` label.
   [(#3113)](https://github.com/PennyLaneAI/catalyst/pull/3113)

--- a/frontend/catalyst/decomposition/graph_op_id.py
+++ b/frontend/catalyst/decomposition/graph_op_id.py
@@ -14,23 +14,62 @@
 
 """Python implementation of Graph Operator ID."""
 
+import contextlib
 from collections.abc import Mapping, Sequence
 from typing import Any
 
 import jax.numpy as jnp
 import pennylane as qp
+from jax._src.lib.mlir import ir
 from pennylane.pytrees import flatten
 
 from catalyst.decomposition.type_utils import (
     convert_item_to_mlir_type,
-    format_dynamic_params_for_id,
-    format_static_data_dict_for_id,
     post_process_concretize_leaves,
     replace_wires_with_placeholder_wires,
 )
 from catalyst.from_plxpr.uid import generate_uid
+from catalyst.jax_extras.lowering import get_mlir_attribute_from_pyval
 
 _SPECIAL_LOWERINGS = {}
+
+
+@contextlib.contextmanager
+def _attribute_context():
+    """Provide an MLIR context and location for attribute construction."""
+    if current := ir.Context.current:
+        with ir.Location.unknown(context=current):
+            yield current
+    else:
+        with ir.Context() as context, ir.Location.unknown(context=context):
+            yield context
+
+
+def format_static_data_dict_for_id(static_data):
+    """Format the static-data group of a GraphOpID with MLIR's attribute printer."""
+    with _attribute_context():
+        attrs = {name: get_mlir_attribute_from_pyval(value) for name, value in static_data.items()}
+        return str(ir.DictAttr.get(attrs))
+
+
+def format_dynamic_params_for_id(dynamic_shape):
+    """Format the dynamic-parameter group of a GraphOpID."""
+
+    def handle_item(item):
+        match item:
+            case str():
+                return item
+            case list() | tuple():
+                return "[" + ",".join(handle_item(i) for i in item) + "]"
+
+    return (
+        "{"
+        + ",".join(
+            name + ":" + "[" + ",".join(handle_item(item) for item in types) + "]"
+            for name, types in dynamic_shape.items()
+        )
+        + "}"
+    )
 
 
 def build_graph_op_id(

--- a/frontend/catalyst/decomposition/graph_op_id.py
+++ b/frontend/catalyst/decomposition/graph_op_id.py
@@ -14,6 +14,7 @@
 
 """Python implementation of Graph Operator ID."""
 
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 import jax.numpy as jnp
@@ -30,6 +31,32 @@ from catalyst.decomposition.type_utils import (
 from catalyst.from_plxpr.uid import generate_uid
 
 _SPECIAL_LOWERINGS = {}
+
+
+def build_graph_op_id(
+    operator_name: str,
+    dynamic_shape: Mapping[str, Sequence[str]],
+    wire_lens: Mapping[str, int],
+    static_data: Mapping[str, Any],
+    *,
+    adjoint: bool = False,
+    num_controls: int = 0,
+    uid: int | None = None,
+) -> str:
+    """Build a canonical frontend GraphOpID from its identity components."""
+    if num_controls < 0:
+        raise ValueError("GraphOpID control count cannot be negative")
+
+    name = f"Adjoint({operator_name})" if adjoint else operator_name
+    if num_controls:
+        prefix = "C" if num_controls == 1 else f"{num_controls}C"
+        name = f"{prefix}({name})"
+
+    dynamic_id = format_dynamic_params_for_id(dict(sorted(dynamic_shape.items())))
+    wire_id = "{" + ",".join(f"{key}:{value}" for key, value in sorted(wire_lens.items())) + "}"
+    static_id = format_static_data_dict_for_id(dict(static_data))
+    uid_id = f"[{uid}]" if uid is not None else ""
+    return name + dynamic_id + wire_id + static_id + uid_id
 
 
 class GraphOpID:
@@ -163,35 +190,23 @@ class GraphOpID:
         """Return the name of the operator."""
         return self.operator_name
 
-    def get_dynamic_shape_id_format(self) -> str:
-        """Return the dynamic shape formatted for GraphOpId."""
-        return format_dynamic_params_for_id(self.dynamic_shape)
-
-    def get_wire_lens_id_format(self) -> str:
-        """Return the wire lengths formatted for GraphOpId."""
-        return "{" + ",".join(f"{name}:{shape}" for name, shape in self.wire_lens.items()) + "}"
-
-    def get_static_data_id_format(self) -> str:
-        """Return the static data formatted for GraphOpId."""
-        return format_static_data_dict_for_id(self.static_data)
-
-    def getGraphOpId(self, adjoint: bool = False) -> str:
+    def getGraphOpId(self, adjoint: bool = False, num_controls: int = 0) -> str:
         """
         Return the GraphOpId as a string.
 
         NOTE: do not modify this method without also modifying the corresponding DecomposableGate
         interface in MLIR.
         """
-        name = self.get_operator_name()
-        if adjoint:
-            name = f"Adjoint({name})"
-        ID_string = (
-            name
-            + self.get_dynamic_shape_id_format()
-            + self.get_wire_lens_id_format()
-            + self.get_static_data_id_format()
-        )
+        uid = None
         if self.extra_data:
             assert self.uid >= 0, f"Failed to compute UID for operator {self.op}"
-            ID_string += "[" + str(self.uid) + "]"
-        return ID_string
+            uid = self.uid
+        return build_graph_op_id(
+            self.get_operator_name(),
+            self.dynamic_shape,
+            self.wire_lens,
+            self.static_data,
+            adjoint=adjoint,
+            num_controls=num_controls,
+            uid=uid,
+        )

--- a/frontend/catalyst/decomposition/graph_op_id.py
+++ b/frontend/catalyst/decomposition/graph_op_id.py
@@ -23,6 +23,7 @@ from pennylane.pytrees import flatten
 from catalyst.decomposition.type_utils import (
     convert_item_to_mlir_type,
     format_dynamic_params_for_id,
+    format_static_data_dict_for_id,
     post_process_concretize_leaves,
     replace_wires_with_placeholder_wires,
 )
@@ -45,15 +46,18 @@ class GraphOpID:
     For example, an Operator2 instance with class name `HybridOpArg`, taking in one float param
     argument named `angle`, one wire argument named `cwires`, one static data argument
     `label="hello"`, and a computed UID of 10 would be parsed to the following graph op ID:
-        HybridOpArg{angle:[tensor<f64>]}{cwires:1}{label:hello}[10]
+        HybridOpArg{angle:[tensor<f64>]}{cwires:1}{label = "hello"}[10]
+
+    The static data group is spelled by MLIR's own attribute printer, applied to the attributes the
+    data lowers to, so each entry reads as it would inside the `static_data` dictionary on the op.
 
     The defining trait of a graph op ID is that it has unique correspondence to decomposition rules.
     In other words, different graph op IDs have different sets of decomposition rules.
 
     For example,
-        PauliRot{angle:[f64]}{wires:1}{pauli_word:X}
+        PauliRot{angle:[f64]}{wires:1}{pauli_word = "X"}
     and
-        PauliRot{angle:[f64]}{wires:2}{pauli_word:XX}
+        PauliRot{angle:[f64]}{wires:2}{pauli_word = "XX"}
     will have different decomposition rules.
 
     Note that this function should not be updated without updating the corresponding method on the
@@ -169,7 +173,7 @@ class GraphOpID:
 
     def get_static_data_id_format(self) -> str:
         """Return the static data formatted for GraphOpId."""
-        return "{" + ",".join(f"{k}:{v}" for k, v in self.static_data.items()) + "}"
+        return format_static_data_dict_for_id(self.static_data)
 
     def getGraphOpId(self, adjoint: bool = False) -> str:
         """

--- a/frontend/catalyst/decomposition/graph_op_id.py
+++ b/frontend/catalyst/decomposition/graph_op_id.py
@@ -48,8 +48,7 @@ def _attribute_context():
 def format_static_data_dict_for_id(static_data):
     """Format the static-data group of a GraphOpID with MLIR's attribute printer."""
     with _attribute_context():
-        attrs = {name: get_mlir_attribute_from_pyval(value) for name, value in static_data.items()}
-        return str(ir.DictAttr.get(attrs))
+        return str(get_mlir_attribute_from_pyval(static_data))
 
 
 def format_dynamic_params_for_id(dynamic_shape):

--- a/frontend/catalyst/decomposition/type_utils.py
+++ b/frontend/catalyst/decomposition/type_utils.py
@@ -14,6 +14,7 @@
 
 """Type handling utilities for decomposition rule lowering."""
 
+import contextlib
 import copy
 import itertools
 import re
@@ -24,6 +25,8 @@ import pennylane as qp
 from jax._src.lib.mlir import ir
 from jax.core import ShapedArray
 from pennylane.pytrees import flatten, unflatten
+
+from catalyst.jax_extras.lowering import get_mlir_attribute_from_pyval
 
 _MLIR_DTYPES_TO_PY_DTYPES = {
     "i1": jnp.bool_,
@@ -77,6 +80,30 @@ def convert_item_to_mlir_type(item, is_special_lowering=False):
         + _PY_DTYPES_TO_MLIR_DTYPES[item.dtype]
         + ">"
     )
+
+
+@contextlib.contextmanager
+def _attribute_context():
+    """Provide an MLIR context and location for attribute construction."""
+    if current := ir.Context.current:
+        with ir.Location.unknown(context=current):
+            yield current
+    else:
+        with ir.Context() as context, ir.Location.unknown(context=context):
+            yield context
+
+
+def format_static_data_dict_for_id(static_data):
+    """Format the static data group of a ``GraphOpId``, including the surrounding braces.
+
+    The values are converted to the attributes they lower to and handed to MLIR's own printer, which
+    is what ``defaultGetGraphOpId`` in mlir/lib/Quantum/IR/QuantumInterfaces.cpp does as well. One
+    printer spelling both sides is what keeps a rule compiled here findable by the
+    ``graph-decomposition`` pass.
+    """
+    with _attribute_context():
+        attrs = {name: get_mlir_attribute_from_pyval(value) for name, value in static_data.items()}
+        return str(ir.DictAttr.get(attrs))
 
 
 def format_dynamic_params_for_id(d):

--- a/frontend/catalyst/decomposition/type_utils.py
+++ b/frontend/catalyst/decomposition/type_utils.py
@@ -14,7 +14,6 @@
 
 """Type handling utilities for decomposition rule lowering."""
 
-import contextlib
 import copy
 import itertools
 import re
@@ -25,8 +24,6 @@ import pennylane as qp
 from jax._src.lib.mlir import ir
 from jax.core import ShapedArray
 from pennylane.pytrees import flatten, unflatten
-
-from catalyst.jax_extras.lowering import get_mlir_attribute_from_pyval
 
 _MLIR_DTYPES_TO_PY_DTYPES = {
     "i1": jnp.bool_,
@@ -79,49 +76,6 @@ def convert_item_to_mlir_type(item, is_special_lowering=False):
         + "x"
         + _PY_DTYPES_TO_MLIR_DTYPES[item.dtype]
         + ">"
-    )
-
-
-@contextlib.contextmanager
-def _attribute_context():
-    """Provide an MLIR context and location for attribute construction."""
-    if current := ir.Context.current:
-        with ir.Location.unknown(context=current):
-            yield current
-    else:
-        with ir.Context() as context, ir.Location.unknown(context=context):
-            yield context
-
-
-def format_static_data_dict_for_id(static_data):
-    """Format the static data group of a ``GraphOpId``, including the surrounding braces.
-
-    The values are converted to the attributes they lower to and handed to MLIR's own printer, which
-    is what ``defaultGetGraphOpId`` in mlir/lib/Quantum/IR/QuantumInterfaces.cpp does as well. One
-    printer spelling both sides is what keeps a rule compiled here findable by the
-    ``graph-decomposition`` pass.
-    """
-    with _attribute_context():
-        attrs = {name: get_mlir_attribute_from_pyval(value) for name, value in static_data.items()}
-        return str(ir.DictAttr.get(attrs))
-
-
-def format_dynamic_params_for_id(d):
-    """Format a structure for ID."""
-
-    def handle_item(item):
-        match item:
-            case str():
-                return item
-            case list() | tuple():
-                return "[" + ",".join(handle_item(i) for i in item) + "]"
-
-    return (
-        "{"
-        + ",".join(
-            k + ":" + "[" + ",".join(handle_item(item) for item in v) + "]" for k, v in d.items()
-        )
-        + "}"
     )
 
 

--- a/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
+++ b/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
@@ -40,8 +40,8 @@ from catalyst.decomposition.decomposition_rules import (
 )
 from catalyst.decomposition.graph_op_id import _SPECIAL_LOWERINGS
 from catalyst.decomposition.type_utils import (
-    convert_item_to_mlir_type,
     format_dynamic_params_for_id,
+    format_static_data_dict_for_id,
     get_dummy_values_for_arg,
 )
 from catalyst.jax_extras.lowering import get_mlir_attribute_from_pyval
@@ -292,9 +292,9 @@ def compile_decomp_rules(
             + "{"
             + f"{wire_argname}:{wire_lens[0]}"
             + "}"
-            + "{"
-            + f"{pauliword_argname}:{repack_static_data[pauliword_argname]}"
-            + "}"
+            + format_static_data_dict_for_id(
+                {pauliword_argname: repack_static_data[pauliword_argname]}
+            )
         )
 
         decomp_rules = fetch_all_reachable_decomposition_rules_from_op(
@@ -313,9 +313,8 @@ def compile_decomp_rules(
             + format_dynamic_params_for_id(dynamic_shape)
             + "{"
             + f"{wire_argname}:{wire_lens[0]}"
-            + "}{"
-            + f"dim:{repack_static_data["dim"]}"
             + "}"
+            + format_static_data_dict_for_id({"dim": repack_static_data["dim"]})
         )
 
         decomp_rules = fetch_all_reachable_decomposition_rules_from_op(
@@ -437,7 +436,7 @@ def compile_decomp_rules(
             + "}"
         )
         if not (op_cls.hybrid_argnames or op_cls.static_argnames):
-            op_id += "{" + ",".join(f"{k}:{v}" for k, v in sorted(repack_static_data.items())) + "}"
+            op_id += format_static_data_dict_for_id(repack_static_data)
         else:
             op_id += "{}"
         if uid is not None:

--- a/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
+++ b/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
@@ -38,12 +38,8 @@ from catalyst.decomposition.decomposition_rules import (
     fetch_all_reachable_decomposition_rules_from_op,
     inject_new_rules_into_module,
 )
-from catalyst.decomposition.graph_op_id import _SPECIAL_LOWERINGS
-from catalyst.decomposition.type_utils import (
-    format_dynamic_params_for_id,
-    format_static_data_dict_for_id,
-    get_dummy_values_for_arg,
-)
+from catalyst.decomposition.graph_op_id import _SPECIAL_LOWERINGS, build_graph_op_id
+from catalyst.decomposition.type_utils import get_dummy_values_for_arg
 from catalyst.jax_extras.lowering import get_mlir_attribute_from_pyval
 from catalyst.jax_extras.patches import mock_attributes
 from catalyst.jax_primitives import (
@@ -246,13 +242,7 @@ def compile_decomp_rules(
     if is_custom_op:
         dynamic_shape = {str(i): ["f64"] for i in range(len(op_cls.dynamic_argnames))}
 
-        op_id = (
-            op_cls.__name__
-            + format_dynamic_params_for_id(dynamic_shape)
-            + "{"
-            + f"wires:{wire_lens[0]}"
-            + "}{}"
-        )
+        op_id = build_graph_op_id(op_cls.__name__, dynamic_shape, {"wires": wire_lens[0]}, {})
 
         decomp_rules = fetch_all_reachable_decomposition_rules_from_op(
             op_name=op_cls.__name__,
@@ -266,13 +256,7 @@ def compile_decomp_rules(
     elif op_cls is qp.MultiRZ:
         dynamic_shape = {qp.MultiRZ.dynamic_argnames[0]: ["f64"]}
         wire_argname = qp.MultiRZ.wire_argnames[0]
-        op_id = (
-            "MultiRZ"
-            + format_dynamic_params_for_id(dynamic_shape)
-            + "{"
-            + f"{wire_argname}:{wire_lens[0]}"
-            + "}{}"
-        )
+        op_id = build_graph_op_id("MultiRZ", dynamic_shape, {wire_argname: wire_lens[0]}, {})
 
         decomp_rules = fetch_all_reachable_decomposition_rules_from_op(
             op_name="MultiRZ",
@@ -286,15 +270,11 @@ def compile_decomp_rules(
         dynamic_shape = {qp.PauliRot.dynamic_argnames[0]: ["f64"]}
         wire_argname = qp.PauliRot.wire_argnames[0]
         pauliword_argname = qp.PauliRot.compilable_argnames[0]
-        op_id = (
-            "PauliRot"
-            + format_dynamic_params_for_id(dynamic_shape)
-            + "{"
-            + f"{wire_argname}:{wire_lens[0]}"
-            + "}"
-            + format_static_data_dict_for_id(
-                {pauliword_argname: repack_static_data[pauliword_argname]}
-            )
+        op_id = build_graph_op_id(
+            "PauliRot",
+            dynamic_shape,
+            {wire_argname: wire_lens[0]},
+            {pauliword_argname: repack_static_data[pauliword_argname]},
         )
 
         decomp_rules = fetch_all_reachable_decomposition_rules_from_op(
@@ -308,13 +288,11 @@ def compile_decomp_rules(
     elif op_cls is qp.PCPhase:
         dynamic_shape = {qp.PCPhase.dynamic_argnames[0]: ["f64"]}
         wire_argname = qp.PCPhase.wire_argnames[0]
-        op_id = (
-            "PCPhase"
-            + format_dynamic_params_for_id(dynamic_shape)
-            + "{"
-            + f"{wire_argname}:{wire_lens[0]}"
-            + "}"
-            + format_static_data_dict_for_id({"dim": repack_static_data["dim"]})
+        op_id = build_graph_op_id(
+            "PCPhase",
+            dynamic_shape,
+            {wire_argname: wire_lens[0]},
+            {"dim": repack_static_data["dim"]},
         )
 
         decomp_rules = fetch_all_reachable_decomposition_rules_from_op(
@@ -327,7 +305,7 @@ def compile_decomp_rules(
 
     elif op_cls is qp.GlobalPhase:
         dynamic_shape = {qp.GlobalPhase.dynamic_argnames[0]: ["f64"]}
-        op_id = "GlobalPhase" + format_dynamic_params_for_id(dynamic_shape) + "{}{}"
+        op_id = build_graph_op_id("GlobalPhase", dynamic_shape, {}, {})
 
         decomp_rules = fetch_all_reachable_decomposition_rules_from_op(
             op_name="GlobalPhase",
@@ -346,13 +324,7 @@ def compile_decomp_rules(
             ]
         }
         wire_argname = qp.QubitUnitary.wire_argnames[0]
-        op_id = (
-            "QubitUnitary"
-            + format_dynamic_params_for_id(dynamic_shape)
-            + "{"
-            + f"{wire_argname}:{wire_lens[0]}"
-            + "}{}"
-        )
+        op_id = build_graph_op_id("QubitUnitary", dynamic_shape, {wire_argname: wire_lens[0]}, {})
 
         decomp_rules = fetch_all_reachable_decomposition_rules_from_op(
             op_name="QubitUnitary",
@@ -428,19 +400,16 @@ def compile_decomp_rules(
             for wire_attr in qubit_map:
                 with_hybrid_wire_lens[wire_attr.name] = len(wire_attr.attr)
 
-        op_id = (
-            op_cls.__name__
-            + format_dynamic_params_for_id(dict(sorted(with_hybrid_dynamic_shape.items())))
-            + "{"
-            + ",".join(f"{name}:{shape}" for name, shape in sorted(with_hybrid_wire_lens.items()))
-            + "}"
+        identity_static_data = (
+            repack_static_data if not (op_cls.hybrid_argnames or op_cls.static_argnames) else {}
         )
-        if not (op_cls.hybrid_argnames or op_cls.static_argnames):
-            op_id += format_static_data_dict_for_id(repack_static_data)
-        else:
-            op_id += "{}"
-        if uid is not None:
-            op_id += f"[{str(uid)}]"
+        op_id = build_graph_op_id(
+            op_cls.__name__,
+            with_hybrid_dynamic_shape,
+            with_hybrid_wire_lens,
+            identity_static_data,
+            uid=uid,
+        )
 
         decomp_rules = fetch_all_reachable_decomposition_rules_from_op(
             op_name=op_cls.__name__,

--- a/frontend/test/lit/test_operator2/test_decomposition_rule_entry_point.py
+++ b/frontend/test/lit/test_operator2/test_decomposition_rule_entry_point.py
@@ -258,8 +258,8 @@ def test_to_compilable_data():
 
 # CHECK: func.func private @"rule_NoParams{}{reg:2}{}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:     "CompilableData{}{wires:1}{a:a,b:b,thing:thing}" = 1 : i64,
-# CHECK-SAME:     "CompilableData{}{wires:1}{a:aa,b:bb,thing:stuff}" = 2 : i64
+# CHECK-SAME:     "CompilableData{}{wires:1}{a = \22a\22, b = \22b\22, thing = \22thing\22}" = 1 : i64,
+# CHECK-SAME:     "CompilableData{}{wires:1}{a = \22aa\22, b = \22bb\22, thing = \22stuff\22}" = 2 : i64
 # CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
 test_to_compilable_data()
 
@@ -283,7 +283,7 @@ def test_from_compilable_data():
         qp.add_decomps(CompilableData, rule)
         result_a1 = compile_decomposition_rules_wrapper(
             "CompilableData",
-            "CompilableData{}{wires:1}{a:1,b:2,thing:3}",
+            "CompilableData{}{wires:1}{a = 1 : i64, b = 2 : i64, thing = 3 : i64}",
             {},
             {"wires": 1},
             {"a": 1, "b": 2, "thing": 3},
@@ -292,7 +292,7 @@ def test_from_compilable_data():
 
         result_a10 = compile_decomposition_rules_wrapper(
             "CompilableData",
-            "CompilableData{}{wires:1}{a:10,b:2,thing:3}",
+            "CompilableData{}{wires:1}{a = 10 : i64, b = 2 : i64, thing = 3 : i64}",
             {},
             {"wires": 1},
             {"a": 10, "b": 2, "thing": 3},
@@ -300,15 +300,15 @@ def test_from_compilable_data():
         print(result_a10)
 
 
-# CHECK: func.func private @"rule_CompilableData{}{wires:1}{a:1,b:2,thing:3}"
+# CHECK: func.func private @"rule_CompilableData{}{wires:1}{a = 1 : i64, b = 2 : i64, thing = 3 : i64}"
 # CHECK-SAME:   resources = {operations = {"SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64}
-# CHECK-SAME:   target_gate = "CompilableData{}{wires:1}{a:1,b:2,thing:3}"
+# CHECK-SAME:   target_gate = "CompilableData{}{wires:1}{a = 1 : i64, b = 2 : i64, thing = 3 : i64}"
 # CHECK: stablehlo.constant dense<1.000000e-01> : tensor<f64>
 # CHECK-NOT: stablehlo.constant dense<1.100000e+00> : tensor<f64>
 #
-# CHECK: func.func private @"rule_CompilableData{}{wires:1}{a:10,b:2,thing:3}"
+# CHECK: func.func private @"rule_CompilableData{}{wires:1}{a = 10 : i64, b = 2 : i64, thing = 3 : i64}"
 # CHECK-SAME:   resources = {operations = {"SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64}
-# CHECK-SAME:   target_gate = "CompilableData{}{wires:1}{a:10,b:2,thing:3}"
+# CHECK-SAME:   target_gate = "CompilableData{}{wires:1}{a = 10 : i64, b = 2 : i64, thing = 3 : i64}"
 # CHECK: stablehlo.constant dense<1.100000e+00> : tensor<f64>
 # CHECK-NOT: stablehlo.constant dense<1.000000e-01> : tensor<f64>
 test_from_compilable_data()
@@ -826,7 +826,7 @@ def test_multiple_rules():
 # CHECK-SAME:   resources = {operations = {"SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64}}
 # CHECK-SAME:   target_gate = "NoParams{}{reg:1}{}"
 # CHECK: func.func private @"rule2_NoParams{}{reg:1}{}"
-# CHECK-SAME:   resources = {operations = {"CompilableData{}{wires:3}{a:a,b:b,thing:thing}" = 1 : i64}}
+# CHECK-SAME:   resources = {operations = {"CompilableData{}{wires:3}{a = \22a\22, b = \22b\22, thing = \22thing\22}" = 1 : i64}}
 # CHECK-SAME:   target_gate = "NoParams{}{reg:1}{}"
 test_multiple_rules()
 

--- a/frontend/test/lit/test_operator2/test_lower_time_rules.py
+++ b/frontend/test/lit/test_operator2/test_lower_time_rules.py
@@ -233,7 +233,7 @@ def test_multiple_rules_chained():
 # CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
 # CHECK: func.func private @"__builtin_rule2_SingleParam{x:[tensor<f64>]}{reg:1}{}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "CompilableData{}{wires:1}{a:a,b:b,thing:thing}" = 1 : i64
+# CHECK-SAME:   "CompilableData{}{wires:1}{a = \22a\22, b = \22b\22, thing = \22thing\22}" = 1 : i64
 # CHECK-SAME:   target_gate = "SingleParam{x:[tensor<f64>]}{reg:1}{}"
 test_multiple_rules_chained()
 
@@ -286,11 +286,11 @@ def test_multiple_rules_chained_and_branch():
 # CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
 # CHECK: func.func private @"__builtin_ruleBC_SingleParam{x:[tensor<f64>]}{reg:1}{}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "CompilableData{}{wires:1}{a:a,b:b,thing:thing}" = 1 : i64
+# CHECK-SAME:   "CompilableData{}{wires:1}{a = \22a\22, b = \22b\22, thing = \22thing\22}" = 1 : i64
 # CHECK-SAME:   target_gate = "SingleParam{x:[tensor<f64>]}{reg:1}{}"
 # CHECK: func.func private @"__builtin_ruleBD_SingleParam{x:[tensor<f64>]}{reg:1}{}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "CompilableData{}{wires:1}{a:alpha,b:beta,thing:stuff}" = 1 : i64
+# CHECK-SAME:   "CompilableData{}{wires:1}{a = \22alpha\22, b = \22beta\22, thing = \22stuff\22}" = 1 : i64
 # CHECK-SAME:   target_gate = "SingleParam{x:[tensor<f64>]}{reg:1}{}"
 test_multiple_rules_chained_and_branch()
 
@@ -343,12 +343,12 @@ def test_with_cycles():
 # CHECK-SAME:   target_gate = "NoParams{}{reg:2}{}"
 # CHECK: func.func private @"__builtin_ruleBC_SingleParam{x:[tensor<f64>]}{reg:1}{}"
 # CHECK-SAME:   resources = {operations = {
-# CHECK-SAME:   "CompilableData{}{wires:1}{a:a,b:b,thing:thing}" = 1 : i64
+# CHECK-SAME:   "CompilableData{}{wires:1}{a = \22a\22, b = \22b\22, thing = \22thing\22}" = 1 : i64
 # CHECK-SAME:   target_gate = "SingleParam{x:[tensor<f64>]}{reg:1}{}"
-# CHECK: func.func private @"__builtin_ruleCA_CompilableData{}{wires:1}{a:a,b:b,thing:thing}"
+# CHECK: func.func private @"__builtin_ruleCA_CompilableData{}{wires:1}{a = \22a\22, b = \22b\22, thing = \22thing\22}"
 # CHECK-SAME:   resources = {operations = {
 # CHECK-SAME:   "NoParams{}{reg:2}{}" = 1 : i64
-# CHECK-SAME:   target_gate = "CompilableData{}{wires:1}{a:a,b:b,thing:thing}"
+# CHECK-SAME:   target_gate = "CompilableData{}{wires:1}{a = \22a\22, b = \22b\22, thing = \22thing\22}"
 # CHECK: func.func private @"__builtin_ruleAB_NoParams{}{reg:3}{}"
 # CHECK-SAME:   resources = {operations = {
 # CHECK-SAME:   "SingleParam{x:[tensor<f64>]}{reg:1}{}" = 1 : i64
@@ -636,6 +636,6 @@ def test_basis_rotation():
 
 
 # CHECK-LABEL: test_basis_rotation
-# CHECK: func.func private @"__builtin__basis_rotation_decomp_BasisRotation{unitary_matrix:[tensor<2x2xcomplex<f64>>]}{wires:2}{check:False}"
-# CHECK-SAME: target_gate = "BasisRotation{unitary_matrix:[tensor<2x2xcomplex<f64>>]}{wires:2}{check:False}"
+# CHECK: func.func private @"__builtin__basis_rotation_decomp_BasisRotation{unitary_matrix:[tensor<2x2xcomplex<f64>>]}{wires:2}{check = false}"
+# CHECK-SAME: target_gate = "BasisRotation{unitary_matrix:[tensor<2x2xcomplex<f64>>]}{wires:2}{check = false}"
 test_basis_rotation()

--- a/frontend/test/lit/test_operator2/test_special_ops_decomp.py
+++ b/frontend/test/lit/test_operator2/test_special_ops_decomp.py
@@ -78,12 +78,12 @@ def test_paulirot():
 # CHECK: qref.paulirot ["X", "X"]({{%.+}}) {{%.+}}, {{%.+}} : !qref.bit, !qref.bit
 # CHECK: qref.paulirot ["Z"]({{%.+}}) {{%.+}} : !qref.bit
 # CHECK: qref.paulirot ["Y", "Z", "X"]({{%.+}}) {{%.+}}, {{%.+}}, {{%.+}} : !qref.bit, !qref.bit, !qref.bit
-# CHECK: func.func private @"__builtin__pauli_rot_decomposition_PauliRot{theta:[f64]}{wires:2}{pauli_word:XX}"
-# CHECK-SAME:   target_gate = "PauliRot{theta:[f64]}{wires:2}{pauli_word:XX}"
-# CHECK: func.func private @"__builtin__pauli_rot_decomposition_PauliRot{theta:[f64]}{wires:1}{pauli_word:Z}"
-# CHECK-SAME:   target_gate = "PauliRot{theta:[f64]}{wires:1}{pauli_word:Z}"
-# CHECK: func.func private @"__builtin__pauli_rot_decomposition_PauliRot{theta:[f64]}{wires:3}{pauli_word:YZX}"
-# CHECK-SAME:   target_gate = "PauliRot{theta:[f64]}{wires:3}{pauli_word:YZX}"
+# CHECK: func.func private @"__builtin__pauli_rot_decomposition_PauliRot{theta:[f64]}{wires:2}{pauli_word = \22XX\22}"
+# CHECK-SAME:   target_gate = "PauliRot{theta:[f64]}{wires:2}{pauli_word = \22XX\22}"
+# CHECK: func.func private @"__builtin__pauli_rot_decomposition_PauliRot{theta:[f64]}{wires:1}{pauli_word = \22Z\22}"
+# CHECK-SAME:   target_gate = "PauliRot{theta:[f64]}{wires:1}{pauli_word = \22Z\22}"
+# CHECK: func.func private @"__builtin__pauli_rot_decomposition_PauliRot{theta:[f64]}{wires:3}{pauli_word = \22YZX\22}"
+# CHECK-SAME:   target_gate = "PauliRot{theta:[f64]}{wires:3}{pauli_word = \22YZX\22}"
 test_paulirot()
 
 
@@ -105,10 +105,10 @@ def test_pcphase():
 # CHECK: func.func public @pcphase()
 # CHECK: qref.pcphase({{%.+}}, dim : 3) {{%.+}}, {{%.+}}, {{%.+}} : !qref.bit, !qref.bit, !qref.bit
 # CHECK: qref.pcphase({{%.+}}, dim : 0) {{%.+}} : !qref.bit
-# CHECK: func.func private @"__builtin__decompose_pcphase_PCPhase{phi:[f64]}{wires:3}{dim:3}"
-# CHECK-SAME:   target_gate = "PCPhase{phi:[f64]}{wires:3}{dim:3}"
-# CHECK: func.func private @"__builtin__decompose_pcphase_PCPhase{phi:[f64]}{wires:1}{dim:0}"
-# CHECK-SAME:   target_gate = "PCPhase{phi:[f64]}{wires:1}{dim:0}"
+# CHECK: func.func private @"__builtin__decompose_pcphase_PCPhase{phi:[f64]}{wires:3}{dim = 3 : i64}"
+# CHECK-SAME:   target_gate = "PCPhase{phi:[f64]}{wires:3}{dim = 3 : i64}"
+# CHECK: func.func private @"__builtin__decompose_pcphase_PCPhase{phi:[f64]}{wires:1}{dim = 0 : i64}"
+# CHECK-SAME:   target_gate = "PCPhase{phi:[f64]}{wires:1}{dim = 0 : i64}"
 test_pcphase()
 
 

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -48,7 +48,7 @@ from catalyst.decomposition.decomposition_rules import (
     name_wrap_adjoint,
     wrap_modifier_id,
 )
-from catalyst.decomposition.graph_op_id import GraphOpID
+from catalyst.decomposition.graph_op_id import GraphOpID, build_graph_op_id
 from catalyst.decomposition.type_utils import (
     convert_item_to_mlir_type,
     get_dummy_values_for_arg,
@@ -70,6 +70,20 @@ class TestGenericUtilities:
         new_op = replace_wires_with_placeholder_wires(op)
 
         assert new_op == qp.ctrl(qp.S(-2), -1)
+
+    def test_build_graph_op_id(self):
+        """The shared builder canonicalizes every frontend identity component."""
+        op_id = build_graph_op_id(
+            "Example",
+            {"z": ["f64"], "a": ["i1"]},
+            {"right": 2, "left": 1},
+            {"label": "value"},
+            adjoint=True,
+            num_controls=2,
+            uid=7,
+        )
+
+        assert op_id == '2C(Adjoint(Example)){a:[i1],z:[f64]}{left:1,right:2}{label = "value"}[7]'
 
     def test_wires_replacement_doesnt_mutate_operator(self):
         """Test that the wires replacement helper does not mutate the incoming operator."""

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -161,7 +161,7 @@ class TestGenericUtilities:
             (SingleParam(Float, Wires([2, 3])), "SingleParam{x:[tensor<f64>]}{reg:2}{}"),
             (
                 CompilableData(True, 3.14, "string", Wires([0, 1])),
-                "CompilableData{}{wires:2}{a:True,b:3.14,thing:string}",
+                'CompilableData{}{wires:2}{a = true, b = 3.140000e+00 : f64, thing = "string"}',
             ),
             (
                 MultipleRegisters(Wires([0, 1, 2]), Wires([3, 4])),
@@ -174,7 +174,7 @@ class TestGenericUtilities:
             (qp.MultiRZ(Float, Wires([0, 2, 3, 4])), "MultiRZ{theta:[f64]}{wires:4}{}"),
             (
                 qp.PauliRot(Float, "XYZ", Wires([1, 2, 3])),
-                "PauliRot{theta:[f64]}{wires:3}{pauli_word:XYZ}",
+                'PauliRot{theta:[f64]}{wires:3}{pauli_word = "XYZ"}',
             ),
             (StaticData("mylabel", Wires([0, 1])), "StaticData{}{reg:2}{}["),
             (
@@ -223,7 +223,7 @@ class TestGenericUtilities:
 
         res = compile_decomposition_rules_wrapper(
             "CompilableData",
-            "CompilableData{}{wires:2}{a:True,b:3.14,thing:string}",
+            'CompilableData{}{wires:2}{a = true, b = 3.140000e+00 : f64, thing = "string"}',
             {},
             {"wires": 2},
             {"a": True, "b": 3.14, "thing": "string"},

--- a/mlir/include/Quantum/IR/QuantumInterfaces.td
+++ b/mlir/include/Quantum/IR/QuantumInterfaces.td
@@ -218,6 +218,8 @@ def DecomposableGate : OpInterface<"DecomposableGate", [QuantumGate]> {
             "```\n"
             "Note that extra data is currently specific to `OperatorOp`s, and should only appear when present."
             "Each of these maps should be sorted lexicographically by key."
+            "The static data map is spelled by MLIR's attribute printer, which the frontend also "
+            "depends on identical id generation."
             "In general, this should be computed by the default here and not overridden.",
             "std::string", "getGraphOpId", (ins), [{}], [{ return ::catalyst::quantum::defaultGetGraphOpId($_op.getOperation()); }]
         >

--- a/mlir/lib/Quantum/IR/QuantumInterfaces.cpp
+++ b/mlir/lib/Quantum/IR/QuantumInterfaces.cpp
@@ -19,7 +19,6 @@
 
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringMap.h"
-#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/raw_ostream.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -36,36 +35,6 @@ using namespace catalyst::quantum;
 //===----------------------------------------------------------------------===//
 
 namespace {
-
-void printAttr(mlir::Attribute attr, llvm::raw_string_ostream &ss) {
-    llvm::TypeSwitch<mlir::Attribute, void>(attr)
-        .Case<mlir::DictionaryAttr>([&](mlir::DictionaryAttr dict) {
-            ss << "{";
-            for (auto [i, entry] : llvm::enumerate(dict)) {
-                if (i > 0) {
-                    ss << ",";
-                }
-
-                ss << entry.getName().str() << ":";
-                printAttr(entry.getValue(), ss);
-            }
-            ss << "}";
-        })
-        .Case<mlir::ArrayAttr>([&](mlir::ArrayAttr arr) {
-            ss << "[";
-            for (auto [i, attr] : llvm::enumerate(arr)) {
-                if (i > 0) {
-                    ss << ",";
-                }
-                printAttr(attr, ss);
-            }
-            ss << "]";
-        })
-        .Case<mlir::StringAttr>([&](mlir::StringAttr attr) { ss << attr.str(); })
-        .Case<mlir::IntegerAttr>([&](mlir::IntegerAttr attr) { ss << attr.getInt(); })
-        .Case<mlir::FloatAttr>([&](mlir::FloatAttr attr) { ss << attr.getValueAsDouble(); })
-        .Default([&](mlir::Attribute attr) { attr.print(ss); });
-}
 
 template <typename T, typename PrintFunc>
 void printSortedMap(const llvm::StringMap<T> &map, llvm::raw_string_ostream &ss,
@@ -151,7 +120,7 @@ std::string defaultGetGraphOpId(Operation *op) {
     ss << wrapModifiers(gate.getOperatorName(), op);
     printDynamicShape(gate.getDynamicShape(), ss);
     printWireLens(gate.getWireLens(), ss);
-    printAttr(gate.getStaticData(), ss);
+    gate.getStaticData().print(ss);
     if (gate.getExtraData() != "") {
         ss << '[' << gate.getExtraData() << ']';
     }

--- a/mlir/test/Quantum/DecomposeLoweringTest.mlir
+++ b/mlir/test/Quantum/DecomposeLoweringTest.mlir
@@ -612,7 +612,7 @@ module @circuit_with_operator_op {
 
   // CHECK-LABEL: func.func private @_my_dummy_decomp
   func.func private @_my_dummy_decomp(%arg0: !quantum.reg, %arg1: tensor<1xf64>, %arg2: tensor<1xi64>) -> !quantum.reg attributes
-      {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "DummyOp{arg:[f64]}{wires:1}{metadata:word}"} {
+      {llvm.linkage = #llvm.linkage<internal>, num_wires = 1 : i64, target_gate = "DummyOp{arg:[f64]}{wires:1}{metadata = \22word\22}"} {
     %0 = stablehlo.slice %arg2 [0:1] : (tensor<1xi64>) -> tensor<1xi64>
     %1 = stablehlo.reshape %0 : (tensor<1xi64>) -> tensor<i64>
     %extracted = tensor.extract %1[] : tensor<i64>
@@ -699,7 +699,7 @@ module @test_paulirot {
     }
 
     // CHECK: my_paulirot_decomp
-    func.func private @my_paulirot_decomp(%inreg : !quantum.reg, %angle_tensor : tensor<f64>, %q_tensor : tensor<3xi64>) -> !quantum.reg attributes {target_gate = "PauliRot{theta:[f64]}{wires:3}{pauli_word:ZXY}"} {
+    func.func private @my_paulirot_decomp(%inreg : !quantum.reg, %angle_tensor : tensor<f64>, %q_tensor : tensor<3xi64>) -> !quantum.reg attributes {target_gate = "PauliRot{theta:[f64]}{wires:3}{pauli_word = \22ZXY\22}"} {
         %pi_by_2 = arith.constant 1.57 : f64
         %m_pi_by_2 = arith.constant -1.57 : f64
         %angle = tensor.extract %angle_tensor[] : tensor<f64>

--- a/mlir/unittests/Quantum/Interfaces/TestDecomposableGateInterface.cpp
+++ b/mlir/unittests/Quantum/Interfaces/TestDecomposableGateInterface.cpp
@@ -219,7 +219,7 @@ module {
     mlir::DictionaryAttr expectedStaticData = mlir::DictionaryAttr::get(&context, {entry});
     ASSERT_EQ(paulirot.getStaticData(), expectedStaticData);
 
-    ASSERT_EQ(paulirot.getGraphOpId(), "PauliRot{theta:[f64]}{wires:3}{pauli_word:XYZ}");
+    ASSERT_EQ(paulirot.getGraphOpId(), "PauliRot{theta:[f64]}{wires:3}{pauli_word = \"XYZ\"}");
 }
 
 TEST(DecomposableGateInterfaceTests, PCPhaseOP) {
@@ -258,7 +258,7 @@ module {
     ASSERT_EQ(pcphase.getStaticData(), expectedStaticData);
 
     // The op carries one control wire, folded into the id (control-outermost).
-    ASSERT_EQ(pcphase.getGraphOpId(), "C(PCPhase){phi:[f64]}{wires:2}{dim:0}");
+    ASSERT_EQ(pcphase.getGraphOpId(), "C(PCPhase){phi:[f64]}{wires:2}{dim = 0 : i64}");
 }
 
 TEST(DecomposableGateInterfaceTests, GlobalPhaseOp) {
@@ -417,7 +417,7 @@ module {
 
     ASSERT_EQ(op.getGraphOpId(),
               "testInterfaceOp{angle:[f64],flag:[i1],index:[i64]}{wire1:1,wire2:1}{"
-              "myStaticArray:[1,2,3],myStaticInt:4,myStaticString:Test}");
+              "myStaticArray = [1, 2, 3], myStaticInt = 4 : i64, myStaticString = \"Test\"}");
 }
 
 TEST(DecomposableGateInterfaceTests, OperatorOpQureg) {
@@ -474,9 +474,9 @@ func.func @testfunc(%first : tensor<1xi64>, %secondthird : tensor<2xi64>) {
         mlir::DictionaryAttr::get(&context, {arrAttr, stringAttr, intAttr});
     ASSERT_EQ(op.getStaticData(), expectedStaticData);
 
-    ASSERT_EQ(op.getGraphOpId(),
-              "testOperatorQureg{angle:[f64],flag:[i1],index:[i64]}{reg:3}{"
-              "myStaticArray:[4,2.400000e+00,4],myStaticInt:8,myStaticString:string}");
+    ASSERT_EQ(op.getGraphOpId(), "testOperatorQureg{angle:[f64],flag:[i1],index:[i64]}{reg:3}{"
+                                 "myStaticArray = [4, 2.400000e+00, 4], myStaticInt = 8 : i64, "
+                                 "myStaticString = \"string\"}");
 }
 
 TEST(DecomposableGateInterfaceTests, OperatorOpUID) {


### PR DESCRIPTION
This PR makes a narrow update to the graph op ID generation mechanism to use a single source of truth for static data portion only. The general approach consists of generating MLIR objects (attributes) first via the Python bindings, and then use the builtin printer to serialize those fields to string for the ID.

This change does not constitute a single source of truth for the entire ID (unlike #3184), as other fields (e.g. parameter printing), and the structure itself, still use duplicated logic across Python & C++ that must be matched precisely. However, the entire could potentially be migrated in stages with this representing the first step.

Additionally, all generation/formatting functions are refactored to be centralized in one place.