### PR TITLE
skip prerelases for `stable` checkout

### DIFF
--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -30,7 +30,7 @@ jobs:
   check-config:
     name: Build Configuration
     needs: [constants]
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
     - name: Checkout Catalyst repo

--- a/.github/workflows/check-pl-compat.yaml
+++ b/.github/workflows/check-pl-compat.yaml
@@ -38,8 +38,11 @@ jobs:
       with:
         fetch-depth: 0
     - if: ${{ inputs.catalyst == 'stable' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        git checkout $(git tag -l 'v*' | sort -V | tail -1)
+        git checkout "$(gh release list --repo ${{ github.repository }} \
+            --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName')"
     - if: ${{ inputs.catalyst == 'release-candidate' }}
       run: |
         # For rc, we install all packages from TestPyPI.


### PR DESCRIPTION
**Context:**
Stable/Stable/Stable is currently failing because the workflow is attempting to install the prerelease version of Catalyst.

**Description of the Change:**
Exclude prereleases from the versions considered or `stable`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
