### PR TITLE
[Optimization] Scope the graph-decomposition lowering fixpoint to circuit functions

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -152,6 +152,7 @@
     [(#3156)](https://github.com/PennyLaneAI/catalyst/pull/3156)
     [(#3158)](https://github.com/PennyLaneAI/catalyst/pull/3158)
     [(#3206)](https://github.com/PennyLaneAI/catalyst/pull/3206)
+    [(#3216)](https://github.com/PennyLaneAI/catalyst/pull/3216)
 
     1. The pass now supports applying a selection of the available decomposition rules via the `target_rules` parameter.
 

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompUtils.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompUtils.cpp
@@ -68,8 +68,16 @@ llvm::SmallVector<Operation *> getDecompositionRoots(ModuleOp module) {
             // Whatever is inside a function is covered by the function itself.
             return WalkResult::skip();
         }
+        if (isa<DecomposableGate>(op)) {
+            gateOutsideFunc = true;
+            return WalkResult::interrupt();
+        }
         return WalkResult::advance();
     });
+
+    if (gateOutsideFunc) {
+        return {module};
+    }
     return roots;
 }
 

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompUtils.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompUtils.cpp
@@ -18,6 +18,8 @@
 
 #include "mlir/IR/BuiltinAttributes.h"
 
+#include "Quantum/IR/QuantumInterfaces.h"
+
 using namespace mlir;
 
 namespace catalyst {
@@ -50,6 +52,25 @@ bool isInDecompRule(Operation *op) {
         op = parentOp;
     }
     return false;
+}
+
+llvm::SmallVector<Operation *> getDecompositionRoots(ModuleOp module) {
+    llvm::SmallVector<Operation *> roots;
+
+    // Any decomposable gate that does not live in a function
+    // can only be reached by rewriting the module itself.
+    bool gateOutsideFunc = false;
+    module.walk<WalkOrder::PreOrder>([&](Operation *op) {
+        if (auto func = dyn_cast<func::FuncOp>(op)) {
+            if (!isDecompositionFunction(func)) {
+                roots.push_back(func);
+            }
+            // Whatever is inside a function is covered by the function itself.
+            return WalkResult::skip();
+        }
+        return WalkResult::advance();
+    });
+    return roots;
 }
 
 } // namespace DecompUtils

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompUtils.hpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/DecompUtils.hpp
@@ -16,8 +16,10 @@
 
 #include <cstdint>
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
 
 namespace catalyst {
@@ -49,6 +51,10 @@ uint64_t getNumWires(mlir::func::FuncOp func);
 
 /// True if @p op is nested inside a decomposition rule function.
 bool isInDecompRule(mlir::Operation *op);
+
+/// The operations of @p module that decomposition should rewrite: basically every function
+/// that is not itself a decomposition rule.
+llvm::SmallVector<mlir::Operation *> getDecompositionRoots(mlir::ModuleOp module);
 
 } // namespace DecompUtils
 } // namespace quantum

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/decompose_lowering.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/decompose_lowering.cpp
@@ -166,8 +166,8 @@ struct DecomposeLoweringPass : impl::DecomposeLoweringPassBase<DecomposeLowering
         catalyst::quantum::ExtractOp::getCanonicalizationPatterns(decompositionPatterns,
                                                                   &getContext());
         FrozenRewritePatternSet frozenPatterns(std::move(decompositionPatterns));
-        for (func::FuncOp func : DecompUtils::getCircuitFuncs(module)) {
-            if (failed(applyPatternsGreedily(func.getBody(), frozenPatterns))) {
+        for (Operation *root : DecompUtils::getDecompositionRoots(module)) {
+            if (failed(applyPatternsGreedily(root, frozenPatterns))) {
                 return signalPassFailure();
             }
         }

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/decompose_lowering.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/decompose_lowering.cpp
@@ -153,13 +153,23 @@ struct DecomposeLoweringPass : impl::DecomposeLoweringPassBase<DecomposeLowering
         // Step 2: Find the target gate set
         findTargetGateSet(module, targetGateSet);
 
+        // Step 3: Apply the decomposition patterns, canonicalizing the insert/extract pairs.
+        //
+        // The patterns are applied per circuit function rather than to the whole module. 
+        // Note with the new updates to the graph-decomposition system, the program module
+        // now carries far more decomposition rules than just the QJIT-ed workflow, and rule
+        // bodies are never rewritten in place, so handing them to the greedy driver causes
+        // overhead without doing anything useful.
         RewritePatternSet decompositionPatterns(&getContext());
         populateDecomposeLoweringPatterns(decompositionPatterns, decompositionRegistry,
                                           targetGateSet);
         catalyst::quantum::ExtractOp::getCanonicalizationPatterns(decompositionPatterns,
                                                                   &getContext());
-        if (failed(applyPatternsGreedily(module, std::move(decompositionPatterns)))) {
-            return signalPassFailure();
+        FrozenRewritePatternSet frozenPatterns(std::move(decompositionPatterns));
+        for (func::FuncOp func : DecompUtils::getCircuitFuncs(module)) {
+            if (failed(applyPatternsGreedily(func.getBody(), frozenPatterns))) {
+                return signalPassFailure();
+            }
         }
     }
 };

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/decompose_lowering.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/decompose_lowering.cpp
@@ -155,7 +155,7 @@ struct DecomposeLoweringPass : impl::DecomposeLoweringPassBase<DecomposeLowering
 
         // Step 3: Apply the decomposition patterns, canonicalizing the insert/extract pairs.
         //
-        // The patterns are applied per circuit function rather than to the whole module. 
+        // The patterns are applied per circuit function rather than to the whole module.
         // Note with the new updates to the graph-decomposition system, the program module
         // now carries far more decomposition rules than just the QJIT-ed workflow, and rule
         // bodies are never rewritten in place, so handing them to the greedy driver causes

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/decompose_lowering.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/decompose_lowering.cpp
@@ -153,7 +153,6 @@ struct DecomposeLoweringPass : impl::DecomposeLoweringPassBase<DecomposeLowering
         // Step 2: Find the target gate set
         findTargetGateSet(module, targetGateSet);
 
-        // Step 3: Apply the decomposition patterns, canonicalizing the insert/extract pairs
         RewritePatternSet decompositionPatterns(&getContext());
         populateDecomposeLoweringPatterns(decompositionPatterns, decompositionRegistry,
                                           targetGateSet);

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
@@ -199,7 +199,7 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
                 return signalPassFailure();
             }
         }
-        
+
         llvm::SmallVector<mlir::Operation *> roots = DecompUtils::getDecompositionRoots(module);
 
         auto countOps = [&roots]() {

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
@@ -199,9 +199,7 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
                 return signalPassFailure();
             }
         }
-
-
-        // TODO: check if it's needed after testing
+        
         llvm::SmallVector<mlir::Operation *> roots = DecompUtils::getDecompositionRoots(module);
 
         auto countOps = [&roots]() {
@@ -226,6 +224,10 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
                 }
             }
             return success();
