### PR TITLE
Fix `runtime_artifacts` walk performance  

### DIFF
--- a/doc/releases/changelog-dev.md
+++ b/doc/releases/changelog-dev.md
@@ -570,6 +570,9 @@
 
 * Fixed the assembly format for `quantum.adjoint` when it has no quantum operands/results.
   [(#2938)](https://github.com/PennyLaneAI/catalyst/pull/2938)
+* Fixed a performance degradation issue with `catalyst.runtime_artifacts`. It now visits module 
+  operations only, instead of every operation in the program.
+  [(#3219)](https://github.com/PennyLaneAI/catalyst/pull/3219)
 
 <h3>Internal changes ⚙️</h3>
 

--- a/frontend/catalyst/utils/runtime_artifacts.py
+++ b/frontend/catalyst/utils/runtime_artifacts.py
@@ -42,22 +42,22 @@ def record_runtime_artifact(module_op, artifact_path):
 def collect_runtime_artifacts(mlir_module, compile_options):
     """Aggregate every ``catalyst.runtime_artifacts`` path into ``compile_options``.
 
-    Walks the module and all nested modules, collecting the artifact paths recorded on each, so the
-    linker receives the full set. The result is stored on ``compile_options.runtime_artifacts``.
+    Collects the paths recorded on ``mlir_module`` and on every module nested within it, in the
+    order first seen, so the linker receives the full set. The result is stored on
+    ``compile_options.runtime_artifacts``.
     """
-    seen = []
+    seen = {}
 
-    def _walk(op):
-        attrs = op.attributes
+    def _walk(module_op):
+        attrs = module_op.attributes
         if RUNTIME_ARTIFACTS_ATTR in attrs:
             for string_attr in attrs[RUNTIME_ARTIFACTS_ATTR]:
-                path = ir.StringAttr(string_attr).value
-                if path not in seen:
-                    seen.append(path)
-        for region in op.regions:
+                seen[ir.StringAttr(string_attr).value] = None
+        for region in module_op.regions:
             for block in region:
                 for child_op in block:
-                    _walk(child_op)
+                    if child_op.operation.name == "builtin.module":
+                        _walk(child_op.operation)
 
     _walk(mlir_module.operation)
     compile_options.runtime_artifacts = tuple(seen)

--- a/frontend/test/pytest/test_runtime_artifacts.py
+++ b/frontend/test/pytest/test_runtime_artifacts.py
@@ -1,0 +1,99 @@
+# Copyright 2026 Xanadu Quantum Technologies Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ``catalyst.runtime_artifacts`` module attribute: the libraries a local
+``runtime_call`` records, and their collection into the compile options."""
+
+import jax.numpy as jnp
+import pennylane as qp
+from jax._src.lib.mlir import ir
+
+from catalyst import qjit
+from catalyst.pipelines import CompileOptions
+from catalyst.utils.runtime_artifacts import collect_runtime_artifacts
+
+qp.runtime_declare("test_artifacts_symbol", "(ptr, u32) -> u64")
+
+LIB_A = "/tmp/libtest_artifact_a.so"
+LIB_B = "/tmp/libtest_artifact_b.so"
+
+
+def lower(fn, args):
+    """Run the capture and lowering stages of ``fn`` and return the artifacts they collected."""
+    compiled = qjit(fn)
+    compiled.jaxpr, *_ = compiled.capture(args)
+    compiled.generate_ir()
+    return compiled.compile_options.runtime_artifacts
+
+
+def test_local_call_library_is_collected():
+    """The library of a local ``runtime_call`` reaches the compile options, named once."""
+
+    def program(session):
+        first = qp.runtime_call("test_artifacts_symbol", session, 100, library=LIB_A)
+        second = qp.runtime_call("test_artifacts_symbol", session, 200, library=LIB_A)
+        return first + second
+
+    assert lower(program, (jnp.uint64(0),)) == (LIB_A,)
+
+
+def test_library_recorded_inside_a_qnode_is_collected():
+    """A call inside a qnode records onto a nested module, which the walk still reaches."""
+
+    @qp.qnode(qp.device("null.qubit", wires=1))
+    def circuit(session):
+        rounds = qp.runtime_call("test_artifacts_symbol", session, 100, library=LIB_B)
+        qp.RX(jnp.float64(rounds) * 0.0, wires=0)
+        return qp.expval(qp.PauliZ(0))
+
+    assert lower(circuit, (jnp.uint64(0),)) == (LIB_B,)
+
+
+def collect_from(mlir_text):
+    """Collect the artifacts of a hand-written module, whose ops need not be registered ones."""
+    context = ir.Context()
+    context.allow_unregistered_dialects = True
+    options = CompileOptions()
+    with context, ir.Location.unknown():
+        collect_runtime_artifacts(ir.Module.parse(mlir_text), options)
+    return options.runtime_artifacts
+
+
+def test_nested_modules_are_collected_and_deduplicated():
+    """Every module is reached at any depth, and a library named by two of them appears once."""
+
+    collected = collect_from("""
+        module attributes {catalyst.runtime_artifacts = ["/outer.so", "/shared.so"]} {
+          module attributes {catalyst.runtime_artifacts = ["/shared.so", "/inner.so"]} {
+            module attributes {catalyst.runtime_artifacts = ["/deepest.so"]} { }
+          }
+        }
+        """)
+
+    assert collected == ("/outer.so", "/shared.so", "/inner.so", "/deepest.so")
+
+
+def test_only_module_operations_are_consulted():
+    """The attribute is read off modules alone, and no other operation is traversed."""
+
+    collected = collect_from("""
+        module attributes {catalyst.runtime_artifacts = ["/outer.so"]} {
+          "some.holder"() ({
+            module attributes {catalyst.runtime_artifacts = ["/under_an_op.so"]} { }
+            "some.terminator"() : () -> ()
+          }) {catalyst.runtime_artifacts = ["/on_an_op.so"]} : () -> ()
+        }
+        """)
+
+    assert collected == ("/outer.so",)


### PR DESCRIPTION
**Context:**
Currently there is a performance degradation issue with `catalyst.runtime_artifacts` where it walks the entire IR operations looking for runtime_artifacts which is unnecessary. 

**Description of the Change:**
It now visits module operations only, instead of every operation in the program.

**Benefits:**

**Possible Drawbacks:**

**Related GitHub Issues:**
[sc-129402]