### PR TITLE
Declare quantum dialect link time dependencies

### DIFF
--- a/mlir/lib/Quantum/IR/CMakeLists.txt
+++ b/mlir/lib/Quantum/IR/CMakeLists.txt
@@ -12,4 +12,9 @@ add_mlir_library(MLIRQuantum
     MLIRQuantumInterfacesIncGen
     MLIRQuantumOpsIncGen
     MLIRQRefOpsIncGen
+
+    LINK_LIBS PRIVATE
+    MLIRMBQC
+    MLIRPBC
+    MLIRQRef
 )


### PR DESCRIPTION
The Quantum dialect now depends on several other dialects (meaning it uses symbols from those compilation units). This can cause downstream build errors, e.g. in a plugin which only links against the Quantum dialect and doesn't know that links to other dependent dialects are needed as well. In a base Catalyst build this is not an issue since all executable targets we have include all dialects anyway.

The fix makes it so those dependencies are explicitly declared by the component that depends on it, which we should follow as a general practice.

We might also want to interrogate whether these dependencies are truly necessary for the Quantum dialect, or whether it could be made more independent. 