+        };
+        auto hasCtrlRegion = [](mlir::Operation *root) {
+            return root->walk([](CtrlOp) { return mlir::WalkResult::interrupt(); })
+                .wasInterrupted();
         };
         auto hasAdjointRegion = [](mlir::Operation *root) {
             return root->walk([](AdjointOp) { return mlir::WalkResult::interrupt(); })

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
@@ -200,16 +200,22 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
             }
         }
 
-        auto countOps = [](ModuleOp m) {
+
+        // TODO: check if it's needed after testing
+        llvm::SmallVector<mlir::Operation *> roots = DecompUtils::getDecompositionRoots(module);
+
+        auto countOps = [&roots]() {
             size_t count = 0;
-            m->walk([&](mlir::Operation *) { count++; });
+            for (mlir::Operation *root : roots) {
+                root->walk([&](mlir::Operation *) { count++; });
+            }
             return count;
         };
 
         // Fixpoint: apply the chosen rules and distribute any `quantum.adjoint` regions they emit,
-        // until the module stops changing.
+        // until the circuit stops changing.
         constexpr unsigned maxIterations = 64;
-        size_t previousOpCount = countOps(module);
+        size_t previousOpCount = countOps();
         ScopedDiagnosticTimer fixpointTimer("decomp:lowering-fixpoint");
         unsigned iterationsRun = 0;
         for (unsigned iter = 0; iter < maxIterations; ++iter) {
@@ -223,31 +229,18 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
             }
 
             // Distribute a `quantum.ctrl` region lazily.
-            bool hasCtrlRegion = module->walk([&](CtrlOp) { return mlir::WalkResult::interrupt(); })
-                                     .wasInterrupted();
-            if (hasCtrlRegion) {
-                OpPassManager ctrlPm("builtin.module");
-                ctrlPm.addPass(createCtrlLoweringPass());
-                if (failed(runPipeline(ctrlPm, module))) {
-                    return signalPassFailure();
-                }
+            if (failed(lowerRoots(hasCtrlRegion, createCtrlLoweringPass))) {
+                return signalPassFailure();
             }
 
             // Distribute a `quantum.adjoint` region lazily.
             // It uses a greedy rewriter that would otherwise DCE gates in circuits that
             // never needed adjoint handling.
-            bool hasAdjointRegion =
-                module->walk([&](AdjointOp) { return mlir::WalkResult::interrupt(); })
-                    .wasInterrupted();
-            if (hasAdjointRegion) {
-                OpPassManager adjointPm("builtin.module");
-                adjointPm.addPass(createAdjointLoweringPass());
-                if (failed(runPipeline(adjointPm, module))) {
-                    return signalPassFailure();
-                }
+            if (failed(lowerRoots(hasAdjointRegion, createAdjointLoweringPass))) {
+                return signalPassFailure();
             }
 
-            size_t currentOpCount = countOps(module);
+            size_t currentOpCount = countOps();
             if (currentOpCount == previousOpCount) {
                 break;
             }

--- a/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
+++ b/mlir/lib/Quantum/Transforms/GraphDecomposition/graph_decomposition.cpp
@@ -212,6 +212,26 @@ struct GraphDecompositionPass : public impl::GraphDecompositionPassBase<GraphDec
             return count;
         };
 
+        // Run a lowering pass over every root that has something for it to lower.
+        auto lowerRoots = [&](llvm::function_ref<bool(mlir::Operation *)> needsLowering,
+                              llvm::function_ref<std::unique_ptr<mlir::Pass>()> makePass) {
+            for (mlir::Operation *root : roots) {
+                if (!needsLowering(root)) {
+                    continue;
+                }
+                OpPassManager pm(root->getName().getStringRef());
+                pm.addPass(makePass());
+                if (failed(runPipeline(pm, root))) {
+                    return failure();
+                }
+            }
+            return success();
+        };
+        auto hasAdjointRegion = [](mlir::Operation *root) {
+            return root->walk([](AdjointOp) { return mlir::WalkResult::interrupt(); })
+                .wasInterrupted();
+        };
+
         // Fixpoint: apply the chosen rules and distribute any `quantum.adjoint` regions they emit,
         // until the circuit stops changing.
         constexpr unsigned maxIterations = 64;


### PR DESCRIPTION
**Context:**
With the new changes to the graph-decomposition system, graph-decomposition applies the solver's chosen rules by iterating decompose-lowering, ctrl-lowering and adjoint-lowering to a fixpoint. Every pass in that loop ran over the whole module. Now that a program module carries the reachable rule closure alongside the QJIT-ed workflow, the rules dominate the module: in a one-gate test circuit (MyOp -> H, gate_set=["H"]) the module holds 125 func.funcs and ~3300 ops, of which the circuit is a handful. `decomp:lowering-fixpoint` was 16.7 ms of a 19.2 ms decomp:total in PR #3206 

**Description of the Change:**

Adds `DecompUtils::getDecompositionRoots` that returns the circuits that the decompose-lowering should decompose/rewrite. Every `func.func` that is not itself a rule will fall back to the module itself when a module holds decomposable gates outside any function.

**Benefits:**

Per-iteration cost is now proportional to the circuit rather than to the available rule set. On the test above:

before:
- decomp:lowering-fixpoint	16.7 ms
- decomp:total	19.2 ms

in this PR:
- decomp:lowering-fixpoint	2.1 ms
- decomp:total:	4.2 ms



**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-130390]