### PR TITLE
use parallel mode for coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,6 +347,9 @@ lit-coverage:
 	@echo "Running lit tests with coverage"
 	$(DIALECTS_BUILD_DIR)/bin/catalyst --tool=opt --emit-bytecode --register-decomp-rule-resource $(MK_DIR)/frontend/test/lit/GraphDecomposition/test_rules.mlir > $(MK_DIR)/frontend/test/lit/GraphDecomposition/test_rules.mlirbc
 	CATALYST_LIBPYTHON=$$($(PYTHON) -c 'from catalyst.utils.runtime_environment import get_libpython_path; print(get_libpython_path())') ENABLE_LIT_COVERAGE=1 COVERAGE_FILE=$(MK_DIR)/.coverage.lit $(PYTHON) $(LLVM_BUILD_DIR)/bin/llvm-lit -sv frontend/test/lit -j$(shell nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)
+	# Each lit worker writes its own .coverage.lit.<host>.<pid>.<random>; merge them into
+	# .coverage.lit, which coverage-frontend then combines with the pytest data.
+	$(PYTHON) -m coverage combine --data-file=$(MK_DIR)/.coverage.lit
 
 coverage-frontend:
 ifeq ($(ENABLE_ASAN),ON)

--- a/frontend/test/lit/lit.cfg.py
+++ b/frontend/test/lit/lit.cfg.py
@@ -69,8 +69,11 @@ if os.environ.get("ENABLE_LIT_COVERAGE", "0") == "1":
     config.environment["COVERAGE_FILE"] = os.environ.get(
         "COVERAGE_FILE", os.path.join(project_root, ".coverage.lit")
     )
+    # lit runs tests in parallel, and coverage's data file is a SQLite database that does not
+    # tolerate concurrent writers. `--parallel-mode` gives each process its own
+    # `.coverage.lit.<host>.<pid>.<random>` file, which `coverage combine` merges afterwards.
     python_executable = (
-        f"{python_executable} -m coverage run --source={catalyst_source} --append --branch"
+        f"{python_executable} -m coverage run --source={catalyst_source} --parallel-mode --branch"
     )
 
 config.substitutions.append(("%PYTHON", python_executable))


### PR DESCRIPTION
**Context:**
make `lit-coverage` runs lit with `-j$(nproc)` while every worker does coverage run -`-append` into one shared `.coverage.lit`. That file is a SQLite database and does not tolerate concurrent writers, so workers intermittently abort.

**Description of the Change:**

- `frontend/test/lit/lit.cfg.py`: --append → --parallel-mode, so each worker writes its own `.coverage.lit.<host>.<pid>.<random>`
 
- Makefile: merge them at the end of `lit-coverage `with coverage combine `--data-file=$(MK_DIR)/.coverage.lit`

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**

Assisted by: Claude Opus 5