### PR TITLE
Allow git+ urls for installing PL LT dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,9 @@ if lq_version is not None:
         if lq_version.startswith("git+")
         else f"pennylane-lightning=={lq_version}"
     )
-    kokkos_dep = "" if lq_version.startswith("git+") else f"pennylane-lightning-kokkos=={lq_version}"
+    kokkos_dep = (
+        "" if lq_version.startswith("git+") else f"pennylane-lightning-kokkos=={lq_version}"
+    )
 else:
     lightning_dep = f"pennylane-lightning>={lq_min_release}"
     kokkos_dep = ""

--- a/setup.py
+++ b/setup.py
@@ -111,12 +111,18 @@ pl_min_release = "0.45.0"
 lq_min_release = pl_min_release
 
 if pl_version is not None:
-    pennylane_dep = f"pennylane=={pl_version}"  # use TestPyPI wheels, git is not allowed on PyPI
+    pennylane_dep = (
+        f"pennylane @ {pl_version}" if pl_version.startswith("git+") else f"pennylane=={pl_version}"
+    )
 else:
     pennylane_dep = f"pennylane>={pl_min_release}"
 if lq_version is not None:
-    lightning_dep = f"pennylane-lightning=={lq_version}"  # use TestPyPI wheels to avoid rebuild
-    kokkos_dep = f"pennylane-lightning-kokkos=={lq_version}"
+    lightning_dep = (
+        f"pennylane-lightning @ {lq_version}"
+        if lq_version.startswith("git+")
+        else f"pennylane-lightning=={lq_version}"
+    )
+    kokkos_dep = "" if lq_version.startswith("git+") else f"pennylane-lightning-kokkos=={lq_version}"
 else:
     lightning_dep = f"pennylane-lightning>={lq_min_release}"
     kokkos_dep = ""


### PR DESCRIPTION
**Context:**
Currently `setup.py` parses `.dep_versions` for testPyPI versions, but do not support installing from branch names or tags specified by git+ urls

**Description of the Change:**

Add support for git+ urls

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
