### PR TITLE
bug fix: `replace_wires_with_placeholder_wires` uses an accumulator to prevent overlapping wires

### DIFF
--- a/frontend/catalyst/decomposition/type_utils.py
+++ b/frontend/catalyst/decomposition/type_utils.py
@@ -15,6 +15,7 @@
 """Type handling utilities for decomposition rule lowering."""
 
 import copy
+import itertools
 import re
 
 import jax.numpy as jnp
@@ -157,10 +158,21 @@ def replace_wires_with_placeholder_wires(node):
     """
     # Wires is a pytree itself, so it has to be marked as a leaf to be replaced as a whole.
     leaves, tree = flatten(copy.deepcopy(node), is_leaf=_is_wires)
-    leaves = [
-        qp.wires.Wires(range(-1, -len(leaf) - 1, -1)) if _is_wires(leaf) else leaf
-        for leaf in leaves
-    ]
+
+    # NOTE: Run an accumulator to generate unique negative wire labels
+    # as some operators like qp.ctrl(qp.H(Wire[1]), Wire[1]) would
+    # fail to unflatten as without this change they would have duplicate wire labels
+    counter = itertools.count(-1, -1)
+    new_leaves = []
+    for leaf in leaves:
+        if _is_wires(leaf):
+            new_wires = qp.wires.Wires([next(counter) for _ in range(len(leaf))])
+            new_leaves.append(new_wires)
+        else:
+            new_leaves.append(leaf)
+
+    leaves = new_leaves
+
     return unflatten(leaves, tree)
 
 

--- a/frontend/test/pytest/test_decomposition.py
+++ b/frontend/test/pytest/test_decomposition.py
@@ -59,6 +59,18 @@ from catalyst.decomposition.type_utils import (
 class TestGenericUtilities:
     """Tests for common decomposition rule lowering utilities."""
 
+    def test_wires_replacement_doesnt_create_overlapping_wire_labels(self):
+        """Test that the helper does not create overlapping wire labels which create
+        validation failures when the operator is unflattened.
+
+        NOTE: Regression test for the accumulator change made in type_utils.py
+        """
+
+        op = qp.ctrl(qp.S(Wire[1]), Wire[1])
+        new_op = replace_wires_with_placeholder_wires(op)
+
+        assert new_op == qp.ctrl(qp.S(-2), -1)
+
     def test_wires_replacement_doesnt_mutate_operator(self):
         """Test that the wires replacement helper does not mutate the incoming operator."""
 


### PR DESCRIPTION
**Context:**

Before, an operator like `qp.ctrl(qp.S(Wire[1]), Wire[1]))` would get processed to `qp.ctrl(qp.S(-1), -1)` by this function which obviously fails because base.wires is overlapping with the control wires.

**Description of the Change:**

Add an accumulator to ensure we have unique wire labels before unflattening.

**Benefits:** Unblocks workflows.

**Possible Drawbacks:** Not the final solution. Ideally this function is removed.

[sc-130376]
