### PR TITLE
Support Ctrl symbolic rules in graph-decomposition

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -21,11 +21,20 @@
 * The graph-based decomposition system now supports **adjoint operators** for `Operator2`.
   [(#3120)](https://github.com/PennyLaneAI/catalyst/pull/3120)
   [(#3115)](https://github.com/PennyLaneAI/catalyst/pull/3115)
+  [(#3204)](https://github.com/PennyLaneAI/catalyst/pull/3204)
 
   For a target gate set, `Adjoint(Op)` is reached through any of three pathways:
     1. Rules registered on the base `Op`,
     2. Rules registered directly for `Adjoint(Op)`, and
     3. Rules *synthesized by distribution* (`decompose(Adjoint(Op)) = adjoint(decompose(Op))`).
+
+  Pathway 2 now also covers the rules PennyLane registers with the *symbolic* operator's arguments,
+  i.e. `rule(base)` rather than the base op's `(*params, wires)`. This is how
+  `self_adjoint`, `adjoint_rotation` and other symbolic rules are written, so `Adjoint(H)`, `Adjoint(X)`,
+  `Adjoint(RZ)`, `Adjoint(Rot)`, ... now decompose straight back to their base operator instead of
+  falling through to the (much longer) distributed rules, or failing to solve at all when the base
+  op is the only member of the target `gate_set`. Rules registered for `Adjoint(Op)` against the base
+  op's parameters keep working: the two conventions are told apart per rule.
 
 * The graph-based decomposition system now supports **controlled operators** for `Operator2`,
   including single control (`C(Op)`), multiple controls (`<n>C(Op)`), and their composition with

--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -54,6 +54,28 @@
   `(decompose-lowering -> ctrl-lowering -> adjoint-lowering)` to a fixpoint.
   Controlled basis gates are only free when their own `<n>C(...)` id is in the target gate set.
 
+  Pathway 1 now also covers the rules PennyLane registers against the *symbolic* operator, i.e.
+  `rule(base, control_wires, control_values, work_wires, work_wire_type)` rather than the base op's
+  `(*params, wires)` — the `flip_zero_ctrl_values(...)` family. These are the rules that terminate a
+  controlled chain in plain gates (`C(Hadamard) -> CH`, `2C(Hadamard) -> H, RY, Toffoli`), so
+  `<n>C(Op)` can now reach a target gate set at all. A resource that is itself a generic symbolic
+  operator is spelled the way the compiler spells a modified operator: the modifier is folded into
+  the base op's id (`2C(S){}{wires:1}{}`), not the wrapper's own arguments. The number of controls
+  an operator instance carries now reaches the rule closure from lowering, so `<n>C(...)` rules are
+  synthesized at trace time rather than only on demand.
+
+  Two defects in applying a register-mode controlled rule are fixed along with it:
+
+  - The rule's operands are now emitted as `func(qreg, param*, inWires*, inCtrlWires*)`, matching
+    what `DecomposeLoweringPass` reads back. They were previously emitted control-wires-first
+    (`qp.capture.subroutine` traces through `jax.jit`, which flattens keyword arguments in sorted
+    order, and `_ctrl_wires` sorts ahead of `wires`), which silently swapped a rule's control and
+    target for a single control and mismatched the tensor shapes for more than one.
+
+  - `DecomposeLoweringPass` now inserts the *control* qubits into the register it hands to a
+    register-mode rule, not just the base qubits. A control qubit left out was read back at its
+    pre-decomposition state, dropping whatever had been applied to it earlier in the circuit.
+
 * The `local-random` unitary folding option for :func:`~.mitigate_with_zne` is now implemented,
   reproducing Mitiq's ``fold_gates_at_random``: every gate is folded ``floor((scale_factor-1)/2)``
   times, then a random subset is folded once more (without replacement) to reach ``scale_factor * n``

--- a/frontend/catalyst/decomposition/decomposition_rules.py
+++ b/frontend/catalyst/decomposition/decomposition_rules.py
@@ -25,6 +25,7 @@ import jax.numpy as jnp
 import pennylane as qp
 from jax._src.lib.mlir import ir
 from pennylane.core.operator import abstractify
+from pennylane.wires import Wires
 
 from catalyst.compiler import _quantum_opt
 from catalyst.decomposition.graph_op_id import GraphOpID
@@ -48,7 +49,13 @@ def _resources_have_measurement(gate_counts) -> bool:
     return any(isinstance(op, _NON_INVERTIBLE_RESOURCE_TYPES) for op in gate_counts)
 
 
-def uses_symbolic_signature(rule) -> bool:
+_SYMBOLIC_ARGNAMES = {
+    "adjoint": ("base",),
+    "control": ("base", "control_wires", "control_values", "work_wires", "work_wire_type"),
+}
+
+
+def uses_symbolic_signature(rule, kind="adjoint") -> bool:
     """Return whether ``rule`` follows the Operator2 symbolic-argument convention.
 
     This is the convention PennyLane uses for its symbolic decomposition rules
@@ -56,7 +63,7 @@ def uses_symbolic_signature(rule) -> bool:
     be used to lower rules registered against ``Adjoint(Op)``.
     """
     try:
-        inspect.signature(rule._impl).bind(base=None)
+        inspect.signature(rule._impl).bind(**{name: None for name in _SYMBOLIC_ARGNAMES[kind]})
     except TypeError:
         return False
     return True
@@ -72,6 +79,21 @@ def build_base_op(op_cls, kwargs, is_custom_op):
     args, kwargs = split_call_args(kwargs, is_custom_op)
     with qp.capture.pause():
         return op_cls(*args, **kwargs)
+
+
+def symbolic_arguments(base_op, kind, ctrl_wires=None) -> dict:
+    """Return the arguments a symbolic ``kind`` rule expects for the given base operator.
+    """
+    if kind == "adjoint":
+        return {"base": base_op}
+    ctrl_wires = Wires(ctrl_wires)
+    return {
+        "base": base_op,
+        "control_wires": ctrl_wires,
+        "control_values": [True] * len(ctrl_wires),
+        "work_wires": Wires([]),
+        "work_wire_type": "borrowed",
+    }
 
 
 # Canonical nesting order for op-level modifiers, listed OUTERMOST first. The compiler's
@@ -522,19 +544,25 @@ def build_rule_module(
     return inlined_module
 
 
-def collect_symbolic_adjoint_resources(op_cls, op_name, kwargs, is_custom_op):
-    """Return resource data for the rules registered against ``Adjoint(op_name)``."""
+# pylint: disable=too-many-arguments
+def collect_symbolic_resources(
+    op_cls, op_name, kwargs, is_custom_op, kind="adjoint", ctrl_wires=()
+):
+    """Return resource data for the rules registered against ``Adjoint(op_name)``/``C(op_name)``.
+    """
+    lookup_name = f"Adjoint({op_name})" if kind == "adjoint" else f"C({op_name})"
     rules = [
         rule
-        for rule in qp.decomposition.list_decomps(f"Adjoint({op_name})")
-        if uses_symbolic_signature(rule)
+        for rule in qp.decomposition.list_decomps(lookup_name)
+        if uses_symbolic_signature(rule, kind)
     ]
     if not rules:
         return [], {}, {}, {}
 
     # The base op is only a carrier of the dummy parameters and wires: the graph reasons about
     # resources in terms of abstract operators, matching `_get_kwargs` in PennyLane's graph.
-    probe_args = {"base": abstractify(build_base_op(op_cls, kwargs, is_custom_op))}
+    base_op = abstractify(build_base_op(op_cls, kwargs, is_custom_op))
+    probe_args = symbolic_arguments(base_op, kind, ctrl_wires)
 
     name_to_resources = {}
     name_to_resource_ids = {}
@@ -559,8 +587,8 @@ def collect_symbolic_adjoint_resources(op_cls, op_name, kwargs, is_custom_op):
     return rules, probe_args, name_to_resources, name_to_resource_ids
 
 
-# pylint: disable=too-many-arguments
-def compile_registered_adjoint_rules(
+# pylint: disable=too-many-arguments,too-many-locals
+def compile_registered_symbolic_rules(
     op_name,
     target_id,
     dynamic_shape,
@@ -569,9 +597,11 @@ def compile_registered_adjoint_rules(
     extra_data=None,
     is_custom_op=False,
     op_cls=None,
+    kind="adjoint",
+    n_ctrl=1,
 ) -> ir.Operation | None:
-    """Return the module of rules registered against ``Adjoint(op_name)`` that follow PennyLane's
-    symbolic-argument convention, or None if there are none.
+    """Return the module of rules registered against ``Adjoint(op_name)``/``C(op_name)`` that follow
+    PennyLane's symbolic-argument convention, or None if there are none.
     """
     if op_cls is None:
         raise ValueError(
@@ -582,19 +612,26 @@ def compile_registered_adjoint_rules(
     extra_data = extra_data or {}
     static_and_extra = static_data | extra_data
     kwargs = prepare_dynamic_op_kwargs(dynamic_shape, wire_lens)
-    device = qp.device("null.qubit", wires=sum(wire_lens.values()))
+    n_base_wires = sum(wire_lens.values())
+    n_ctrl = n_ctrl if kind == "control" else 0
+    device = qp.device("null.qubit", wires=n_base_wires + n_ctrl)
 
-    rules, probe_args, name_to_resources, name_to_resource_ids = collect_symbolic_adjoint_resources(
-        op_cls, op_name, kwargs | static_and_extra, is_custom_op
+    rules, probe_args, name_to_resources, name_to_resource_ids = collect_symbolic_resources(
+        op_cls,
+        op_name,
+        kwargs | static_and_extra,
+        is_custom_op,
+        kind=kind,
+        ctrl_wires=range(n_base_wires, n_base_wires + n_ctrl),
     )
     if not rules:
         return None
 
     def rule_to_subroutine(rule):
-        def decomp_rule(*_args, **_kwargs):
+        def decomp_rule(*_args, _ctrl_wires=None, **_kwargs):
             with qp.capture.pause():
                 base = op_cls(*_args, **_kwargs)
-            rule._impl(base=base)
+            rule._impl(**symbolic_arguments(base, kind, _ctrl_wires))
 
         decomp_rule_no_static_args = partial(decomp_rule, **static_and_extra)
         decomp_rule_no_static_args.__name__ = rule.name + "_" + target_id
@@ -617,20 +654,25 @@ def compile_registered_adjoint_rules(
     if not subroutines:
         return None
 
+    ctrl_wires = (
+        jnp.array(range(n_base_wires, n_base_wires + n_ctrl), dtype=int)
+        if kind == "control"
+        else None
+    )
     call_args, call_kwargs = split_call_args(kwargs, is_custom_op)
 
     return build_rule_module(
-        subroutines, device, call_args, call_kwargs, None, name_to_resource_ids, target_id
+        subroutines, device, call_args, call_kwargs, ctrl_wires, name_to_resource_ids, target_id
     )
 
 
-def registered_adjoint_rule_strings(op_name, target_id, **kwargs) -> list[str]:
-    """Return the rule strings from :func:`compile_registered_adjoint_rules`."""
+def registered_symbolic_rule_strings(op_name, target_id, kind, **kwargs) -> list[str]:
+    """Return the rule strings from :func:`compile_registered_symbolic_rules`."""
     try:
-        module = compile_registered_adjoint_rules(op_name, target_id, **kwargs)
+        module = compile_registered_symbolic_rules(op_name, target_id, kind=kind, **kwargs)
     except Exception as e:  # pylint: disable=broad-except
         warnings.warn(
-            f"Failed to lower the registered adjoint decomposition rules for {target_id}: {e}",
+            f"Failed to lower the registered {kind} decomposition rules for {target_id}: {e}",
             category=RuleLoweringWarning,
         )
         return []
@@ -688,9 +730,10 @@ def adjoint_variant_rule_strings(
     # TODO: the on-demand decomp rules are skipped for now.
     if op_cls is not None:
         out.extend(
-            registered_adjoint_rule_strings(
+            registered_symbolic_rule_strings(
                 op_name,
                 adj_id,
+                "adjoint",
                 dynamic_shape=dynamic_shape,
                 wire_lens=wire_lens,
                 static_data=static_data,
@@ -737,13 +780,16 @@ def control_variant_rule_strings(
     static_data,
     extra_data=None,
     is_custom_op=False,
+    op_cls=None,
 ):
     """Return the rule strings whose ``target_gate`` is ``<n>C(op_name)`` for each ``n`` in
     ``ctrl_counts``.
 
     The control analogue of :func:`adjoint_variant_rule_strings`. ``op_id`` is the *base* op's
-    graphOpId (e.g. ``"RX{...}"``). For each control count ``n`` three pathways contribute:
+    graphOpId (e.g. ``"RX{...}"``). For each control count ``n`` these pathways contribute:
       1. rules registered directly against ``<n>C(op_name)`` (``list_decomps("C(RX)")``),
+      1b. those same registered rules written against the symbolic operator's arguments, which is
+         how PennyLane itself writes them (``flip_zero_ctrl_values(...)``),
       2. rules synthesized by distributing each base rule of ``op_name`` over ``n`` controls
          (the ``wrap_control`` pathway), and
       3. rules for the nested modifier ``<n>C(Adjoint(op_name))`` synthesized by controlling each
@@ -755,18 +801,20 @@ def control_variant_rule_strings(
     for n in ctrl_counts:
         ctrl_mod = _control_modifier(n)
         ctrl_name = f"{ctrl_mod}({op_name})"
+        ctrl_id = wrap_modifier_id(op_id, ctrl_mod)
         # (1) Rules registered directly against <n>C(op_name):
         try:
             out.extend(
                 get_rule_strings_from_module(
                     compile_decomposition_rules(
                         ctrl_name,
-                        wrap_modifier_id(op_id, ctrl_mod),
+                        ctrl_id,
                         dynamic_shape,
                         wire_lens,
                         static_data,
                         extra_data=extra_data,
                         is_custom_op=is_custom_op,
+                        skip_rule=partial(uses_symbolic_signature, kind="control"),
                     )
                 )
             )
@@ -951,6 +999,7 @@ def fetch_all_reachable_decomposition_rules_from_op(
                     static_data,
                     extra_data=extra_data,
                     is_custom_op=is_custom_op,
+                    op_cls=op_classes.get(name),
                 )
             )
         return out
@@ -985,7 +1034,7 @@ def fetch_all_reachable_decomposition_rules_from_op(
                 skip_rule=uses_symbolic_signature if is_adjoint else None,
             )[0]
             if is_adjoint and (this_op_cls := op_classes.get(this_name)) is not None:
-                found |= collect_symbolic_adjoint_resources(
+                found |= collect_symbolic_resources(
                     this_op_cls, this_name, all_kwargs, this_is_custom_op
                 )[2]
             resources |= {(explore_name, name): res for name, res in found.items()}

--- a/frontend/catalyst/decomposition/decomposition_rules.py
+++ b/frontend/catalyst/decomposition/decomposition_rules.py
@@ -82,8 +82,7 @@ def build_base_op(op_cls, kwargs, is_custom_op):
 
 
 def symbolic_arguments(base_op, kind, ctrl_wires=None) -> dict:
-    """Return the arguments a symbolic ``kind`` rule expects for the given base operator.
-    """
+    """Return the arguments a symbolic ``kind`` rule expects for the given base operator."""
     if kind == "adjoint":
         return {"base": base_op}
     ctrl_wires = Wires(ctrl_wires)
@@ -548,8 +547,7 @@ def build_rule_module(
 def collect_symbolic_resources(
     op_cls, op_name, kwargs, is_custom_op, kind="adjoint", ctrl_wires=()
 ):
-    """Return resource data for the rules registered against ``Adjoint(op_name)``/``C(op_name)``.
-    """
+    """Return resource data for the rules registered against ``Adjoint(op_name)``/``C(op_name)``."""
     lookup_name = f"Adjoint({op_name})" if kind == "adjoint" else f"C({op_name})"
     rules = [
         rule

--- a/frontend/catalyst/decomposition/decomposition_rules.py
+++ b/frontend/catalyst/decomposition/decomposition_rules.py
@@ -16,6 +16,7 @@
 
 # pylint: disable=protected-access,bare-except
 
+import inspect
 import warnings
 from collections import deque
 from functools import partial
@@ -23,7 +24,7 @@ from functools import partial
 import jax.numpy as jnp
 import pennylane as qp
 from jax._src.lib.mlir import ir
-from jaxlib.mlir.dialects.builtin import ModuleOp
+from pennylane.core.operator import abstractify
 
 from catalyst.compiler import _quantum_opt
 from catalyst.decomposition.graph_op_id import GraphOpID
@@ -45,6 +46,32 @@ _NON_INVERTIBLE_RESOURCE_TYPES = (qp.ops.MidMeasure, qp.ops.PauliMeasure)
 def _resources_have_measurement(gate_counts) -> bool:
     """Return whether a rule's declared resources contain a mid-circuit measurement."""
     return any(isinstance(op, _NON_INVERTIBLE_RESOURCE_TYPES) for op in gate_counts)
+
+
+def uses_symbolic_signature(rule) -> bool:
+    """Return whether ``rule`` follows the Operator2 symbolic-argument convention.
+
+    This is the convention PennyLane uses for its symbolic decomposition rules
+    (e.g., ``self_adjoint``, ``adjoint_rotation``) and is the only one that can
+    be used to lower rules registered against ``Adjoint(Op)``.
+    """
+    try:
+        inspect.signature(rule._impl).bind(base=None)
+    except TypeError:
+        return False
+    return True
+
+
+def build_base_op(op_cls, kwargs, is_custom_op):
+    """Instantiate the base operator of a PennyLane's symbolic rule from prepared rule kwargs.
+
+    Note that we have to pause capture here, because the base operator is only a carrier of
+    the traced parameters and wires, and the rule body is what decides whether (and how) it
+    gets applied.
+    """
+    args, kwargs = split_call_args(kwargs, is_custom_op)
+    with qp.capture.pause():
+        return op_cls(*args, **kwargs)
 
 
 # Canonical nesting order for op-level modifiers, listed OUTERMOST first. The compiler's
@@ -247,9 +274,13 @@ def split_call_args(kwargs, is_custom_op):
     return (), kwargs
 
 
-def collect_resources_for_op(op_name, kwargs, is_custom_op=False, adjoint_resources=False):
+def collect_resources_for_op(
+    op_name, kwargs, is_custom_op=False, adjoint_resources=False, skip_rule=None
+):
     """Return resource data for all decomposition rules associated to op_name."""
     decomp_rules = list(qp.decomposition.list_decomps(op_name))
+    if skip_rule is not None:
+        decomp_rules = [rule for rule in decomp_rules if not skip_rule(rule)]
     args, kwargs = split_call_args(kwargs, is_custom_op)
 
     # map each rule to its resources, in a more generic format
@@ -297,6 +328,7 @@ def compile_decomposition_rules(
     wrap_adjoint=False,
     wrap_control=False,
     n_ctrl=1,
+    skip_rule=None,
 ) -> ir.Operation:
     """
     Return the top-level ``builtin.module`` operation containing the decomposition rules for an
@@ -318,6 +350,9 @@ def compile_decomposition_rules(
     Note that ``wrap_adjoint`` and ``wrap_control`` may be combined to synthesize the nested modifier
     ``<n>C(Adjoint(op_name))``: adjoint is applied innermost and control outermost (the canonical
     order matching the compiler's ``wrapModifiers``).
+
+    ``skip_rule`` leaves out the rules that another pathway is responsible for; see
+    :func:`collect_resources_for_op`.
     """
     kwargs = prepare_dynamic_op_kwargs(dynamic_shape, wire_lens)
     extra_data = extra_data or {}
@@ -325,7 +360,11 @@ def compile_decomposition_rules(
     device = qp.device("null.qubit", wires=n_base_wires + (n_ctrl if wrap_control else 0))
 
     name_to_resources, name_to_resource_ids, decomp_rules = collect_resources_for_op(
-        op_name, kwargs | static_data | extra_data, is_custom_op, adjoint_resources=wrap_adjoint
+        op_name,
+        kwargs | static_data | extra_data,
+        is_custom_op,
+        adjoint_resources=wrap_adjoint,
+        skip_rule=skip_rule,
     )
 
     # TODO: The modified target id and the wrapped resource ids are derived here by string-wrapping
@@ -392,16 +431,30 @@ def compile_decomposition_rules(
 
     call_args, call_kwargs = split_call_args(kwargs, is_custom_op)
 
+    return build_rule_module(
+        subroutines, device, call_args, call_kwargs, ctrl_wires, name_to_resource_ids, target_id
+    )
+
+
+# pylint: disable=too-many-arguments
+def build_rule_module(
+    subroutines, device, call_args, call_kwargs, ctrl_wires, name_to_resource_ids, target_id
+) -> ir.Operation:
+    """Trace ``subroutines`` into a module of standalone decomposition-rule functions.
+    """
+
     @qp.qjit(target="mlir", capture=True, collect_decomp_rules=False)
     @qp.qnode(device=device)
     def circuit():
         for subroutine in subroutines:
-            if wrap_control:
+            if ctrl_wires is not None:
                 subroutine(*call_args, _ctrl_wires=ctrl_wires, **call_kwargs)
             else:
                 subroutine(*call_args, **call_kwargs)
 
     module = circuit.mlir_module
+    if module is None:
+        raise RuntimeError(f"Failed to trace the decomposition rules for {target_id}")
 
     def update_funcop_attributes(op):
         """Update the decomposition rule attributes if op is a decomposition rule.
@@ -470,13 +523,139 @@ def compile_decomposition_rules(
     return inlined_module
 
 
+def collect_symbolic_adjoint_resources(op_cls, op_name, kwargs, is_custom_op):
+    """Return resource data for the rules registered against ``Adjoint(op_name)``.
+    """
+    rules = [
+        rule
+        for rule in qp.decomposition.list_decomps(f"Adjoint({op_name})")
+        if uses_symbolic_signature(rule)
+    ]
+    if not rules:
+        return [], {}, {}, {}
+
+    # The base op is only a carrier of the dummy parameters and wires: the graph reasons about
+    # resources in terms of abstract operators, matching `_get_kwargs` in PennyLane's graph.
+    probe_args = {"base": abstractify(build_base_op(op_cls, kwargs, is_custom_op))}
+
+    name_to_resources = {}
+    name_to_resource_ids = {}
+    for rule in rules:
+        try:
+            resources = rule.compute_resources(**probe_args)
+            name_to_resources[rule.name] = resources.gate_counts
+            # The rule body names the ops it produces itself, so unlike the distribution pathway
+            # these ids carry no added modifier.
+            # TODO: a resource op that is itself symbolic (e.g. a generic `Controlled(GlobalPhase)`
+            # rep) does not spell the compiler's canonical `C(GlobalPhase){...}` id here; such a
+            # rule registers an id the solver cannot match.
+            name_to_resource_ids[rule.name] = {
+                GraphOpID(op).getGraphOpId(): count for op, count in resources.gate_counts.items()
+            }
+        except Exception as e:  # pylint: disable=broad-except
+            warnings.warn(
+                f"Failed to get resources for the {rule.name} decomposition rule: {e}",
+                category=RuleLoweringWarning,
+            )
+
+    return rules, probe_args, name_to_resources, name_to_resource_ids
+
+
+# pylint: disable=too-many-arguments
+def compile_registered_adjoint_rules(
+    op_name,
+    target_id,
+    dynamic_shape,
+    wire_lens,
+    static_data,
+    extra_data=None,
+    is_custom_op=False,
+    op_cls=None,
+) -> ir.Operation | None:
+    """Return the module of rules registered against ``Adjoint(op_name)`` that follow PennyLane's
+    symbolic-argument convention, or None if there are none.
+    """
+    if op_cls is None:
+        raise ValueError(
+            f"The operator class of {op_name!r} is needed to lower the decomposition rules "
+            f"registered against {target_id}"
+        )
+
+    extra_data = extra_data or {}
+    static_and_extra = static_data | extra_data
+    kwargs = prepare_dynamic_op_kwargs(dynamic_shape, wire_lens)
+    device = qp.device("null.qubit", wires=sum(wire_lens.values()))
+
+    rules, probe_args, name_to_resources, name_to_resource_ids = collect_symbolic_adjoint_resources(
+        op_cls, op_name, kwargs | static_and_extra, is_custom_op
+    )
+    if not rules:
+        return None
+
+    def rule_to_subroutine(rule):
+        def decomp_rule(*_args, **_kwargs):
+            with qp.capture.pause():
+                base = op_cls(*_args, **_kwargs)
+            rule._impl(base=base)
+
+        decomp_rule_no_static_args = partial(decomp_rule, **static_and_extra)
+        decomp_rule_no_static_args.__name__ = rule.name + "_" + target_id
+        return qp.capture.subroutine(decomp_rule_no_static_args)
+
+    subroutines = []
+    for rule in rules:
+        if rule.name not in name_to_resource_ids:
+            continue
+        if _resources_have_measurement(name_to_resources[rule.name]):
+            warnings.warn(
+                f"Skipped the {rule.name} decomposition rule for {target_id}: it contains a "
+                "mid-circuit measurement, which is not supported with adjoint or control regions.",
+                category=RuleLoweringWarning,
+            )
+            continue
+        if rule.is_applicable(**probe_args):
+            subroutines.append(rule_to_subroutine(rule))
+
+    if not subroutines:
+        return None
+
+    call_args, call_kwargs = split_call_args(kwargs, is_custom_op)
+
+    return build_rule_module(
+        subroutines, device, call_args, call_kwargs, None, name_to_resource_ids, target_id
+    )
+
+
+def registered_adjoint_rule_strings(op_name, target_id, **kwargs) -> list[str]:
+    """Return the rule strings from :func:`compile_registered_adjoint_rules`."""
+    try:
+        module = compile_registered_adjoint_rules(op_name, target_id, **kwargs)
+    except Exception as e:  # pylint: disable=broad-except
+        warnings.warn(
+            f"Failed to lower the registered adjoint decomposition rules for {target_id}: {e}",
+            category=RuleLoweringWarning,
+        )
+        return []
+    return get_rule_strings_from_module(module) if module is not None else []
+
+
 def adjoint_variant_rule_strings(
-    op_name, op_id, dynamic_shape, wire_lens, static_data, extra_data=None, is_custom_op=False
+    op_name,
+    op_id,
+    dynamic_shape,
+    wire_lens,
+    static_data,
+    extra_data=None,
+    is_custom_op=False,
+    op_cls=None,
 ):
     """Return the rule strings whose ``target_gate`` is ``Adjoint(op_name)``.
 
-    ``op_id`` is the *base* op's graphOpId (e.g. ``"S{...}"``). Two pathways contribute:
-      1. rules registered directly against ``Adjoint(op_name)`` (``list_decomps("Adjoint(S)")``), and
+    ``op_id`` is the *base* op's graphOpId (e.g. ``"S{...}"``). Three pathways contribute:
+      1. rules registered directly against ``Adjoint(op_name)`` (``list_decomps("Adjoint(S)")``),
+         written against the base op's parameters,
+      1b. those same registered rules written against the symbolic operator's arguments, which is
+         how PennyLane itself writes them (``self_adjoint``, ``adjoint_rotation``, ...), and
       2. rules synthesized by distributing each base rule of ``op_name`` over adjoint
          (the ``wrap_adjoint`` pathway), dropping any whose body is non-invertible.
 
@@ -486,18 +665,20 @@ def adjoint_variant_rule_strings(
     """
     out = []
     adj_name = f"Adjoint({op_name})"
-    # (1) Rules registered directly against Adjoint(op_name):
+    adj_id = name_wrap_adjoint(op_id)
+    # (1) Rules registered directly against Adjoint(op_name), taking the base op's arguments:
     try:
         out.extend(
             get_rule_strings_from_module(
                 compile_decomposition_rules(
                     adj_name,
-                    name_wrap_adjoint(op_id),
+                    adj_id,
                     dynamic_shape,
                     wire_lens,
                     static_data,
                     extra_data=extra_data,
                     is_custom_op=is_custom_op,
+                    skip_rule=uses_symbolic_signature,
                 )
             )
         )
@@ -505,6 +686,20 @@ def adjoint_variant_rule_strings(
         warnings.warn(
             f"Failed to lower the decomposition rules for {adj_name}: {e}",
             category=RuleLoweringWarning,
+        )
+    # TODO: the on-demand decomp rules are skipped for now.
+    if op_cls is not None:
+        out.extend(
+            registered_adjoint_rule_strings(
+                op_name,
+                adj_id,
+                dynamic_shape=dynamic_shape,
+                wire_lens=wire_lens,
+                static_data=static_data,
+                extra_data=extra_data,
+                is_custom_op=is_custom_op,
+                op_cls=op_cls,
+            )
         )
     # (2) Rules for Adjoint(op_name) synthesized by adjointing each base rule of op_name:
     try:
@@ -698,12 +893,15 @@ def fetch_all_reachable_decomposition_rules_from_op(
     extra_data=None,
     is_custom_op=False,
     n_ctrls=0,
+    op_cls=None,
 ):
     extra_data = extra_data or {}
     queue = deque()
     start = (op_name, dynamic_shape, wire_lens, static_data, extra_data, is_custom_op)
     queue.append(start)
     visited = [start]
+
+    op_classes = {op_name: op_cls} if op_cls is not None else {}
 
     # Control counts to synthesize `<n>C(...)` rules for. A single control is always captured
     # proactively; a multi-controlled instance (`n_ctrls > 1`) additionally needs its own count.
@@ -742,6 +940,7 @@ def fetch_all_reachable_decomposition_rules_from_op(
                     static_data,
                     extra_data=extra_data,
                     is_custom_op=is_custom_op,
+                    op_cls=op_classes.get(name),
                 )
             )
             out.extend(
@@ -773,44 +972,60 @@ def fetch_all_reachable_decomposition_rules_from_op(
         ) = queue.popleft()
         this_extra_data = this_extra_data or {}
         this_kwargs = prepare_dynamic_op_kwargs(this_dynamic_shape, this_wire_lens)
-        # Explore ops reachable through the rules of both this op and its adjoint:
-        for explore_name in _op_variant_names(this_name):
-            resources, _, _ = collect_resources_for_op(
-                explore_name, this_kwargs | this_static_data | this_extra_data, this_is_custom_op
-            )
-            for _rule_name, resource in resources.items():
-                try:
-                    for op, _count in resource.items():
-                        graph_op_id = GraphOpID(op)
-                        probe = (
-                            graph_op_id.get_operator_name(),
-                            graph_op_id.dynamic_shape,
-                            graph_op_id.wire_lens,
-                            graph_op_id.static_data,
-                            graph_op_id.extra_data,
-                            graph_op_id.is_custom_op,
-                        )
+        all_kwargs = this_kwargs | this_static_data | this_extra_data
 
-                        if not probe in visited:
-                            visited.append(probe)
-                            queue.append(probe)
-                            rules.extend(
-                                compile_variants(
-                                    probe[0],
-                                    graph_op_id.getGraphOpId(),
-                                    probe[1],
-                                    probe[2],
-                                    probe[3],
-                                    probe[4],
-                                    probe[5],
-                                )
-                            )
-                except Exception as e:
-                    warnings.warn(
-                        f"Failed to lower the {_rule_name} decomposition rule for {this_name}: {e}",
-                        category=RuleLoweringWarning,
+        # Explore ops reachable through the rules of both this op and its adjoint, under both
+        # argument conventions:
+        resources = {}
+
+        for explore_name in _op_variant_names(this_name):
+            is_adjoint = explore_name.startswith("Adjoint(")
+            found = collect_resources_for_op(
+                explore_name,
+                all_kwargs,
+                this_is_custom_op,
+                skip_rule=uses_symbolic_signature if is_adjoint else None,
+            )[0]
+            if is_adjoint and (this_op_cls := op_classes.get(this_name)) is not None:
+                found |= collect_symbolic_adjoint_resources(
+                    this_op_cls, this_name, all_kwargs, this_is_custom_op
+                )[2]
+            resources |= {(explore_name, name): res for name, res in found.items()}
+
+        for (_, _rule_name), resource in resources.items():
+            try:
+                for op, _ in resource.items():
+                    graph_op_id = GraphOpID(op)
+                    probe = (
+                        graph_op_id.get_operator_name(),
+                        graph_op_id.dynamic_shape,
+                        graph_op_id.wire_lens,
+                        graph_op_id.static_data,
+                        graph_op_id.extra_data,
+                        graph_op_id.is_custom_op,
                     )
-                continue
+                    op_classes.setdefault(probe[0], type(op))
+
+                    if not probe in visited:
+                        visited.append(probe)
+                        queue.append(probe)
+                        rules.extend(
+                            compile_variants(
+                                probe[0],
+                                graph_op_id.getGraphOpId(),
+                                probe[1],
+                                probe[2],
+                                probe[3],
+                                probe[4],
+                                probe[5],
+                            )
+                        )
+            except Exception as e:
+                warnings.warn(
+                    f"Failed to lower the {_rule_name} decomposition rule for {this_name}: {e}",
+                    category=RuleLoweringWarning,
+                )
+            continue
     return rules
 
 

--- a/frontend/catalyst/decomposition/decomposition_rules.py
+++ b/frontend/catalyst/decomposition/decomposition_rules.py
@@ -25,6 +25,8 @@ import jax.numpy as jnp
 import pennylane as qp
 from jax._src.lib.mlir import ir
 from pennylane.core.operator import abstractify
+from pennylane.ops.op_math.adjoint2 import Adjoint2
+from pennylane.ops.op_math.controlled2 import ControlledOp2
 from pennylane.wires import Wires
 
 from catalyst.compiler import _quantum_opt
@@ -79,6 +81,23 @@ def build_base_op(op_cls, kwargs, is_custom_op):
     args, kwargs = split_call_args(kwargs, is_custom_op)
     with qp.capture.pause():
         return op_cls(*args, **kwargs)
+
+
+def rule_call_operands(call_args, call_kwargs, ctrl_wires=None) -> list:
+    """Flatten a decomposition rule's call into positional operands.
+    """
+    operands = [*call_args, *(call_kwargs[name] for name in sorted(call_kwargs))]
+    if ctrl_wires is not None:
+        operands.append(ctrl_wires)
+    return operands
+
+
+def unpack_rule_operands(operands, n_params, kwarg_names, has_ctrl_wires):
+    """Recover ``(params, kwargs, control wires)`` from :func:`rule_call_operands`' flattening."""
+    params = tuple(operands[:n_params])
+    named = dict(zip(kwarg_names, operands[n_params : n_params + len(kwarg_names)], strict=True))
+    ctrl_wires = operands[n_params + len(kwarg_names)] if has_ctrl_wires else None
+    return params, named, ctrl_wires
 
 
 def symbolic_arguments(base_op, kind, ctrl_wires=None) -> dict:
@@ -169,8 +188,19 @@ def wrap_modifier_id(op_id: str, modifier: str) -> str:
 
 
 def name_wrap_adjoint(op_id: str) -> str:
-    """Name-wrap the adjoint modifier around a graphOpId (``RX{...}`` -> ``Adjoint(RX){...}``)."""
+    """Name-wrap the adjoint modifier around a ``graphOpId`` (``RX{...}`` -> ``Adjoint(RX){...}``)."""
     return wrap_modifier_id(op_id, "Adjoint")
+
+
+def resource_graph_op_id(op) -> str:
+    """Return the ``graphOpId`` that a rule's resource operator denotes."""
+    if isinstance(op, Adjoint2):
+        return name_wrap_adjoint(resource_graph_op_id(op.base))
+    if isinstance(op, ControlledOp2):
+        return wrap_modifier_id(
+            resource_graph_op_id(op.base), _control_modifier(len(op.control_wires))
+        )
+    return GraphOpID(op).getGraphOpId()
 
 
 def name_unwrap_adjoint(op_name: str, op_id: str) -> str:
@@ -404,10 +434,17 @@ def compile_decomposition_rules(
             for rule_name, ids in name_to_resource_ids.items()
         }
 
+    call_args, call_kwargs = split_call_args(kwargs, is_custom_op)
+    kwarg_names = sorted(call_kwargs)
+
     # The static_data was only needed to instantiate the correct decomp rule
-    # Once we have the correct rules, don't send them into qjit
+    # Once we have the correct rules, don't send them into qjit: they are closed over instead.
     def rule_to_subroutine(rule):
-        def decomp_rule(*_args, _ctrl_wires=None, **_kwargs):
+        def decomp_rule(*_operands):
+            _args, _kwargs, _ctrl_wires = unpack_rule_operands(
+                _operands, len(call_args), kwarg_names, wrap_control
+            )
+            _kwargs |= static_data | extra_data
             # Apply adjoint innermost, control outermost (canonical `C(Adjoint(Op))`).
             body = qp.adjoint(rule._impl) if wrap_adjoint else rule._impl
             if wrap_control:
@@ -415,14 +452,10 @@ def compile_decomposition_rules(
             else:
                 body(*_args, **_kwargs)
 
-        decomp_rule_no_static_args = partial(decomp_rule, **static_data)
-        if extra_data:
-            decomp_rule_no_static_args = partial(decomp_rule_no_static_args, **extra_data)
-
         # keep the frontend name for readability, append target op_id for symbol uniqueness
-        decomp_rule_no_static_args.__name__ = rule.name + "_" + target_id
+        decomp_rule.__name__ = rule.name + "_" + target_id
 
-        return qp.capture.subroutine(decomp_rule_no_static_args)
+        return qp.capture.subroutine(decomp_rule)
 
     condition_args, condition_kwargs = split_call_args(
         kwargs | static_data | extra_data, is_custom_op
@@ -444,13 +477,10 @@ def compile_decomposition_rules(
         if rule.is_applicable(*condition_args, **condition_kwargs):
             subroutines.append(rule_to_subroutine(rule))
 
-    # For control distribution, the extra control wires are
-    # added to each rule body via the `_ctrl_wires` keyword argument.
+    # For control distribution: the extra control wires trail the base wires in the rule's operands.
     ctrl_wires = (
         jnp.array(range(n_base_wires, n_base_wires + n_ctrl), dtype=int) if wrap_control else None
     )
-
-    call_args, call_kwargs = split_call_args(kwargs, is_custom_op)
 
     return build_rule_module(
         subroutines, device, call_args, call_kwargs, ctrl_wires, name_to_resource_ids, target_id
@@ -462,15 +492,13 @@ def build_rule_module(
     subroutines, device, call_args, call_kwargs, ctrl_wires, name_to_resource_ids, target_id
 ) -> ir.Operation:
     """Trace ``subroutines`` into a module of standalone decomposition-rule functions."""
+    operands = rule_call_operands(call_args, call_kwargs, ctrl_wires)
 
     @qp.qjit(target="mlir", capture=True, collect_decomp_rules=False)
     @qp.qnode(device=device)
     def circuit():
         for subroutine in subroutines:
-            if ctrl_wires is not None:
-                subroutine(*call_args, _ctrl_wires=ctrl_wires, **call_kwargs)
-            else:
-                subroutine(*call_args, **call_kwargs)
+            subroutine(*operands)
 
     module = circuit.mlir_module
     if module is None:
@@ -569,12 +597,10 @@ def collect_symbolic_resources(
             resources = rule.compute_resources(**probe_args)
             name_to_resources[rule.name] = resources.gate_counts
             # The rule body names the ops it produces itself, so unlike the distribution pathway
-            # these ids carry no added modifier.
-            # TODO: a resource op that is itself symbolic (e.g. a generic `Controlled(GlobalPhase)`
-            # rep) does not spell the compiler's canonical `C(GlobalPhase){...}` id here; such a
-            # rule registers an id the solver cannot match.
+            # these ids carry no added modifier; a resource that is itself symbolic is spelled the
+            # way the compiler spells it (see :func:`resource_graph_op_id`).
             name_to_resource_ids[rule.name] = {
-                GraphOpID(op).getGraphOpId(): count for op, count in resources.gate_counts.items()
+                resource_graph_op_id(op): count for op, count in resources.gate_counts.items()
             }
         except Exception as e:  # pylint: disable=broad-except
             warnings.warn(
@@ -625,15 +651,20 @@ def compile_registered_symbolic_rules(
     if not rules:
         return None
 
+    call_args, call_kwargs = split_call_args(kwargs, is_custom_op)
+    kwarg_names = sorted(call_kwargs)
+
     def rule_to_subroutine(rule):
-        def decomp_rule(*_args, _ctrl_wires=None, **_kwargs):
+        def decomp_rule(*_operands):
+            _args, _kwargs, _ctrl_wires = unpack_rule_operands(
+                _operands, len(call_args), kwarg_names, kind == "control"
+            )
             with qp.capture.pause():
-                base = op_cls(*_args, **_kwargs)
+                base = op_cls(*_args, **_kwargs, **static_and_extra)
             rule._impl(**symbolic_arguments(base, kind, _ctrl_wires))
 
-        decomp_rule_no_static_args = partial(decomp_rule, **static_and_extra)
-        decomp_rule_no_static_args.__name__ = rule.name + "_" + target_id
-        return qp.capture.subroutine(decomp_rule_no_static_args)
+        decomp_rule.__name__ = rule.name + "_" + target_id
+        return qp.capture.subroutine(decomp_rule)
 
     subroutines = []
     for rule in rules:
@@ -657,7 +688,6 @@ def compile_registered_symbolic_rules(
         if kind == "control"
         else None
     )
-    call_args, call_kwargs = split_call_args(kwargs, is_custom_op)
 
     return build_rule_module(
         subroutines, device, call_args, call_kwargs, ctrl_wires, name_to_resource_ids, target_id
@@ -823,8 +853,7 @@ def control_variant_rule_strings(
             )
         # (1.2) The same, for the rules taking the symbolic operator's arguments.
         # TODO: the on-demand decomp rules are skipped for now.
-        # TODO: only a single control for now.
-        if n == 1 and op_cls is not None:
+        if op_cls is not None:
             out.extend(
                 registered_symbolic_rule_strings(
                     op_name,
@@ -1055,9 +1084,32 @@ def fetch_all_reachable_decomposition_rules_from_op(
                 )[2]
             resources |= {(explore_name, name): res for name, res in found.items()}
 
+        # And through the rules registered against its controlled form, one entry per control
+        # count since the products of a controlled rule depend on how many controls it has.
+        if (this_op_cls := op_classes.get(this_name)) is not None:
+            n_base_wires = sum(this_wire_lens.values())
+            for n in ctrl_counts:
+                found = collect_symbolic_resources(
+                    this_op_cls,
+                    this_name,
+                    all_kwargs,
+                    this_is_custom_op,
+                    kind="control",
+                    ctrl_wires=range(n_base_wires, n_base_wires + n),
+                )[2]
+                resources |= {
+                    (f"{_control_modifier(n)}({this_name})", name): res
+                    for name, res in found.items()
+                }
+
         for (_, _rule_name), resource in resources.items():
             try:
                 for op, _ in resource.items():
+                    # A generic symbolic resource stands for its base under a modifier, and it is
+                    # the base that owns the decomposition rules; `compile_variants` re-derives the
+                    # modifier variants from there.
+                    while isinstance(op, (Adjoint2, ControlledOp2)):
+                        op = op.base
                     graph_op_id = GraphOpID(op)
                     probe = (
                         graph_op_id.get_operator_name(),

--- a/frontend/catalyst/decomposition/decomposition_rules.py
+++ b/frontend/catalyst/decomposition/decomposition_rules.py
@@ -440,8 +440,7 @@ def compile_decomposition_rules(
 def build_rule_module(
     subroutines, device, call_args, call_kwargs, ctrl_wires, name_to_resource_ids, target_id
 ) -> ir.Operation:
-    """Trace ``subroutines`` into a module of standalone decomposition-rule functions.
-    """
+    """Trace ``subroutines`` into a module of standalone decomposition-rule functions."""
 
     @qp.qjit(target="mlir", capture=True, collect_decomp_rules=False)
     @qp.qnode(device=device)
@@ -524,8 +523,7 @@ def build_rule_module(
 
 
 def collect_symbolic_adjoint_resources(op_cls, op_name, kwargs, is_custom_op):
-    """Return resource data for the rules registered against ``Adjoint(op_name)``.
-    """
+    """Return resource data for the rules registered against ``Adjoint(op_name)``."""
     rules = [
         rule
         for rule in qp.decomposition.list_decomps(f"Adjoint({op_name})")

--- a/frontend/catalyst/decomposition/decomposition_rules.py
+++ b/frontend/catalyst/decomposition/decomposition_rules.py
@@ -84,8 +84,7 @@ def build_base_op(op_cls, kwargs, is_custom_op):
 
 
 def rule_call_operands(call_args, call_kwargs, ctrl_wires=None) -> list:
-    """Flatten a decomposition rule's call into positional operands.
-    """
+    """Flatten a decomposition rule's call into positional operands."""
     operands = [*call_args, *(call_kwargs[name] for name in sorted(call_kwargs))]
     if ctrl_wires is not None:
         operands.append(ctrl_wires)

--- a/frontend/catalyst/decomposition/decomposition_rules.py
+++ b/frontend/catalyst/decomposition/decomposition_rules.py
@@ -1083,24 +1083,11 @@ def fetch_all_reachable_decomposition_rules_from_op(
                 )[2]
             resources |= {(explore_name, name): res for name, res in found.items()}
 
-        # And through the rules registered against its controlled form, one entry per control
-        # count since the products of a controlled rule depend on how many controls it has.
-        if (this_op_cls := op_classes.get(this_name)) is not None:
-            n_base_wires = sum(this_wire_lens.values())
-            for n in ctrl_counts:
-                found = collect_symbolic_resources(
-                    this_op_cls,
-                    this_name,
-                    all_kwargs,
-                    this_is_custom_op,
-                    kind="control",
-                    ctrl_wires=range(n_base_wires, n_base_wires + n),
-                )[2]
-                resources |= {
-                    (f"{_control_modifier(n)}({this_name})", name): res
-                    for name, res in found.items()
-                }
-
+        # TODO: the rules registered against the *controlled* form are not explored here. Doing so
+        # discovers ops (e.g. `ControlledQubitUnitary`) whose own rules call out to a jitted
+        # classical helper, and such a rule cannot be lifted out of its module: the call is left
+        # dangling and the injected IR fails to verify. So the products of a registered `C(...)`
+        # rule currently have to be in the target gate set.
         for (_, _rule_name), resource in resources.items():
             try:
                 for op, _ in resource.items():

--- a/frontend/catalyst/decomposition/decomposition_rules.py
+++ b/frontend/catalyst/decomposition/decomposition_rules.py
@@ -802,7 +802,7 @@ def control_variant_rule_strings(
         ctrl_mod = _control_modifier(n)
         ctrl_name = f"{ctrl_mod}({op_name})"
         ctrl_id = wrap_modifier_id(op_id, ctrl_mod)
-        # (1) Rules registered directly against <n>C(op_name):
+        # (1.1) Rules registered directly against <n>C(op_name):
         try:
             out.extend(
                 get_rule_strings_from_module(
@@ -822,6 +822,24 @@ def control_variant_rule_strings(
             warnings.warn(
                 f"Failed to lower the decomposition rules for {ctrl_name}: {e}",
                 category=RuleLoweringWarning,
+            )
+        # (1.2) The same, for the rules taking the symbolic operator's arguments.
+        # TODO: the on-demand decomp rules are skipped for now.
+        # TODO: only a single control for now.
+        if n == 1 and op_cls is not None:
+            out.extend(
+                registered_symbolic_rule_strings(
+                    op_name,
+                    ctrl_id,
+                    "control",
+                    n_ctrl=n,
+                    dynamic_shape=dynamic_shape,
+                    wire_lens=wire_lens,
+                    static_data=static_data,
+                    extra_data=extra_data,
+                    is_custom_op=is_custom_op,
+                    op_cls=op_cls,
+                )
             )
         # (2) <n>C(op_name) by controlling each base rule, and
         # (3) <n>C(Adjoint(op_name)) by controlling each adjointed base rule.

--- a/frontend/catalyst/decomposition/rule_lowering_warning.py
+++ b/frontend/catalyst/decomposition/rule_lowering_warning.py
@@ -28,7 +28,7 @@ def _env_flag(name: str, default: str) -> bool:
 
 
 # Default is "1".
-SILENCE_RULE_LOWERING_WARNINGS = _env_flag("CATALYST_SILENCE_RULE_LOWERING_WARNINGS", "1")
+SILENCE_RULE_LOWERING_WARNINGS = _env_flag("CATALYST_SILENCE_RULE_LOWERING_WARNINGS", "0")
 
 if SILENCE_RULE_LOWERING_WARNINGS:  # pragma: no-cover
     warnings.filterwarnings("ignore", category=RuleLoweringWarning)

--- a/frontend/catalyst/decomposition/rule_lowering_warning.py
+++ b/frontend/catalyst/decomposition/rule_lowering_warning.py
@@ -28,7 +28,7 @@ def _env_flag(name: str, default: str) -> bool:
 
 
 # Default is "1".
-SILENCE_RULE_LOWERING_WARNINGS = _env_flag("CATALYST_SILENCE_RULE_LOWERING_WARNINGS", "0")
+SILENCE_RULE_LOWERING_WARNINGS = _env_flag("CATALYST_SILENCE_RULE_LOWERING_WARNINGS", "1")
 
 if SILENCE_RULE_LOWERING_WARNINGS:  # pragma: no-cover
     warnings.filterwarnings("ignore", category=RuleLoweringWarning)

--- a/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
+++ b/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
@@ -261,6 +261,7 @@ def compile_decomp_rules(
             wire_lens={"wires": wire_lens[0]},
             static_data={},
             is_custom_op=True,
+            op_cls=op_cls,
         )
 
     elif op_cls is qp.MultiRZ:
@@ -280,6 +281,7 @@ def compile_decomp_rules(
             dynamic_shape=dynamic_shape,
             wire_lens={f"{wire_argname}": wire_lens[0]},
             static_data={},
+            op_cls=op_cls,
         )
 
     elif op_cls is qp.PauliRot:
@@ -303,6 +305,7 @@ def compile_decomp_rules(
             dynamic_shape=dynamic_shape,
             wire_lens={f"{wire_argname}": wire_lens[0]},
             static_data=repack_static_data,
+            op_cls=op_cls,
         )
 
     elif op_cls is qp.PCPhase:
@@ -324,6 +327,7 @@ def compile_decomp_rules(
             dynamic_shape=dynamic_shape,
             wire_lens={f"{wire_argname}": wire_lens[0]},
             static_data=repack_static_data,
+            op_cls=op_cls,
         )
 
     elif op_cls is qp.GlobalPhase:
@@ -336,6 +340,7 @@ def compile_decomp_rules(
             dynamic_shape=dynamic_shape,
             wire_lens={},
             static_data={},
+            op_cls=op_cls,
         )
 
     elif op_cls is qp.QubitUnitary:
@@ -361,6 +366,7 @@ def compile_decomp_rules(
             dynamic_shape=dynamic_shape,
             wire_lens={f"{wire_argname}": wire_lens[0]},
             static_data={},
+            op_cls=op_cls,
         )
 
     else:
@@ -450,6 +456,7 @@ def compile_decomp_rules(
             wire_lens=non_hybrid_wire_lens,
             static_data=repack_static_data,
             extra_data=extra_data,
+            op_cls=op_cls,
         )
 
     inject_new_rules_into_module(module, decomp_rules)

--- a/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
+++ b/frontend/catalyst/from_plxpr/qref_operator2_primitives.py
@@ -229,6 +229,7 @@ def compile_decomp_rules(
     module,
     op_cls,
     is_custom_op=False,
+    n_ctrls=0,
     params=None,
     param_map=None,
     wire_lens=None,
@@ -262,6 +263,7 @@ def compile_decomp_rules(
             static_data={},
             is_custom_op=True,
             op_cls=op_cls,
+            n_ctrls=n_ctrls,
         )
 
     elif op_cls is qp.MultiRZ:
@@ -282,6 +284,7 @@ def compile_decomp_rules(
             wire_lens={f"{wire_argname}": wire_lens[0]},
             static_data={},
             op_cls=op_cls,
+            n_ctrls=n_ctrls,
         )
 
     elif op_cls is qp.PauliRot:
@@ -306,6 +309,7 @@ def compile_decomp_rules(
             wire_lens={f"{wire_argname}": wire_lens[0]},
             static_data=repack_static_data,
             op_cls=op_cls,
+            n_ctrls=n_ctrls,
         )
 
     elif op_cls is qp.PCPhase:
@@ -328,6 +332,7 @@ def compile_decomp_rules(
             wire_lens={f"{wire_argname}": wire_lens[0]},
             static_data=repack_static_data,
             op_cls=op_cls,
+            n_ctrls=n_ctrls,
         )
 
     elif op_cls is qp.GlobalPhase:
@@ -341,6 +346,7 @@ def compile_decomp_rules(
             wire_lens={},
             static_data={},
             op_cls=op_cls,
+            n_ctrls=n_ctrls,
         )
 
     elif op_cls is qp.QubitUnitary:
@@ -367,6 +373,7 @@ def compile_decomp_rules(
             wire_lens={f"{wire_argname}": wire_lens[0]},
             static_data={},
             op_cls=op_cls,
+            n_ctrls=n_ctrls,
         )
 
     else:
@@ -457,6 +464,7 @@ def compile_decomp_rules(
             static_data=repack_static_data,
             extra_data=extra_data,
             op_cls=op_cls,
+            n_ctrls=n_ctrls,
         )
 
     inject_new_rules_into_module(module, decomp_rules)
@@ -496,6 +504,7 @@ def _qref_operator_p_lowering(jax_ctx: mlir.LoweringRuleContext, *args, op_cls, 
             compile_decomp_rules(
                 module=jax_ctx.module_context.module,
                 op_cls=op_cls,
+                n_ctrls=n_ctrls,
                 wire_lens=wire_lens,
                 repack_static_data=repack_static_data,
             )
@@ -537,6 +546,7 @@ def _qref_operator_p_lowering(jax_ctx: mlir.LoweringRuleContext, *args, op_cls, 
                 module=jax_ctx.module_context.module,
                 op_cls=op_cls,
                 is_custom_op=True,
+                n_ctrls=n_ctrls,
                 wire_lens=wire_lens,
             )
 
@@ -591,6 +601,7 @@ def _qref_operator_p_lowering(jax_ctx: mlir.LoweringRuleContext, *args, op_cls, 
             module=jax_ctx.module_context.module,
             op_cls=op_cls,
             is_custom_op=False,
+            n_ctrls=n_ctrls,
             params=params,
             param_map=param_map,
             wire_lens=wire_lens,

--- a/frontend/test/lit/test_operator2/test_symbolic_registered_rules.py
+++ b/frontend/test/lit/test_operator2/test_symbolic_registered_rules.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Test the lowering of decomposition rules registered against ``Adjoint(Op)`` and written against the
+*symbolic* operator's arguments following PennyLane's conventions.
+"""
+
+# RUN: %PYTHON %s | FileCheck %s
+
+# pylint: disable = line-too-long,unused-argument,missing-function-docstring
+
+import pennylane as qp
+from operator2_dummy_gates import NoParams, SingleParam
+from pennylane.typing import Float, Wire
+
+from catalyst.decomposition.decomposition_rules import (
+    fetch_all_reachable_decomposition_rules_from_op,
+)
+
+
+def _base_rule():
+    def base_resource_fn(reg):
+        return {SingleParam(x=Float, reg=Wire[2]): 1}
+
+    @qp.register_resources(base_resource_fn)
+    def base_rule(reg):
+        SingleParam(x=0.1, reg=reg[0:2])
+
+    return base_rule
+
+
+def _self_adjoint_rule():
+    """Test the lowering into a rule for ``Adjoint(NoParams)`` that applies the
+    bare base op without regions."""
+
+    @qp.register_resources(lambda base: {qp.core.abstractify(base): 1})
+    def self_adjoint(base):
+        qp.apply(base)
+
+    return self_adjoint
+
+
+def test_registered_self_adjoint_rule_targets_the_adjoint_op():
+    """Test the lowering into a rule for ``Adjoint(NoParams)`` that applies the
+    bare base op without regions."""
+    with qp.decomposition.local_decomps():
+        qp.add_decomps(NoParams, _base_rule())
+        qp.add_decomps("Adjoint(NoParams)", _self_adjoint_rule())
+
+        print(
+            "\n".join(
+                fetch_all_reachable_decomposition_rules_from_op(
+                    op_name="NoParams",
+                    op_id="NoParams{}{reg:2}{}",
+                    dynamic_shape={},
+                    wire_lens={"reg": 2},
+                    static_data={},
+                    op_cls=NoParams,
+                )
+            )
+        )
+
+    # CHECK-DAG: func.func private @"__builtin_self_adjoint_Adjoint(NoParams){}{reg:2}{}"(%arg0: !qref.reg<2>, %arg1: tensor<2xi64>){{.*}}"NoParams{}{reg:2}{}" = 1 : i64{{.*}}target_gate = "Adjoint(NoParams){}{reg:2}{}"
+    # CHECK-DAG: func.func private @"__builtin_base_rule_NoParams{}{reg:2}{}"{{.*}}target_gate = "NoParams{}{reg:2}{}"
+
+
+test_registered_self_adjoint_rule_targets_the_adjoint_op()

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -48,8 +48,6 @@ from catalyst.decomposition.decomposition_rules import (
     name_unwrap_adjoint,
     name_unwrap_control,
     name_wrap_adjoint,
-    register_op_class,
-    resolve_op_class,
     uses_symbolic_signature,
     wrap_modifier_id,
 )
@@ -528,21 +526,11 @@ class TestSymbolicRules:
             rule = qp.list_decomps(op_name)[rule_name]
             assert uses_symbolic_signature(rule) is symbolic
 
-    def test_resolve_op_class(self):
-        """Test an operator class is resolved from a built-in name or from one seen while tracing, and
-        an unknown name resolves to None."""
-
-        assert resolve_op_class("Hadamard") is qp.Hadamard
-        assert resolve_op_class("NoSuchOperator") is None
-        assert resolve_op_class("NoParams") is None or resolve_op_class("NoParams") is NoParams
-        register_op_class(NoParams)
-        assert resolve_op_class("NoParams") is NoParams
-
     def test_self_adjoint_rule_is_lowered(self):
         """Test ``self_adjoint`` rule on ``Adjoint(Hadamard)``."""
 
         module = compile_registered_adjoint_rules(
-            "Hadamard", "Adjoint(Hadamard){}{wires:1}{}", {}, {"wires": 1}, {}
+            "Hadamard", "Adjoint(Hadamard){}{wires:1}{}", {}, {"wires": 1}, {}, op_cls=qp.Hadamard
         )
         (rule,) = get_rule_strings_from_module(module)
 
@@ -562,6 +550,7 @@ class TestSymbolicRules:
             {"wires": 1},
             {},
             is_custom_op=True,
+            op_cls=qp.RZ,
         )
         (rule,) = get_rule_strings_from_module(module)
 
@@ -586,12 +575,13 @@ class TestSymbolicRules:
                 is None
             )
 
-    def test_unresolvable_op_class_raises(self):
-        """Test lowering cannot proceed without the base operator's class."""
+    def test_missing_op_class_raises(self):
+        """Test lowering cannot proceed without the base operator's class: these rules take a base
+        operator instance, which the operator's name alone cannot produce."""
 
-        with pytest.raises(ValueError, match="Cannot resolve the operator class"):
+        with pytest.raises(ValueError, match="operator class of 'Hadamard' is needed"):
             compile_registered_adjoint_rules(
-                "NoSuchOperator", "Adjoint(NoSuchOperator){}{wires:1}{}", {}, {"wires": 1}, {}
+                "Hadamard", "Adjoint(Hadamard){}{wires:1}{}", {}, {"wires": 1}, {}
             )
 
 

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -30,6 +30,7 @@ from operator2_dummy_gates import (
     StaticData,
 )
 from pennylane import qnode
+from pennylane.core.operator import abstractify
 from pennylane.decomposition import add_decomps, local_decomps, register_resources
 from pennylane.typing import Bool, Complex, Float, Int, Wire
 from pennylane.wires import Wires
@@ -48,6 +49,7 @@ from catalyst.decomposition.decomposition_rules import (
     name_unwrap_adjoint,
     name_unwrap_control,
     name_wrap_adjoint,
+    resource_graph_op_id,
     uses_symbolic_signature,
     wrap_modifier_id,
 )
@@ -560,25 +562,56 @@ class TestSymbolicRules:
         assert "qref.adjoint" not in rule
         assert "stablehlo.negate" in rule
 
-    def test_controlled_rule_is_lowered_with_control_wires_first(self):
-        """Test a rule registered on ``C(op)`` takes the control wires ahead of the base wires,
-        the same operand order the control distribution pathway uses."""
+    @pytest.mark.parametrize(
+        "n_ctrl, target_id, signature, resource",
+        [
+            (
+                1,
+                "C(Hadamard){}{wires:1}{}",
+                "(%arg0: !qref.reg<2>, %arg1: tensor<1xi64>, %arg2: tensor<1xi64>)",
+                '"CH{}{wires:2}{}" = 1 : i64',
+            ),
+            (
+                2,
+                "2C(Hadamard){}{wires:1}{}",
+                "(%arg0: !qref.reg<3>, %arg1: tensor<1xi64>, %arg2: tensor<2xi64>)",
+                '"Toffoli{}{wires:3}{}" = 1 : i64',
+            ),
+        ],
+    )
+    def test_controlled_rule_is_lowered(self, n_ctrl, target_id, signature, resource):
+        """Test a rule registered on ``C(op)`` is lowered for each control count, with the control
+        wires *after* the base wires: the compiler reads a register-mode rule as
+        ``func(qreg, param*, inWires*, inCtrlWires*)``."""
 
         module = compile_registered_symbolic_rules(
             "Hadamard",
-            "C(Hadamard){}{wires:1}{}",
+            target_id,
             {},
             {"wires": 1},
             {},
             op_cls=qp.Hadamard,
             kind="control",
-            n_ctrl=1,
+            n_ctrl=n_ctrl,
         )
         (rule,) = get_rule_strings_from_module(module)
 
-        assert 'target_gate = "C(Hadamard){}{wires:1}{}"' in rule
-        assert '"CH{}{wires:2}{}" = 1 : i64' in rule
-        assert "(%arg0: !qref.reg<2>, %arg1: tensor<1xi64>, %arg2: tensor<1xi64>)" in rule
+        assert f'target_gate = "{target_id}"' in rule
+        assert resource in rule
+        assert signature in rule
+
+    def test_symbolic_resource_id_is_canonical(self):
+        """Test a resource that is itself symbolic is spelled the way the compiler spells a
+        modified operator: the base op's id with the modifier folded into its name."""
+
+        base = abstractify(qp.S(wires=jnp.array([0])))
+        assert resource_graph_op_id(base) == "S{}{wires:1}{}"
+        assert resource_graph_op_id(qp.adjoint(base)) == "Adjoint(S){}{wires:1}{}"
+        assert resource_graph_op_id(qp.ctrl(base, control=[1, 2])) == "2C(S){}{wires:1}{}"
+        # A concrete controlled class is *not* a generic wrapper and keeps its own id.
+        assert (
+            resource_graph_op_id(abstractify(qp.CH(wires=jnp.array([0, 1])))) == "CH{}{wires:2}{}"
+        )
 
     def test_no_registered_symbolic_rules(self):
         """Test an op with no symbolic rules registered against its adjoint yields no module."""

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -43,9 +43,14 @@ from catalyst.decomposition.decomposition_rules import (
     _modifier_kind,
     compile_decomposition_rules_wrapper,
     compile_reachable_decomposition_rules_wrapper,
+    compile_registered_adjoint_rules,
+    get_rule_strings_from_module,
     name_unwrap_adjoint,
     name_unwrap_control,
     name_wrap_adjoint,
+    register_op_class,
+    resolve_op_class,
+    uses_symbolic_signature,
     wrap_modifier_id,
 )
 from catalyst.decomposition.graph_op_id import GraphOpID
@@ -493,6 +498,101 @@ class TestModifierIds:
         assert _MODIFIER_CANONICAL_ORDER == ("C", "Adjoint")
         with pytest.raises(ValueError, match="Non-canonical modifier order"):
             wrap_modifier_id(op_id, "Adjoint")
+
+
+class TestSymbolicRules:
+    """Tests for the rules registered against a symbolic operator that take the symbolic
+    op's args; following the convention in PennyLane."""
+
+    @pytest.mark.parametrize(
+        "op_name, rule_name, symbolic",
+        [
+            ("Adjoint(Hadamard)", "decompose_to_base", True),
+            ("Adjoint(Rot)", "_adjoint_rot", True),
+            ("Adjoint(RZ)", "adjoint_rotation", True),
+            ("Adjoint(NoParams)", "adj_rule", False),
+        ],
+    )
+    def test_uses_symbolic_signature(self, op_name, rule_name, symbolic):
+        """Test a rule is recognized as symbolic exactly when its body accepts the symbolic operator's
+        arguments."""
+
+        with local_decomps():
+
+            @register_resources({NoParams: 1})
+            def adj_rule(reg):
+                NoParams(reg=reg)
+
+            add_decomps("Adjoint(NoParams)", adj_rule)
+
+            rule = qp.list_decomps(op_name)[rule_name]
+            assert uses_symbolic_signature(rule) is symbolic
+
+    def test_resolve_op_class(self):
+        """Test an operator class is resolved from a built-in name or from one seen while tracing, and
+        an unknown name resolves to None."""
+
+        assert resolve_op_class("Hadamard") is qp.Hadamard
+        assert resolve_op_class("NoSuchOperator") is None
+        assert resolve_op_class("NoParams") is None or resolve_op_class("NoParams") is NoParams
+        register_op_class(NoParams)
+        assert resolve_op_class("NoParams") is NoParams
+
+    def test_self_adjoint_rule_is_lowered(self):
+        """Test ``self_adjoint`` rule on ``Adjoint(Hadamard)``."""
+
+        module = compile_registered_adjoint_rules(
+            "Hadamard", "Adjoint(Hadamard){}{wires:1}{}", {}, {"wires": 1}, {}
+        )
+        (rule,) = get_rule_strings_from_module(module)
+
+        assert 'target_gate = "Adjoint(Hadamard){}{wires:1}{}"' in rule
+        assert 'resources = {operations = {"Hadamard{}{wires:1}{}" = 1 : i64}}' in rule
+        assert "qref.adjoint" not in rule
+        assert "(%arg0: !qref.reg<1>, %arg1: tensor<1xi64>)" in rule
+        assert rule.count('gate_name = "Hadamard"') == 1
+
+    def test_adjoint_rotation_rule_is_lowered(self):
+        """Test ``adjoint_rotation`` reads the angle off the base operator."""
+
+        module = compile_registered_adjoint_rules(
+            "RZ",
+            "Adjoint(RZ){0:[f64]}{wires:1}{}",
+            {"0": ["f64"]},
+            {"wires": 1},
+            {},
+            is_custom_op=True,
+        )
+        (rule,) = get_rule_strings_from_module(module)
+
+        assert 'target_gate = "Adjoint(RZ){0:[f64]}{wires:1}{}"' in rule
+        assert 'resources = {operations = {"RZ{0:[f64]}{wires:1}{}" = 1 : i64}}' in rule
+        assert "qref.adjoint" not in rule
+        assert "stablehlo.negate" in rule
+
+    def test_no_registered_symbolic_rules(self):
+        """Test an op with no symbolic rules registered against its adjoint yields no module."""
+
+        with local_decomps():
+            assert (
+                compile_registered_adjoint_rules(
+                    "NoParams",
+                    "Adjoint(NoParams){}{reg:2}{}",
+                    {},
+                    {"reg": 2},
+                    {},
+                    op_cls=NoParams,
+                )
+                is None
+            )
+
+    def test_unresolvable_op_class_raises(self):
+        """Test lowering cannot proceed without the base operator's class."""
+
+        with pytest.raises(ValueError, match="Cannot resolve the operator class"):
+            compile_registered_adjoint_rules(
+                "NoSuchOperator", "Adjoint(NoSuchOperator){}{wires:1}{}", {}, {"wires": 1}, {}
+            )
 
 
 if __name__ == "__main__":

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -43,7 +43,7 @@ from catalyst.decomposition.decomposition_rules import (
     _modifier_kind,
     compile_decomposition_rules_wrapper,
     compile_reachable_decomposition_rules_wrapper,
-    compile_registered_adjoint_rules,
+    compile_registered_symbolic_rules,
     get_rule_strings_from_module,
     name_unwrap_adjoint,
     name_unwrap_control,
@@ -503,15 +503,16 @@ class TestSymbolicRules:
     op's args; following the convention in PennyLane."""
 
     @pytest.mark.parametrize(
-        "op_name, rule_name, symbolic",
+        "op_name, kind, rule_name, symbolic",
         [
-            ("Adjoint(Hadamard)", "decompose_to_base", True),
-            ("Adjoint(Rot)", "_adjoint_rot", True),
-            ("Adjoint(RZ)", "adjoint_rotation", True),
-            ("Adjoint(NoParams)", "adj_rule", False),
+            ("Adjoint(Hadamard)", "adjoint", "decompose_to_base", True),
+            ("Adjoint(Rot)", "adjoint", "_adjoint_rot", True),
+            ("Adjoint(RZ)", "adjoint", "adjoint_rotation", True),
+            ("C(Hadamard)", "control", "flip_zero_ctrl_values(_controlled_hadamard)", True),
+            ("Adjoint(NoParams)", "adjoint", "adj_rule", False),
         ],
     )
-    def test_uses_symbolic_signature(self, op_name, rule_name, symbolic):
+    def test_uses_symbolic_signature(self, op_name, kind, rule_name, symbolic):
         """Test a rule is recognized as symbolic exactly when its body accepts the symbolic operator's
         arguments."""
 
@@ -524,12 +525,12 @@ class TestSymbolicRules:
             add_decomps("Adjoint(NoParams)", adj_rule)
 
             rule = qp.list_decomps(op_name)[rule_name]
-            assert uses_symbolic_signature(rule) is symbolic
+            assert uses_symbolic_signature(rule, kind) is symbolic
 
     def test_self_adjoint_rule_is_lowered(self):
         """Test ``self_adjoint`` rule on ``Adjoint(Hadamard)``."""
 
-        module = compile_registered_adjoint_rules(
+        module = compile_registered_symbolic_rules(
             "Hadamard", "Adjoint(Hadamard){}{wires:1}{}", {}, {"wires": 1}, {}, op_cls=qp.Hadamard
         )
         (rule,) = get_rule_strings_from_module(module)
@@ -543,7 +544,7 @@ class TestSymbolicRules:
     def test_adjoint_rotation_rule_is_lowered(self):
         """Test ``adjoint_rotation`` reads the angle off the base operator."""
 
-        module = compile_registered_adjoint_rules(
+        module = compile_registered_symbolic_rules(
             "RZ",
             "Adjoint(RZ){0:[f64]}{wires:1}{}",
             {"0": ["f64"]},
@@ -559,12 +560,32 @@ class TestSymbolicRules:
         assert "qref.adjoint" not in rule
         assert "stablehlo.negate" in rule
 
+    def test_controlled_rule_is_lowered_with_control_wires_first(self):
+        """Test a rule registered on ``C(op)`` takes the control wires ahead of the base wires,
+        the same operand order the control distribution pathway uses."""
+
+        module = compile_registered_symbolic_rules(
+            "Hadamard",
+            "C(Hadamard){}{wires:1}{}",
+            {},
+            {"wires": 1},
+            {},
+            op_cls=qp.Hadamard,
+            kind="control",
+            n_ctrl=1,
+        )
+        (rule,) = get_rule_strings_from_module(module)
+
+        assert 'target_gate = "C(Hadamard){}{wires:1}{}"' in rule
+        assert '"CH{}{wires:2}{}" = 1 : i64' in rule
+        assert "(%arg0: !qref.reg<2>, %arg1: tensor<1xi64>, %arg2: tensor<1xi64>)" in rule
+
     def test_no_registered_symbolic_rules(self):
         """Test an op with no symbolic rules registered against its adjoint yields no module."""
 
         with local_decomps():
             assert (
-                compile_registered_adjoint_rules(
+                compile_registered_symbolic_rules(
                     "NoParams",
                     "Adjoint(NoParams){}{reg:2}{}",
                     {},
@@ -580,7 +601,7 @@ class TestSymbolicRules:
         operator instance, which the operator's name alone cannot produce."""
 
         with pytest.raises(ValueError, match="operator class of 'Hadamard' is needed"):
-            compile_registered_adjoint_rules(
+            compile_registered_symbolic_rules(
                 "Hadamard", "Adjoint(Hadamard){}{wires:1}{}", {}, {"wires": 1}, {}
             )
 

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecomposeLoweringImpl.hpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecomposeLoweringImpl.hpp
@@ -256,17 +256,17 @@ class BaseSignatureAnalyzer {
 
             // Every qubit the rule acts on has to be put back into the register it reads from,
             // control qubits included: the rule addresses them by index, so a control qubit left
-            // out here would be read at its pre-decomposition state.
-            for (const auto &[qubits, indices] :
-                 {std::make_pair(signature.inQubits, signature.inWireIndices),
-                  std::make_pair(signature.inCtrlQubits, signature.inCtrlWireIndices)}) {
+            // out here would be read back at its pre-decomposition state.
+            auto insertQubits = [&](mlir::ValueRange qubits, ArrayRef<QubitIndex> indices) {
                 for (auto [i, qubit] : llvm::enumerate(qubits)) {
                     const QubitIndex &index = indices[i];
                     updatedQreg =
                         quantum::InsertOp::create(rewriter, loc, updatedQreg.getType(), updatedQreg,
                                                   index.getValue(), index.getAttr(), qubit);
                 }
-            }
+            };
+            insertQubits(signature.inQubits, signature.inWireIndices);
+            insertQubits(signature.inCtrlQubits, signature.inCtrlWireIndices);
             std::move_backward(operands.begin() + qregIdx, operands.end() - 1, operands.end());
             operands[qregIdx] = updatedQreg;
         }

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecomposeLoweringImpl.hpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecomposeLoweringImpl.hpp
@@ -254,11 +254,18 @@ class BaseSignatureAnalyzer {
         if (hasQreg) {
             Value updatedQreg = getUpdatedQreg(rewriter, loc);
 
-            for (auto [i, qubit] : llvm::enumerate(signature.inQubits)) {
-                const QubitIndex &index = signature.inWireIndices[i];
-                updatedQreg =
-                    quantum::InsertOp::create(rewriter, loc, updatedQreg.getType(), updatedQreg,
-                                              index.getValue(), index.getAttr(), qubit);
+            // Every qubit the rule acts on has to be put back into the register it reads from,
+            // control qubits included: the rule addresses them by index, so a control qubit left
+            // out here would be read at its pre-decomposition state.
+            for (const auto &[qubits, indices] :
+                 {std::make_pair(signature.inQubits, signature.inWireIndices),
+                  std::make_pair(signature.inCtrlQubits, signature.inCtrlWireIndices)}) {
+                for (auto [i, qubit] : llvm::enumerate(qubits)) {
+                    const QubitIndex &index = indices[i];
+                    updatedQreg =
+                        quantum::InsertOp::create(rewriter, loc, updatedQreg.getType(), updatedQreg,
+                                                  index.getValue(), index.getAttr(), qubit);
+                }
             }
             std::move_backward(operands.begin() + qregIdx, operands.end() - 1, operands.end());
             operands[qregIdx] = updatedQreg;


### PR DESCRIPTION
**Context:**
A follow-up PR to #3204; adding support for the symbolic rules PL registers for `C(Op)` [here](https://github.com/PennyLaneAI/pennylane/blob/main/pennylane/decomposition/symbolic_decomposition.py).

Check [the changelog](https://github.com/PennyLaneAI/catalyst/pull/3213/changes) for details.
 
**Description of the Change:**

**Benefits:**


**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-130374]
[sc-130810]