### PR TITLE
Silence RuleLoweringWarnings by default

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -59,6 +59,7 @@
   `CATALYST_SILENCE_RULE_LOWERING_WARNINGS=0`. This helps debug unexpected decompositions where
   rules cannot be lowered and they are silently dropped from the graph-decomposition system instead
   of raising an error.
+  [(#3190)](https://github.com/PennyLaneAI/catalyst/pull/3190)
 
 * Add the `XMEM_REPLY_BRAM` memory type and use it to allocate reply buffers in dedicated BRAM.
   [(#3148)](https://github.com/PennyLaneAI/catalyst/pull/3148)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -55,12 +55,6 @@
 
 <h3>Improvements 🛠</h3>
 
-* `RuleLoweringWarning` is now silenced by default. To display these warnings, set
-  `CATALYST_SILENCE_RULE_LOWERING_WARNINGS=0`. This helps debug unexpected decompositions where
-  rules cannot be lowered and they are silently dropped from the graph-decomposition system instead
-  of raising an error.
-  [(#3190)](https://github.com/PennyLaneAI/catalyst/pull/3190)
-
 * Add the `XMEM_REPLY_BRAM` memory type and use it to allocate reply buffers in dedicated BRAM.
   [(#3148)](https://github.com/PennyLaneAI/catalyst/pull/3148)
 
@@ -172,6 +166,12 @@
     Gates with null decomposition rules are simply removed.
 
     6. The pass can now handle register-mode rules that target gates in control flow regions whose qubits were extracted outside the region.
+
+  - `RuleLoweringWarning` is silenced by default. To display these warnings, set
+    `CATALYST_SILENCE_RULE_LOWERING_WARNINGS=0`. This helps debug unexpected decompositions where
+    rules cannot be lowered and they are silently dropped from the graph-decomposition system instead
+    of raising an error.
+    [(#3190)](https://github.com/PennyLaneAI/catalyst/pull/3190)
 
 * A failure during AOT compilation is now downgraded to a warning and logged.
   [(#3100)](https://github.com/PennyLaneAI/catalyst/pull/3100)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -57,8 +57,8 @@
 
 * `RuleLoweringWarning` is now silenced by default. To display these warnings, set
   `CATALYST_SILENCE_RULE_LOWERING_WARNINGS=0`. This helps debug unexpected decompositions where
-  un-lowerable rules are silently dropped from the graph-decomposition system instead of raising
-  an error.
+  rules cannot be lowered and they are silently dropped from the graph-decomposition system instead
+  of raising an error.
 
 * Add the `XMEM_REPLY_BRAM` memory type and use it to allocate reply buffers in dedicated BRAM.
   [(#3148)](https://github.com/PennyLaneAI/catalyst/pull/3148)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -55,6 +55,11 @@
 
 <h3>Improvements 🛠</h3>
 
+* `RuleLoweringWarning` is now silenced by default. To display these warnings, set
+  `CATALYST_SILENCE_RULE_LOWERING_WARNINGS=0`. This helps debug unexpected decompositions where
+  un-lowerable rules are silently dropped from the graph-decomposition system instead of raising
+  an error.
+
 * Add the `XMEM_REPLY_BRAM` memory type and use it to allocate reply buffers in dedicated BRAM.
   [(#3148)](https://github.com/PennyLaneAI/catalyst/pull/3148)
 

--- a/frontend/catalyst/decomposition/rule_lowering_warning.py
+++ b/frontend/catalyst/decomposition/rule_lowering_warning.py
@@ -14,8 +14,20 @@
 
 """This module provides a warning category for grouping decomposition rule lowering warnings."""
 
+import os
 import warnings
 
 
 class RuleLoweringWarning(Warning):
     pass
+
+
+def _env_flag(name: str, default: str) -> bool:
+    """Read a boolean environment variable, treating "0"/"false"/"" as false."""
+    return os.environ.get(name, default).strip().lower() not in ("", "0", "false")
+
+# Default is "1".
+SILENCE_RULE_LOWERING_WARNINGS = _env_flag("CATALYST_SILENCE_RULE_LOWERING_WARNINGS", "1")
+
+if SILENCE_RULE_LOWERING_WARNINGS:
+    warnings.filterwarnings("ignore", category=RuleLoweringWarning)

--- a/frontend/catalyst/decomposition/rule_lowering_warning.py
+++ b/frontend/catalyst/decomposition/rule_lowering_warning.py
@@ -26,6 +26,7 @@ def _env_flag(name: str, default: str) -> bool:
     """Read a boolean environment variable, treating "0"/"false"/"" as false."""
     return os.environ.get(name, default).strip().lower() not in ("", "0", "false")
 
+
 # Default is "1".
 SILENCE_RULE_LOWERING_WARNINGS = _env_flag("CATALYST_SILENCE_RULE_LOWERING_WARNINGS", "1")
 

--- a/frontend/catalyst/decomposition/rule_lowering_warning.py
+++ b/frontend/catalyst/decomposition/rule_lowering_warning.py
@@ -30,5 +30,5 @@ def _env_flag(name: str, default: str) -> bool:
 # Default is "1".
 SILENCE_RULE_LOWERING_WARNINGS = _env_flag("CATALYST_SILENCE_RULE_LOWERING_WARNINGS", "1")
 
-if SILENCE_RULE_LOWERING_WARNINGS:
+if SILENCE_RULE_LOWERING_WARNINGS:  # pragma: no-cover
     warnings.filterwarnings("ignore", category=RuleLoweringWarning)

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -198,7 +198,6 @@ class TestGenericUtilities:
             )
         assert isinstance(res, str)
 
-    @pytest.mark.filterwarnings("ignore::catalyst.decomposition.RuleLoweringWarning")
     def test_wrapper_passes_compilable_data_to_conditions(self, mocker):
         """Test that decomposition conditions receive compilable operator data."""
         mock_decomp = mocker.MagicMock()
@@ -276,7 +275,6 @@ class TestTraceTime:
         assert 'target_gate = "NoParams{}{reg:2}{}"' in mlir
         assert 'target_gate = "Adjoint(NoParams){}{reg:2}{}"' in mlir
 
-    @pytest.mark.filterwarnings("ignore::catalyst.decomposition.RuleLoweringWarning")
     def test_adjoint_gate_captures_base_and_adjoint(self):
         """Lowering the Adjoint of a gate captures the rules registered against both the plain gate
         and its adjoint."""
@@ -299,7 +297,6 @@ class TestTraceTime:
         assert 'target_gate = "NoParams{}{reg:2}{}"' in mlir
         assert 'target_gate = "Adjoint(NoParams){}{reg:2}{}"' in mlir
 
-    @pytest.mark.filterwarnings("ignore::catalyst.decomposition.RuleLoweringWarning")
     def test_distribution_rule_synthesized_from_base_only(self):
         """With only a base rule registered (no Adjoint(Op) rule), lowering still synthesizes a rule
         for Adjoint(Op) by distributing the base rule over adjoint (case 3): its resources are the
@@ -327,7 +324,6 @@ class TestTraceTime:
         )
         assert "qref.adjoint" in mlir
 
-    @pytest.mark.filterwarnings("ignore::catalyst.decomposition.RuleLoweringWarning")
     def test_no_distribution_rule_for_non_invertible_body(self):
         """A distribution rule is NOT synthesized when the base rule body is non-invertible (contains
         a mid-circuit measurement): the base rule is still lowered, but no Adjoint(Op) rule."""
@@ -400,7 +396,6 @@ class TestOnDemand:
         with pytest.raises(ValueError, match="not a control id"):
             name_unwrap_control("RX", "Adjoint(RX){0:[f64]}{wires:1}{}")
 
-    @pytest.mark.filterwarnings("ignore::catalyst.decomposition.RuleLoweringWarning")
     @pytest.mark.parametrize(
         "op_id, extra_ctrl_target",
         [
@@ -424,7 +419,6 @@ class TestOnDemand:
         if extra_ctrl_target is not None:
             assert extra_ctrl_target in module_str
 
-    @pytest.mark.filterwarnings("ignore::catalyst.decomposition.RuleLoweringWarning")
     def test_control_variant_warns_and_skips_on_failure(self, mocker):
         """control_variant_rule_strings warns and skips a rule when it fails to compile."""
 


### PR DESCRIPTION
**Context:**
`RuleLoweringWarning` is now silenced by default. To display these warnings, set `CATALYST_SILENCE_RULE_LOWERING_WARNINGS=0`. This helps debug unexpected decompositions where rules cannot be lowered, they are silently dropped from the graph-decomposition system instead of raising an error.

**Description of the Change:**

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-130028]
