### PR TITLE
Stop reporting Adjoint(PBC op) in resource analysis

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -496,7 +496,7 @@
 * The ``ResourceAnalysis`` pass no longer reports PBC Pauli product rotations and measurements
   with an ``Adjoint(...)`` prefix. Resource keys such as ``Adjoint(PPR-pi/4)`` and ``Adjoint(PPM)`` 
   are now counted under ``PPR-pi/4`` and ``PPM`` instead.
-  [(#XXXX)](https://github.com/PennyLaneAI/catalyst/pull/XXXX)
+  [(#3210)](https://github.com/PennyLaneAI/catalyst/pull/3210)
 
 * Removes the non-graph decomposition fallback when `capture=True` is enabled.
   [(#3058)](https://github.com/PennyLaneAI/catalyst/pull/3058/)

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -493,6 +493,11 @@
   (``any_commuting_depth`` / ``qubit_disjoint_depth``).
   [(#3081)](https://github.com/PennyLaneAI/catalyst/pull/3081)
 
+* The ``ResourceAnalysis`` pass no longer reports PBC Pauli product rotations and measurements
+  with an ``Adjoint(...)`` prefix. Resource keys such as ``Adjoint(PPR-pi/4)`` and ``Adjoint(PPM)`` 
+  are now counted under ``PPR-pi/4`` and ``PPM`` instead.
+  [(#XXXX)](https://github.com/PennyLaneAI/catalyst/pull/XXXX)
+
 * Removes the non-graph decomposition fallback when `capture=True` is enabled.
   [(#3058)](https://github.com/PennyLaneAI/catalyst/pull/3058/)
 

--- a/frontend/test/pytest/test_peephole_optimizations.py
+++ b/frontend/test/pytest/test_peephole_optimizations.py
@@ -227,8 +227,7 @@ def test_convert_clifford_to_ppr():
     ppm_specs_output = qp.specs(test_convert_clifford_to_ppr_workflow, level=1)().resources
 
     gate_types = ppm_specs_output.quantum_operations
-    assert gate_types.get("Adjoint(PPR-pi/4)", 0) == 2
-    assert gate_types.get("PPR-pi/4-w1", 0) == 4
+    assert gate_types.get("PPR-pi/4-w1", 0) == 6
     assert gate_types.get("PPR-pi/4-w2", 0) == 1
     assert gate_types.get("PPR-pi/8-w1", 0) == 1
     assert ppm_specs_output.any_commuting_depth == 3
@@ -283,8 +282,7 @@ def test_commute_ppr():
     gate_types = ppm_specs_output.quantum_operations
 
     assert gate_types.get("PPM-w1", 0) == 2
-    assert gate_types.get("Adjoint(PPR-pi/4)", 0) == 2
-    assert gate_types.get("PPR-pi/4-w1", 0) == 4
+    assert gate_types.get("PPR-pi/4-w1", 0) == 6
     assert gate_types.get("PPR-pi/4-w2", 0) == 1
     assert gate_types.get("PPR-pi/8-w1", 0) == 1
     assert ppm_specs_output.any_commuting_depth == 5
@@ -343,8 +341,7 @@ def test_ppr_to_ppm_auto_corrected():
     gate_types = specs_output.resources.quantum_operations
 
     assert gate_types["GlobalPhase"] == 4
-    assert gate_types["PPR-pi/4-w1"] == 4
-    assert gate_types["Adjoint(PPR-pi/4)"] == 2
+    assert gate_types["PPR-pi/4-w1"] == 6
     assert gate_types["PPR-pi/4-w2"] == 1
     assert gate_types["PPR-pi/8-w1"] == 1
 
@@ -370,8 +367,8 @@ def test_ppr_to_ppm_inject_magic_state():
 
     specs_output = qp.specs(test_ppr_to_ppm_workflow, level=1)()
     gate_types = specs_output.resources.quantum_operations
-    assert gate_types["Adjoint(PPR-pi/4)"] == 2
-    assert gate_types["PPR-pi/4-w1"] == 4
+
+    assert gate_types["PPR-pi/4-w1"] == 6
     assert gate_types["PPR-pi/4-w2"] == 1
     assert gate_types["PPR-pi/8-w1"] == 1
     assert gate_types["PPM-w1"] == 2
@@ -398,8 +395,7 @@ def test_ppr_to_ppm_pauli_corrected():
 
     specs_output = qp.specs(test_ppr_to_ppm_workflow, level=1)()
     gate_types = specs_output.resources.quantum_operations
-    assert gate_types["PPR-pi/4-w1"] == 4
-    assert gate_types["Adjoint(PPR-pi/4)"] == 2
+    assert gate_types["PPR-pi/4-w1"] == 6
     assert gate_types["PPR-pi/4-w2"] == 1
     assert gate_types["PPR-pi/8-w1"] == 1
     assert gate_types["PPM-w1"] == 2
@@ -448,9 +444,8 @@ def test_commute_ppr_and_merge_ppr_ppm_with_max_pauli_size():
 
     g_specs = qp.specs(g_workflow, level=3)().resources
     gate_types = g_specs.quantum_operations
-    assert gate_types.get("Adjoint(PPM)", 0) == 1
-    assert gate_types.get("PPM-w1", 0) == 1
-    assert gate_types.get("Adjoint(PPR-pi/4)", 0) == 1
+    assert gate_types.get("PPM-w1", 0) == 2
+    assert gate_types.get("PPR-pi/4-w1", 0) == 1
     assert gate_types.get("PPR-pi/4-w2", 0) == 2
     assert gate_types.get("PPR-pi/8-w1", 0) == 2
     assert g_specs.any_commuting_depth == 3

--- a/mlir/include/PBC/IR/PBCOps.td
+++ b/mlir/include/PBC/IR/PBCOps.td
@@ -136,7 +136,7 @@ def FabricateOp : PBC_Op<"fabricate",
 }
 
 def PPRotationOp : PBC_Op<"ppr", [PBCOpInterface, AttrSizedOperandSegments,
-    DeclareOpInterfaceMethods<ResourceQuantumOpInterface, ["getResourceAdjointFlag", "getResourceDetailedName"]>]> {
+    DeclareOpInterfaceMethods<ResourceQuantumOpInterface, ["getResourceDetailedName"]>]> {
     let summary = "Pauli Product Rotation on qubits.";
 
     let description = [{
@@ -357,7 +357,7 @@ def PPRotationArbitraryOp : PBC_Op<"ppr.arbitrary", [PBCOpInterface, AttrSizedOp
 }
 
 def PPMeasurementOp : PBC_Op<"ppm", [PBCOpInterface,
-    DeclareOpInterfaceMethods<ResourceQuantumOpInterface, ["getResourceAdjointFlag", "getResourceDetailedName"]>]> {
+    DeclareOpInterfaceMethods<ResourceQuantumOpInterface, ["getResourceDetailedName"]>]> {
     let summary = "Pauli Product Measurement on qubits.";
 
     let description = [{

--- a/mlir/lib/PBC/IR/PBCOps.cpp
+++ b/mlir/lib/PBC/IR/PBCOps.cpp
@@ -255,9 +255,6 @@ llvm::StringRef PPMeasurementOp::getResourceName() { return "PPM"; }
 llvm::StringRef RefPPMeasurementOp::getResourceName() { return "PPM"; }
 llvm::StringRef SelectPPMeasurementOp::getResourceName() { return "PPM"; }
 
-bool PPRotationOp::getResourceAdjointFlag() { return getRotationKind() < 0; }
-bool PPMeasurementOp::getResourceAdjointFlag() { return getNegated(); }
-
 std::string getDetailedStateName(LogicalInitKind initState) {
     switch (initState) {
     case LogicalInitKind::zero:

--- a/mlir/test/Catalyst/ResourceAnalysisTest.mlir
+++ b/mlir/test/Catalyst/ResourceAnalysisTest.mlir
@@ -715,46 +715,6 @@ func.func @resolvable_nested_for_loop(%arg0: !quantum.bit) -> !quantum.bit {
 
 // -----
 
-// An enclosing induction variable used as the inner loop's lower bound is
-// currently unresolved, so the inner loop remains dynamic.
-
-// CHECK-LABEL: "dyn_for_loop_1": {
-// CHECK: "quantum_operations"
-// CHECK:   "PauliX": 1
-// CHECK-LABEL: "for_loop_1": {
-// CHECK: "function_calls"
-// CHECK:   "dynamic":
-// CHECK:       "dyn_for_loop_1"
-// CHECK: "quantum_operations": {}
-// CHECK-LABEL: "induction_variable_lower_bound_nested_for_loop": {
-// CHECK: "function_calls"
-// CHECK:   "static":
-// CHECK:       "for_loop_1": 8
-// CHECK: "quantum_operations": {}
-func.func @induction_variable_lower_bound_nested_for_loop(
-    %arg0: !quantum.bit) -> !quantum.bit {
-    %c0 = arith.constant 0 : index
-    %c1 = arith.constant 1 : index
-    %c8 = arith.constant 8 : index
-
-    // Python code:
-    // for i in range(8):
-    //     for j in range(i, 8):
-    //         qp.PauliX(0)
-
-    %q = scf.for %i = %c0 to %c8 step %c1 iter_args(%outer_arg = %arg0) -> !quantum.bit {
-        %inner = scf.for %j = %i to %c8 step %c1
-            iter_args(%inner_arg = %outer_arg) -> !quantum.bit {
-            %out = quantum.custom "PauliX"() %inner_arg : !quantum.bit
-            scf.yield %out : !quantum.bit
-        }
-        scf.yield %inner : !quantum.bit
-    }
-    return %q : !quantum.bit
-}
-
-// -----
-
 // The outer, middle, and inner loops execute 8, 28, and 56 times, so their
 // preserved call edges have average multiplicities 8, 3.5, and 2.
 

--- a/mlir/test/Catalyst/ResourceAnalysisTest.mlir
+++ b/mlir/test/Catalyst/ResourceAnalysisTest.mlir
@@ -715,6 +715,46 @@ func.func @resolvable_nested_for_loop(%arg0: !quantum.bit) -> !quantum.bit {
 
 // -----
 
+// An enclosing induction variable used as the inner loop's lower bound is
+// currently unresolved, so the inner loop remains dynamic.
+
+// CHECK-LABEL: "dyn_for_loop_1": {
+// CHECK: "quantum_operations"
+// CHECK:   "PauliX": 1
+// CHECK-LABEL: "for_loop_1": {
+// CHECK: "function_calls"
+// CHECK:   "dynamic":
+// CHECK:       "dyn_for_loop_1"
+// CHECK: "quantum_operations": {}
+// CHECK-LABEL: "induction_variable_lower_bound_nested_for_loop": {
+// CHECK: "function_calls"
+// CHECK:   "static":
+// CHECK:       "for_loop_1": 8
+// CHECK: "quantum_operations": {}
+func.func @induction_variable_lower_bound_nested_for_loop(
+    %arg0: !quantum.bit) -> !quantum.bit {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c8 = arith.constant 8 : index
+
+    // Python code:
+    // for i in range(8):
+    //     for j in range(i, 8):
+    //         qp.PauliX(0)
+
+    %q = scf.for %i = %c0 to %c8 step %c1 iter_args(%outer_arg = %arg0) -> !quantum.bit {
+        %inner = scf.for %j = %i to %c8 step %c1
+            iter_args(%inner_arg = %outer_arg) -> !quantum.bit {
+            %out = quantum.custom "PauliX"() %inner_arg : !quantum.bit
+            scf.yield %out : !quantum.bit
+        }
+        scf.yield %inner : !quantum.bit
+    }
+    return %q : !quantum.bit
+}
+
+// -----
+
 // The outer, middle, and inner loops execute 8, 28, and 56 times, so their
 // preserved call edges have average multiplicities 8, 3.5, and 2.
 
@@ -2309,11 +2349,9 @@ func.func public @test_ops_with_ctrl_ref() {
 // CHECK:   "pbc.fabricate": 1
 // CHECK:   "pbc.prepare": 2
 // CHECK: "1"
-// CHECK:   "Adjoint(PPR-identity)": 1
-// CHECK:   "PPR-identity": 1
+// CHECK:   "PPR-identity": 2
 // CHECK: "2"
-// CHECK:   "Adjoint(PPM)": 1
-// CHECK:   "PPM": 1
+// CHECK:   "PPM": 2
 // CHECK:   "PPR-pi/4": 1
 // CHECK: "3"
 // CHECK:   "PPR-pi/8": 1


### PR DESCRIPTION
**Context:**
Previously, when reporting PPM(-) or PPR(-rotation), the resource analysis prints `Adjoint(PPM)` or `Adjoint(PPR)`. This PR remove the `Adjoint` of PBC. This to avoid confusing using actual `adjoint` op or flag. 